### PR TITLE
Add instructor class detail view

### DIFF
--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -57,6 +57,7 @@ exports.getClassesByInstructor = async (instructorId) => {
       "c.start_date",
       "c.end_date",
       "c.price",
+      "c.max_students",
       "c.status",
       "c.moderation_status",
       "cat.name as category"

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
@@ -1,0 +1,91 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import { fetchInstructorClassById } from "@/services/instructor/classService";
+
+export default function InstructorClassDetailPage() {
+  const { id } = useRouter().query;
+  const [details, setDetails] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchInstructorClassById(id);
+        setDetails(data);
+      } catch (err) {
+        console.error("Failed to load class", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-800">📄 Class Details (ID: {id})</h1>
+        <Link href="/dashboard/instructor/online-classes" className="text-sm text-blue-600 hover:underline">
+          ← Back to My Classes
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="bg-white rounded-xl shadow-xl p-6 border border-gray-100 text-center">Loading...</div>
+      ) : (
+        <div className="bg-white rounded-xl shadow-xl p-6 border border-gray-100 space-y-6">
+          {details?.cover_image && (
+            <img src={details.cover_image} alt="Class Cover" className="w-full h-64 object-cover rounded-lg" />
+          )}
+          {details?.demo_video_url && (
+            <video controls className="w-full mt-4 rounded-lg" src={details.demo_video_url} />
+          )}
+
+          <div className="space-y-1">
+            <h2 className="text-2xl font-semibold text-yellow-600">{details?.title}</h2>
+            <p className="text-gray-500 text-sm">Instructor: {details?.instructor}</p>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-6 pt-4 text-sm">
+            <div className="space-y-1">
+              <p><strong>🗓️ Start Date:</strong> {details?.start_date}</p>
+              <p><strong>🗖 End Date:</strong> {details?.end_date || '-'}</p>
+              <p><strong>🏷️ Category:</strong> {details?.category || '-'}</p>
+            </div>
+            <div className="space-y-1">
+              <p>
+                <strong>📌 Status:</strong>{' '}
+                <span className="px-2 py-1 bg-green-100 text-green-700 rounded-full text-xs font-medium">
+                  {details?.status}
+                </span>
+              </p>
+              {details?.price && <p><strong>💵 Price:</strong> ${details.price}</p>}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-semibold text-gray-700 mb-2">📘 Description</h3>
+            <p className="text-gray-600 leading-relaxed" dangerouslySetInnerHTML={{ __html: details?.description }} />
+          </div>
+
+          <div className="pt-4 flex flex-wrap gap-4">
+            <Link
+              href={`/dashboard/instructor/online-classes/${id}`}
+              className="bg-yellow-500 text-black px-4 py-2 rounded shadow hover:bg-yellow-600 text-sm"
+            >
+              🚀 Manage Class
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+InstructorClassDetailPage.getLayout = function getLayout(page) {
+  return <InstructorLayout>{page}</InstructorLayout>;
+};

--- a/frontend/src/pages/dashboard/instructor/online-classes/index.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/index.js
@@ -119,6 +119,12 @@ export default function MyClasses() {
               <p className="text-sm text-gray-600 flex items-center gap-2 mb-1">
                 <FaClock /> Schedule: {cls.scheduleStatus}
               </p>
+              {typeof cls.price !== "undefined" && (
+                <p className="text-sm text-gray-600 mb-1">💵 Price: ${cls.price ?? 0}</p>
+              )}
+              {typeof cls.max_students !== "undefined" && (
+                <p className="text-sm text-gray-600 mb-1">👥 Max Students: {cls.max_students}</p>
+              )}
               <div className="flex gap-2 mb-4 mt-2">
                 <span
                   className={`px-3 py-1 rounded-full text-xs font-bold ${
@@ -146,6 +152,12 @@ export default function MyClasses() {
                 className="block bg-yellow-500 text-black text-center py-2 px-4 rounded hover:bg-yellow-600 font-semibold"
               >
                 Manage Class
+              </Link>
+              <Link
+                href={`/dashboard/instructor/online-classes/${cls.id}/details`}
+                className="block bg-blue-500 text-white text-center py-2 px-4 rounded hover:bg-blue-600 font-semibold mt-2"
+              >
+                View Details
               </Link>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- include `max_students` when listing instructor classes
- show price and capacity on instructor class cards
- add a View Details button for each instructor class
- add instructor class details page mirroring admin view

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`
- `npm run lint` in `frontend` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af4cdbbac83288b7a14afbcf8e73e