### PR TITLE
Implement class view tracking

### DIFF
--- a/backend/src/migrations/20250627120000_create_class_views_table.js
+++ b/backend/src/migrations/20250627120000_create_class_views_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_views', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.uuid('viewer_id').references('id').inTable('users').onDelete('SET NULL');
+    table.string('ip_address');
+    table.string('user_agent');
+    table.timestamp('viewed_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_views');
+};

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -62,6 +62,9 @@ exports.getAllClasses = catchAsync(async (_req, res) => {
 
 exports.getClassById = catchAsync(async (req, res) => {
   const cls = await service.getClassById(req.params.id);
+  if (cls) {
+    cls.views = await service.getClassViewCount(req.params.id);
+  }
   sendSuccess(res, cls);
 });
 
@@ -125,6 +128,15 @@ exports.getPublishedClasses = catchAsync(async (_req, res) => {
 
 exports.getPublicClassDetails = catchAsync(async (req, res) => {
   const cls = await service.getPublicClassDetails(req.params.id);
+  if (cls) {
+    await service.recordClassView(
+      req.params.id,
+      req.user?.id,
+      req.ip,
+      req.headers["user-agent"]
+    );
+    cls.views = await service.getClassViewCount(req.params.id);
+  }
   sendSuccess(res, cls);
 });
 

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -36,12 +36,14 @@ exports.getClassById = async (id) => {
     .select(
       "c.*",
       "u.full_name as instructor",
+      "u.avatar_url as instructor_image",
       "cat.name as category"
     )
     .where("c.id", id)
     .first();
   if (cls) {
     cls.tags = await exports.getClassTags(id);
+    cls.views = await exports.getClassViewCount(id);
   }
   return cls;
 };
@@ -145,6 +147,7 @@ exports.getPublicClassDetails = async (id) => {
 
   if (cls) {
     cls.tags = await exports.getClassTags(id);
+    cls.views = await exports.getClassViewCount(id);
     const enrolled = parseInt(cls.enrolled_count, 10) || 0;
     cls.enrolled_count = enrolled;
     cls.spots_left =
@@ -196,4 +199,18 @@ exports.getClassTags = async (classId) => {
     .join("class_tags as t", "m.tag_id", "t.id")
     .where("m.class_id", classId)
     .select("t.id", "t.name", "t.slug");
+};
+
+exports.recordClassView = async (classId, viewerId, ip, userAgent) => {
+  return db('class_views').insert({
+    class_id: classId,
+    viewer_id: viewerId || null,
+    ip_address: ip,
+    user_agent: userAgent,
+  });
+};
+
+exports.getClassViewCount = async (classId) => {
+  const [row] = await db('class_views').where({ class_id: classId }).count();
+  return parseInt(row.count, 10) || 0;
 };

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -50,16 +50,23 @@ export default function AdminClassDetailPage() {
           />
         )}
         {details?.demo_video_url && (
-          <video
-            controls
-            className="w-full mt-4 rounded-lg"
-            src={details.demo_video_url}
-          />
+          <video controls className="w-full mt-4 rounded-lg">
+            <source src={details.demo_video_url} />
+          </video>
         )}
 
-        <div className="space-y-1">
-          <h2 className="text-2xl font-semibold text-yellow-600">{details?.title}</h2>
-          <p className="text-gray-500 text-sm">Instructor: {details?.instructor}</p>
+        <div className="space-y-1 flex items-center gap-4">
+          {details?.instructor_image && (
+            <img
+              src={details.instructor_image}
+              alt={details.instructor}
+              className="w-12 h-12 rounded-full object-cover"
+            />
+          )}
+          <div>
+            <h2 className="text-2xl font-semibold text-yellow-600">{details?.title}</h2>
+            <p className="text-gray-500 text-sm">Instructor: {details?.instructor}</p>
+          </div>
         </div>
 
         <div className="grid md:grid-cols-2 gap-6 pt-4 text-sm">
@@ -76,6 +83,7 @@ export default function AdminClassDetailPage() {
               </span>
             </p>
             {details?.price && <p><strong>💵 Price:</strong> ${details.price}</p>}
+            <p><strong>👁️ Views:</strong> {details?.views ?? 0}</p>
           </div>
         </div>
 

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
@@ -42,12 +42,23 @@ export default function InstructorClassDetailPage() {
             <img src={details.cover_image} alt="Class Cover" className="w-full h-64 object-cover rounded-lg" />
           )}
           {details?.demo_video_url && (
-            <video controls className="w-full mt-4 rounded-lg" src={details.demo_video_url} />
+            <video controls className="w-full mt-4 rounded-lg">
+              <source src={details.demo_video_url} />
+            </video>
           )}
 
-          <div className="space-y-1">
-            <h2 className="text-2xl font-semibold text-yellow-600">{details?.title}</h2>
-            <p className="text-gray-500 text-sm">Instructor: {details?.instructor}</p>
+          <div className="space-y-1 flex items-center gap-4">
+            {details?.instructor_image && (
+              <img
+                src={details.instructor_image}
+                alt={details.instructor}
+                className="w-12 h-12 rounded-full object-cover"
+              />
+            )}
+            <div>
+              <h2 className="text-2xl font-semibold text-yellow-600">{details?.title}</h2>
+              <p className="text-gray-500 text-sm">Instructor: {details?.instructor}</p>
+            </div>
           </div>
 
           <div className="grid md:grid-cols-2 gap-6 pt-4 text-sm">
@@ -64,6 +75,7 @@ export default function InstructorClassDetailPage() {
                 </span>
               </p>
               {details?.price && <p><strong>💵 Price:</strong> ${details.price}</p>}
+              <p><strong>👁️ Views:</strong> {details?.views ?? 0}</p>
             </div>
           </div>
 

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -9,6 +9,9 @@ const formatClass = (cls) => ({
   demo_video_url: cls.demo_video_url
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`
     : null,
+  instructor_image: cls.instructor_image
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`
+    : null,
   trending: Boolean(cls.trending),
 
   start_date: cls.start_date ? toDateInput(cls.start_date) : "",
@@ -16,6 +19,7 @@ const formatClass = (cls) => ({
 
   approvalStatus: cls.moderation_status || "Pending",
   scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),
+  views: cls.views || 0,
 });
 
 const computeScheduleStatus = (start, end) => {

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -9,6 +9,9 @@ const formatClass = (cls) => ({
   demo_video_url: cls.demo_video_url
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`
     : null,
+  instructor_image: cls.instructor_image
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`
+    : null,
   trending: Boolean(cls.trending),
 
   start_date: cls.start_date ? toDateInput(cls.start_date) : "",
@@ -16,6 +19,7 @@ const formatClass = (cls) => ({
 
   approvalStatus: cls.moderation_status || "Pending",
   scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),
+  views: cls.views || 0,
 });
 
 const computeScheduleStatus = (start, end) => {


### PR DESCRIPTION
## Summary
- track class page views in new `class_views` table
- expose view count in class API responses and record a view whenever the public class endpoint is hit
- show instructor avatar, demo video, and view count on class detail pages

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685bac9e667c832890768603838831d0