### PR TITLE
Restrict superadmin deletion

### DIFF
--- a/backend/src/modules/users/usersmanagement/users.controller.js
+++ b/backend/src/modules/users/usersmanagement/users.controller.js
@@ -72,6 +72,16 @@ exports.updateUserStatus = catchAsync(async (req, res) => {
 
 exports.deleteUser = async (req, res) => {
   const { id } = req.params;
+  const user = await db("users").where({ id }).first();
+  if (!user) {
+    return res.status(404).json({ message: "User not found" });
+  }
+
+  const role = (user.role || "").toLowerCase();
+  if (role === "superadmin") {
+    return res.status(403).json({ message: "Cannot delete SuperAdmin user" });
+  }
+
   await db("users").where({ id }).del();
   res.json({ message: "User deleted" });
 };
@@ -160,6 +170,13 @@ exports.bulkDeleteUsers = catchAsync(async (req, res) => {
   if (!Array.isArray(ids) || !ids.length) {
     throw new AppError("Invalid user IDs for bulk delete", 400);
   }
+  const superAdmins = await db("users")
+    .whereIn("id", ids)
+    .whereRaw("LOWER(role) = ?", ["superadmin"]);
+  if (superAdmins.length) {
+    throw new AppError("Cannot delete SuperAdmin user(s)", 403);
+  }
+
   await service.bulkDeleteUsers(ids);
   sendSuccess(res, null, "Selected users deleted");
 });

--- a/frontend/src/components/admin/users/UserCard.js
+++ b/frontend/src/components/admin/users/UserCard.js
@@ -62,6 +62,10 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
   };
 
   const handleDelete = async () => {
+    if (role?.toLowerCase() === "superadmin") {
+      toast.error("Cannot delete SuperAdmin user");
+      return;
+    }
     if (!confirm(`Are you sure you want to delete ${user.name}?`)) return;
     try {
       await deleteUser(user.id);
@@ -78,12 +82,14 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
 
   return (
     <div className="relative bg-white rounded-xl shadow-md border p-5 flex flex-col justify-between">
-      <input
-        type="checkbox"
-        className="absolute top-3 right-3 w-4 h-4 accent-blue-500"
-        checked={isSelected}
-        onChange={() => onSelect(user.id)}
-      />
+      {role?.toLowerCase() !== "superadmin" && (
+        <input
+          type="checkbox"
+          className="absolute top-3 right-3 w-4 h-4 accent-blue-500"
+          checked={isSelected}
+          onChange={() => onSelect(user.id)}
+        />
+      )}
 
       <div className="flex items-center mb-4">
         <div className="w-16 h-16 rounded-full overflow-hidden border-2 border-gray-300 bg-white shadow mr-4">
@@ -154,12 +160,14 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
         >
           <Edit className="w-4 h-4 mr-1" /> Edit
         </button>
-        <button
-          onClick={handleDelete}
-          className="flex items-center text-sm bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded-lg transition"
-        >
-          <Trash2 className="w-4 h-4 mr-1" /> Delete
-        </button>
+        {role?.toLowerCase() !== "superadmin" && (
+          <button
+            onClick={handleDelete}
+            className="flex items-center text-sm bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded-lg transition"
+          >
+            <Trash2 className="w-4 h-4 mr-1" /> Delete
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/admin/users/UserList.js
+++ b/frontend/src/components/admin/users/UserList.js
@@ -134,7 +134,9 @@ export default function UserList({ users, setUsers }) {
                 currentUsers.every((u) => selectedIds.includes(u.id))
               }
               onChange={(e) => {
-                const visibleIds = currentUsers.map((u) => u.id);
+                const visibleIds = currentUsers
+                  .filter((u) => u.role?.toLowerCase() !== "superadmin")
+                  .map((u) => u.id);
                 if (e.target.checked) {
                   const combined = Array.from(new Set([...selectedIds, ...visibleIds]));
                   setSelectedIds(combined);


### PR DESCRIPTION
## Summary
- prevent deletion of SuperAdmin users on the backend
- hide delete option for SuperAdmin user cards
- skip SuperAdmin accounts when selecting all users

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c75432c508328b8fb7047d59f3116