### PR TITLE
Fix create admin class exports

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -46,7 +46,7 @@ function FloatingInput({ label, name, value, onChange, type = "text", ...props }
   );
 }
 
-export function CreateOnlineClass() {
+function CreateOnlineClass() {
   const [step, setStep] = useState(1);
   const [formData, setFormData] = useState({
     title: '',
@@ -67,10 +67,7 @@ export function CreateOnlineClass() {
     allowInstallments: false,
     isApproved: false,
     lessons: [],
-    title: '', instructor: '', category: '', tags: '', level: '', language: '',
-    description: '', image: '', imagePreview: '', demoVideo: null, demoPreview: '',
-    startDate: '', endDate: '', price: '', isFree: false, maxStudents: '',
-    allowInstallments: false, isApproved: false, lessons: [],
+    tags: '',
   });
   const [categories, setCategories] = useState([]);
   const [existingTitles, setExistingTitles] = useState([]);


### PR DESCRIPTION
## Summary
- remove duplicate export on create admin class page
- clean up redundant state definition

## Testing
- `npm test --silent`
- `npm run lint` *(fails: React Hook "useRef" cannot be called inside a callback)*

------
https://chatgpt.com/codex/tasks/task_e_685a6c6616e88328b1abe82ba8a68306