### PR TITLE
Enable instructor dashboard stats API

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -298,3 +298,14 @@ exports.updateAvailability = async (req, res) => {
 
     res.json({ message: 'Availability updated successfully' });
 };
+
+/**
+ * @desc Get dashboard statistics for instructor
+ * @route GET /api/users/instructor/dashboard-stats
+ * @access Instructor
+ */
+exports.getDashboardStats = async (req, res) => {
+    const userId = req.user.id;
+    const data = await require('./instructor.service').getDashboardStats(userId);
+    res.json({ data });
+};

--- a/backend/src/modules/users/instructor/instructor.routes.js
+++ b/backend/src/modules/users/instructor/instructor.routes.js
@@ -140,4 +140,12 @@ router.patch(
  */
 router.patch("/change-password", verifyToken, isInstructor, controller.changePassword);
 
+// Dashboard statistics
+router.get(
+  "/dashboard-stats",
+  verifyToken,
+  isInstructor,
+  controller.getDashboardStats
+);
+
 module.exports = router;

--- a/backend/src/modules/users/instructor/instructor.service.js
+++ b/backend/src/modules/users/instructor/instructor.service.js
@@ -88,7 +88,33 @@ const updateInstructorProfile = async (userId, userData, instructorData, socialL
   });
 };
 
+// 📊 Dashboard stats for instructor dashboard
+const getDashboardStats = async (userId) => {
+  const [tutorialRow] = await db('tutorials')
+    .where({ instructor_id: userId })
+    .count();
+  const [classRow] = await db('online_classes')
+    .where({ instructor_id: userId })
+    .count();
+  const [studentRow] = await db('class_enrollments as ce')
+    .join('online_classes as c', 'ce.class_id', 'c.id')
+    .where('c.instructor_id', userId)
+    .countDistinct('ce.user_id');
+  const [upcomingRow] = await db('online_classes')
+    .where({ instructor_id: userId })
+    .where('start_date', '>', db.fn.now())
+    .count();
+
+  return {
+    totalTutorials: parseInt(tutorialRow.count, 10) || 0,
+    totalClasses: parseInt(classRow.count, 10) || 0,
+    totalStudents: parseInt(studentRow.count, 10) || 0,
+    upcomingSessions: parseInt(upcomingRow.count, 10) || 0,
+  };
+};
+
 module.exports = {
   getInstructorProfile,
   updateInstructorProfile,
+  getDashboardStats,
 };

--- a/backend/tests/instructorDashboardRoutes.test.js
+++ b/backend/tests/instructorDashboardRoutes.test.js
@@ -1,0 +1,33 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database', () => ({
+  raw: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('../src/modules/users/instructor/instructor.service', () => ({
+  getDashboardStats: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: '1' }; next(); },
+  isInstructor: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/users/instructor/instructor.service');
+const routes = require('../src/modules/users/instructor/instructor.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/users/instructor', routes);
+
+describe('GET /api/users/instructor/dashboard-stats', () => {
+  it('returns dashboard stats', async () => {
+    const mockStats = { totalTutorials: 1 };
+    service.getDashboardStats.mockResolvedValue(mockStats);
+
+    const res = await request(app).get('/api/users/instructor/dashboard-stats');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mockStats);
+    expect(service.getDashboardStats).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/dashboard/instructor/index.js
+++ b/frontend/src/pages/dashboard/instructor/index.js
@@ -23,6 +23,7 @@ import { Calendar, momentLocalizer } from "react-big-calendar";
 import moment from "moment";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import "tailwindcss/tailwind.css";
+import { fetchInstructorDashboardStats } from "@/services/instructor/instructorService";
 
 const localizer = momentLocalizer(moment);
 
@@ -87,10 +88,16 @@ export default function InstructorDashboard() {
   const [counts, setCounts] = useState({});
 
   useEffect(() => {
-    setTimeout(() => {
+    async function loadStats() {
+      try {
+        const data = await fetchInstructorDashboardStats();
+        if (data) setCounts(data);
+      } catch (err) {
+        console.error('Failed to load dashboard stats', err);
+      }
       setChartData(mockChartData);
-      setCounts(mockDashboardCounts);
-    }, 500);
+    }
+    loadStats();
   }, []);
 
   const cardStyle = "bg-white shadow-sm border rounded-2xl p-5 hover:shadow-md transition duration-300";

--- a/frontend/src/services/instructor/instructorService.js
+++ b/frontend/src/services/instructor/instructorService.js
@@ -87,3 +87,8 @@ export const updateInstructorAvailability = async (availability) => {
   const res = await api.patch("/users/instructor/availability", { availability });
   return res.data;
 };
+
+export const fetchInstructorDashboardStats = async () => {
+  const res = await api.get("/users/instructor/dashboard-stats");
+  return res.data?.data;
+};


### PR DESCRIPTION
## Summary
- add dashboard stats endpoint for instructors
- fetch instructor dashboard stats on the dashboard page
- expose service method for fetching stats on client
- test new API route

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685a6c8d7c708328b212d5222ab56dad