### PR TITLE
Extend verifyToken to include verification flags

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -32,9 +32,18 @@ const verifyToken = async (req, res, next) => {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await userModel.findById(decoded.id);
+    if (!user) {
+      return res.status(401).json({ message: "Invalid or expired token" });
+    }
     const roles = await userModel.getUserRoles(decoded.id);
-    const userRoles = roles.length ? roles : [decoded.role];
-    req.user = { ...decoded, roles: userRoles, role: userRoles[0] };
+    const userRoles = roles.length ? roles : [user.role];
+    req.user = {
+      ...decoded,
+      ...user,
+      roles: userRoles,
+      role: userRoles[0],
+    };
     next();
   } catch (err) {
     return res.status(401).json({ message: "Invalid or expired token" });


### PR DESCRIPTION
## Summary
- fetch full user details inside auth middleware
- include email and phone verification status on `req.user`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fd222c6188328b6cc6b69c3f32027