### PR TITLE
Add moderation status migration

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -79,6 +79,7 @@
 - **Purpose**: Tutorial master table
 - **Primary Key**: `id`
 - **Foreign Keys**: `creator_id, category_id → categories(id)`
+- **Columns**: `moderation_status`, `rejection_reason`
 
 ### `tutorial_chapters`
 - **Purpose**: Chapters per tutorial

--- a/backend/src/migrations/20250614220000_add_moderation_status_to_tutorials.js
+++ b/backend/src/migrations/20250614220000_add_moderation_status_to_tutorials.js
@@ -1,0 +1,20 @@
+exports.up = async function(knex) {
+  await knex.schema.alterTable('tutorials', function(table) {
+    table.enu('moderation_status', ['pending', 'approved', 'rejected']).nullable();
+    table.text('rejection_reason');
+  });
+  await knex.raw(`
+    ALTER TABLE tutorials
+    DROP CONSTRAINT IF EXISTS tutorials_moderation_status_check;
+    ALTER TABLE tutorials
+    ADD CONSTRAINT tutorials_moderation_status_check
+    CHECK (moderation_status IS NULL OR moderation_status IN ('pending','approved','rejected'));
+  `);
+};
+
+exports.down = async function(knex) {
+  await knex.schema.alterTable('tutorials', function(table) {
+    table.dropColumn('rejection_reason');
+    table.dropColumn('moderation_status');
+  });
+};


### PR DESCRIPTION
## Summary
- add DB migration for tutorial moderation status
- document moderation columns in schema overview

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d841d06b483289bf7e83fa6759b03