### PR TITLE
Fix ad components when targetRoles missing

### DIFF
--- a/frontend/src/components/admin/ads/AdCard.js
+++ b/frontend/src/components/admin/ads/AdCard.js
@@ -42,8 +42,13 @@ export default function AdCard({
         <p className="text-sm text-gray-600 line-clamp-2">{ad.description}</p>
         <div className="flex flex-wrap gap-1 text-xs text-gray-500">
           <span className="bg-gray-100 px-2 py-0.5 rounded">{ad.adType}</span>
-          {ad.targetRoles.map(role => (
-            <span key={role} className="bg-blue-50 text-blue-600 px-2 py-0.5 rounded capitalize">{role}</span>
+          {ad.targetRoles?.map((role) => (
+            <span
+              key={role}
+              className="bg-blue-50 text-blue-600 px-2 py-0.5 rounded capitalize"
+            >
+              {role}
+            </span>
           ))}
         </div>
       </div>

--- a/frontend/src/components/admin/ads/PreviewModal.js
+++ b/frontend/src/components/admin/ads/PreviewModal.js
@@ -13,7 +13,9 @@ const PreviewModal = ({ ad, onClose }) => {
         <img src={ad.image} alt={ad.title} className="w-full h-48 object-cover rounded mb-4" />
         <h2 className="text-xl font-bold mb-2">{ad.title}</h2>
         <p className="text-sm text-gray-700 mb-2">{ad.description}</p>
-        <p className="text-xs text-gray-500 mb-1">🎯 Target: {ad.targetRoles.join(', ')}</p>
+        <p className="text-xs text-gray-500 mb-1">
+          🎯 Target: {(ad.targetRoles || []).join(', ')}
+        </p>
         <p className="text-xs text-gray-500 mb-1">📅 {ad.startAt} → {ad.endAt}</p>
         <p className="text-xs text-blue-500">👁️ {ad.views} views</p>
         <p className="text-xs text-purple-500">📌 Type: {ad.adType}</p>

--- a/frontend/src/components/admin/ads/PreviewModalinstrutor.js
+++ b/frontend/src/components/admin/ads/PreviewModalinstrutor.js
@@ -13,7 +13,9 @@ const PreviewModalinstrutor = ({ ad, onClose }) => {
         <img src={ad.image} alt={ad.title} className="w-full h-48 object-cover rounded mb-4" />
         <h2 className="text-xl font-bold mb-2">{ad.title}</h2>
         <p className="text-sm text-gray-700 mb-2">{ad.description}</p>
-        <p className="text-xs text-gray-500 mb-1">🎯 Target: {ad.targetRoles.join(', ')}</p>
+        <p className="text-xs text-gray-500 mb-1">
+          🎯 Target: {(ad.targetRoles || []).join(', ')}
+        </p>
         <p className="text-xs text-gray-500 mb-1">📅 {ad.startAt} → {ad.endAt}</p>
         <p className="text-xs text-blue-500">👁️ {ad.views} views</p>
         <p className="text-xs text-purple-500">📌 Type: {ad.adType}</p>

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -15,6 +15,7 @@ export const fetchAds = async () => {
     ...ad,
     image: `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.image_url}`,
     link: ad.link_url,
+    targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
   }));
 };
 
@@ -26,6 +27,7 @@ export const fetchAdById = async (id) => {
     ...ad,
     image: `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.image_url}`,
     link: ad.link_url,
+    targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
   };
 };
 


### PR DESCRIPTION
## Summary
- handle missing targetRoles when mapping in AdCard and preview modals
- default `targetRoles` in ad service responses

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_685317bec5208328bd885369ffea7de0