### PR TITLE
Protect admin tutorials routes

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import toast from "react-hot-toast";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
 import MediaStep from "@/components/tutorials/create/MediaStep";
@@ -14,7 +15,7 @@ import {
 import { fetchAllCategories } from "@/services/admin/categoryService";
 import { fetchChaptersByTutorial } from "@/services/admin/tutorialChapterService";
 
-export default function EditTutorialPage() {
+function EditTutorialPage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -158,3 +159,5 @@ export default function EditTutorialPage() {
     </AdminLayout>
   );
 }
+
+export default withAuthProtection(EditTutorialPage, ["admin", "superadmin"]);

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import toast, { Toaster } from "react-hot-toast";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
 import MediaStep from "@/components/tutorials/create/MediaStep";
@@ -9,7 +10,7 @@ import ReviewStep from "@/components/tutorials/create/ReviewStep";
 import { createTutorial } from "@/services/admin/tutorialService";
 import { fetchAllCategories } from "@/services/admin/categoryService";
 
-export default function CreateTutorialPage() {
+function CreateTutorialPage() {
   const [step, setStep] = useState(1);
   const router = useRouter();
   const [tutorialData, setTutorialData] = useState({
@@ -191,3 +192,5 @@ export default function CreateTutorialPage() {
     </AdminLayout>
   );
 }
+
+export default withAuthProtection(CreateTutorialPage, ["admin", "superadmin"]);

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import { Button } from "@/components/ui/button";
 import { FaEdit, FaTrash, FaPlus } from "react-icons/fa";
 import toast, { Toaster } from "react-hot-toast";
@@ -17,7 +18,7 @@ import {
 } from "@/services/admin/tutorialService";
 
 
-export default function AdminTutorialsPage() {
+function AdminTutorialsPage() {
   const router = useRouter();
   const [tutorials, setTutorials] = useState([]);
 
@@ -462,3 +463,5 @@ export default function AdminTutorialsPage() {
     </AdminLayout>
   );
 }
+
+export default withAuthProtection(AdminTutorialsPage, ["admin", "superadmin"]);


### PR DESCRIPTION
## Summary
- secure admin tutorials index, create and edit pages with `withAuthProtection`

## Testing
- `npm test` (fails: jest not found)
- `npm run lint` in `frontend` (fails: cannot find `@eslint/eslintrc`)
- `npm test` in `backend` (fails: jest not found)
- `npm run lint` in `backend` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_6857bacf6e7c8328b4f0c832ee790036