### PR TITLE
Organize tutorial uploads by role

### DIFF
--- a/backend/src/modules/users/tutorials/tutorialUploadMiddleware.js
+++ b/backend/src/modules/users/tutorials/tutorialUploadMiddleware.js
@@ -3,14 +3,21 @@ const multer = require("multer");
 const path = require("path");
 const fs = require("fs");
 
-// Ensure uploads/tutorials folder exists
-const uploadPath = path.join(__dirname, "../../../../uploads/tutorials");
-if (!fs.existsSync(uploadPath)) fs.mkdirSync(uploadPath, { recursive: true });
+// Helper to determine base directory based on user role
+const resolveUploadPath = (req) => {
+  const base = path.join(__dirname, "../../../../uploads/tutorials");
+  let role = req.user?.role?.toLowerCase() || "other";
+  if (["superadmin", "admin"].includes(role)) role = "admin";
+  const roleDir = path.join(base, role);
+  if (!fs.existsSync(roleDir)) fs.mkdirSync(roleDir, { recursive: true });
+  return roleDir;
+};
 
 // Configure multer storage
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
-    cb(null, uploadPath);
+    const dir = resolveUploadPath(req);
+    cb(null, dir);
   },
   filename: (req, file, cb) => {
     const timestamp = Date.now();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,13 @@
+# Backend Architecture Overview
+
+This project uses a modular Express.js structure. Each user role (Admin, Instructor and Student) has its own set of controllers and routes under `src/modules/users`. Tutorials and their related resources live under `src/modules/users/tutorials`.
+
+Uploaded tutorial assets are stored in role specific folders:
+
+```
+backend/uploads/tutorials/admin/
+backend/uploads/tutorials/instructor/
+backend/uploads/tutorials/student/
+```
+
+The upload middleware automatically places files in these folders based on the authenticated user's role.


### PR DESCRIPTION
## Summary
- store tutorial uploads in role specific directories
- document directory structure in `docs/architecture.md`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b358a939883289d9b2a727323ff77