### PR TITLE
Add auth to online classes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ The backend exposes role-based endpoints for managing instructor bookings:
 - `PATCH /api/bookings/instructor/:id` – update a booking (e.g. approve or decline)
 
 Admin routes remain available under `/api/bookings/admin`.
+
+## Online Classes API
+
+Endpoints for creating and managing live classes are served under `/api/users/classes`:
+
+- `GET /api/users/classes` – list published classes
+- `GET /api/users/classes/:id` – view a specific class
+- `POST /api/users/classes/admin` – create a class (requires instructor or admin token)
+- `PUT /api/users/classes/admin/:id` – update a class
+- `DELETE /api/users/classes/admin/:id` – delete a class

--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -6,6 +6,12 @@ jest.mock('../class.service', () => ({
   getAllClasses: jest.fn()
 }));
 const service = require('../class.service');
+// Mock auth middleware to bypass authentication
+jest.mock('../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+}));
+
 const routes = require('../class.routes');
 
 const app = express();

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -3,12 +3,38 @@ const router = express.Router();
 const controller = require("./class.controller");
 const validate = require("../../middleware/validate");
 const validator = require("./class.validator");
+const {
+  verifyToken,
+  isInstructorOrAdmin,
+} = require("../../middleware/auth/authMiddleware");
 
-router.post("/admin", validate(validator.create), controller.createClass);
-router.get("/admin", controller.getAllClasses);
-router.get("/admin/:id", controller.getClassById);
-router.put("/admin/:id", validate(validator.update), controller.updateClass);
-router.delete("/admin/:id", controller.deleteClass);
+router.post(
+  "/admin",
+  verifyToken,
+  isInstructorOrAdmin,
+  validate(validator.create),
+  controller.createClass
+);
+router.get("/admin", verifyToken, isInstructorOrAdmin, controller.getAllClasses);
+router.get(
+  "/admin/:id",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.getClassById
+);
+router.put(
+  "/admin/:id",
+  verifyToken,
+  isInstructorOrAdmin,
+  validate(validator.update),
+  controller.updateClass
+);
+router.delete(
+  "/admin/:id",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.deleteClass
+);
 
 router.get("/", controller.getPublishedClasses);
 router.get("/:id", controller.getPublicClassDetails);

--- a/backend/tests/categoryRoutes.test.js
+++ b/backend/tests/categoryRoutes.test.js
@@ -11,6 +11,7 @@ jest.mock('../src/modules/users/categories/category.service', () => ({
   delete: jest.fn(),
   exists: jest.fn(),
   findBySlug: jest.fn(),
+  countChildren: jest.fn(),
 
 }));
 

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -21,6 +21,11 @@ The backend exposes a REST API under the `/api` prefix. Below is a brief outline
 - `/categories` – browse and manage categories
 - `/tutorials` – public tutorial browsing and admin management
 - `/classes` – published classes and enrollment
+  - `GET /api/users/classes` – list published classes
+  - `GET /api/users/classes/:id` – view details for a published class
+  - `POST /api/users/classes/admin` – create a class (instructor or admin)
+  - `PUT /api/users/classes/admin/:id` – update a class
+  - `DELETE /api/users/classes/admin/:id` – remove a class
 - `/admin` – administrator dashboard features
 - `/instructor` – instructor tools
 - `/student` – student account endpoints


### PR DESCRIPTION
## Summary
- secure admin online class routes with authentication
- document online class endpoints
- update tests to mock auth middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ec201dd0832891247277778d4fd4