### PR TITLE
Disable SuperAdmin role edits

### DIFF
--- a/backend/src/modules/users/usersmanagement/users.controller.js
+++ b/backend/src/modules/users/usersmanagement/users.controller.js
@@ -102,6 +102,12 @@ exports.changeUserRole = catchAsync(async (req, res) => {
     return res.status(400).json({ message: "Invalid role" });
   }
 
+  // Disallow changing role of SuperAdmin
+  const target = await service.getUserById(req.params.id);
+  if (target && target.role && target.role.toLowerCase() === "superadmin") {
+    throw new AppError("Cannot change role for SuperAdmin user", 403);
+  }
+
   const updatedUser = await service.changeUserRole(req.params.id, formattedRole);
   res.json({ success: true, message: "User role updated", data: updatedUser });
 });

--- a/backend/src/modules/users/usersmanagement/users.service.js
+++ b/backend/src/modules/users/usersmanagement/users.service.js
@@ -102,8 +102,18 @@ exports.updateUserProfile = async (id, data) => {
  * Change user role
  */
 exports.changeUserRole = async (id, role) => {
+  // Ensure target user exists
+  const user = await db("users").where({ id }).first();
+  if (!user) throw new AppError("User not found", 404);
+
+  // Disallow changing SuperAdmin role
+  if (user.role && user.role.toLowerCase() === "superadmin") {
+    throw new AppError("Cannot change role for SuperAdmin user", 403);
+  }
+
   const roleRow = await db("roles").where({ name: role }).first();
   if (!roleRow) throw new AppError("Role not found", 404);
+
   await db("users").where({ id }).update({ role }); // keep legacy column updated
   await db("user_roles").where({ user_id: id }).del();
   await db("user_roles").insert({ user_id: id, role_id: roleRow.id });

--- a/frontend/src/components/admin/users/UserCard.js
+++ b/frontend/src/components/admin/users/UserCard.js
@@ -19,6 +19,7 @@ import { formatDistanceToNow } from "date-fns";
 export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect }) {
   const [enabled, setEnabled] = useState(user.status?.toLowerCase() === "active");
   const [role, setRole] = useState(user.role);
+  const isSuperAdmin = user.role?.toLowerCase() === "superadmin";
 
   const roleColors = {
     admin: "bg-yellow-100 text-yellow-700",
@@ -50,6 +51,7 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
   };
 
   const handleRoleChange = async (e) => {
+    if (isSuperAdmin) return;
     const newRole = e.target.value;
     try {
       await updateUserRole(user.id, newRole);
@@ -113,6 +115,7 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
         <select
           value={role}
           onChange={handleRoleChange}
+          disabled={isSuperAdmin}
           className="mt-2 w-full px-2 py-1 text-sm border border-gray-300 rounded-md"
         >
           <option value="admin">Admin</option>


### PR DESCRIPTION
## Summary
- prevent changing the role of a SuperAdmin user on the backend
- block role updates in the admin dashboard UI for SuperAdmin users

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c761637e08328a48223e827c57eec