### PR TITLE
Fix missing duration fields

### DIFF
--- a/backend/src/migrations/20250614120000_add_duration_to_tutorials.js
+++ b/backend/src/migrations/20250614120000_add_duration_to_tutorials.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('tutorials', function(table) {
+    table.integer('duration');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('tutorials', function(table) {
+    table.dropColumn('duration');
+  });
+};

--- a/backend/src/migrations/20250614120500_add_duration_to_tutorial_chapters.js
+++ b/backend/src/migrations/20250614120500_add_duration_to_tutorial_chapters.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('tutorial_chapters', function(table) {
+    table.integer('duration');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('tutorial_chapters', function(table) {
+    table.dropColumn('duration');
+  });
+};

--- a/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
+++ b/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
@@ -39,7 +39,11 @@ exports.updateChapter = catchAsync(async (req, res) => {
   const chapter = await service.findById(id);
   if (!chapter) throw new AppError("Chapter not found", 404);
 
-  const updated = await service.update(id, req.body);
+  const data = { ...req.body };
+  if (data.duration) {
+    data.duration = parseInt(data.duration);
+  }
+  const updated = await service.update(id, data);
   sendSuccess(res, updated, "Chapter updated");
 });
 

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -43,7 +43,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     description,
     category_id,
     level,
-    duration,
+    duration: duration ? parseInt(duration) : null,
     price,
     instructor_id,
     status,
@@ -84,6 +84,9 @@ exports.getTutorialById = catchAsync(async (req, res) => {
 
 exports.updateTutorial = catchAsync(async (req, res) => {
   const data = req.body;
+  if (data.duration) {
+    data.duration = parseInt(data.duration);
+  }
   if (req.files?.thumbnail) {
     data.cover_image = `/uploads/tutorials/${req.files.thumbnail[0].filename}`;
   }


### PR DESCRIPTION
## Summary
- add duration column to tutorials
- add duration column to tutorial_chapters
- parse duration values on tutorial & chapter create/update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d635407ac832882598e5e540296d1