### PR TITLE
Enable chat messages for video calls

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -147,6 +147,36 @@ app.get("/api/video-calls/:roomId/participants", (req, res) => {
   res.json(participants[roomId] || []);
 });
 
+// Simple in-memory store for call messages
+const callMessages = {};
+
+// Retrieve all messages for a room
+app.get("/api/video-calls/:roomId/messages", (req, res) => {
+  const { roomId } = req.params;
+  res.json(callMessages[roomId] || []);
+});
+
+// Post a new message to a room
+app.post("/api/video-calls/:roomId/messages", (req, res) => {
+  const { roomId } = req.params;
+  const { sender, text } = req.body || {};
+  if (!text || !text.trim()) {
+    return res.status(400).json({ message: "Message text required" });
+  }
+  const message = {
+    id: Date.now(),
+    sender: sender || "Anonymous",
+    text: text.trim(),
+    timestamp: new Date().toISOString(),
+  };
+  if (callMessages[roomId]) {
+    callMessages[roomId].push(message);
+  } else {
+    callMessages[roomId] = [message];
+  }
+  res.status(201).json(message);
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // ⚠️ Global Error Handler
 // ─────────────────────────────────────────────────────────────────────────────

--- a/frontend/src/components/video-call/ChatDuringCall.js
+++ b/frontend/src/components/video-call/ChatDuringCall.js
@@ -1,13 +1,27 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { FaPaperPlane } from "react-icons/fa";
+import { fetchCallMessages, sendCallMessage } from "@/services/videoCallService";
 
-const ChatDuringCall = () => {
+const ChatDuringCall = ({ chatId }) => {
   const [messages, setMessages] = useState([]);
   const [newMessage, setNewMessage] = useState("");
 
-  const sendMessage = () => {
-    if (!newMessage.trim()) return;
-    setMessages([...messages, { sender: "You", text: newMessage }]);
+  useEffect(() => {
+    if (!chatId) return;
+    fetchCallMessages(chatId)
+      .then(setMessages)
+      .catch(() => setMessages([]));
+  }, [chatId]);
+
+  const sendMessage = async () => {
+    const text = newMessage.trim();
+    if (!text) return;
+    try {
+      const saved = await sendCallMessage(chatId, { sender: "You", text });
+      setMessages((prev) => [...prev, saved]);
+    } catch {
+      // fail silently for this demo
+    }
     setNewMessage("");
   };
 

--- a/frontend/src/services/videoCallService.js
+++ b/frontend/src/services/videoCallService.js
@@ -4,3 +4,13 @@ export const fetchParticipants = async (roomId) => {
   const { data } = await api.get(`/video-calls/${roomId}/participants`);
   return data;
 };
+
+export const fetchCallMessages = async (roomId) => {
+  const { data } = await api.get(`/video-calls/${roomId}/messages`);
+  return data;
+};
+
+export const sendCallMessage = async (roomId, payload) => {
+  const { data } = await api.post(`/video-calls/${roomId}/messages`, payload);
+  return data;
+};


### PR DESCRIPTION
## Summary
- store video call chat messages on the backend
- expose REST endpoints to fetch and post messages
- fetch messages in ChatDuringCall and send to backend
- support sending/receiving messages via videoCallService

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1df77e188328b739e9684914bd47