### PR TITLE
Enable ads image upload and enforce unique titles

### DIFF
--- a/backend/src/migrations/20250617000001_add_unique_ads_title.js
+++ b/backend/src/migrations/20250617000001_add_unique_ads_title.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('ads', function(table) {
+    table.unique('title');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('ads', function(table) {
+    table.dropUnique('title');
+  });
+};

--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -1,10 +1,29 @@
 const { v4: uuidv4 } = require("uuid");
 const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
 const service = require("./ads.service");
 
 exports.createAd = catchAsync(async (req, res) => {
-  const data = { ...req.body, id: uuidv4(), created_by: req.user.id };
+  const { title, description, link_url } = req.body;
+
+  if (await service.findByTitle(title)) {
+    throw new AppError("Ad title already exists", 409);
+  }
+
+  if (!req.file && !req.body.image_url) {
+    throw new AppError("Image is required", 400);
+  }
+
+  const data = {
+    id: uuidv4(),
+    title,
+    description,
+    link_url,
+    created_by: req.user.id,
+    image_url: req.file ? `/uploads/ads/${req.file.filename}` : req.body.image_url,
+  };
+
   const ad = await service.createAd(data);
   sendSuccess(res, ad, "Ad created");
 });

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -4,8 +4,16 @@ const controller = require("./ads.controller");
 const validate = require("../../middleware/validate");
 const { verifyToken, isInstructorOrAdmin } = require("../../middleware/auth/authMiddleware");
 const validator = require("./ads.validator");
+const upload = require("./adsUploadMiddleware");
 
-router.post("/admin", verifyToken, isInstructorOrAdmin, validate(validator.create), controller.createAd);
+router.post(
+  "/admin",
+  verifyToken,
+  isInstructorOrAdmin,
+  upload.single("image"),
+  validate(validator.create),
+  controller.createAd
+);
 router.get("/", controller.getAds);
 router.get("/:id", controller.getAdById);
 

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -12,3 +12,7 @@ exports.getAds = async () => {
 exports.getAdById = async (id) => {
   return db("ads").where({ id }).first();
 };
+
+exports.findByTitle = async (title) => {
+  return db("ads").where({ title }).first();
+};

--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -4,7 +4,7 @@ exports.create = z.object({
   body: z.object({
     title: z.string().min(3),
     description: z.string().optional(),
-    image_url: z.string().min(1),
+    image_url: z.string().min(1).optional(),
     link_url: z.string().url().optional(),
   })
 });

--- a/backend/src/modules/ads/adsUploadMiddleware.js
+++ b/backend/src/modules/ads/adsUploadMiddleware.js
@@ -1,0 +1,27 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const uploadDir = path.join(__dirname, '../../../../uploads/ads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    cb(null, `ad-${Date.now()}${ext}`);
+  },
+});
+
+const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
+const fileFilter = (req, file, cb) => {
+  cb(null, allowed.includes(file.mimetype));
+};
+
+module.exports = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: 2 * 1024 * 1024 }, // 2MB
+});

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -5,6 +5,7 @@ jest.mock('../src/modules/ads/ads.service', () => ({
   getAds: jest.fn(),
   createAd: jest.fn(),
   getAdById: jest.fn(),
+  findByTitle: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -55,12 +55,15 @@ export default function CreateAdPage() {
     }
 
     try {
-      await createAd({
-        title: formData.title,
-        description: formData.description,
-        image_url: formData.image,
-        link_url: formData.link,
-      });
+      const blob = await fetch(formData.image).then((r) => r.blob());
+      const file = new File([blob], "ad.jpg", { type: blob.type });
+      const payload = new FormData();
+      payload.append("title", formData.title);
+      payload.append("description", formData.description);
+      payload.append("link_url", formData.link);
+      payload.append("image", file);
+
+      await createAd(payload);
       router.push("/dashboard/admin/ads");
     } catch (err) {
       setError("Failed to create ad");

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -1,7 +1,9 @@
 import api from "@/services/api/api";
 
 export const createAd = async (payload) => {
-  const { data } = await api.post("/ads/admin", payload);
+  const { data } = await api.post("/ads/admin", payload, {
+    headers: payload instanceof FormData ? { "Content-Type": "multipart/form-data" } : {},
+  });
   return data?.data;
 };
 


### PR DESCRIPTION
## Summary
- add migration to make ad titles unique
- create multer middleware for ad image uploads
- check for duplicate titles on ad creation
- support file uploads in ads routes
- update admin and instructor create ad pages to send FormData
- allow multipart payload in ad service

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685140c0b10c8328874c25bbaaa33d6d