### PR TITLE
Add category filter to tutorials

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -36,6 +36,8 @@
     "zod": "^3.25.20"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -74,6 +74,7 @@ router.post("/admin/bulk-delete", verifyToken, isAdmin, controller.bulkDeleteTut
 
 // ✅ Public routes (no auth required)
 router.get("/featured", controller.getFeaturedTutorials);
+router.get("/category/:categoryId", controller.getTutorialsByCategory);
 router.get("/", controller.getPublishedTutorials);
 router.get("/:id", controller.getPublicTutorialDetails);
 

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -92,6 +92,16 @@ exports.getPublishedTutorials = async () => {
     .orderBy("created_at", "desc");
 };
 
+exports.getTutorialsByCategory = async (categoryId) => {
+  return db("tutorials")
+    .where({
+      category_id: categoryId,
+      status: "published",
+      moderation_status: "Approved",
+    })
+    .orderBy("created_at", "desc");
+};
+
 exports.getPublicTutorialDetails = async (id) => {
   const tutorial = await db("tutorials")
     .where({ id, status: "published", moderation_status: "Approved" })

--- a/backend/tests/tutorialRoutes.test.js
+++ b/backend/tests/tutorialRoutes.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database', () => ({
+  raw: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({
+  getTutorialsByCategory: jest.fn(),
+}));
+
+const service = require('../src/modules/users/tutorials/tutorial.service');
+const routes = require('../src/modules/users/tutorials/tutorial.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/users/tutorials', routes);
+
+describe('GET /api/users/tutorials/category/:categoryId', () => {
+  it('returns tutorials for the given category', async () => {
+    const mockTutorials = [{ id: '1', title: 'Test Tutorial' }];
+    service.getTutorialsByCategory.mockResolvedValue(mockTutorials);
+
+    const res = await request(app).get('/api/users/tutorials/category/123');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mockTutorials);
+    expect(service.getTutorialsByCategory).toHaveBeenCalledWith('123');
+  });
+});


### PR DESCRIPTION
## Summary
- query tutorials by category in service
- expose new /category/:categoryId route
- integrate jest & supertest for testing
- test route returns expected tutorials

## Testing
- `cd backend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e5e3bebe08328996bab059e4fe23a