### PR TITLE
Fix admin role check

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -33,7 +33,8 @@ const verifyToken = async (req, res, next) => {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     const roles = await userModel.getUserRoles(decoded.id);
-    req.user = { ...decoded, roles, role: roles[0] };
+    const userRoles = roles.length ? roles : [decoded.role];
+    req.user = { ...decoded, roles: userRoles, role: userRoles[0] };
     next();
   } catch (err) {
     return res.status(401).json({ message: "Invalid or expired token" });

--- a/backend/src/modules/roles/roles.controller.js
+++ b/backend/src/modules/roles/roles.controller.js
@@ -55,7 +55,7 @@ exports.assignPermissions = catchAsync(async (req, res) => {
   const role = await service.assignPermissions(
     req.params.id,
     req.body.permissionIds || [],
-    req.user.id
+    req.user?.id
   );
   sendSuccess(res, role, "Permissions assigned");
 });


### PR DESCRIPTION
## Summary
- fix user role detection when DB lacks role records
- make role permission controller tolerate missing user object

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684ec82f29e4832890db224275ad28fb