### PR TITLE
Fix API port mismatch

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -118,7 +118,8 @@ app.use(errorHandler); // ✅ After all routes
 // 🚀 Start Server
 // ─────────────────────────────────────────────────────────────────────────────
 
-const PORT = process.env.PORT || 5001;
+// Default to port 5000 to match example env and docker-compose
+const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => {
   console.log(`✅ Server running on http://localhost:${PORT}`);
 });

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -5,13 +5,13 @@ const nextConfig = {
       {
         protocol: 'http',
         hostname: 'localhost',
-        port: '5001',
+        port: '5000',
         pathname: '/uploads/**', // legacy path
       },
       {
         protocol: 'http',
         hostname: 'localhost',
-        port: '5001',
+        port: '5000',
         pathname: '/api/uploads/**', // Allow images served via API
       },
     ],

--- a/frontend/src/config/config.js
+++ b/frontend/src/config/config.js
@@ -1,2 +1,3 @@
 // 📁 config.js
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5001';
+// Default API URL should align with backend PORT (5000)
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000';

--- a/frontend/src/pages/profile/change-password.js
+++ b/frontend/src/pages/profile/change-password.js
@@ -55,10 +55,10 @@ const ChangePasswordPage = ({ prevStep }) => {
       let body = {};
 
       if (user.role === "Student") {
-        endpoint = "http://localhost:5001/api/users/student/change-password";
+        endpoint = "http://localhost:5000/api/users/student/change-password";
         body = { currentPassword, newPassword };
       } else if (user.role === "Admin" || user.role === "SuperAdmin") {
-        endpoint = `http://localhost:5001/api/users/admin/reset-password/${user.id}`;
+        endpoint = `http://localhost:5000/api/users/admin/reset-password/${user.id}`;
         method = "POST";
         body = { newPassword };
       } else {

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -8,7 +8,8 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5001/api",
+  // Default to port 5000 to mirror backend configuration
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api",
   withCredentials: true, // ✅ KEEP this to send cookies with requests
 });
 


### PR DESCRIPTION
## Summary
- default server port to 5000 to match docs and compose
- update frontend config and API base URL to use port 5000
- update profile change-password endpoints
- adjust Next.js config for images

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685402c6d0dc832881135a049ec6bb0d