### PR TITLE
Enable admin payment settings

### DIFF
--- a/backend/src/modules/paymentConfig/paymentConfig.controller.js
+++ b/backend/src/modules/paymentConfig/paymentConfig.controller.js
@@ -1,0 +1,13 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./paymentConfig.service");
+
+exports.getSettings = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings || {});
+});
+
+exports.updateSettings = catchAsync(async (req, res) => {
+  const settings = await service.updateSettings(req.body);
+  sendSuccess(res, settings, "Settings updated");
+});

--- a/backend/src/modules/paymentConfig/paymentConfig.routes.js
+++ b/backend/src/modules/paymentConfig/paymentConfig.routes.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./paymentConfig.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.get("/", controller.getSettings);
+router.put("/", controller.updateSettings);
+
+module.exports = router;

--- a/backend/src/modules/paymentConfig/paymentConfig.service.js
+++ b/backend/src/modules/paymentConfig/paymentConfig.service.js
@@ -1,0 +1,26 @@
+const db = require("../../config/database");
+
+const SETTINGS_KEY = "payment_settings";
+
+exports.getSettings = async () => {
+  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (!row) return null;
+  try {
+    return JSON.parse(row.value);
+  } catch (_err) {
+    return null;
+  }
+};
+
+exports.updateSettings = async (settings) => {
+  const value = JSON.stringify(settings);
+  const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (existing) {
+    await db("settings")
+      .where({ key: SETTINGS_KEY })
+      .update({ value, updated_at: db.fn.now() });
+  } else {
+    await db("settings").insert({ key: SETTINGS_KEY, value });
+  }
+  return settings;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -19,6 +19,7 @@ const roleRoutes = require("./modules/roles/roles.routes");
 const planRoutes = require("./modules/plans/plans.routes");
 const paymentRoutes = require("./modules/payments/payments.routes");
 const paymentMethodRoutes = require("./modules/paymentMethods/paymentMethods.routes");
+const paymentConfigRoutes = require("./modules/paymentConfig/paymentConfig.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -74,6 +75,7 @@ app.use("/api/roles", roleRoutes); // 🛡️ Role and permission management
 app.use("/api/plans", planRoutes); // 💳 Subscription plans
 app.use("/api/payments/admin", paymentRoutes); // 💵 Payments management
 app.use("/api/payment-methods/admin", paymentMethodRoutes); // 💳 Payment methods
+app.use("/api/payments/config", paymentConfigRoutes); // ⚙️ Payment settings
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/frontend/src/services/admin/paymentConfigService.js
+++ b/frontend/src/services/admin/paymentConfigService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchPaymentConfig = async () => {
+  const { data } = await api.get("/payments/config");
+  return data?.data ?? null;
+};
+
+export const updatePaymentConfig = async (payload) => {
+  const { data } = await api.put("/payments/config", payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- add payment configuration module to backend
- expose payment config routes
- allow admin to view and save payment configuration in dashboard
- add service for payment config API calls

## Testing
- `npm test` in backend *(fails: jest not found)*
- `npm test` in frontend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685116f68df8832888a5c3796b0a13e8