### PR TITLE
Fix session expiry handling

### DIFF
--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -5,6 +5,7 @@
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 import api from "./api";
 import { toast } from "react-toastify";
+import Router from "next/router";
 import useAuthStore from "@/store/auth/authStore";
 
 let isRefreshing = false;
@@ -74,6 +75,9 @@ api.interceptors.response.use(
         authStore.logout();
         toast.info("You have been logged out.");
         toast.error("Session expired. Please log in again.");
+        if (typeof window !== "undefined") {
+          Router.push("/auth/login");
+        }
         return Promise.reject(refreshErr);
       } finally {
         isRefreshing = false;


### PR DESCRIPTION
## Summary
- redirect to login when token refresh fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eb74a835c832888e9a84efca5333b