### PR TITLE
Center ad overlay in hero

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -190,8 +190,8 @@ const Hero = () => {
               className="object-cover"
               priority
             />
-            <div className="absolute inset-0 bg-gradient-to-br from-black/70 via-black/40 to-transparent z-10 flex items-center">
-              <div className="px-6 md:px-10 py-8 max-w-xl text-white">
+            <div className="absolute inset-0 bg-gradient-to-br from-black/70 via-black/40 to-transparent z-10 flex items-end justify-center pb-8 text-center">
+              <div className="px-6 md:px-10 max-w-xl text-white">
                 <h3 className="text-2xl md:text-4xl font-bold mb-3 leading-snug drop-shadow-xl">
                   {ads[currentAd].title}
                 </h3>


### PR DESCRIPTION
## Summary
- align ad text and button to the center bottom of the hero banner

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6852baef89148328929498d9f5c2972d