### PR TITLE
Apply auth protection to admin category pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/categories/create.js
+++ b/frontend/src/pages/dashboard/admin/categories/create.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import { ArrowLeftCircle, Upload } from "lucide-react";
 import Link from "next/link";
 import { toast } from "react-toastify";
@@ -9,7 +10,7 @@ import {
   createCategory,
 } from "@/services/admin/categoryService";
 
-export default function CreateCategory() {
+function CreateCategory() {
   const [name, setName] = useState("");
   const [parentId, setParentId] = useState("");
   const [status, setStatus] = useState("active");
@@ -176,3 +177,5 @@ export default function CreateCategory() {
 CreateCategory.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+export default withAuthProtection(CreateCategory, ["admin", "superadmin"]);

--- a/frontend/src/pages/dashboard/admin/categories/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/categories/edit/[id].js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import { ArrowLeftCircle, Upload } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -10,7 +11,7 @@ import {
   updateCategory,
 } from "@/services/admin/categoryService";
 
-export default function EditCategory() {
+function EditCategory() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -188,3 +189,5 @@ export default function EditCategory() {
 EditCategory.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+export default withAuthProtection(EditCategory, ["admin", "superadmin"]);

--- a/frontend/src/pages/dashboard/admin/categories/index.js
+++ b/frontend/src/pages/dashboard/admin/categories/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Plus, Search, FolderKanban, Pencil, Trash2 } from "lucide-react";
 import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import {
   fetchAllCategories,
   deleteCategory,
@@ -9,7 +10,7 @@ import {
 } from "@/services/admin/categoryService";
 import { toast } from "react-toastify";
 
-export default function AdminCategoryIndex() {
+function AdminCategoryIndex() {
   const [categories, setCategories] = useState([]);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
@@ -228,3 +229,5 @@ export default function AdminCategoryIndex() {
 AdminCategoryIndex.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+export default withAuthProtection(AdminCategoryIndex, ["admin", "superadmin"]);


### PR DESCRIPTION
## Summary
- protect admin category pages using `withAuthProtection`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857cece6ef48328b0b7d1fec8eacb58