### PR TITLE
Add toast notifications to admin classes page

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -1,6 +1,7 @@
 // ✅ AdminClassesTable.js with Full Routing, Labeled Buttons, and Tooltips
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import { toast } from "react-toastify";
 import {
   FaCalendarAlt,
   FaSearch,
@@ -61,6 +62,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+    toast.success("Classes exported");
   };
 
   const handleStatusChange = (id, newStatus) => {
@@ -68,11 +70,13 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
       prev.map(cls => (cls.id === id ? { ...cls, status: newStatus } : cls))
     );
     setModalClass(null);
+    toast.success(`Class ${newStatus.toLowerCase()}`);
   };
 
   const handleDeleteClass = (id) => {
     setClassList(prev => prev.filter(cls => cls.id !== id));
     setModalClass(null);
+    toast.success("Class deleted");
   };
 
   const handlePrev = () => setCurrentPage(prev => Math.max(prev - 1, 1));


### PR DESCRIPTION
## Summary
- show toast notifications in AdminClassesTable for exporting, approving, rejecting and deleting classes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591e66016c832887697976d8ab377b