### PR TITLE
Add notifications support for auth actions

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -5,6 +5,7 @@ const userModel = require("../../users/user.model");
 const db = require("../../../config/database");
 const { sendOtpEmail } = require("../../../utils/email");
 const AppError = require("../../../utils/AppError");
+const notificationService = require("../../notifications/notifications.service");
 
 // ─────────────────────────────────────────────────────────────
 // 🔧 Config Constants
@@ -54,6 +55,12 @@ exports.registerUser = async (data) => {
   const accessToken = generateAccessToken({ id: newUser.id, role: tokenRoles[0], roles: tokenRoles });
   const refreshToken = generateRefreshToken({ id: newUser.id });
 
+  await notificationService.createNotification({
+    user_id: newUser.id,
+    type: "welcome",
+    message: "Welcome to SkillBridge!",
+  });
+
   return { accessToken, refreshToken, user: { ...newUser, roles } };
 };
 
@@ -77,6 +84,12 @@ exports.loginUser = async ({ email, password }) => {
   const tokenRoles = roles.length ? roles : [user.role];
   const accessToken = generateAccessToken({ id: user.id, role: tokenRoles[0], roles: tokenRoles });
   const refreshToken = generateRefreshToken({ id: user.id });
+
+  await notificationService.createNotification({
+    user_id: user.id,
+    type: "login",
+    message: "You have logged in successfully",
+  });
 
   return { accessToken, refreshToken, user: { ...user, roles } };
 };

--- a/backend/src/modules/notifications/notifications.controller.js
+++ b/backend/src/modules/notifications/notifications.controller.js
@@ -1,0 +1,15 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
+const service = require("./notifications.service");
+
+exports.getMyNotifications = catchAsync(async (req, res) => {
+  const data = await service.getUserNotifications(req.user.id);
+  sendSuccess(res, data);
+});
+
+exports.markRead = catchAsync(async (req, res) => {
+  const note = await service.markAsRead(req.params.id, req.user.id);
+  if (!note) throw new AppError("Notification not found", 404);
+  sendSuccess(res, note, "Notification marked as read");
+});

--- a/backend/src/modules/notifications/notifications.routes.js
+++ b/backend/src/modules/notifications/notifications.routes.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./notifications.controller");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken);
+
+router.get("/", controller.getMyNotifications);
+router.patch("/:id/read", controller.markRead);
+
+module.exports = router;

--- a/backend/src/modules/notifications/notifications.service.js
+++ b/backend/src/modules/notifications/notifications.service.js
@@ -1,0 +1,20 @@
+const db = require("../../config/database");
+
+exports.createNotification = async ({ user_id, type, message }) => {
+  const [row] = await db("notifications")
+    .insert({ user_id, type, message, created_at: new Date() })
+    .returning("*");
+  return row;
+};
+
+exports.getUserNotifications = (userId) => {
+  return db("notifications").where({ user_id: userId }).orderBy("created_at", "desc");
+};
+
+exports.markAsRead = async (id, userId) => {
+  const [row] = await db("notifications")
+    .where({ id, user_id: userId })
+    .update({ read: true, read_at: new Date() })
+    .returning("*");
+  return row;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -69,6 +69,7 @@ const payoutRoutes = require("./modules/payouts/payouts.routes");
 const adsRoutes = require("./modules/ads/ads.routes");
 const publicInstructorRoutes = require("./modules/instructors/instructor.routes");
 const cartRoutes = require("./modules/cart/cart.routes");
+const notificationRoutes = require("./modules/notifications/notifications.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -139,6 +140,7 @@ app.use("/api/payouts/admin", payoutRoutes); // 🏦 Instructor payouts
 app.use("/api/ads", adsRoutes); // 📢 Advertisements
 app.use("/api/instructors", publicInstructorRoutes); // 📚 Public instructor listing
 app.use("/api/cart", cartRoutes); // 🛒 Shopping cart
+app.use("/api/notifications", notificationRoutes); // 🔔 User notifications
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/backend/tests/notificationRoutes.test.js
+++ b/backend/tests/notificationRoutes.test.js
@@ -1,0 +1,40 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  getUserNotifications: jest.fn(),
+  markAsRead: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'user1' }; next(); },
+}));
+
+const service = require('../src/modules/notifications/notifications.service');
+const routes = require('../src/modules/notifications/notifications.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/notifications', routes);
+
+describe('GET /api/notifications', () => {
+  it('returns notifications list', async () => {
+    const mock = [{ id: '1' }];
+    service.getUserNotifications.mockResolvedValue(mock);
+    const res = await request(app).get('/api/notifications');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getUserNotifications).toHaveBeenCalledWith('user1');
+  });
+});
+
+describe('PATCH /api/notifications/:id/read', () => {
+  it('marks notification as read', async () => {
+    const mockNote = { id: '1', read: true };
+    service.markAsRead.mockResolvedValue(mockNote);
+    const res = await request(app).patch('/api/notifications/1/read');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mockNote);
+    expect(service.markAsRead).toHaveBeenCalledWith('1', 'user1');
+  });
+});

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -15,6 +15,7 @@ import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
 import InputField from "@/shared/components/auth/InputField";
 import SocialLogin from "@/shared/components/auth/SocialLogin";
 import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
 
 // ─────────────────────
 // 🔐 Validation schema
@@ -30,6 +31,7 @@ export default function Login() {
   const user = useAuthStore((state) => state.user);
   const login = useAuthStore((state) => state.login);
   const hasHydrated = useAuthStore((state) => state.hasHydrated);
+  const fetchNotifications = useNotificationStore((state) => state.fetch);
 
   // ─────────────────────
   // 📝 Form setup
@@ -72,6 +74,7 @@ export default function Login() {
   try {
     const loggedInUser = await login(data);
     toast.success("Login successful");
+    fetchNotifications();
 
     const profilePaths = {
       admin: "/dashboard/admin/profile/edit",

--- a/frontend/src/pages/auth/register.js
+++ b/frontend/src/pages/auth/register.js
@@ -15,11 +15,13 @@ import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
 import InputField from "@/shared/components/auth/InputField";
 import SocialRegister from "@/shared/components/auth/SocialRegister";
 import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
 import { registerSchema } from "@/utils/auth/validationSchemas";
 
 export default function Register() {
   const router = useRouter();
   const { register: registerUser, user, hasHydrated } = useAuthStore();
+  const fetchNotifications = useNotificationStore((state) => state.fetch);
 
   const {
     register,
@@ -52,6 +54,7 @@ export default function Register() {
       const { full_name, email, phone, password, role } = data;
       await registerUser({ full_name, email, phone, password, role });
       toast.success("Registration successful");
+      fetchNotifications();
       router.push("/auth/login");
     } catch (err) {
       const msg =

--- a/frontend/src/services/notificationService.js
+++ b/frontend/src/services/notificationService.js
@@ -1,35 +1,11 @@
-const MOCK_MODE = true; // Set to false when backend is ready
+import api from "@/services/api/api";
 
-// Get User Notifications (Mock or Live)
-export const getNotifications = async (userId) => {
-  if (MOCK_MODE) {
-    // ✅ Mocked notifications
-    return [
-      {
-        id: 1,
-        message: `Welcome back, User ${userId}!`,
-        timestamp: new Date().toISOString(),
-      },
-      {
-        id: 2,
-        message: "You have been added to the 'AI Pioneers' group.",
-        timestamp: new Date(Date.now() - 3600000).toISOString(), // 1hr ago
-      },
-    ];
-  } else {
-    const API_URL = process.env.NEXT_PUBLIC_API_URL;
-    const response = await axios.get(`${API_URL}/notifications/${userId}`);
-    return response.data;
-  }
+export const getNotifications = async () => {
+  const res = await api.get("/notifications");
+  return res.data.data || res.data;
 };
 
-// Mark Notification as Read (Mock or Live)
-export const markNotificationAsRead = async (notificationId) => {
-  if (MOCK_MODE) {
-    console.log(`Mock: Marked notification ${notificationId} as read`);
-    return { success: true };
-  } else {
-    const API_URL = process.env.NEXT_PUBLIC_API_URL;
-    return await axios.put(`${API_URL}/notifications/${notificationId}/read`);
-  }
+export const markNotificationAsRead = async (id) => {
+  const res = await api.patch(`/notifications/${id}/read`);
+  return res.data.data || res.data;
 };

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+import { getNotifications, markNotificationAsRead } from "@/services/notificationService";
+
+const useNotificationStore = create((set) => ({
+  items: [],
+  loading: false,
+
+  fetch: async () => {
+    set({ loading: true });
+    try {
+      const data = await getNotifications();
+      set({ items: data, loading: false });
+    } catch (err) {
+      set({ loading: false });
+    }
+  },
+
+  markRead: async (id) => {
+    await markNotificationAsRead(id);
+    set((state) => ({
+      items: state.items.map((n) => (n.id === id ? { ...n, read: true } : n)),
+    }));
+  },
+}));
+
+export default useNotificationStore;


### PR DESCRIPTION
## Summary
- implement notification service, controller and routes on backend
- create login/register notifications when users authenticate
- expose `/api/notifications` route
- support notifications in frontend with zustand store
- fetch notifications after login and registration
- provide backend tests for new routes

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685cdb66a1988328b842f23e519d471d