### PR TITLE
Fix role lookup case sensitivity

### DIFF
--- a/backend/src/modules/instructors/instructor.service.js
+++ b/backend/src/modules/instructors/instructor.service.js
@@ -3,7 +3,8 @@ const db = require("../../config/database");
 exports.getPublicInstructors = async () => {
   return db("users")
     .join("instructor_profiles", "users.id", "instructor_profiles.user_id")
-    .where({ "users.role": "instructor", "users.status": "active" })
+    .whereRaw("LOWER(users.role) = ?", ["instructor"])
+    .andWhere({ "users.status": "active" })
     .select(
       "users.id",
       "users.full_name",
@@ -19,7 +20,8 @@ exports.getPublicInstructors = async () => {
 exports.getPublicInstructor = async (id) => {
   return db("users")
     .join("instructor_profiles", "users.id", "instructor_profiles.user_id")
-    .where({ "users.id": id, "users.role": "instructor" })
+    .where({ "users.id": id })
+    .andWhereRaw("LOWER(users.role) = ?", ["instructor"])
     .first(
       "users.id",
       "users.full_name",


### PR DESCRIPTION
## Summary
- return instructors even if role has different casing by using `LOWER`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68557b0e279c83289502860780f60a44