### PR TITLE
Fix user status enum and add alerts

### DIFF
--- a/backend/src/migrations/20250613180000_update_user_status_enum.js
+++ b/backend/src/migrations/20250613180000_update_user_status_enum.js
@@ -1,0 +1,17 @@
+exports.up = function(knex) {
+  return knex.raw(`
+    ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS users_status_check,
+    ADD CONSTRAINT users_status_check
+    CHECK (status IN ('pending', 'active', 'inactive', 'suspended', 'banned'));
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.raw(`
+    ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS users_status_check,
+    ADD CONSTRAINT users_status_check
+    CHECK (status IN ('pending', 'active', 'banned'));
+  `);
+};

--- a/backend/src/modules/users/usersmanagement/users.validator.js
+++ b/backend/src/modules/users/usersmanagement/users.validator.js
@@ -2,12 +2,12 @@
 const { z } = require("zod");
 
 exports.statusSchema = z.object({
-  status: z.enum(["pending", "active"]),
+  status: z.enum(["pending", "active", "inactive", "suspended"]),
 });
 
 exports.bulkStatusSchema = z.object({
   ids: z.array(z.string().uuid()),
-  status: z.enum(["pending", "active"]),
+  status: z.enum(["pending", "active", "inactive", "suspended"]),
 });
 
 

--- a/backend/src/utils/enums.js
+++ b/backend/src/utils/enums.js
@@ -1,3 +1,9 @@
 // 📁 src/utils/enums.js
 exports.ROLES = Object.freeze({ STUDENT: "student", INSTRUCTOR: "instructor", ADMIN: "admin", SUPERADMIN: "superadmin" });
-exports.STATUS = Object.freeze({ ACTIVE: "active", BANNED: "banned", PENDING: "pending" });
+exports.STATUS = Object.freeze({
+  ACTIVE: "active",
+  INACTIVE: "inactive",
+  SUSPENDED: "suspended",
+  BANNED: "banned",
+  PENDING: "pending",
+});

--- a/frontend/src/components/admin/users/UserCard.js
+++ b/frontend/src/components/admin/users/UserCard.js
@@ -37,10 +37,12 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
 
   const toggleStatus = async () => {
     const newStatus = enabled ? "inactive" : "active";
+    if (!window.confirm(`Set ${user.name} as ${newStatus}?`)) return;
     try {
       await updateUserStatus(user.id, newStatus);
       setEnabled(!enabled);
       toast.success(`${user.name} is now ${newStatus}`);
+      alert(`${user.name} is now ${newStatus}`);
     } catch (err) {
       toast.error("Failed to update status");
       console.error("Status error:", err);
@@ -65,6 +67,7 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
       await deleteUser(user.id);
       onDelete(user.id);
       toast.success(`${user.name} deleted`);
+      alert(`${user.name} deleted`);
     } catch (err) {
       toast.error("Failed to delete user");
       console.error("Delete error:", err);


### PR DESCRIPTION
## Summary
- update enums to support `inactive` and `suspended`
- migration to extend allowed statuses
- show alert after status change and after deleting a user

## Testing
- `npm test` *(backend – fails: no test specified)*
- `npm test` *(frontend – fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b3b87fd9c8328a1ca1403b895c3ab