### PR TITLE
Fix user status API and add confirmation

### DIFF
--- a/backend/src/modules/users/usersmanagement/users.validator.js
+++ b/backend/src/modules/users/usersmanagement/users.validator.js
@@ -2,12 +2,12 @@
 const { z } = require("zod");
 
 exports.statusSchema = z.object({
-  status: z.enum(["pending", "active"]),
+  status: z.enum(["pending", "active", "inactive", "suspended"]),
 });
 
 exports.bulkStatusSchema = z.object({
   ids: z.array(z.string().uuid()),
-  status: z.enum(["pending", "active"]),
+  status: z.enum(["pending", "active", "inactive", "suspended"]),
 });
 
 

--- a/frontend/src/components/admin/users/UserCard.js
+++ b/frontend/src/components/admin/users/UserCard.js
@@ -37,6 +37,7 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
 
   const toggleStatus = async () => {
     const newStatus = enabled ? "inactive" : "active";
+    if (!window.confirm(`Set ${user.name} as ${newStatus}?`)) return;
     try {
       await updateUserStatus(user.id, newStatus);
       setEnabled(!enabled);


### PR DESCRIPTION
## Summary
- permit `inactive` and `suspended` statuses in the admin validators
- ask for confirmation before toggling a user's status

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b3b87fd9c8328a1ca1403b895c3ab