### PR TITLE
Fix tutorial media upload handling

### DIFF
--- a/backend/src/modules/users/tutorials/chapters/uploadChapterVideo.js
+++ b/backend/src/modules/users/tutorials/chapters/uploadChapterVideo.js
@@ -2,12 +2,21 @@ const multer = require("multer");
 const path = require("path");
 const fs = require("fs");
 
-// Ensure directory exists
-const uploadPath = path.join(__dirname, "../../../../../uploads/tutorials/chapters");
-if (!fs.existsSync(uploadPath)) fs.mkdirSync(uploadPath, { recursive: true });
+// Resolve directory based on user role
+const resolvePath = (req) => {
+  const base = path.join(__dirname, "../../../../../uploads/tutorials/chapters");
+  let role = req.user?.role?.toLowerCase() || "other";
+  if (["superadmin", "admin"].includes(role)) role = "admin";
+  const dir = path.join(base, role);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  return dir;
+};
 
 const storage = multer.diskStorage({
-  destination: (_req, _file, cb) => cb(null, uploadPath),
+  destination: (req, _file, cb) => {
+    const dir = resolvePath(req);
+    cb(null, dir);
+  },
   filename: (_req, file, cb) => {
     const ext = path.extname(file.originalname);
     cb(null, `chapter_${Date.now()}${ext}`);

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -72,7 +72,7 @@ export default function CreateTutorialPage() {
       const chapters = tutorialData.chapters.map((ch, idx) => ({
         title: ch.title,
         duration: ch.duration,
-        video_url: ch.video,
+        video_url: ch.videoUrl,
         order: idx + 1,
         is_preview: ch.preview,
       }));

--- a/frontend/src/services/admin/tutorialChapterService.js
+++ b/frontend/src/services/admin/tutorialChapterService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const uploadChapterVideo = async (file, onUploadProgress) => {
+  const formData = new FormData();
+  formData.append("video", file);
+  const res = await api.post("/users/tutorials/chapters/upload", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+    onUploadProgress,
+  });
+  return res.data;
+};

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -23,8 +23,23 @@ export const createTutorial = async (formData) => {
  * @returns {Promise<Array>} Array of tutorial objects
  */
 export const fetchAllTutorials = async () => {
-  const res = await api.get("/users/tutorials/admin");
-  return res.data?.data ?? [];
+  const { data } = await api.get("/users/tutorials/admin");
+  const tutorials = data?.data ?? [];
+  return tutorials.map((t) => ({
+    id: t.id,
+    title: t.title,
+    thumbnail: t.thumbnail_url
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${t.thumbnail_url}`
+      : null,
+    createdAt: t.created_at,
+    updatedAt: t.updated_at,
+    instructor: t.instructor_name,
+    category: t.category_name,
+    status: t.status === "published" ? "Published" : "Draft",
+    approvalStatus: t.moderation_status ?? "Pending",
+    rating: t.rating,
+    views: t.views,
+  }));
 };
 
 /**
@@ -36,5 +51,20 @@ export const fetchAllTutorials = async () => {
 export const permanentlyDeleteTutorial = async (id) => {
   const res = await api.delete(`/users/tutorials/admin/${id}`);
   return res.data;
+};
+
+export const toggleTutorialStatus = async (id) => {
+  const { data } = await api.patch(`/users/tutorials/admin/${id}/status`);
+  return data?.data;
+};
+
+export const approveTutorial = async (id) => {
+  const { data } = await api.patch(`/users/tutorials/admin/${id}/approve`);
+  return data?.data;
+};
+
+export const rejectTutorial = async (id, reason) => {
+  const { data } = await api.patch(`/users/tutorials/admin/${id}/reject`, { reason });
+  return data?.data;
 };
 


### PR DESCRIPTION
## Summary
- organize tutorial and chapter media uploads by user role
- save thumbnail and preview paths correctly on create/update
- add service and client upload for chapter videos
- display proper tutorial details in admin list and enable approval actions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbd34c3108328a6fa2093a17f5d2b