### PR TITLE
Implement basic lesson management

### DIFF
--- a/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
+++ b/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
@@ -1,0 +1,70 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn(() => Promise.resolve(null));
+  db.select = jest.fn(() => db);
+  db.insert = jest.fn(() => db);
+  db.update = jest.fn(() => db);
+  return db;
+});
+
+jest.mock('../classAssignment.service', () => ({
+  getByClass: jest.fn(),
+  createAssignment: jest.fn(),
+  updateAssignment: jest.fn(),
+  deleteAssignment: jest.fn(),
+}));
+const service = require('../classAssignment.service');
+
+jest.mock('../../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'test-user' }; next(); },
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+  isStudent: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const routes = require('../../class.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/classes', routes);
+
+describe('Class assignment routes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('get assignments by class', async () => {
+    const list = [{ id: '1' }];
+    service.getByClass.mockResolvedValue(list);
+    const res = await request(app).get('/classes/assignments/class/abc');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual(list);
+  });
+
+  test('create assignment', async () => {
+    service.createAssignment.mockResolvedValue({ id: '1' });
+    const res = await request(app)
+      .post('/classes/assignments/class/abc')
+      .send({ title: 'New' });
+    expect(res.statusCode).toBe(200);
+    expect(service.createAssignment).toHaveBeenCalled();
+  });
+
+  test('update assignment', async () => {
+    service.updateAssignment.mockResolvedValue({ id: '1' });
+    const res = await request(app)
+      .put('/classes/assignments/1')
+      .send({ title: 'Edit' });
+    expect(res.statusCode).toBe(200);
+    expect(service.updateAssignment).toHaveBeenCalled();
+  });
+
+  test('delete assignment', async () => {
+    service.deleteAssignment.mockResolvedValue();
+    const res = await request(app).delete('/classes/assignments/1');
+    expect(res.statusCode).toBe(200);
+    expect(service.deleteAssignment).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/classes/assignments/classAssignment.controller.js
+++ b/backend/src/modules/classes/assignments/classAssignment.controller.js
@@ -1,3 +1,4 @@
+const { v4: uuidv4 } = require("uuid");
 const catchAsync = require("../../../utils/catchAsync");
 const { sendSuccess } = require("../../../utils/response");
 const service = require("./classAssignment.service");
@@ -5,4 +6,24 @@ const service = require("./classAssignment.service");
 exports.getAssignmentsByClass = catchAsync(async (req, res) => {
   const assignments = await service.getByClass(req.params.classId);
   sendSuccess(res, assignments);
+});
+
+exports.createAssignment = catchAsync(async (req, res) => {
+  const data = {
+    ...req.body,
+    id: uuidv4(),
+    class_id: req.params.classId,
+  };
+  const assignment = await service.createAssignment(data);
+  sendSuccess(res, assignment, "Assignment created");
+});
+
+exports.updateAssignment = catchAsync(async (req, res) => {
+  const assignment = await service.updateAssignment(req.params.assignmentId, req.body);
+  sendSuccess(res, assignment, "Assignment updated");
+});
+
+exports.deleteAssignment = catchAsync(async (req, res) => {
+  await service.deleteAssignment(req.params.assignmentId);
+  sendSuccess(res, null, "Assignment deleted");
 });

--- a/backend/src/modules/classes/assignments/classAssignment.routes.js
+++ b/backend/src/modules/classes/assignments/classAssignment.routes.js
@@ -1,6 +1,10 @@
 const router = require("express").Router();
 const ctrl = require("./classAssignment.controller");
+const { verifyToken, isInstructorOrAdmin } = require("../../../middleware/auth/authMiddleware");
 
 router.get("/class/:classId", ctrl.getAssignmentsByClass);
+router.post("/class/:classId", verifyToken, isInstructorOrAdmin, ctrl.createAssignment);
+router.put("/:assignmentId", verifyToken, isInstructorOrAdmin, ctrl.updateAssignment);
+router.delete("/:assignmentId", verifyToken, isInstructorOrAdmin, ctrl.deleteAssignment);
 
 module.exports = router;

--- a/backend/src/modules/classes/assignments/classAssignment.service.js
+++ b/backend/src/modules/classes/assignments/classAssignment.service.js
@@ -3,3 +3,17 @@ const db = require("../../../config/database");
 exports.getByClass = async (class_id) => {
   return db("class_assignments").where({ class_id }).orderBy("created_at", "asc");
 };
+
+exports.createAssignment = async (data) => {
+  const [row] = await db("class_assignments").insert(data).returning("*");
+  return row;
+};
+
+exports.updateAssignment = async (id, data) => {
+  const [row] = await db("class_assignments").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.deleteAssignment = async (id) => {
+  return db("class_assignments").where({ id }).del();
+};

--- a/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
+++ b/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
@@ -1,0 +1,73 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn(() => Promise.resolve(null));
+  db.select = jest.fn(() => db);
+  db.insert = jest.fn(() => db);
+  db.update = jest.fn(() => db);
+  return db;
+});
+
+jest.mock('../classLesson.service', () => ({
+  getByClass: jest.fn(),
+  createLesson: jest.fn(),
+  updateLesson: jest.fn(),
+  deleteLesson: jest.fn(),
+}));
+const service = require('../classLesson.service');
+
+jest.mock('../../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'test-user' };
+    next();
+  },
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+  isStudent: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const routes = require('../../class.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/classes', routes);
+
+describe('Class lesson routes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('get lessons by class', async () => {
+    const list = [{ id: '1' }];
+    service.getByClass.mockResolvedValue(list);
+    const res = await request(app).get('/classes/lessons/class/abc');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual(list);
+  });
+
+  test('create lesson', async () => {
+    service.createLesson.mockResolvedValue({ id: '1' });
+    const res = await request(app)
+      .post('/classes/lessons/class/abc')
+      .send({ title: 'New Lesson' });
+    expect(res.statusCode).toBe(200);
+    expect(service.createLesson).toHaveBeenCalled();
+  });
+
+  test('update lesson', async () => {
+    service.updateLesson.mockResolvedValue({ id: '1' });
+    const res = await request(app)
+      .put('/classes/lessons/1')
+      .send({ title: 'Edit' });
+    expect(res.statusCode).toBe(200);
+    expect(service.updateLesson).toHaveBeenCalled();
+  });
+
+  test('delete lesson', async () => {
+    service.deleteLesson.mockResolvedValue();
+    const res = await request(app).delete('/classes/lessons/1');
+    expect(res.statusCode).toBe(200);
+    expect(service.deleteLesson).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/classes/lessons/classLesson.controller.js
+++ b/backend/src/modules/classes/lessons/classLesson.controller.js
@@ -1,3 +1,4 @@
+const { v4: uuidv4 } = require("uuid");
 const catchAsync = require("../../../utils/catchAsync");
 const { sendSuccess } = require("../../../utils/response");
 const service = require("./classLesson.service");
@@ -5,4 +6,24 @@ const service = require("./classLesson.service");
 exports.getLessonsByClass = catchAsync(async (req, res) => {
   const lessons = await service.getByClass(req.params.classId);
   sendSuccess(res, lessons);
+});
+
+exports.createLesson = catchAsync(async (req, res) => {
+  const data = {
+    ...req.body,
+    id: uuidv4(),
+    class_id: req.params.classId,
+  };
+  const lesson = await service.createLesson(data);
+  sendSuccess(res, lesson, "Lesson created");
+});
+
+exports.updateLesson = catchAsync(async (req, res) => {
+  const lesson = await service.updateLesson(req.params.lessonId, req.body);
+  sendSuccess(res, lesson, "Lesson updated");
+});
+
+exports.deleteLesson = catchAsync(async (req, res) => {
+  await service.deleteLesson(req.params.lessonId);
+  sendSuccess(res, null, "Lesson deleted");
 });

--- a/backend/src/modules/classes/lessons/classLesson.routes.js
+++ b/backend/src/modules/classes/lessons/classLesson.routes.js
@@ -1,6 +1,10 @@
 const router = require("express").Router();
 const ctrl = require("./classLesson.controller");
+const { verifyToken, isInstructorOrAdmin } = require("../../../middleware/auth/authMiddleware");
 
 router.get("/class/:classId", ctrl.getLessonsByClass);
+router.post("/class/:classId", verifyToken, isInstructorOrAdmin, ctrl.createLesson);
+router.put("/:lessonId", verifyToken, isInstructorOrAdmin, ctrl.updateLesson);
+router.delete("/:lessonId", verifyToken, isInstructorOrAdmin, ctrl.deleteLesson);
 
 module.exports = router;

--- a/backend/src/modules/classes/lessons/classLesson.service.js
+++ b/backend/src/modules/classes/lessons/classLesson.service.js
@@ -3,3 +3,17 @@ const db = require("../../../config/database");
 exports.getByClass = async (class_id) => {
   return db("class_lessons").where({ class_id }).orderBy("order", "asc");
 };
+
+exports.createLesson = async (data) => {
+  const [row] = await db("class_lessons").insert(data).returning("*");
+  return row;
+};
+
+exports.updateLesson = async (id, data) => {
+  const [row] = await db("class_lessons").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.deleteLesson = async (id) => {
+  return db("class_lessons").where({ id }).del();
+};

--- a/frontend/src/components/instructors/LessonManager.js
+++ b/frontend/src/components/instructors/LessonManager.js
@@ -1,19 +1,31 @@
 // components/instructor/LessonManager.js
 import { useState } from "react";
+import { createClassLesson, deleteClassLesson } from "@/services/instructor/classService";
 export default function LessonManager({ classId, initialLessons = [] }) {
   const [lessons, setLessons] = useState(initialLessons);
   const [newTitle, setNewTitle] = useState("");
   const [newDuration, setNewDuration] = useState("");
 
-  const addLesson = () => {
-    if (!newTitle || !newDuration) return;
-    setLessons([...lessons, { title: newTitle, duration: newDuration }]);
-    setNewTitle("");
-    setNewDuration("");
+  const addLesson = async () => {
+    if (!newTitle) return;
+    try {
+      const lesson = await createClassLesson(classId, { title: newTitle });
+      setLessons([...lessons, lesson]);
+      setNewTitle("");
+      setNewDuration("");
+    } catch (err) {
+      console.error("Failed to create lesson", err);
+    }
   };
 
-  const removeLesson = (index) => {
-    setLessons(lessons.filter((_, i) => i !== index));
+  const removeLesson = async (index) => {
+    const lesson = lessons[index];
+    try {
+      await deleteClassLesson(lesson.id);
+      setLessons(lessons.filter((_, i) => i !== index));
+    } catch (err) {
+      console.error("Failed to delete lesson", err);
+    }
   };
 
   return (

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -88,3 +88,21 @@ export const fetchClassManagementData = async (id) => {
     assignments: data.data.assignments || [],
   };
 };
+
+export const createClassLesson = async (classId, payload) => {
+  const { data } = await api.post(`/users/classes/lessons/class/${classId}`, payload);
+  return data?.data;
+};
+
+export const deleteClassLesson = async (lessonId) => {
+  await api.delete(`/users/classes/lessons/${lessonId}`);
+};
+
+export const createClassAssignment = async (classId, payload) => {
+  const { data } = await api.post(`/users/classes/assignments/class/${classId}`, payload);
+  return data?.data;
+};
+
+export const deleteClassAssignment = async (assignmentId) => {
+  await api.delete(`/users/classes/assignments/${assignmentId}`);
+};


### PR DESCRIPTION
## Summary
- add create/update/delete services for class lessons and assignments
- expose new lesson and assignment API routes
- wire up instructor lesson manager to call backend
- extend instructor class service with lesson and assignment helpers
- add unit tests for new routes

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685afb6cff308328a800b04f9b4bf264