### PR TITLE
Fix refresh token error handling

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -58,10 +58,17 @@ exports.refreshToken = catchAsync((req, res) => {
   const token = req.cookies.refreshToken;
   if (!token) return res.status(401).json({ message: "Missing refresh token" });
 
-  const decoded = authService.verifyRefreshToken(token);
-  const accessToken = authService.generateAccessToken({ id: decoded.id, role: decoded.role });
-
-  res.json({ accessToken });
+  try {
+    const decoded = authService.verifyRefreshToken(token);
+    const accessToken = authService.generateAccessToken({
+      id: decoded.id,
+      role: decoded.role,
+    });
+    res.json({ accessToken });
+  } catch (err) {
+    console.error("❌ Refresh token error:", err.message);
+    return res.status(401).json({ message: "Invalid or expired refresh token" });
+  }
 });
 
 /**


### PR DESCRIPTION
## Summary
- handle errors in refreshToken controller

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684fecce65408328b98506672fd1b2aa