### PR TITLE
Connect instructor bookings page to API

### DIFF
--- a/frontend/src/services/instructor/bookingService.js
+++ b/frontend/src/services/instructor/bookingService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchInstructorBookings = async () => {
+  const { data } = await api.get("/bookings/instructor");
+  return data?.data ?? [];
+};
+
+export const updateInstructorBooking = async (id, payload) => {
+  const { data } = await api.patch(`/bookings/instructor/${id}`, payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- add instructor booking service
- load instructor bookings from API and support cancelling bookings

## Testing
- `npm test` within `backend` *(fails: jest not found)*
- `npm test` within `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540c70c33883288a3c38a42dac43db