### PR TITLE
Implement booking API call and rescheduling

### DIFF
--- a/frontend/src/components/student/instructors/BookingRequestModal.js
+++ b/frontend/src/components/student/instructors/BookingRequestModal.js
@@ -1,8 +1,25 @@
 // components/student/instructors/BookingRequestModal.js
+import { useEffect } from "react";
 import { motion } from "framer-motion";
-import { FaComments, FaCheck, FaTimes, FaCalendarCheck  } from "react-icons/fa";
+import { FaCalendarCheck } from "react-icons/fa";
+import { createStudentBooking } from "@/services/student/bookingService";
 
-export default function BookingRequestModal({ instructorName, onClose }) {
+export default function BookingRequestModal({ instructor, onClose }) {
+  useEffect(() => {
+    if (!instructor) return;
+    const now = new Date();
+    const start = new Date(now.getTime() + 3600 * 1000); // default 1h from now
+    const end = new Date(start.getTime() + 60 * 60 * 1000); // 1h duration
+    createStudentBooking({
+      instructor_id: instructor.id,
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+      notes: `Auto booked with ${instructor.name}`,
+    }).catch((err) => {
+      console.error("Booking request failed", err);
+    });
+  }, [instructor]);
+
   return (
     <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-60 z-50">
       <motion.div
@@ -11,7 +28,7 @@ export default function BookingRequestModal({ instructorName, onClose }) {
         className="bg-white p-6 rounded-xl max-w-md text-center"
       >
         <h3 className="text-xl font-bold mb-3">Request Sent!</h3>
-        <p className="text-gray-700">Lesson request sent to <strong>{instructorName}</strong>.</p>
+        <p className="text-gray-700">Lesson request sent to <strong>{instructor?.name}</strong>.</p>
         <button
           onClick={onClose}
           className="mt-4 bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-600 flex items-center gap-2"

--- a/frontend/src/pages/dashboard/student/bookings.js
+++ b/frontend/src/pages/dashboard/student/bookings.js
@@ -20,6 +20,24 @@ export default function StudentBookingsPage() {
   const [loading, setLoading] = useState(true);
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [bookingToCancel, setBookingToCancel] = useState(null);
+  const handleReschedule = async (booking) => {
+    const input = prompt('Enter new start time (YYYY-MM-DD HH:MM)');
+    if (!input) return;
+    const start = new Date(input);
+    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    await updateStudentBooking(booking.id, {
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+      status: 'pending',
+    });
+    setBookings((prev) =>
+      prev.map((b) =>
+        b.id === booking.id
+          ? { ...b, start_time: start.toISOString(), end_time: end.toISOString(), status: 'pending' }
+          : b
+      )
+    );
+  };
 
   useEffect(() => {
     fetchStudentBookings()
@@ -104,7 +122,7 @@ export default function StudentBookingsPage() {
                       {booking.subject} with {booking.instructor_name}
                     </h3>
                     <p className="text-sm text-gray-500">
-                      {new Date(booking.start_time).toLocaleString()}
+                      {new Date(booking.start_time).toLocaleString(undefined, { timeZoneName: 'short' })}
                     </p>
                   </div>
                 </div>
@@ -122,7 +140,7 @@ export default function StudentBookingsPage() {
                       </button>
                       <button
                         className="bg-yellow-400 text-black px-3 py-1 rounded hover:bg-yellow-500 text-sm"
-                        onClick={() => alert('Reschedule requested')}
+                        onClick={() => handleReschedule(booking)}
                       >
                         Reschedule
                       </button>

--- a/frontend/src/pages/instructors/[id].js
+++ b/frontend/src/pages/instructors/[id].js
@@ -134,7 +134,7 @@ export default function InstructorProfilePage() {
         {/* Booking Modal */}
         {showBooking && (
           <BookingRequestModal
-            instructorName={instructor.name}
+            instructor={instructor}
             onClose={() => setShowBooking(false)}
           />
         )}


### PR DESCRIPTION
## Summary
- connect `BookingRequestModal` to backend API
- allow students to reschedule bookings and show timezone info
- update instructor page to pass full instructor object

## Testing
- `npx jest --version` *(fails: Need to install jest)*
- `npm test --silent` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685410b093b483289dfb80f2082a1a51