### PR TITLE
Implement API fetch for class student

### DIFF
--- a/frontend/src/pages/api/classes/[classId]/students/[studentId].js
+++ b/frontend/src/pages/api/classes/[classId]/students/[studentId].js
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+export default async function handler(req, res) {
+  const { classId, studentId } = req.query;
+
+  try {
+    const { data } = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/classes/admin/${classId}/students/${studentId}`
+    );
+    return res.status(200).json(data.data || data);
+  } catch (err) {
+    const status = err.response?.status || 500;
+    const message = err.response?.data?.message || 'Failed to fetch student';
+    res.status(status).json({ error: message });
+  }
+}

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students.js
@@ -1,29 +1,38 @@
 // pages/dashboard/admin/online-classes/[id]/students/[studentId].js
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 
 export default function ManageStudentInClassPage() {
   const { id, studentId } = useRouter().query;
 
-  // Replace with actual fetch
-  const student = {
-    id: studentId,
-    name: "Mohammed Al-Salem",
-    email: "m.salem@email.com",
-    status: "Confirmed",
-    lessons: [
-      { title: "Intro to React", completed: true, testScore: 85 },
-      { title: "JSX & Components", completed: true, testScore: 90 },
-      { title: "Props & State", completed: false, testScore: null },
-    ],
-    attendance: [
-      { lesson: "Intro to React", attended: true },
-      { lesson: "JSX & Components", attended: true },
-      { lesson: "Props & State", attended: false },
-    ],
-    notes: ["Very engaged", "Asked thoughtful questions"],
-    certificateIssued: false,
-  };
+  const [student, setStudent] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id || !studentId) return;
+    async function fetchStudent() {
+      try {
+        const res = await fetch(`/api/classes/${id}/students/${studentId}`);
+        if (!res.ok) throw new Error("Failed to fetch");
+        const data = await res.json();
+        setStudent(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchStudent();
+  }, [id, studentId]);
+
+  if (loading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (!student) {
+    return <div className="p-6">Student not found.</div>;
+  }
 
   return (
     <div className="p-6 space-y-6">


### PR DESCRIPTION
## Summary
- add API route to retrieve class student data
- load student data on manage student page via useEffect

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6858fab869948328a6f822779b52c683