### PR TITLE
Add admin bookings API

### DIFF
--- a/backend/src/modules/bookings/bookings.controller.js
+++ b/backend/src/modules/bookings/bookings.controller.js
@@ -1,0 +1,44 @@
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./bookings.service");
+const { v4: uuidv4 } = require("uuid");
+
+exports.createBooking = catchAsync(async (req, res) => {
+  const { student_id, instructor_id, start_time, end_time, notes, status } = req.body;
+  if (!student_id || !instructor_id || !start_time || !end_time) {
+    throw new AppError("Missing required fields", 400);
+  }
+  const booking = await service.create({
+    id: uuidv4(),
+    student_id,
+    instructor_id,
+    start_time,
+    end_time,
+    notes,
+    status: status || "pending",
+  });
+  sendSuccess(res, booking, "Booking created");
+});
+
+exports.getBookings = catchAsync(async (_req, res) => {
+  const data = await service.getAll();
+  sendSuccess(res, data);
+});
+
+exports.getBooking = catchAsync(async (req, res) => {
+  const booking = await service.getById(req.params.id);
+  if (!booking) throw new AppError("Booking not found", 404);
+  sendSuccess(res, booking);
+});
+
+exports.updateBooking = catchAsync(async (req, res) => {
+  const booking = await service.update(req.params.id, req.body);
+  if (!booking) throw new AppError("Booking not found", 404);
+  sendSuccess(res, booking, "Booking updated");
+});
+
+exports.deleteBooking = catchAsync(async (req, res) => {
+  await service.delete(req.params.id);
+  sendSuccess(res, null, "Booking deleted");
+});

--- a/backend/src/modules/bookings/bookings.routes.js
+++ b/backend/src/modules/bookings/bookings.routes.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./bookings.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.post("/", controller.createBooking);
+router.get("/", controller.getBookings);
+router.get("/:id", controller.getBooking);
+router.patch("/:id", controller.updateBooking);
+router.delete("/:id", controller.deleteBooking);
+
+module.exports = router;

--- a/backend/src/modules/bookings/bookings.service.js
+++ b/backend/src/modules/bookings/bookings.service.js
@@ -1,0 +1,23 @@
+const db = require("../../config/database");
+
+exports.create = async (data) => {
+  const [row] = await db("bookings").insert(data).returning("*");
+  return row;
+};
+
+exports.getAll = async () => {
+  return db("bookings").select("*").orderBy("requested_at", "desc");
+};
+
+exports.getById = async (id) => {
+  return db("bookings").where({ id }).first();
+};
+
+exports.update = async (id, data) => {
+  const [row] = await db("bookings").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.delete = async (id) => {
+  return db("bookings").where({ id }).del();
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,6 +13,7 @@ const authRoutes = require("./modules/auth/routes/auth.routes");
 const userRoutes = require("./modules/users/user.routes");
 const verifyRoutes = require("./modules/verify/verify.routes"); // ✅ OTP routes
 const certificatePublicRoutes = require("./modules/users/tutorials/certificate/certificatePublic.routes");
+const adminBookingRoutes = require("./modules/bookings/bookings.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -62,6 +63,7 @@ app.use("/api/auth", authRoutes);      // 🔐 Auth: login, register, password r
 app.use("/api/users", userRoutes);     // 👤 Users: profile, avatar, demo video
 app.use("/api/verify", verifyRoutes);  // ✅ OTP: send/confirm email/phone
 app.use("/api/certificates", certificatePublicRoutes); // 🎓 Public certificate verification
+app.use("/api/bookings/admin", adminBookingRoutes); // 📅 Admin bookings management
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/backend/tests/adminBookingRoutes.test.js
+++ b/backend/tests/adminBookingRoutes.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/bookings/bookings.service', () => ({
+  getAll: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/bookings/bookings.service');
+const routes = require('../src/modules/bookings/bookings.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/bookings/admin', routes);
+
+describe('GET /api/bookings/admin', () => {
+  it('returns list of bookings', async () => {
+    const mock = [{ id: '1' }];
+    service.getAll.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/bookings/admin');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getAll).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add booking module (controller, service, routes)
- expose `/api/bookings/admin` route in server
- test admin bookings route

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684e7964e0388328b2abb2b61783f563