### PR TITLE
Connect cart page to backend

### DIFF
--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -14,6 +14,7 @@ import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
 import useAdminStore from "@/store/admin/adminStore";
 import { API_BASE_URL } from '@/config/config';
+import { getCartItems } from '@/services/cartService';
 
 // ✅ Assets
 import logo from "@/shared/assets/images/login/logo.png";
@@ -35,10 +36,7 @@ const Navbar = () => {
   const router = useRouter();
   const userRole = user?.role?.toLowerCase();
 
-  const cartItems = [
-    { id: 1, name: "Premium Course", price: "$50", link: "/cart" },
-    { id: 2, name: "E-Book", price: "$20", link: "/cart" }
-  ];
+  const [cartItems, setCartItems] = useState([]);
 
   const unreadMessages = [
     { id: 1, text: "New message from Instructor", link: "/messages" },
@@ -82,6 +80,12 @@ const Navbar = () => {
     }, 100);
     return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    getCartItems()
+      .then((items) => setCartItems(items))
+      .catch(() => setCartItems([]));
+  }, [user]);
 
   useEffect(() => {
     function handleClickOutside(event) {

--- a/frontend/src/pages/cart/index.js
+++ b/frontend/src/pages/cart/index.js
@@ -86,7 +86,7 @@ const CartPage = () => {
             {/* Cart Items with Animation */}
             <ul className="space-y-6">
               <AnimatePresence>
-                {cartItems.map((item) => (
+                {cartItems.map((item, index) => (
                   <motion.li
                     key={item.id}
                     initial={{ opacity: 0, y: -10 }}
@@ -98,7 +98,9 @@ const CartPage = () => {
                     <div className="flex items-center space-x-4">
                       <FaGift className="text-yellow-500 text-4xl" />
                       <div>
-                        <h3 className="text-lg font-semibold">{item.name}</h3>
+                        <h3 className="text-lg font-semibold">
+                          {index + 1}. {item.name}
+                        </h3>
                         <p className="text-gray-400">${item.price} per item</p>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- fetch cart items from backend in `Navbar`
- show actual item count in cart badge
- number cart items on the `/cart` page

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685bdeab368c8328909496c5969087d3