### PR TITLE
Fix ad analytics 404

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -65,15 +65,25 @@ exports.deleteAd = catchAsync(async (req, res) => {
 
 exports.getAdAnalytics = catchAsync(async (req, res) => {
   const data = await service.getAdAnalytics(req.params.id);
-  if (!data) throw new AppError("Analytics not found", 404);
+  const base = {
+    views: 0,
+    ctr: 0,
+    conversions: 0,
+    reach: 0,
+    devices: [],
+    locationStats: [],
+    analytics: [],
+  };
+  if (!data) {
+    sendSuccess(res, base);
+    return;
+  }
   const response = {
+    ...base,
     views: data.views,
     ctr: data.ctr,
     conversions: data.clicks,
     reach: data.unique_viewers,
-    devices: [],
-    locationStats: [],
-    analytics: [],
   };
   sendSuccess(res, response);
 });


### PR DESCRIPTION
## Summary
- avoid 404 when analytics row missing by returning default analytics

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b8fc8dd48328be7914a2fa1947f3