### PR TITLE
Add ads module and integrate create ads page

### DIFF
--- a/backend/src/migrations/20250616000000_create_ads_table.js
+++ b/backend/src/migrations/20250616000000_create_ads_table.js
@@ -1,0 +1,16 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ads', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.string('title').notNullable();
+    table.text('description');
+    table.string('image_url').notNullable();
+    table.string('link_url');
+    table.uuid('created_by').references('id').inTable('users').onDelete('SET NULL');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('ads');
+};

--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -1,0 +1,20 @@
+const { v4: uuidv4 } = require("uuid");
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./ads.service");
+
+exports.createAd = catchAsync(async (req, res) => {
+  const data = { ...req.body, id: uuidv4(), created_by: req.user.id };
+  const ad = await service.createAd(data);
+  sendSuccess(res, ad, "Ad created");
+});
+
+exports.getAds = catchAsync(async (_req, res) => {
+  const ads = await service.getAds();
+  sendSuccess(res, ads);
+});
+
+exports.getAdById = catchAsync(async (req, res) => {
+  const ad = await service.getAdById(req.params.id);
+  sendSuccess(res, ad);
+});

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./ads.controller");
+const validate = require("../../middleware/validate");
+const { verifyToken, isInstructorOrAdmin } = require("../../middleware/auth/authMiddleware");
+const validator = require("./ads.validator");
+
+router.post("/admin", verifyToken, isInstructorOrAdmin, validate(validator.create), controller.createAd);
+router.get("/", controller.getAds);
+router.get("/:id", controller.getAdById);
+
+module.exports = router;

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -1,0 +1,14 @@
+const db = require("../../config/database");
+
+exports.createAd = async (data) => {
+  const [row] = await db("ads").insert(data).returning("*");
+  return row;
+};
+
+exports.getAds = async () => {
+  return db("ads").orderBy("created_at", "desc");
+};
+
+exports.getAdById = async (id) => {
+  return db("ads").where({ id }).first();
+};

--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -1,0 +1,10 @@
+const { z } = require("zod");
+
+exports.create = z.object({
+  body: z.object({
+    title: z.string().min(3),
+    description: z.string().optional(),
+    image_url: z.string().min(1),
+    link_url: z.string().url().optional(),
+  })
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -21,6 +21,7 @@ const paymentRoutes = require("./modules/payments/payments.routes");
 const paymentMethodRoutes = require("./modules/paymentMethods/paymentMethods.routes");
 const paymentConfigRoutes = require("./modules/paymentConfig/paymentConfig.routes");
 const payoutRoutes = require("./modules/payouts/payouts.routes");
+const adsRoutes = require("./modules/ads/ads.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -78,6 +79,7 @@ app.use("/api/payments/admin", paymentRoutes); // 💵 Payments management
 app.use("/api/payment-methods/admin", paymentMethodRoutes); // 💳 Payment methods
 app.use("/api/payments/config", paymentConfigRoutes); // ⚙️ Payment settings
 app.use("/api/payouts/admin", payoutRoutes); // 🏦 Instructor payouts
+app.use("/api/ads", adsRoutes); // 📢 Advertisements
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/ads/ads.service', () => ({
+  getAds: jest.fn(),
+  createAd: jest.fn(),
+  getAdById: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'user1' };
+    next();
+  },
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/ads/ads.service');
+const routes = require('../src/modules/ads/ads.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/ads', routes);
+
+describe('GET /api/ads', () => {
+  it('returns ads list', async () => {
+    const mock = [{ id: '1' }];
+    service.getAds.mockResolvedValue(mock);
+    const res = await request(app).get('/api/ads');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+  });
+});
+
+describe('POST /api/ads/admin', () => {
+  it('creates ad', async () => {
+    const payload = { title: 'Test', image_url: 'img.jpg' };
+    service.createAd.mockResolvedValue({ id: '1', ...payload });
+    const res = await request(app).post('/api/ads/admin').send(payload);
+    expect(res.status).toBe(200);
+    expect(service.createAd).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -12,8 +12,9 @@ import {
 import SidebarMenu from "@/components/shared/SidebarMenu";
 import Chatbot from "@/components/shared/Chatbot";
 import heroImage from "@/shared/assets/images/home/hero.png";
+import { getAds } from "@/services/adsService";
 
-const ads = [
+const defaultAds = [
   {
     id: 1,
     title: "🔥 Black Friday Deal: 50% Off!",
@@ -41,19 +42,33 @@ const ads = [
 const Hero = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isChatOpen, setIsChatOpen] = useState(false);
+  const [ads, setAds] = useState(defaultAds);
   const [currentAd, setCurrentAd] = useState(0);
   const [searchText, setSearchText] = useState("");
   const [searchSuggestions, setSearchSuggestions] = useState([]);
 
   const typewriterText = ["Empower Learning", "Connect Minds", "Master New Skills"];
 
+  useEffect(() => {
+    const fetchAds = async () => {
+      try {
+        const data = await getAds();
+        if (data.length) setAds(data);
+      } catch (err) {
+        console.error("Failed to fetch ads", err);
+      }
+    };
+    fetchAds();
+  }, []);
+
   // Auto-rotate Ads Every 5 Seconds
   useEffect(() => {
+    if (!ads.length) return;
     const interval = setInterval(() => {
       setCurrentAd((prev) => (prev + 1) % ads.length);
     }, 5000);
     return () => clearInterval(interval);
-  }, []);
+  }, [ads]);
 
   // Search Suggestions
   useEffect(() => {

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -5,6 +5,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import ImageCropUpload from "@/components/shared/ImageCropUpload";
 import PlanLimitHint from "@/components/shared/PlanLimitHint";
 import plansConfig from "@/config/plansConfig";
+import { createAd } from "@/services/admin/adService";
 
 const currentUserPlan = "basic"; // "basic" | "regular" | "prime"
 const { maxAdDuration } = plansConfig[currentUserPlan];
@@ -46,28 +47,24 @@ export default function CreateAdPage() {
     }
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    const start = new Date(formData.startAt);
-    const end = new Date(formData.endAt);
-    const diffInDays = Math.ceil((end - start) / (1000 * 60 * 60 * 24));
-
-    if (!formData.title || !formData.image || !formData.startAt || !formData.endAt) {
-      setError("Please fill in all required fields.");
-      return;
-    }
-    if (start > end) {
-      setError("End date must be after start date.");
-      return;
-    }
-    if (diffInDays > maxAdDuration) {
-      setError(`Your plan only allows ads for up to ${maxAdDuration} days.`);
+    if (!formData.title || !formData.image) {
+      setError("Title and image are required.");
       return;
     }
 
-    console.log("Creating ad:", formData);
-    alert("Ad created successfully!");
-    router.push("/admin/ads");
+    try {
+      await createAd({
+        title: formData.title,
+        description: formData.description,
+        image_url: formData.image,
+        link_url: formData.link,
+      });
+      router.push("/dashboard/admin/ads");
+    } catch (err) {
+      setError("Failed to create ad");
+    }
   };
 
   return (

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const createAd = async (payload) => {
+  const { data } = await api.post("/ads/admin", payload);
+  return data?.data;
+};
+
+export const fetchAds = async () => {
+  const { data } = await api.get("/ads");
+  return data?.data ?? [];
+};

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -1,15 +1,6 @@
-import axios from "axios";
+import api from "@/services/api/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
-
-// Get all Ads
 export const getAds = async () => {
-  const response = await axios.get(`${API_URL}/ads`);
-  return response.data;
-};
-
-// Create a new Ad (Admin Only)
-export const createAd = async (adData) => {
-  const response = await axios.post(`${API_URL}/ads`, adData);
-  return response.data;
+  const { data } = await api.get("/ads");
+  return data?.data ?? [];
 };


### PR DESCRIPTION
## Summary
- support ads management via `/api/ads`
- allow admins or instructors to create ads
- fetch ads in hero section
- connect admin create ads page with backend
- add tests for ads routes

## Testing
- `npm test --prefix backend --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851238a453c8328a914a8793ff62fea