### PR TITLE
Add OTP API calls for email/phone verification

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/Verification.js
@@ -1,8 +1,24 @@
 import { useState, useCallback } from "react";
 import { motion } from "framer-motion";
-import { FaArrowLeft, FaArrowRight, FaUpload, FaCheckCircle, FaEnvelope, FaPhone, FaCropAlt, FaTrash, FaFilePdf } from "react-icons/fa";
+import {
+  FaArrowLeft,
+  FaArrowRight,
+  FaUpload,
+  FaCheckCircle,
+  FaEnvelope,
+  FaPhone,
+  FaCropAlt,
+  FaTrash,
+  FaFilePdf,
+} from "react-icons/fa";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage"; // ✅ Import the cropping function
+import {
+  sendEmailOtp,
+  sendPhoneOtp,
+  confirmEmailOtp,
+  confirmPhoneOtp,
+} from "@/services/verificationService";
 
 const Verification = ({ onNext, onBack }) => {
   const [emailVerified, setEmailVerified] = useState(false);
@@ -22,22 +38,28 @@ const Verification = ({ onNext, onBack }) => {
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
 
-  // ✅ Mock function to simulate sending OTP (Replace with API call)
-  const sendOtp = (type) => {
-    setOtpSent((prev) => ({ ...prev, [type]: true }));
-    setShowOtpModal(type);
+  // ✅ Send OTP via API
+  const sendOtp = async (type) => {
+    try {
+      if (type === "email") await sendEmailOtp();
+      else await sendPhoneOtp();
+      setOtpSent((prev) => ({ ...prev, [type]: true }));
+      setShowOtpModal(type);
+    } catch (err) {
+      alert("Failed to send OTP");
+    }
   };
 
-  // ✅ Handle OTP verification
-  const verifyOtp = (type) => {
+  // ✅ Handle OTP verification via API
+  const verifyOtp = async (type) => {
     const enteredOTP = type === "email" ? emailOTP : phoneOTP;
-    const correctOTP = "123456"; // Mock OTP (replace with real validation)
-
-    if (enteredOTP === correctOTP) {
+    try {
+      if (type === "email") await confirmEmailOtp(enteredOTP);
+      else await confirmPhoneOtp(enteredOTP);
       if (type === "email") setEmailVerified(true);
       if (type === "phone") setPhoneVerified(true);
       setShowOtpModal(null);
-    } else {
+    } catch (err) {
       alert("Invalid OTP. Please try again.");
     }
   };

--- a/frontend/src/pages/dashboard/student/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/Verification.js
@@ -12,6 +12,12 @@ import {
 } from "react-icons/fa";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
+import {
+  sendEmailOtp,
+  sendPhoneOtp,
+  confirmEmailOtp,
+  confirmPhoneOtp,
+} from "@/services/verificationService";
 
 const Verification = ({ nextStep, prevStep }) => {
   const [emailVerified, setEmailVerified] = useState(false);
@@ -24,17 +30,23 @@ const Verification = ({ nextStep, prevStep }) => {
   const [identityPreview, setIdentityPreview] = useState(null);
   const [isPDF, setIsPDF] = useState(false);
 
-  const sendOtp = (type) => {
-    setOtpSent((prev) => ({ ...prev, [type]: true }));
+  const sendOtp = async (type) => {
+    try {
+      if (type === "email") await sendEmailOtp();
+      else await sendPhoneOtp();
+      setOtpSent((prev) => ({ ...prev, [type]: true }));
+    } catch (err) {
+      alert("Failed to send OTP");
+    }
   };
 
-  const verifyOtp = (type) => {
+  const verifyOtp = async (type) => {
     const enteredOTP = type === "email" ? emailOTP : phoneOTP;
-    const correctOTP = "123456";
-
-    if (enteredOTP === correctOTP) {
+    try {
+      if (type === "email") await confirmEmailOtp(enteredOTP);
+      else await confirmPhoneOtp(enteredOTP);
       type === "email" ? setEmailVerified(true) : setPhoneVerified(true);
-    } else {
+    } catch (err) {
       alert("Invalid OTP. Please try again.");
     }
   };

--- a/frontend/src/pages/profile/steps/Verification.js
+++ b/frontend/src/pages/profile/steps/Verification.js
@@ -3,6 +3,12 @@ import { motion } from "framer-motion";
 import { FaArrowLeft, FaArrowRight, FaUpload, FaCheckCircle, FaEnvelope, FaPhone, FaCropAlt, FaTrash, FaFilePdf } from "react-icons/fa";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage"; // ✅ Import the cropping function
+import {
+  sendEmailOtp,
+  sendPhoneOtp,
+  confirmEmailOtp,
+  confirmPhoneOtp,
+} from "@/services/verificationService";
 
 const Verification = ({ onNext, onBack }) => {
   const [emailVerified, setEmailVerified] = useState(false);
@@ -22,22 +28,28 @@ const Verification = ({ onNext, onBack }) => {
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
 
-  // ✅ Mock function to simulate sending OTP (Replace with API call)
-  const sendOtp = (type) => {
-    setOtpSent((prev) => ({ ...prev, [type]: true }));
-    setShowOtpModal(type);
+  // ✅ Send OTP via API
+  const sendOtp = async (type) => {
+    try {
+      if (type === "email") await sendEmailOtp();
+      else await sendPhoneOtp();
+      setOtpSent((prev) => ({ ...prev, [type]: true }));
+      setShowOtpModal(type);
+    } catch (err) {
+      alert("Failed to send OTP");
+    }
   };
 
-  // ✅ Handle OTP verification
-  const verifyOtp = (type) => {
+  // ✅ Handle OTP verification via API
+  const verifyOtp = async (type) => {
     const enteredOTP = type === "email" ? emailOTP : phoneOTP;
-    const correctOTP = "123456"; // Mock OTP (replace with real validation)
-
-    if (enteredOTP === correctOTP) {
+    try {
+      if (type === "email") await confirmEmailOtp(enteredOTP);
+      else await confirmPhoneOtp(enteredOTP);
       if (type === "email") setEmailVerified(true);
       if (type === "phone") setPhoneVerified(true);
       setShowOtpModal(null);
-    } else {
+    } catch (err) {
       alert("Invalid OTP. Please try again.");
     }
   };

--- a/frontend/src/services/verificationService.js
+++ b/frontend/src/services/verificationService.js
@@ -1,0 +1,21 @@
+import api from "@/services/api/api";
+
+export const sendEmailOtp = async () => {
+  const res = await api.post("/verify/email/send");
+  return res.data;
+};
+
+export const sendPhoneOtp = async () => {
+  const res = await api.post("/verify/phone/send");
+  return res.data;
+};
+
+export const confirmEmailOtp = async (code) => {
+  const res = await api.post("/verify/email/confirm", { code });
+  return res.data;
+};
+
+export const confirmPhoneOtp = async (code) => {
+  const res = await api.post("/verify/phone/confirm", { code });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- implement `verificationService` with API helpers
- integrate OTP API calls into verification steps for profiles

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6853c1b0795483289f94dfaf939147ac