### PR TITLE
Implement dynamic tag suggestions for online class creation

### DIFF
--- a/backend/src/modules/classes/classTag.controller.js
+++ b/backend/src/modules/classes/classTag.controller.js
@@ -3,8 +3,11 @@ const { sendSuccess } = require("../../utils/response");
 const service = require("./classTag.service");
 const slugify = require("slugify");
 
-exports.listTags = catchAsync(async (_req, res) => {
-  const tags = await service.getAllTags();
+exports.listTags = catchAsync(async (req, res) => {
+  const { search = "" } = req.query;
+  const tags = search
+    ? await service.searchTags(search)
+    : await service.getAllTags();
   sendSuccess(res, tags);
 });
 

--- a/backend/src/modules/classes/classTag.service.js
+++ b/backend/src/modules/classes/classTag.service.js
@@ -14,3 +14,12 @@ exports.createTag = async (data) => {
   const [row] = await db("class_tags").insert(data).returning("*");
   return row;
 };
+
+exports.searchTags = async (search, limit = 10) => {
+  return db("class_tags")
+    .modify(query => {
+      if (search) query.whereILike("name", `%${search}%`);
+    })
+    .orderBy("name")
+    .limit(limit);
+};

--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -1,7 +1,7 @@
 // Full updated CreateOnlineClass page with responsive layout and upload progress
 // File: pages/dashboard/admin/online-classes/create.js
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaTrash, FaSpinner } from 'react-icons/fa';
 import dynamic from 'next/dynamic';
@@ -70,7 +70,8 @@ function CreateOnlineClass() {
   });
   const [categories, setCategories] = useState([]);
   const [existingTitles, setExistingTitles] = useState([]);
-  const [availableTags, setAvailableTags] = useState([]);
+  const [allTags, setAllTags] = useState([]);
+  const [tagSuggestions, setTagSuggestions] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
   const [tagInput, setTagInput] = useState('');
 
@@ -79,19 +80,17 @@ function CreateOnlineClass() {
   const [uploadProgress, setUploadProgress] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const filteredTagSuggestions = availableTags.filter(
-    (t) =>
-      t.name.toLowerCase().includes(tagInput.toLowerCase()) &&
-      !selectedTags.includes(t.name)
+  const filteredTagSuggestions = tagSuggestions.filter(
+    (t) => !selectedTags.includes(t.name)
   );
 
-  const addTag = (tag) => {
+  const addTag = useCallback((tag) => {
     const name = tag.trim();
     if (name && !selectedTags.includes(name)) {
       setSelectedTags((prev) => [...prev, name]);
     }
     setTagInput('');
-  };
+  }, [selectedTags]);
 
   const handleTagKeyDown = (e) => {
     if (e.key === 'Enter') {
@@ -124,7 +123,7 @@ function CreateOnlineClass() {
     const loadTags = async () => {
       try {
         const tags = await fetchClassTags();
-        setAvailableTags(tags);
+        setAllTags(tags);
       } catch (err) {
         console.error('Failed to load tags', err);
       }
@@ -215,6 +214,22 @@ function CreateOnlineClass() {
     }
   }, [user]);
 
+  useEffect(() => {
+    if (!tagInput) {
+      setTagSuggestions([]);
+      return;
+    }
+    const handler = setTimeout(async () => {
+      try {
+        const suggestions = await fetchClassTags(tagInput);
+        setTagSuggestions(suggestions);
+      } catch (err) {
+        console.error('Failed to fetch tags', err);
+      }
+    }, 300);
+    return () => clearTimeout(handler);
+  }, [tagInput]);
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (step === 1) {
@@ -244,7 +259,7 @@ function CreateOnlineClass() {
         if (selectedTags.length) payload.append('tags', JSON.stringify(selectedTags));
 
         const newTags = selectedTags.filter(
-          (t) => !availableTags.some((a) => a.name.toLowerCase() === t.toLowerCase())
+          (t) => !allTags.some((a) => a.name.toLowerCase() === t.toLowerCase())
         );
         if (newTags.length) {
           const created = await Promise.all(
@@ -255,7 +270,7 @@ function CreateOnlineClass() {
               })
             )
           );
-          setAvailableTags((prev) => [...prev, ...created.filter(Boolean)]);
+          setAllTags((prev) => [...prev, ...created.filter(Boolean)]);
         }
 
         setIsSubmitting(true);

--- a/frontend/src/services/admin/classTagService.js
+++ b/frontend/src/services/admin/classTagService.js
@@ -1,7 +1,9 @@
 import api from "@/services/api/api";
 
-export const fetchClassTags = async () => {
-  const { data } = await api.get("/users/classes/tags");
+export const fetchClassTags = async (search) => {
+  const { data } = await api.get("/users/classes/tags", {
+    params: search ? { search } : {},
+  });
   return data?.data ?? [];
 };
 


### PR DESCRIPTION
## Summary
- support searching class tags by query in backend
- allow frontend to request tag suggestions with a search parameter
- fetch suggestions as the admin types and show them for selection

## Testing
- `npm run lint` *(fails: React lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a043aefc8328a9d8a4d7122c9829