### PR TITLE
Fix bulk tutorial deletion

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -193,10 +193,10 @@ exports.bulkApproveTutorials = catchAsync(async (req, res) => {
 });
 
 
-exports.bulkTrashTutorials = catchAsync(async (req, res) => {
-  await service.bulkUpdateStatus(req.body.ids, "archived");
+exports.bulkDeleteTutorials = catchAsync(async (req, res) => {
+  await service.bulkDeleteTutorials(req.body.ids);
 
-  sendSuccess(res, { message: "Bulk archived" });
+  sendSuccess(res, { message: "Selected tutorials deleted" });
 });
 
 exports.getArchivedTutorials = catchAsync(async (req, res) => {

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -68,6 +68,7 @@ router.use("/certificate", require("./certificate/tutorialCertificate.routes"));
 
 // ✅ Bulk actions
 router.patch("/admin/bulk/approve", verifyToken, isAdmin, controller.bulkApproveTutorials);
+router.post("/admin/bulk-delete", verifyToken, isAdmin, controller.bulkDeleteTutorials);
 
 
 

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -69,6 +69,10 @@ exports.bulkUpdateStatus = async (ids, status) => {
   return db("tutorials").whereIn("id", ids).update({ status });
 };
 
+exports.bulkDeleteTutorials = async (ids) => {
+  return db("tutorials").whereIn("id", ids).del();
+};
+
 exports.getArchivedTutorials = async () => {
   return db("tutorials")
     .where({ status: "archived" })

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -12,6 +12,8 @@ import {
   toggleTutorialStatus,
   approveTutorial,
   rejectTutorial,
+  bulkApproveTutorials,
+  bulkDeleteTutorials,
 } from "@/services/admin/tutorialService";
 
 
@@ -182,7 +184,7 @@ export default function AdminTutorialsPage() {
   const handleBulkDelete = async () => {
     if (selectedTutorials.length === 0) return;
     try {
-      await Promise.all(selectedTutorials.map((id) => permanentlyDeleteTutorial(id)));
+      await bulkDeleteTutorials(selectedTutorials);
       setTutorials((prev) => prev.filter((tut) => !selectedTutorials.includes(tut.id)));
       toast.success("Selected tutorials deleted!");
     } catch (err) {
@@ -193,17 +195,23 @@ export default function AdminTutorialsPage() {
     }
   };
 
-  const handleBulkApprove = () => {
+  const handleBulkApprove = async () => {
     if (selectedTutorials.length === 0) return;
-    setTutorials((prev) =>
-      prev.map((tut) =>
-        selectedTutorials.includes(tut.id)
-          ? { ...tut, approvalStatus: "Approved", updatedAt: new Date().toISOString() }
-          : tut
-      )
-    );
+    try {
+      await bulkApproveTutorials(selectedTutorials);
+      setTutorials((prev) =>
+        prev.map((tut) =>
+          selectedTutorials.includes(tut.id)
+            ? { ...tut, approvalStatus: "Approved", updatedAt: new Date().toISOString() }
+            : tut
+        )
+      );
+      toast.success("Selected tutorials approved!");
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to approve tutorials");
+    }
     setSelectedTutorials([]);
-    toast.success("Selected tutorials approved!");
   };
 
   return (
@@ -242,7 +250,7 @@ export default function AdminTutorialsPage() {
               className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded"
               disabled={selectedTutorials.length === 0}
             >
-              🗑️ Move to Trash
+              🗑️ Delete Selected
             </Button>
 
             <Button
@@ -399,7 +407,7 @@ export default function AdminTutorialsPage() {
                   <button
                     onClick={() => openDeleteModal(tutorial.id)}
                     className="text-red-500 hover:text-red-700"
-                    title="Move to Trash"
+                    title="Delete"
                   >
                     <FaTrash />
                   </button>

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -99,4 +99,14 @@ export const updateTutorial = async (id, formData) => {
   return data?.data;
 };
 
+export const bulkApproveTutorials = async (ids) => {
+  await api.patch("/users/tutorials/admin/bulk/approve", { ids });
+  return true;
+};
+
+export const bulkDeleteTutorials = async (ids) => {
+  await api.post("/users/tutorials/admin/bulk-delete", { ids });
+  return true;
+};
+
 


### PR DESCRIPTION
## Summary
- add backend API to delete tutorials in bulk
- wire up bulk delete service and page actions
- change UI text to "Delete Selected"

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: Next.js not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684dcfa387e083288766c4097802f53b