### PR TITLE
Fix admin category service endpoints

### DIFF
--- a/frontend/src/pages/dashboard/admin/categories/create.js
+++ b/frontend/src/pages/dashboard/admin/categories/create.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { ArrowLeftCircle, Upload } from "lucide-react";
 import Link from "next/link";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import { useRouter } from "next/router";
 import {
   fetchCategoryTree,

--- a/frontend/src/pages/dashboard/admin/categories/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/categories/edit/[id].js
@@ -3,7 +3,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { ArrowLeftCircle, Upload } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import {
   fetchCategoryTree,
   fetchCategoryById,


### PR DESCRIPTION
## Summary
- use `/users/categories` endpoints for create/update/delete
- use `react-toastify` for category admin pages

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca32c08ac8328af10b9136699076f