### PR TITLE
Link admin announcements to backend

### DIFF
--- a/frontend/src/services/admin/communityService.js
+++ b/frontend/src/services/admin/communityService.js
@@ -63,3 +63,22 @@ export const deleteTag = async (id) => {
   await api.delete(`/community/admin/tags/${id}`);
   return true;
 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Announcements
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const fetchAnnouncements = async () => {
+  const { data } = await api.get('/community/admin/announcements');
+  return data?.data ?? [];
+};
+
+export const createAnnouncement = async (payload) => {
+  const { data } = await api.post('/community/admin/announcements', payload);
+  return data?.data;
+};
+
+export const deleteAnnouncement = async (id) => {
+  await api.delete(`/community/admin/announcements/${id}`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- connect announcements admin page to backend services
- add admin announcement API helpers

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684e8fd4a0948328bde509ad6c15a0b6