### PR TITLE
Fix instructor class link path

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/index.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/index.js
@@ -142,7 +142,7 @@ export default function MyClasses() {
                 </span>
               </div>
               <Link
-                href={`/dashboard/instructor/online-classe/${cls.id}`}
+                href={`/dashboard/instructor/online-classes/${cls.id}`}
                 className="block bg-yellow-500 text-black text-center py-2 px-4 rounded hover:bg-yellow-600 font-semibold"
               >
                 Manage Class


### PR DESCRIPTION
## Summary
- fix the link to instructor online class detail page

## Testing
- `npm test` (fails: jest not found)
- `npm test` in backend (fails: jest not found)

------
https://chatgpt.com/codex/tasks/task_e_685adc68b79883289db12659b44a9f91