### PR TITLE
Restrict resource uploads to live sessions

### DIFF
--- a/frontend/src/components/instructors/ResourceUploadSection.js
+++ b/frontend/src/components/instructors/ResourceUploadSection.js
@@ -1,13 +1,13 @@
 // components/instructor/ResourceUploadSection.js
 import { useState } from "react";
 
-export default function ResourceUploadSection({ classId }) {
+export default function ResourceUploadSection({ classId, isLive = false }) {
   const [resources, setResources] = useState([]);
   const [linkInput, setLinkInput] = useState("");
   const [fileName, setFileName] = useState("");
 
   const addLink = () => {
-    if (!linkInput || !fileName) return;
+    if (!isLive || !linkInput || !fileName) return;
     setResources([...resources, { name: fileName, type: "link", value: linkInput }]);
     setLinkInput("");
     setFileName("");
@@ -15,47 +15,63 @@ export default function ResourceUploadSection({ classId }) {
 
   const handleFileUpload = (e) => {
     const file = e.target.files[0];
-    if (file) {
-      // Just store name for now — later send to backend
+    if (!isLive || !file) return;
+    if (
+      file.type === "application/pdf" ||
+      file.type.startsWith("image/")
+    ) {
       setResources([...resources, { name: file.name, type: "file", value: file }]);
+    } else {
+      alert("Only PDF or image files are allowed");
     }
   };
 
   return (
     <div className="text-sm text-white space-y-4">
-      {/* Add External Link */}
-      <div className="space-y-2">
-        <input
-          type="text"
-          placeholder="File name (e.g., React Guide)"
-          value={fileName}
-          onChange={(e) => setFileName(e.target.value)}
-          className="w-full px-3 py-2 rounded bg-gray-700 text-white"
-        />
-        <input
-          type="text"
-          placeholder="Paste external link (https://...)"
-          value={linkInput}
-          onChange={(e) => setLinkInput(e.target.value)}
-          className="w-full px-3 py-2 rounded bg-gray-700 text-white"
-        />
-        <button
-          onClick={addLink}
-          className="w-full bg-yellow-500 text-black py-2 rounded hover:bg-yellow-600 font-semibold"
-        >
-          Add Link
-        </button>
-      </div>
+      {!isLive && (
+        <p className="text-yellow-300">
+          Resource uploading is only available during live sessions.
+        </p>
+      )}
 
-      {/* Upload File */}
-      <div>
-        <label className="block mb-1 text-yellow-300">Upload File</label>
-        <input
-          type="file"
-          onChange={handleFileUpload}
-          className="block w-full text-sm text-white bg-gray-800 border border-gray-600 rounded file:mr-4 file:py-2 file:px-4 file:border-0 file:text-sm file:font-semibold file:bg-yellow-500 file:text-black hover:file:bg-yellow-600"
-        />
-      </div>
+      {isLive && (
+        <>
+          {/* Add External Link */}
+          <div className="space-y-2">
+            <input
+              type="text"
+              placeholder="File name (e.g., React Guide)"
+              value={fileName}
+              onChange={(e) => setFileName(e.target.value)}
+              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+            />
+            <input
+              type="text"
+              placeholder="Paste external link (https://...)"
+              value={linkInput}
+              onChange={(e) => setLinkInput(e.target.value)}
+              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+            />
+            <button
+              onClick={addLink}
+              className="w-full bg-yellow-500 text-black py-2 rounded hover:bg-yellow-600 font-semibold"
+            >
+              Add Link
+            </button>
+          </div>
+
+          {/* Upload File */}
+          <div>
+            <label className="block mb-1 text-yellow-300">Upload File</label>
+            <input
+              type="file"
+              onChange={handleFileUpload}
+              accept="application/pdf,image/*"
+              className="block w-full text-sm text-white bg-gray-800 border border-gray-600 rounded file:mr-4 file:py-2 file:px-4 file:border-0 file:text-sm file:font-semibold file:bg-yellow-500 file:text-black hover:file:bg-yellow-600"
+            />
+          </div>
+        </>
+      )}
 
       {/* Resource List */}
       <div className="mt-4 space-y-2">

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id].js
@@ -9,6 +9,13 @@ import CertificateIssuancePanel from "@/components/instructors/CertificateIssuan
 import AssignmentManager from "@/components/instructors/AssignmentManager"; // ✅ Assignment Manager added
 import { fetchClassManagementData } from "@/services/instructor/classService";
 
+const isClassLive = (start, end) => {
+  const now = new Date();
+  const s = start ? new Date(start) : null;
+  const e = end ? new Date(end) : null;
+  return s && now >= s && (!e || now <= e);
+};
+
 export default function InstructorClassRoom() {
   const router = useRouter();
   const { id } = router.query;
@@ -63,7 +70,7 @@ export default function InstructorClassRoom() {
         {/* Upload Materials */}
         <div className="bg-gray-800 p-4 rounded-lg shadow-md">
           <h2 className="text-lg font-semibold text-yellow-300 mb-2">📤 Upload Materials</h2>
-          <ResourceUploadSection classId={id} />
+          <ResourceUploadSection classId={id} isLive={isClassLive(classData.start_date, classData.end_date)} />
         </div>
 
         {/* Breakout Room Control */}


### PR DESCRIPTION
## Summary
- only allow uploading during live classes
- limit file uploads to pdf or images

## Testing
- `npm test --silent` (fails: jest not found)
- `npm run lint` in `frontend` (fails: Cannot find package '@eslint/eslintrc')
- `npm test --silent` in `backend` (fails: jest not found)
- `npm run lint` in `backend` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_685b98c8bed08328a34dfef002396575