### PR TITLE
Fix admin permissions page

### DIFF
--- a/frontend/src/pages/dashboard/admin/permissions/index.js
+++ b/frontend/src/pages/dashboard/admin/permissions/index.js
@@ -1,7 +1,11 @@
 import React, { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { PlusCircle } from "lucide-react";
-import { fetchAllPermissions } from "@/services/admin/roleService";
+import { PlusCircle, Trash2 } from "lucide-react";
+import {
+  fetchAllPermissions,
+  createPermission,
+  deletePermission,
+} from "@/services/admin/roleService";
 
 export default function PermissionsPage() {
   const [permissions, setPermissions] = useState([]);
@@ -12,12 +16,19 @@ export default function PermissionsPage() {
     fetchAllPermissions().then(setPermissions);
   }, []);
 
-  const handleAdd = () => {
-    if (newPermission && !permissions.includes(newPermission)) {
-      setPermissions([...permissions, newPermission]);
-    }
+  const handleAdd = async () => {
+    if (!newPermission.trim()) return;
+    if (permissions.some((p) => p.code === newPermission)) return;
+    const created = await createPermission({ code: newPermission });
+    setPermissions([...permissions, created]);
     setNewPermission("");
     setShowAddModal(false);
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm("Delete this permission?")) return;
+    await deletePermission(id);
+    setPermissions((perms) => perms.filter((p) => p.id !== id));
   };
 
   return (
@@ -35,8 +46,15 @@ export default function PermissionsPage() {
 
         <ul className="space-y-2">
           {permissions.map((perm) => (
-            <li key={perm} className="p-3 border rounded-xl bg-white capitalize">
-              {perm.replace(/_/g, " ")}
+            <li
+              key={perm.id}
+              className="p-3 border rounded-xl bg-white capitalize flex justify-between items-center"
+            >
+              {perm.code.replace(/_/g, " ")}
+              <Trash2
+                className="w-4 h-4 text-red-600 cursor-pointer"
+                onClick={() => handleDelete(perm.id)}
+              />
             </li>
           ))}
         </ul>

--- a/frontend/src/services/admin/roleService.js
+++ b/frontend/src/services/admin/roleService.js
@@ -34,3 +34,18 @@ export const deleteRole = async (id) => {
   await api.delete(`/roles/${id}`);
   return true;
 };
+
+export const createPermission = async (payload) => {
+  const { data } = await api.post('/roles/permissions', payload);
+  return data?.data;
+};
+
+export const updatePermission = async (id, payload) => {
+  const { data } = await api.put(`/roles/permissions/${id}`, payload);
+  return data?.data;
+};
+
+export const deletePermission = async (id) => {
+  await api.delete(`/roles/permissions/${id}`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- implement permission CRUD API helpers
- enable creating and deleting permissions from the admin UI

## Testing
- `npm test` in `backend`
- `npm run lint` in `frontend` *(fails: 56 errors, 169 warnings)*
- `npm run build` in `frontend` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_684f01c2f3788328ae9dec4b8800ca91