### PR TITLE
Fix admin class creation to save price

### DIFF
--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -16,6 +16,7 @@ exports.getAllClasses = async () => {
       "c.cover_image",
       "c.start_date",
       "c.end_date",
+      "c.price",
       "c.status",
       "c.moderation_status",
       "u.full_name as instructor",

--- a/backend/src/modules/classes/class.validator.js
+++ b/backend/src/modules/classes/class.validator.js
@@ -1,5 +1,11 @@
 const { z } = require("zod");
 
+const toNumber = (val) => {
+  if (typeof val === 'number') return val;
+  if (typeof val === 'string' && val.trim() !== '') return parseFloat(val);
+  return undefined;
+};
+
 exports.create = z.object({
   body: z.object({
     instructor_id: z.string().uuid(),
@@ -10,8 +16,8 @@ exports.create = z.object({
     start_date: z.string().optional(),
     end_date: z.string().optional(),
     category_id: z.string().uuid().optional(),
-    price: z.string().optional(),
-    max_students: z.string().optional(),
+    price: z.preprocess(toNumber, z.number().optional()),
+    max_students: z.preprocess(toNumber, z.number().int().optional()),
     language: z.string().optional(),
     demo_video_url: z.string().optional(),
     allow_installments: z.preprocess(
@@ -34,8 +40,8 @@ exports.update = z.object({
     start_date: z.string().optional(),
     end_date: z.string().optional(),
     category_id: z.string().uuid().optional(),
-    price: z.string().optional(),
-    max_students: z.string().optional(),
+    price: z.preprocess(toNumber, z.number().optional()),
+    max_students: z.preprocess(toNumber, z.number().int().optional()),
     language: z.string().optional(),
     demo_video_url: z.string().optional(),
     allow_installments: z.preprocess(

--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -223,6 +223,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
               <th className="px-6 py-3 text-left">Start Date</th>
               <th className="px-6 py-3 text-left">End Date</th>
               <th className="px-6 py-3 text-left">Category</th>
+              <th className="px-6 py-3 text-left">Price</th>
               <th className="px-6 py-3 text-left">Schedule</th>
               <th className="px-6 py-3 text-left">Publish</th>
               <th className="px-6 py-3 text-left">Approval</th>
@@ -246,6 +247,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
                 <td className="px-6 py-4">{cls.start_date}</td>
                 <td className="px-6 py-4">{cls.end_date || '-'}</td>
                 <td className="px-6 py-4">{cls.category || '-'}</td>
+                <td className="px-6 py-4">${cls.price ?? '-'}</td>
                 <td className="px-6 py-4">
                   <span className={`px-3 py-1 rounded-full text-xs font-bold ${{
                     Upcoming: 'bg-green-100 text-green-800',

--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -253,6 +253,18 @@ function CreateOnlineClass() {
         if (formData.demoVideo) payload.append('demo_video', formData.demoVideo);
         if (formData.startDate) payload.append('start_date', formData.startDate);
         if (formData.endDate) payload.append('end_date', formData.endDate);
+        if (formData.price)
+          payload.append(
+            'price',
+            Number(formData.price).toFixed(2)
+          );
+        if (formData.maxStudents)
+          payload.append('max_students', formData.maxStudents);
+        if (formData.language) payload.append('language', formData.language);
+        payload.append(
+          'allow_installments',
+          formData.allowInstallments ? 'true' : 'false'
+        );
         payload.append('status', formData.isApproved ? 'published' : 'draft');
         if (formData.category) payload.append('category_id', formData.category);
 


### PR DESCRIPTION
## Summary
- parse numeric fields in class validator
- include price and other details when creating a class

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6859be9c9c0c8328987584726b11833d