### PR TITLE
Improve admin ad creation UX

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -20,13 +20,13 @@ export default function CreateAdPage() {
     endAt: "",
     targetRoles: [],
     adType: "promotion",
-    placement: "dashboard",
     priority: 0,
     link: "",
     allowBranding: false,
     isActive: true,
   });
   const [error, setError] = useState(null);
+  const [titleError, setTitleError] = useState(null);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -66,7 +66,12 @@ export default function CreateAdPage() {
       await createAd(payload);
       router.push("/dashboard/admin/ads");
     } catch (err) {
-      setError("Failed to create ad");
+      const message = err?.response?.data?.message || "Failed to create ad";
+      if (message.toLowerCase().includes("title")) {
+        setTitleError(message);
+      } else {
+        setError(message);
+      }
     }
   };
 
@@ -85,8 +90,19 @@ export default function CreateAdPage() {
             <div className="space-y-4">
               <div>
                 <label className="block font-medium">Title *</label>
-                <input type="text" name="title" value={formData.title} onChange={handleChange}
-                  className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-blue-500" />
+                <input
+                  type="text"
+                  name="title"
+                  value={formData.title}
+                  onChange={(e) => {
+                    setTitleError(null);
+                    handleChange(e);
+                  }}
+                  className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-blue-500"
+                />
+                {titleError && (
+                  <p className="text-red-600 text-sm mt-1">{titleError}</p>
+                )}
               </div>
               <div>
                 <label className="block font-medium">Description</label>
@@ -132,18 +148,6 @@ export default function CreateAdPage() {
                   <option value="announcement">Announcement</option>
                   <option value="internal">Internal</option>
                 </select>
-              </div>
-              <div>
-                <label className="block font-medium">Placement *</label>
-                <select name="placement" value={formData.placement} onChange={handleChange}>
-                  <option value="dashboard">Dashboard</option>
-                  <option value="course-detail">Course Detail</option>
-                  <option value="checkout">Checkout</option>
-                  <option value="community">Community</option>
-                  <option value="search-results">Search Results</option>
-                  <option value="email">Email</option>
-                </select>
-
               </div>
               <div>
                 <label className="block font-medium">Priority *</label>

--- a/frontend/src/pages/dashboard/instructor/ads/create.js
+++ b/frontend/src/pages/dashboard/instructor/ads/create.js
@@ -20,13 +20,13 @@ export default function CreateAdPage() {
     endAt: "",
     targetRoles: [],
     adType: "promotion",
-    placement: "dashboard",
     priority: 0,
     link: "",
     allowBranding: false,
     isActive: true,
   });
   const [error, setError] = useState(null);
+  const [titleError, setTitleError] = useState(null);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -66,7 +66,12 @@ export default function CreateAdPage() {
       await createAd(payload);
       router.push("/dashboard/instructor/ads");
     } catch (err) {
-      setError("Failed to create ad");
+      const message = err?.response?.data?.message || "Failed to create ad";
+      if (message.toLowerCase().includes("title")) {
+        setTitleError(message);
+      } else {
+        setError(message);
+      }
     }
   };
 
@@ -85,8 +90,19 @@ export default function CreateAdPage() {
             <div className="space-y-4">
               <div>
                 <label className="block font-medium">Title *</label>
-                <input type="text" name="title" value={formData.title} onChange={handleChange}
-                  className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-blue-500" />
+                <input
+                  type="text"
+                  name="title"
+                  value={formData.title}
+                  onChange={(e) => {
+                    setTitleError(null);
+                    handleChange(e);
+                  }}
+                  className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-blue-500"
+                />
+                {titleError && (
+                  <p className="text-red-600 text-sm mt-1">{titleError}</p>
+                )}
               </div>
               <div>
                 <label className="block font-medium">Description</label>


### PR DESCRIPTION
## Summary
- remove Placement field from admin/instructor ad creation
- surface backend title errors near the title input for admins and instructors

## Testing
- `npm test` (fails: jest not found)
- `npm test` in frontend (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68514d93a2b48328b8cc89acc17d8582