### PR TITLE
Integrate class analytics with backend

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -1,6 +1,15 @@
 const request = require('supertest');
 const express = require('express');
 
+// Mock database to avoid connection attempts
+jest.mock('../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn(() => Promise.resolve(null));
+  db.raw = jest.fn(() => Promise.resolve());
+  return db;
+});
+
 jest.mock('../class.service', () => ({
   createClass: jest.fn(),
   getAllClasses: jest.fn()

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -69,3 +69,8 @@ exports.getPublicClassDetails = catchAsync(async (req, res) => {
   const cls = await service.getPublicClassDetails(req.params.id);
   sendSuccess(res, cls);
 });
+
+exports.getClassAnalytics = catchAsync(async (req, res) => {
+  const data = await service.getClassAnalytics(req.params.id);
+  sendSuccess(res, data);
+});

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -24,6 +24,12 @@ router.get(
   isInstructorOrAdmin,
   controller.getClassById
 );
+router.get(
+  "/admin/:id/analytics",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.getClassAnalytics
+);
 router.put(
   "/admin/:id",
   verifyToken,

--- a/backend/tests/classAnalyticsRoutes.test.js
+++ b/backend/tests/classAnalyticsRoutes.test.js
@@ -1,0 +1,34 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database', () => ({
+  raw: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../src/modules/classes/class.service', () => ({
+  getClassAnalytics: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/classes/class.service');
+const routes = require('../src/modules/classes/class.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/users/classes', routes);
+
+describe('GET /api/users/classes/admin/:id/analytics', () => {
+  it('returns class analytics', async () => {
+    const analytics = { totalStudents: 3 };
+    service.getClassAnalytics.mockResolvedValue(analytics);
+
+    const res = await request(app).get('/api/users/classes/admin/1/analytics');
+    expect(res.status).toBe(200);
+    expect(service.getClassAnalytics).toHaveBeenCalledWith('1');
+    expect(res.body.data).toEqual(analytics);
+  });
+});

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -1,48 +1,57 @@
 // pages/dashboard/admin/online-classes/[id]/analytics.js
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import { useEffect, useState } from "react";
+import { fetchAdminClassAnalytics } from "@/services/admin/classService";
 import {
-  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
-  PieChart, Pie, Cell, Legend
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  PieChart,
+  Pie,
+  Cell,
+  Legend,
 } from "recharts";
-
-const mockAnalytics = {
-  totalStudents: 42,
-  totalRevenue: 2100,
-  totalAttendance: 30,
-  completed: 25,
-  revenueBreakdown: {
-    full: 30,
-    installments: 10,
-    free: 2
-  },
-  locations: [
-    { name: "Saudi Arabia", value: 20 },
-    { name: "Egypt", value: 10 },
-    { name: "UAE", value: 5 },
-    { name: "Other", value: 7 },
-  ],
-  devices: [
-    { name: "Desktop", value: 28 },
-    { name: "Mobile", value: 14 }
-  ],
-  registrationTrend: [
-    { date: "Apr 1", students: 5 },
-    { date: "Apr 5", students: 8 },
-    { date: "Apr 10", students: 12 },
-    { date: "Apr 15", students: 17 },
-  ],
-};
 
 const COLORS = ["#60a5fa", "#34d399", "#fbbf24", "#f87171"];
 
 export default function AnalyticsDashboard() {
   const router = useRouter();
   const { id } = router.query;
+  const [stats, setStats] = useState(null);
 
-  const avgRevenue = (mockAnalytics.totalRevenue / mockAnalytics.totalStudents).toFixed(2);
-  const attendanceRate = ((mockAnalytics.totalAttendance / mockAnalytics.totalStudents) * 100).toFixed(1);
-  const completionRate = ((mockAnalytics.completed / mockAnalytics.totalStudents) * 100).toFixed(1);
+  useEffect(() => {
+    if (!id) return;
+    fetchAdminClassAnalytics(id)
+      .then((data) => setStats(data))
+      .catch((err) => {
+        console.error("Failed to load analytics", err);
+        setStats(null);
+      });
+  }, [id]);
+
+  if (!stats) {
+    return (
+      <div className="p-6 text-center text-sm text-muted-foreground">Loading...</div>
+    );
+  }
+
+  const avgRevenue =
+    stats.totalStudents > 0
+      ? (stats.totalRevenue / stats.totalStudents).toFixed(2)
+      : "0";
+  const attendanceRate =
+    stats.totalStudents > 0
+      ? ((stats.totalAttendance / stats.totalStudents) * 100).toFixed(1)
+      : "0";
+  const completionRate =
+    stats.totalStudents > 0
+      ? ((stats.completed / stats.totalStudents) * 100).toFixed(1)
+      : "0";
 
   return (
     <div className="p-6 space-y-6">
@@ -51,20 +60,20 @@ export default function AnalyticsDashboard() {
       <div className="grid md:grid-cols-3 gap-6">
         <div className="bg-white p-6 rounded-xl shadow border">
           <h2 className="text-lg font-semibold text-gray-700 mb-2">👥 Total Enrolled Students</h2>
-          <p className="text-3xl font-bold text-green-600">{mockAnalytics.totalStudents}</p>
+          <p className="text-3xl font-bold text-green-600">{stats.totalStudents}</p>
         </div>
 
         <div className="bg-white p-6 rounded-xl shadow border">
           <h2 className="text-lg font-semibold text-gray-700 mb-2">💰 Total Revenue</h2>
-          <p className="text-3xl font-bold text-indigo-600">${mockAnalytics.totalRevenue}</p>
+          <p className="text-3xl font-bold text-indigo-600">${stats.totalRevenue}</p>
         </div>
 
         <div className="bg-white p-6 rounded-xl shadow border">
           <h2 className="text-lg font-semibold text-gray-700 mb-2">💳 Revenue Breakdown</h2>
           <ul className="text-gray-700 space-y-1">
-            <li><strong>Full Payments:</strong> {mockAnalytics.revenueBreakdown.full}</li>
-            <li><strong>Installments:</strong> {mockAnalytics.revenueBreakdown.installments}</li>
-            <li><strong>Free Seats:</strong> {mockAnalytics.revenueBreakdown.free}</li>
+            <li><strong>Full Payments:</strong> {stats.revenueBreakdown.full}</li>
+            <li><strong>Installments:</strong> {stats.revenueBreakdown.installments}</li>
+            <li><strong>Free Seats:</strong> {stats.revenueBreakdown.free}</li>
           </ul>
         </div>
       </div>
@@ -91,8 +100,8 @@ export default function AnalyticsDashboard() {
           <h2 className="text-lg font-semibold text-gray-700 mb-4">🌍 Top Countries</h2>
           <ResponsiveContainer width="100%" height={300}>
             <PieChart>
-              <Pie data={mockAnalytics.locations} dataKey="value" nameKey="name" outerRadius={100}>
-                {mockAnalytics.locations.map((entry, index) => (
+              <Pie data={stats.locations} dataKey="value" nameKey="name" outerRadius={100}>
+                {stats.locations.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                 ))}
               </Pie>
@@ -106,8 +115,8 @@ export default function AnalyticsDashboard() {
           <h2 className="text-lg font-semibold text-gray-700 mb-4">📱 Devices Used</h2>
           <ResponsiveContainer width="100%" height={300}>
             <PieChart>
-              <Pie data={mockAnalytics.devices} dataKey="value" nameKey="name" outerRadius={100}>
-                {mockAnalytics.devices.map((entry, index) => (
+              <Pie data={stats.devices} dataKey="value" nameKey="name" outerRadius={100}>
+                {stats.devices.map((entry, index) => (
                   <Cell key={`cell-dev-${index}`} fill={COLORS[index % COLORS.length]} />
                 ))}
               </Pie>
@@ -121,7 +130,7 @@ export default function AnalyticsDashboard() {
       <div className="bg-white p-6 rounded-xl shadow border">
         <h2 className="text-lg font-semibold text-gray-700 mb-4">📈 Registration Trend</h2>
         <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={mockAnalytics.registrationTrend}>
+          <BarChart data={stats.registrationTrend}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="date" />
             <YAxis />

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -28,3 +28,8 @@ export const deleteAdminClass = async (id) => {
   await api.delete(`/users/classes/admin/${id}`);
   return true;
 };
+
+export const fetchAdminClassAnalytics = async (id) => {
+  const { data } = await api.get(`/users/classes/admin/${id}/analytics`);
+  return data?.data ?? {};
+};


### PR DESCRIPTION
## Summary
- support fetching analytics for an online class
- expose `GET /api/users/classes/admin/:id/analytics` on backend
- consume analytics in the admin dashboard analytics page
- add Jest test for analytics route
- mock database in routes test to avoid connection

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6859156eb0608328bfda3670af62a04b