### PR TITLE
Show booking notes in admin table

### DIFF
--- a/frontend/src/components/admin/bookings/BookingModal.js
+++ b/frontend/src/components/admin/bookings/BookingModal.js
@@ -49,6 +49,11 @@ export default function BookingModal({ booking, onClose, onCancel }) {
           <div><strong>Time:</strong> {booking.time}</div>
           <div><strong>Duration:</strong> {booking.duration}</div>
           <div><strong>Status:</strong> <span className="capitalize">{booking.status}</span></div>
+          {booking.notes && (
+            <div className="whitespace-pre-wrap">
+              <strong>Notes:</strong> {booking.notes}
+            </div>
+          )}
         </div>
 
         {(booking.status?.toLowerCase() === 'pending' ||

--- a/frontend/src/components/admin/bookings/BookingRow.js
+++ b/frontend/src/components/admin/bookings/BookingRow.js
@@ -33,6 +33,7 @@ export default function BookingRow({ booking, onView }) {
           {booking.status?.charAt(0).toUpperCase() + booking.status?.slice(1)}
         </span>
       </td>
+      <td className="px-4 py-2 max-w-xs truncate">{booking.notes || '—'}</td>
     </tr>
   );
 }

--- a/frontend/src/pages/dashboard/admin/bookings/index.js
+++ b/frontend/src/pages/dashboard/admin/bookings/index.js
@@ -105,6 +105,7 @@ export default function AdminBookingsPage() {
                 <th className="px-4 py-2">Time</th>
                 <th className="px-4 py-2">Duration</th>
                 <th className="px-4 py-2">Status</th>
+                <th className="px-4 py-2">Notes</th>
               </tr>
             </thead>
             <tbody>
@@ -117,7 +118,7 @@ export default function AdminBookingsPage() {
               ))}
               {filtered.length === 0 && (
                 <tr>
-                  <td colSpan={7} className="text-center text-gray-400 py-8">
+                  <td colSpan={8} className="text-center text-gray-400 py-8">
                     No bookings found.
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- display notes column in admin bookings table
- include notes in each table row
- show notes in booking modal

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6856ea4ebae48328ac4f3c6731545ff3