### PR TITLE
Fix token expiry response

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -28,7 +28,7 @@ const verifyToken = (req, res, next) => {
     req.user = decoded;
     next();
   } catch (err) {
-    return res.status(403).json({ message: "Invalid or expired token" });
+    return res.status(401).json({ message: "Invalid or expired token" });
   }
 };
 


### PR DESCRIPTION
## Summary
- return HTTP 401 when an access token is invalid or expired

## Testing
- `npm test` in `/backend` *(fails: Error: no test specified)*
- `npm run lint` in `/frontend` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca2146bec8328ae1beb3db79788bc