### PR TITLE
Fix duplicate default export in online class page

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -36,7 +36,7 @@ function FloatingInput({ label, name, value, onChange, type = "text", ...props }
   );
 }
 
-export default function CreateOnlineClass() {
+function CreateOnlineClass() {
   const [step, setStep] = useState(1);
   const [formData, setFormData] = useState({
     title: '',


### PR DESCRIPTION
## Summary
- remove redundant default export in online class creation page

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6857f4412f80832880ce487399a23e8e