### PR TITLE
Remove superadmin role from user creation

### DIFF
--- a/frontend/src/components/admin/users/AddUserForm.js
+++ b/frontend/src/components/admin/users/AddUserForm.js
@@ -69,7 +69,6 @@ export default function AddUserForm() {
         className="w-full px-3 py-2 border rounded"
       >
         <option value="admin">Admin</option>
-        <option value="superadmin">Superadmin</option>
         <option value="instructor">Instructor</option>
         <option value="student">Student</option>
       </select>


### PR DESCRIPTION
## Summary
- remove `superadmin` option from the AddUserForm

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d3c16930c8328964bcf91a35deaf4