### PR TITLE
Implement role CRUD in admin dashboard

### DIFF
--- a/frontend/src/components/admin/roles/AddRoleModal.js
+++ b/frontend/src/components/admin/roles/AddRoleModal.js
@@ -1,0 +1,52 @@
+import { useState, useEffect } from "react";
+
+export default function AddRoleModal({ isOpen, onClose, onSubmit }) {
+  const [form, setForm] = useState({ name: "", description: "" });
+
+  useEffect(() => {
+    if (isOpen) setForm({ name: "", description: "" });
+  }, [isOpen]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = () => {
+    if (!form.name.trim()) return;
+    onSubmit(form);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black bg-opacity-40 flex items-center justify-center">
+      <div className="bg-white p-6 rounded-lg w-full max-w-md">
+        <h2 className="text-lg font-semibold mb-4">Add New Role</h2>
+        <input
+          type="text"
+          name="name"
+          placeholder="Role Name"
+          value={form.name}
+          onChange={handleChange}
+          className="w-full border p-2 rounded mb-3"
+        />
+        <textarea
+          name="description"
+          placeholder="Description"
+          value={form.description}
+          onChange={handleChange}
+          className="w-full border p-2 rounded mb-4"
+        />
+        <div className="flex justify-end gap-3">
+          <button onClick={onClose} className="px-4 py-2 bg-gray-200 rounded">
+            Cancel
+          </button>
+          <button onClick={handleSubmit} className="px-4 py-2 bg-blue-600 text-white rounded">
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/roles/EditRoleModal.js
+++ b/frontend/src/components/admin/roles/EditRoleModal.js
@@ -1,0 +1,52 @@
+import { useState, useEffect } from "react";
+
+export default function EditRoleModal({ isOpen, onClose, role, onSubmit }) {
+  const [form, setForm] = useState({ name: "", description: "" });
+
+  useEffect(() => {
+    if (role) setForm({ name: role.name || "", description: role.description || "" });
+  }, [role]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = () => {
+    if (!form.name.trim()) return;
+    onSubmit(form);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black bg-opacity-40 flex items-center justify-center">
+      <div className="bg-white p-6 rounded-lg w-full max-w-md">
+        <h2 className="text-lg font-semibold mb-4">Edit Role</h2>
+        <input
+          type="text"
+          name="name"
+          placeholder="Role Name"
+          value={form.name}
+          onChange={handleChange}
+          className="w-full border p-2 rounded mb-3"
+        />
+        <textarea
+          name="description"
+          placeholder="Description"
+          value={form.description}
+          onChange={handleChange}
+          className="w-full border p-2 rounded mb-4"
+        />
+        <div className="flex justify-end gap-3">
+          <button onClick={onClose} className="px-4 py-2 bg-gray-200 rounded">
+            Cancel
+          </button>
+          <button onClick={handleSubmit} className="px-4 py-2 bg-blue-600 text-white rounded">
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/roles/RoleManagement.js
+++ b/frontend/src/components/admin/roles/RoleManagement.js
@@ -1,11 +1,21 @@
 import React, { useState, useEffect } from "react";
-import { ShieldCheck } from "lucide-react";
+import { ShieldCheck, PlusCircle, PenSquare, Trash2 } from "lucide-react";
 import PermissionAssignment from "./PermissionAssignment";
-import { fetchAllRoles, fetchRoleById } from "@/services/admin/roleService";
+import AddRoleModal from "./AddRoleModal";
+import EditRoleModal from "./EditRoleModal";
+import {
+  fetchAllRoles,
+  fetchRoleById,
+  createRole,
+  updateRole,
+  deleteRole,
+} from "@/services/admin/roleService";
 
 export default function RoleManagement() {
   const [roles, setRoles] = useState([]);
   const [selectedRole, setSelectedRole] = useState(null);
+  const [showAdd, setShowAdd] = useState(false);
+  const [editRole, setEditRole] = useState(null);
 
   useEffect(() => {
     fetchAllRoles().then((data) => {
@@ -21,12 +31,38 @@ export default function RoleManagement() {
     setSelectedRole(detailed);
   };
 
+  const handleAddRole = async (payload) => {
+    const newRole = await createRole(payload);
+    setRoles((r) => [...r, newRole]);
+    setShowAdd(false);
+  };
+
+  const handleUpdateRole = async (payload) => {
+    const updated = await updateRole(editRole.id, payload);
+    setRoles((r) => r.map((ro) => (ro.id === updated.id ? updated : ro)));
+    setEditRole(null);
+    if (selectedRole?.id === updated.id) setSelectedRole(updated);
+  };
+
+  const handleDeleteRole = async (id) => {
+    if (!confirm("Delete this role?")) return;
+    await deleteRole(id);
+    setRoles((r) => r.filter((ro) => ro.id !== id));
+    if (selectedRole?.id === id) setSelectedRole(null);
+  };
+
   return (
     <div className="flex space-x-8">
       <div className="w-1/4 bg-white rounded-2xl shadow-md border border-gray-100 p-5">
         <h3 className="font-semibold text-xl flex items-center mb-4 text-gray-800">
           <ShieldCheck className="mr-2 text-yellow-500" /> Roles
         </h3>
+        <button
+          onClick={() => setShowAdd(true)}
+          className="flex items-center text-sm mb-4 bg-yellow-100 hover:bg-yellow-200 rounded-xl py-2 px-3"
+        >
+          <PlusCircle className="w-4 h-4 mr-1 text-yellow-600" /> Add Role
+        </button>
         <ul className="space-y-2">
           {roles.map((role) => (
             <li
@@ -38,7 +74,25 @@ export default function RoleManagement() {
               }`}
               onClick={() => handleSelect(role)}
             >
-              {role.name}
+              <div className="flex justify-between items-center">
+                <span>{role.name}</span>
+                <span className="flex gap-1">
+                  <PenSquare
+                    className="w-4 h-4 cursor-pointer"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setEditRole(role);
+                    }}
+                  />
+                  <Trash2
+                    className="w-4 h-4 cursor-pointer text-red-600"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteRole(role.id);
+                    }}
+                  />
+                </span>
+              </div>
             </li>
           ))}
         </ul>
@@ -47,6 +101,21 @@ export default function RoleManagement() {
       <div className="w-3/4 bg-white rounded-2xl shadow-md border border-gray-100 p-5">
         {selectedRole && <PermissionAssignment role={selectedRole} />}
       </div>
+      {showAdd && (
+        <AddRoleModal
+          isOpen={showAdd}
+          onClose={() => setShowAdd(false)}
+          onSubmit={handleAddRole}
+        />
+      )}
+      {editRole && (
+        <EditRoleModal
+          isOpen={Boolean(editRole)}
+          role={editRole}
+          onClose={() => setEditRole(null)}
+          onSubmit={handleUpdateRole}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/services/admin/roleService.js
+++ b/frontend/src/services/admin/roleService.js
@@ -19,3 +19,18 @@ export const updateRolePermissions = async (id, permissionIds) => {
   const { data } = await api.post(`/roles/${id}/permissions`, { permissionIds });
   return data?.data;
 };
+
+export const createRole = async (payload) => {
+  const { data } = await api.post("/roles", payload);
+  return data?.data;
+};
+
+export const updateRole = async (id, payload) => {
+  const { data } = await api.put(`/roles/${id}`, payload);
+  return data?.data;
+};
+
+export const deleteRole = async (id) => {
+  await api.delete(`/roles/${id}`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- add modals for creating and editing roles
- enable add/edit/delete in RoleManagement
- expose create/update/delete API functions in role service

## Testing
- `npm test` (fails: jest not found)
- `npm test` in frontend (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_684f00660710832884f1d9d7e8f07093