### PR TITLE
Restrict admin role update options

### DIFF
--- a/backend/src/modules/users/usersmanagement/users.controller.js
+++ b/backend/src/modules/users/usersmanagement/users.controller.js
@@ -28,13 +28,8 @@ exports.createUser = catchAsync(async (req, res) => {
 
   const hashedPassword = await bcrypt.hash(password, 10);
 
-  const allowedRoles = ["Admin", "SuperAdmin", "Instructor", "Student"];
-  let formattedRole;
-  if (role.toLowerCase() === "superadmin") {
-    formattedRole = "SuperAdmin";
-  } else {
-    formattedRole = role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
-  }
+  const allowedRoles = ["Admin", "Instructor", "Student"];
+  const formattedRole = role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
   if (!allowedRoles.includes(formattedRole)) {
     return res.status(400).json({ message: "Invalid role" });
   }
@@ -100,13 +95,8 @@ exports.changeUserRole = catchAsync(async (req, res) => {
   }
 
   // Normalize and validate role
-  const allowedRoles = ["Admin", "SuperAdmin", "Instructor", "Student"];
-  let formattedRole;
-  if (role.toLowerCase() === "superadmin") {
-    formattedRole = "SuperAdmin";
-  } else {
-    formattedRole = role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
-  }
+  const allowedRoles = ["Admin", "Instructor", "Student"];
+  const formattedRole = role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
 
   if (!allowedRoles.includes(formattedRole)) {
     return res.status(400).json({ message: "Invalid role" });

--- a/backend/src/modules/users/usersmanagement/users.validator.js
+++ b/backend/src/modules/users/usersmanagement/users.validator.js
@@ -12,7 +12,7 @@ exports.bulkStatusSchema = z.object({
 
 
 exports.roleSchema = z.object({
-  role: z.enum(["admin", "superadmin", "instructor", "student"]),
+  role: z.enum(["admin", "instructor", "student"]),
 });
 
 
@@ -27,7 +27,7 @@ exports.createUserSchema = z.object({
   email: z.string().email(),
   phone: z.string().min(8),
   password: z.string().min(8), // ✅ Still called "password" for frontend clarity
-  role: z.enum(["admin", "superadmin", "instructor", "student"]),
+  role: z.enum(["admin", "instructor", "student"]),
 });
 
 

--- a/frontend/src/components/admin/users/UserCard.js
+++ b/frontend/src/components/admin/users/UserCard.js
@@ -116,7 +116,6 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
           className="mt-2 w-full px-2 py-1 text-sm border border-gray-300 rounded-md"
         >
           <option value="admin">Admin</option>
-          <option value="superadmin">SuperAdmin</option>
           <option value="instructor">Instructor</option>
           <option value="student">Student</option>
         </select>


### PR DESCRIPTION
## Summary
- limit allowed roles when creating or changing a user
- update user role validator
- remove `SuperAdmin` option from dashboard user card

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` in `frontend` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3f27dc808328ab4b39152077035b