### PR TITLE
Add client directive to instructor class page

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -1,4 +1,5 @@
 // File: pages/dashboard/instructor/online-classes/create.js
+'use client';
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/router';


### PR DESCRIPTION
## Summary
- ensure the instructor online class creation page is executed client-side

## Testing
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a92348248832893a63e86c536a94f