### PR TITLE
Add backend payment method API and integrate checkout

### DIFF
--- a/backend/src/modules/paymentMethods/paymentMethods.controller.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.controller.js
@@ -15,6 +15,11 @@ exports.getMethods = catchAsync(async (_req, res) => {
   sendSuccess(res, data);
 });
 
+exports.getActiveMethods = catchAsync(async (_req, res) => {
+  const data = await service.getActive();
+  sendSuccess(res, data);
+});
+
 exports.getMethod = catchAsync(async (req, res) => {
   const method = await service.getById(req.params.id);
   if (!method) throw new AppError("Payment method not found", 404);

--- a/backend/src/modules/paymentMethods/paymentMethods.public.routes.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.public.routes.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./paymentMethods.controller");
+
+router.get("/", controller.getActiveMethods);
+
+module.exports = router;

--- a/backend/src/modules/paymentMethods/paymentMethods.service.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.service.js
@@ -14,6 +14,13 @@ exports.getAll = () => {
   return db("payment_methods_config").select("*").orderBy("id");
 };
 
+exports.getActive = () => {
+  return db("payment_methods_config")
+    .where({ active: true })
+    .select("*")
+    .orderBy("id");
+};
+
 exports.getById = (id) => {
   return db("payment_methods_config").where({ id }).first();
 };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -63,6 +63,7 @@ const roleRoutes = require("./modules/roles/roles.routes");
 const planRoutes = require("./modules/plans/plans.routes");
 const paymentRoutes = require("./modules/payments/payments.routes");
 const paymentMethodRoutes = require("./modules/paymentMethods/paymentMethods.routes");
+const paymentMethodsPublicRoutes = require("./modules/paymentMethods/paymentMethods.public.routes");
 const paymentConfigRoutes = require("./modules/paymentConfig/paymentConfig.routes");
 const payoutRoutes = require("./modules/payouts/payouts.routes");
 const adsRoutes = require("./modules/ads/ads.routes");
@@ -130,6 +131,7 @@ app.use("/api/bookings/instructor", instructorBookingRoutes); // 👩‍🏫 Ins
 app.use("/api/community/admin", adminCommunityRoutes); // 🗣️ Admin community management
 app.use("/api/roles", roleRoutes); // 🛡️ Role and permission management
 app.use("/api/plans", planRoutes); // 💳 Subscription plans
+app.use("/api/payment-methods", paymentMethodsPublicRoutes); // 💳 Public payment methods
 app.use("/api/payments/admin", paymentRoutes); // 💵 Payments management
 app.use("/api/payment-methods/admin", paymentMethodRoutes); // 💳 Payment methods
 app.use("/api/payments/config", paymentConfigRoutes); // ⚙️ Payment settings

--- a/frontend/src/components/payments/PaymentProviderConfig.js
+++ b/frontend/src/components/payments/PaymentProviderConfig.js
@@ -1,30 +1,60 @@
+import { useEffect, useState } from "react";
+import {
+  fetchMethodById,
+  updateMethod,
+} from "@/services/admin/paymentMethodService";
+
 export default function PaymentProviderConfig({ providerId }) {
-    return (
-      <form className="space-y-4 bg-white p-6 rounded-xl shadow">
-        <label className="block">
-          <span className="text-sm">Client ID</span>
-          <input type="text" className="w-full border rounded p-2" placeholder="Enter client ID" />
-        </label>
-        <label className="block">
-          <span className="text-sm">Secret Key</span>
-          <input type="password" className="w-full border rounded p-2" placeholder="Enter secret" />
-        </label>
-        <label className="block">
-          <span className="text-sm">Mode</span>
-          <select className="w-full border rounded p-2">
-            <option value="sandbox">Sandbox</option>
-            <option value="live">Live</option>
-          </select>
-        </label>
-        <label className="block">
-          <span className="text-sm">Available For</span>
-          <select className="w-full border rounded p-2" multiple>
-            <option value="student">Student</option>
-            <option value="instructor">Instructor</option>
-          </select>
-        </label>
-        <button className="bg-yellow-400 px-6 py-2 rounded-full text-white">Save Configuration</button>
-      </form>
-    );
-  }
-  
+  const [settings, setSettings] = useState("{}");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!providerId) return;
+    const load = async () => {
+      try {
+        const method = await fetchMethodById(providerId);
+        setSettings(JSON.stringify(method?.settings || {}, null, 2));
+      } catch (err) {
+        console.error("Failed to load method", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [providerId]);
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    try {
+      const parsed = settings ? JSON.parse(settings) : {};
+      await updateMethod(providerId, { settings: parsed });
+      alert("Configuration saved");
+    } catch (err) {
+      console.error("Failed to save settings", err);
+      alert("Failed to save configuration");
+    }
+  };
+
+  if (loading) return <p>Loading...</p>;
+
+  return (
+    <form
+      onSubmit={handleSave}
+      className="space-y-4 bg-white p-6 rounded-xl shadow"
+    >
+      <label className="block text-sm font-medium">Settings (JSON)</label>
+      <textarea
+        className="w-full border rounded p-2 font-mono text-sm"
+        rows={10}
+        value={settings}
+        onChange={(e) => setSettings(e.target.value)}
+      />
+      <button
+        type="submit"
+        className="bg-yellow-400 px-6 py-2 rounded-full text-white"
+      >
+        Save Configuration
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -68,7 +68,13 @@ export default function AdminPaymentsPage() {
           fetchPayouts(),
         ]);
         setTransactions(txns);
-        setMethods(mths);
+        setMethods(
+          mths.map((m) => ({
+            ...m,
+            configurable: true,
+            configPath: `/dashboard/admin/payments/methods/configure/${m.id}`,
+          }))
+        );
         setPayouts(pouts);
 
         if (cfg) {

--- a/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
@@ -1,0 +1,17 @@
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { useRouter } from "next/router";
+import PaymentProviderConfig from "@/components/payments/PaymentProviderConfig";
+
+export default function ConfigurePaymentMethodPage() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  return (
+    <AdminLayout title="Configure Payment Method">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Configure {id}</h1>
+        <PaymentProviderConfig providerId={id} />
+      </div>
+    </AdminLayout>
+  );
+}

--- a/frontend/src/pages/dashboard/admin/payments/methods/create.js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/create.js
@@ -12,17 +12,37 @@ export default function CreatePaymentMethodPage() {
     icon: "",
     active: true,
     is_default: false,
+    settings: {},
+    settingsText: "{}",
   });
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
-    setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+    if (name === "settings") {
+      setForm((prev) => ({ ...prev, settingsText: value }));
+    } else {
+      setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+    }
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await createMethod(form);
+      let settings = {};
+      try {
+        settings = form.settingsText ? JSON.parse(form.settingsText) : {};
+      } catch (err) {
+        alert("Invalid JSON in settings");
+        return;
+      }
+      await createMethod({
+        name: form.name,
+        type: form.type,
+        icon: form.icon,
+        active: form.active,
+        is_default: form.is_default,
+        settings,
+      });
       router.push("/dashboard/admin/payments");
     } catch (err) {
       console.error("Failed to create method", err);
@@ -76,6 +96,16 @@ export default function CreatePaymentMethodPage() {
               value={form.icon}
               onChange={handleChange}
               className="w-full border p-2 rounded"
+            />
+          </div>
+          <div>
+            <label className="block font-semibold mb-1">Settings (JSON)</label>
+            <textarea
+              name="settings"
+              rows={5}
+              value={form.settingsText}
+              onChange={handleChange}
+              className="w-full border p-2 rounded font-mono text-sm"
             />
           </div>
           <label className="flex items-center gap-2">

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { fetchPaymentMethods } from '@/services/paymentMethodService';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import {
@@ -19,21 +20,11 @@ const iconMap = {
   coinbase: <FaEthereum />,
 };
 
-export const allMethods = [
-  { id: 1, name: "stripe", label: "Stripe", icon: "stripe", type: "Gateway", active: true },
-  { id: 2, name: "paypal", label: "PayPal", icon: "paypal", type: "Gateway", active: true },
-  { id: 3, name: "moyasar", label: "Moyasar", icon: "moyasar", type: "Gateway", active: true },
-  { id: 4, name: "paystack", label: "Paystack", icon: "paystack", type: "Gateway", active: true },
-  { id: 5, name: "bank", label: "Bank Transfer", icon: "bank", type: "Manual", active: true },
-  { id: 6, name: "usdt", label: "USDT (Tether)", icon: "usdt", type: "Crypto", active: true },
-  { id: 7, name: "binance", label: "Binance Pay", icon: "binance", type: "Crypto", active: true },
-  { id: 8, name: "coinbase", label: "Coinbase", icon: "coinbase", type: "Crypto", active: true },
-];
-
 export default function CheckoutPage() {
   const router = useRouter();
   const { classId } = router.query;
   const [classInfo, setClassInfo] = useState(null);
+  const [methods, setMethods] = useState([]);
   const [selectedMethod, setSelectedMethod] = useState('stripe');
   const [promoCode, setPromoCode] = useState('');
   const [discount, setDiscount] = useState(0);
@@ -58,6 +49,16 @@ export default function CheckoutPage() {
       const found = mockClasses.find((cls) => cls.id === classId);
       setClassInfo(found);
     }
+    const loadMethods = async () => {
+      try {
+        const data = await fetchPaymentMethods();
+        setMethods(data);
+        if (data.length > 0) setSelectedMethod(data[0].name);
+      } catch (err) {
+        console.error('Failed to load payment methods', err);
+      }
+    };
+    loadMethods();
   }, [classId]);
 
   const handleApplyPromo = () => {
@@ -94,7 +95,7 @@ export default function CheckoutPage() {
 
   if (!classInfo) return <div className="text-white text-center mt-32">Loading...</div>;
   const finalPrice = classInfo.price - discount;
-  const availableMethods = allMethods.filter(m => m.active).slice(0, 4);
+  const availableMethods = methods.filter((m) => m.active);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-950 to-gray-900 text-white">

--- a/frontend/src/services/paymentMethodService.js
+++ b/frontend/src/services/paymentMethodService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const fetchPaymentMethods = async () => {
+  const { data } = await api.get("/payment-methods");
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- expose public payment methods API on the backend
- implement active method query in paymentMethods service
- add React component for configuring provider settings
- fetch methods from API in admin and checkout pages
- allow JSON settings when creating a payment method

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685c67de77a48328b2f751701184244b