### PR TITLE
Fix CORS origin handling and improve instructor UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
 
    ```bash
    cp backend/.env.example backend/.env
+   # edit backend/.env and set your secrets
+   # Optionally set FRONTEND_URL to match your frontend port
    ```
 
 2. Initialize the database (run migrations and seeds):

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,4 @@ DATABASE_URL=postgres://user:password@localhost:5432/skillbridge_db
 JWT_SECRET=your_jwt_secret
 CLOUDINARY_API_KEY=your_key
 SMTP_HOST=smtp.mailtrap.io
+FRONTEND_URL=http://localhost:3000

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -50,9 +50,12 @@ app.use(express.json());
 app.use(cookieParser());
 
 // 🌐 Allow frontend to communicate with backend (CORS)
+// Allow overriding the allowed origin via FRONTEND_URL env var. This is useful
+// when the frontend runs on a different port (e.g. 3001 in Docker).
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
 app.use(
   cors({
-    origin: "http://localhost:3000", // ✅ Replace with your frontend domain
+    origin: FRONTEND_URL,
     credentials: true,
   })
 );

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,6 +22,7 @@ Follow these steps to run SkillBridge on your local machine.
    ```bash
    cp backend/.env.example backend/.env
    # edit backend/.env and set your secrets
+   # Optionally change FRONTEND_URL if your frontend runs on another port
    ```
 
 3. (Optional) Install dependencies for manual development:

--- a/frontend/src/components/website/sections/InstructorBooking.js
+++ b/frontend/src/components/website/sections/InstructorBooking.js
@@ -75,7 +75,10 @@ export default function InstructorBooking() {
       (i) =>
         (!onlyAvailable || i.availableNow) &&
         (!showFavoritesOnly || favorites.includes(i.id)) &&
-        (selectedCategory === "All" || i.expertise === selectedCategory) &&
+        (selectedCategory === "All" ||
+          (Array.isArray(i.expertise)
+            ? i.expertise.includes(selectedCategory)
+            : i.expertise === selectedCategory)) &&
         i.name.toLowerCase().includes(searchQuery.toLowerCase())
     )
     .sort((a, b) => {
@@ -181,8 +184,11 @@ export default function InstructorBooking() {
 
       {/* Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
-        {filtered.map((i) => (
-          <motion.div
+        {filtered.length === 0 ? (
+          <p className="col-span-full text-gray-400">No instructors found.</p>
+        ) : (
+          filtered.map((i) => (
+            <motion.div
             key={i.id}
             whileHover={{ scale: 1.05 }}
             className="p-6 bg-gray-800 rounded-lg shadow-lg text-center flex flex-col items-center relative"
@@ -236,8 +242,9 @@ export default function InstructorBooking() {
                 <FaHeart />
               </button>
             </div>
-          </motion.div>
-        ))}
+            </motion.div>
+          ))
+        )}
       </div>
 
       {/* Request Modal */}


### PR DESCRIPTION
## Summary
- allow overriding frontend origin in CORS setup via `FRONTEND_URL`
- document new env variable in `.env.example`, README and installation guide
- handle expertise arrays and empty list state in InstructorBooking

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557743dd38832886e5dbffc197113f