### PR TITLE
Fix tutorial creation category field

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -1,5 +1,23 @@
 const { z } = require("zod");
 
+// Helper preprocessor for boolean values coming from multipart/form-data
+const toBoolean = (val) => {
+  if (typeof val === "string") return val === "true";
+  return val;
+};
+
+// Helper preprocessor to safely parse JSON strings
+const parseJson = (val) => {
+  if (typeof val === "string") {
+    try {
+      return JSON.parse(val);
+    } catch (_) {
+      return undefined;
+    }
+  }
+  return val;
+};
+
 exports.create = z.object({
   body: z.object({
     title: z.string().min(3),
@@ -7,17 +25,26 @@ exports.create = z.object({
     category_id: z.string(), // assuming UUID
     level: z.string(),
     price: z.string().optional(),
-    is_paid: z.boolean().optional(),
-    tags: z.array(z.string()).optional(),
-    chapters: z.array(z.object({
-      title: z.string(),
-      content: z.string().optional(),
-      video_url: z.string().url().optional(),
-      order: z.number()
-    })).optional(),
+    is_paid: z.preprocess(toBoolean, z.boolean().optional()),
+    tags: z.preprocess(parseJson, z.array(z.string()).optional()),
+    chapters: z
+      .preprocess(
+        parseJson,
+        z
+          .array(
+            z.object({
+              title: z.string(),
+              content: z.string().optional(),
+              video_url: z.string().url().optional(),
+              order: z.number(),
+              is_preview: z.boolean().optional(),
+            })
+          )
+          .optional()
+      ),
     cover_image: z.string().url().optional(),
     preview_video: z.string().url().optional(),
-  })
+  }),
 });
 
 exports.update = exports.create;

--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-export default function BasicInfoStep({ tutorialData, setTutorialData, onNext }) {
+export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, categories = [] }) {
   const [errors, setErrors] = useState({});
 
   const handleChange = (field, value) => {
@@ -71,17 +71,22 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext })
         <select
           className="w-full p-2 border rounded mt-1"
           value={tutorialData.category}
-          onChange={(e) => handleChange("category", e.target.value)}
+          onChange={(e) => {
+            const selected = categories.find((c) => c.id === e.target.value);
+            handleChange("category", e.target.value);
+            handleChange("categoryName", selected ? selected.name : "");
+          }}
         >
           <option value="">Select a Category</option>
-          <option value="React">React</option>
-          <option value="Node.js">Node.js</option>
-          <option value="AI">AI</option>
-          <option value="Design">Design</option>
-          <option value="Medical">Medical</option>
-          <option value="Nursing">Nursing</option>
+          {categories.map((cat) => (
+            <option key={cat.id} value={cat.id}>
+              {cat.name}
+            </option>
+          ))}
         </select>
-        {errors.category && <p className="text-red-500 text-sm mt-1">{errors.category}</p>}
+        {errors.category && (
+          <p className="text-red-500 text-sm mt-1">{errors.category}</p>
+        )}
       </div>
 
       {/* Level */}

--- a/frontend/src/components/tutorials/create/MediaStep.js
+++ b/frontend/src/components/tutorials/create/MediaStep.js
@@ -2,8 +2,8 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export default function MediaStep({ tutorialData, setTutorialData, onNext, onBack }) {
-  const [thumbnailPreview, setThumbnailPreview] = useState(tutorialData.thumbnail || null);
-  const [previewVideo, setPreviewVideo] = useState(tutorialData.preview || null);
+  const [thumbnailPreview, setThumbnailPreview] = useState(null);
+  const [previewVideo, setPreviewVideo] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(0);
 
   const handleThumbnailUpload = (e) => {

--- a/frontend/src/components/tutorials/create/ReviewStep.js
+++ b/frontend/src/components/tutorials/create/ReviewStep.js
@@ -25,7 +25,10 @@ export default function ReviewStep({ tutorialData, onBack, onPublish }) {
           </h3>
           <p><strong>Title:</strong> {tutorialData.title}</p>
           <p><strong>Short Description:</strong> {tutorialData.shortDescription}</p>
-          <p><strong>Category:</strong> {tutorialData.category}</p>
+          <p>
+            <strong>Category:</strong>{" "}
+            {tutorialData.categoryName || tutorialData.category}
+          </p>
           <p><strong>Level:</strong> {tutorialData.level}</p>
           {tutorialData.tags.length > 0 && (
             <p><strong>Tags:</strong> {tutorialData.tags.join(", ")}</p>
@@ -56,14 +59,14 @@ export default function ReviewStep({ tutorialData, onBack, onPublish }) {
             <FaCheckCircle /> Media
           </h3>
           <div className="flex gap-6 items-center">
-            {tutorialData.thumbnail && (
+            {tutorialData.thumbnail instanceof File && (
               <img
                 src={URL.createObjectURL(tutorialData.thumbnail)}
                 alt="Thumbnail Preview"
                 className="w-32 h-20 object-cover rounded shadow"
               />
             )}
-            {tutorialData.preview && (
+            {tutorialData.preview instanceof File && (
               <video
                 src={URL.createObjectURL(tutorialData.preview)}
                 controls

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -7,6 +7,7 @@ import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
 import MediaStep from "@/components/tutorials/create/MediaStep";
 import ReviewStep from "@/components/tutorials/create/ReviewStep";
 import { createTutorial } from "@/services/admin/tutorialService";
+import { fetchAllCategories } from "@/services/admin/categoryService";
 
 export default function CreateTutorialPage() {
   const [step, setStep] = useState(1);
@@ -15,6 +16,7 @@ export default function CreateTutorialPage() {
     title: "",
     shortDescription: "",
     category: "",
+    categoryName: "",
     level: "",
     tags: [],
     chapters: [],
@@ -24,18 +26,33 @@ export default function CreateTutorialPage() {
     isFree: false,
   });
 
+  const [categories, setCategories] = useState([]);
+
   useEffect(() => {
     const savedDraft = localStorage.getItem("tutorialDraft");
     if (savedDraft) {
-      setTutorialData(JSON.parse(savedDraft));
+      const draft = JSON.parse(savedDraft);
+      setTutorialData({ ...draft, thumbnail: null, preview: null });
     }
+
+    const loadCategories = async () => {
+      try {
+        const result = await fetchAllCategories();
+        setCategories(result || []);
+      } catch (err) {
+        console.error("Failed to load categories", err);
+      }
+    };
+
+    loadCategories();
   }, []);
 
   const nextStep = () => setStep((prev) => prev + 1);
   const prevStep = () => setStep((prev) => prev - 1);
 
   const saveDraft = () => {
-    localStorage.setItem("tutorialDraft", JSON.stringify(tutorialData));
+    const { thumbnail, preview, ...serializable } = tutorialData;
+    localStorage.setItem("tutorialDraft", JSON.stringify(serializable));
     alert("✅ Draft saved successfully!");
   };
 
@@ -103,6 +120,7 @@ export default function CreateTutorialPage() {
               tutorialData={tutorialData}
               setTutorialData={setTutorialData}
               onNext={nextStep}
+              categories={categories}
             />
           )}
           {step === 2 && (

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { fetchAllCategories } from "@/services/admin/categoryService";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
@@ -11,6 +12,7 @@ export default function CreateTutorialPage() {
     title: "",
     shortDescription: "",
     category: "",
+    categoryName: "",
     level: "",
     tags: [],
     chapters: [],
@@ -20,18 +22,33 @@ export default function CreateTutorialPage() {
     isFree: false,
   });
 
+  const [categories, setCategories] = useState([]);
+
   useEffect(() => {
     const savedDraft = localStorage.getItem("tutorialDraft");
     if (savedDraft) {
-      setTutorialData(JSON.parse(savedDraft));
+      const draft = JSON.parse(savedDraft);
+      setTutorialData({ ...draft, thumbnail: null, preview: null });
     }
+
+    const loadCategories = async () => {
+      try {
+        const result = await fetchAllCategories();
+        setCategories(result || []);
+      } catch (err) {
+        console.error("Failed to load categories", err);
+      }
+    };
+
+    loadCategories();
   }, []);
 
   const nextStep = () => setStep((prev) => prev + 1);
   const prevStep = () => setStep((prev) => prev - 1);
 
   const saveDraft = () => {
-    localStorage.setItem("tutorialDraft", JSON.stringify(tutorialData));
+    const { thumbnail, preview, ...serializable } = tutorialData;
+    localStorage.setItem("tutorialDraft", JSON.stringify(serializable));
     alert("✅ Draft saved successfully!");
   };
 
@@ -62,6 +79,7 @@ export default function CreateTutorialPage() {
               tutorialData={tutorialData}
               setTutorialData={setTutorialData}
               onNext={nextStep}
+              categories={categories}
             />
           )}
           {step === 2 && (


### PR DESCRIPTION
## Summary
- fetch categories when creating tutorials
- store both category ID and name in tutorial draft
- display category name in review step
- ensure category ID is sent to the backend

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm run lint --prefix frontend` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d58175d288328a7cef1b0a0ec6620