### PR TITLE
Add demo video upload for classes

### DIFF
--- a/backend/src/migrations/20250620121500_add_demo_video_to_online_classes.js
+++ b/backend/src/migrations/20250620121500_add_demo_video_to_online_classes.js
@@ -1,0 +1,17 @@
+exports.up = async function(knex) {
+  const exists = await knex.schema.hasColumn('online_classes', 'demo_video_url');
+  if (!exists) {
+    await knex.schema.alterTable('online_classes', table => {
+      table.string('demo_video_url', 1024);
+    });
+  }
+};
+
+exports.down = async function(knex) {
+  const exists = await knex.schema.hasColumn('online_classes', 'demo_video_url');
+  if (exists) {
+    await knex.schema.alterTable('online_classes', table => {
+      table.dropColumn('demo_video_url');
+    });
+  }
+};

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -21,8 +21,11 @@ const generateUniqueSlug = async (title) => {
 exports.createClass = catchAsync(async (req, res) => {
   const slug = await generateUniqueSlug(req.body.title);
   const data = { ...req.body, id: uuidv4(), slug };
-  if (req.file) {
-    data.cover_image = `/uploads/classes/${req.file.filename}`;
+  if (req.files?.cover_image?.[0]) {
+    data.cover_image = `/uploads/classes/${req.files.cover_image[0].filename}`;
+  }
+  if (req.files?.demo_video?.[0]) {
+    data.demo_video_url = `/uploads/classes/${req.files.demo_video[0].filename}`;
   }
   const cls = await service.createClass(data);
   sendSuccess(res, cls, "Class created");
@@ -44,12 +47,19 @@ exports.updateClass = catchAsync(async (req, res) => {
   if (data.title && data.title !== existing.title) {
     data.slug = await generateUniqueSlug(data.title);
   }
-  if (req.file) {
+  if (req.files?.cover_image?.[0]) {
     if (existing?.cover_image) {
       const oldPath = path.join(__dirname, '../../../', existing.cover_image);
       if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
     }
-    data.cover_image = `/uploads/classes/${req.file.filename}`;
+    data.cover_image = `/uploads/classes/${req.files.cover_image[0].filename}`;
+  }
+  if (req.files?.demo_video?.[0]) {
+    if (existing?.demo_video_url) {
+      const oldPath = path.join(__dirname, '../../../', existing.demo_video_url);
+      if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
+    }
+    data.demo_video_url = `/uploads/classes/${req.files.demo_video[0].filename}`;
   }
   const cls = await service.updateClass(req.params.id, data);
   sendSuccess(res, cls);

--- a/backend/src/modules/classes/class.validator.js
+++ b/backend/src/modules/classes/class.validator.js
@@ -13,6 +13,7 @@ exports.create = z.object({
     price: z.string().optional(),
     max_students: z.string().optional(),
     language: z.string().optional(),
+    demo_video_url: z.string().optional(),
     allow_installments: z.preprocess(
       (v) => (typeof v === 'string' ? v === 'true' : v),
       z.boolean().optional()
@@ -35,6 +36,7 @@ exports.update = z.object({
     price: z.string().optional(),
     max_students: z.string().optional(),
     language: z.string().optional(),
+    demo_video_url: z.string().optional(),
     allow_installments: z.preprocess(
       (v) => (typeof v === 'string' ? v === 'true' : v),
       z.boolean().optional()

--- a/backend/src/modules/classes/classUploadMiddleware.js
+++ b/backend/src/modules/classes/classUploadMiddleware.js
@@ -16,9 +16,20 @@ const storage = multer.diskStorage({
   },
 });
 
-const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
-const fileFilter = (req, file, cb) => {
-  cb(null, allowed.includes(file.mimetype));
+const imageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
+const videoTypes = ['video/mp4', 'video/quicktime', 'video/x-matroska', 'video/webm'];
+
+const fileFilter = (_req, file, cb) => {
+  if (file.fieldname === 'cover_image') {
+    cb(null, imageTypes.includes(file.mimetype));
+  } else if (file.fieldname === 'demo_video') {
+    cb(null, videoTypes.includes(file.mimetype));
+  } else {
+    cb(null, false);
+  }
 };
 
-module.exports = multer({ storage, fileFilter, limits: { fileSize: 2 * 1024 * 1024 } }).single('cover_image');
+module.exports = multer({ storage, fileFilter, limits: { fileSize: 50 * 1024 * 1024 } }).fields([
+  { name: 'cover_image', maxCount: 1 },
+  { name: 'demo_video', maxCount: 1 },
+]);

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -49,6 +49,13 @@ export default function AdminClassDetailPage() {
             className="w-full h-64 object-cover rounded-lg"
           />
         )}
+        {details?.demo_video_url && (
+          <video
+            controls
+            className="w-full mt-4 rounded-lg"
+            src={details.demo_video_url}
+          />
+        )}
 
         <div className="space-y-1">
           <h2 className="text-2xl font-semibold text-yellow-600">{details?.title}</h2>

--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -48,6 +48,8 @@ function CreateOnlineClass() {
     description: '',
     image: '',
     imagePreview: '',
+    demoVideo: null,
+    demoPreview: '',
     startDate: '',
     endDate: '',
     price: '',
@@ -98,6 +100,13 @@ function CreateOnlineClass() {
         setFormData(prev => ({ ...prev, image: file, imagePreview: reader.result }));
       };
       reader.readAsDataURL(file);
+    }
+  };
+
+  const handleVideoUpload = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      setFormData(prev => ({ ...prev, demoVideo: file, demoPreview: URL.createObjectURL(file) }));
     }
   };
 
@@ -156,6 +165,7 @@ function CreateOnlineClass() {
         if (formData.description) payload.append('description', formData.description);
         if (formData.level) payload.append('level', formData.level);
         if (formData.image) payload.append('cover_image', formData.image);
+        if (formData.demoVideo) payload.append('demo_video', formData.demoVideo);
         if (formData.startDate) payload.append('start_date', formData.startDate);
         if (formData.endDate) payload.append('end_date', formData.endDate);
         payload.append('status', formData.isApproved ? 'published' : 'draft');
@@ -177,16 +187,24 @@ function CreateOnlineClass() {
       </h1>
 
       {/* Step Indicators */}
-      <div className="flex justify-between items-center mb-6">
-        {[1, 2].map((s) => (
+      <div className="mb-6">
+        <div className="flex justify-between items-center mb-2">
+          {[1, 2].map((s) => (
+            <div
+              key={s}
+              className={`flex-1 text-center text-xs sm:text-sm py-2 rounded-full mx-1 transition-all duration-300 ${step === s ? 'bg-yellow-500 text-white shadow-md' : 'bg-gray-200 text-gray-600'
+                }`}
+            >
+              Step {s}
+            </div>
+          ))}
+        </div>
+        <div className="w-full bg-gray-200 h-2 rounded">
           <div
-            key={s}
-            className={`flex-1 text-center text-xs sm:text-sm py-2 rounded-full mx-1 transition-all duration-300 ${step === s ? 'bg-yellow-500 text-white shadow-md' : 'bg-gray-200 text-gray-600'
-              }`}
-          >
-            Step {s}
-          </div>
-        ))}
+            className="bg-yellow-500 h-2 rounded transition-all duration-300"
+            style={{ width: `${(step / 2) * 100}%` }}
+          />
+        </div>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-4">
@@ -249,6 +267,13 @@ function CreateOnlineClass() {
                   <input type="file" accept="image/*" onChange={handleImageUpload} />
                   {formData.imagePreview && (
                     <img src={formData.imagePreview} alt="Preview" className="mt-2 w-40 h-auto rounded shadow transition-transform duration-300 hover:scale-105" />
+                  )}
+                </div>
+                <div className="sm:col-span-2">
+                  <label className="block mb-1 text-sm text-gray-600">Upload Demo Video</label>
+                  <input type="file" accept="video/*" onChange={handleVideoUpload} />
+                  {formData.demoPreview && (
+                    <video src={formData.demoPreview} controls className="mt-2 w-full rounded" />
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- allow uploading class demo videos with multer field handler
- store demo video URL in `online_classes` table via new migration
- validate new `demo_video_url` in class validator
- handle demo video in class controller
- display uploaded demo videos in admin class details
- enhance class creation UI with demo video field and progress bar

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859349966e083288a01cb0d284f7ef0