### PR TITLE
Add role-based booking API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
 4. Visit `http://localhost:3001` to access the frontend. The API is available at `http://localhost:5000`.
 
 For detailed instructions see [docs/installation.md](docs/installation.md).
+
+## Booking API
+
+The backend exposes role-based endpoints for managing instructor bookings:
+
+- `POST /api/bookings/student` – create a booking as the logged-in student
+- `GET /api/bookings/student` – list bookings for the current student
+- `GET /api/bookings/instructor` – list bookings for the logged-in instructor
+- `PATCH /api/bookings/instructor/:id` – update a booking (e.g. approve or decline)
+
+Admin routes remain available under `/api/bookings/admin`.

--- a/backend/src/modules/bookings/bookings.controller.js
+++ b/backend/src/modules/bookings/bookings.controller.js
@@ -38,6 +38,36 @@ exports.updateBooking = catchAsync(async (req, res) => {
   sendSuccess(res, booking, "Booking updated");
 });
 
+// Student: create a booking for themselves
+exports.createBookingAsStudent = catchAsync(async (req, res) => {
+  const { instructor_id, start_time, end_time, notes } = req.body;
+  if (!instructor_id || !start_time || !end_time) {
+    throw new AppError("Missing required fields", 400);
+  }
+  const booking = await service.create({
+    id: uuidv4(),
+    student_id: req.user.id,
+    instructor_id,
+    start_time,
+    end_time,
+    notes,
+    status: "pending",
+  });
+  sendSuccess(res, booking, "Booking created");
+});
+
+// Get bookings for logged in student
+exports.getStudentBookings = catchAsync(async (req, res) => {
+  const data = await service.getByStudent(req.user.id);
+  sendSuccess(res, data);
+});
+
+// Get bookings for logged in instructor
+exports.getInstructorBookings = catchAsync(async (req, res) => {
+  const data = await service.getByInstructor(req.user.id);
+  sendSuccess(res, data);
+});
+
 exports.deleteBooking = catchAsync(async (req, res) => {
   await service.delete(req.params.id);
   sendSuccess(res, null, "Booking deleted");

--- a/backend/src/modules/bookings/bookings.service.js
+++ b/backend/src/modules/bookings/bookings.service.js
@@ -9,6 +9,20 @@ exports.getAll = async () => {
   return db("bookings").select("*").orderBy("requested_at", "desc");
 };
 
+// Get bookings for a specific student
+exports.getByStudent = async (studentId) => {
+  return db("bookings")
+    .where({ student_id: studentId })
+    .orderBy("requested_at", "desc");
+};
+
+// Get bookings for a specific instructor
+exports.getByInstructor = async (instructorId) => {
+  return db("bookings")
+    .where({ instructor_id: instructorId })
+    .orderBy("requested_at", "desc");
+};
+
 exports.getById = async (id) => {
   return db("bookings").where({ id }).first();
 };

--- a/backend/src/modules/bookings/instructor.routes.js
+++ b/backend/src/modules/bookings/instructor.routes.js
@@ -1,0 +1,10 @@
+const router = require("express").Router();
+const controller = require("./bookings.controller");
+const { verifyToken, isInstructor } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isInstructor);
+
+router.get("/", controller.getInstructorBookings);
+router.patch("/:id", controller.updateBooking);
+
+module.exports = router;

--- a/backend/src/modules/bookings/student.routes.js
+++ b/backend/src/modules/bookings/student.routes.js
@@ -1,0 +1,11 @@
+const router = require("express").Router();
+const controller = require("./bookings.controller");
+const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isStudent);
+
+router.post("/", controller.createBookingAsStudent);
+router.get("/", controller.getStudentBookings);
+router.patch("/:id", controller.updateBooking);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -14,6 +14,8 @@ const userRoutes = require("./modules/users/user.routes");
 const verifyRoutes = require("./modules/verify/verify.routes"); // ✅ OTP routes
 const certificatePublicRoutes = require("./modules/users/tutorials/certificate/certificatePublic.routes");
 const adminBookingRoutes = require("./modules/bookings/bookings.routes");
+const studentBookingRoutes = require("./modules/bookings/student.routes");
+const instructorBookingRoutes = require("./modules/bookings/instructor.routes");
 const adminCommunityRoutes = require("./modules/community/admin/admin.routes");
 const roleRoutes = require("./modules/roles/roles.routes");
 const planRoutes = require("./modules/plans/plans.routes");
@@ -76,6 +78,8 @@ app.use("/api/users", userRoutes);     // 👤 Users: profile, avatar, demo vide
 app.use("/api/verify", verifyRoutes);  // ✅ OTP: send/confirm email/phone
 app.use("/api/certificates", certificatePublicRoutes); // 🎓 Public certificate verification
 app.use("/api/bookings/admin", adminBookingRoutes); // 📅 Admin bookings management
+app.use("/api/bookings/student", studentBookingRoutes); // 🎒 Student bookings
+app.use("/api/bookings/instructor", instructorBookingRoutes); // 👩‍🏫 Instructor bookings
 app.use("/api/community/admin", adminCommunityRoutes); // 🗣️ Admin community management
 app.use("/api/roles", roleRoutes); // 🛡️ Role and permission management
 app.use("/api/plans", planRoutes); // 💳 Subscription plans


### PR DESCRIPTION
## Summary
- allow instructors and students to manage their own bookings
- expose `/api/bookings/student` and `/api/bookings/instructor` routes
- document new endpoints in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f82e04048328aca2246f9c762076