### PR TITLE
Centralize role definitions

### DIFF
--- a/backend/src/migrations/20250517175840_create_users_table.js
+++ b/backend/src/migrations/20250517175840_create_users_table.js
@@ -1,3 +1,5 @@
+const { ROLE_NAMES } = require("../utils/enums");
+
 exports.up = function(knex) {
   return knex.schema.createTable('users', function(table) {
     table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
@@ -5,7 +7,7 @@ exports.up = function(knex) {
     table.string('email').notNullable().unique();
     table.string('phone').unique();
     table.text('password_hash').notNullable();
-    table.enu('role', ['Student', 'Instructor', 'User', 'Admin']).notNullable();
+    table.enu('role', ROLE_NAMES).notNullable();
     table.string('avatar_url');
     table.boolean('is_email_verified').defaultTo(false);
     table.enu("status", ["pending", "active", "banned"]).notNullable().defaultTo("pending");

--- a/backend/src/migrations/20250517180443_create_roles_table.js
+++ b/backend/src/migrations/20250517180443_create_roles_table.js
@@ -1,7 +1,7 @@
 exports.up = function(knex) {
   return knex.schema.createTable('roles', function(table) {
     table.increments('id').primary();
-    table.string('name').notNullable().unique(); // e.g. Admin, Student, Instructor
+    table.string('name').notNullable().unique(); // e.g. Student, Instructor, Admin, SuperAdmin
     table.text('description');
     table.timestamp('created_at').defaultTo(knex.fn.now());
   });

--- a/backend/src/migrations/20250518203516_update_user_role_enum.js
+++ b/backend/src/migrations/20250518203516_update_user_role_enum.js
@@ -1,17 +1,23 @@
+const { ROLE_NAMES } = require("../utils/enums");
+
 exports.up = async function(knex) {
+  const roles = ROLE_NAMES.map((r) => `'${r}'`).join(', ');
   await knex.raw(`
     ALTER TABLE users
     DROP CONSTRAINT IF EXISTS users_role_check,
-    ADD CONSTRAINT users_role_check 
-    CHECK (role IN ('Student', 'Instructor', 'Admin', 'SuperAdmin'));
+    ADD CONSTRAINT users_role_check
+    CHECK (role IN (${roles}));
   `);
 };
 
 exports.down = async function(knex) {
+  const roles = ROLE_NAMES.filter((r) => r !== 'SuperAdmin')
+    .map((r) => `'${r}'`)
+    .join(', ');
   await knex.raw(`
     ALTER TABLE users
     DROP CONSTRAINT IF EXISTS users_role_check,
-    ADD CONSTRAINT users_role_check 
-    CHECK (role IN ('Student', 'Instructor', 'Admin'));
+    ADD CONSTRAINT users_role_check
+    CHECK (role IN (${roles}));
   `);
 };

--- a/backend/src/utils/enums.js
+++ b/backend/src/utils/enums.js
@@ -1,5 +1,14 @@
 // 📁 src/utils/enums.js
-exports.ROLES = Object.freeze({ STUDENT: "student", INSTRUCTOR: "instructor", ADMIN: "admin", SUPERADMIN: "superadmin" });
+// Central list of valid user roles
+const ROLE_NAMES = ["Student", "Instructor", "Admin", "SuperAdmin"];
+exports.ROLE_NAMES = ROLE_NAMES;
+
+exports.ROLES = Object.freeze({
+  STUDENT: "student",
+  INSTRUCTOR: "instructor",
+  ADMIN: "admin",
+  SUPERADMIN: "superadmin",
+});
 exports.STATUS = Object.freeze({
   ACTIVE: "active",
   INACTIVE: "inactive",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,8 @@
 # Backend Architecture Overview
 
-This project uses a modular Express.js structure. Each user role (Admin, Instructor and Student) has its own set of controllers and routes under `src/modules/users`. Tutorials and their related resources live under `src/modules/users/tutorials`.
+This project uses a modular Express.js structure. Each user role (Student, Instructor, Admin and SuperAdmin) has its own set of controllers and routes under `src/modules/users`. Tutorials and their related resources live under `src/modules/users/tutorials`.
+
+The valid roles available in the system are `Student`, `Instructor`, `Admin` and `SuperAdmin`. These values are referenced throughout the codebase and database migrations from a single shared constant.
 
 Uploaded tutorial assets are stored in role specific folders:
 


### PR DESCRIPTION
## Summary
- expose `ROLE_NAMES` in `enums.js`
- use `ROLE_NAMES` in user table migration
- update role enum migration to reference the constant
- clarify example in roles table migration
- document the canonical list of roles in `architecture.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fd223c6d08328a1e66701bf55aaf0