### PR TITLE
Fix unit test mocks for class routes

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -19,6 +19,7 @@ const service = require('../class.service');
 jest.mock('../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (_req, _res, next) => next(),
   isInstructorOrAdmin: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
 }));
 
 const routes = require('../class.routes');

--- a/backend/tests/classAnalyticsRoutes.test.js
+++ b/backend/tests/classAnalyticsRoutes.test.js
@@ -12,6 +12,7 @@ jest.mock('../src/modules/classes/class.service', () => ({
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (_req, _res, next) => next(),
   isInstructorOrAdmin: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
 }));
 
 const service = require('../src/modules/classes/class.service');


### PR DESCRIPTION
## Summary
- ensure `isAdmin` middleware is mocked in class route tests

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685943742bd88328af2f3f52fcba31f7