### PR TITLE
Enable instructor availability management

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -255,3 +255,46 @@ exports.changePassword = async (req, res) => {
 
     res.json({ message: "Password changed successfully." });
 };
+
+/**
+ * @desc Get instructor availability
+ * @route GET /api/users/instructor/availability
+ * @access Instructor
+ */
+exports.getAvailability = async (req, res) => {
+    const userId = req.user.id;
+    const [profile] = await db('instructor_profiles')
+        .where({ user_id: userId })
+        .select('availability');
+
+    let availability = [];
+    if (profile && profile.availability) {
+        try {
+            availability = JSON.parse(profile.availability);
+        } catch (_) {
+            availability = [];
+        }
+    }
+
+    res.json({ availability });
+};
+
+/**
+ * @desc Update instructor availability
+ * @route PATCH /api/users/instructor/availability
+ * @access Instructor
+ */
+exports.updateAvailability = async (req, res) => {
+    const userId = req.user.id;
+    const { availability } = req.body;
+
+    if (!Array.isArray(availability)) {
+        return res.status(400).json({ message: 'Availability must be an array' });
+    }
+
+    await db('instructor_profiles')
+        .where({ user_id: userId })
+        .update({ availability: JSON.stringify(availability) });
+
+    res.json({ message: 'Availability updated successfully' });
+};

--- a/backend/src/modules/users/instructor/instructor.routes.js
+++ b/backend/src/modules/users/instructor/instructor.routes.js
@@ -101,6 +101,20 @@ router.delete("/:id/demo", verifyToken, isInstructor, controller.deleteDemoVideo
  */
 router.patch("/status", verifyToken, isInstructor, controller.toggleStatus);
 
+// Availability management
+router.get(
+  "/availability",
+  verifyToken,
+  isInstructor,
+  controller.getAvailability
+);
+router.patch(
+  "/availability",
+  verifyToken,
+  isInstructor,
+  controller.updateAvailability
+);
+
 
 /**
  * @desc Upload demo video

--- a/frontend/src/pages/dashboard/instructor/availability.js
+++ b/frontend/src/pages/dashboard/instructor/availability.js
@@ -6,7 +6,11 @@ import interactionPlugin from '@fullcalendar/interaction';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { Dialog } from '@headlessui/react';
 import useAuthStore from '@/store/auth/authStore';
-import { toggleInstructorStatus } from '@/services/instructor/instructorService';
+import {
+  toggleInstructorStatus,
+  getInstructorAvailability,
+  updateInstructorAvailability,
+} from '@/services/instructor/instructorService';
 import { toast } from 'react-toastify';
 
 export default function InstructorAvailabilityPage() {
@@ -21,6 +25,20 @@ export default function InstructorAvailabilityPage() {
   useEffect(() => {
     setAvailable(user?.is_online ?? false);
   }, [user]);
+
+  useEffect(() => {
+    async function fetchAvailability() {
+      try {
+        const res = await getInstructorAvailability();
+        if (Array.isArray(res.availability)) {
+          setAvailability(res.availability);
+        }
+      } catch (err) {
+        console.error('Failed to load availability', err);
+      }
+    }
+    fetchAvailability();
+  }, []);
 
   const categoryColors = {
     'Office Hour': '#34d399',
@@ -118,6 +136,21 @@ export default function InstructorAvailabilityPage() {
             slotMinTime="08:00:00"
             slotMaxTime="20:00:00"
           />
+        </div>
+        <div className="mt-4">
+          <button
+            onClick={async () => {
+              try {
+                await updateInstructorAvailability(availability);
+                toast.success('Availability saved');
+              } catch (err) {
+                toast.error('Failed to save availability');
+              }
+            }}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            Save Availability
+          </button>
         </div>
 
         {/* Legend */}

--- a/frontend/src/services/instructor/instructorService.js
+++ b/frontend/src/services/instructor/instructorService.js
@@ -76,3 +76,14 @@ export const getInstructorStatus = async () => {
   const res = await api.get("/users/instructor/profile/status");
   return res.data;
 };
+
+// 🔹 Availability endpoints
+export const getInstructorAvailability = async () => {
+  const res = await api.get("/users/instructor/availability");
+  return res.data;
+};
+
+export const updateInstructorAvailability = async (availability) => {
+  const res = await api.patch("/users/instructor/availability", { availability });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- add API controllers and routes to get and update instructor availability
- expose availability functions in instructorService
- load and save availability on instructor dashboard page

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f60c695c8328a9a119eb740d22fa