### PR TITLE
Add wishlist and enrollment checks

### DIFF
--- a/frontend/src/components/online-classes/ClassCard.js
+++ b/frontend/src/components/online-classes/ClassCard.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
+import { FaHeart } from 'react-icons/fa';
+import { toast } from 'react-toastify';
 
 function ClassCard({ classData, index }) {
   const {
@@ -13,16 +15,34 @@ function ClassCard({ classData, index }) {
     image,
   } = classData;
 
+  const addToWishlist = (e) => {
+    e.preventDefault();
+    const stored = JSON.parse(localStorage.getItem('wishlist')) || [];
+    if (stored.find((c) => c.id === id)) {
+      toast.info('Already in wishlist');
+      return;
+    }
+    stored.push({ id, title, image, instructor, price });
+    localStorage.setItem('wishlist', JSON.stringify(stored));
+    toast.success('Added to wishlist');
+  };
+
   return (
     <Link href={`/online-classes/${id}`}>
-      <div className="cursor-pointer bg-gray-900 rounded-lg shadow-lg p-5 flex flex-col hover:shadow-xl hover:ring-2 hover:ring-yellow-500 transition">
+      <div className="cursor-pointer bg-gray-900 rounded-lg shadow-lg p-5 flex flex-col hover:shadow-xl hover:ring-2 hover:ring-yellow-500 transition relative">
         {/* Image */}
-        <div className="h-40 mb-4 overflow-hidden rounded-md">
+        <div className="h-40 mb-4 overflow-hidden rounded-md relative">
           <img
             src={image || '/default-class.jpg'}
             alt={title}
             className="w-full h-full object-cover"
           />
+          <button
+            onClick={addToWishlist}
+            className="absolute top-2 right-2 bg-gray-800 bg-opacity-70 hover:bg-opacity-100 p-2 rounded-full"
+          >
+            <FaHeart className="text-yellow-400" />
+          </button>
         </div>
 
         {/* Title & Instructor */}

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -5,6 +5,8 @@ import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import { FaFacebook, FaTwitter, FaWhatsapp } from 'react-icons/fa';
 import { fetchClassDetails } from '@/services/classService';
+import useAuthStore from '@/store/auth/authStore';
+import { toast } from 'react-toastify';
 
 
 export default function ClassDetailsPage() {
@@ -13,6 +15,21 @@ export default function ClassDetailsPage() {
   const [classInfo, setClassInfo] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const { user, isAuthenticated } = useAuthStore();
+
+  const handleProceed = () => {
+    if (!isAuthenticated()) {
+      toast.info('Please login or create an account to proceed');
+      router.push('/auth/login');
+      return;
+    }
+    if (user.role?.toLowerCase() !== 'student') {
+      toast.error('You must use a student account to enroll');
+      router.push('/auth/login');
+      return;
+    }
+    router.push(`/payments/checkout?classId=${id}`);
+  };
 
   useEffect(() => {
     if (!id) return;
@@ -144,7 +161,7 @@ export default function ClassDetailsPage() {
           <p className="text-xl font-semibold mb-2">Ready to join <strong>{classInfo.title}</strong>?</p>
           <p className="text-sm text-gray-400 mb-5">Click below to secure your seat and start learning!</p>
           <button
-            onClick={() => router.push(`/payments/checkout?classId=${id}`)}
+            onClick={handleProceed}
             disabled={typeof classInfo.spots_left === 'number' && classInfo.spots_left <= 0}
             className={`w-full sm:w-auto px-8 py-3 font-semibold rounded-full transition duration-300 shadow-lg ${
               typeof classInfo.spots_left === 'number' && classInfo.spots_left <= 0

--- a/frontend/src/pages/payments/success.js
+++ b/frontend/src/pages/payments/success.js
@@ -5,19 +5,31 @@ import Link from 'next/link';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import { FaCheckCircle, FaArrowRight, FaCalendarAlt, FaChalkboardTeacher, FaDownload, FaRegFilePdf } from 'react-icons/fa';
+import { enrollInClass, fetchClassDetails } from '@/services/classService';
+import { toast } from 'react-toastify';
 
 export default function PaymentSuccessPage() {
   const router = useRouter();
-  const { linkId } = router.query;
+  const { classId } = router.query;
   const [classInfo, setClassInfo] = useState(null);
 
   useEffect(() => {
-    const enrolled = JSON.parse(localStorage.getItem("enrolledClasses") || "[]");
-    const matched = enrolled.find(cls => cls.linkId === linkId);
-    if (matched) {
-      setClassInfo(matched);
-    }
-  }, [linkId]);
+    if (!classId) return;
+    const enroll = async () => {
+      try {
+        await enrollInClass(classId);
+      } catch (_) {
+        toast.error('Failed to register for class');
+      }
+      try {
+        const details = await fetchClassDetails(classId);
+        setClassInfo(details?.data ?? details);
+      } catch (_) {
+        setClassInfo(null);
+      }
+    };
+    enroll();
+  }, [classId]);
 
   if (!classInfo) return <div className="text-white text-center mt-32">Loading...</div>;
 


### PR DESCRIPTION
## Summary
- add heart button on class cards to store wishlist in localStorage
- require login and student role before proceeding to pay for a class
- automatically enroll the student after payment success

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb271880c832889fa73ab3cc5185e