### PR TITLE
Fix missing category_id column for classes

### DIFF
--- a/backend/src/migrations/20250617110500_add_category_id_to_online_classes.js
+++ b/backend/src/migrations/20250617110500_add_category_id_to_online_classes.js
@@ -1,0 +1,14 @@
+exports.up = async function(knex) {
+  const exists = await knex.schema.hasColumn('online_classes', 'category_id');
+  if (!exists) {
+    return knex.schema.alterTable('online_classes', function(table) {
+      table.uuid('category_id').references('id').inTable('categories').onDelete('SET NULL');
+    });
+  }
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('online_classes', function(table) {
+    table.dropColumn('category_id');
+  });
+};

--- a/backend/src/migrations/20250617111000_change_cover_image_to_text_in_online_classes.js
+++ b/backend/src/migrations/20250617111000_change_cover_image_to_text_in_online_classes.js
@@ -1,0 +1,11 @@
+exports.up = async function(knex) {
+  await knex.schema.alterTable('online_classes', table => {
+    table.text('cover_image').alter();
+  });
+};
+
+exports.down = async function(knex) {
+  await knex.schema.alterTable('online_classes', table => {
+    table.string('cover_image').alter();
+  });
+};

--- a/backend/src/modules/classes/class.validator.js
+++ b/backend/src/modules/classes/class.validator.js
@@ -3,12 +3,13 @@ const { z } = require("zod");
 exports.create = z.object({
   body: z.object({
     instructor_id: z.string().uuid(),
-    title: z.string().min(3),
+    title: z.string().min(3).max(255),
     description: z.string().optional(),
     level: z.string().optional(),
-    cover_image: z.string().optional(),
+    cover_image: z.string().url().max(255).optional(),
     start_date: z.string().optional(),
     end_date: z.string().optional(),
+    category_id: z.string().uuid().optional(),
     status: z.enum(["draft", "published", "archived"]).optional(),
   })
 });
@@ -16,12 +17,13 @@ exports.create = z.object({
 exports.update = z.object({
   body: z.object({
     instructor_id: z.string().uuid().optional(),
-    title: z.string().min(3).optional(),
+    title: z.string().min(3).max(255).optional(),
     description: z.string().optional(),
     level: z.string().optional(),
-    cover_image: z.string().optional(),
+    cover_image: z.string().url().max(255).optional(),
     start_date: z.string().optional(),
     end_date: z.string().optional(),
+    category_id: z.string().uuid().optional(),
     status: z.enum(["draft", "published", "archived"]).optional(),
   })
 });


### PR DESCRIPTION
## Summary
- add migration to change cover_image column type in online_classes
- validate URLs and length for class titles and images

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857feb1f264832884aa1dfed58cab60