### PR TITLE
Remove duplicate admin trash route

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -74,8 +74,7 @@ router.use("/certificate", require("./certificate/tutorialCertificate.routes"));
 router.patch("/admin/bulk/approve", verifyToken, isAdmin, controller.bulkApproveTutorials);
 router.patch("/admin/bulk/trash", verifyToken, isInstructorOrAdmin, controller.bulkTrashTutorials);
 
-// Archived tutorials
-router.get("/admin/trash", verifyToken, isInstructorOrAdmin, controller.getArchivedTutorials);
+
 
 // ✅ Public routes (no auth required)
 router.get("/featured", controller.getFeaturedTutorials);


### PR DESCRIPTION
## Summary
- deduplicate `/admin/trash` tutorial route so only one is defined

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684db0c43f2c8328a9261731dd6ce3ff