### PR TITLE
Fix admin category image display

### DIFF
--- a/frontend/src/pages/dashboard/admin/categories/index.js
+++ b/frontend/src/pages/dashboard/admin/categories/index.js
@@ -135,7 +135,7 @@ export default function AdminCategoryIndex() {
                     <td className="px-4 py-3">{parent.name}</td>
                     <td className="px-4 py-3">
                       <img
-                        src={getImage(parent.image)}
+                        src={getImage(parent.image_url)}
                         alt={parent.name}
                         onError={(e) => { e.target.src = getImage(); }}
                         className="h-10 w-10 rounded object-cover"
@@ -167,7 +167,7 @@ export default function AdminCategoryIndex() {
                       </td>
                       <td className="px-4 py-3">
                         <img
-                          src={getImage(child.image)}
+                          src={getImage(child.image_url)}
                           alt={child.name}
                           onError={(e) => { e.target.src = getImage(); }}
                           className="h-10 w-10 rounded object-cover"


### PR DESCRIPTION
## Summary
- use `image_url` field when displaying categories in the admin dashboard

## Testing
- `npm run lint` *(fails: prompts for eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_684ca70028f88328a3cfcb766d676af5