### PR TITLE
Add instructor middleware and routes

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -63,6 +63,17 @@ const isInstructor = (req, res, next) => {
 };
 
 /**
+ * 🔐 Middleware: Allow Instructor or Admin roles
+ */
+const isInstructorOrAdmin = (req, res, next) => {
+  const role = req.user?.role;
+  if (role === "Instructor" || isAdminRole(role)) {
+    return next();
+  }
+  return res.status(403).json({ message: "Instructor or Admin access only" });
+};
+
+/**
  * 🔐 Middleware: Restrict access to Student only
  */
 const isStudent = (req, res, next) => {
@@ -86,6 +97,7 @@ module.exports = {
   isAdmin,
   isSuperAdmin,
   isInstructor,
+  isInstructorOrAdmin,
   isStudent,
   isSelfOrAdmin,
 };

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -5,13 +5,13 @@ const controller = require("./tutorial.controller");
 const validate = require("../../../middleware/validate");
 const upload = require("./tutorialUploadMiddleware");
 const tutorialValidator = require("./tutorial.validator");
-const { isAdmin, verifyToken } = require("../../../middleware/auth/authMiddleware");
+const { isAdmin, verifyToken, isInstructorOrAdmin } = require("../../../middleware/auth/authMiddleware");
 
 // ✅ Admin routes
 router.post(
   "/admin",
   verifyToken,
-  isAdmin,
+  isInstructorOrAdmin,
   upload.fields([
     { name: "thumbnail", maxCount: 1 },
     { name: "preview", maxCount: 1 },
@@ -20,13 +20,13 @@ router.post(
   controller.createTutorial
 );
 
-router.get("/admin", verifyToken, isAdmin, controller.getAllTutorials);
-router.get("/admin/:id", verifyToken, isAdmin, controller.getTutorialById);
+router.get("/admin", verifyToken, isInstructorOrAdmin, controller.getAllTutorials);
+router.get("/admin/:id", verifyToken, isInstructorOrAdmin, controller.getTutorialById);
 
 router.put(
   "/admin/:id",
   verifyToken,
-  isAdmin,
+  isInstructorOrAdmin,
   upload.fields([
     { name: "thumbnail", maxCount: 1 },
     { name: "preview", maxCount: 1 },
@@ -35,12 +35,12 @@ router.put(
   controller.updateTutorial
 );
 
-router.patch("/admin/:id/trash", verifyToken, isAdmin, controller.softDeleteTutorial);
-router.patch("/admin/:id/restore", verifyToken, isAdmin, controller.restoreTutorial);
-router.delete("/admin/:id", verifyToken, isAdmin, controller.permanentlyDeleteTutorial);
+router.patch("/admin/:id/trash", verifyToken, isInstructorOrAdmin, controller.softDeleteTutorial);
+router.patch("/admin/:id/restore", verifyToken, isInstructorOrAdmin, controller.restoreTutorial);
+router.delete("/admin/:id", verifyToken, isInstructorOrAdmin, controller.permanentlyDeleteTutorial);
 
 // ✅ Status and moderation
-router.patch("/admin/:id/status", verifyToken, isAdmin, controller.togglePublishStatus);
+router.patch("/admin/:id/status", verifyToken, isInstructorOrAdmin, controller.togglePublishStatus);
 router.patch("/admin/:id/approve", verifyToken, isAdmin, controller.approveTutorial);
 router.patch(
   "/admin/:id/reject",
@@ -70,7 +70,7 @@ router.use("/certificate", require("./certificate/tutorialCertificate.routes"));
 
 // ✅ Bulk actions
 router.patch("/admin/bulk/approve", verifyToken, isAdmin, controller.bulkApproveTutorials);
-router.patch("/admin/bulk/trash", verifyToken, isAdmin, controller.bulkTrashTutorials);
+router.patch("/admin/bulk/trash", verifyToken, isInstructorOrAdmin, controller.bulkTrashTutorials);
 
 // ✅ Public routes (no auth required)
 router.get("/featured", controller.getFeaturedTutorials);


### PR DESCRIPTION
## Summary
- add `isInstructorOrAdmin` auth middleware
- allow instructors to manage tutorials via protected routes

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b305edb9c8328b8c5b0850a577117