### PR TITLE
Improve admin permissions page UI

### DIFF
--- a/frontend/src/pages/dashboard/admin/permissions/index.js
+++ b/frontend/src/pages/dashboard/admin/permissions/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { PlusCircle, Trash2 } from "lucide-react";
+import toast from "react-hot-toast";
 import {
   fetchAllPermissions,
   createPermission,
@@ -11,24 +12,48 @@ export default function PermissionsPage() {
   const [permissions, setPermissions] = useState([]);
   const [showAddModal, setShowAddModal] = useState(false);
   const [newPermission, setNewPermission] = useState("");
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    fetchAllPermissions().then(setPermissions);
+    (async () => {
+      try {
+        setLoading(true);
+        const data = await fetchAllPermissions();
+        setPermissions(data);
+      } catch (err) {
+        console.error(err);
+        toast.error("Failed to load permissions");
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, []);
 
   const handleAdd = async () => {
     if (!newPermission.trim()) return;
     if (permissions.some((p) => p.code === newPermission)) return;
-    const created = await createPermission({ code: newPermission });
-    setPermissions([...permissions, created]);
+    try {
+      const created = await createPermission({ code: newPermission });
+      setPermissions([...permissions, created]);
+      toast.success("Permission added");
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to add permission");
+    }
     setNewPermission("");
     setShowAddModal(false);
   };
 
   const handleDelete = async (id) => {
     if (!confirm("Delete this permission?")) return;
-    await deletePermission(id);
-    setPermissions((perms) => perms.filter((p) => p.id !== id));
+    try {
+      await deletePermission(id);
+      setPermissions((perms) => perms.filter((p) => p.id !== id));
+      toast.success("Permission removed");
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to delete");
+    }
   };
 
   return (
@@ -44,20 +69,45 @@ export default function PermissionsPage() {
           Add Permission
         </button>
 
-        <ul className="space-y-2">
-          {permissions.map((perm) => (
-            <li
-              key={perm.id}
-              className="p-3 border rounded-xl bg-white capitalize flex justify-between items-center"
-            >
-              {perm.code.replace(/_/g, " ")}
-              <Trash2
-                className="w-4 h-4 text-red-600 cursor-pointer"
-                onClick={() => handleDelete(perm.id)}
-              />
-            </li>
-          ))}
-        </ul>
+        <div className="overflow-x-auto rounded-xl shadow">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="px-4 py-2 text-left">Permission</th>
+                <th className="px-4 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {permissions.map((perm) => (
+                <tr key={perm.id} className="bg-white hover:bg-gray-50">
+                  <td className="px-4 py-2 capitalize">
+                    {perm.code.replace(/_/g, " ")}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <Trash2
+                      className="w-4 h-4 text-red-600 cursor-pointer"
+                      onClick={() => handleDelete(perm.id)}
+                    />
+                  </td>
+                </tr>
+              ))}
+              {permissions.length === 0 && !loading && (
+                <tr>
+                  <td className="px-4 py-3 text-center" colSpan="2">
+                    No permissions found
+                  </td>
+                </tr>
+              )}
+              {loading && (
+                <tr>
+                  <td className="px-4 py-3 text-center" colSpan="2">
+                    Loading...
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
 
         {showAddModal && (
           <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-40 z-50">


### PR DESCRIPTION
## Summary
- add toast notifications and loading state to permission list
- handle API errors when fetching, adding or deleting permissions
- style permissions as a simple table with placeholders

## Testing
- `npm run lint` *(fails: React Hook "useRef" cannot be called inside a callback)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fef67b3388328997723063a0f5d4b