### PR TITLE
Format class dates

### DIFF
--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -1,4 +1,5 @@
 import api from "@/services/api/api";
+import { toDateInput } from "@/utils/date";
 
 const formatClass = (cls) => ({
   ...cls,
@@ -8,6 +9,9 @@ const formatClass = (cls) => ({
   demo_video_url: cls.demo_video_url
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`
     : null,
+
+  start_date: cls.start_date ? toDateInput(cls.start_date) : "",
+  end_date: cls.end_date ? toDateInput(cls.end_date) : "",
 
   approvalStatus: cls.moderation_status || "Pending",
   scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -1,0 +1,8 @@
+// utils/date.js
+
+export function toDateInput(value) {
+  if (!value) return '';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toISOString().split('T')[0];
+}


### PR DESCRIPTION
## Summary
- convert class timestamps to `YYYY-MM-DD` strings for display

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6859abcb1ec083289bd1e76829a0ad34