### PR TITLE
Fix demo video path encoding

### DIFF
--- a/backend/src/modules/classes/classUploadMiddleware.js
+++ b/backend/src/modules/classes/classUploadMiddleware.js
@@ -7,11 +7,16 @@ if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir, { recursive: true });
 }
 
+const sanitizeName = (name) =>
+  name
+    .replace(/\s+/g, '-') // replace spaces with dashes
+    .replace(/[^a-zA-Z0-9+_.-]/g, ''); // remove characters like '#'
+
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, uploadDir),
   filename: (_req, file, cb) => {
     const ext = path.extname(file.originalname);
-    const base = path.basename(file.originalname, ext).replace(/\s+/g, '-');
+    const base = sanitizeName(path.basename(file.originalname, ext));
     cb(null, `${Date.now()}-${base}${ext}`);
   },
 });

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -51,7 +51,7 @@ export default function AdminClassDetailPage() {
         )}
         {details?.demo_video_url && (
           <video controls className="w-full mt-4 rounded-lg">
-            <source src={details.demo_video_url} />
+            <source src={encodeURI(details.demo_video_url)} />
           </video>
         )}
 

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
@@ -43,7 +43,7 @@ export default function InstructorClassDetailPage() {
           )}
           {details?.demo_video_url && (
             <video controls className="w-full mt-4 rounded-lg">
-              <source src={details.demo_video_url} />
+              <source src={encodeURI(details.demo_video_url)} />
             </video>
           )}
 

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -203,7 +203,7 @@ export default function ClassDetailsPage() {
 
         {classInfo.demo_video_url ? (
           <video
-            src={classInfo.demo_video_url}
+            src={encodeURI(classInfo.demo_video_url)}
             controls
             className="w-full rounded-xl shadow-2xl mb-10 max-h-[500px] object-cover border border-gray-800"
           />

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -7,7 +7,9 @@ const formatClass = (cls) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
     : null,
   demo_video_url: cls.demo_video_url
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`
+    ? encodeURI(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
+      )
     : null,
   instructor_image: cls.instructor_image
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -7,7 +7,9 @@ const formatClass = (cls) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`
     : null,
   demo_video_url: cls.demo_video_url
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.demo_video_url}`
+    ? encodeURI(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.demo_video_url}`,
+      )
     : null,
   instructor_image: cls.instructor_image
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.instructor_image}`

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -7,7 +7,9 @@ const formatClass = (cls) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
     : null,
   demo_video_url: cls.demo_video_url
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`
+    ? encodeURI(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
+      )
     : null,
   instructor_image: cls.instructor_image
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`


### PR DESCRIPTION
## Summary
- URL-encode demo video links from the API
- URL-encode demo video src in class detail pages

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c56350ebc8328a2e253bed8467746