### PR TITLE
Disable caching for Express

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,6 +16,11 @@ const certificatePublicRoutes = require("./modules/users/tutorials/certificate/c
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
+app.disable('etag');       // prevent 304 responses due to ETag
+app.use((req, res, next) => {
+  res.set('Cache-Control', 'no-store');
+  next();
+});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 🔧 Global Middleware Setup


### PR DESCRIPTION
## Summary
- disable `etag` in server
- add middleware to set `Cache-Control: no-store`

## Testing
- `npm install` *(fails: Could not acquire DB connection)*
- `npm start` *(fails: Unable to acquire a connection)*

------
https://chatgpt.com/codex/tasks/task_e_684db07d09e88328b6869ab75cbc3f1c