### PR TITLE
Add shared FloatingInput component

### DIFF
--- a/frontend/src/components/shared/FloatingInput.js
+++ b/frontend/src/components/shared/FloatingInput.js
@@ -1,0 +1,21 @@
+export default function FloatingInput({ label, name, value, onChange, type = "text", ...props }) {
+  return (
+    <div className="relative mt-4 w-full">
+      <input
+        type={type}
+        name={name}
+        value={value}
+        onChange={onChange}
+        className="peer w-full border border-gray-300 rounded px-3 pt-5 pb-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 text-sm"
+        placeholder={label}
+        {...props}
+      />
+      <label
+        htmlFor={name}
+        className="absolute left-3 top-2 text-gray-500 text-xs transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:top-2 peer-focus:text-xs peer-focus:text-yellow-600"
+      >
+        {label}
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `FloatingInput` component under `components/shared`
- allow instructor class creation page to import `FloatingInput` successfully

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685ace142c948328a22567243bb5eae1