### PR TITLE
Fix missing category_id column for classes

### DIFF
--- a/backend/src/migrations/20250617110500_add_category_id_to_online_classes.js
+++ b/backend/src/migrations/20250617110500_add_category_id_to_online_classes.js
@@ -1,0 +1,14 @@
+exports.up = async function(knex) {
+  const exists = await knex.schema.hasColumn('online_classes', 'category_id');
+  if (!exists) {
+    return knex.schema.alterTable('online_classes', function(table) {
+      table.uuid('category_id').references('id').inTable('categories').onDelete('SET NULL');
+    });
+  }
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('online_classes', function(table) {
+    table.dropColumn('category_id');
+  });
+};

--- a/backend/src/modules/classes/class.validator.js
+++ b/backend/src/modules/classes/class.validator.js
@@ -9,6 +9,7 @@ exports.create = z.object({
     cover_image: z.string().optional(),
     start_date: z.string().optional(),
     end_date: z.string().optional(),
+    category_id: z.string().uuid().optional(),
     status: z.enum(["draft", "published", "archived"]).optional(),
   })
 });
@@ -22,6 +23,7 @@ exports.update = z.object({
     cover_image: z.string().optional(),
     start_date: z.string().optional(),
     end_date: z.string().optional(),
+    category_id: z.string().uuid().optional(),
     status: z.enum(["draft", "published", "archived"]).optional(),
   })
 });


### PR DESCRIPTION
## Summary
- add migration to add `category_id` column in `online_classes`
- validate `category_id` for class creation and updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857feb1f264832884aa1dfed58cab60