### PR TITLE
Fix auto logout when token expired

### DIFF
--- a/frontend/src/utils/auth/tokenUtils.js
+++ b/frontend/src/utils/auth/tokenUtils.js
@@ -1,0 +1,15 @@
+export function getTokenExpiration(token) {
+  try {
+    const payloadPart = token.split('.')[1];
+    const decoded = JSON.parse(atob(payloadPart));
+    return typeof decoded.exp === 'number' ? decoded.exp * 1000 : null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+export function isTokenExpired(token) {
+  const exp = getTokenExpiration(token);
+  if (!exp) return true;
+  return Date.now() >= exp;
+}


### PR DESCRIPTION
## Summary
- create token utility to check expiration
- logout in withAuthProtection when token is missing or expired

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_684d3451b034832880ddd3f4fd56eeb9