### PR TITLE
Connect admin bookings page to backend API

### DIFF
--- a/frontend/src/components/admin/bookings/BookingModal.js
+++ b/frontend/src/components/admin/bookings/BookingModal.js
@@ -1,14 +1,16 @@
 import { FaTimes } from 'react-icons/fa';
 import { useState } from 'react';
 
-export default function BookingModal({ booking, onClose }) {
+export default function BookingModal({ booking, onClose, onCancel }) {
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [cancelReason, setCancelReason] = useState('');
 
   if (!booking) return null;
 
   const handleCancel = () => {
-    console.log(`Cancel booking ${booking.id} - Reason:`, cancelReason);
+    if (onCancel) {
+      onCancel(booking.id, cancelReason);
+    }
     setShowCancelConfirm(false);
     onClose();
   };
@@ -49,7 +51,8 @@ export default function BookingModal({ booking, onClose }) {
           <div><strong>Status:</strong> <span className="capitalize">{booking.status}</span></div>
         </div>
 
-        {booking.status === 'Scheduled' && (
+        {(booking.status?.toLowerCase() === 'pending' ||
+          booking.status?.toLowerCase() === 'approved') && (
           <div className="mt-6">
             <button
               onClick={() => setShowCancelConfirm(true)}

--- a/frontend/src/components/admin/bookings/BookingRow.js
+++ b/frontend/src/components/admin/bookings/BookingRow.js
@@ -1,8 +1,10 @@
 export default function BookingRow({ booking, onView }) {
   const statusColors = {
-    Scheduled: 'bg-yellow-100 text-yellow-800',
-    Completed: 'bg-green-100 text-green-700',
-    Cancelled: 'bg-red-100 text-red-600',
+    pending: 'bg-yellow-100 text-yellow-800',
+    approved: 'bg-blue-100 text-blue-700',
+    declined: 'bg-red-100 text-red-600',
+    cancelled: 'bg-red-100 text-red-600',
+    completed: 'bg-green-100 text-green-700',
   };
 
   return (
@@ -24,9 +26,11 @@ export default function BookingRow({ booking, onView }) {
       <td className="px-4 py-2">{booking.duration}</td>
       <td className="px-4 py-2">
         <span
-          className={`text-xs px-2 py-1 rounded-full ${statusColors[booking.status]}`}
+          className={`text-xs px-2 py-1 rounded-full ${
+            statusColors[booking.status?.toLowerCase()] || 'bg-gray-100 text-gray-600'
+          }`}
         >
-          {booking.status}
+          {booking.status?.charAt(0).toUpperCase() + booking.status?.slice(1)}
         </span>
       </td>
     </tr>

--- a/frontend/src/services/admin/bookingService.js
+++ b/frontend/src/services/admin/bookingService.js
@@ -1,0 +1,26 @@
+import api from "@/services/api/api";
+
+export const fetchAllBookings = async () => {
+  const { data } = await api.get("/bookings/admin");
+  return data?.data ?? [];
+};
+
+export const fetchBookingById = async (id) => {
+  const { data } = await api.get(`/bookings/admin/${id}`);
+  return data?.data;
+};
+
+export const createBooking = async (payload) => {
+  const { data } = await api.post("/bookings/admin", payload);
+  return data?.data;
+};
+
+export const updateBooking = async (id, payload) => {
+  const { data } = await api.patch(`/bookings/admin/${id}`, payload);
+  return data?.data;
+};
+
+export const deleteBooking = async (id) => {
+  await api.delete(`/bookings/admin/${id}`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- create `bookingService` for admin API calls
- adapt `BookingModal` and `BookingRow` for real booking statuses
- fetch bookings from API and allow cancelling

## Testing
- `npm ls` *(fails: missing packages)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7b72024c8328adfccf2185ad301c