### PR TITLE
Fix instructor details on class page

### DIFF
--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -132,11 +132,13 @@ exports.getPublishedClasses = async () => {
 exports.getPublicClassDetails = async (id) => {
   const cls = await db("online_classes as c")
     .leftJoin("users as u", "c.instructor_id", "u.id")
+    .leftJoin("instructor_profiles as p", "u.id", "p.user_id")
     .leftJoin("categories as cat", "c.category_id", "cat.id")
     .select(
       "c.*",
       "u.full_name as instructor",
       "u.avatar_url as instructor_image",
+      "p.experience as instructor_bio",
       "cat.name as category",
       db.raw(
         "(SELECT COUNT(*) FROM class_enrollments ce WHERE ce.class_id = c.id) as enrolled_count"

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -1,10 +1,24 @@
 import api from "@/services/api/api";
 
+const formatClass = (cls) => ({
+  ...cls,
+  cover_image: cls.cover_image
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
+    : null,
+  demo_video_url: cls.demo_video_url
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`
+    : null,
+  instructor_image: cls.instructor_image
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`
+    : null,
+  instructorBio: cls.instructor_bio || cls.instructorBio,
+});
+
 export const fetchPublishedClasses = async () => {
   const { data } = await api.get("/users/classes");
   const list = data?.data ?? [];
   const formatted = list.map((cls) => ({
-    ...cls,
+    ...formatClass(cls),
     trending: Boolean(cls.trending),
   }));
   return { ...data, data: formatted };
@@ -12,7 +26,8 @@ export const fetchPublishedClasses = async () => {
 
 export const fetchClassDetails = async (id) => {
   const res = await api.get(`/users/classes/${id}`);
-  return res.data;
+  const cls = res.data?.data ?? res.data;
+  return cls ? formatClass(cls) : cls;
 };
 
 export const enrollInClass = async (id) => {


### PR DESCRIPTION
## Summary
- include instructor profile info in `getPublicClassDetails`
- expose API base URL when loading class data on the frontend

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3b8cf4708328a94312027fb0f387