### PR TITLE
Fix admin classes table fields

### DIFF
--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -6,11 +6,32 @@ exports.createClass = async (data) => {
 };
 
 exports.getAllClasses = async () => {
-  return db("online_classes").orderBy("created_at", "desc");
+  return db("online_classes as c")
+    .leftJoin("users as u", "c.instructor_id", "u.id")
+    .leftJoin("categories as cat", "c.category_id", "cat.id")
+    .select(
+      "c.id",
+      "c.title",
+      "c.start_date",
+      "c.end_date",
+      "c.status",
+      "u.full_name as instructor",
+      "cat.name as category"
+    )
+    .orderBy("c.created_at", "desc");
 };
 
 exports.getClassById = async (id) => {
-  return db("online_classes").where({ id }).first();
+  return db("online_classes as c")
+    .leftJoin("users as u", "c.instructor_id", "u.id")
+    .leftJoin("categories as cat", "c.category_id", "cat.id")
+    .select(
+      "c.*",
+      "u.full_name as instructor",
+      "cat.name as category"
+    )
+    .where("c.id", id)
+    .first();
 };
 
 exports.updateClass = async (id, data) => {

--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -18,7 +18,7 @@ import {
 export default function AdminClassesTable({ classes = [], loading = false }) {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterStatus, setFilterStatus] = useState("");
-  const [sortKey, setSortKey] = useState("date");
+  const [sortKey, setSortKey] = useState("start_date");
   const [classList, setClassList] = useState(classes);
   const [modalClass, setModalClass] = useState(null);
   const [modalType, setModalType] = useState(null);
@@ -44,9 +44,14 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
   );
 
   const exportCSV = () => {
-    const headers = ["Title", "Instructor", "Date", "Category", "Price", "Status"];
+    const headers = ["Title", "Instructor", "Start Date", "End Date", "Category", "Status"];
     const rows = classList.map(cls => [
-      cls.title, cls.instructor, cls.date, cls.category, cls.price, cls.status
+      cls.title,
+      cls.instructor,
+      cls.start_date,
+      cls.end_date,
+      cls.category,
+      cls.status
     ]);
     const csvContent = [headers, ...rows].map(e => e.join(",")).join("\n");
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
@@ -118,7 +123,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
             className="border border-gray-300 rounded-xl px-4 py-2 text-sm"
             onChange={(e) => setSortKey(e.target.value)}
           >
-            <option value="date">Sort by Date</option>
+            <option value="start_date">Sort by Start Date</option>
             <option value="title">Sort by Title</option>
             <option value="instructor">Sort by Instructor</option>
           </select>
@@ -149,9 +154,9 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
             <tr>
               <th className="px-6 py-3 text-left">Title</th>
               <th className="px-6 py-3 text-left">Instructor</th>
-              <th className="px-6 py-3 text-left">Date</th>
+              <th className="px-6 py-3 text-left">Start Date</th>
+              <th className="px-6 py-3 text-left">End Date</th>
               <th className="px-6 py-3 text-left">Category</th>
-              <th className="px-6 py-3 text-left">Price</th>
               <th className="px-6 py-3 text-left">Status</th>
               <th className="px-6 py-3 text-right">Actions</th>
             </tr>
@@ -161,9 +166,9 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
               <tr key={cls.id} className="hover:bg-yellow-50">
                 <td className="px-6 py-4 font-semibold">{cls.title}</td>
                 <td className="px-6 py-4">{cls.instructor}</td>
-                <td className="px-6 py-4">{cls.date}</td>
-                <td className="px-6 py-4">{cls.category}</td>
-                <td className="px-6 py-4">${cls.price}</td>
+                <td className="px-6 py-4">{cls.start_date}</td>
+                <td className="px-6 py-4">{cls.end_date || '-'}</td>
+                <td className="px-6 py-4">{cls.category || '-'}</td>
                 <td className="px-6 py-4">
                   <span className={`px-3 py-1 rounded-full text-xs font-bold ${{
                     Upcoming: 'bg-green-100 text-green-800',


### PR DESCRIPTION
## Summary
- join user and category tables to provide names for admin classes
- show start and end dates in admin classes table

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6858f721a72883288c10d54c65fed5c4