### PR TITLE
Add plans frontend integration

### DIFF
--- a/backend/src/modules/plans/plans.controller.js
+++ b/backend/src/modules/plans/plans.controller.js
@@ -1,0 +1,91 @@
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./plans.service");
+const slugify = require("slugify");
+
+exports.createPlan = catchAsync(async (req, res) => {
+  const {
+    name,
+    slug,
+    price_monthly,
+    price_yearly,
+    currency = "USD",
+    recommended = false,
+    active = true,
+    features = [],
+  } = req.body;
+
+  if (!name) throw new AppError("Name is required", 400);
+
+  const planSlug = slug || slugify(name, { lower: true, strict: true });
+  const exists = await service.findBySlug(planSlug);
+  if (exists) throw new AppError("Plan slug already exists", 409);
+
+  const plan = await service.createPlan({
+    name,
+    slug: planSlug,
+    price_monthly: price_monthly || 0,
+    price_yearly: price_yearly || 0,
+    currency,
+    recommended,
+    active,
+  });
+
+  await service.setFeatures(plan.id, Array.isArray(features) ? features : []);
+  const full = await service.getPlanById(plan.id);
+  sendSuccess(res, full, "Plan created");
+});
+
+exports.getPlans = catchAsync(async (_req, res) => {
+  const plans = await service.getPlans();
+  sendSuccess(res, plans);
+});
+
+exports.getPlan = catchAsync(async (req, res) => {
+  const plan = await service.getPlanById(req.params.id);
+  if (!plan) throw new AppError("Plan not found", 404);
+  sendSuccess(res, plan);
+});
+
+exports.updatePlan = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  const {
+    name,
+    slug,
+    price_monthly,
+    price_yearly,
+    currency,
+    recommended,
+    active,
+    features,
+  } = req.body;
+
+  const updates = {};
+  if (name) updates.name = name;
+  if (price_monthly !== undefined) updates.price_monthly = price_monthly;
+  if (price_yearly !== undefined) updates.price_yearly = price_yearly;
+  if (currency) updates.currency = currency;
+  if (recommended !== undefined) updates.recommended = recommended;
+  if (active !== undefined) updates.active = active;
+
+  if (slug || name) {
+    const planSlug = slug || slugify(name, { lower: true, strict: true });
+    const existing = await service.findBySlug(planSlug);
+    if (existing && existing.id != id) throw new AppError("Plan slug already exists", 409);
+    updates.slug = planSlug;
+  }
+
+  const updated = await service.updatePlan(id, updates);
+  if (!updated) throw new AppError("Plan not found", 404);
+
+  if (features) await service.setFeatures(id, Array.isArray(features) ? features : []);
+  const full = await service.getPlanById(id);
+  sendSuccess(res, full, "Plan updated");
+});
+
+exports.deletePlan = catchAsync(async (req, res) => {
+  const count = await service.deletePlan(req.params.id);
+  if (!count) throw new AppError("Plan not found", 404);
+  sendSuccess(res, null, "Plan deleted");
+});

--- a/backend/src/modules/plans/plans.routes.js
+++ b/backend/src/modules/plans/plans.routes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./plans.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.getPlans);
+router.get("/:id", controller.getPlan);
+router.post("/", verifyToken, isAdmin, controller.createPlan);
+router.put("/:id", verifyToken, isAdmin, controller.updatePlan);
+router.delete("/:id", verifyToken, isAdmin, controller.deletePlan);
+
+module.exports = router;

--- a/backend/src/modules/plans/plans.service.js
+++ b/backend/src/modules/plans/plans.service.js
@@ -1,0 +1,46 @@
+const db = require("../../config/database");
+
+exports.createPlan = async (data) => {
+  const [row] = await db("plans").insert(data).returning("*");
+  return row;
+};
+
+exports.findBySlug = (slug) => db("plans").where({ slug }).first();
+
+exports.getPlans = async () => {
+  const plans = await db("plans").select("*").orderBy("id");
+  const features = await db("plan_features").select("*");
+  return plans.map((p) => ({
+    ...p,
+    features: features.filter((f) => f.plan_id === p.id),
+  }));
+};
+
+exports.getPlanById = async (id) => {
+  const plan = await db("plans").where({ id }).first();
+  if (!plan) return null;
+  const feats = await db("plan_features").where({ plan_id: id }).select("*");
+  plan.features = feats;
+  return plan;
+};
+
+exports.updatePlan = async (id, data) => {
+  const [row] = await db("plans").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.deletePlan = (id) => db("plans").where({ id }).del();
+
+exports.setFeatures = async (planId, features = []) => {
+  await db("plan_features").where({ plan_id: planId }).del();
+  if (features.length) {
+    const rows = features.map((f) => ({
+      plan_id: planId,
+      feature_key: f.feature_key,
+      value: f.value,
+      description: f.description || null,
+    }));
+    await db("plan_features").insert(rows);
+  }
+  return db("plan_features").where({ plan_id: planId }).select("*");
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,6 +16,7 @@ const certificatePublicRoutes = require("./modules/users/tutorials/certificate/c
 const adminBookingRoutes = require("./modules/bookings/bookings.routes");
 const adminCommunityRoutes = require("./modules/community/admin/admin.routes");
 const roleRoutes = require("./modules/roles/roles.routes");
+const planRoutes = require("./modules/plans/plans.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -68,6 +69,7 @@ app.use("/api/certificates", certificatePublicRoutes); // 🎓 Public certificat
 app.use("/api/bookings/admin", adminBookingRoutes); // 📅 Admin bookings management
 app.use("/api/community/admin", adminCommunityRoutes); // 🗣️ Admin community management
 app.use("/api/roles", roleRoutes); // 🛡️ Role and permission management
+app.use("/api/plans", planRoutes); // 💳 Subscription plans
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -1,67 +1,64 @@
-// Enhanced CreatePlanPage with duration, presets, validation, and preview
-import { useState } from "react";
-import { ChromePicker } from "react-color";
-import AdminLayout from "@/components/layouts/AdminLayout";
-import { FaSave, FaArrowLeft, FaPlus, FaTrash } from "react-icons/fa";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { FaSave, FaArrowLeft } from "react-icons/fa";
 import Link from "next/link";
+import { createPlan } from "@/services/admin/planService";
+import useAuthStore from "@/store/auth/authStore";
+import { toast } from "react-toastify";
 
 export default function CreatePlanPage() {
   const router = useRouter();
+  const { accessToken, user, hasHydrated } = useAuthStore();
 
   const [form, setForm] = useState({
     name: "",
-    price: "",
-    duration: "Monthly",
-    popular: false,
-    color: "#ffffff",
-    textColor: "#000000",
-    categories: []
+    priceMonthly: 0,
+    priceYearly: 0,
+    currency: "USD",
+    recommended: false,
+    active: true,
   });
 
-  const [showBgPicker, setShowBgPicker] = useState(false);
-  const [showTextPicker, setShowTextPicker] = useState(false);
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    if (!form.name || !form.price) {
-      alert("Please enter both name and price.");
+  useEffect(() => {
+    if (!hasHydrated) return;
+    if (!accessToken || !user) {
+      router.replace("/auth/login");
       return;
     }
-    console.log("Submitting Plan:", form);
-    router.push("/dashboard/admin/plans");
+    const role = user.role?.toLowerCase() ?? "";
+    if (role !== "admin" && role !== "superadmin") {
+      router.replace("/403");
+    }
+  }, [accessToken, hasHydrated, router, user]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await createPlan({
+        name: form.name,
+        price_monthly: Number(form.priceMonthly),
+        price_yearly: Number(form.priceYearly),
+        currency: form.currency,
+        recommended: form.recommended,
+        active: form.active,
+        features: [],
+      });
+      toast.success("Plan created");
+      router.push("/dashboard/admin/plans");
+    } catch (err) {
+      console.error("Create failed", err);
+      toast.error("Failed to create plan");
+    }
   };
 
-  const handleAddCategory = () => {
-    setForm((prev) => ({
-      ...prev,
-      categories: [...prev.categories, { title: "", rules: [] }]
-    }));
-  };
-
-  const handleAddRule = (catIndex) => {
-    const updated = [...form.categories];
-    updated[catIndex].rules.push({ label: "", type: "boolean", value: false });
-    setForm({ ...form, categories: updated });
-  };
-
-  const handleCategoryChange = (index, value) => {
-    const updated = [...form.categories];
-    updated[index].title = value;
-    setForm({ ...form, categories: updated });
-  };
-
-  const handleRuleChange = (catIndex, ruleIndex, field, value) => {
-    const updated = [...form.categories];
-    updated[catIndex].rules[ruleIndex][field] = value;
-    setForm({ ...form, categories: updated });
-  };
-
-  const removeCategory = (index) => {
-    const updated = [...form.categories];
-    updated.splice(index, 1);
-    setForm({ ...form, categories: updated });
-  };
+  if (!hasHydrated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-white">
+        <p className="text-gray-500 text-lg">Loading...</p>
+      </div>
+    );
+  }
 
   return (
     <AdminLayout title="Create New Plan">
@@ -79,190 +76,59 @@ export default function CreatePlanPage() {
         </button>
       </div>
 
-      <div className="bg-white rounded shadow p-6 space-y-6">
-        <input
-          className="w-full border px-4 py-2 rounded"
-          placeholder="Plan Name"
-          value={form.name}
-          onChange={(e) => setForm({ ...form, name: e.target.value })}
-        />
-        <input
-          className="w-full border px-4 py-2 rounded"
-          placeholder="Price (e.g., $20/month)"
-          value={form.price}
-          onChange={(e) => setForm({ ...form, price: e.target.value })}
-        />
-
+      <form className="bg-white rounded shadow p-6 space-y-4" onSubmit={handleSubmit}>
         <div>
-          <label className="block text-sm font-medium mb-1">Plan Duration</label>
-          <select
+          <label className="block text-sm font-medium mb-1">Plan Name</label>
+          <input
             className="w-full border px-4 py-2 rounded"
-            value={form.duration}
-            onChange={(e) => setForm({ ...form, duration: e.target.value })}
-          >
-            <option value="Monthly">Monthly</option>
-            <option value="Yearly">Yearly</option>
-          </select>
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            required
+          />
         </div>
-
-        <label className="inline-flex items-center gap-2">
+        <div>
+          <label className="block text-sm font-medium mb-1">Monthly Price</label>
+          <input
+            type="number"
+            className="w-full border px-4 py-2 rounded"
+            value={form.priceMonthly}
+            onChange={(e) => setForm({ ...form, priceMonthly: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Yearly Price</label>
+          <input
+            type="number"
+            className="w-full border px-4 py-2 rounded"
+            value={form.priceYearly}
+            onChange={(e) => setForm({ ...form, priceYearly: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Currency</label>
+          <input
+            className="w-full border px-4 py-2 rounded"
+            value={form.currency}
+            onChange={(e) => setForm({ ...form, currency: e.target.value })}
+          />
+        </div>
+        <label className="flex items-center gap-2">
           <input
             type="checkbox"
-            checked={form.popular}
-            onChange={(e) => setForm({ ...form, popular: e.target.checked })}
+            checked={form.recommended}
+            onChange={(e) => setForm({ ...form, recommended: e.target.checked })}
           />
-          Mark as Most Popular
+          Recommended
         </label>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block font-medium mb-2">Background Color</label>
-            <div className="flex items-center gap-3">
-              <div
-                className="w-10 h-10 rounded border cursor-pointer"
-                style={{ backgroundColor: form.color }}
-                onClick={() => setShowBgPicker(!showBgPicker)}
-              />
-              <input
-                type="text"
-                className="border px-3 py-1 rounded w-full"
-                value={form.color}
-                onChange={(e) => setForm({ ...form, color: e.target.value })}
-              />
-            </div>
-            {showBgPicker && (
-              <div className="mt-2">
-                <ChromePicker
-                  color={form.color}
-                  onChangeComplete={(color) =>
-                    setForm({ ...form, color: color.hex })
-                  }
-                />
-              </div>
-            )}
-          </div>
-
-          <div>
-            <label className="block font-medium mb-2">Text Color</label>
-            <div className="flex items-center gap-3">
-              <div
-                className="w-10 h-10 rounded border cursor-pointer"
-                style={{ backgroundColor: form.textColor }}
-                onClick={() => setShowTextPicker(!showTextPicker)}
-              />
-              <input
-                type="text"
-                className="border px-3 py-1 rounded w-full"
-                value={form.textColor}
-                onChange={(e) => setForm({ ...form, textColor: e.target.value })}
-              />
-            </div>
-            {showTextPicker && (
-              <div className="mt-2">
-                <ChromePicker
-                  color={form.textColor}
-                  onChangeComplete={(color) =>
-                    setForm({ ...form, textColor: color.hex })
-                  }
-                />
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium mb-1">Quick Color Presets</label>
-          <div className="flex gap-2 flex-wrap">
-            {["#1f2937", "#facc15", "#6366f1", "#10b981", "#dc2626"].map((bg, idx) => (
-              <button
-                key={idx}
-                type="button"
-                className="px-4 py-2 rounded shadow"
-                style={{ backgroundColor: bg, color: "#ffffff" }}
-                onClick={() =>
-                  setForm({ ...form, color: bg, textColor: "#ffffff" })
-                }
-              >
-                {bg}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="space-y-6">
-          {form.categories.map((cat, catIndex) => (
-            <div key={catIndex} className="border-t pt-4 space-y-4">
-              <div className="flex justify-between items-center">
-                <input
-                  className="w-full border px-3 py-2 rounded"
-                  placeholder="Category Title"
-                  value={cat.title}
-                  onChange={(e) => handleCategoryChange(catIndex, e.target.value)}
-                />
-                <button className="text-red-500 ml-4" onClick={() => removeCategory(catIndex)}>
-                  <FaTrash />
-                </button>
-              </div>
-
-              {cat.rules.map((rule, ruleIndex) => (
-                <div key={ruleIndex} className="grid grid-cols-3 gap-4">
-                  <input
-                    className="border px-2 py-1 rounded"
-                    placeholder="Rule Label"
-                    value={rule.label}
-                    onChange={(e) => handleRuleChange(catIndex, ruleIndex, "label", e.target.value)}
-                  />
-                  <select
-                    className="border px-2 py-1 rounded"
-                    value={rule.type}
-                    onChange={(e) => handleRuleChange(catIndex, ruleIndex, "type", e.target.value)}
-                  >
-                    <option value="boolean">Toggle</option>
-                    <option value="number">Number</option>
-                    <option value="text">Text</option>
-                  </select>
-                  {rule.type === "boolean" ? (
-                    <label className="inline-flex items-center gap-2">
-                      <input
-                        type="checkbox"
-                        checked={rule.value}
-                        onChange={(e) => handleRuleChange(catIndex, ruleIndex, "value", e.target.checked)}
-                      />
-                      Enabled
-                    </label>
-                  ) : (
-                    <input
-                      className="border px-2 py-1 rounded"
-                      placeholder={rule.type === "number" ? "0" : "Enter value"}
-                      value={rule.value}
-                      onChange={(e) => handleRuleChange(catIndex, ruleIndex, "value", e.target.value)}
-                    />
-                  )}
-                </div>
-              ))}
-
-              <button className="text-blue-500 mt-2" onClick={() => handleAddRule(catIndex)}>
-                <FaPlus className="inline-block mr-1" /> Add Rule
-              </button>
-            </div>
-          ))}
-        </div>
-
-        <button className="mt-4 bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded" onClick={handleAddCategory}>
-          <FaPlus className="inline-block mr-2" /> Add Category
-        </button>
-
-        <div className="mt-10 p-4 rounded shadow border" style={{ backgroundColor: form.color, color: form.textColor }}>
-          <h2 className="text-xl font-bold">{form.name || "Plan Title"}</h2>
-          <p className="text-lg">{form.price || "$0.00"}</p>
-          <p className="text-sm italic">{form.duration}</p>
-          {form.popular && (
-            <span className="inline-block bg-yellow-100 text-yellow-700 px-2 py-1 rounded-full text-xs font-semibold mt-2">
-              🌟 Popular
-            </span>
-          )}
-        </div>
-      </div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={form.active}
+            onChange={(e) => setForm({ ...form, active: e.target.checked })}
+          />
+          Active
+        </label>
+      </form>
     </AdminLayout>
   );
 }

--- a/frontend/src/pages/dashboard/admin/plans/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/plans/edit/[id].js
@@ -1,115 +1,94 @@
-import { useState, useEffect } from "react";
-import { ChromePicker } from "react-color";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { FaSave, FaArrowLeft, FaPlus, FaTrash } from "react-icons/fa";
+import { FaSave, FaArrowLeft } from "react-icons/fa";
 import Link from "next/link";
-
-const mockPlanData = {
-  1: {
-    name: "Basic Plan",
-    price: "$10/month",
-    duration: "Monthly",
-    popular: false,
-    color: "#1f2937",
-    textColor: "#ffffff",
-    categories: [
-      {
-        title: "Community",
-        rules: [
-          { label: "Read Forum", type: "boolean", value: true },
-          { label: "Post Questions", type: "boolean", value: false }
-        ]
-      }
-    ]
-  },
-  2: {
-    name: "Premium Plan",
-    price: "$30/month",
-    duration: "Monthly",
-    popular: true,
-    color: "#facc15",
-    textColor: "#111827",
-    categories: [
-      {
-        title: "Live Classes",
-        rules: [
-          { label: "Join Sessions", type: "boolean", value: true },
-          { label: "Max Classes", type: "number", value: 20 }
-        ]
-      }
-    ]
-  }
-};
+import {
+  fetchPlanById,
+  updatePlan,
+} from "@/services/admin/planService";
+import useAuthStore from "@/store/auth/authStore";
+import { toast } from "react-toastify";
 
 export default function EditPlanPage() {
   const router = useRouter();
   const { id } = router.query;
+  const { accessToken, user, hasHydrated } = useAuthStore();
 
   const [form, setForm] = useState(null);
-  const [showBgPicker, setShowBgPicker] = useState(false);
-  const [showTextPicker, setShowTextPicker] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!router.isReady) return;
-    const planData = mockPlanData[router.query.id];
-    if (planData) {
-      setForm(planData);
-    } else {
-      setForm({
-        name: "",
-        price: "",
-        duration: "Monthly",
-        popular: false,
-        color: "#ffffff",
-        textColor: "#000000",
-        categories: []
-      });
-    }
-  }, [router.isReady]);
+    if (!router.isReady || !hasHydrated) return;
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    if (!form.name || !form.price) {
-      alert("Please fill in both name and price.");
+    if (!accessToken || !user) {
+      router.replace("/auth/login");
       return;
     }
-    console.log("Updated Plan:", form);
-    router.push("/dashboard/admin/plans");
+    const role = user.role?.toLowerCase() ?? "";
+    if (role !== "admin" && role !== "superadmin") {
+      router.replace("/403");
+      return;
+    }
+
+    const loadPlan = async () => {
+      try {
+        const data = await fetchPlanById(id);
+        if (data) {
+          setForm({
+            name: data.name,
+            priceMonthly: data.price_monthly,
+            priceYearly: data.price_yearly,
+            currency: data.currency,
+            recommended: data.recommended,
+            active: data.active,
+          });
+        }
+      } catch (err) {
+        toast.error("Failed to load plan");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPlan();
+  }, [accessToken, hasHydrated, id, router, user]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form) return;
+    try {
+      await updatePlan(id, {
+        name: form.name,
+        price_monthly: Number(form.priceMonthly),
+        price_yearly: Number(form.priceYearly),
+        currency: form.currency,
+        recommended: form.recommended,
+        active: form.active,
+      });
+      toast.success("Plan updated");
+      router.push("/dashboard/admin/plans");
+    } catch (err) {
+      console.error("Update failed", err);
+      toast.error("Failed to update plan");
+    }
   };
 
-  const handleAddCategory = () => {
-    setForm((prev) => ({
-      ...prev,
-      categories: [...prev.categories, { title: "", rules: [] }]
-    }));
-  };
+  if (!hasHydrated || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-white">
+        <p className="text-gray-500 text-lg">Loading...</p>
+      </div>
+    );
+  }
 
-  const handleCategoryChange = (index, value) => {
-    const updated = [...form.categories];
-    updated[index].title = value;
-    setForm({ ...form, categories: updated });
-  };
-
-  const handleAddRule = (catIndex) => {
-    const updated = [...form.categories];
-    updated[catIndex].rules.push({ label: "", type: "boolean", value: false });
-    setForm({ ...form, categories: updated });
-  };
-
-  const handleRuleChange = (catIndex, ruleIndex, field, value) => {
-    const updated = [...form.categories];
-    updated[catIndex].rules[ruleIndex][field] = value;
-    setForm({ ...form, categories: updated });
-  };
-
-  const removeCategory = (index) => {
-    const updated = [...form.categories];
-    updated.splice(index, 1);
-    setForm({ ...form, categories: updated });
-  };
-
-  if (!form) return <AdminLayout title="Edit Plan"><p>Loading...</p></AdminLayout>;
+  if (!form) {
+    return (
+      <AdminLayout>
+        <div className="p-6">Plan not found.</div>
+      </AdminLayout>
+    );
+  }
 
   return (
     <AdminLayout title={`Edit ${form.name}`}>
@@ -127,190 +106,61 @@ export default function EditPlanPage() {
         </button>
       </div>
 
-      <div className="bg-white rounded shadow p-6 space-y-6">
-        <input
-          className="w-full border px-4 py-2 rounded"
-          placeholder="Plan Name"
-          value={form.name}
-          onChange={(e) => setForm({ ...form, name: e.target.value })}
-        />
-        <input
-          className="w-full border px-4 py-2 rounded"
-          placeholder="Price"
-          value={form.price}
-          onChange={(e) => setForm({ ...form, price: e.target.value })}
-        />
-
+      <form className="bg-white rounded shadow p-6 space-y-4" onSubmit={handleSubmit}>
         <div>
-          <label className="block text-sm font-medium mb-1">Plan Duration</label>
-          <select
+          <label className="block text-sm font-medium mb-1">Plan Name</label>
+          <input
             className="w-full border px-4 py-2 rounded"
-            value={form.duration || "Monthly"}
-            onChange={(e) => setForm({ ...form, duration: e.target.value })}
-          >
-            <option value="Monthly">Monthly</option>
-            <option value="Yearly">Yearly</option>
-          </select>
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            required
+          />
         </div>
-
-        <label className="inline-flex items-center gap-2">
+        <div>
+          <label className="block text-sm font-medium mb-1">Monthly Price</label>
+          <input
+            type="number"
+            className="w-full border px-4 py-2 rounded"
+            value={form.priceMonthly}
+            onChange={(e) => setForm({ ...form, priceMonthly: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Yearly Price</label>
+          <input
+            type="number"
+            className="w-full border px-4 py-2 rounded"
+            value={form.priceYearly}
+            onChange={(e) => setForm({ ...form, priceYearly: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Currency</label>
+          <input
+            className="w-full border px-4 py-2 rounded"
+            value={form.currency}
+            onChange={(e) => setForm({ ...form, currency: e.target.value })}
+          />
+        </div>
+        <label className="flex items-center gap-2">
           <input
             type="checkbox"
-            checked={form.popular}
-            onChange={(e) => setForm({ ...form, popular: e.target.checked })}
+            checked={form.recommended}
+            onChange={(e) =>
+              setForm({ ...form, recommended: e.target.checked })
+            }
           />
-          Mark as Most Popular
+          Recommended
         </label>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block font-medium mb-2">Background Color</label>
-            <div className="flex items-center gap-3">
-              <div
-                className="w-10 h-10 rounded border cursor-pointer"
-                style={{ backgroundColor: form.color }}
-                onClick={() => setShowBgPicker(!showBgPicker)}
-              />
-              <input
-                type="text"
-                className="border px-3 py-1 rounded w-full"
-                value={form.color}
-                onChange={(e) => setForm({ ...form, color: e.target.value })}
-              />
-            </div>
-            {showBgPicker && (
-              <div className="mt-2">
-                <ChromePicker
-                  color={form.color}
-                  onChangeComplete={(color) =>
-                    setForm({ ...form, color: color.hex })
-                  }
-                />
-              </div>
-            )}
-          </div>
-
-          <div>
-            <label className="block font-medium mb-2">Text Color</label>
-            <div className="flex items-center gap-3">
-              <div
-                className="w-10 h-10 rounded border cursor-pointer"
-                style={{ backgroundColor: form.textColor }}
-                onClick={() => setShowTextPicker(!showTextPicker)}
-              />
-              <input
-                type="text"
-                className="border px-3 py-1 rounded w-full"
-                value={form.textColor}
-                onChange={(e) => setForm({ ...form, textColor: e.target.value })}
-              />
-            </div>
-            {showTextPicker && (
-              <div className="mt-2">
-                <ChromePicker
-                  color={form.textColor}
-                  onChangeComplete={(color) =>
-                    setForm({ ...form, textColor: color.hex })
-                  }
-                />
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium mb-1">Quick Color Presets</label>
-          <div className="flex gap-2 flex-wrap">
-            {["#1f2937", "#facc15", "#6366f1", "#10b981", "#dc2626"].map((bg, idx) => (
-              <button
-                key={idx}
-                type="button"
-                className="px-4 py-2 rounded shadow"
-                style={{ backgroundColor: bg, color: "#ffffff" }}
-                onClick={() =>
-                  setForm({ ...form, color: bg, textColor: "#ffffff" })
-                }
-              >
-                {bg}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="space-y-6">
-          {form.categories.map((cat, catIndex) => (
-            <div key={catIndex} className="border-t pt-4 space-y-4">
-              <div className="flex justify-between items-center">
-                <input
-                  className="w-full border px-3 py-2 rounded"
-                  placeholder="Category Title"
-                  value={cat.title}
-                  onChange={(e) => handleCategoryChange(catIndex, e.target.value)}
-                />
-                <button className="text-red-500 ml-4" onClick={() => removeCategory(catIndex)}>
-                  <FaTrash />
-                </button>
-              </div>
-
-              {cat.rules.map((rule, ruleIndex) => (
-                <div key={ruleIndex} className="grid grid-cols-3 gap-4">
-                  <input
-                    className="border px-2 py-1 rounded"
-                    placeholder="Rule Label"
-                    value={rule.label}
-                    onChange={(e) => handleRuleChange(catIndex, ruleIndex, "label", e.target.value)}
-                  />
-                  <select
-                    className="border px-2 py-1 rounded"
-                    value={rule.type}
-                    onChange={(e) => handleRuleChange(catIndex, ruleIndex, "type", e.target.value)}
-                  >
-                    <option value="boolean">Toggle</option>
-                    <option value="number">Number</option>
-                    <option value="text">Text</option>
-                  </select>
-                  {rule.type === "boolean" ? (
-                    <label className="inline-flex items-center gap-2">
-                      <input
-                        type="checkbox"
-                        checked={rule.value}
-                        onChange={(e) => handleRuleChange(catIndex, ruleIndex, "value", e.target.checked)}
-                      />
-                      Enabled
-                    </label>
-                  ) : (
-                    <input
-                      className="border px-2 py-1 rounded"
-                      placeholder={rule.type === "number" ? "0" : "Value"}
-                      value={rule.value}
-                      onChange={(e) => handleRuleChange(catIndex, ruleIndex, "value", e.target.value)}
-                    />
-                  )}
-                </div>
-              ))}
-
-              <button className="text-blue-500 mt-2" onClick={() => handleAddRule(catIndex)}>
-                <FaPlus className="inline-block mr-1" /> Add Rule
-              </button>
-            </div>
-          ))}
-        </div>
-
-        <button className="mt-4 bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded" onClick={handleAddCategory}>
-          <FaPlus className="inline-block mr-2" /> Add Category
-        </button>
-
-        <div className="mt-10 p-4 rounded shadow border" style={{ backgroundColor: form.color, color: form.textColor }}>
-          <h2 className="text-xl font-bold">{form.name || "Plan Title"}</h2>
-          <p className="text-lg">{form.price || "$0.00"}</p>
-          <p className="text-sm italic">{form.duration || "Monthly"}</p>
-          {form.popular && (
-            <span className="inline-block bg-yellow-100 text-yellow-700 px-2 py-1 rounded-full text-xs font-semibold mt-2">
-              🌟 Popular
-            </span>
-          )}
-        </div>
-      </div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={form.active}
+            onChange={(e) => setForm({ ...form, active: e.target.checked })}
+          />
+          Active
+        </label>
+      </form>
     </AdminLayout>
   );
 }

--- a/frontend/src/pages/dashboard/admin/plans/index.js
+++ b/frontend/src/pages/dashboard/admin/plans/index.js
@@ -1,172 +1,132 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import {
-  FaPlus, FaEdit, FaTrash, FaToggleOn, FaToggleOff, FaStar, FaExchangeAlt
-} from "react-icons/fa";
+import { FaPlus, FaEdit, FaTrash, FaToggleOn, FaToggleOff } from "react-icons/fa";
 import Link from "next/link";
-
-// Mock Data with Monthly & Yearly Plans
-const mockPlans = [
-  {
-    id: 1,
-    name: "Basic Plan",
-    price: "$10/month",
-    duration: "Monthly",
-    popular: false,
-    active: true,
-    color: "bg-gray-800",
-    textColor: "text-white"
-  },
-  {
-    id: 2,
-    name: "Regular Plan",
-    price: "$20/month",
-    duration: "Monthly",
-    popular: false,
-    active: true,
-    color: "bg-yellow-500",
-    textColor: "text-gray-900"
-  },
-  {
-    id: 3,
-    name: "Premium Plan",
-    price: "$30/month",
-    duration: "Monthly",
-    popular: true,
-    active: true,
-    color: "bg-yellow-500",
-    textColor: "text-gray-900"
-  },
-  {
-    id: 4,
-    name: "Premium Yearly",
-    price: "$300/year",
-    duration: "Yearly",
-    popular: true,
-    active: true,
-    color: "bg-purple-600",
-    textColor: "text-white"
-  },
-  {
-    id: 5,
-    name: "Basic Yearly",
-    price: "$100/year",
-    duration: "Yearly",
-    popular: false,
-    active: true,
-    color: "bg-gray-600",
-    textColor: "text-white"
-  },
-  {
-    id: 6,
-    name: "Regular Yearly",
-    price: "$200/year",
-    duration: "Yearly",
-    popular: false,
-    active: true,
-    color: "bg-indigo-600",
-    textColor: "text-white"
-  }
-];
+import { fetchPlans, deletePlan, updatePlan } from "@/services/admin/planService";
+import useAuthStore from "@/store/auth/authStore";
+import { toast } from "react-toastify";
 
 export default function PlansIndex() {
-  const [plans, setPlans] = useState(mockPlans);
+  const [plans, setPlans] = useState([]);
+  const [loading, setLoading] = useState(true);
 
-  const toggleActive = (id) => {
-    setPlans((prev) =>
-      prev.map((plan) =>
-        plan.id === id ? { ...plan, active: !plan.active } : plan
-      )
-    );
-  };
+  const router = useRouter();
+  const { accessToken, user, hasHydrated } = useAuthStore();
 
-  const deletePlan = (id) => {
-    if (confirm("Are you sure you want to delete this plan?")) {
-      setPlans((prev) => prev.filter((plan) => plan.id !== id));
+  useEffect(() => {
+    if (!hasHydrated) return;
+
+    if (!accessToken || !user) {
+      router.replace("/auth/login");
+      return;
+    }
+
+    const role = user.role?.toLowerCase() ?? "";
+    if (role !== "admin" && role !== "superadmin") {
+      router.replace("/403");
+      return;
+    }
+
+    const loadPlans = async () => {
+      try {
+        const data = await fetchPlans();
+        setPlans(data);
+      } catch (err) {
+        console.error("Failed to load plans", err);
+        toast.error("Failed to load plans");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPlans();
+  }, [accessToken, hasHydrated, router, user]);
+
+  const toggleActive = async (id) => {
+    const plan = plans.find((p) => p.id === id);
+    if (!plan) return;
+    try {
+      await updatePlan(id, { active: !plan.active });
+      setPlans((prev) =>
+        prev.map((p) => (p.id === id ? { ...p, active: !p.active } : p))
+      );
+      toast.success("Plan updated");
+    } catch (err) {
+      console.error("Toggle failed", err);
+      toast.error("Failed to update plan");
     }
   };
 
-  const monthlyPlans = plans.filter((p) => p.duration === "Monthly");
-  const yearlyPlans = plans.filter((p) => p.duration === "Yearly");
+  const removePlan = async (id) => {
+    if (!confirm("Are you sure you want to delete this plan?")) return;
+    try {
+      await deletePlan(id);
+      setPlans((prev) => prev.filter((p) => p.id !== id));
+      toast.success("Plan deleted");
+    } catch (err) {
+      console.error("Delete plan failed", err);
+      toast.error("Failed to delete plan");
+    }
+  };
 
-  const renderPlanCards = (planList) => (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      {planList.map((plan) => (
-        <div
-          key={plan.id}
-          className={`rounded-2xl overflow-hidden shadow-md transform hover:scale-[1.02] transition-all duration-300 border border-gray-200 ${plan.color} ${plan.textColor}`}
-        >
-          <div className="p-6">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-xl font-extrabold">{plan.name}</h2>
-              {plan.popular && (
-                <span className="bg-yellow-100 text-yellow-700 text-xs font-semibold px-3 py-1 rounded-full inline-flex items-center gap-1">
-                  <FaStar className="text-yellow-500" /> Popular
-                </span>
-              )}
-            </div>
-
-            <p className="text-2xl font-bold mb-2">{plan.price}</p>
-            <p className="text-sm opacity-90 mb-4">{plan.duration}</p>
-
-            <div className="flex flex-wrap gap-2 mt-auto">
-              <Link href={`/dashboard/admin/plans/edit/${plan.id}`}>
-                <button className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 rounded text-sm flex items-center gap-1">
-                  <FaEdit /> Edit
-                </button>
-              </Link>
-              <button
-                onClick={() => deletePlan(plan.id)}
-                className="bg-red-600 hover:bg-red-700 text-white px-3 py-1.5 rounded text-sm flex items-center gap-1"
-              >
-                <FaTrash /> Delete
-              </button>
-              <button
-                onClick={() => toggleActive(plan.id)}
-                className={`${
-                  plan.active ? "bg-green-600" : "bg-gray-500"
-                } hover:opacity-90 text-white px-3 py-1.5 rounded text-sm flex items-center gap-1`}
-              >
-                {plan.active ? <FaToggleOn /> : <FaToggleOff />}
-                {plan.active ? "Active" : "Inactive"}
-              </button>
-            </div>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
+  if (!hasHydrated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-white">
+        <p className="text-gray-500 text-lg">Loading...</p>
+      </div>
+    );
+  }
 
   return (
     <AdminLayout title="Manage Subscription Plans">
       <div className="bg-white rounded-xl p-6 shadow mb-10">
         <div className="flex flex-wrap justify-between items-center gap-4 mb-6">
           <h1 className="text-3xl font-bold text-gray-800">📦 Subscription Plans</h1>
-          <div className="flex gap-3">
-          
-            <Link href="/dashboard/admin/plans/create">
-              <button className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded-lg flex items-center gap-2 shadow">
-                <FaPlus /> Add Plan
-              </button>
-            </Link>
-          </div>
+          <Link href="/dashboard/admin/plans/create">
+            <button className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded-lg flex items-center gap-2 shadow">
+              <FaPlus /> Add Plan
+            </button>
+          </Link>
         </div>
-
-        <hr className="mb-8 border-t border-gray-300" />
-
-        <div className="space-y-12">
-          <div>
-            <h2 className="text-2xl font-semibold mb-4 text-gray-700">📆 Monthly Plans</h2>
-            {renderPlanCards(monthlyPlans)}
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <div className="space-y-4">
+            {plans.map((plan) => (
+              <div
+                key={plan.id}
+                className="border rounded p-4 flex justify-between items-center"
+              >
+                <div>
+                  <h2 className="font-bold text-lg">{plan.name}</h2>
+                  <p className="text-sm text-gray-600">
+                    Monthly: {plan.price_monthly} {plan.currency} | Yearly: {plan.price_yearly} {plan.currency}
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => toggleActive(plan.id)}
+                    className="px-3 py-1 rounded text-white bg-gray-600 hover:opacity-80"
+                  >
+                    {plan.active ? <FaToggleOn /> : <FaToggleOff />}
+                  </button>
+                  <Link href={`/dashboard/admin/plans/edit/${plan.id}`}>
+                    <button className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded flex items-center gap-1">
+                      <FaEdit /> Edit
+                    </button>
+                  </Link>
+                  <button
+                    onClick={() => removePlan(plan.id)}
+                    className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded flex items-center gap-1"
+                  >
+                    <FaTrash /> Delete
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
-
-          <hr className="my-10 border-t border-gray-200" />
-
-          <div>
-            <h2 className="text-2xl font-semibold mb-4 text-gray-700">📅 Yearly Plans</h2>
-            {renderPlanCards(yearlyPlans)}
-          </div>
-        </div>
+        )}
       </div>
     </AdminLayout>
   );

--- a/frontend/src/services/admin/planService.js
+++ b/frontend/src/services/admin/planService.js
@@ -1,0 +1,26 @@
+import api from "@/services/api/api";
+
+export const fetchPlans = async () => {
+  const { data } = await api.get("/plans");
+  return data?.data ?? [];
+};
+
+export const fetchPlanById = async (id) => {
+  const { data } = await api.get(`/plans/${id}`);
+  return data?.data ?? null;
+};
+
+export const createPlan = async (payload) => {
+  const { data } = await api.post("/plans", payload);
+  return data?.data;
+};
+
+export const updatePlan = async (id, payload) => {
+  const { data } = await api.put(`/plans/${id}`, payload);
+  return data?.data;
+};
+
+export const deletePlan = async (id) => {
+  await api.delete(`/plans/${id}`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- create `planService` for admin API calls
- fetch and manage plans using backend data
- add forms to create and edit plans with backend

## Testing
- `npm install` in `backend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ff40fea2c832881ce7b831d21179f