### PR TITLE
Add admin instructors API

### DIFF
--- a/backend/src/modules/users/admin/admin.routes.js
+++ b/backend/src/modules/users/admin/admin.routes.js
@@ -10,6 +10,7 @@ const { adminChangePasswordSchema } = require("./admin.validator");
 const { verifyToken, isAdmin, isSuperAdmin } = require("../../../middleware/auth/authMiddleware");
 const upload = require("./adminUploadMiddleware");
 const categoryRoutes = require("../categories/category.routes");
+const instructorAdminRoutes = require("./instructors/instructorAdmin.routes");
 // const classRoutes = require("../classes/class.routes");
 
 
@@ -65,6 +66,11 @@ router.post("/reset-password/:userId", isSuperAdmin, controller.resetPasswordAsA
 
 
 router.use("/", require("../usersmanagement/users.routes"));
+
+// ─────────────────────────────────────────────
+// 📋 Instructor management (GET/POST/PATCH)
+// ─────────────────────────────────────────────
+router.use("/instructors", instructorAdminRoutes);
 
 // ─────────────────────────────────────────────
 // 📋 Category CRUD (GET/POST/PUT/DELETE )

--- a/backend/src/modules/users/admin/instructors/instructorAdmin.controller.js
+++ b/backend/src/modules/users/admin/instructors/instructorAdmin.controller.js
@@ -1,0 +1,22 @@
+const service = require("./instructorAdmin.service");
+const { sendSuccess } = require("../../../../utils/response");
+const catchAsync = require("../../../../utils/catchAsync");
+const AppError = require("../../../../utils/AppError");
+
+exports.getAll = catchAsync(async (_req, res) => {
+  const instructors = await service.getAllInstructors();
+  sendSuccess(res, instructors, "Instructors fetched");
+});
+
+exports.getById = catchAsync(async (req, res) => {
+  const instructor = await service.getInstructorById(req.params.id);
+  if (!instructor) throw new AppError("Instructor not found", 404);
+  sendSuccess(res, instructor, "Instructor fetched");
+});
+
+exports.updateStatus = catchAsync(async (req, res) => {
+  const { status } = req.body;
+  if (!status) throw new AppError("Status required", 400);
+  const updated = await service.updateInstructorStatus(req.params.id, status);
+  sendSuccess(res, updated, "Status updated");
+});

--- a/backend/src/modules/users/admin/instructors/instructorAdmin.routes.js
+++ b/backend/src/modules/users/admin/instructors/instructorAdmin.routes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./instructorAdmin.controller");
+const { verifyToken, isAdmin } = require("../../../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.get("/", controller.getAll);
+router.get("/:id", controller.getById);
+router.patch("/:id/status", controller.updateStatus);
+
+module.exports = router;

--- a/backend/src/modules/users/admin/instructors/instructorAdmin.service.js
+++ b/backend/src/modules/users/admin/instructors/instructorAdmin.service.js
@@ -1,0 +1,41 @@
+const db = require("../../../../config/database");
+
+exports.getAllInstructors = async () => {
+  return await db("users")
+    .join("instructor_profiles", "users.id", "instructor_profiles.user_id")
+    .select(
+      "users.id",
+      "users.full_name",
+      "users.email",
+      "users.phone",
+      "users.status",
+      "users.avatar_url",
+      "instructor_profiles.expertise",
+      "instructor_profiles.experience",
+      "instructor_profiles.pricing"
+    );
+};
+
+exports.getInstructorById = async (id) => {
+  const [user] = await db("users")
+    .where({ "users.id": id })
+    .join("instructor_profiles", "users.id", "instructor_profiles.user_id")
+    .select(
+      "users.id",
+      "users.full_name",
+      "users.email",
+      "users.phone",
+      "users.status",
+      "users.avatar_url",
+      "instructor_profiles.expertise",
+      "instructor_profiles.experience",
+      "instructor_profiles.pricing",
+      "instructor_profiles.demo_video_url"
+    );
+  return user;
+};
+
+exports.updateInstructorStatus = async (id, status) => {
+  await db("users").where({ id }).update({ status });
+  return { id, status };
+};

--- a/backend/tests/adminInstructorRoutes.test.js
+++ b/backend/tests/adminInstructorRoutes.test.js
@@ -1,0 +1,29 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/users/admin/instructors/instructorAdmin.service', () => ({
+  getAllInstructors: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/users/admin/instructors/instructorAdmin.service');
+const routes = require('../src/modules/users/admin/instructors/instructorAdmin.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/users/admin/instructors', routes);
+
+describe('GET /api/users/admin/instructors', () => {
+  it('returns list of instructors', async () => {
+    const mockInstructors = [{ id: '1', full_name: 'Jane' }];
+    service.getAllInstructors.mockResolvedValue(mockInstructors);
+
+    const res = await request(app).get('/api/users/admin/instructors');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mockInstructors);
+  });
+});


### PR DESCRIPTION
## Summary
- enable admin instructor management routes
- implement controller and service for admin instructor operations
- add unit test for admin instructor list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e611702bc8328910b0350c373f612