### PR TITLE
Enable deleting student bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The backend exposes role-based endpoints for managing instructor bookings:
 
 - `POST /api/bookings/student` – create a booking as the logged-in student
 - `GET /api/bookings/student` – list bookings for the current student
+- `PATCH /api/bookings/student/:id` – update a booking for the current student
+- `DELETE /api/bookings/student/:id` – delete one of the student's bookings
 - `GET /api/bookings/instructor` – list bookings for the logged-in instructor
 - `PATCH /api/bookings/instructor/:id` – update a booking (e.g. approve or decline)
 

--- a/backend/src/modules/bookings/bookings.controller.js
+++ b/backend/src/modules/bookings/bookings.controller.js
@@ -68,6 +68,16 @@ exports.getInstructorBookings = catchAsync(async (req, res) => {
   sendSuccess(res, data);
 });
 
+// Delete a booking belonging to the logged in student
+exports.deleteStudentBooking = catchAsync(async (req, res) => {
+  const booking = await service.getById(req.params.id);
+  if (!booking || booking.student_id !== req.user.id) {
+    throw new AppError("Booking not found", 404);
+  }
+  await service.delete(req.params.id);
+  sendSuccess(res, null, "Booking deleted");
+});
+
 exports.deleteBooking = catchAsync(async (req, res) => {
   await service.delete(req.params.id);
   sendSuccess(res, null, "Booking deleted");

--- a/backend/src/modules/bookings/student.routes.js
+++ b/backend/src/modules/bookings/student.routes.js
@@ -16,5 +16,6 @@ router.patch(
   validate({ body: updateBookingSchema }),
   controller.updateBooking
 );
+router.delete("/:id", controller.deleteStudentBooking);
 
 module.exports = router;

--- a/frontend/src/pages/dashboard/student/bookings.js
+++ b/frontend/src/pages/dashboard/student/bookings.js
@@ -8,10 +8,12 @@ import {
   FaTimesCircle,
   FaComments,
   FaSpinner,
+  FaTrashAlt,
 } from 'react-icons/fa';
 import {
   fetchStudentBookings,
   updateStudentBooking,
+  deleteStudentBooking,
 } from '@/services/student/bookingService';
 
 export default function StudentBookingsPage() {
@@ -67,6 +69,13 @@ export default function StudentBookingsPage() {
       )
     );
     setShowCancelModal(false);
+  };
+
+  const handleDelete = async (id) => {
+    if (window.confirm('Delete this booking?')) {
+      await deleteStudentBooking(id);
+      setBookings((prev) => prev.filter((b) => b.id !== id));
+    }
   };
 
   if (loading) {
@@ -163,6 +172,12 @@ export default function StudentBookingsPage() {
                       Cancel
                     </button>
                   )}
+                  <button
+                    className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600 text-sm"
+                    onClick={() => handleDelete(booking.id)}
+                  >
+                    <FaTrashAlt className="inline mr-1" /> Delete
+                  </button>
                 </div>
               </div>
             ))}

--- a/frontend/src/services/student/bookingService.js
+++ b/frontend/src/services/student/bookingService.js
@@ -14,3 +14,8 @@ export const createStudentBooking = async (payload) => {
   const { data } = await api.post("/bookings/student", payload);
   return data?.data;
 };
+
+export const deleteStudentBooking = async (id) => {
+  await api.delete(`/bookings/student/${id}`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- allow students to delete their own bookings via new API route
- expose DELETE endpoint in docs
- support deletion from the student dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f3b2c6d88328b6a575227825a7f1