### PR TITLE
Fix admin category service endpoints

### DIFF
--- a/frontend/src/services/admin/categoryService.js
+++ b/frontend/src/services/admin/categoryService.js
@@ -16,20 +16,20 @@ export const fetchCategoryById = async (id) => {
 };
 
 export const createCategory = async (formData) => {
-  const { data } = await api.post("/users/categories/create", formData, {
+  const { data } = await api.post("/users/admin/categories/create", formData, {
     headers: { "Content-Type": "multipart/form-data" },
   });
   return data?.data;
 };
 
 export const updateCategory = async (id, formData) => {
-  const { data } = await api.put(`/users/categories/${id}`, formData, {
+  const { data } = await api.put(`/users/admin/categories/${id}`, formData, {
     headers: { "Content-Type": "multipart/form-data" },
   });
   return data?.data;
 };
 
 export const deleteCategory = async (id) => {
-  await api.delete(`/users/categories/${id}`);
+  await api.delete(`/users/admin/categories/${id}`);
   return true;
 };


### PR DESCRIPTION
## Summary
- use `/users/admin/categories` endpoints for create/update/delete

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ca32c08ac8328af10b9136699076f