### PR TITLE
Persist lessons during class creation

### DIFF
--- a/frontend/src/components/instructors/LessonManager.js
+++ b/frontend/src/components/instructors/LessonManager.js
@@ -1,15 +1,23 @@
 // components/instructor/LessonManager.js
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { createClassLesson, deleteClassLesson } from "@/services/instructor/classService";
 export default function LessonManager({ classId, initialLessons = [] }) {
   const [lessons, setLessons] = useState(initialLessons);
   const [newTitle, setNewTitle] = useState("");
   const [newDuration, setNewDuration] = useState("");
 
+  // Sync lessons when parent provides new list from backend
+  useEffect(() => {
+    setLessons(initialLessons);
+  }, [initialLessons]);
+
   const addLesson = async () => {
     if (!newTitle) return;
     try {
-      const lesson = await createClassLesson(classId, { title: newTitle });
+      const lesson = await createClassLesson(classId, {
+        title: newTitle,
+        order: lessons.length + 1,
+      });
       setLessons([...lessons, lesson]);
       setNewTitle("");
       setNewDuration("");

--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -12,7 +12,7 @@ import InstructorLayout from '@/components/layouts/InstructorLayout';
 import withAuthProtection from '@/hooks/withAuthProtection';
 
 import { fetchAllCategories } from '@/services/instructor/categoryService';
-import { createInstructorClass } from '@/services/instructor/classService';
+import { createInstructorClass, createClassLesson } from '@/services/instructor/classService';
 import { fetchClassTags, createClassTag } from '@/services/instructor/classTagService';
 import useAuthStore from '@/store/auth/authStore';
 import FloatingInput from '@/components/shared/FloatingInput';
@@ -172,10 +172,23 @@ function CreateOnlineClass() {
           setAllTags((prev) => [...prev, ...created.filter(Boolean)]);
         }
 
-        await createInstructorClass(payload, (e) => {
+        const created = await createInstructorClass(payload, (e) => {
           const percent = Math.round((e.loaded * 100) / e.total);
           setUploadProgress(percent);
         });
+
+        if (created) {
+          for (const [idx, l] of formData.lessons.entries()) {
+            try {
+              await createClassLesson(created.id, {
+                title: l.title,
+                order: idx + 1
+              });
+            } catch (err) {
+              console.error('Failed to create lesson', err);
+            }
+          }
+        }
 
         toast.success('Class created successfully!');
         router.push('/dashboard/instructor/online-classes');


### PR DESCRIPTION
## Summary
- allow saving lessons when creating a class
- refresh and order lessons on manage page

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8e7877808328ae604f925370099f