### PR TITLE
Fix class image URLs for admin pages

### DIFF
--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -1,27 +1,38 @@
 import api from "@/services/api/api";
 
+const formatClass = (cls) => ({
+  ...cls,
+  cover_image: cls.cover_image
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
+    : null,
+  demo_video_url: cls.demo_video_url
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`
+    : null,
+});
+
 export const fetchAdminClasses = async () => {
   const { data } = await api.get("/users/classes/admin");
-  return data?.data ?? [];
+  const list = data?.data ?? [];
+  return list.map(formatClass);
 };
 
 export const fetchAdminClassById = async (id) => {
   const { data } = await api.get(`/users/classes/admin/${id}`);
-  return data?.data ?? null;
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const createAdminClass = async (payload) => {
   const { data } = await api.post("/users/classes/admin", payload, {
     headers: { "Content-Type": "multipart/form-data" },
   });
-  return data?.data;
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const updateAdminClass = async (id, payload) => {
   const { data } = await api.put(`/users/classes/admin/${id}`, payload, {
     headers: { "Content-Type": "multipart/form-data" },
   });
-  return data?.data;
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const deleteAdminClass = async (id) => {


### PR DESCRIPTION
## Summary
- ensure uploaded image paths from the API include the backend origin

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68593bc5f900832882d56f0332875297