### PR TITLE
Improve category form error handling

### DIFF
--- a/frontend/src/pages/dashboard/admin/categories/create.js
+++ b/frontend/src/pages/dashboard/admin/categories/create.js
@@ -70,7 +70,12 @@ export default function CreateCategory() {
       router.push("/dashboard/admin/categories");
     } catch (err) {
       console.error("Failed to create category", err);
-      toast.error("Failed to create category");
+      const msg =
+        err?.response?.data?.message ||
+        err?.response?.data?.error ||
+        err?.message ||
+        "Failed to create category";
+      toast.error(msg);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/dashboard/admin/categories/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/categories/edit/[id].js
@@ -83,7 +83,12 @@ export default function EditCategory() {
       router.push("/dashboard/admin/categories");
     } catch (err) {
       console.error("Failed to update category", err);
-      toast.error("Failed to update category");
+      const msg =
+        err?.response?.data?.message ||
+        err?.response?.data?.error ||
+        err?.message ||
+        "Failed to update category";
+      toast.error(msg);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- display server error messages when creating or editing admin categories

## Testing
- `npm --prefix frontend run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cab0645f083289b8698840231d9db