### PR TITLE
Fix tutorial form validation

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -1,5 +1,23 @@
 const { z } = require("zod");
 
+// Helper preprocessor for boolean values coming from multipart/form-data
+const toBoolean = (val) => {
+  if (typeof val === "string") return val === "true";
+  return val;
+};
+
+// Helper preprocessor to safely parse JSON strings
+const parseJson = (val) => {
+  if (typeof val === "string") {
+    try {
+      return JSON.parse(val);
+    } catch (_) {
+      return undefined;
+    }
+  }
+  return val;
+};
+
 exports.create = z.object({
   body: z.object({
     title: z.string().min(3),
@@ -7,17 +25,26 @@ exports.create = z.object({
     category_id: z.string(), // assuming UUID
     level: z.string(),
     price: z.string().optional(),
-    is_paid: z.boolean().optional(),
-    tags: z.array(z.string()).optional(),
-    chapters: z.array(z.object({
-      title: z.string(),
-      content: z.string().optional(),
-      video_url: z.string().url().optional(),
-      order: z.number()
-    })).optional(),
+    is_paid: z.preprocess(toBoolean, z.boolean().optional()),
+    tags: z.preprocess(parseJson, z.array(z.string()).optional()),
+    chapters: z
+      .preprocess(
+        parseJson,
+        z
+          .array(
+            z.object({
+              title: z.string(),
+              content: z.string().optional(),
+              video_url: z.string().url().optional(),
+              order: z.number(),
+              is_preview: z.boolean().optional(),
+            })
+          )
+          .optional()
+      ),
     cover_image: z.string().url().optional(),
     preview_video: z.string().url().optional(),
-  })
+  }),
 });
 
 exports.update = exports.create;


### PR DESCRIPTION
## Summary
- handle string boolean/JSON parsing in tutorial validator to allow multipart form submissions
- run backend `npm test`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d58175d288328a7cef1b0a0ec6620