### PR TITLE
Implement notification center

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -16,6 +16,7 @@ import useAuthStore from "@/store/auth/authStore";
 import { toast } from "react-toastify";
 import { FaCog } from "react-icons/fa";
 import { toggleInstructorStatus } from "@/services/instructor/instructorService";
+import useNotificationStore from "@/store/notifications/notificationStore";
 
 export default function Header() {
   const user = useAuthStore((state) => state.user);
@@ -29,6 +30,10 @@ export default function Header() {
   const [available, setAvailable] = useState(user?.is_online ?? false);
   const dropdownRef = useRef(null);
   const notifRef = useRef(null);
+  const notifications = useNotificationStore((state) => state.items);
+  const fetchNotifications = useNotificationStore((state) => state.fetch);
+  const markRead = useNotificationStore((state) => state.markRead);
+  const unreadCount = notifications.filter((n) => !n.read).length;
   const router = useRouter();
 
   const profileLink =
@@ -86,11 +91,10 @@ export default function Header() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [user]);
 
-  const notifications = [
-    "🔔 New user registered",
-    "💬 You have 2 new messages",
-    "⚙️ Settings updated",
-  ];
+  useEffect(() => {
+    if (user) fetchNotifications();
+  }, [user, fetchNotifications]);
+
 
   return (
     <header className="bg-white dark:bg-gray-900 shadow-sm px-6 py-4 flex justify-between items-center sticky top-0 z-30">
@@ -157,7 +161,7 @@ export default function Header() {
             aria-label="Toggle notifications"
           />
           <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full w-4 h-4 flex items-center justify-center">
-            {notifications.length}
+            {unreadCount}
           </span>
 
           <AnimatePresence>
@@ -170,11 +174,18 @@ export default function Header() {
                 className="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50"
               >
                 <ul className="text-sm text-gray-700 dark:text-gray-200 max-h-60 overflow-y-auto divide-y">
-                  {notifications.map((n, idx) => (
-                    <li key={idx} className="px-4 py-2">
-                      {n}
+                  {notifications.map((n) => (
+                    <li
+                      key={n.id}
+                      onClick={() => markRead(n.id)}
+                      className={`px-4 py-2 cursor-pointer ${n.read ? 'text-gray-500' : ''}`}
+                    >
+                      {n.message}
                     </li>
                   ))}
+                  {notifications.length === 0 && (
+                    <li className="px-4 py-2 text-center text-sm text-gray-500">No notifications</li>
+                  )}
                 </ul>
               </motion.div>
             )}

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -15,6 +15,7 @@ import useAuthStore from "@/store/auth/authStore";
 import useAdminStore from "@/store/admin/adminStore";
 import { API_BASE_URL } from '@/config/config';
 import useCartStore from '@/store/cart/cartStore';
+import useNotificationStore from '@/store/notifications/notificationStore';
 
 // ✅ Assets
 import logo from "@/shared/assets/images/login/logo.png";
@@ -38,14 +39,14 @@ const Navbar = () => {
 
   const { items: cartItems, fetchCart } = useCartStore();
 
+  const notifications = useNotificationStore((state) => state.items);
+  const fetchNotifications = useNotificationStore((state) => state.fetch);
+  const markRead = useNotificationStore((state) => state.markRead);
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
   const unreadMessages = [
     { id: 1, text: "New message from Instructor", link: "/messages" },
     { id: 2, text: "Course reminder", link: "/messages" }
-  ];
-
-  const unreadNotifications = [
-    { id: 1, text: "Assignment due soon", link: "/notifications" },
-    { id: 2, text: "Live class starts in 30 min", link: "/notifications" }
   ];
 
   useEffect(() => {
@@ -84,6 +85,10 @@ const Navbar = () => {
   useEffect(() => {
     fetchCart();
   }, [user, fetchCart]);
+
+  useEffect(() => {
+    if (user) fetchNotifications();
+  }, [user, fetchNotifications]);
 
   useEffect(() => {
     function handleClickOutside(event) {
@@ -144,9 +149,9 @@ const Navbar = () => {
 
             <motion.button whileHover={{ scale: 1.1 }} onClick={() => setNotificationOpen(!notificationOpen)} className="relative text-2xl">
               <FaBell />
-              {unreadNotifications.length > 0 && (
+              {unreadCount > 0 && (
                 <span className="absolute -top-1 -right-1 bg-red-500 text-xs px-2 rounded-full text-white">
-                  {unreadNotifications.length}
+                  {unreadCount}
                 </span>
               )}
             </motion.button>
@@ -264,6 +269,27 @@ const Navbar = () => {
                     <Image src={saudiFlag} alt="AR" width={20} height={20} className="rounded-full" />
                     Arabic
                   </li>
+                </ul>
+              </div>
+            )}
+
+            {notificationOpen && (
+              <div className="absolute top-20 right-48 bg-white text-gray-800 w-72 rounded-xl shadow-xl border border-gray-200 p-4 z-50">
+                <h4 className="text-base font-semibold mb-2 border-b pb-1">Notifications</h4>
+                <ul className="space-y-3 text-sm max-h-60 overflow-y-auto">
+                  {notifications.map((note) => (
+                    <li
+                      key={note.id}
+                      onClick={() => markRead(note.id)}
+                      className={`flex justify-between items-center hover:bg-gray-50 p-2 rounded-md cursor-pointer ${note.read ? 'text-gray-400' : ''}`}
+                    >
+                      <span>{note.message}</span>
+                      {!note.read && <span className="ml-2 text-xs text-red-500">new</span>}
+                    </li>
+                  ))}
+                  {notifications.length === 0 && (
+                    <li className="text-center text-sm text-gray-500 py-2">No notifications</li>
+                  )}
                 </ul>
               </div>
             )}


### PR DESCRIPTION
## Summary
- load notifications into website navbar and dashboard header
- show unread notification count
- add dropdowns to mark notifications as read

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
- `npm run lint` in `frontend` *(fails: 47 errors, 173 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685cddde22b48328a015b101757a7bb2