### PR TITLE
Standardize OTP column naming

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -32,6 +32,7 @@
 - **Purpose**: Handles password reset OTPs
 - **Primary Key**: `id`
 - **Foreign Keys**: `user_id → users(id)`
+- **Columns**: `user_id`, `code`, `expires_at`, `used`, `created_at`
 
 
 ## Classes Tables

--- a/backend/src/migrations/20250517180429_create_password_resets_table.js
+++ b/backend/src/migrations/20250517180429_create_password_resets_table.js
@@ -2,7 +2,7 @@ exports.up = function(knex) {
   return knex.schema.createTable('password_resets', function(table) {
     table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
     table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
-    table.string('token').unique().notNullable();
+    table.string('code').unique().notNullable();
     table.timestamp('expires_at').notNullable();
     table.boolean('used').defaultTo(false);
     table.timestamp('created_at').defaultTo(knex.fn.now());


### PR DESCRIPTION
## Summary
- rename `token` column to `code` in password reset migration
- document password reset table columns

## Testing
- `npm test` (fails: no tests)
- `npm test` in frontend (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_684b128c74e08328ba69c2d1ea27879f