### PR TITLE
Fix tag input functions on create class page

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -67,10 +67,6 @@ function CreateOnlineClass() {
     allowInstallments: false,
     isApproved: false,
     lessons: [],
-    title: '', instructor: '', category: '', tags: '', level: '', language: '',
-    description: '', image: '', imagePreview: '', demoVideo: null, demoPreview: '',
-    startDate: '', endDate: '', price: '', isFree: false, maxStudents: '',
-    allowInstallments: false, isApproved: false, lessons: [],
   });
   const [categories, setCategories] = useState([]);
   const [existingTitles, setExistingTitles] = useState([]);
@@ -88,6 +84,23 @@ function CreateOnlineClass() {
       t.name.toLowerCase().includes(tagInput.toLowerCase()) &&
       !selectedTags.includes(t.name)
   );
+
+  const addTag = (tag) => {
+    const name = tag.trim();
+    if (name && !selectedTags.includes(name)) {
+      setSelectedTags((prev) => [...prev, name]);
+    }
+    setTagInput('');
+  };
+
+  const handleTagKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addTag(tagInput);
+    } else if (e.key === 'Backspace' && !tagInput) {
+      setSelectedTags((prev) => prev.slice(0, -1));
+    }
+  };
 
   useEffect(() => {
     const loadCategories = async () => {


### PR DESCRIPTION
## Summary
- clean up initial form state
- add `addTag` and `handleTagKeyDown` helpers for the tag field on the admin create class page

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598e4e7f848328827f074d1ffa8ec8