### PR TITLE
Enable status choice on class creation

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -52,7 +52,7 @@ describe('Class routes', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toEqual(data);
     expect(service.createClass).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 'draft' })
+      expect.objectContaining({ status: 'published' })
     );
   });
 

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -21,12 +21,12 @@ const generateUniqueSlug = async (title) => {
 
 exports.createClass = catchAsync(async (req, res) => {
   const slug = await generateUniqueSlug(req.body.title);
-  const { tags: rawTags, ...body } = req.body;
+  const { tags: rawTags, status, ...body } = req.body;
   const data = {
     ...body,
     id: uuidv4(),
     slug,
-    status: "draft",
+    status: status || "draft",
     moderation_status: "Pending",
   };
   if (req.files?.cover_image?.[0]) {


### PR DESCRIPTION
## Summary
- let API keep the requested status when creating online classes
- adjust related tests to expect provided status

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685af152b5ec83288e402eba4db44610