### PR TITLE
Fix env variable name

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,6 @@
 // 📁 .env.example
 PORT=5000
-DB_URL=postgres://user:password@localhost:5432/skillbridge_db
+DATABASE_URL=postgres://user:password@localhost:5432/skillbridge_db
 JWT_SECRET=your_jwt_secret
 CLOUDINARY_API_KEY=your_key
 SMTP_HOST=smtp.mailtrap.io


### PR DESCRIPTION
## Summary
- rename `DB_URL` to `DATABASE_URL` in the backend env example

## Testing
- `npm test` (fails: Error: no test specified)
- node -e "require('dotenv').config({path: '.env'}); console.log(process.env.DATABASE_URL);"

------
https://chatgpt.com/codex/tasks/task_e_684b132834b0832898c3ba5fd6620f01