### PR TITLE
Fix phone input styling

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css"; // ✅ Toast notifications
 import "react-quill/dist/quill.snow.css";       // ✅ Rich text editor
+import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
 import "@/styles/globals.css";    
 import "@/services/api/tokenInterceptor";
 import useAuthStore from "@/store/auth/authStore";

--- a/frontend/src/shared/components/auth/PhoneInputField.js
+++ b/frontend/src/shared/components/auth/PhoneInputField.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PhoneInput from "react-phone-input-2";
-import "react-phone-input-2/lib/style.css";
 
 export default function PhoneInputField({ label, value, onChange, ...rest }) {
   return (
@@ -13,6 +12,7 @@ export default function PhoneInputField({ label, value, onChange, ...rest }) {
         inputClass="!bg-gray-700 !text-white !w-full !py-2 !pl-12 !pr-3 !border !rounded-lg"
         buttonClass="!bg-gray-700 border-r !border-gray-600"
         containerClass="!w-full"
+        dropdownStyle={{ backgroundColor: "#374151", color: "#fff" }}
         {...rest}
       />
     </div>


### PR DESCRIPTION
## Summary
- ensure react-phone-input-2 styles load globally
- clean up phone input component
- style dropdown for readability

## Testing
- `npm test` *(fails: package.json missing)*
- `cd frontend && npm test` *(fails: jest not found)*
- `cd backend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d5568bb08328bbf74c5b220fde3c