### PR TITLE
Fix ParticipantList controls and side panel width

### DIFF
--- a/frontend/src/components/video-call/ParticipantList.js
+++ b/frontend/src/components/video-call/ParticipantList.js
@@ -1,4 +1,5 @@
 // ParticipantList.js
+import { useState } from "react";
 import { FaMicrophoneSlash, FaUserShield, FaTimes } from "react-icons/fa";
 
 const participantsMock = [
@@ -8,31 +9,46 @@ const participantsMock = [
 ];
 
 export default function ParticipantList({ chatId, userRole = "participant" }) {
+  const [participants, setParticipants] = useState(participantsMock);
+
   const handleMute = (id) => {
-    console.log("Muted", id);
+    setParticipants((prev) =>
+      prev.map((p) =>
+        p.id === id ? { ...p, isMuted: !p.isMuted } : p
+      )
+    );
     // TODO: Emit socket event or API call
   };
 
   const handleRemove = (id) => {
-    console.log("Removed", id);
+    setParticipants((prev) => prev.filter((p) => p.id !== id));
     // TODO: Emit socket event or API call
   };
 
   const handleMakeCoHost = (id) => {
-    console.log("Promoted to Co-Host", id);
+    setParticipants((prev) =>
+      prev.map((p) =>
+        p.id === id ? { ...p, role: "co-host" } : p
+      )
+    );
     // TODO: Emit socket event or API call
   };
 
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-semibold text-yellow-400">👥 Participants</h3>
-      {participantsMock.map((user) => (
+      {participants.map((user) => (
         <div
           key={user.id}
           className="flex justify-between items-center bg-gray-700 p-3 rounded-lg"
         >
           <div>
-            <div className="font-medium">{user.name}</div>
+            <div className="font-medium flex items-center gap-1">
+              {user.name}
+              {user.isMuted && (
+                <FaMicrophoneSlash className="text-red-500" />
+              )}
+            </div>
             <div className="text-sm text-gray-300">{user.role}</div>
           </div>
           {userRole === "host" && user.role !== "host" && (

--- a/frontend/src/components/video-call/VideoCallScreen.js
+++ b/frontend/src/components/video-call/VideoCallScreen.js
@@ -104,7 +104,7 @@ const VideoCallScreen = ({ chatId, userRole = roles.PARTICIPANT }) => {
               </div>
             </div>
             {(isChatOpen || isParticipantsOpen) && (
-              <div className="fixed top-0 right-0 h-full w-[90%] md:static md:w-[300px] bg-gray-800 p-4 rounded-lg shadow border-2 border-yellow-500 z-40 overflow-y-auto">
+              <div className="fixed top-0 right-0 h-full w-full max-w-xs md:static md:w-[300px] bg-gray-800 p-4 rounded-lg shadow border-2 border-yellow-500 z-40 overflow-y-auto">
                 {isParticipantsOpen && (
                   <ParticipantList chatId={chatId} userRole={userRole} />
                 )}


### PR DESCRIPTION
## Summary
- make ParticipantList buttons mutate state instead of only logging
- show mute indicator beside participant names
- ensure side panel opens at a sensible width across breakpoints

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685b17187998832881f6ec17ebad5286