### PR TITLE
Serve uploads path

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -58,8 +58,10 @@ app.use(
 app.use(morgan("dev"));
 
 // 📁 Serve uploaded static files (avatars, identity, etc.)
-// Optional: Support both `/uploads` and `/api/uploads`
-app.use("/api/uploads", express.static(path.join(__dirname, "../uploads")));
+// Support both `/uploads` and `/api/uploads` to allow direct access in production
+const uploadsDir = path.join(__dirname, "../uploads");
+app.use("/api/uploads", express.static(uploadsDir));
+app.use("/uploads", express.static(uploadsDir));
 
 
 


### PR DESCRIPTION
## Summary
- serve uploads at `/uploads` and `/api/uploads`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851740b51e883289188244b9601b404