### PR TITLE
Protect admin tutorials routes

### DIFF
--- a/frontend/src/hooks/withAuthProtection.js
+++ b/frontend/src/hooks/withAuthProtection.js
@@ -25,7 +25,7 @@ export default function withAuthProtection(Component, allowedRoles = []) {
           allowedRoles.length &&
           !allowedRoles.includes(user.role?.toLowerCase())
         ) {
-          router.replace("/403");
+          router.replace("/error/403");
         }
       }
     }, [hydrated, user, accessToken]);

--- a/frontend/src/pages/dashboard/admin/index.js
+++ b/frontend/src/pages/dashboard/admin/index.js
@@ -34,7 +34,7 @@ function AdminDashboardHome() {
       if (!user) {
         router.replace("/auth/login");
       } else if (!["admin", "superadmin"].includes(user.role?.toLowerCase())) {
-        router.replace("/403");
+        router.replace("/error/403");
       }
     }
   }, [user, hydrated]);

--- a/frontend/src/pages/dashboard/admin/instructors/index.js
+++ b/frontend/src/pages/dashboard/admin/instructors/index.js
@@ -32,7 +32,7 @@ export default function AdminInstructorsPage() {
 
     const role = user.role?.toLowerCase() ?? '';
     if (role !== 'admin' && role !== 'superadmin') {
-      router.replace('/403');
+      router.replace('/error/403');
       return;
     }
 

--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -28,7 +28,7 @@ export default function CreatePlanPage() {
     }
     const role = user.role?.toLowerCase() ?? "";
     if (role !== "admin" && role !== "superadmin") {
-      router.replace("/403");
+      router.replace("/error/403");
     }
   }, [accessToken, hasHydrated, router, user]);
 

--- a/frontend/src/pages/dashboard/admin/plans/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/plans/edit/[id].js
@@ -27,7 +27,7 @@ export default function EditPlanPage() {
     }
     const role = user.role?.toLowerCase() ?? "";
     if (role !== "admin" && role !== "superadmin") {
-      router.replace("/403");
+      router.replace("/error/403");
       return;
     }
 

--- a/frontend/src/pages/dashboard/admin/plans/index.js
+++ b/frontend/src/pages/dashboard/admin/plans/index.js
@@ -24,7 +24,7 @@ export default function PlansIndex() {
 
     const role = user.role?.toLowerCase() ?? "";
     if (role !== "admin" && role !== "superadmin") {
-      router.replace("/403");
+      router.replace("/error/403");
       return;
     }
 

--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -1,8 +1,9 @@
 // EditTutorialPage.js
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
 import MediaStep from "@/components/tutorials/create/MediaStep";
@@ -14,7 +15,7 @@ import {
 import { fetchAllCategories } from "@/services/admin/categoryService";
 import { fetchChaptersByTutorial } from "@/services/admin/tutorialChapterService";
 
-export default function EditTutorialPage() {
+function EditTutorialPage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -158,3 +159,5 @@ export default function EditTutorialPage() {
     </AdminLayout>
   );
 }
+
+export default withAuthProtection(EditTutorialPage, ["admin", "superadmin"]);

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
-import toast, { Toaster } from "react-hot-toast";
+import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
 import MediaStep from "@/components/tutorials/create/MediaStep";
@@ -9,7 +10,7 @@ import ReviewStep from "@/components/tutorials/create/ReviewStep";
 import { createTutorial } from "@/services/admin/tutorialService";
 import { fetchAllCategories } from "@/services/admin/categoryService";
 
-export default function CreateTutorialPage() {
+function CreateTutorialPage() {
   const [step, setStep] = useState(1);
   const router = useRouter();
   const [tutorialData, setTutorialData] = useState({
@@ -106,7 +107,6 @@ export default function CreateTutorialPage() {
 
   return (
     <AdminLayout>
-      <Toaster position="top-center" />
       <div className="p-8 bg-gray-100 min-h-screen max-w-4xl mx-auto">
         <h1 className="text-3xl font-bold text-gray-800 mb-8">🎬 Create New Tutorial</h1>
 
@@ -191,3 +191,5 @@ export default function CreateTutorialPage() {
     </AdminLayout>
   );
 }
+
+export default withAuthProtection(CreateTutorialPage, ["admin", "superadmin"]);

--- a/frontend/src/pages/dashboard/admin/users/index.js
+++ b/frontend/src/pages/dashboard/admin/users/index.js
@@ -24,7 +24,7 @@ export default function UsersPage() {
 
     const role = user.role?.toLowerCase() ?? "";
     if (role !== "admin" && role !== "superadmin") {
-      router.replace("/403");
+      router.replace("/error/403");
       return;
     }
 

--- a/frontend/src/pages/error/403.js
+++ b/frontend/src/pages/error/403.js
@@ -1,11 +1,18 @@
 // 📁 pages/403.js
+import Link from "next/link";
+
 export default function AccessDenied() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 text-center">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100 text-center space-y-6">
       <div>
         <h1 className="text-5xl font-bold text-red-600 mb-4">403</h1>
         <p className="text-lg text-gray-700">Access Denied — You are not authorized to view this page.</p>
       </div>
+      <Link href="/" passHref>
+        <button className="px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition">
+          Go Home
+        </button>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show an error page when logged-in users lack access to admin routes
- link from the error page back to the home page

## Testing
- `npm test` (frontend) failed: `jest: not found`
- `npm run lint` (frontend) failed: `Cannot find package '@eslint/eslintrc'`
- `npm test` (backend) failed: `jest: not found`
- `npm run lint` (backend) failed: `Missing script: "lint"`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6857bacf6e7c8328b4f0c832ee790036