### PR TITLE
Fix class service trending property

### DIFF
--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -9,6 +9,7 @@ const formatClass = (cls) => ({
   demo_video_url: cls.demo_video_url
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`
     : null,
+  trending: Boolean(cls.trending),
 
   start_date: cls.start_date ? toDateInput(cls.start_date) : "",
   end_date: cls.end_date ? toDateInput(cls.end_date) : "",

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -1,8 +1,13 @@
 import api from "@/services/api/api";
 
 export const fetchPublishedClasses = async () => {
-  const res = await api.get("/users/classes");
-  return res.data;
+  const { data } = await api.get("/users/classes");
+  const list = data?.data ?? [];
+  const formatted = list.map((cls) => ({
+    ...cls,
+    trending: Boolean(cls.trending),
+  }));
+  return { ...data, data: formatted };
 };
 
 export const fetchClassDetails = async (id) => {


### PR DESCRIPTION
## Summary
- expose `trending` flag when fetching classes
- normalize `trending` in admin class formatter

## Testing
- `npm test --silent` (fails: jest not found)
- `npm test --silent` in frontend (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_685a47a0ca50832895535bd71b0a7510