### PR TITLE
Add admin payment routes

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -1,0 +1,49 @@
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./payments.service");
+const { v4: uuidv4 } = require("uuid");
+
+exports.createPayment = catchAsync(async (req, res) => {
+  const { user_id, method_id, item_type, item_id, amount, currency, status, reference_id } = req.body;
+  if (!user_id || !method_id || !item_type || !item_id || !amount) {
+    throw new AppError("Missing required fields", 400);
+  }
+
+  const payment = await service.create({
+    id: uuidv4(),
+    user_id,
+    method_id,
+    item_type,
+    item_id,
+    amount,
+    currency: currency || "USD",
+    status: status || "pending",
+    reference_id,
+    paid_at: status === "paid" ? new Date() : null,
+  });
+
+  sendSuccess(res, payment, "Payment created");
+});
+
+exports.getPayments = catchAsync(async (_req, res) => {
+  const data = await service.getAll();
+  sendSuccess(res, data);
+});
+
+exports.getPayment = catchAsync(async (req, res) => {
+  const payment = await service.getById(req.params.id);
+  if (!payment) throw new AppError("Payment not found", 404);
+  sendSuccess(res, payment);
+});
+
+exports.updatePayment = catchAsync(async (req, res) => {
+  const payment = await service.update(req.params.id, req.body);
+  if (!payment) throw new AppError("Payment not found", 404);
+  sendSuccess(res, payment, "Payment updated");
+});
+
+exports.deletePayment = catchAsync(async (req, res) => {
+  await service.delete(req.params.id);
+  sendSuccess(res, null, "Payment deleted");
+});

--- a/backend/src/modules/payments/payments.routes.js
+++ b/backend/src/modules/payments/payments.routes.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./payments.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.post("/", controller.createPayment);
+router.get("/", controller.getPayments);
+router.get("/:id", controller.getPayment);
+router.patch("/:id", controller.updatePayment);
+router.delete("/:id", controller.deletePayment);
+
+module.exports = router;

--- a/backend/src/modules/payments/payments.service.js
+++ b/backend/src/modules/payments/payments.service.js
@@ -1,0 +1,23 @@
+const db = require("../../config/database");
+
+exports.create = async (data) => {
+  const [row] = await db("payments").insert(data).returning("*");
+  return row;
+};
+
+exports.getAll = async () => {
+  return db("payments").select("*").orderBy("created_at", "desc");
+};
+
+exports.getById = async (id) => {
+  return db("payments").where({ id }).first();
+};
+
+exports.update = async (id, data) => {
+  const [row] = await db("payments").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.delete = async (id) => {
+  return db("payments").where({ id }).del();
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -17,6 +17,7 @@ const adminBookingRoutes = require("./modules/bookings/bookings.routes");
 const adminCommunityRoutes = require("./modules/community/admin/admin.routes");
 const roleRoutes = require("./modules/roles/roles.routes");
 const planRoutes = require("./modules/plans/plans.routes");
+const paymentRoutes = require("./modules/payments/payments.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -70,6 +71,7 @@ app.use("/api/bookings/admin", adminBookingRoutes); // 📅 Admin bookings manag
 app.use("/api/community/admin", adminCommunityRoutes); // 🗣️ Admin community management
 app.use("/api/roles", roleRoutes); // 🛡️ Role and permission management
 app.use("/api/plans", planRoutes); // 💳 Subscription plans
+app.use("/api/payments/admin", paymentRoutes); // 💵 Payments management
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/backend/tests/adminPaymentRoutes.test.js
+++ b/backend/tests/adminPaymentRoutes.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/payments/payments.service', () => ({
+  getAll: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/payments/payments.service');
+const routes = require('../src/modules/payments/payments.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payments/admin', routes);
+
+describe('GET /api/payments/admin', () => {
+  it('returns list of payments', async () => {
+    const mock = [{ id: '1' }];
+    service.getAll.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/payments/admin');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getAll).toHaveBeenCalled();
+  });
+});

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -29,6 +29,10 @@ The backend exposes a REST API under the `/api` prefix. Below is a brief outline
 
 `/api/bookings/admin` – CRUD operations for session bookings (admin only).
 
+## Payment Management
+
+`/api/payments/admin` – CRUD operations for user payments (admin only).
+
 ## Community Management
 
 `/api/community/admin` – manage announcements, reports, tags and settings.


### PR DESCRIPTION
## Summary
- add new payments module with CRUD service and controller
- expose `/api/payments/admin` route in the server
- update API docs to mention payment management
- test payments admin route

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6850092997908328bf1db361cf03e8b3