### PR TITLE
Add moderation and publish workflow

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -27,12 +27,24 @@ const generateUniqueSlug = async (title) => {
 
 exports.createTutorial = catchAsync(async (req, res) => {
   const {
-    title, description, category_id, level, duration,
-    price, status = "draft", chapters = []
+    title,
+    description,
+    category_id,
+    level,
+    duration,
+    price,
+    status = "draft",
+    chapters = [],
   } = req.body;
 
+  // 🚫 Prevent duplicate titles
+  const existing = await db("tutorials").where({ title }).first();
+  if (existing) {
+    return res.status(400).json({ message: "Tutorial title already exists" });
+  }
+
   const instructor_id = req.user.id;
-  const slug = slugify(title, { lower: true, strict: true });
+  const slug = await generateUniqueSlug(title);
   const id = uuidv4();
 
   // Save tutorial
@@ -47,6 +59,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     price,
     instructor_id,
     status,
+    moderation_status: status === "published" ? "pending" : null,
     thumbnail_url: req.file ? `/uploads/tutorials/${req.file.filename}` : null,
   };
   await service.createTutorial(tutorial);

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -54,20 +54,20 @@ exports.bulkUpdateStatus = async (ids, status) => {
 
 exports.getFeaturedTutorials = async () => {
   return db("tutorials")
-    .where({ status: "published" })
+    .where({ status: "published", moderation_status: "approved" })
     .orderBy("created_at", "desc")
     .limit(6);
 };
 
 exports.getPublishedTutorials = async () => {
   return db("tutorials")
-    .where({ status: "published" })
+    .where({ status: "published", moderation_status: "approved" })
     .orderBy("created_at", "desc");
 };
 
 exports.getPublicTutorialDetails = async (id) => {
   const tutorial = await db("tutorials")
-    .where({ id, status: "published" })
+    .where({ id, status: "published", moderation_status: "approved" })
     .first();
 
   if (!tutorial) return null;

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -24,6 +24,7 @@ exports.create = z.object({
     description: z.string().optional(),
     category_id: z.string(), // assuming UUID
     level: z.string(),
+    status: z.enum(["draft", "published", "archived"]).optional(),
     price: z.string().optional(),
     is_paid: z.preprocess(toBoolean, z.boolean().optional()),
     tags: z.preprocess(parseJson, z.array(z.string()).optional()),

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
-import { toast } from "react-hot-toast";
+import toast, { Toaster } from "react-hot-toast";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
@@ -53,18 +53,14 @@ export default function CreateTutorialPage() {
   const nextStep = () => setStep((prev) => prev + 1);
   const prevStep = () => setStep((prev) => prev - 1);
 
-  const saveDraft = () => {
-    const { thumbnail, preview, ...serializable } = tutorialData;
-    localStorage.setItem("tutorialDraft", JSON.stringify(serializable));
-    alert("✅ Draft saved successfully!");
-  };
 
-  const publishTutorial = async () => {
+  const submitTutorial = async (status) => {
     const formData = new FormData();
     formData.append("title", tutorialData.title);
     formData.append("description", tutorialData.shortDescription);
     formData.append("category_id", tutorialData.category);
     formData.append("level", tutorialData.level);
+    formData.append("status", status);
     formData.append("is_paid", (!tutorialData.isFree).toString());
     if (!tutorialData.isFree) {
       formData.append("price", tutorialData.price);
@@ -87,17 +83,29 @@ export default function CreateTutorialPage() {
 
     try {
       await createTutorial(formData);
-      toast.success("Tutorial created successfully!");
+      toast.success(
+        status === "draft"
+          ? "Tutorial saved as draft!"
+          : "Tutorial submitted for approval!"
+      );
       localStorage.removeItem("tutorialDraft");
       router.push("/dashboard/admin/tutorials");
     } catch (err) {
       console.error(err);
-      toast.error("Failed to create tutorial");
+      if (err.response?.data?.message) {
+        toast.error(err.response.data.message);
+      } else {
+        toast.error("Failed to create tutorial");
+      }
     }
   };
 
+  const publishTutorial = () => submitTutorial("published");
+  const saveDraft = () => submitTutorial("draft");
+
   return (
     <AdminLayout>
+      <Toaster position="top-center" />
       <div className="p-8 bg-gray-100 min-h-screen">
         <h1 className="text-3xl font-bold text-gray-800 mb-8">🎬 Create New Tutorial</h1>
 


### PR DESCRIPTION
## Summary
- allow status on tutorial creation
- prevent duplicate titles server-side
- mark published tutorials as pending moderation
- filter public views by moderation status
- support publishing or drafting tutorials from frontend
- show toast messages when creating tutorials

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm run lint --prefix frontend` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d68518f1083289b2b2b008ba39eda