### PR TITLE
Add admin instructor deletion

### DIFF
--- a/backend/src/modules/users/admin/instructors/instructorAdmin.controller.js
+++ b/backend/src/modules/users/admin/instructors/instructorAdmin.controller.js
@@ -20,3 +20,8 @@ exports.updateStatus = catchAsync(async (req, res) => {
   const updated = await service.updateInstructorStatus(req.params.id, status);
   sendSuccess(res, updated, "Status updated");
 });
+
+exports.deleteInstructor = catchAsync(async (req, res) => {
+  await service.deleteInstructor(req.params.id);
+  sendSuccess(res, null, "Instructor deleted");
+});

--- a/backend/src/modules/users/admin/instructors/instructorAdmin.routes.js
+++ b/backend/src/modules/users/admin/instructors/instructorAdmin.routes.js
@@ -8,5 +8,6 @@ router.use(verifyToken, isAdmin);
 router.get("/", controller.getAll);
 router.get("/:id", controller.getById);
 router.patch("/:id/status", controller.updateStatus);
+router.delete("/:id", controller.deleteInstructor);
 
 module.exports = router;

--- a/backend/src/modules/users/admin/instructors/instructorAdmin.service.js
+++ b/backend/src/modules/users/admin/instructors/instructorAdmin.service.js
@@ -45,3 +45,7 @@ exports.updateInstructorStatus = async (id, status) => {
   await db("users").where({ id }).update({ status });
   return { id, status };
 };
+
+exports.deleteInstructor = async (id) => {
+  await db("users").where({ id }).del();
+};

--- a/backend/tests/adminInstructorRoutes.test.js
+++ b/backend/tests/adminInstructorRoutes.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 jest.mock('../src/modules/users/admin/instructors/instructorAdmin.service', () => ({
   getAllInstructors: jest.fn(),
+  deleteInstructor: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -25,5 +26,15 @@ describe('GET /api/users/admin/instructors', () => {
     const res = await request(app).get('/api/users/admin/instructors');
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mockInstructors);
+  });
+});
+
+describe('DELETE /api/users/admin/instructors/:id', () => {
+  it('deletes instructor', async () => {
+    service.deleteInstructor.mockResolvedValue();
+
+    const res = await request(app).delete('/api/users/admin/instructors/123');
+    expect(res.status).toBe(200);
+    expect(service.deleteInstructor).toHaveBeenCalledWith('123');
   });
 });

--- a/frontend/src/pages/dashboard/admin/instructors/index.js
+++ b/frontend/src/pages/dashboard/admin/instructors/index.js
@@ -5,7 +5,7 @@ import InstructorCard from '@/components/admin/instructors/InstructorCard';
 import FilterBar from '@/components/admin/instructors/FilterBar';
 import BulkActions from '@/components/admin/instructors/BulkActions';
 import InstructorDetailsModal from '@/components/admin/instructors/InstructorDetailsModal';
-import { fetchAllInstructors, updateInstructorStatus } from '@/services/admin/instructorService';
+import { fetchAllInstructors, updateInstructorStatus, deleteInstructor as apiDeleteInstructor } from '@/services/admin/instructorService';
 import useAuthStore from '@/store/auth/authStore';
 import { toast } from 'react-toastify';
 
@@ -81,14 +81,28 @@ export default function AdminInstructorsPage() {
     }
   };
 
-  const deleteInstructor = (id) => {
-    setInstructors((prev) => prev.filter((i) => i.id !== id));
-    setSelectedIds((prev) => prev.filter((sid) => sid !== id));
+  const deleteInstructor = async (id) => {
+    try {
+      await apiDeleteInstructor(id);
+      setInstructors((prev) => prev.filter((i) => i.id !== id));
+      setSelectedIds((prev) => prev.filter((sid) => sid !== id));
+      toast.success('Instructor deleted');
+    } catch (err) {
+      toast.error('Failed to delete instructor');
+      console.error('Delete instructor error:', err);
+    }
   };
 
-  const deleteSelected = () => {
-    setInstructors((prev) => prev.filter((i) => !selectedIds.includes(i.id)));
-    setSelectedIds([]);
+  const deleteSelected = async () => {
+    try {
+      await Promise.all(selectedIds.map((id) => apiDeleteInstructor(id)));
+      setInstructors((prev) => prev.filter((i) => !selectedIds.includes(i.id)));
+      setSelectedIds([]);
+      toast.success('Selected instructors deleted');
+    } catch (err) {
+      toast.error('Failed to delete selected');
+      console.error('Bulk delete error:', err);
+    }
   };
 
   const updateInstructor = (updated) => {

--- a/frontend/src/services/admin/instructorService.js
+++ b/frontend/src/services/admin/instructorService.js
@@ -14,3 +14,8 @@ export const updateInstructorStatus = async (id, status) => {
   const { data } = await api.patch(`/users/admin/instructors/${id}/status`, { status });
   return data?.data;
 };
+
+export const deleteInstructor = async (id) => {
+  const { data } = await api.delete(`/users/admin/instructors/${id}`);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- enable deleting instructors via API
- call the new API from the admin instructors page
- support bulk deletion in UI
- cover the delete route with a test

## Testing
- `npm test` (backend tests)
- `npm test` (frontend: fails, missing script)


------
https://chatgpt.com/codex/tasks/task_e_684e67942ecc8328bfd57e3b45ac2f07