### PR TITLE
Fix admin reports to fetch API

### DIFF
--- a/frontend/src/pages/dashboard/admin/community/reports/index.js
+++ b/frontend/src/pages/dashboard/admin/community/reports/index.js
@@ -1,31 +1,28 @@
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaExclamationCircle, FaTrash, FaEye } from "react-icons/fa";
-
-const mockReports = [
-  {
-    id: 1,
-    type: "discussion",
-    reason: "Inappropriate language",
-    content: "This is stupid!",
-    user: "user123",
-    discussionId: 5,
-  },
-  {
-    id: 2,
-    type: "reply",
-    reason: "Spam / promotion",
-    content: "Buy my course here: spamlink.com",
-    user: "marketer99",
-    discussionId: 2,
-  },
-];
+import { fetchReports } from "@/services/admin/communityService";
 
 export default function AdminCommunityReportsPage() {
   const [reports, setReports] = useState([]);
 
   useEffect(() => {
-    setReports(mockReports);
+    const load = async () => {
+      try {
+        const data = await fetchReports();
+        const formatted = (data || []).map((r) => ({
+          id: r.id,
+          reason: r.reason,
+          content: r.content || "",
+          user: r.reporter_id,
+          discussionId: r.discussion_id,
+        }));
+        setReports(formatted);
+      } catch (err) {
+        console.error("Failed to load reports", err);
+      }
+    };
+    load();
   }, []);
 
   const handleReview = (report) => {

--- a/frontend/src/services/admin/communityService.js
+++ b/frontend/src/services/admin/communityService.js
@@ -24,3 +24,13 @@ export const deleteDiscussionById = async (id) => {
   await api.delete(`/community/admin/discussions/${id}`);
   return true;
 };
+
+export const fetchReports = async () => {
+  const { data } = await api.get("/community/admin/reports");
+  return data?.data ?? [];
+};
+
+export const updateReportStatus = async (id, status) => {
+  const { data } = await api.patch(`/community/admin/reports/${id}`, { status });
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- integrate admin reports page with backend API
- expose API helpers for fetching and updating reports

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8a9e25c083289c89bbceede3aeb0