### PR TITLE
Fix role name className interpolation

### DIFF
--- a/frontend/src/components/admin/roles/RoleManagement.js
+++ b/frontend/src/components/admin/roles/RoleManagement.js
@@ -67,7 +67,7 @@ export default function RoleManagement() {
           {roles.map((role) => (
             <li
               key={role.id}
-              className={`p-3 rounded-xl cursor-pointer transition duration-200$${'{'}
+              className={`p-3 rounded-xl cursor-pointer transition duration-200 ${
                 selectedRole?.id === role.id
                   ? "bg-yellow-500 text-white shadow-md"
                   : "hover:bg-yellow-50 text-gray-700"


### PR DESCRIPTION
## Summary
- fix a stray interpolation in `RoleManagement` component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe5335f4c8328b22f96b567cd7d35