### PR TITLE
Connect admin community dashboard to API

### DIFF
--- a/backend/src/modules/community/admin/admin.controller.js
+++ b/backend/src/modules/community/admin/admin.controller.js
@@ -30,3 +30,9 @@ exports.unlockDiscussion = catchAsync(async (req, res) => {
   if (!row) throw new AppError("Discussion not found", 404);
   sendSuccess(res, row, "Discussion unlocked");
 });
+
+// Dashboard stats for admin overview
+exports.getDashboardData = catchAsync(async (_req, res) => {
+  const data = await service.getDashboardData();
+  sendSuccess(res, data);
+});

--- a/backend/src/modules/community/admin/admin.routes.js
+++ b/backend/src/modules/community/admin/admin.routes.js
@@ -18,6 +18,9 @@ router.delete("/discussions/:id", controller.deleteDiscussion);
 router.patch("/discussions/:id/lock", controller.lockDiscussion);
 router.patch("/discussions/:id/unlock", controller.unlockDiscussion);
 
+// Dashboard stats
+router.get("/stats", controller.getDashboardData);
+
 
 // Tags
 router.get("/tags", tagsController.listTags);

--- a/backend/src/modules/community/admin/admin.service.js
+++ b/backend/src/modules/community/admin/admin.service.js
@@ -19,3 +19,60 @@ exports.setLocked = async (id, locked) => {
     .returning("*");
   return row;
 };
+
+// Aggregate numbers for the admin dashboard
+exports.getDashboardData = async () => {
+  const [discussionsRow] = await db("community_discussions").count();
+  const [pendingReportsRow] = await db("community_reports")
+    .where({ status: "pending" })
+    .count();
+  const [contributorsRow] = await db("community_contributors").count();
+  const [repliesRow] = await db("community_replies")
+    .where("created_at", ">=", db.raw("now() - interval '7 days'"))
+    .count();
+
+  const top = await db("community_contributors")
+    .join("users", "community_contributors.user_id", "users.id")
+    .orderBy("community_contributors.score", "desc")
+    .first(
+      "users.full_name as name",
+      "users.avatar_url as avatar",
+      "community_contributors.discussions_count as contributions",
+      "community_contributors.score as reputation"
+    );
+
+  const activityData = [];
+  for (let i = 4; i >= 0; i--) {
+    const start = new Date();
+    start.setUTCHours(0, 0, 0, 0);
+    start.setDate(start.getDate() - i);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+
+    const [dCount] = await db("community_discussions")
+      .whereBetween("created_at", [start, end])
+      .count();
+    const [rCount] = await db("community_reports")
+      .whereBetween("reported_at", [start, end])
+      .count();
+    const [replyCount] = await db("community_replies")
+      .whereBetween("created_at", [start, end])
+      .count();
+
+    activityData.push({
+      date: start.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+      discussions: parseInt(dCount.count, 10) || 0,
+      reports: parseInt(rCount.count, 10) || 0,
+      replies: parseInt(replyCount.count, 10) || 0,
+    });
+  }
+
+  return {
+    totalDiscussions: parseInt(discussionsRow.count, 10) || 0,
+    pendingReports: parseInt(pendingReportsRow.count, 10) || 0,
+    contributors: parseInt(contributorsRow.count, 10) || 0,
+    repliesThisWeek: parseInt(repliesRow.count, 10) || 0,
+    topContributor: top || null,
+    activityData,
+  };
+};

--- a/backend/tests/adminCommunityRoutes.test.js
+++ b/backend/tests/adminCommunityRoutes.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 jest.mock('../src/modules/community/admin/admin.service', () => ({
   getAllDiscussions: jest.fn(),
+  getDashboardData: jest.fn(),
 }));
 
 
@@ -69,6 +70,18 @@ describe('GET /api/community/admin/announcements', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
     expect(annService.getAllAnnouncements).toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/community/admin/stats', () => {
+  it('returns dashboard stats', async () => {
+    const mock = { totalDiscussions: 5 };
+    service.getDashboardData.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/community/admin/stats');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getDashboardData).toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/pages/dashboard/admin/community/index.js
+++ b/frontend/src/pages/dashboard/admin/community/index.js
@@ -19,26 +19,7 @@ import {
   Legend,
 } from "recharts";
 
-const mockStats = {
-  totalDiscussions: 128,
-  pendingReports: 6,
-  contributors: 87,
-  repliesThisWeek: 342,
-  topContributor: {
-    name: "John Doe",
-    avatar: "/avatars/john.png",
-    contributions: 50,
-    reputation: 820,
-  },
-};
-
-const activityData = [
-  { date: "May 1", discussions: 5, reports: 2, replies: 30 },
-  { date: "May 2", discussions: 8, reports: 1, replies: 40 },
-  { date: "May 3", discussions: 3, reports: 3, replies: 22 },
-  { date: "May 4", discussions: 6, reports: 0, replies: 35 },
-  { date: "May 5", discussions: 7, reports: 1, replies: 38 },
-];
+import { fetchDashboardStats } from "@/services/admin/communityService";
 
 const NavCard = ({ href, icon, label }) => (
   <Link href={href}>
@@ -57,7 +38,37 @@ const StatCard = ({ label, value, color }) => (
 );
 
 export default function AdminCommunityDashboard() {
-  const stats = mockStats;
+  const [stats, setStats] = useState(null);
+  const [activityData, setActivityData] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchDashboardStats();
+        if (data) {
+          setStats({
+            totalDiscussions: data.totalDiscussions,
+            pendingReports: data.pendingReports,
+            contributors: data.contributors,
+            repliesThisWeek: data.repliesThisWeek,
+            topContributor: data.topContributor || {},
+          });
+          setActivityData(data.activityData || []);
+        }
+      } catch (err) {
+        console.error("Dashboard fetch error:", err);
+      }
+    };
+    load();
+  }, []);
+
+  if (!stats) {
+    return (
+      <AdminLayout title="Community Dashboard">
+        <div className="p-6">Loading...</div>
+      </AdminLayout>
+    );
+  }
 
   return (
     <AdminLayout title="Community Dashboard">

--- a/frontend/src/services/admin/communityService.js
+++ b/frontend/src/services/admin/communityService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const fetchDashboardStats = async () => {
+  const { data } = await api.get("/community/admin/stats");
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- provide backend dashboard data route
- expose controller to gather counts and chart info
- fetch dashboard stats in frontend instead of using mocks
- add test for new stats endpoint

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_684e849e247c8328b8211e2300442237