### PR TITLE
Add community admin endpoints

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -192,6 +192,7 @@
 - **Purpose**: Questions posted by users
 - **Primary Key**: `id`
 - **Foreign Keys**: `user_id`
+- **Columns**: `title`, `content`, `resolved`, `locked`, timestamps
 
 ### `community_replies`
 - **Purpose**: Answers/comments

--- a/backend/src/migrations/20250615000000_add_locked_to_community_discussions.js
+++ b/backend/src/migrations/20250615000000_add_locked_to_community_discussions.js
@@ -1,0 +1,15 @@
+// 📁 migrations/20250615000000_add_locked_to_community_discussions.js
+exports.up = async function(knex) {
+  const exists = await knex.schema.hasColumn('community_discussions', 'locked');
+  if (!exists) {
+    await knex.schema.alterTable('community_discussions', function(table) {
+      table.boolean('locked').defaultTo(false);
+    });
+  }
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('community_discussions', function(table) {
+    table.dropColumn('locked');
+  });
+};

--- a/backend/src/modules/community/admin/admin.controller.js
+++ b/backend/src/modules/community/admin/admin.controller.js
@@ -1,0 +1,32 @@
+const catchAsync = require("../../../utils/catchAsync");
+const AppError = require("../../../utils/AppError");
+const { sendSuccess } = require("../../../utils/response");
+const service = require("./admin.service");
+
+exports.getDiscussions = catchAsync(async (_req, res) => {
+  const list = await service.getAllDiscussions();
+  sendSuccess(res, list);
+});
+
+exports.getDiscussion = catchAsync(async (req, res) => {
+  const discussion = await service.getDiscussionById(req.params.id);
+  if (!discussion) throw new AppError("Discussion not found", 404);
+  sendSuccess(res, discussion);
+});
+
+exports.deleteDiscussion = catchAsync(async (req, res) => {
+  await service.deleteDiscussion(req.params.id);
+  sendSuccess(res, null, "Discussion deleted");
+});
+
+exports.lockDiscussion = catchAsync(async (req, res) => {
+  const row = await service.setLocked(req.params.id, true);
+  if (!row) throw new AppError("Discussion not found", 404);
+  sendSuccess(res, row, "Discussion locked");
+});
+
+exports.unlockDiscussion = catchAsync(async (req, res) => {
+  const row = await service.setLocked(req.params.id, false);
+  if (!row) throw new AppError("Discussion not found", 404);
+  sendSuccess(res, row, "Discussion unlocked");
+});

--- a/backend/src/modules/community/admin/admin.routes.js
+++ b/backend/src/modules/community/admin/admin.routes.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./admin.controller");
+const { verifyToken, isAdmin } = require("../../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.get("/discussions", controller.getDiscussions);
+router.get("/discussions/:id", controller.getDiscussion);
+router.delete("/discussions/:id", controller.deleteDiscussion);
+router.patch("/discussions/:id/lock", controller.lockDiscussion);
+router.patch("/discussions/:id/unlock", controller.unlockDiscussion);
+
+module.exports = router;

--- a/backend/src/modules/community/admin/admin.service.js
+++ b/backend/src/modules/community/admin/admin.service.js
@@ -1,0 +1,21 @@
+const db = require("../../../config/database");
+
+exports.getAllDiscussions = async () => {
+  return db("community_discussions").select("*").orderBy("created_at", "desc");
+};
+
+exports.getDiscussionById = async (id) => {
+  return db("community_discussions").where({ id }).first();
+};
+
+exports.deleteDiscussion = async (id) => {
+  return db("community_discussions").where({ id }).del();
+};
+
+exports.setLocked = async (id, locked) => {
+  const [row] = await db("community_discussions")
+    .where({ id })
+    .update({ locked, updated_at: db.fn.now() })
+    .returning("*");
+  return row;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -14,6 +14,7 @@ const userRoutes = require("./modules/users/user.routes");
 const verifyRoutes = require("./modules/verify/verify.routes"); // ✅ OTP routes
 const certificatePublicRoutes = require("./modules/users/tutorials/certificate/certificatePublic.routes");
 const adminBookingRoutes = require("./modules/bookings/bookings.routes");
+const adminCommunityRoutes = require("./modules/community/admin/admin.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -64,6 +65,7 @@ app.use("/api/users", userRoutes);     // 👤 Users: profile, avatar, demo vide
 app.use("/api/verify", verifyRoutes);  // ✅ OTP: send/confirm email/phone
 app.use("/api/certificates", certificatePublicRoutes); // 🎓 Public certificate verification
 app.use("/api/bookings/admin", adminBookingRoutes); // 📅 Admin bookings management
+app.use("/api/community/admin", adminCommunityRoutes); // 🗣️ Admin community management
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/backend/tests/adminCommunityRoutes.test.js
+++ b/backend/tests/adminCommunityRoutes.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/community/admin/admin.service', () => ({
+  getAllDiscussions: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/community/admin/admin.service');
+const routes = require('../src/modules/community/admin/admin.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/community/admin', routes);
+
+describe('GET /api/community/admin/discussions', () => {
+  it('returns list of discussions', async () => {
+    const mock = [{ id: '1' }];
+    service.getAllDiscussions.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/community/admin/discussions');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getAllDiscussions).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- support `locked` status for discussions
- add admin Community module with CRUD routes
- expose admin community routes from the server
- document new `locked` column in DB schema
- test admin community routes

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684e80b2533483288a7b0952d678ffc9