### PR TITLE
Fix admin class list to display price

### DIFF
--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -16,6 +16,7 @@ exports.getAllClasses = async () => {
       "c.cover_image",
       "c.start_date",
       "c.end_date",
+      "c.price",
       "c.status",
       "c.moderation_status",
       "u.full_name as instructor",

--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -223,6 +223,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
               <th className="px-6 py-3 text-left">Start Date</th>
               <th className="px-6 py-3 text-left">End Date</th>
               <th className="px-6 py-3 text-left">Category</th>
+              <th className="px-6 py-3 text-left">Price</th>
               <th className="px-6 py-3 text-left">Schedule</th>
               <th className="px-6 py-3 text-left">Publish</th>
               <th className="px-6 py-3 text-left">Approval</th>
@@ -246,6 +247,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
                 <td className="px-6 py-4">{cls.start_date}</td>
                 <td className="px-6 py-4">{cls.end_date || '-'}</td>
                 <td className="px-6 py-4">{cls.category || '-'}</td>
+                <td className="px-6 py-4">${cls.price ?? '-'}</td>
                 <td className="px-6 py-4">
                   <span className={`px-3 py-1 rounded-full text-xs font-bold ${{
                     Upcoming: 'bg-green-100 text-green-800',


### PR DESCRIPTION
## Summary
- include price in `getAllClasses`
- show price column in admin classes table

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6859be9c9c0c8328987584726b11833d