### PR TITLE
Replace mock tutorials with API calls

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -3,21 +3,35 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { motion } from "framer-motion"; // Smooth animation
+import { fetchTutorialDetails } from "@/services/tutorialService";
 
 export default function ViewTutorialPage() {
   const router = useRouter();
   const { id } = router.query;
   const [tutorial, setTutorial] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [curriculumOpen, setCurriculumOpen] = useState(true); // For mobile accordion
 
   useEffect(() => {
-    if (id) {
-      const found = sampleTutorials.find((tut) => tut.id === parseInt(id));
-      setTutorial(found);
-    }
+    if (!id) return;
+    const load = async () => {
+      try {
+        const data = await fetchTutorialDetails(id);
+        setTutorial(data?.data || data || null);
+      } catch (err) {
+        console.error(err);
+        setError("Failed to load tutorial");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [id]);
 
-  if (!tutorial) return <div className="p-6">Loading...</div>;
+  if (loading) return <div className="p-6">Loading tutorial...</div>;
+  if (error) return <div className="p-6 text-red-500">{error}</div>;
+  if (!tutorial) return <div className="p-6">Tutorial not found.</div>;
 
   return (
     <InstructorLayout>
@@ -162,43 +176,3 @@ export default function ViewTutorialPage() {
   );
 }
 
-// Mock Data
-const sampleTutorials = [
-  {
-    id: 1,
-    title: "Mastering React.js",
-    status: "Draft",
-    updatedAt: "2024-05-01T10:00:00Z",
-    thumbnail: "https://via.placeholder.com/1200x600",
-    progress: 40,
-    shortDescription: "Learn everything about building modern web apps using React.js and Next.js.",
-    tags: ["React", "Frontend", "JavaScript"],
-    chapters: [
-      { title: "Getting Started", lessons: ["Introduction", "Installing Tools"] },
-      { title: "Core Concepts", lessons: ["JSX", "Components", "State Management"] }
-    ],
-    preview: null
-  },
-  {
-    id: 2,
-    title: "Node.js Basics",
-    status: "Submitted",
-    updatedAt: "2024-05-02T14:30:00Z",
-    thumbnail: "https://via.placeholder.com/1200x600",
-    shortDescription: "A practical guide to backend development using Node.js and Express.",
-    tags: ["Node.js", "Backend", "JavaScript"],
-    chapters: [],
-    preview: null
-  },
-  {
-    id: 3,
-    title: "Introduction to AI",
-    status: "Approved",
-    updatedAt: "2024-05-03T09:00:00Z",
-    thumbnail: "https://via.placeholder.com/1200x600",
-    shortDescription: "Understand the basics of artificial intelligence and machine learning.",
-    tags: ["AI", "Machine Learning", "Python"],
-    chapters: [],
-    preview: null
-  }
-];

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -1,38 +1,31 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { FaPlus, FaEdit, FaEye, FaTrash } from "react-icons/fa";
-
-const sampleTutorials = [
-  {
-    id: 1,
-    title: "Mastering React.js",
-    status: "Draft",
-    updatedAt: "2024-05-01T10:00:00Z",
-    thumbnail: "https://via.placeholder.com/300x180",
-    progress: 40,
-  },
-  {
-    id: 2,
-    title: "Node.js Basics",
-    status: "Submitted",
-    updatedAt: "2024-05-02T14:30:00Z",
-    thumbnail: "https://via.placeholder.com/300x180",
-  },
-  {
-    id: 3,
-    title: "Introduction to AI",
-    status: "Approved",
-    updatedAt: "2024-05-03T09:00:00Z",
-    thumbnail: "https://via.placeholder.com/300x180",
-  },
-];
+import { fetchPublishedTutorials } from "@/services/tutorialService";
 
 export default function InstructorTutorialsPage() {
   const router = useRouter();
-  const [tutorials, setTutorials] = useState(sampleTutorials);
+  const [tutorials, setTutorials] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchPublishedTutorials();
+        setTutorials(data?.data || data || []);
+      } catch (err) {
+        console.error(err);
+        setError("Failed to load tutorials");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
 
   const handleSearch = (query) => {
     setSearchQuery(query.toLowerCase());
@@ -53,6 +46,14 @@ export default function InstructorTutorialsPage() {
     const matchesStatus = statusFilter ? tut.status === statusFilter : true;
     return matchesTitle && matchesStatus;
   });
+
+  if (loading) {
+    return <div className="p-6">Loading tutorials...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-500">{error}</div>;
+  }
 
   return (
     <InstructorLayout>

--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -7,6 +7,8 @@ export default function StudentTutorialsPage() {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState("all");
   const [tutorials, setTutorials] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const load = async () => {
@@ -23,8 +25,11 @@ export default function StudentTutorialsPage() {
           };
         });
         setTutorials(enriched);
+        setLoading(false);
       } catch (err) {
         console.error(err);
+        setError("Failed to load tutorials");
+        setLoading(false);
       }
     };
     load();
@@ -35,6 +40,14 @@ export default function StudentTutorialsPage() {
     const matchesFilter = filter === "all" || (filter === "completed" && tut.isCompleted) || (filter === "in-progress" && !tut.isCompleted);
     return matchesSearch && matchesFilter;
   });
+
+  if (loading) {
+    return <div className="p-6">Loading tutorials...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-500">{error}</div>;
+  }
 
   return (
     <StudentLayout>

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -5,148 +5,13 @@ import { FaStar, FaClock, FaFire, FaEye, FaArrowUp } from "react-icons/fa";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import FilterSidebar from "@/components/tutorials/FilterSidebar";
-
-const tutorials = [
-  {
-    id: 1,
-    title: "Mastering React.js",
-    instructor: "John Doe",
-    duration: "30 min",
-    category: "React",
-    level: "Beginner",
-    rating: 4.8,
-    views: 100,
-    thumbnail: "https://codemanbd.com/wp-content/uploads/2024/03/Mastering-React-JS.jpg",
-    trending: true,
-    preview: "https://www.w3schools.com/html/mov_bbb.mp4",
-    tags: ["Beginner Friendly", "Hands-on"]
-  },
-  {
-    id: 2,
-    title: "Node.js Full Stack",
-    instructor: "Jane Smith",
-    duration: "45 min",
-    category: "Node.js",
-    level: "Intermediate",
-    rating: 4.2,
-    views: 200,
-    thumbnail: "https://i.ytimg.com/vi/YYmzj5DK_5s/hq720.jpg",
-    tags: ["Full Stack"]
-  },
-  {
-    id: 3,
-    title: "Deep Learning Basics",
-    instructor: "Alan Turing",
-    duration: "1h 10m",
-    category: "AI",
-    level: "Advanced",
-    rating: 5.0,
-    views: 150,
-    thumbnail: "https://i.ytimg.com/vi/bpFjQGCa7Xg/maxresdefault.jpg",
-    trending: true,
-    tags: ["Top Rated"]
-  },
-  {
-    id: 4,
-    title: "UI/UX Design Mastery",
-    instructor: "Sarah Adams",
-    duration: "50 min",
-    category: "Design",
-    level: "Intermediate",
-    rating: 4.7,
-    views: 180,
-    thumbnail: "https://framerusercontent.com/assets/EKEOIDPjqN813mQCpOA23uDFcns.jpg",
-    tags: ["Design"]
-  },
-  {
-    id: 5,
-    title: "Advanced JavaScript",
-    instructor: "Elon Dev",
-    duration: "40 min",
-    category: "JavaScript",
-    level: "Advanced",
-    rating: 4.9,
-    views: 220,
-    thumbnail: "https://i.ytimg.com/vi/IljVmcDDrOg/maxresdefault.jpg",
-    tags: ["Advanced"]
-  },
-  {
-    id: 6,
-    title: "Intro to TypeScript",
-    instructor: "Clara Lee",
-    duration: "35 min",
-    category: "TypeScript",
-    level: "Beginner",
-    rating: 4.6,
-    views: 175,
-    thumbnail: "https://i.ytimg.com/vi/BCg4U1FzODs/maxresdefault.jpg",
-    tags: ["Beginner Friendly"]
-  },
-  {
-    id: 7,
-    title: "Next.js Crash Course",
-    instructor: "Mark Evans",
-    duration: "1h 20m",
-    category: "React",
-    level: "Intermediate",
-    rating: 4.9,
-    views: 320,
-    thumbnail: "https://i.ytimg.com/vi/1WmNXEVia8I/maxresdefault.jpg",
-    trending: true,
-    tags: ["Full Stack"]
-  },
-  {
-    id: 8,
-    title: "Responsive Web Design",
-    instructor: "Laura Bennett",
-    duration: "45 min",
-    category: "Design",
-    level: "Beginner",
-    rating: 4.5,
-    views: 250,
-    thumbnail: "https://i.ytimg.com/vi/srvUrASNj0s/maxresdefault.jpg",
-    tags: ["CSS", "HTML"]
-  },
-  {
-    id: 9,
-    title: "Python for Beginners",
-    instructor: "Dr. Zainab",
-    duration: "1h",
-    category: "Python",
-    level: "Beginner",
-    rating: 4.3,
-    views: 180,
-    thumbnail: "https://i.ytimg.com/vi/_uQrJ0TkZlc/maxresdefault.jpg",
-    tags: ["Beginner Friendly"]
-  },
-  {
-    id: 10,
-    title: "Docker Essentials",
-    instructor: "Mohamed Ali",
-    duration: "50 min",
-    category: "DevOps",
-    level: "Intermediate",
-    rating: 4.4,
-    views: 210,
-    thumbnail: "https://i.ytimg.com/vi/Gjnup-PuquQ/maxresdefault.jpg",
-    tags: ["Containers"]
-  },
-  {
-    id: 11,
-    title: "Git & GitHub Essentials",
-    instructor: "Emily Davis",
-    duration: "30 min",
-    category: "Tools",
-    level: "Beginner",
-    rating: 4.7,
-    views: 300,
-    thumbnail: "https://i.ytimg.com/vi/apGV9Kg7ics/maxresdefault.jpg",
-    tags: ["Git", "Version Control"]
-  },
-];
+import { fetchPublishedTutorials } from "@/services/tutorialService";
 
 
 const TutorialsSection = () => {
+  const [tutorials, setTutorials] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [sortBy, setSortBy] = useState("default");
   const [visibleCount, setVisibleCount] = useState(6);
   const [searchQuery, setSearchQuery] = useState("");
@@ -160,6 +25,21 @@ const TutorialsSection = () => {
     };
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    const loadTutorials = async () => {
+      try {
+        const data = await fetchPublishedTutorials();
+        setTutorials(data?.data || data || []);
+      } catch (err) {
+        console.error(err);
+        setError("Failed to load tutorials");
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadTutorials();
   }, []);
 
   const sortedTutorials = [...tutorials]
@@ -192,6 +72,22 @@ const TutorialsSection = () => {
       if (loader.current) observer.unobserve(loader.current);
     };
   }, [loader, sortedTutorials.length]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-yellow-400">
+        ⏳ Loading tutorials...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-red-500">
+        {error}
+      </div>
+    );
+  }
 
   return (
     <section className="bg-gray-900 text-white min-h-screen relative">
@@ -287,6 +183,9 @@ const TutorialsSection = () => {
                   </div>
                 </motion.div>
               ))}
+              {visibleTutorials.length === 0 && (
+                <p className="col-span-full text-center text-gray-400">No tutorials found.</p>
+              )}
             </div>
 
             {visibleCount < sortedTutorials.length && (


### PR DESCRIPTION
## Summary
- fetch published tutorials on the public tutorials page
- load tutorials from the API on instructor dashboard
- fetch data for instructor tutorial view/edit pages
- add loading/error states to student dashboard

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5e3f067483289cccc84377e59db1