### PR TITLE
Fix tutorial draft preview bug

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -1,5 +1,23 @@
 const { z } = require("zod");
 
+// Helper preprocessor for boolean values coming from multipart/form-data
+const toBoolean = (val) => {
+  if (typeof val === "string") return val === "true";
+  return val;
+};
+
+// Helper preprocessor to safely parse JSON strings
+const parseJson = (val) => {
+  if (typeof val === "string") {
+    try {
+      return JSON.parse(val);
+    } catch (_) {
+      return undefined;
+    }
+  }
+  return val;
+};
+
 exports.create = z.object({
   body: z.object({
     title: z.string().min(3),
@@ -7,17 +25,26 @@ exports.create = z.object({
     category_id: z.string(), // assuming UUID
     level: z.string(),
     price: z.string().optional(),
-    is_paid: z.boolean().optional(),
-    tags: z.array(z.string()).optional(),
-    chapters: z.array(z.object({
-      title: z.string(),
-      content: z.string().optional(),
-      video_url: z.string().url().optional(),
-      order: z.number()
-    })).optional(),
+    is_paid: z.preprocess(toBoolean, z.boolean().optional()),
+    tags: z.preprocess(parseJson, z.array(z.string()).optional()),
+    chapters: z
+      .preprocess(
+        parseJson,
+        z
+          .array(
+            z.object({
+              title: z.string(),
+              content: z.string().optional(),
+              video_url: z.string().url().optional(),
+              order: z.number(),
+              is_preview: z.boolean().optional(),
+            })
+          )
+          .optional()
+      ),
     cover_image: z.string().url().optional(),
     preview_video: z.string().url().optional(),
-  })
+  }),
 });
 
 exports.update = exports.create;

--- a/frontend/src/components/tutorials/create/MediaStep.js
+++ b/frontend/src/components/tutorials/create/MediaStep.js
@@ -2,8 +2,8 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export default function MediaStep({ tutorialData, setTutorialData, onNext, onBack }) {
-  const [thumbnailPreview, setThumbnailPreview] = useState(tutorialData.thumbnail || null);
-  const [previewVideo, setPreviewVideo] = useState(tutorialData.preview || null);
+  const [thumbnailPreview, setThumbnailPreview] = useState(null);
+  const [previewVideo, setPreviewVideo] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(0);
 
   const handleThumbnailUpload = (e) => {

--- a/frontend/src/components/tutorials/create/ReviewStep.js
+++ b/frontend/src/components/tutorials/create/ReviewStep.js
@@ -56,14 +56,14 @@ export default function ReviewStep({ tutorialData, onBack, onPublish }) {
             <FaCheckCircle /> Media
           </h3>
           <div className="flex gap-6 items-center">
-            {tutorialData.thumbnail && (
+            {tutorialData.thumbnail instanceof File && (
               <img
                 src={URL.createObjectURL(tutorialData.thumbnail)}
                 alt="Thumbnail Preview"
                 className="w-32 h-20 object-cover rounded shadow"
               />
             )}
-            {tutorialData.preview && (
+            {tutorialData.preview instanceof File && (
               <video
                 src={URL.createObjectURL(tutorialData.preview)}
                 controls

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -27,7 +27,8 @@ export default function CreateTutorialPage() {
   useEffect(() => {
     const savedDraft = localStorage.getItem("tutorialDraft");
     if (savedDraft) {
-      setTutorialData(JSON.parse(savedDraft));
+      const draft = JSON.parse(savedDraft);
+      setTutorialData({ ...draft, thumbnail: null, preview: null });
     }
   }, []);
 
@@ -35,7 +36,8 @@ export default function CreateTutorialPage() {
   const prevStep = () => setStep((prev) => prev - 1);
 
   const saveDraft = () => {
-    localStorage.setItem("tutorialDraft", JSON.stringify(tutorialData));
+    const { thumbnail, preview, ...serializable } = tutorialData;
+    localStorage.setItem("tutorialDraft", JSON.stringify(serializable));
     alert("✅ Draft saved successfully!");
   };
 

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -23,7 +23,8 @@ export default function CreateTutorialPage() {
   useEffect(() => {
     const savedDraft = localStorage.getItem("tutorialDraft");
     if (savedDraft) {
-      setTutorialData(JSON.parse(savedDraft));
+      const draft = JSON.parse(savedDraft);
+      setTutorialData({ ...draft, thumbnail: null, preview: null });
     }
   }, []);
 
@@ -31,7 +32,8 @@ export default function CreateTutorialPage() {
   const prevStep = () => setStep((prev) => prev - 1);
 
   const saveDraft = () => {
-    localStorage.setItem("tutorialDraft", JSON.stringify(tutorialData));
+    const { thumbnail, preview, ...serializable } = tutorialData;
+    localStorage.setItem("tutorialDraft", JSON.stringify(serializable));
     alert("✅ Draft saved successfully!");
   };
 


### PR DESCRIPTION
## Summary
- prevent file objects from being stored in tutorial drafts
- restore drafts without thumbnail or preview data
- safeguard `createObjectURL` calls against invalid objects

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm run lint --prefix frontend` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d58175d288328a7cef1b0a0ec6620