### PR TITLE
Update class and instructor pages

### DIFF
--- a/frontend/src/pages/instructors/[id].js
+++ b/frontend/src/pages/instructors/[id].js
@@ -3,40 +3,18 @@ import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
 import StudentLayout from "@/components/layouts/StudentLayout";
-import {
-  Star,
-  CheckCircle,
-  UserCheck,
-  MessageCircle,
-  Clock,
-} from "lucide-react";
-
+import { FaUserCheck, FaComments } from "react-icons/fa";
 import BookingRequestModal from "@/components/student/instructors/BookingRequestModal";
-
-const mockInstructors = [
-  {
-    id: 1,
-    name: "Dr. John Doe",
-    expertise: "Data Science",
-    experience: "10+ Years",
-    rating: 4.9,
-    bio: "Dr. John Doe has taught Data Science for over a decade, specializing in Python, machine learning, and data visualization.",
-    avatar: "https://www.iwcf.org/wp-content/uploads/2018/12/Instructor-top-of-page-image-new.jpg",
-    tags: ["Python", "Beginner Friendly", "ML", "Pandas"],
-    verified: true,
-    slots: ["10:00 AM", "2:00 PM", "5:00 PM"],
-    reviews: [
-      { name: "Alice", rating: 5, text: "Amazing instructor!" },
-      { name: "Bob", rating: 4, text: "Very detailed and clear explanations." }
-    ]
-  },
-  // Add other instructors...
-];
+import { fetchPublicInstructorById } from "@/services/public/instructorService";
+import { fetchPublishedClasses } from "@/services/classService";
+import { fetchPublishedTutorials } from "@/services/tutorialService";
 
 export default function InstructorProfilePage() {
   const router = useRouter();
   const { id } = router.query;
   const [instructor, setInstructor] = useState(null);
+  const [stats, setStats] = useState({ classes: 0, tutorials: 0 });
+  const [loading, setLoading] = useState(true);
   const [showBooking, setShowBooking] = useState(false);
   const { user } = useAuthStore();
 
@@ -52,81 +30,65 @@ export default function InstructorProfilePage() {
   };
 
   useEffect(() => {
-    if (id) {
-      const data = mockInstructors.find((ins) => ins.id === parseInt(id));
-      setInstructor(data || null);
-    }
+    if (!id) return;
+    const load = async () => {
+      try {
+        setLoading(true);
+        const data = await fetchPublicInstructorById(id);
+        setInstructor(data);
+
+        const classRes = await fetchPublishedClasses();
+        const classList = classRes?.data ?? classRes ?? [];
+        const classCount = classList.filter(
+          (c) => String(c.instructor_id) === String(id)
+        ).length;
+
+        const tutRes = await fetchPublishedTutorials();
+        const tutList = tutRes?.data ?? tutRes ?? [];
+        const tutCount = tutList.filter(
+          (t) => String(t.creator_id) === String(id)
+        ).length;
+
+        setStats({ classes: classCount, tutorials: tutCount });
+      } catch (err) {
+        console.error("Failed to load instructor", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [id]);
 
-  if (!instructor) return <p className="p-6">Loading instructor details...</p>;
+  if (loading) return <p className="p-6">Loading instructor details...</p>;
+  if (!instructor) return <p className="p-6">Instructor not found.</p>;
 
   return (
     <StudentLayout>
       <section className="py-10 px-6 max-w-3xl mx-auto bg-white rounded-xl shadow">
         {/* Profile Header */}
         <div className="flex flex-col items-center text-center">
-          <img src={instructor.avatar} className="w-32 h-32 rounded-full border-4 border-yellow-400 mb-4" />
-          <h1 className="text-2xl font-bold">{instructor.name}</h1>
-          <p className="text-gray-500">{instructor.expertise} · {instructor.experience}</p>
-          <div className="mt-2 flex items-center gap-1">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <FaStar key={i} className={i < Math.floor(instructor.rating) ? "text-yellow-400" : "text-gray-300"} />
-            ))}
-            <span className="text-sm text-gray-600">({instructor.rating})</span>
-            {instructor.verified && (
-              <span className="ml-2 text-green-600 text-sm flex items-center gap-1">
-                <FaCheckCircle  /> Verified
-              </span>
-            )}
+          <img
+            src={instructor.avatar_url}
+            className="w-32 h-32 rounded-full border-4 border-yellow-400 mb-4"
+          />
+          <h1 className="text-2xl font-bold">{instructor.full_name}</h1>
+          <p className="text-gray-500">
+            {instructor.expertise} {instructor.experience ? `· ${instructor.experience}` : ""}
+          </p>
+          <div className="mt-2 text-sm text-gray-600">
+            Classes taught: {stats.classes} · Tutorials: {stats.tutorials}
           </div>
         </div>
 
-        {/* Bio Section */}
+        {/* About */}
         <div className="mt-6 text-left">
           <h2 className="text-lg font-semibold mb-2">About</h2>
-          <p className="text-gray-700">{instructor.bio}</p>
-        </div>
-
-        {/* Tags */}
-        <div className="mt-4">
-          <h2 className="text-lg font-semibold mb-2">Skills & Tags</h2>
-          <div className="flex flex-wrap gap-2">
-            {instructor.tags.map((tag, idx) => (
-              <span key={idx} className="bg-yellow-100 text-yellow-800 text-xs px-3 py-1 rounded-full">{tag}</span>
-            ))}
-          </div>
-        </div>
-
-        {/* Available Time Slots */}
-        <div className="mt-6">
-          <h2 className="text-lg font-semibold mb-2">Available Time Slots</h2>
-          <div className="flex flex-wrap gap-2">
-            {instructor.slots.map((slot, i) => (
-              <span key={i} className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full flex items-center gap-1">
-                <FaClock /> {slot}
-              </span>
-            ))}
-          </div>
-        </div>
-
-        {/* Reviews */}
-        <div className="mt-6">
-          <h2 className="text-lg font-semibold mb-2">Student Reviews</h2>
-          <div className="space-y-3">
-            {instructor.reviews.map((rev, i) => (
-              <div key={i} className="bg-gray-100 rounded-lg p-3">
-                <div className="flex items-center justify-between">
-                  <span className="font-semibold">{rev.name}</span>
-                  <div className="flex">
-                    {Array.from({ length: 5 }).map((_, j) => (
-                      <FaStar key={j} className={j < rev.rating ? "text-yellow-400" : "text-gray-300"} />
-                    ))}
-                  </div>
-                </div>
-                <p className="text-gray-600 mt-1 text-sm">{rev.text}</p>
-              </div>
-            ))}
-          </div>
+          <p className="text-gray-700">
+            {instructor.expertise} {instructor.experience ? `· ${instructor.experience}` : ""}
+          </p>
+          {instructor.pricing && (
+            <p className="text-gray-700 mt-2">Pricing: {instructor.pricing}</p>
+          )}
         </div>
 
         {/* Actions */}

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -43,22 +43,43 @@ export default function ClassDetailsPage() {
       <Navbar />
 
       <main className="max-w-6xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-col md:flex-row items-start gap-8 mb-10">
-          <div className="flex-1">
-            <h1 className="text-yellow-400 text-xl font-semibold uppercase tracking-wide mb-2">Featured Class</h1>
-            <h2 className="text-4xl font-extrabold leading-tight tracking-tight text-yellow-400 mb-4">
-              {classInfo.title}
-            </h2>
-            <p className="text-sm text-gray-400">
-              <span className="font-semibold text-white">Instructor:</span> {classInfo.instructor}
-            </p>
-            {classInfo.instructorBio && (
-              <p className="italic mt-2 text-gray-400">{classInfo.instructorBio}</p>
-            )}
+        <div className="mb-10">
+          <div className="flex items-center gap-4 mb-6">
+            <img
+              src={classInfo.cover_image}
+              alt={classInfo.title}
+              className="w-20 h-20 rounded-full object-cover border-2 border-yellow-400"
+            />
+            <div>
+              <h1 className="text-yellow-400 text-xl font-semibold uppercase tracking-wide">
+                Featured Class
+              </h1>
+              <h2 className="text-4xl font-extrabold leading-tight tracking-tight text-yellow-400">
+                {classInfo.title}
+              </h2>
+            </div>
           </div>
-          <div className="w-32 h-32 rounded-full overflow-hidden border-2 border-yellow-400 shadow-md">
-            <img src={classInfo.instructor_image} alt={classInfo.instructor} className="w-full h-full object-cover" />
+          <div className="flex items-center gap-4">
+            <img
+              src={classInfo.instructor_image}
+              alt={classInfo.instructor}
+              className="w-16 h-16 rounded-full object-cover border-2 border-yellow-400"
+            />
+            <div>
+              <p className="text-sm text-gray-400">
+                <span className="font-semibold text-white">Instructor:</span>{" "}
+                <a href={`/instructors/${classInfo.instructor_id}`} className="hover:underline">
+                  {classInfo.instructor}
+                </a>
+              </p>
+              {classInfo.instructorBio && (
+                <p className="italic mt-1 text-gray-400">{classInfo.instructorBio}</p>
+              )}
+            </div>
           </div>
+          <p className="text-xs text-gray-500 mt-2">
+            Note: Classes on SkillBridge may be created by instructors or administrators.
+          </p>
         </div>
 
         {classInfo.demo_video_url ? (


### PR DESCRIPTION
## Summary
- show class image beside title and link to instructor page
- add note about class creator on class details page
- fetch instructor details from API instead of mock data
- show counts for classes and tutorials on instructor page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a553193248328a1f9841e6f603240