### PR TITLE
Fix tag suggestions and slugify

### DIFF
--- a/frontend/src/components/shared/FloatingInput.js
+++ b/frontend/src/components/shared/FloatingInput.js
@@ -1,0 +1,21 @@
+export default function FloatingInput({ label, name, value, onChange, type = "text", ...props }) {
+  return (
+    <div className="relative mt-4 w-full">
+      <input
+        type={type}
+        name={name}
+        value={value}
+        onChange={onChange}
+        className="peer w-full border border-gray-300 rounded px-3 pt-5 pb-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 text-sm"
+        placeholder={label}
+        {...props}
+      />
+      <label
+        htmlFor={name}
+        className="absolute left-3 top-2 text-gray-500 text-xs transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:top-2 peer-focus:text-xs peer-focus:text-yellow-600"
+      >
+        {label}
+      </label>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -1,7 +1,7 @@
 // File: pages/dashboard/instructor/online-classes/create.js
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { toast } from 'react-toastify';
@@ -21,7 +21,13 @@ import FloatingInput from '@/components/shared/FloatingInput';
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
 import 'react-quill/dist/quill.snow.css';
 
-const slugify = (text) => text.toLowerCase().trim().replace(/[^"]+/g, '').replace(/ +/g, '-');
+// Generate a URL friendly slug from a string
+const slugify = (text) =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w ]+/g, '')
+    .replace(/ +/g, '-');
 
 function CreateOnlineClass() {
   const router = useRouter();
@@ -55,6 +61,18 @@ function CreateOnlineClass() {
   const [allTags, setAllTags] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
   const [tagInput, setTagInput] = useState('');
+
+  // Filter tag suggestions based on user input and exclude already selected tags
+  const filteredTagSuggestions = useMemo(
+    () =>
+      allTags.filter(
+        (t) =>
+          tagInput &&
+          t.name.toLowerCase().includes(tagInput.toLowerCase()) &&
+          !selectedTags.includes(t.name)
+      ),
+    [allTags, tagInput, selectedTags]
+  );
 
   useEffect(() => {
     fetchAllCategories().then(setCategories);


### PR DESCRIPTION
## Summary
- improve slugify helper for instructor class creation page
- add filtered tag suggestions using `useMemo`

## Testing
- `npm test` in `frontend` *(fails: jest not found)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ace142c948328a22567243bb5eae1