### PR TITLE
Fetch admin discussions from backend

### DIFF
--- a/frontend/src/services/admin/communityService.js
+++ b/frontend/src/services/admin/communityService.js
@@ -4,3 +4,23 @@ export const fetchDashboardStats = async () => {
   const { data } = await api.get("/community/admin/stats");
   return data?.data;
 };
+
+export const fetchDiscussions = async () => {
+  const { data } = await api.get("/community/admin/discussions");
+  return data?.data ?? [];
+};
+
+export const fetchDiscussionById = async (id) => {
+  const { data } = await api.get(`/community/admin/discussions/${id}`);
+  return data?.data ?? null;
+};
+
+export const lockDiscussionById = async (id) => {
+  const { data } = await api.patch(`/community/admin/discussions/${id}/lock`);
+  return data?.data;
+};
+
+export const deleteDiscussionById = async (id) => {
+  await api.delete(`/community/admin/discussions/${id}`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- add admin community discussion API helpers
- query backend for discussions list and individual details
- wire up lock & delete actions to backend endpoints

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684e8908e9bc8328887b48ccdf6e3546