### PR TITLE
Fix categories mapping in instructor class page

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -75,8 +75,12 @@ function CreateOnlineClass() {
   );
 
   useEffect(() => {
-    fetchAllCategories().then(setCategories);
-    fetchClassTags().then(setAllTags);
+    fetchAllCategories({ status: 'active', limit: 100 })
+      .then((res) => setCategories(res?.data || []))
+      .catch(() => setCategories([]));
+    fetchClassTags()
+      .then(setAllTags)
+      .catch(() => setAllTags([]));
   }, []);
 
   const handleChange = (e) => {


### PR DESCRIPTION
## Summary
- ensure categories list is properly fetched for instructor class creation

## Testing
- `npm test --silent`
- `npx eslint src/pages/dashboard/instructor/online-classes/create.js | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_685ad79998dc83289758a4f190073d1c