### PR TITLE
Fix tutorials route path

### DIFF
--- a/backend/src/modules/users/user.routes.js
+++ b/backend/src/modules/users/user.routes.js
@@ -25,8 +25,8 @@ router.use("/categories", categoryRoutes);
  *          - Admin management (POST/PUT/DELETE /admin/...)
  *          Uses internal middleware for protection
  */
-const tutorialRoutes = require("./tutorials/tutorial.routes")
-router.use("/users/tutorials", tutorialRoutes);
+const tutorialRoutes = require("./tutorials/tutorial.routes");
+router.use("/tutorials", tutorialRoutes);
 
 
 // ==============================================


### PR DESCRIPTION
## Summary
- fix path to tutorials routes so API is `/api/users/tutorials` not `/api/users/users/tutorials`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fe960dd1c8328b7494574f7aca00b