### PR TITLE
Update ClassCard to use id in links

### DIFF
--- a/frontend/src/components/online-classes/ClassCard.js
+++ b/frontend/src/components/online-classes/ClassCard.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 function ClassCard({ classData, index }) {
   const {
+    id,
     title,
     instructor,
     date,
@@ -13,7 +14,7 @@ function ClassCard({ classData, index }) {
   } = classData;
 
   return (
-    <Link href={`/online-classes/${index}`}>
+    <Link href={`/online-classes/${id}`}>
       <div className="cursor-pointer bg-gray-900 rounded-lg shadow-lg p-5 flex flex-col hover:shadow-xl hover:ring-2 hover:ring-yellow-500 transition">
         {/* Image */}
         <div className="h-40 mb-4 overflow-hidden rounded-md">


### PR DESCRIPTION
## Summary
- changed ClassCard to use `classData.id` for the link target

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/eslintrc`)*

------
https://chatgpt.com/codex/tasks/task_e_685a49154e708328b8ad7608ff872515