### PR TITLE
Enable assignment CRUD via API

### DIFF
--- a/frontend/src/components/instructors/AssignmentManager.js
+++ b/frontend/src/components/instructors/AssignmentManager.js
@@ -1,32 +1,114 @@
-import Link from 'next/link';
-import { FaPlus, FaClipboardList } from 'react-icons/fa';
+import { useState, useEffect } from "react";
+import { createClassAssignment, deleteClassAssignment } from "@/services/instructor/classService";
+import { fetchClassAssignments } from "@/services/classService";
+import { toDateInput } from "@/utils/date";
 
-export default function AssignmentManager({ classId, assignments = [] }) {
+export default function AssignmentManager({ classId, initialAssignments = [] }) {
+  const [assignments, setAssignments] = useState(initialAssignments);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [dueDate, setDueDate] = useState("");
+
+  // Sync when parent provides new assignments
+  useEffect(() => {
+    setAssignments(initialAssignments);
+  }, [initialAssignments]);
+
+  // Load assignments when class changes
+  useEffect(() => {
+    if (!classId) return;
+    const load = async () => {
+      try {
+        const list = await fetchClassAssignments(classId);
+        setAssignments(list);
+      } catch (err) {
+        console.error("Failed to load assignments", err);
+      }
+    };
+    load();
+  }, [classId]);
+
+  const addAssignment = async () => {
+    if (!title) return;
+    try {
+      const payload = {
+        title,
+        description,
+        due_date: dueDate || null,
+      };
+      const assignment = await createClassAssignment(classId, payload);
+      setAssignments([...assignments, assignment]);
+      setTitle("");
+      setDescription("");
+      setDueDate("");
+    } catch (err) {
+      console.error("Failed to create assignment", err);
+    }
+  };
+
+  const removeAssignment = async (index) => {
+    const assignment = assignments[index];
+    try {
+      await deleteClassAssignment(assignment.id);
+      setAssignments(assignments.filter((_, i) => i !== index));
+    } catch (err) {
+      console.error("Failed to delete assignment", err);
+    }
+  };
+
   return (
-    <div className="space-y-4">
-      <Link
-        href={`/dashboard/instructor/assignments/create?classId=${classId}`}
-        className="flex items-center gap-2 bg-yellow-500 hover:bg-yellow-600 text-black font-bold px-4 py-3 rounded-full justify-center"
-      >
-        <FaPlus /> Create New Assignment
-      </Link>
+    <div className="text-sm text-white">
+      <div className="mb-4 space-y-2">
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Assignment title"
+          className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+        />
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+          className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+        />
+        <input
+          type="date"
+          value={dueDate}
+          onChange={(e) => setDueDate(e.target.value)}
+          className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+        />
+        <button
+          onClick={addAssignment}
+          className="w-full bg-yellow-500 text-black py-2 rounded hover:bg-yellow-600 font-semibold"
+        >
+          Add Assignment
+        </button>
+      </div>
 
-      <Link
-        href={`/dashboard/instructor/assignments/list?classId=${classId}`}
-        className="flex items-center gap-2 bg-gray-700 hover:bg-gray-600 text-white font-bold px-4 py-3 rounded-full justify-center"
-      >
-        <FaClipboardList /> View My Assignments
-      </Link>
-
-      {assignments.length > 0 && (
-        <ul className="mt-2 space-y-2 text-sm">
-          {assignments.map((a) => (
-            <li key={a.id} className="bg-gray-700 p-2 rounded">
-              {a.title}
-            </li>
-          ))}
-        </ul>
-      )}
+      <ul className="space-y-3">
+        {assignments.map((a, i) => (
+          <li
+            key={a.id}
+            className="bg-gray-700 p-3 rounded flex justify-between items-center"
+          >
+            <div>
+              <p className="font-medium">{a.title}</p>
+              {a.due_date && (
+                <p className="text-gray-400 text-xs">
+                  Due: {toDateInput(a.due_date)}
+                </p>
+              )}
+            </div>
+            <button
+              onClick={() => removeAssignment(i)}
+              className="text-red-400 hover:underline text-xs"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- make `AssignmentManager` capable of creating and listing assignments via the API
- fetch instructor classes in create assignment page and save to backend

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685b9ce45f148328918329d0293c2dbe