### PR TITLE
Add wishlist & like support for online classes

### DIFF
--- a/backend/src/migrations/20250627130000_create_class_wishlist_table.js
+++ b/backend/src/migrations/20250627130000_create_class_wishlist_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_wishlist', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'class_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_wishlist');
+};

--- a/backend/src/migrations/20250627130100_create_class_likes_table.js
+++ b/backend/src/migrations/20250627130100_create_class_likes_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_likes', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'class_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_likes');
+};

--- a/backend/src/migrations/20250627130200_create_tutorial_wishlist_table.js
+++ b/backend/src/migrations/20250627130200_create_tutorial_wishlist_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_wishlist', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'tutorial_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_wishlist');
+};

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -16,6 +16,8 @@ router.use("/enroll", require("./enrollments/classEnrollment.routes"));
 // Class lessons and assignments
 router.use("/lessons", require("./lessons/classLesson.routes"));
 router.use("/assignments", require("./assignments/classAssignment.routes"));
+router.use("/wishlist", require("./wishlist/classWishlist.routes"));
+router.use("/likes", require("./likes/classLike.routes"));
 // Attendance tracking
 router.use("/attendance", require("./attendance/classAttendance.routes"));
 

--- a/backend/src/modules/classes/likes/classLike.controller.js
+++ b/backend/src/modules/classes/likes/classLike.controller.js
@@ -1,0 +1,18 @@
+const catchAsync = require('../../../utils/catchAsync');
+const { sendSuccess } = require('../../../utils/response');
+const service = require('./classLike.service');
+
+exports.add = catchAsync(async (req, res) => {
+  await service.add(req.user.id, req.params.classId);
+  sendSuccess(res, null, 'Class liked');
+});
+
+exports.remove = catchAsync(async (req, res) => {
+  await service.remove(req.user.id, req.params.classId);
+  sendSuccess(res, null, 'Like removed');
+});
+
+exports.listMine = catchAsync(async (req, res) => {
+  const list = await service.listByUser(req.user.id);
+  sendSuccess(res, list);
+});

--- a/backend/src/modules/classes/likes/classLike.routes.js
+++ b/backend/src/modules/classes/likes/classLike.routes.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const ctrl = require('./classLike.controller');
+const { verifyToken, isStudent } = require('../../../middleware/auth/authMiddleware');
+
+router.get('/my', verifyToken, isStudent, ctrl.listMine);
+router.post('/:classId', verifyToken, isStudent, ctrl.add);
+router.delete('/:classId', verifyToken, isStudent, ctrl.remove);
+
+module.exports = router;

--- a/backend/src/modules/classes/likes/classLike.service.js
+++ b/backend/src/modules/classes/likes/classLike.service.js
@@ -1,0 +1,21 @@
+const db = require('../../../config/database');
+const { v4: uuidv4 } = require('uuid');
+
+exports.add = async (userId, classId) => {
+  const [item] = await db('class_likes')
+    .insert({ id: uuidv4(), user_id: userId, class_id: classId })
+    .onConflict(['user_id','class_id']).ignore()
+    .returning('*');
+  return item;
+};
+
+exports.remove = async (userId, classId) => {
+  return db('class_likes').where({ user_id: userId, class_id: classId }).del();
+};
+
+exports.listByUser = async (userId) => {
+  return db('class_likes as l')
+    .join('online_classes as c','l.class_id','c.id')
+    .select('c.*','l.created_at')
+    .where('l.user_id', userId);
+};

--- a/backend/src/modules/classes/wishlist/classWishlist.controller.js
+++ b/backend/src/modules/classes/wishlist/classWishlist.controller.js
@@ -1,0 +1,18 @@
+const catchAsync = require('../../../utils/catchAsync');
+const { sendSuccess } = require('../../../utils/response');
+const service = require('./classWishlist.service');
+
+exports.add = catchAsync(async (req, res) => {
+  await service.add(req.user.id, req.params.classId);
+  sendSuccess(res, null, 'Added to wishlist');
+});
+
+exports.remove = catchAsync(async (req, res) => {
+  await service.remove(req.user.id, req.params.classId);
+  sendSuccess(res, null, 'Removed from wishlist');
+});
+
+exports.listMine = catchAsync(async (req, res) => {
+  const list = await service.listByUser(req.user.id);
+  sendSuccess(res, list);
+});

--- a/backend/src/modules/classes/wishlist/classWishlist.routes.js
+++ b/backend/src/modules/classes/wishlist/classWishlist.routes.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const ctrl = require('./classWishlist.controller');
+const { verifyToken, isStudent } = require('../../../middleware/auth/authMiddleware');
+
+router.get('/my', verifyToken, isStudent, ctrl.listMine);
+router.post('/:classId', verifyToken, isStudent, ctrl.add);
+router.delete('/:classId', verifyToken, isStudent, ctrl.remove);
+
+module.exports = router;

--- a/backend/src/modules/classes/wishlist/classWishlist.service.js
+++ b/backend/src/modules/classes/wishlist/classWishlist.service.js
@@ -1,0 +1,21 @@
+const db = require('../../../config/database');
+const { v4: uuidv4 } = require('uuid');
+
+exports.add = async (userId, classId) => {
+  const [item] = await db('class_wishlist')
+    .insert({ id: uuidv4(), user_id: userId, class_id: classId })
+    .onConflict(['user_id','class_id']).ignore()
+    .returning('*');
+  return item;
+};
+
+exports.remove = async (userId, classId) => {
+  return db('class_wishlist').where({ user_id: userId, class_id: classId }).del();
+};
+
+exports.listByUser = async (userId) => {
+  return db('class_wishlist as w')
+    .join('online_classes as c','w.class_id','c.id')
+    .select('c.*','w.created_at')
+    .where('w.user_id', userId);
+};

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -58,6 +58,7 @@ router.use("/reviews", require("./reviews/tutorialReview.routes"));
 router.use("/comments", require("./comments/tutorialComment.routes"));
 
 router.use("/enroll", require("./enrollments/tutorialEnrollment.routes"));
+router.use("/wishlist", require("./wishlist/tutorialWishlist.routes"));
 
 router.use("/certificate", require("./certificate/tutorialCertificate.routes"));
 

--- a/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.controller.js
+++ b/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.controller.js
@@ -1,0 +1,18 @@
+const catchAsync = require('../../../utils/catchAsync');
+const { sendSuccess } = require('../../../utils/response');
+const service = require('./tutorialWishlist.service');
+
+exports.add = catchAsync(async (req, res) => {
+  await service.add(req.user.id, req.params.tutorialId);
+  sendSuccess(res, null, 'Added to wishlist');
+});
+
+exports.remove = catchAsync(async (req, res) => {
+  await service.remove(req.user.id, req.params.tutorialId);
+  sendSuccess(res, null, 'Removed from wishlist');
+});
+
+exports.listMine = catchAsync(async (req, res) => {
+  const list = await service.listByUser(req.user.id);
+  sendSuccess(res, list);
+});

--- a/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.routes.js
+++ b/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.routes.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const ctrl = require('./tutorialWishlist.controller');
+const { verifyToken, isStudent } = require('../../../../middleware/auth/authMiddleware');
+
+router.get('/my', verifyToken, isStudent, ctrl.listMine);
+router.post('/:tutorialId', verifyToken, isStudent, ctrl.add);
+router.delete('/:tutorialId', verifyToken, isStudent, ctrl.remove);
+
+module.exports = router;

--- a/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.service.js
+++ b/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.service.js
@@ -1,0 +1,21 @@
+const db = require('../../../config/database');
+const { v4: uuidv4 } = require('uuid');
+
+exports.add = async (userId, tutorialId) => {
+  const [item] = await db('tutorial_wishlist')
+    .insert({ id: uuidv4(), user_id: userId, tutorial_id: tutorialId })
+    .onConflict(['user_id','tutorial_id']).ignore()
+    .returning('*');
+  return item;
+};
+
+exports.remove = async (userId, tutorialId) => {
+  return db('tutorial_wishlist').where({ user_id: userId, tutorial_id: tutorialId }).del();
+};
+
+exports.listByUser = async (userId) => {
+  return db('tutorial_wishlist as w')
+    .join('tutorials as t','w.tutorial_id','t.id')
+    .select('t.*','w.created_at')
+    .where('w.user_id', userId);
+};

--- a/frontend/src/components/dashboard/SidebarLinks/studentLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/studentLinks.js
@@ -16,7 +16,8 @@ import {
   ClipboardList,
   Users,
   Users2,
-  Home
+  Home,
+  Heart
 } from 'lucide-react';
 
 export const studentNavLinks = [
@@ -32,6 +33,7 @@ export const studentNavLinks = [
     items: [
       { label: 'My Classes', href: '/dashboard/student/online-classe', icon: BookOpen },
       { label: 'My Tutorials', href: '/dashboard/student/tutorials', icon: Brain },
+      { label: 'Wishlist', href: '/dashboard/student/wishlist', icon: Heart },
       { label: 'Assignments', href: '/dashboard/student/assignments', icon: FileText },
       { label: 'Certificates', href: '/dashboard/student/certificates', icon: GraduationCap },
     ]

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -5,7 +5,8 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import {
   FaBell, FaEnvelope, FaGlobe, FaShoppingCart, FaUserCircle, FaCog,
-  FaLock, FaSignOutAlt, FaLanguage, FaSignInAlt, FaUserPlus
+  FaLock, FaSignOutAlt, FaLanguage, FaSignInAlt, FaUserPlus,
+  FaHeart, FaThumbsUp
 } from "react-icons/fa";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
@@ -210,6 +211,12 @@ const Navbar = () => {
                     <Link href="/profile/change-password" className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 transition rounded-md">
                       <FaLock className="text-gray-500" />
                       <span>Change Password</span>
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/dashboard/student/wishlist" className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 transition rounded-md">
+                      <FaHeart className="text-gray-500" />
+                      <span>Wishlist</span>
                     </Link>
                   </li>
                   {userRole === "superadmin" && profile?.job_title && (

--- a/frontend/src/components/website/sections/OnlineClasses.js
+++ b/frontend/src/components/website/sections/OnlineClasses.js
@@ -5,9 +5,20 @@ import {
   FaCalendarAlt,
   FaBookOpen,
   FaVideo,
+  FaHeart,
+  FaThumbsUp,
 } from "react-icons/fa";
 import { useRouter } from "next/router";
-import { fetchPublishedClasses } from "@/services/classService";
+import {
+  fetchPublishedClasses,
+  addClassToWishlist,
+  removeClassFromWishlist,
+  likeClass,
+  unlikeClass,
+  getMyClassWishlist,
+  getMyLikedClasses,
+} from "@/services/classService";
+import useAuthStore from "@/store/auth/authStore";
 
 // Initial category options include the special "Trending" filter
 const initialCategories = ["All", "Trending"];
@@ -29,6 +40,9 @@ const OnlineClasses = () => {
   const [visibleCount, setVisibleCount] = useState(6);
   const [classes, setClasses] = useState([]);
   const [categories, setCategories] = useState(initialCategories);
+  const [wishlistIds, setWishlistIds] = useState([]);
+  const [likedIds, setLikedIds] = useState([]);
+  const user = useAuthStore((state) => state.user);
   const router = useRouter();
 
   useEffect(() => {
@@ -55,6 +69,21 @@ const OnlineClasses = () => {
     };
     load();
   }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    const load = async () => {
+      try {
+        const w = await getMyClassWishlist();
+        setWishlistIds(w.map((c) => c.id));
+        const l = await getMyLikedClasses();
+        setLikedIds(l.map((c) => c.id));
+      } catch (err) {
+        console.error('Failed to load wishlist/likes', err);
+      }
+    };
+    load();
+  }, [user]);
 
   // Filter logic
   const filteredClasses = classes.filter(
@@ -129,6 +158,38 @@ const OnlineClasses = () => {
                 whileHover={{ scale: 1.03 }}
                 className="bg-gray-800 p-6 rounded-2xl shadow-xl relative group hover:ring-2 hover:ring-yellow-400 transition-all"
               >
+                <div className="absolute top-3 right-3 flex flex-col items-end gap-1">
+                  <button
+                    onClick={async () => {
+                      if (!user) return router.push('/auth/login');
+                      if (likedIds.includes(classItem.id)) {
+                        await unlikeClass(classItem.id);
+                        setLikedIds(likedIds.filter((i) => i !== classItem.id));
+                      } else {
+                        await likeClass(classItem.id);
+                        setLikedIds([...likedIds, classItem.id]);
+                      }
+                    }}
+                    className="bg-gray-700 bg-opacity-70 hover:bg-opacity-100 p-2 rounded-full"
+                  >
+                    <FaThumbsUp className={likedIds.includes(classItem.id) ? 'text-yellow-400' : 'text-gray-300'} />
+                  </button>
+                  <button
+                    onClick={async () => {
+                      if (!user) return router.push('/auth/login');
+                      if (wishlistIds.includes(classItem.id)) {
+                        await removeClassFromWishlist(classItem.id);
+                        setWishlistIds(wishlistIds.filter((i) => i !== classItem.id));
+                      } else {
+                        await addClassToWishlist(classItem.id);
+                        setWishlistIds([...wishlistIds, classItem.id]);
+                      }
+                    }}
+                    className="bg-gray-700 bg-opacity-70 hover:bg-opacity-100 p-2 rounded-full"
+                  >
+                    <FaHeart className={wishlistIds.includes(classItem.id) ? 'text-yellow-400' : 'text-gray-300'} />
+                  </button>
+                </div>
                 {classItem.trending && (
                   <span className="absolute top-3 left-3 bg-yellow-500 text-gray-900 px-3 py-1 text-xs font-bold rounded-full shadow-sm">
                     🔥 Trending

--- a/frontend/src/pages/dashboard/student/wishlist/index.js
+++ b/frontend/src/pages/dashboard/student/wishlist/index.js
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import StudentLayout from '@/components/layouts/StudentLayout';
+import { getMyClassWishlist, removeClassFromWishlist } from '@/services/classService';
+import { getMyTutorialWishlist, removeTutorialFromWishlist } from '@/services/tutorialService';
+
+export default function WishlistPage() {
+  const [classes, setClasses] = useState([]);
+  const [tutorials, setTutorials] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const c = await getMyClassWishlist();
+        const t = await getMyTutorialWishlist();
+        setClasses(c);setTutorials(t);
+      } catch (err) { console.error(err); }
+    };
+    load();
+  }, []);
+
+  const removeClass = async(id) => {
+    await removeClassFromWishlist(id);
+    setClasses(classes.filter(c=>c.id!==id));
+  };
+  const removeTutorial = async(id) => {
+    await removeTutorialFromWishlist(id);
+    setTutorials(tutorials.filter(t=>t.id!==id));
+  };
+
+  return (
+    <StudentLayout>
+      <h1 className="text-2xl font-bold mb-6 text-yellow-600">My Wishlist</h1>
+      <h2 className="text-xl font-semibold mb-2">Classes</h2>
+      {classes.length===0? <p className="text-gray-500">No classes in wishlist.</p>:
+        <ul className="space-y-2">{classes.map(c=>(
+          <li key={c.id} className="flex justify-between bg-white p-3 rounded-md shadow">
+            <span>{c.title}</span>
+            <button onClick={()=>removeClass(c.id)} className="text-red-500">Remove</button>
+          </li>))}
+        </ul>}
+      <h2 className="text-xl font-semibold mt-6 mb-2">Tutorials</h2>
+      {tutorials.length===0? <p className="text-gray-500">No tutorials in wishlist.</p>:
+        <ul className="space-y-2">{tutorials.map(t=>(
+          <li key={t.id} className="flex justify-between bg-white p-3 rounded-md shadow">
+            <span>{t.title}</span>
+            <button onClick={()=>removeTutorial(t.id)} className="text-red-500">Remove</button>
+          </li>))}
+        </ul>}
+    </StudentLayout>
+  );
+}

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -39,3 +39,33 @@ export const fetchClassAssignments = async (classId) => {
   const { data } = await api.get(`/users/classes/assignments/class/${classId}`);
   return data?.data ?? [];
 };
+
+export const addClassToWishlist = async (id) => {
+  const { data } = await api.post(`/users/classes/wishlist/${id}`);
+  return data;
+};
+
+export const removeClassFromWishlist = async (id) => {
+  const { data } = await api.delete(`/users/classes/wishlist/${id}`);
+  return data;
+};
+
+export const getMyClassWishlist = async () => {
+  const { data } = await api.get('/users/classes/wishlist/my');
+  return data?.data ?? [];
+};
+
+export const likeClass = async (id) => {
+  const { data } = await api.post(`/users/classes/likes/${id}`);
+  return data;
+};
+
+export const unlikeClass = async (id) => {
+  const { data } = await api.delete(`/users/classes/likes/${id}`);
+  return data;
+};
+
+export const getMyLikedClasses = async () => {
+  const { data } = await api.get('/users/classes/likes/my');
+  return data?.data ?? [];
+};

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -15,3 +15,18 @@ export const fetchTutorialDetails = async (id) => {
   return res.data;
 };
 
+export const addTutorialToWishlist = async (id) => {
+  const { data } = await api.post(`/users/tutorials/wishlist/${id}`);
+  return data;
+};
+
+export const removeTutorialFromWishlist = async (id) => {
+  const { data } = await api.delete(`/users/tutorials/wishlist/${id}`);
+  return data;
+};
+
+export const getMyTutorialWishlist = async () => {
+  const { data } = await api.get('/users/tutorials/wishlist/my');
+  return data?.data ?? [];
+};
+


### PR DESCRIPTION
## Summary
- create migrations for wishlist & likes
- add wishlist/like routes and services in backend
- support tutorial wishlist
- expand class and tutorial services with wishlist APIs
- show like/wishlist buttons in online classes section
- add wishlist page for students with sidebar/nav links

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_685bb9f413348328908a57923e103415