### PR TITLE
Add popup for admin user creation

### DIFF
--- a/frontend/src/pages/dashboard/admin/users/create.js
+++ b/frontend/src/pages/dashboard/admin/users/create.js
@@ -1,14 +1,26 @@
 // pages/dashboard/admin/users/create.js
+import { useState } from "react";
+import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import AddUserForm from "@/components/admin/users/AddUserForm";
+import AddUserModal from "@/components/admin/users/AddUserModal";
+import { createUser } from "@/services/admin/userService";
 
 export default function CreateUserPage() {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(true);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    router.push("/dashboard/admin/users");
+  };
+
+  const handleSubmit = async (formData) => {
+    await createUser(formData);
+  };
+
   return (
     <AdminLayout>
-      <div className="p-8 max-w-2xl mx-auto">
-        <h1 className="text-2xl font-bold mb-6">Add New User</h1>
-        <AddUserForm />
-      </div>
+      <AddUserModal isOpen={isOpen} onClose={handleClose} onSubmit={handleSubmit} />
     </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- show `AddUserModal` on the admin create user route

## Testing
- `npm install` *(fails: Next.js ESLint interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684d3d09c5fc8328a50b6bafd3933806