### PR TITLE
Fix auth error feedback

### DIFF
--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -43,7 +43,11 @@ api.interceptors.response.use(
     const originalRequest = error.config;
     const authStore = useAuthStore.getState();
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    const isAuthRoute =
+      originalRequest?.url?.includes("/auth/login") ||
+      originalRequest?.url?.includes("/auth/register");
+
+    if (error.response?.status === 401 && !originalRequest._retry && !isAuthRoute) {
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });


### PR DESCRIPTION
## Summary
- skip token refresh logic when login or register requests fail

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b38d4c3cc8328a4a72064cd5b7555