### PR TITLE
Fix refresh token handler

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -54,7 +54,7 @@ exports.login = catchAsync(async (req, res) => {
  * @desc Refresh access token using refresh token cookie
  * @access Public
  */
-exports.refreshToken = catchAsync((req, res) => {
+exports.refreshToken = catchAsync(async (req, res) => {
   const token = req.cookies.refreshToken;
   if (!token) return res.status(401).json({ message: "Missing refresh token" });
 

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -83,12 +83,16 @@ function generateAccessToken(payload) {
   return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: ACCESS_EXPIRES_IN });
 }
 
+exports.generateAccessToken = generateAccessToken;
+
 /**
  * Generate JWT refresh token
  */
 function generateRefreshToken(payload) {
   return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: REFRESH_EXPIRES_IN });
 }
+
+exports.generateRefreshToken = generateRefreshToken;
 
 /**
  * Verify JWT refresh token


### PR DESCRIPTION
## Summary
- export token generation helpers from `auth.service`
- fix controller wrapper for refresh tokens

## Testing
- `npm install --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684ff142c2dc832893a91d39df148acd