### PR TITLE
Add base roles seed

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -33,7 +33,8 @@ const verifyToken = async (req, res, next) => {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     const roles = await userModel.getUserRoles(decoded.id);
-    req.user = { ...decoded, roles, role: roles[0] };
+    const userRoles = roles.length ? roles : [decoded.role];
+    req.user = { ...decoded, roles: userRoles, role: userRoles[0] };
     next();
   } catch (err) {
     return res.status(401).json({ message: "Invalid or expired token" });

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -49,8 +49,9 @@ exports.registerUser = async (data) => {
   }
 
   const roles = await userModel.getUserRoles(newUser.id);
+  const tokenRoles = roles.length ? roles : [newUser.role];
 
-  const accessToken = generateAccessToken({ id: newUser.id, role: roles[0], roles });
+  const accessToken = generateAccessToken({ id: newUser.id, role: tokenRoles[0], roles: tokenRoles });
   const refreshToken = generateRefreshToken({ id: newUser.id });
 
   return { accessToken, refreshToken, user: { ...newUser, roles } };
@@ -68,7 +69,8 @@ exports.loginUser = async ({ email, password }) => {
   if (!match) throw new AppError("Invalid credentials", 401);
 
   const roles = await userModel.getUserRoles(user.id);
-  const accessToken = generateAccessToken({ id: user.id, role: roles[0], roles });
+  const tokenRoles = roles.length ? roles : [user.role];
+  const accessToken = generateAccessToken({ id: user.id, role: tokenRoles[0], roles: tokenRoles });
   const refreshToken = generateRefreshToken({ id: user.id });
 
   return { accessToken, refreshToken, user: { ...user, roles } };

--- a/backend/src/modules/roles/roles.controller.js
+++ b/backend/src/modules/roles/roles.controller.js
@@ -55,7 +55,7 @@ exports.assignPermissions = catchAsync(async (req, res) => {
   const role = await service.assignPermissions(
     req.params.id,
     req.body.permissionIds || [],
-    req.user.id
+    req.user?.id
   );
   sendSuccess(res, role, "Permissions assigned");
 });

--- a/backend/src/seeds/02_roles_seed.js
+++ b/backend/src/seeds/02_roles_seed.js
@@ -1,0 +1,10 @@
+exports.seed = async function (knex) {
+  await knex("roles").del();
+  const roles = [
+    { name: "SuperAdmin", description: "Platform owner with full access", created_at: new Date() },
+    { name: "Admin", description: "Administrator with management privileges", created_at: new Date() },
+    { name: "Instructor", description: "Can create and manage courses", created_at: new Date() },
+    { name: "Student", description: "Standard learner account", created_at: new Date() },
+  ];
+  await knex("roles").insert(roles);
+};


### PR DESCRIPTION
## Summary
- seed default roles to populate RBAC tables
- preserve roles when seeding SuperAdmin user

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec82f29e4832890db224275ad28fb