### PR TITLE
Fix slug duplication check on category creation

### DIFF
--- a/backend/src/modules/users/categories/category.controller.js
+++ b/backend/src/modules/users/categories/category.controller.js
@@ -26,15 +26,18 @@ exports.createCategory = catchAsync(async (req, res) => {
   const image_url = req.file ? `/uploads/categories/${req.file.filename}` : null;
   const slug = slugify(name, { lower: true, strict: true });
 
-const category = await service.create({
-  id: uuidv4(), // ✅ add this line
-  name: name.trim(),
-  parent_id: parent_id || null,
-  status,
-  image_url,
-  slug,
-});
+  // Prevent duplicate slug across categories
+  const slugExists = await service.findBySlug(slug);
+  if (slugExists) throw new AppError("Category slug already exists", 409);
 
+  const category = await service.create({
+    id: uuidv4(),
+    name: name.trim(),
+    parent_id: parent_id || null,
+    status,
+    image_url,
+    slug,
+  });
 
   sendSuccess(res, category, "Category created");
 });

--- a/backend/src/modules/users/categories/category.service.js
+++ b/backend/src/modules/users/categories/category.service.js
@@ -4,6 +4,9 @@ exports.create = async (data) => db("categories").insert(data).returning("*").th
 
 exports.findById = async (id) => db("categories").where({ id }).first();
 
+// Find category by slug
+exports.findBySlug = async (slug) => db("categories").where({ slug }).first();
+
 exports.exists = async ({ name, parent_id }) => {
   return db("categories")
     .where({ name })


### PR DESCRIPTION
## Summary
- avoid duplicate slugs when creating categories
- expose `findBySlug` in service to look up slugs

## Testing
- `npm test` in `backend` *(fails: no tests specified)*
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d3855dd388328a5857357da2580f1