### PR TITLE
Improve class details page

### DIFF
--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -52,28 +52,44 @@ export default function ClassDetailsPage() {
             <p className="text-sm text-gray-400">
               <span className="font-semibold text-white">Instructor:</span> {classInfo.instructor}
             </p>
-            <p className="italic mt-2 text-gray-400">{classInfo.instructorBio}</p>
+            {classInfo.instructorBio && (
+              <p className="italic mt-2 text-gray-400">{classInfo.instructorBio}</p>
+            )}
           </div>
           <div className="w-32 h-32 rounded-full overflow-hidden border-2 border-yellow-400 shadow-md">
-            <img src={classInfo.instructorImage} alt={classInfo.instructor} className="w-full h-full object-cover" />
+            <img src={classInfo.instructor_image} alt={classInfo.instructor} className="w-full h-full object-cover" />
           </div>
         </div>
 
-        <img
-          src={classInfo.image}
-          alt={classInfo.title}
-          className="w-full rounded-xl shadow-2xl mb-10 max-h-[500px] object-cover border border-gray-800"
-        />
+        {classInfo.demo_video_url ? (
+          <video
+            src={classInfo.demo_video_url}
+            controls
+            className="w-full rounded-xl shadow-2xl mb-10 max-h-[500px] object-cover border border-gray-800"
+          />
+        ) : (
+          <img
+            src={classInfo.cover_image}
+            alt={classInfo.title}
+            className="w-full rounded-xl shadow-2xl mb-10 max-h-[500px] object-cover border border-gray-800"
+          />
+        )}
 
         <p className="mb-8 text-lg leading-relaxed text-gray-300 text-justify">
           {classInfo.description}
         </p>
 
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-12 text-sm text-gray-300">
-          <p><strong>Date:</strong> {classInfo.date}</p>
-          <p><strong>Duration:</strong> {classInfo.duration}</p>
+          {classInfo.start_date && (
+            <p><strong>Date:</strong> {new Date(classInfo.start_date).toLocaleDateString()}</p>
+          )}
+          {classInfo.duration && (
+            <p><strong>Duration:</strong> {classInfo.duration}</p>
+          )}
           <p><strong>Category:</strong> {classInfo.category}</p>
-          <p><strong>Available Spots:</strong> {classInfo.spotsLeft}</p>
+          {typeof classInfo.spots_left === 'number' && (
+            <p><strong>Available Spots:</strong> {classInfo.spots_left}</p>
+          )}
           <p><strong>Price:</strong> {classInfo.price === 0 ? 'Free' : `$${classInfo.price}`}</p>
         </div>
 
@@ -100,9 +116,18 @@ export default function ClassDetailsPage() {
           <p className="text-sm text-gray-400 mb-5">Click below to secure your seat and start learning!</p>
           <button
             onClick={() => router.push(`/payments/checkout?classId=${id}`)}
-            className="w-full sm:w-auto px-8 py-3 bg-yellow-500 text-gray-900 font-semibold rounded-full hover:bg-yellow-600 transition duration-300 shadow-lg"
+            disabled={typeof classInfo.spots_left === 'number' && classInfo.spots_left <= 0}
+            className={`w-full sm:w-auto px-8 py-3 font-semibold rounded-full transition duration-300 shadow-lg ${
+              typeof classInfo.spots_left === 'number' && classInfo.spots_left <= 0
+                ? 'bg-gray-600 text-gray-400 cursor-not-allowed'
+                : 'bg-yellow-500 text-gray-900 hover:bg-yellow-600'
+            }`}
           >
-            {classInfo.price === 0 ? 'Enroll for Free' : 'Proceed to Payment'}
+            {typeof classInfo.spots_left === 'number' && classInfo.spots_left <= 0
+              ? 'Class Full'
+              : classInfo.price === 0
+              ? 'Enroll for Free'
+              : 'Proceed to Payment'}
           </button>
         </section>
 


### PR DESCRIPTION
## Summary
- enrich public class detail API with instructor, category and spot count
- show demo video or cover image on class detail page
- display instructor details and spots left
- disable registration button when class is full

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685a4d33c32483289eda48e7b212eede