### PR TITLE
Fix moderation status migration

### DIFF
--- a/backend/src/migrations/20250614220000_add_moderation_status_to_tutorials.js
+++ b/backend/src/migrations/20250614220000_add_moderation_status_to_tutorials.js
@@ -3,13 +3,17 @@ exports.up = async function(knex) {
     table.enu('moderation_status', ['pending', 'approved', 'rejected']).nullable();
     table.text('rejection_reason');
   });
-  await knex.raw(`
-    ALTER TABLE tutorials
-    DROP CONSTRAINT IF EXISTS tutorials_moderation_status_check;
-    ALTER TABLE tutorials
-    ADD CONSTRAINT tutorials_moderation_status_check
-    CHECK (moderation_status IS NULL OR moderation_status IN ('pending','approved','rejected'));
-  `);
+  // Knex's `enu` helper automatically creates a CHECK constraint that doesn't
+  // allow NULL values. We need to drop that default constraint and replace it
+  // with one that permits `NULL` so drafts can be saved without a moderation
+  // status. Running the DROP and ADD as separate statements avoids issues with
+  // drivers that reject multi‑statement queries.
+  await knex.raw(
+    `ALTER TABLE tutorials DROP CONSTRAINT IF EXISTS tutorials_moderation_status_check`
+  );
+  await knex.raw(
+    `ALTER TABLE tutorials ADD CONSTRAINT tutorials_moderation_status_check CHECK (moderation_status IS NULL OR moderation_status IN ('pending','approved','rejected'))`
+  );
 };
 
 exports.down = async function(knex) {


### PR DESCRIPTION
## Summary
- fix tutorials migration so the null-friendly CHECK constraint is applied

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d8e406efc8328b19a90c78d21e6e2