### PR TITLE
Fix tutorial APIs and integrate frontend calls

### DIFF
--- a/backend/src/modules/users/tutorials/certificate/certificate.service.js
+++ b/backend/src/modules/users/tutorials/certificate/certificate.service.js
@@ -1,4 +1,4 @@
-const db = require("../../../config/database");
+const db = require("../../../../config/database");
 const { v4: uuidv4 } = require("uuid");
 
 // Generate a unique certificate code

--- a/backend/src/modules/users/tutorials/certificate/certificatePublic.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/certificatePublic.controller.js
@@ -1,7 +1,7 @@
-const db = require("../../../config/database");
-const catchAsync = require("../../../utils/catchAsync");
-const { sendSuccess } = require("../../../utils/response");
-const AppError = require("../../../utils/AppError");
+const db = require("../../../../config/database");
+const catchAsync = require("../../../../utils/catchAsync");
+const { sendSuccess } = require("../../../../utils/response");
+const AppError = require("../../../../utils/AppError");
 
 exports.verifyByCode = catchAsync(async (req, res) => {
   const { code } = req.params;

--- a/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
@@ -1,4 +1,7 @@
 const service = require("./certificate.service");
+const catchAsync = require("../../../../utils/catchAsync");
+const { sendSuccess } = require("../../../../utils/response");
+const AppError = require("../../../../utils/AppError");
 
 exports.generateCertificate = catchAsync(async (req, res) => {
   const { tutorialId } = req.params;

--- a/backend/src/modules/users/tutorials/certificate/tutorialCertificate.routes.js
+++ b/backend/src/modules/users/tutorials/certificate/tutorialCertificate.routes.js
@@ -1,6 +1,6 @@
 const router = require("express").Router();
 const ctrl = require("./tutorialCertificate.controller");
-const { verifyToken, isStudent } = require("../../../middleware/authMiddleware");
+const { verifyToken, isStudent } = require("../../../../middleware/auth/authMiddleware");
 
 router.post("/:tutorialId/certificate/generate", verifyToken, isStudent, ctrl.generateCertificate);
 

--- a/backend/src/modules/users/tutorials/chapters/tutorialChapter.routes.js
+++ b/backend/src/modules/users/tutorials/chapters/tutorialChapter.routes.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const ctrl = require("./tutorialChapter.controller");
-const { verifyToken, isInstructorOrAdmin } = require("../../../middleware/authMiddleware");
+const { verifyToken, isInstructorOrAdmin } = require("../../../../middleware/auth/authMiddleware");
 
 router.post("/", verifyToken, isInstructorOrAdmin, ctrl.createChapter);
 router.patch("/:id", verifyToken, isInstructorOrAdmin, ctrl.updateChapter);

--- a/backend/src/modules/users/tutorials/chapters/uploadChapterVideo.js
+++ b/backend/src/modules/users/tutorials/chapters/uploadChapterVideo.js
@@ -3,7 +3,7 @@ const path = require("path");
 const fs = require("fs");
 
 // Ensure directory exists
-const uploadPath = path.join(__dirname, "../../../uploads/tutorials/chapters");
+const uploadPath = path.join(__dirname, "../../../../../uploads/tutorials/chapters");
 if (!fs.existsSync(uploadPath)) fs.mkdirSync(uploadPath, { recursive: true });
 
 const storage = multer.diskStorage({

--- a/backend/src/modules/users/tutorials/comments/tutorialComment.controller.js
+++ b/backend/src/modules/users/tutorials/comments/tutorialComment.controller.js
@@ -1,6 +1,6 @@
-const db = require("../../../config/database");
-const catchAsync = require("../../../utils/catchAsync");
-const { sendSuccess } = require("../../../utils/response");
+const db = require("../../../../config/database");
+const catchAsync = require("../../../../utils/catchAsync");
+const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 
 // Post a comment

--- a/backend/src/modules/users/tutorials/comments/tutorialComment.routes.js
+++ b/backend/src/modules/users/tutorials/comments/tutorialComment.routes.js
@@ -1,6 +1,6 @@
 const router = require("express").Router();
 const ctrl = require("./tutorialComment.controller");
-const { verifyToken, isStudent } = require("../../../middleware/authMiddleware");
+const { verifyToken, isStudent } = require("../../../../middleware/auth/authMiddleware");
 
 router.post("/:tutorialId", verifyToken, isStudent, ctrl.createComment);
 router.get("/:tutorialId", ctrl.getComments);

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -1,6 +1,6 @@
-const db = require("../../../config/database");
-const catchAsync = require("../../../utils/catchAsync");
-const { sendSuccess } = require("../../../utils/response");
+const db = require("../../../../config/database");
+const catchAsync = require("../../../../utils/catchAsync");
+const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 
 // Enroll in tutorial

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.routes.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.routes.js
@@ -1,6 +1,6 @@
 const router = require("express").Router();
 const ctrl = require("./tutorialEnrollment.controller");
-const { verifyToken, isStudent } = require("../../../middleware/authMiddleware");
+const { verifyToken, isStudent } = require("../../../../middleware/auth/authMiddleware");
 
 router.post("/:tutorialId", verifyToken, isStudent, ctrl.enroll);
 router.post("/:tutorialId/complete", verifyToken, isStudent, ctrl.complete);

--- a/backend/src/modules/users/tutorials/reviews/tutorialReview.controller.js
+++ b/backend/src/modules/users/tutorials/reviews/tutorialReview.controller.js
@@ -1,6 +1,6 @@
-const db = require("../../../config/database");
-const catchAsync = require("../../../utils/catchAsync");
-const { sendSuccess } = require("../../../utils/response");
+const db = require("../../../../config/database");
+const catchAsync = require("../../../../utils/catchAsync");
+const { sendSuccess } = require("../../../../utils/response");
 
 // Submit or update a review
 exports.submitReview = catchAsync(async (req, res) => {

--- a/backend/src/modules/users/tutorials/reviews/tutorialReview.routes.js
+++ b/backend/src/modules/users/tutorials/reviews/tutorialReview.routes.js
@@ -1,6 +1,6 @@
 const router = require("express").Router();
 const ctrl = require("./tutorialReview.controller");
-const { verifyToken, isStudent } = require("../../../middleware/authMiddleware");
+const { verifyToken, isStudent } = require("../../../../middleware/auth/authMiddleware");
 
 // POST /api/tutorials/reviews/:tutorialId
 router.post("/:tutorialId", verifyToken, isStudent, ctrl.submitReview);

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -4,6 +4,9 @@ const fs = require("fs");
 const db = require("../../../config/database"); // ✅ Required for slug check
 const service = require("./tutorial.service");
 
+const catchAsync = require("../../../utils/catchAsync");
+const { v4: uuidv4 } = require("uuid");
+
 
 const { sendSuccess } = require("../../../utils/response");
 const slugify = require("slugify");

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -63,8 +63,6 @@ router.use("/enroll", require("./enrollments/tutorialEnrollment.routes"));
 
 router.use("/certificate", require("./certificate/tutorialCertificate.routes"));
 
-app.use("/api/certificates", require("./modules/users/certificates/certificatePublic.routes"));
-
 
 
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,6 +12,7 @@ require("dotenv").config(); // ✅ Load environment variables from .env file
 const authRoutes = require("./modules/auth/routes/auth.routes");
 const userRoutes = require("./modules/users/user.routes");
 const verifyRoutes = require("./modules/verify/verify.routes"); // ✅ OTP routes
+const certificatePublicRoutes = require("./modules/users/tutorials/certificate/certificatePublic.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -55,6 +56,7 @@ app.use("/api/uploads", express.static(path.join(__dirname, "../uploads")));
 app.use("/api/auth", authRoutes);      // 🔐 Auth: login, register, password reset
 app.use("/api/users", userRoutes);     // 👤 Users: profile, avatar, demo video
 app.use("/api/verify", verifyRoutes);  // ✅ OTP: send/confirm email/phone
+app.use("/api/certificates", certificatePublicRoutes); // 🎓 Public certificate verification
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -1,25 +1,7 @@
 import { useState, useEffect } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
-import { FaBookOpen, FaPlayCircle, FaCheckCircle, FaFilter, FaSearch } from "react-icons/fa";
-
-const mockTutorials = [
-  {
-    id: 1,
-    title: "Mastering React.js",
-    category: "Frontend",
-    instructor: "John Doe",
-    description: "Complete React.js course covering fundamentals and advanced topics.",
-    chapters: ["Intro", "Components", "Hooks", "State Management"],
-  },
-  {
-    id: 2,
-    title: "Advanced JavaScript",
-    category: "JavaScript",
-    instructor: "Elon Dev",
-    description: "Deep dive into JS ES6+, closures, promises, and more.",
-    chapters: ["Scope", "Promises", "Async/Await", "Advanced Patterns"],
-  },
-];
+import { FaBookOpen, FaPlayCircle, FaCheckCircle } from "react-icons/fa";
+import { fetchPublishedTutorials } from "@/services/tutorialService";
 
 export default function StudentTutorialsPage() {
   const [search, setSearch] = useState("");
@@ -27,17 +9,25 @@ export default function StudentTutorialsPage() {
   const [tutorials, setTutorials] = useState([]);
 
   useEffect(() => {
-    const enriched = mockTutorials.map((tut) => {
-      const saved = localStorage.getItem(`progress-tutorial-${tut.id}`);
-      const progress = saved ? JSON.parse(saved) : { completedChapters: [], completedQuiz: false };
-      return {
-        ...tut,
-        completedLessons: progress.completedChapters.length,
-        totalLessons: tut.chapters.length,
-        isCompleted: progress.completedQuiz,
-      };
-    });
-    setTutorials(enriched);
+    const load = async () => {
+      try {
+        const data = await fetchPublishedTutorials();
+        const enriched = data.map((tut) => {
+          const saved = localStorage.getItem(`progress-tutorial-${tut.id}`);
+          const progress = saved ? JSON.parse(saved) : { completedChapters: [], completedQuiz: false };
+          return {
+            ...tut,
+            completedLessons: progress.completedChapters.length,
+            totalLessons: tut.chapters?.length || 0,
+            isCompleted: progress.completedQuiz,
+          };
+        });
+        setTutorials(enriched);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
   }, []);
 
   const filtered = tutorials.filter(tut => {

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -1,0 +1,17 @@
+import api from "@/services/api/api";
+
+export const fetchFeaturedTutorials = async () => {
+  const res = await api.get("/users/tutorials/featured");
+  return res.data;
+};
+
+export const fetchPublishedTutorials = async () => {
+  const res = await api.get("/users/tutorials");
+  return res.data;
+};
+
+export const fetchTutorialDetails = async (id) => {
+  const res = await api.get(`/users/tutorials/${id}`);
+  return res.data;
+};
+


### PR DESCRIPTION
## Summary
- fix backend tutorial module imports and mount certificate public routes
- correct upload paths and remove leftover code
- add tutorial API service on the frontend
- use live API data for the student tutorial dashboard

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_684b2bc9906083289e3a60f73bd4e468