### PR TITLE
Implement admin tutorial creation

### DIFF
--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -1,0 +1,19 @@
+// 📁 src/services/admin/tutorialService.js
+// Admin specific API calls for managing tutorials
+
+import api from "@/services/api/api";
+
+/**
+ * Create a new tutorial as an admin or instructor.
+ * Expects multipart/form-data with fields matching the backend validator.
+ *
+ * @param {FormData} formData - Tutorial payload
+ * @returns {Promise<Object>} Created tutorial record
+ */
+export const createTutorial = async (formData) => {
+  const { data } = await api.post("/users/tutorials/admin", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return data?.data;
+};
+


### PR DESCRIPTION
## Summary
- add admin tutorial service for API access
- enable publishing tutorials from admin create page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d414b2aa08328833d1ce7f32f6f49