### PR TITLE
Show booking type with images

### DIFF
--- a/frontend/src/components/admin/bookings/BookingModal.js
+++ b/frontend/src/components/admin/bookings/BookingModal.js
@@ -44,11 +44,16 @@ export default function BookingModal({ booking, onClose, onCancel }) {
             </div>
           </div>
 
-          <div><strong>Class:</strong> {booking.classTitle}</div>
+          <div><strong>Booking Type:</strong> {booking.type}</div>
           <div><strong>Date:</strong> {booking.date}</div>
           <div><strong>Time:</strong> {booking.time}</div>
           <div><strong>Duration:</strong> {booking.duration}</div>
           <div><strong>Status:</strong> <span className="capitalize">{booking.status}</span></div>
+          {booking.notes && (
+            <div className="whitespace-pre-wrap">
+              <strong>Notes:</strong> {booking.notes}
+            </div>
+          )}
         </div>
 
         {(booking.status?.toLowerCase() === 'pending' ||

--- a/frontend/src/components/admin/bookings/BookingRow.js
+++ b/frontend/src/components/admin/bookings/BookingRow.js
@@ -20,10 +20,10 @@ export default function BookingRow({ booking, onView }) {
         <img src={booking.instructor.avatar} className="w-8 h-8 rounded-full" alt="instructor" />
         {booking.instructor.name}
       </td>
-      <td className="px-4 py-2">{booking.classTitle}</td>
-      <td className="px-4 py-2">{booking.date}</td>
-      <td className="px-4 py-2">{booking.time}</td>
-      <td className="px-4 py-2">{booking.duration}</td>
+      <td className="px-4 py-2">{booking.type}</td>
+      <td className="px-4 py-2 whitespace-nowrap">{booking.date}</td>
+      <td className="px-4 py-2 whitespace-nowrap">{booking.time}</td>
+      <td className="px-4 py-2 whitespace-nowrap">{booking.duration}</td>
       <td className="px-4 py-2">
         <span
           className={`text-xs px-2 py-1 rounded-full ${
@@ -33,6 +33,7 @@ export default function BookingRow({ booking, onView }) {
           {booking.status?.charAt(0).toUpperCase() + booking.status?.slice(1)}
         </span>
       </td>
+      <td className="px-4 py-2 max-w-xs truncate">{booking.notes || '—'}</td>
     </tr>
   );
 }

--- a/frontend/src/pages/dashboard/admin/bookings/index.js
+++ b/frontend/src/pages/dashboard/admin/bookings/index.js
@@ -8,6 +8,7 @@ import {
   fetchAllBookings,
   updateBooking,
 } from '@/services/admin/bookingService';
+import { API_BASE_URL } from '@/config/config';
 import { toast } from 'react-toastify';
 
 export default function AdminBookingsPage() {
@@ -37,17 +38,17 @@ export default function AdminBookingsPage() {
           id: b.id,
           student: {
             name: b.student_name || b.student_id,
-            avatar:
-              b.student_avatar_url ||
-              "https://via.placeholder.com/40x40?text=S",
+            avatar: b.student_avatar_url
+              ? `${API_BASE_URL}${b.student_avatar_url}`
+              : "https://via.placeholder.com/40x40?text=S",
           },
           instructor: {
             name: b.instructor_name || b.instructor_id,
-            avatar:
-              b.instructor_avatar_url ||
-              "https://via.placeholder.com/40x40?text=I",
+            avatar: b.instructor_avatar_url
+              ? `${API_BASE_URL}${b.instructor_avatar_url}`
+              : "https://via.placeholder.com/40x40?text=I",
           },
-          classTitle: b.class_title || "—",
+          type: b.class_title ? "Class" : "Tutorial",
           date: b.start_time
             ? new Date(b.start_time).toISOString().split("T")[0]
             : "",
@@ -77,7 +78,7 @@ export default function AdminBookingsPage() {
     const match =
       b.student.name.toLowerCase().includes(keyword) ||
       b.instructor.name.toLowerCase().includes(keyword) ||
-      b.classTitle.toLowerCase().includes(keyword);
+      b.type.toLowerCase().includes(keyword);
     return statusFilter === 'all' ? match : match && b.status === statusFilter;
   });
 
@@ -95,16 +96,17 @@ export default function AdminBookingsPage() {
         />
 
         <div className="overflow-x-auto bg-white rounded shadow">
-          <table className="w-full table-auto text-sm">
+          <table className="min-w-full table-auto text-sm">
             <thead className="bg-gray-100 text-left">
               <tr>
                 <th className="px-4 py-2">Student</th>
                 <th className="px-4 py-2">Instructor</th>
-                <th className="px-4 py-2">Class</th>
+                <th className="px-4 py-2">Booking Type</th>
                 <th className="px-4 py-2">Date</th>
                 <th className="px-4 py-2">Time</th>
                 <th className="px-4 py-2">Duration</th>
                 <th className="px-4 py-2">Status</th>
+                <th className="px-4 py-2">Notes</th>
               </tr>
             </thead>
             <tbody>
@@ -117,7 +119,7 @@ export default function AdminBookingsPage() {
               ))}
               {filtered.length === 0 && (
                 <tr>
-                  <td colSpan={7} className="text-center text-gray-400 py-8">
+                  <td colSpan={8} className="text-center text-gray-400 py-8">
                     No bookings found.
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- prefix avatar URLs with API base path when listing admin bookings
- rename Class column to Booking Type
- show booking type in rows and modal
- keep dates and times readable

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6856ea4ebae48328ac4f3c6731545ff3