### PR TITLE
Implement payouts API & connect admin dashboard

### DIFF
--- a/backend/src/modules/payouts/payouts.controller.js
+++ b/backend/src/modules/payouts/payouts.controller.js
@@ -1,0 +1,43 @@
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./payouts.service");
+const { v4: uuidv4 } = require("uuid");
+
+exports.createPayout = catchAsync(async (req, res) => {
+  const { instructor_id, amount, currency, status, notes } = req.body;
+  if (!instructor_id || !amount) {
+    throw new AppError("Instructor and amount are required", 400);
+  }
+  const payout = await service.create({
+    id: uuidv4(),
+    instructor_id,
+    amount,
+    currency: currency || "USD",
+    status: status || "pending",
+    notes,
+  });
+  sendSuccess(res, payout, "Payout request created");
+});
+
+exports.getPayouts = catchAsync(async (_req, res) => {
+  const data = await service.getAll();
+  sendSuccess(res, data);
+});
+
+exports.getPayout = catchAsync(async (req, res) => {
+  const payout = await service.getById(req.params.id);
+  if (!payout) throw new AppError("Payout not found", 404);
+  sendSuccess(res, payout);
+});
+
+exports.updatePayout = catchAsync(async (req, res) => {
+  const payout = await service.update(req.params.id, req.body);
+  if (!payout) throw new AppError("Payout not found", 404);
+  sendSuccess(res, payout, "Payout updated");
+});
+
+exports.deletePayout = catchAsync(async (req, res) => {
+  await service.delete(req.params.id);
+  sendSuccess(res, null, "Payout deleted");
+});

--- a/backend/src/modules/payouts/payouts.routes.js
+++ b/backend/src/modules/payouts/payouts.routes.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./payouts.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.post("/", controller.createPayout);
+router.get("/", controller.getPayouts);
+router.get("/:id", controller.getPayout);
+router.patch("/:id", controller.updatePayout);
+router.delete("/:id", controller.deletePayout);
+
+module.exports = router;

--- a/backend/src/modules/payouts/payouts.service.js
+++ b/backend/src/modules/payouts/payouts.service.js
@@ -1,0 +1,23 @@
+const db = require("../../config/database");
+
+exports.create = async (data) => {
+  const [row] = await db("payouts").insert(data).returning("*");
+  return row;
+};
+
+exports.getAll = async () => {
+  return db("payouts").select("*").orderBy("requested_at", "desc");
+};
+
+exports.getById = async (id) => {
+  return db("payouts").where({ id }).first();
+};
+
+exports.update = async (id, data) => {
+  const [row] = await db("payouts").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.delete = async (id) => {
+  return db("payouts").where({ id }).del();
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -20,6 +20,7 @@ const planRoutes = require("./modules/plans/plans.routes");
 const paymentRoutes = require("./modules/payments/payments.routes");
 const paymentMethodRoutes = require("./modules/paymentMethods/paymentMethods.routes");
 const paymentConfigRoutes = require("./modules/paymentConfig/paymentConfig.routes");
+const payoutRoutes = require("./modules/payouts/payouts.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -76,6 +77,7 @@ app.use("/api/plans", planRoutes); // 💳 Subscription plans
 app.use("/api/payments/admin", paymentRoutes); // 💵 Payments management
 app.use("/api/payment-methods/admin", paymentMethodRoutes); // 💳 Payment methods
 app.use("/api/payments/config", paymentConfigRoutes); // ⚙️ Payment settings
+app.use("/api/payouts/admin", payoutRoutes); // 🏦 Instructor payouts
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -24,6 +24,7 @@ import {
   deleteMethod,
 } from '@/services/admin/paymentMethodService';
 import { fetchPaymentConfig, updatePaymentConfig } from '@/services/admin/paymentConfigService';
+import { fetchPayouts, updatePayout } from '@/services/admin/payoutService';
 import { toast } from 'react-toastify';
 
 import {
@@ -135,13 +136,15 @@ export default function AdminPaymentsPage() {
   useEffect(() => {
     const loadData = async () => {
       try {
-        const [txns, mths, cfg] = await Promise.all([
+        const [txns, mths, cfg, pouts] = await Promise.all([
           fetchPayments(),
           fetchMethods(),
           fetchPaymentConfig(),
+          fetchPayouts(),
         ]);
         setTransactions(txns);
         setMethods(mths);
+        setPayouts(pouts);
 
         if (cfg) {
           const merged = {
@@ -242,33 +245,7 @@ export default function AdminPaymentsPage() {
     }
   };
 
-  // Payouts mock
-  const [payouts, setPayouts] = useState([
-    {
-      id: "PAYOUT-001",
-      date: "2025-05-10",
-      instructor: "Ahmed Salah",
-      amount: 150.0,
-      method: "Bank Transfer",
-      status: "Pending",
-    },
-    {
-      id: "PAYOUT-002",
-      date: "2025-05-08",
-      instructor: "Nour Hassan",
-      amount: 90.0,
-      method: "Crypto Wallet",
-      status: "Paid",
-    },
-    {
-      id: "PAYOUT-003",
-      date: "2025-05-07",
-      instructor: "Mariam Omar",
-      amount: 120.0,
-      method: "PayPal",
-      status: "Rejected",
-    },
-  ]);
+  const [payouts, setPayouts] = useState([]);
 
   const summaryCards = [
     {
@@ -296,10 +273,15 @@ export default function AdminPaymentsPage() {
     },
   ];
 
-  const updateStatus = (id, newStatus) => {
-    setPayouts((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, status: newStatus } : p))
-    );
+  const updateStatus = async (id, newStatus) => {
+    try {
+      const updated = await updatePayout(id, { status: newStatus });
+      setPayouts((prev) =>
+        prev.map((p) => (p.id === id ? { ...p, status: updated.status } : p))
+      );
+    } catch (err) {
+      toast.error("Failed to update payout status");
+    }
   };
 
   const renderTabContent = () => {

--- a/frontend/src/services/admin/payoutService.js
+++ b/frontend/src/services/admin/payoutService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchPayouts = async () => {
+  const { data } = await api.get("/payouts/admin");
+  return data?.data ?? [];
+};
+
+export const updatePayout = async (id, payload) => {
+  const { data } = await api.patch(`/payouts/admin/${id}`, payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- add payouts module (service, controller, routes) on the backend
- expose `/api/payouts/admin` endpoints via server.js
- create `payoutService` for admin frontend
- load payouts data in admin payments page
- allow changing payout status using API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511f0d40f8832897cae8321394a4d0