### PR TITLE
Implement dynamic tag suggestions for online class creation

### DIFF
--- a/backend/src/modules/classes/classTag.controller.js
+++ b/backend/src/modules/classes/classTag.controller.js
@@ -3,8 +3,11 @@ const { sendSuccess } = require("../../utils/response");
 const service = require("./classTag.service");
 const slugify = require("slugify");
 
-exports.listTags = catchAsync(async (_req, res) => {
-  const tags = await service.getAllTags();
+exports.listTags = catchAsync(async (req, res) => {
+  const { search = "" } = req.query;
+  const tags = search
+    ? await service.searchTags(search)
+    : await service.getAllTags();
   sendSuccess(res, tags);
 });
 

--- a/backend/src/modules/classes/classTag.service.js
+++ b/backend/src/modules/classes/classTag.service.js
@@ -14,3 +14,12 @@ exports.createTag = async (data) => {
   const [row] = await db("class_tags").insert(data).returning("*");
   return row;
 };
+
+exports.searchTags = async (search, limit = 10) => {
+  return db("class_tags")
+    .modify(query => {
+      if (search) query.whereILike("name", `%${search}%`);
+    })
+    .orderBy("name")
+    .limit(limit);
+};

--- a/frontend/src/services/admin/classTagService.js
+++ b/frontend/src/services/admin/classTagService.js
@@ -1,7 +1,9 @@
 import api from "@/services/api/api";
 
-export const fetchClassTags = async () => {
-  const { data } = await api.get("/users/classes/tags");
+export const fetchClassTags = async (search) => {
+  const { data } = await api.get("/users/classes/tags", {
+    params: search ? { search } : {},
+  });
   return data?.data ?? [];
 };
 


### PR DESCRIPTION
## Summary
- support searching class tags by query in backend
- allow frontend to request tag suggestions with a search parameter
- fetch suggestions as the admin types and show them for selection
- restore lesson plan step in the admin class creation page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a043aefc8328a9d8a4d7122c9829