### PR TITLE
Connect contributors page to backend

### DIFF
--- a/backend/src/modules/community/admin/admin.routes.js
+++ b/backend/src/modules/community/admin/admin.routes.js
@@ -4,6 +4,7 @@ const controller = require("./admin.controller");
 const tagsController = require("./tags.controller");
 const announcementsController = require("./announcements.controller");
 const reportsController = require("./reports.controller");
+const contributorsController = require("./contributors.controller");
 
 const { verifyToken, isAdmin } = require("../../../middleware/auth/authMiddleware");
 
@@ -20,6 +21,9 @@ router.patch("/discussions/:id/unlock", controller.unlockDiscussion);
 
 // Dashboard stats
 router.get("/stats", controller.getDashboardData);
+
+// Contributors
+router.get("/contributors", contributorsController.listContributors);
 
 
 // Tags

--- a/backend/src/modules/community/admin/contributors.controller.js
+++ b/backend/src/modules/community/admin/contributors.controller.js
@@ -1,0 +1,9 @@
+const catchAsync = require("../../../utils/catchAsync");
+const { sendSuccess } = require("../../../utils/response");
+const service = require("./contributors.service");
+
+exports.listContributors = catchAsync(async (req, res) => {
+  const limit = parseInt(req.query.limit, 10) || 20;
+  const contributors = await service.getTopContributors(limit);
+  sendSuccess(res, contributors);
+});

--- a/backend/src/modules/community/admin/contributors.service.js
+++ b/backend/src/modules/community/admin/contributors.service.js
@@ -1,0 +1,14 @@
+const db = require("../../../config/database");
+
+exports.getTopContributors = async (limit = 20) => {
+  return db("community_contributors")
+    .join("users", "community_contributors.user_id", "users.id")
+    .select(
+      "users.full_name as name",
+      "users.avatar_url as avatar",
+      "community_contributors.discussions_count as contributions",
+      "community_contributors.score as reputation"
+    )
+    .orderBy("community_contributors.score", "desc")
+    .limit(limit);
+};

--- a/backend/tests/adminCommunityRoutes.test.js
+++ b/backend/tests/adminCommunityRoutes.test.js
@@ -20,6 +20,10 @@ jest.mock('../src/modules/community/admin/reports.service', () => ({
   updateStatus: jest.fn(),
 }));
 
+jest.mock('../src/modules/community/admin/contributors.service', () => ({
+  getTopContributors: jest.fn(),
+}));
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
@@ -29,6 +33,7 @@ const service = require('../src/modules/community/admin/admin.service');
 
 const tagService = require('../src/modules/community/admin/tags.service');
 const annService = require('../src/modules/community/admin/announcements.service');
+const contributorsService = require('../src/modules/community/admin/contributors.service');
 
 const routes = require('../src/modules/community/admin/admin.routes');
 
@@ -82,6 +87,18 @@ describe('GET /api/community/admin/stats', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
     expect(service.getDashboardData).toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/community/admin/contributors', () => {
+  it('returns contributors', async () => {
+    const mock = [{ name: 'Jane' }];
+    contributorsService.getTopContributors.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/community/admin/contributors');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(contributorsService.getTopContributors).toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/pages/dashboard/admin/community/contributors/index.js
+++ b/frontend/src/pages/dashboard/admin/community/contributors/index.js
@@ -1,19 +1,22 @@
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSearch, FaDownload } from "react-icons/fa";
-
-const mockContributors = [
-  { name: "John Doe", contributions: 50, reputation: 800, avatar: "/avatars/john.png" },
-  { name: "Jane Smith", contributions: 45, reputation: 720, avatar: "/avatars/jane.png" },
-  { name: "Emily Johnson", contributions: 38, reputation: 650, avatar: "" },
-];
+import { fetchContributors } from "@/services/admin/communityService";
 
 export default function AdminContributorsPage() {
   const [contributors, setContributors] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
-    setContributors(mockContributors);
+    const load = async () => {
+      try {
+        const data = await fetchContributors();
+        setContributors(data);
+      } catch (err) {
+        console.error("Contributors fetch error:", err);
+      }
+    };
+    load();
   }, []);
 
   const filtered = contributors.filter((c) =>

--- a/frontend/src/services/admin/communityService.js
+++ b/frontend/src/services/admin/communityService.js
@@ -35,6 +35,11 @@ export const updateReportStatus = async (id, status) => {
   return data?.data;
 };
 
+export const fetchContributors = async () => {
+  const { data } = await api.get('/community/admin/contributors');
+  return data?.data ?? [];
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tags
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add backend service/controller/route for contributors
- expose contributors route via `admin.routes`
- test new API endpoint
- fetch contributors on admin page instead of using mock data

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684e8e4ad40083289e12af74d77714c8