### PR TITLE
Implement student class enrollment API

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -15,9 +15,17 @@ jest.mock('../class.service', () => ({
   getAllClasses: jest.fn()
 }));
 const service = require('../class.service');
+// Mock enrollment service to avoid DB calls when routes are loaded
+jest.mock('../enrollments/classEnrollment.service', () => ({
+  findEnrollment: jest.fn(),
+  createEnrollment: jest.fn(),
+  markCompleted: jest.fn(),
+  getByUser: jest.fn(),
+}));
 // Mock auth middleware to bypass authentication
 jest.mock('../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (_req, _res, next) => next(),
+  isStudent: (_req, _res, next) => next(),
   isInstructorOrAdmin: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
 }));

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -11,6 +11,9 @@ const {
   isAdmin,
 } = require("../../middleware/auth/authMiddleware");
 
+// Student enrollments
+router.use("/enroll", require("./enrollments/classEnrollment.routes"));
+
 router.post(
   "/admin",
   verifyToken,

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -1,0 +1,60 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn(() => Promise.resolve(null));
+  db.join = jest.fn(() => db);
+  db.leftJoin = jest.fn(() => db);
+  db.select = jest.fn(() => db);
+  db.insert = jest.fn(() => db);
+  db.update = jest.fn(() => db);
+  return db;
+});
+
+jest.mock('../classEnrollment.service', () => ({
+  findEnrollment: jest.fn(),
+  createEnrollment: jest.fn(),
+  markCompleted: jest.fn(),
+  getByUser: jest.fn()
+}));
+const service = require('../classEnrollment.service');
+
+jest.mock('../../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'test-user' };
+    next();
+  },
+  isStudent: (_req, _res, next) => next(),
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const routes = require('../../class.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/classes', routes);
+
+describe('Class enrollment routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('enroll in class', async () => {
+    service.findEnrollment.mockResolvedValue(null);
+    service.createEnrollment.mockResolvedValue({ id: '1' });
+    const res = await request(app).post('/classes/enroll/abc');
+    expect(res.statusCode).toBe(200);
+    expect(service.createEnrollment).toHaveBeenCalled();
+  });
+
+  test('get my enrollments', async () => {
+    const list = [{ id: '1' }];
+    service.getByUser.mockResolvedValue(list);
+    const res = await request(app).get('/classes/enroll/my');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual(list);
+  });
+});

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -1,0 +1,26 @@
+const { v4: uuidv4 } = require("uuid");
+const catchAsync = require("../../../utils/catchAsync");
+const { sendSuccess } = require("../../../utils/response");
+const service = require("./classEnrollment.service");
+
+exports.enroll = catchAsync(async (req, res) => {
+  const { classId } = req.params;
+  const user_id = req.user.id;
+  const exists = await service.findEnrollment(user_id, classId);
+  if (exists) return sendSuccess(res, exists, "Already enrolled");
+
+  const data = { id: uuidv4(), user_id, class_id: classId, status: "enrolled" };
+  await service.createEnrollment(data);
+  sendSuccess(res, data, "Enrolled successfully");
+});
+
+exports.complete = catchAsync(async (req, res) => {
+  const { classId } = req.params;
+  await service.markCompleted(req.user.id, classId);
+  sendSuccess(res, null, "Marked as completed");
+});
+
+exports.getMyEnrollments = catchAsync(async (req, res) => {
+  const data = await service.getByUser(req.user.id);
+  sendSuccess(res, data);
+});

--- a/backend/src/modules/classes/enrollments/classEnrollment.routes.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.routes.js
@@ -1,0 +1,9 @@
+const router = require("express").Router();
+const ctrl = require("./classEnrollment.controller");
+const { verifyToken, isStudent } = require("../../../middleware/auth/authMiddleware");
+
+router.post("/:classId", verifyToken, isStudent, ctrl.enroll);
+router.post("/:classId/complete", verifyToken, isStudent, ctrl.complete);
+router.get("/my", verifyToken, isStudent, ctrl.getMyEnrollments);
+
+module.exports = router;

--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -1,0 +1,29 @@
+const db = require("../../../config/database");
+
+exports.findEnrollment = async (user_id, class_id) => {
+  return db("class_enrollments").where({ user_id, class_id }).first();
+};
+
+exports.createEnrollment = async (data) => {
+  await db("class_enrollments").insert(data);
+  return data;
+};
+
+exports.markCompleted = async (user_id, class_id) => {
+  return db("class_enrollments")
+    .where({ user_id, class_id })
+    .update({ status: "completed" });
+};
+
+exports.getByUser = async (user_id) => {
+  return db("class_enrollments")
+    .join("online_classes", "online_classes.id", "class_enrollments.class_id")
+    .leftJoin("users as u", "online_classes.instructor_id", "u.id")
+    .where("class_enrollments.user_id", user_id)
+    .select(
+      "online_classes.*",
+      "class_enrollments.status",
+      "class_enrollments.enrolled_at",
+      "u.full_name as instructor"
+    );
+};

--- a/backend/tests/classAnalyticsRoutes.test.js
+++ b/backend/tests/classAnalyticsRoutes.test.js
@@ -8,9 +8,16 @@ jest.mock('../src/config/database', () => ({
 jest.mock('../src/modules/classes/class.service', () => ({
   getClassAnalytics: jest.fn(),
 }));
+jest.mock('../src/modules/classes/enrollments/classEnrollment.service', () => ({
+  findEnrollment: jest.fn(),
+  createEnrollment: jest.fn(),
+  markCompleted: jest.fn(),
+  getByUser: jest.fn(),
+}));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (_req, _res, next) => next(),
+  isStudent: (_req, _res, next) => next(),
   isInstructorOrAdmin: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
 }));

--- a/frontend/src/pages/dashboard/student/online-classe/index.js
+++ b/frontend/src/pages/dashboard/student/online-classe/index.js
@@ -15,6 +15,7 @@ import {
   FaSortAmountDown
 } from 'react-icons/fa';
 import StudentLayout from '@/components/layouts/StudentLayout';
+import { fetchMyEnrolledClasses } from '@/services/classService';
 
 export default function MyEnrolledClassesPage() {
   const [classes, setClasses] = useState([]);
@@ -24,42 +25,15 @@ export default function MyEnrolledClassesPage() {
   const [sortOrder, setSortOrder] = useState('asc');
 
   useEffect(() => {
-    const mockData = [
-      {
-        id: '1',
-        title: 'React & Next.js Bootcamp',
-        instructor: 'Ayman Khalid',
-        startDate: '2025-05-01T10:00:00',
-        status: 'Live',
-        tags: ['Frontend', 'React'],
-        progress: 75,
-        joined: true,
-        linkId: 'react-next-bootcamp'
-      },
-      {
-        id: '2',
-        title: 'Python for Beginners',
-        instructor: 'Sara Ahmed',
-        startDate: '2025-06-10T15:00:00',
-        status: 'Upcoming',
-        tags: ['Python', 'Beginner'],
-        progress: 0,
-        joined: false
-      },
-      {
-        id: '3',
-        title: 'UI/UX Design Masterclass',
-        instructor: 'Mohammed Zain',
-        startDate: '2025-04-15T08:30:00',
-        status: 'Completed',
-        tags: ['Design', 'UX'],
-        progress: 100,
-        joined: true
+    const load = async () => {
+      try {
+        const list = await fetchMyEnrolledClasses();
+        setClasses(list);
+      } catch (err) {
+        console.error('Failed to load classes', err);
       }
-    ];
-
-    localStorage.setItem('enrolledClasses', JSON.stringify(mockData));
-    setClasses(mockData);
+    };
+    load();
   }, []);
 
   const filteredClasses = classes

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -1,0 +1,26 @@
+import api from "@/services/api/api";
+
+export const fetchPublishedClasses = async () => {
+  const res = await api.get("/users/classes");
+  return res.data;
+};
+
+export const fetchClassDetails = async (id) => {
+  const res = await api.get(`/users/classes/${id}`);
+  return res.data;
+};
+
+export const enrollInClass = async (id) => {
+  const { data } = await api.post(`/users/classes/enroll/${id}`);
+  return data;
+};
+
+export const markClassCompleted = async (id) => {
+  const { data } = await api.post(`/users/classes/enroll/${id}/complete`);
+  return data;
+};
+
+export const fetchMyEnrolledClasses = async () => {
+  const { data } = await api.get("/users/classes/enroll/my");
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- add class enrollment controller, service, and routes
- hook enrollment router into class routes
- mock enrollment service and student auth in tests
- create client `classService` and use it in student dashboard

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6859ac34371c8328b9dac612285a2ff5