### PR TITLE
Fix tutorials moderation migration

### DIFF
--- a/backend/src/migrations/20250614220000_add_moderation_status_to_tutorials.js
+++ b/backend/src/migrations/20250614220000_add_moderation_status_to_tutorials.js
@@ -3,7 +3,7 @@ exports.up = async function(knex) {
   const hasModeration = await knex.schema.hasColumn("tutorials", "moderation_status");
   const hasRejectionReason = await knex.schema.hasColumn("tutorials", "rejection_reason");
 
-  return knex.schema.alterTable("tutorials", function(table) {
+  await knex.schema.alterTable("tutorials", function(table) {
     if (!hasModeration) {
       table.enu("moderation_status", ["pending", "approved", "rejected"]).defaultTo("pending");
     }


### PR DESCRIPTION
## Summary
- fix `add_moderation_status_to_tutorials` migration so constraint updates run

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in `frontend` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d938400f483289814bd3e8c8f9bb5