### PR TITLE
Add online classes API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ The backend exposes role-based endpoints for managing instructor bookings:
 - `PATCH /api/bookings/instructor/:id` – update a booking (e.g. approve or decline)
 
 Admin routes remain available under `/api/bookings/admin`.
+
+## Online Classes API
+
+Endpoints for creating and managing live classes are served under `/api/users/classes`:
+
+- `GET /api/users/classes` – list published classes
+- `GET /api/users/classes/:id` – view a specific class
+- `POST /api/users/classes/admin` – create a class (requires instructor or admin token)
+- `PUT /api/users/classes/admin/:id` – update a class
+- `DELETE /api/users/classes/admin/:id` – delete a class

--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -6,6 +6,12 @@ jest.mock('../class.service', () => ({
   getAllClasses: jest.fn()
 }));
 const service = require('../class.service');
+// Mock auth middleware to bypass authentication
+jest.mock('../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+}));
+
 const routes = require('../class.routes');
 
 const app = express();

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -3,12 +3,38 @@ const router = express.Router();
 const controller = require("./class.controller");
 const validate = require("../../middleware/validate");
 const validator = require("./class.validator");
+const {
+  verifyToken,
+  isInstructorOrAdmin,
+} = require("../../middleware/auth/authMiddleware");
 
-router.post("/admin", validate(validator.create), controller.createClass);
-router.get("/admin", controller.getAllClasses);
-router.get("/admin/:id", controller.getClassById);
-router.put("/admin/:id", validate(validator.update), controller.updateClass);
-router.delete("/admin/:id", controller.deleteClass);
+router.post(
+  "/admin",
+  verifyToken,
+  isInstructorOrAdmin,
+  validate(validator.create),
+  controller.createClass
+);
+router.get("/admin", verifyToken, isInstructorOrAdmin, controller.getAllClasses);
+router.get(
+  "/admin/:id",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.getClassById
+);
+router.put(
+  "/admin/:id",
+  verifyToken,
+  isInstructorOrAdmin,
+  validate(validator.update),
+  controller.updateClass
+);
+router.delete(
+  "/admin/:id",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.deleteClass
+);
 
 router.get("/", controller.getPublishedClasses);
 router.get("/:id", controller.getPublicClassDetails);

--- a/backend/tests/categoryRoutes.test.js
+++ b/backend/tests/categoryRoutes.test.js
@@ -11,6 +11,7 @@ jest.mock('../src/modules/users/categories/category.service', () => ({
   delete: jest.fn(),
   exists: jest.fn(),
   findBySlug: jest.fn(),
+  countChildren: jest.fn(),
 
 }));
 

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -21,6 +21,11 @@ The backend exposes a REST API under the `/api` prefix. Below is a brief outline
 - `/categories` – browse and manage categories
 - `/tutorials` – public tutorial browsing and admin management
 - `/classes` – published classes and enrollment
+  - `GET /api/users/classes` – list published classes
+  - `GET /api/users/classes/:id` – view details for a published class
+  - `POST /api/users/classes/admin` – create a class (instructor or admin)
+  - `PUT /api/users/classes/admin/:id` – update a class
+  - `DELETE /api/users/classes/admin/:id` – remove a class
 - `/admin` – administrator dashboard features
 - `/instructor` – instructor tools
 - `/student` – student account endpoints

--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -1,5 +1,5 @@
 // ✅ AdminClassesTable.js with Full Routing, Labeled Buttons, and Tooltips
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import {
   FaCalendarAlt,
@@ -15,7 +15,7 @@ import {
   FaChevronRight
 } from "react-icons/fa";
 
-export default function AdminClassesTable({ classes = [] }) {
+export default function AdminClassesTable({ classes = [], loading = false }) {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterStatus, setFilterStatus] = useState("");
   const [sortKey, setSortKey] = useState("date");
@@ -24,6 +24,10 @@ export default function AdminClassesTable({ classes = [] }) {
   const [modalType, setModalType] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(5);
+
+  useEffect(() => {
+    setClassList(classes);
+  }, [classes]);
 
   const filteredClasses = classList
     .filter((cls) =>
@@ -68,6 +72,22 @@ export default function AdminClassesTable({ classes = [] }) {
 
   const handlePrev = () => setCurrentPage(prev => Math.max(prev - 1, 1));
   const handleNext = () => setCurrentPage(prev => Math.min(prev + 1, totalPages));
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-2xl shadow-2xl p-8 border border-gray-100 text-center">
+        Loading classes...
+      </div>
+    );
+  }
+
+  if (!classList.length) {
+    return (
+      <div className="bg-white rounded-2xl shadow-2xl p-8 border border-gray-100 text-center">
+        No classes found.
+      </div>
+    );
+  }
 
   return (
     <div className="bg-white rounded-2xl shadow-2xl p-8 border border-gray-100">

--- a/frontend/src/pages/dashboard/admin/online-classes/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/index.js
@@ -1,51 +1,41 @@
-import Link from 'next/link';
-import AdminLayout from '@/components/layouts/AdminLayout';
-import AdminClassesTable from '@/components/admin/online-classes/AdminClassesTable';
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
+import AdminClassesTable from "@/components/admin/online-classes/AdminClassesTable";
+import { fetchAdminClasses } from "@/services/admin/classService";
 
+function AdminOnlineClassesPage() {
+  const [classes, setClasses] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const list = await fetchAdminClasses();
+        setClasses(list);
+      } catch (err) {
+        console.error("Failed to load classes", err);
+        setError("Failed to load classes");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
 
-const dummyClasses = [
-  {
-    id: 1, title: "React & Next.js Bootcamp", instructor: "Ayman Khalid", date: "2025-05-13", category: "Web Development", price: 49, status: "Upcoming"
-  },
-  {
-    id: 2, title: "UX Design Fundamentals", instructor: "Lina Al Harthy", date: "2025-05-18", category: "Design", price: 0, status: "Full"
-  },
-  {
-    id: 3, title: "Java for Beginners", instructor: "Omar Al-Fahad", date: "2025-06-01", category: "Programming", price: 30, status: "Upcoming"
-  },
-  {
-    id: 4, title: "Python for Data Analysis", instructor: "Sara Al-Bassam", date: "2025-04-22", category: "Data Science", price: 55, status: "Ongoing"
-  },
-  {
-    id: 5, title: "AI & Machine Learning Intro", instructor: "Dr. Ahmed Al-Qahtani", date: "2025-03-01", category: "AI", price: 120, status: "Completed"
-  },
-  {
-    id: 6, title: "Cybersecurity Basics", instructor: "Noura Fahad", date: "2025-07-01", category: "Security", price: 35, status: "Upcoming"
-  },
-  {
-    id: 7, title: "Advanced CSS Techniques", instructor: "Bader Saleh", date: "2025-06-15", category: "Web Design", price: 20, status: "Ongoing"
-  },
-  {
-    id: 8, title: "Cloud Computing Fundamentals", instructor: "Huda Al Saud", date: "2025-06-10", category: "Cloud", price: 65, status: "Upcoming"
-  }
-];
-
-
-export default function AdminOnlineClassesPage() {
   return (
     <div className="p-6 space-y-6">
       <div className="flex flex-col md:flex-row justify-between items-center gap-4">
         <h1 className="text-2xl font-bold text-gray-800">📚 Manage Online Classes</h1>
-
         <Link href="/dashboard/admin/online-classes/create" className="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold px-4 py-2 rounded-lg shadow transition duration-200">
           ➕ Create New Class
         </Link>
       </div>
-
-
-      <AdminClassesTable classes={dummyClasses} />
-
+      {error && <p className="text-red-600">{error}</p>}
+      <AdminClassesTable classes={classes} loading={loading} />
     </div>
   );
 }
@@ -53,3 +43,5 @@ export default function AdminOnlineClassesPage() {
 AdminOnlineClassesPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+export default withAuthProtection(AdminOnlineClassesPage, ["admin", "superadmin", "instructor"]);

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -1,0 +1,26 @@
+import api from "@/services/api/api";
+
+export const fetchAdminClasses = async () => {
+  const { data } = await api.get("/users/classes/admin");
+  return data?.data ?? [];
+};
+
+export const fetchAdminClassById = async (id) => {
+  const { data } = await api.get(`/users/classes/admin/${id}`);
+  return data?.data ?? null;
+};
+
+export const createAdminClass = async (payload) => {
+  const { data } = await api.post("/users/classes/admin", payload);
+  return data?.data;
+};
+
+export const updateAdminClass = async (id, payload) => {
+  const { data } = await api.put(`/users/classes/admin/${id}`, payload);
+  return data?.data;
+};
+
+export const deleteAdminClass = async (id) => {
+  await api.delete(`/users/classes/admin/${id}`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- add admin classService for `/api/users/classes`
- fetch online classes in admin dashboard
- show loading and empty states in admin classes table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ec201dd0832891247277778d4fd4