### PR TITLE
Add subscription plans API

### DIFF
--- a/backend/src/modules/plans/plans.controller.js
+++ b/backend/src/modules/plans/plans.controller.js
@@ -1,0 +1,91 @@
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./plans.service");
+const slugify = require("slugify");
+
+exports.createPlan = catchAsync(async (req, res) => {
+  const {
+    name,
+    slug,
+    price_monthly,
+    price_yearly,
+    currency = "USD",
+    recommended = false,
+    active = true,
+    features = [],
+  } = req.body;
+
+  if (!name) throw new AppError("Name is required", 400);
+
+  const planSlug = slug || slugify(name, { lower: true, strict: true });
+  const exists = await service.findBySlug(planSlug);
+  if (exists) throw new AppError("Plan slug already exists", 409);
+
+  const plan = await service.createPlan({
+    name,
+    slug: planSlug,
+    price_monthly: price_monthly || 0,
+    price_yearly: price_yearly || 0,
+    currency,
+    recommended,
+    active,
+  });
+
+  await service.setFeatures(plan.id, Array.isArray(features) ? features : []);
+  const full = await service.getPlanById(plan.id);
+  sendSuccess(res, full, "Plan created");
+});
+
+exports.getPlans = catchAsync(async (_req, res) => {
+  const plans = await service.getPlans();
+  sendSuccess(res, plans);
+});
+
+exports.getPlan = catchAsync(async (req, res) => {
+  const plan = await service.getPlanById(req.params.id);
+  if (!plan) throw new AppError("Plan not found", 404);
+  sendSuccess(res, plan);
+});
+
+exports.updatePlan = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  const {
+    name,
+    slug,
+    price_monthly,
+    price_yearly,
+    currency,
+    recommended,
+    active,
+    features,
+  } = req.body;
+
+  const updates = {};
+  if (name) updates.name = name;
+  if (price_monthly !== undefined) updates.price_monthly = price_monthly;
+  if (price_yearly !== undefined) updates.price_yearly = price_yearly;
+  if (currency) updates.currency = currency;
+  if (recommended !== undefined) updates.recommended = recommended;
+  if (active !== undefined) updates.active = active;
+
+  if (slug || name) {
+    const planSlug = slug || slugify(name, { lower: true, strict: true });
+    const existing = await service.findBySlug(planSlug);
+    if (existing && existing.id != id) throw new AppError("Plan slug already exists", 409);
+    updates.slug = planSlug;
+  }
+
+  const updated = await service.updatePlan(id, updates);
+  if (!updated) throw new AppError("Plan not found", 404);
+
+  if (features) await service.setFeatures(id, Array.isArray(features) ? features : []);
+  const full = await service.getPlanById(id);
+  sendSuccess(res, full, "Plan updated");
+});
+
+exports.deletePlan = catchAsync(async (req, res) => {
+  const count = await service.deletePlan(req.params.id);
+  if (!count) throw new AppError("Plan not found", 404);
+  sendSuccess(res, null, "Plan deleted");
+});

--- a/backend/src/modules/plans/plans.routes.js
+++ b/backend/src/modules/plans/plans.routes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./plans.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.getPlans);
+router.get("/:id", controller.getPlan);
+router.post("/", verifyToken, isAdmin, controller.createPlan);
+router.put("/:id", verifyToken, isAdmin, controller.updatePlan);
+router.delete("/:id", verifyToken, isAdmin, controller.deletePlan);
+
+module.exports = router;

--- a/backend/src/modules/plans/plans.service.js
+++ b/backend/src/modules/plans/plans.service.js
@@ -1,0 +1,46 @@
+const db = require("../../config/database");
+
+exports.createPlan = async (data) => {
+  const [row] = await db("plans").insert(data).returning("*");
+  return row;
+};
+
+exports.findBySlug = (slug) => db("plans").where({ slug }).first();
+
+exports.getPlans = async () => {
+  const plans = await db("plans").select("*").orderBy("id");
+  const features = await db("plan_features").select("*");
+  return plans.map((p) => ({
+    ...p,
+    features: features.filter((f) => f.plan_id === p.id),
+  }));
+};
+
+exports.getPlanById = async (id) => {
+  const plan = await db("plans").where({ id }).first();
+  if (!plan) return null;
+  const feats = await db("plan_features").where({ plan_id: id }).select("*");
+  plan.features = feats;
+  return plan;
+};
+
+exports.updatePlan = async (id, data) => {
+  const [row] = await db("plans").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.deletePlan = (id) => db("plans").where({ id }).del();
+
+exports.setFeatures = async (planId, features = []) => {
+  await db("plan_features").where({ plan_id: planId }).del();
+  if (features.length) {
+    const rows = features.map((f) => ({
+      plan_id: planId,
+      feature_key: f.feature_key,
+      value: f.value,
+      description: f.description || null,
+    }));
+    await db("plan_features").insert(rows);
+  }
+  return db("plan_features").where({ plan_id: planId }).select("*");
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,6 +16,7 @@ const certificatePublicRoutes = require("./modules/users/tutorials/certificate/c
 const adminBookingRoutes = require("./modules/bookings/bookings.routes");
 const adminCommunityRoutes = require("./modules/community/admin/admin.routes");
 const roleRoutes = require("./modules/roles/roles.routes");
+const planRoutes = require("./modules/plans/plans.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -68,6 +69,7 @@ app.use("/api/certificates", certificatePublicRoutes); // 🎓 Public certificat
 app.use("/api/bookings/admin", adminBookingRoutes); // 📅 Admin bookings management
 app.use("/api/community/admin", adminCommunityRoutes); // 🗣️ Admin community management
 app.use("/api/roles", roleRoutes); // 🛡️ Role and permission management
+app.use("/api/plans", planRoutes); // 💳 Subscription plans
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {


### PR DESCRIPTION
## Summary
- implement new `plans` module with CRUD API
- expose `/api/plans` routes
- wire plan routes in server

## Testing
- `npm install` in `backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ff40fea2c832881ce7b831d21179f