### PR TITLE
Connect community settings to backend

### DIFF
--- a/backend/src/modules/community/admin/admin.routes.js
+++ b/backend/src/modules/community/admin/admin.routes.js
@@ -5,6 +5,7 @@ const tagsController = require("./tags.controller");
 const announcementsController = require("./announcements.controller");
 const reportsController = require("./reports.controller");
 const contributorsController = require("./contributors.controller");
+const settingsController = require("./settings.controller");
 
 const { verifyToken, isAdmin } = require("../../../middleware/auth/authMiddleware");
 
@@ -41,5 +42,9 @@ router.delete("/announcements/:id", announcementsController.deleteAnnouncement);
 // Reports
 router.get("/reports", reportsController.listReports);
 router.patch("/reports/:id", reportsController.updateReport);
+
+// Settings
+router.get("/settings", settingsController.getSettings);
+router.put("/settings", settingsController.updateSettings);
 
 module.exports = router;

--- a/backend/src/modules/community/admin/settings.controller.js
+++ b/backend/src/modules/community/admin/settings.controller.js
@@ -1,0 +1,13 @@
+const catchAsync = require("../../../utils/catchAsync");
+const { sendSuccess } = require("../../../utils/response");
+const service = require("./settings.service");
+
+exports.getSettings = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings);
+});
+
+exports.updateSettings = catchAsync(async (req, res) => {
+  const settings = await service.updateSettings(req.body);
+  sendSuccess(res, settings, "Settings updated");
+});

--- a/backend/src/modules/community/admin/settings.service.js
+++ b/backend/src/modules/community/admin/settings.service.js
@@ -1,0 +1,26 @@
+const db = require("../../../config/database");
+
+const SETTINGS_KEY = "community_settings";
+
+exports.getSettings = async () => {
+  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (!row) return [];
+  try {
+    return JSON.parse(row.value);
+  } catch (err) {
+    return [];
+  }
+};
+
+exports.updateSettings = async (settings) => {
+  const value = JSON.stringify(settings);
+  const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (existing) {
+    await db("settings")
+      .where({ key: SETTINGS_KEY })
+      .update({ value, updated_at: db.fn.now() });
+  } else {
+    await db("settings").insert({ key: SETTINGS_KEY, value });
+  }
+  return settings;
+};

--- a/backend/tests/adminCommunityRoutes.test.js
+++ b/backend/tests/adminCommunityRoutes.test.js
@@ -24,6 +24,11 @@ jest.mock('../src/modules/community/admin/contributors.service', () => ({
   getTopContributors: jest.fn(),
 }));
 
+jest.mock('../src/modules/community/admin/settings.service', () => ({
+  getSettings: jest.fn(),
+  updateSettings: jest.fn(),
+}));
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
@@ -34,6 +39,7 @@ const service = require('../src/modules/community/admin/admin.service');
 const tagService = require('../src/modules/community/admin/tags.service');
 const annService = require('../src/modules/community/admin/announcements.service');
 const contributorsService = require('../src/modules/community/admin/contributors.service');
+const settingsService = require('../src/modules/community/admin/settings.service');
 
 const routes = require('../src/modules/community/admin/admin.routes');
 
@@ -99,6 +105,32 @@ describe('GET /api/community/admin/contributors', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
     expect(contributorsService.getTopContributors).toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/community/admin/settings', () => {
+  it('returns settings', async () => {
+    const mock = [{ key: 'foo' }];
+    settingsService.getSettings.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/community/admin/settings');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(settingsService.getSettings).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/community/admin/settings', () => {
+  it('updates settings', async () => {
+    const payload = [{ key: 'foo' }];
+    settingsService.updateSettings.mockResolvedValue(payload);
+
+    const res = await request(app)
+      .put('/api/community/admin/settings')
+      .send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(payload);
+    expect(settingsService.updateSettings).toHaveBeenCalledWith(payload);
   });
 });
 

--- a/frontend/src/pages/dashboard/admin/community/settings.js
+++ b/frontend/src/pages/dashboard/admin/community/settings.js
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import SettingsPanel from "@/components/admin/community/SettingsPanel";
+import {
+  fetchCommunitySettings,
+  updateCommunitySettings,
+} from "@/services/admin/communityService";
 
 const defaultSettings = [
   { key: "allowGuestPosts", label: "Allow guest users to post", enabled: false },
@@ -13,7 +17,11 @@ export default function AdminCommunitySettingsPage() {
   const [settings, setSettings] = useState([]);
 
   useEffect(() => {
-    setSettings(defaultSettings); // Load from API/backend in real use
+    const load = async () => {
+      const data = await fetchCommunitySettings();
+      setSettings(data.length ? data : defaultSettings);
+    };
+    load();
   }, []);
 
   const handleToggle = (key) => {
@@ -24,10 +32,9 @@ export default function AdminCommunitySettingsPage() {
     );
   };
 
-  const handleSave = () => {
-    // In real case, you'd call an API to save settings
+  const handleSave = async () => {
+    await updateCommunitySettings(settings);
     alert("Settings saved successfully!");
-    console.log("Saved settings:", settings);
   };
 
   return (

--- a/frontend/src/services/admin/communityService.js
+++ b/frontend/src/services/admin/communityService.js
@@ -82,3 +82,17 @@ export const deleteAnnouncement = async (id) => {
   await api.delete(`/community/admin/announcements/${id}`);
   return true;
 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Settings
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const fetchCommunitySettings = async () => {
+  const { data } = await api.get('/community/admin/settings');
+  return data?.data ?? [];
+};
+
+export const updateCommunitySettings = async (payload) => {
+  const { data } = await api.put('/community/admin/settings', payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- add community settings controller and service to backend
- expose settings routes under `/api/community/admin`
- cover new endpoints with tests
- add frontend calls for fetching/updating settings
- load actual settings in admin page instead of mock data

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_684e9324baf8832890ca169e2616c434