### PR TITLE
Fix tutorial backend controllers and services

### DIFF
--- a/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
+++ b/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
@@ -72,3 +72,18 @@ exports.getChaptersByTutorial = catchAsync(async (req, res) => {
   sendSuccess(res, chapters, "Chapters fetched");
 });
 
+// Reorder chapters within a tutorial
+exports.reorderChapters = catchAsync(async (req, res) => {
+  const { tutorialId } = req.params;
+  const { orderedIds } = req.body;
+
+  if (!Array.isArray(orderedIds)) {
+    throw new AppError("orderedIds must be an array", 400);
+  }
+
+  const updates = orderedIds.map((id, index) => ({ id, order: index + 1 }));
+  await service.reorderChapters(tutorialId, updates);
+
+  sendSuccess(res, null, "Chapters reordered");
+});
+

--- a/backend/src/modules/users/tutorials/chapters/tutorialChapter.service.js
+++ b/backend/src/modules/users/tutorials/chapters/tutorialChapter.service.js
@@ -23,3 +23,14 @@ exports.getByTutorial = async (tutorial_id) => {
 exports.delete = async (id) => {
   return db("tutorial_chapters").where({ id }).del();
 };
+
+exports.reorderChapters = async (tutorial_id, orders) => {
+  return db.transaction(async (trx) => {
+    for (const { id, order } of orders) {
+      await db("tutorial_chapters")
+        .where({ id, tutorial_id })
+        .update({ order })
+        .transacting(trx);
+    }
+  });
+};

--- a/backend/src/modules/users/tutorials/comments/tutorialComment.service.js
+++ b/backend/src/modules/users/tutorials/comments/tutorialComment.service.js
@@ -1,0 +1,18 @@
+const db = require("../../../../config/database");
+
+exports.createComment = async (data) => {
+  await db("tutorial_comments").insert(data);
+  return data;
+};
+
+exports.getByTutorial = async (tutorial_id) => {
+  return db("tutorial_comments")
+    .join("users", "users.id", "tutorial_comments.user_id")
+    .where("tutorial_comments.tutorial_id", tutorial_id)
+    .select(
+      "tutorial_comments.*",
+      "users.full_name",
+      "users.avatar_url"
+    )
+    .orderBy("created_at", "asc");
+};

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.service.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.service.js
@@ -1,0 +1,26 @@
+const db = require("../../../../config/database");
+
+exports.findEnrollment = async (user_id, tutorial_id) => {
+  return db("tutorial_enrollments")
+    .where({ user_id, tutorial_id })
+    .first();
+};
+
+exports.createEnrollment = async (data) => {
+  await db("tutorial_enrollments").insert(data);
+  return data;
+};
+
+exports.markCompleted = async (user_id, tutorial_id) => {
+  return db("tutorial_enrollments")
+    .where({ user_id, tutorial_id })
+    .update({ status: "completed" });
+};
+
+exports.getByUser = async (user_id) => {
+  return db("tutorial_enrollments")
+    .join("tutorials", "tutorials.id", "tutorial_enrollments.tutorial_id")
+    .where("tutorial_enrollments.user_id", user_id)
+    .select("tutorials.*", "tutorial_enrollments.status", "tutorial_enrollments.enrolled_at");
+};
+

--- a/backend/src/modules/users/tutorials/reviews/tutorialReview.service.js
+++ b/backend/src/modules/users/tutorials/reviews/tutorialReview.service.js
@@ -1,0 +1,34 @@
+const db = require("../../../../config/database");
+
+exports.upsertReview = async ({ tutorial_id, user_id, rating, comment }) => {
+  const exists = await db("tutorial_reviews")
+    .where({ tutorial_id, user_id })
+    .first();
+
+  if (exists) {
+    return db("tutorial_reviews")
+      .where({ tutorial_id, user_id })
+      .update({ rating, comment, created_at: db.fn.now() });
+  }
+
+  return db("tutorial_reviews").insert({
+    tutorial_id,
+    user_id,
+    rating,
+    comment,
+  });
+};
+
+exports.getByTutorial = async (tutorial_id) => {
+  return db("tutorial_reviews")
+    .join("users", "users.id", "tutorial_reviews.user_id")
+    .where("tutorial_reviews.tutorial_id", tutorial_id)
+    .select(
+      "tutorial_reviews.id",
+      "tutorial_reviews.rating",
+      "tutorial_reviews.comment",
+      "tutorial_reviews.created_at",
+      "users.full_name",
+      "users.avatar_url"
+    );
+};

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -3,6 +3,7 @@ const path = require("path");
 const fs = require("fs");
 const db = require("../../../config/database"); // ✅ Required for slug check
 const service = require("./tutorial.service");
+const chapterService = require("./chapters/tutorialChapter.service");
 
 const catchAsync = require("../../../utils/catchAsync");
 const { v4: uuidv4 } = require("uuid");
@@ -48,7 +49,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     status,
     thumbnail_url: req.file ? `/uploads/tutorials/${req.file.filename}` : null,
   };
-  await tutorialService.create(tutorial);
+  await service.createTutorial(tutorial);
 
   // Save chapters (if any)
   for (let i = 0; i < chapters.length; i++) {


### PR DESCRIPTION
## Summary
- hook up chapter service in tutorial controller
- add reorder chapters controller and service
- implement CRUD helpers in tutorial service modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b31df572883288165b8709ff64912