### PR TITLE
Add admin permissions page

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -2,7 +2,7 @@
 import {
   LayoutDashboard, CreditCard, Users, BadgeCheck, BookOpen, Brain, FileText, CalendarCheck2,
   UserCog, Megaphone, Settings, Phone, Plug, Globe, Mail, ImageIcon, ShieldCheck,
-  MessageCircleQuestion, BellRing, FileSignature, LayoutTemplate, Contact,
+  Key, MessageCircleQuestion, BellRing, FileSignature, LayoutTemplate, Contact,
   SearchCheck, ClipboardList, FolderKanban, DollarSign, Home, MessageCircle, Network, BookMarked,            // For Blogs
   HelpCircle,            // For FAQs
   LifeBuoy
@@ -34,7 +34,8 @@ export const adminNavLinks = [
       { label: 'Bookings', href: '/dashboard/admin/bookings', icon: CalendarCheck2 },
       { label: 'Community', href: '/dashboard/admin/community', icon: Users },
       { label: 'Community Groups', href: '/dashboard/admin/groups', icon: Users },
-      { label: 'Roles & Permissions', href: '/dashboard/admin/roles', icon: ShieldCheck },
+      { label: 'Roles', href: '/dashboard/admin/roles', icon: ShieldCheck },
+      { label: 'Permissions', href: '/dashboard/admin/permissions', icon: Key },
     ]
   },
   {

--- a/frontend/src/pages/dashboard/admin/permissions/index.js
+++ b/frontend/src/pages/dashboard/admin/permissions/index.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from "react";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { PlusCircle } from "lucide-react";
+import { fetchAllPermissions } from "@/services/admin/roleService";
+
+export default function PermissionsPage() {
+  const [permissions, setPermissions] = useState([]);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [newPermission, setNewPermission] = useState("");
+
+  useEffect(() => {
+    fetchAllPermissions().then(setPermissions);
+  }, []);
+
+  const handleAdd = () => {
+    if (newPermission && !permissions.includes(newPermission)) {
+      setPermissions([...permissions, newPermission]);
+    }
+    setNewPermission("");
+    setShowAddModal(false);
+  };
+
+  return (
+    <AdminLayout>
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-6">Permissions</h1>
+
+        <button
+          className="flex items-center mb-4 bg-yellow-100 hover:bg-yellow-200 rounded-xl py-2 px-4"
+          onClick={() => setShowAddModal(true)}
+        >
+          <PlusCircle className="w-5 h-5 mr-2 text-yellow-600" />
+          Add Permission
+        </button>
+
+        <ul className="space-y-2">
+          {permissions.map((perm) => (
+            <li key={perm} className="p-3 border rounded-xl bg-white capitalize">
+              {perm.replace(/_/g, " ")}
+            </li>
+          ))}
+        </ul>
+
+        {showAddModal && (
+          <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-40 z-50">
+            <div className="bg-white p-6 rounded-xl w-full max-w-md">
+              <h3 className="text-lg font-bold mb-4">Add New Permission</h3>
+              <input
+                value={newPermission}
+                onChange={(e) => setNewPermission(e.target.value)}
+                placeholder="e.g. manage_users"
+                className="w-full border p-2 rounded mb-4"
+              />
+              <div className="flex justify-end gap-4">
+                <button
+                  className="bg-gray-300 hover:bg-gray-400 text-gray-800 px-4 py-2 rounded"
+                  onClick={() => setShowAddModal(false)}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded"
+                  onClick={handleAdd}
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}

--- a/frontend/src/pages/dashboard/admin/roles/index.js
+++ b/frontend/src/pages/dashboard/admin/roles/index.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import RoleManagement from "@/components/admin/roles/RoleManagement";
 
-export default function RolesPermissionsPage() {
+export default function RolesPage() {
   const [editingRules, setEditingRules] = useState(false);
   const [selectedRole, setSelectedRole] = useState(null);
 
@@ -19,7 +19,7 @@ export default function RolesPermissionsPage() {
   return (
     <AdminLayout>
       <div className="p-8">
-        <h1 className="text-3xl font-bold mb-6">Roles & Permissions Management</h1>
+        <h1 className="text-3xl font-bold mb-6">Roles Management</h1>
 
         <RoleManagement onEditRules={handleEditRules} />
 


### PR DESCRIPTION
## Summary
- add dedicated admin page for managing permissions
- rename Roles screen heading
- add menu link for Permissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684efba2885483289f4b4f8c99ca75b4