### PR TITLE
Fix admin tutorial notifications

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { Button } from "@/components/ui/button";
 import { FaEdit, FaTrash, FaPlus } from "react-icons/fa";
-import { toast } from "react-hot-toast";
+import toast, { Toaster } from "react-hot-toast";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import RejectionReasonModal from "@/components/common/RejectionReasonModal";
@@ -176,6 +176,7 @@ export default function AdminTutorialsPage() {
 
   return (
     <AdminLayout>
+      <Toaster position="top-center" />
       <div className="p-6 bg-gray-100 min-h-screen space-y-8">
 
         {/* Header */}


### PR DESCRIPTION
## Summary
- ensure toast notifications render on admin tutorial list

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (interactive prompt prevents automatic run)

------
https://chatgpt.com/codex/tasks/task_e_684d6c67b4348328a265989a6936464e