### PR TITLE
Add cart API and integrate with class details page

### DIFF
--- a/backend/src/modules/cart/cart.controller.js
+++ b/backend/src/modules/cart/cart.controller.js
@@ -1,0 +1,24 @@
+const service = require('./cart.service');
+const { sendSuccess } = require('../../utils/response');
+
+exports.addItem = (req, res) => {
+  const item = service.add(req.body);
+  sendSuccess(res, item, 'Item added to cart');
+};
+
+exports.getItems = (_req, res) => {
+  const items = service.list();
+  sendSuccess(res, items);
+};
+
+exports.updateItem = (req, res) => {
+  const item = service.update(parseInt(req.params.id, 10), req.body.quantity);
+  if (!item) return res.status(404).json({ message: 'Item not found' });
+  sendSuccess(res, item, 'Cart updated');
+};
+
+exports.removeItem = (req, res) => {
+  const item = service.remove(parseInt(req.params.id, 10));
+  if (!item) return res.status(404).json({ message: 'Item not found' });
+  sendSuccess(res, null, 'Item removed');
+};

--- a/backend/src/modules/cart/cart.routes.js
+++ b/backend/src/modules/cart/cart.routes.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const controller = require('./cart.controller');
+
+router.post('/add', controller.addItem);
+router.get('/', controller.getItems);
+router.put('/update/:id', controller.updateItem);
+router.delete('/remove/:id', controller.removeItem);
+
+module.exports = router;

--- a/backend/src/modules/cart/cart.service.js
+++ b/backend/src/modules/cart/cart.service.js
@@ -1,0 +1,27 @@
+const cart = [];
+
+exports.list = () => cart;
+
+exports.add = (item) => {
+  const existing = cart.find((c) => c.id === item.id);
+  if (existing) {
+    existing.quantity += item.quantity || 1;
+    return existing;
+  }
+  const newItem = { ...item, quantity: item.quantity || 1 };
+  cart.push(newItem);
+  return newItem;
+};
+
+exports.update = (id, quantity) => {
+  const item = cart.find((c) => c.id === id);
+  if (!item) return null;
+  item.quantity = quantity;
+  return item;
+};
+
+exports.remove = (id) => {
+  const index = cart.findIndex((c) => c.id === id);
+  if (index === -1) return null;
+  return cart.splice(index, 1)[0];
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -67,6 +67,7 @@ const paymentConfigRoutes = require("./modules/paymentConfig/paymentConfig.route
 const payoutRoutes = require("./modules/payouts/payouts.routes");
 const adsRoutes = require("./modules/ads/ads.routes");
 const publicInstructorRoutes = require("./modules/instructors/instructor.routes");
+const cartRoutes = require("./modules/cart/cart.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -135,6 +136,7 @@ app.use("/api/payments/config", paymentConfigRoutes); // ⚙️ Payment settings
 app.use("/api/payouts/admin", payoutRoutes); // 🏦 Instructor payouts
 app.use("/api/ads", adsRoutes); // 📢 Advertisements
 app.use("/api/instructors", publicInstructorRoutes); // 📚 Public instructor listing
+app.use("/api/cart", cartRoutes); // 🛒 Shopping cart
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -5,6 +5,7 @@ import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import { FaFacebook, FaTwitter, FaWhatsapp } from 'react-icons/fa';
 import { fetchClassDetails } from '@/services/classService';
+import { addToCart } from '@/services/cartService';
 import useAuthStore from '@/store/auth/authStore';
 import { toast } from 'react-toastify';
 
@@ -17,7 +18,7 @@ export default function ClassDetailsPage() {
   const [error, setError] = useState(null);
   const { user, isAuthenticated } = useAuthStore();
 
-  const handleProceed = () => {
+  const handleAddToCart = async () => {
     if (!isAuthenticated()) {
       toast.info('Please login or create an account to proceed');
       router.push('/auth/login');
@@ -28,7 +29,14 @@ export default function ClassDetailsPage() {
       router.push('/auth/login');
       return;
     }
-    router.push(`/payments/checkout?classId=${id}`);
+    try {
+      await addToCart({ id: classInfo.id, name: classInfo.title, price: classInfo.price });
+      toast.success('Added to cart');
+      router.push('/cart');
+    } catch (err) {
+      console.error('Failed to add to cart', err);
+      toast.error('Failed to add to cart');
+    }
   };
 
   useEffect(() => {
@@ -161,7 +169,7 @@ export default function ClassDetailsPage() {
           <p className="text-xl font-semibold mb-2">Ready to join <strong>{classInfo.title}</strong>?</p>
           <p className="text-sm text-gray-400 mb-5">Click below to secure your seat and start learning!</p>
           <button
-            onClick={handleProceed}
+            onClick={handleAddToCart}
             disabled={typeof classInfo.spots_left === 'number' && classInfo.spots_left <= 0}
             className={`w-full sm:w-auto px-8 py-3 font-semibold rounded-full transition duration-300 shadow-lg ${
               typeof classInfo.spots_left === 'number' && classInfo.spots_left <= 0
@@ -173,7 +181,7 @@ export default function ClassDetailsPage() {
               ? 'Class Full'
               : classInfo.price === 0
               ? 'Enroll for Free'
-              : 'Proceed to Payment'}
+              : 'Add to Cart'}
           </button>
         </section>
 

--- a/frontend/src/services/cartService.js
+++ b/frontend/src/services/cartService.js
@@ -1,48 +1,44 @@
+import api from "@/services/api/api";
 import mockCart from "@/mocks/sampleCart.json"; // Import mock data
-const API_BASE_URL = "https://your-backend-api.com/api"; // Change this to your backend URL
+
+const MOCK_MODE = false;
 
 export const getCartItems = async () => {
+  if (MOCK_MODE) {
     return new Promise((resolve) => {
-      setTimeout(() => resolve(mockCart), 500); // Simulate network delay
+      setTimeout(() => resolve(mockCart), 500);
     });
-  };
+  }
+  const res = await api.get('/cart');
+  return res.data?.data ?? res.data;
+};
 
 export const addToCart = async (item) => {
   try {
-    const response = await fetch(`${API_BASE_URL}/cart/add`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(item),
-    });
-    return await response.json();
+    const { data } = await api.post('/cart/add', item);
+    return data;
   } catch (error) {
-    console.error("Error adding item to cart:", error);
+    console.error('Error adding item to cart:', error);
     return null;
   }
 };
 
 export const updateCartItem = async (id, quantity) => {
   try {
-    const response = await fetch(`${API_BASE_URL}/cart/update/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ quantity }),
-    });
-    return await response.json();
+    const { data } = await api.put(`/cart/update/${id}`, { quantity });
+    return data;
   } catch (error) {
-    console.error("Error updating cart item:", error);
+    console.error('Error updating cart item:', error);
     return null;
   }
 };
 
 export const removeCartItem = async (id) => {
   try {
-    const response = await fetch(`${API_BASE_URL}/cart/remove/${id}`, {
-      method: "DELETE",
-    });
-    return await response.json();
+    const { data } = await api.delete(`/cart/remove/${id}`);
+    return data;
   } catch (error) {
-    console.error("Error removing item from cart:", error);
+    console.error('Error removing item from cart:', error);
     return null;
   }
 };


### PR DESCRIPTION
## Summary
- add in-memory cart module with CRUD API
- register cart routes in backend server
- update cart service to use API
- replace "Proceed to Payment" with functional "Add to Cart" button

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685bc754f1bc8328891cac08cc94d60d