### PR TITLE
Connect admin dashboard to backend

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -182,3 +182,13 @@ exports.uploadIdentityDoc = async (req, res) => {
     res.status(500).json({ message: "Failed to upload identity document" });
   }
 };
+
+/**
+ * @desc Get aggregated dashboard statistics
+ * @route GET /api/users/admin/dashboard-stats
+ * @access Admin
+ */
+exports.getDashboardStats = async (_req, res) => {
+  const data = await require("./admin.service").getDashboardStats();
+  res.status(200).json({ data });
+};

--- a/backend/src/modules/users/admin/admin.routes.js
+++ b/backend/src/modules/users/admin/admin.routes.js
@@ -51,6 +51,11 @@ router.post(
   controller.uploadIdentityDoc
 );
 
+// ---------------------------------------------------------------------------
+// 📊 Dashboard stats
+// ---------------------------------------------------------------------------
+router.get("/dashboard-stats", controller.getDashboardStats);
+
 
 
 

--- a/backend/src/modules/users/admin/admin.service.js
+++ b/backend/src/modules/users/admin/admin.service.js
@@ -33,3 +33,27 @@ exports.updateAdminProfile = async (userId, data) => {
     });
   }
 };
+
+// ---------------------------------------------------------------------------
+// 📊 Dashboard statistics for the main admin dashboard
+// ---------------------------------------------------------------------------
+
+exports.getDashboardStats = async () => {
+  const [userRow] = await db("users").count();
+  const [instructorRow] = await db("users")
+    .where({ role: "Instructor" })
+    .count();
+  const [studentRow] = await db("users")
+    .where({ role: "Student" })
+    .count();
+  const [tutorialRow] = await db("tutorials").count();
+  const [classRow] = await db("online_classes").count();
+
+  return {
+    totalUsers: parseInt(userRow.count, 10) || 0,
+    instructors: parseInt(instructorRow.count, 10) || 0,
+    students: parseInt(studentRow.count, 10) || 0,
+    tutorials: parseInt(tutorialRow.count, 10) || 0,
+    classes: parseInt(classRow.count, 10) || 0,
+  };
+};

--- a/backend/tests/adminDashboardRoutes.test.js
+++ b/backend/tests/adminDashboardRoutes.test.js
@@ -1,0 +1,35 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database', () => ({
+  raw: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../src/modules/users/admin/admin.service', () => ({
+  getDashboardStats: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+  isSuperAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/users/admin/admin.service');
+const routes = require('../src/modules/users/admin/admin.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/users/admin', routes);
+
+describe('GET /api/users/admin/dashboard-stats', () => {
+  it('returns dashboard stats', async () => {
+    const mockStats = { totalUsers: 5 };
+    service.getDashboardStats.mockResolvedValue(mockStats);
+
+    const res = await request(app).get('/api/users/admin/dashboard-stats');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mockStats);
+    expect(service.getDashboardStats).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/admin/StatsGrid.js
+++ b/frontend/src/components/admin/StatsGrid.js
@@ -1,31 +1,10 @@
 // components/admin/StatsGrid.js
-import { FaUsers, FaDollarSign, FaChalkboardTeacher, FaBook, FaVideo, FaClipboardList,FaBookDead, FaBookOpen  } from 'react-icons/fa';
-
-const stats = [
-  { icon: <FaUsers />, label: "Total Users", value: 1240, color: "text-blue-500" },
-  { icon: <FaUsers />, label: "Inactive Users", value: 1240, color: "text-red-500" },
-  { icon: <FaDollarSign />, label: "Monthly Revenue", value: "$12,980", color: "text-green-500" },
-  { icon: <FaChalkboardTeacher />, label: "Active Instructors", value: 87, color: "text-purple-500" },
-  { icon: <FaBook />, label: "Published Tutorials", value: 321, color: "text-indigo-500" },
-  { icon: <FaVideo />, label: "Upcoming Live Classes", value: 14, color: "text-yellow-500" },
-  { icon: <FaVideo />, label: "Ongoing Live Classes", value: 3, color: "text-red-500" },
-  { icon: <FaVideo />, label: "Pending Class Approvals", value: 5, color: "text-pink-500" },
-  { icon: <FaBookOpen />, label: "Pending Tutorial Reviews", value: 12, color: "text-orange-500" },
-  { icon: <FaBook />, label: "Published Tutorials", value: 321, color: "text-indigo-500" },
-  { icon: <FaBookDead />, label: "Rejected Tutorials", value: 4, color: "text-red-500" },
-  { icon: <FaClipboardList />, label: "Tutorial Enrollments", value: 7800, color: "text-blue-600" },
-
-];
-
-
-
-export default function StatsGrid() {
+export default function StatsGrid({ stats = [] }) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
       {stats.map((stat, idx) => (
         <div key={idx} className="bg-white p-6 rounded-xl shadow flex items-center gap-4">
           <div className={`${stat.color} text-3xl`}>{stat.icon}</div>
-
           <div>
             <p className="text-gray-500 text-sm">{stat.label}</p>
             <h3 className="text-xl font-bold">{stat.value}</h3>

--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -81,3 +81,11 @@ export const changeAdminPassword = async (adminId, newPassword) => {
   });
   return res.data;
 };
+
+/**
+ * 📊 Fetch dashboard statistics for admin home page
+ */
+export const fetchAdminDashboardStats = async () => {
+  const res = await api.get('/users/admin/dashboard-stats');
+  return res.data?.data;
+};


### PR DESCRIPTION
## Summary
- add dashboard stats endpoint in backend
- support stats retrieval in admin service
- update dashboard page to show backend stats
- make StatsGrid accept dynamic data
- test new admin stats route

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685161152a348328a6ddab771fda2870