### PR TITLE
Fix class status mappings

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -85,7 +85,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
   
   const handleStatusChange = async (id, newStatus) => {
     try {
-      await updateAdminClass(id, { status: newStatus });
+      await updateAdminClass(id, { status: STATUS_REVERSE[newStatus] });
 
       setClassList(prev =>
         prev.map(cls => (cls.id === id ? { ...cls, status: newStatus } : cls))

--- a/frontend/src/pages/dashboard/admin/online-classes/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/edit/[id].js
@@ -140,11 +140,9 @@ export default function EditClassPage() {
           className="w-full border rounded px-4 py-2"
         >
           <option value="">Select Status</option>
-          <option value="Pending">Pending</option>
-          <option value="Upcoming">Upcoming</option>
-          <option value="Ongoing">Ongoing</option>
-          <option value="Completed">Completed</option>
-          <option value="Rejected">Rejected</option>
+          <option value="draft">Pending</option>
+          <option value="published">Approved</option>
+          <option value="archived">Rejected</option>
         </select>
 
         <button type="submit" className="bg-yellow-500 hover:bg-yellow-600 text-white px-6 py-2 rounded shadow">

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -1,27 +1,38 @@
 import api from "@/services/api/api";
 
+const formatClass = (cls) => ({
+  ...cls,
+  cover_image: cls.cover_image
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
+    : null,
+  demo_video_url: cls.demo_video_url
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`
+    : null,
+});
+
 export const fetchAdminClasses = async () => {
   const { data } = await api.get("/users/classes/admin");
-  return data?.data ?? [];
+  const list = data?.data ?? [];
+  return list.map(formatClass);
 };
 
 export const fetchAdminClassById = async (id) => {
   const { data } = await api.get(`/users/classes/admin/${id}`);
-  return data?.data ?? null;
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const createAdminClass = async (payload) => {
   const { data } = await api.post("/users/classes/admin", payload, {
     headers: { "Content-Type": "multipart/form-data" },
   });
-  return data?.data;
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const updateAdminClass = async (id, payload) => {
   const { data } = await api.put(`/users/classes/admin/${id}`, payload, {
     headers: { "Content-Type": "multipart/form-data" },
   });
-  return data?.data;
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const deleteAdminClass = async (id) => {


### PR DESCRIPTION
## Summary
- map table actions to proper backend status values
- show correct options when editing class status

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68593bc5f900832882d56f0332875297