### PR TITLE
Fix tutorial moderation status enum

### DIFF
--- a/backend/src/migrations/20250614220000_add_moderation_status_to_tutorials.js
+++ b/backend/src/migrations/20250614220000_add_moderation_status_to_tutorials.js
@@ -5,7 +5,7 @@ exports.up = async function(knex) {
 
   await knex.schema.alterTable("tutorials", function(table) {
     if (!hasModeration) {
-      table.enu("moderation_status", ["pending", "approved", "rejected"]).defaultTo("pending");
+      table.enu("moderation_status", ["Pending", "Approved", "Rejected"]).defaultTo("Pending");
     }
     if (!hasRejectionReason) {
       table.text("rejection_reason");
@@ -20,7 +20,7 @@ exports.up = async function(knex) {
     `ALTER TABLE tutorials DROP CONSTRAINT IF EXISTS tutorials_moderation_status_check`
   );
   await knex.raw(
-    `ALTER TABLE tutorials ADD CONSTRAINT tutorials_moderation_status_check CHECK (moderation_status IS NULL OR moderation_status IN ('pending','approved','rejected'))`
+    `ALTER TABLE tutorials ADD CONSTRAINT tutorials_moderation_status_check CHECK (moderation_status IS NULL OR moderation_status IN ('Pending','Approved','Rejected'))`
   );
 };
 

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -59,7 +59,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     price,
     instructor_id,
     status,
-    moderation_status: status === "published" ? "pending" : null,
+    moderation_status: status === "published" ? "Pending" : null,
     thumbnail_url: req.file ? `/uploads/tutorials/${req.file.filename}` : null,
   };
   await service.createTutorial(tutorial);
@@ -141,21 +141,21 @@ exports.togglePublishStatus = catchAsync(async (req, res) => {
 
 
 exports.approveTutorial = catchAsync(async (req, res) => {
-  await service.updateModeration(req.params.id, "approved");
+  await service.updateModeration(req.params.id, "Approved");
 
   sendSuccess(res, { message: "Tutorial approved" });
 });
 
 
 exports.rejectTutorial = catchAsync(async (req, res) => {
-  await service.updateModeration(req.params.id, "rejected", req.body.reason);
+  await service.updateModeration(req.params.id, "Rejected", req.body.reason);
 
   sendSuccess(res, { message: "Tutorial rejected" });
 });
 
 
 exports.bulkApproveTutorials = catchAsync(async (req, res) => {
-  await service.bulkUpdateModeration(req.body.ids, "approved");
+  await service.bulkUpdateModeration(req.body.ids, "Approved");
 
   sendSuccess(res, { message: "Bulk approval done" });
 });

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -60,20 +60,20 @@ exports.getArchivedTutorials = async () => {
 
 exports.getFeaturedTutorials = async () => {
   return db("tutorials")
-    .where({ status: "published", moderation_status: "approved" })
+    .where({ status: "published", moderation_status: "Approved" })
     .orderBy("created_at", "desc")
     .limit(6);
 };
 
 exports.getPublishedTutorials = async () => {
   return db("tutorials")
-    .where({ status: "published", moderation_status: "approved" })
+    .where({ status: "published", moderation_status: "Approved" })
     .orderBy("created_at", "desc");
 };
 
 exports.getPublicTutorialDetails = async (id) => {
   const tutorial = await db("tutorials")
-    .where({ id, status: "published", moderation_status: "approved" })
+    .where({ id, status: "published", moderation_status: "Approved" })
     .first();
 
   if (!tutorial) return null;


### PR DESCRIPTION
## Summary
- sync moderator status values with database enum
- align tutorial approval queries with enum

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684db63c90a88328bd1c46920f61a52a