### PR TITLE
Fix 403 error when loading wishlist

### DIFF
--- a/frontend/src/components/website/sections/OnlineClasses.js
+++ b/frontend/src/components/website/sections/OnlineClasses.js
@@ -71,7 +71,7 @@ const OnlineClasses = () => {
   }, []);
 
   useEffect(() => {
-    if (!user) return;
+    if (!user || user.role?.toLowerCase() !== 'student') return;
     const load = async () => {
       try {
         const w = await getMyClassWishlist();

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -69,8 +69,15 @@ export const removeClassFromWishlist = async (id) => {
 };
 
 export const getMyClassWishlist = async () => {
-  const { data } = await api.get('/users/classes/wishlist/my');
-  return data?.data ?? [];
+  try {
+    const { data } = await api.get('/users/classes/wishlist/my');
+    return data?.data ?? [];
+  } catch (err) {
+    if (err.response && [401, 403].includes(err.response.status)) {
+      return [];
+    }
+    throw err;
+  }
 };
 
 export const likeClass = async (id) => {
@@ -84,8 +91,15 @@ export const unlikeClass = async (id) => {
 };
 
 export const getMyLikedClasses = async () => {
-  const { data } = await api.get('/users/classes/likes/my');
-  return data?.data ?? [];
+  try {
+    const { data } = await api.get('/users/classes/likes/my');
+    return data?.data ?? [];
+  } catch (err) {
+    if (err.response && [401, 403].includes(err.response.status)) {
+      return [];
+    }
+    throw err;
+  }
 };
 
 export const fetchClassReviews = async (classId) => {


### PR DESCRIPTION
## Summary
- avoid wishlist and like API calls unless current user is a Student
- handle 401/403 responses gracefully in classService helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c706e8350832889aa4c38bdf7b9a9