### PR TITLE
Fix ad creation image upload

### DIFF
--- a/frontend/src/components/shared/ImageCropUpload.js
+++ b/frontend/src/components/shared/ImageCropUpload.js
@@ -17,7 +17,10 @@ export default function ImageCropUpload({ value, onChange }) {
       const reader = new FileReader();
       reader.readAsDataURL(file);
       reader.onload = () => {
-        setImageSrc(reader.result);
+        const dataUrl = reader.result;
+        setImageSrc(dataUrl);
+        setPreview(dataUrl);
+        onChange(dataUrl); // prefill with original image in case cropping is skipped
       };
     }
   };


### PR DESCRIPTION
## Summary
- automatically set the selected image when users choose a file so form validation passes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685149ca444c83288785604453d7dcae