### PR TITLE
Fix phone input styling

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css"; // ✅ Toast notifications
 import "react-quill/dist/quill.snow.css";       // ✅ Rich text editor
+import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
 import "@/styles/globals.css";    
 import "@/services/api/tokenInterceptor";
 import useAuthStore from "@/store/auth/authStore";

--- a/frontend/src/shared/components/auth/PhoneInputField.js
+++ b/frontend/src/shared/components/auth/PhoneInputField.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PhoneInput from "react-phone-input-2";
-import "react-phone-input-2/lib/style.css";
 
 export default function PhoneInputField({ label, value, onChange, ...rest }) {
   return (


### PR DESCRIPTION
## Summary
- ensure react-phone-input-2 styles load globally
- clean up phone input component

## Testing
- `npm test` *(fails: jest not found)*
- `cd backend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d5568bb08328bbf74c5b220fde3c