### PR TITLE
Fix permissions assignment

### DIFF
--- a/frontend/src/components/admin/roles/PermissionAssignment.js
+++ b/frontend/src/components/admin/roles/PermissionAssignment.js
@@ -4,6 +4,7 @@ import {
   fetchAllPermissions,
   updateRolePermissions,
   fetchRoleById,
+  createPermission,
 } from "@/services/admin/roleService";
 
 export default function PermissionAssignment({ role }) {
@@ -38,18 +39,21 @@ export default function PermissionAssignment({ role }) {
     );
   };
 
-  const handleAddNewPermission = () => {
+  const handleAddNewPermission = async () => {
     if (newPermission && !permissions.some((p) => p.code === newPermission)) {
-      const tempPerm = { id: `new_${newPermission}`, code: newPermission };
-      setPermissions([...permissions, tempPerm]);
-      setAssignedPermissions([...assignedPermissions, newPermission]);
+      const created = await createPermission({ code: newPermission });
+      setPermissions([...permissions, created]);
+      setAssignedPermissions([...assignedPermissions, created.code]);
     }
     setNewPermission("");
     setShowAddModal(false);
   };
 
   const handleSave = async () => {
-    await updateRolePermissions(role.id, assignedPermissions);
+    const ids = assignedPermissions
+      .map((code) => permissions.find((p) => p.code === code)?.id)
+      .filter(Boolean);
+    await updateRolePermissions(role.id, ids);
   };
 
   return (


### PR DESCRIPTION
## Summary
- call `createPermission` when adding new permission
- convert permission codes to IDs before saving

## Testing
- `npm run lint` *(fails: 56 errors, 169 warnings)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe8f57c7083289ccb79de90f078e0