### PR TITLE
Fix role lookup case sensitivity

### DIFF
--- a/backend/src/modules/instructors/instructor.service.js
+++ b/backend/src/modules/instructors/instructor.service.js
@@ -3,7 +3,8 @@ const db = require("../../config/database");
 exports.getPublicInstructors = async () => {
   return db("users")
     .join("instructor_profiles", "users.id", "instructor_profiles.user_id")
-    .where({ "users.role": "instructor", "users.status": "active" })
+    .whereRaw("LOWER(users.role) = ?", ["instructor"])
+    .andWhere({ "users.status": "active" })
     .select(
       "users.id",
       "users.full_name",
@@ -19,7 +20,8 @@ exports.getPublicInstructors = async () => {
 exports.getPublicInstructor = async (id) => {
   return db("users")
     .join("instructor_profiles", "users.id", "instructor_profiles.user_id")
-    .where({ "users.id": id, "users.role": "instructor" })
+    .where({ "users.id": id })
+    .andWhereRaw("LOWER(users.role) = ?", ["instructor"])
     .first(
       "users.id",
       "users.full_name",

--- a/frontend/src/components/website/sections/InstructorBooking.js
+++ b/frontend/src/components/website/sections/InstructorBooking.js
@@ -98,7 +98,7 @@ export default function InstructorBooking() {
 
   const handleRequest = async (instructor) => {
 
-    if (!user || user.role !== "student") {
+    if (!user || user.role?.toLowerCase() !== "student") {
       router.push("/auth/login");
       return;
     }

--- a/frontend/src/pages/dashboard/instructor/bookings/index.js
+++ b/frontend/src/pages/dashboard/instructor/bookings/index.js
@@ -109,6 +109,13 @@ export default function InstructorBookingsPage() {
                   </td>
                 </tr>
               ))}
+              {bookings.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="text-center text-gray-400 py-8">
+                    No bookings found.
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- return instructors even if role has different casing by using `LOWER`
- show a message if instructors have no bookings
- ensure website booking button works for `Student` role regardless of case

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68557b0e279c83289502860780f60a44