### PR TITLE
Fix ads image display and uploading

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -6,7 +6,13 @@ const nextConfig = {
         protocol: 'http',
         hostname: 'localhost',
         port: '5001',
-        pathname: '/uploads/**', // Allows all files under /uploads
+        pathname: '/uploads/**', // legacy path
+      },
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '5001',
+        pathname: '/api/uploads/**', // Allow images served via API
       },
     ],
   },

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -13,8 +13,7 @@ export const fetchAds = async () => {
   const ads = data?.data ?? [];
   return ads.map((ad) => ({
     ...ad,
-    image: ad.image_url,
+    image: `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.image_url}`,
     link: ad.link_url,
   }));
-
 };

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -6,7 +6,7 @@ export const getAds = async () => {
   const ads = data?.data ?? [];
   return ads.map((ad) => ({
     ...ad,
-    image: ad.image_url,
+    image: `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.image_url}`,
     link: ad.link_url,
   }));
 


### PR DESCRIPTION
## Summary
- prefix API URL for ad images
- allow /api/uploads images in Next.js config

## Testing
- `npm test --silent` in `frontend` *(fails: jest not found)*
- `npm test --silent` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525c46fd9483288e4061a6ac3ccc68