### PR TITLE
Fix notification dropdown and add admin alerts

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -61,6 +61,17 @@ exports.registerUser = async (data) => {
     message: "Welcome to SkillBridge!",
   });
 
+  const admins = await userModel.findAdmins();
+  await Promise.all(
+    admins.map((admin) =>
+      notificationService.createNotification({
+        user_id: admin.id,
+        type: "new_user",
+        message: `${newUser.full_name} joined as ${newUser.role}`,
+      })
+    )
+  );
+
   return { accessToken, refreshToken, user: { ...newUser, roles } };
 };
 

--- a/backend/src/modules/users/user.model.js
+++ b/backend/src/modules/users/user.model.js
@@ -88,6 +88,13 @@ exports.findByPhone = async (phone) => {
   return db("users").where({ phone }).first();
 };
 
+// Fetch Admin and SuperAdmin users
+exports.findAdmins = () => {
+  return db("users")
+    .select("id")
+    .whereIn("role", ["Admin", "SuperAdmin"]);
+};
+
 
 /**
  * ➕ Insert a new user

--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -199,20 +199,18 @@ export default function Header() {
                     <li className="px-4 py-2 text-center text-sm text-gray-500">No notifications</li>
                   )}
                 </ul>
-                {notifications.length > 10 && (
-                  <div className="mt-2 text-center">
-                    <Link
-                      href={
-                        userRole
-                          ? `/dashboard/${userRole}/notifications`
-                          : '/notifications'
-                      }
-                      className="text-blue-600 hover:underline text-sm"
-                    >
-                      View All
-                    </Link>
-                  </div>
-                )}
+                <div className="mt-2 text-center">
+                  <Link
+                    href={
+                      userRole
+                        ? `/dashboard/${userRole}/notifications`
+                        : '/notifications'
+                    }
+                    className="text-blue-600 hover:underline text-sm"
+                  >
+                    View All
+                  </Link>
+                </div>
               </motion.div>
             )}
           </AnimatePresence>

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -172,7 +172,7 @@ const Navbar = () => {
               {notificationOpen && (
                 <div
                   ref={dropdownRef}
-                  className="absolute right-0 mt-2 top-full bg-white text-gray-800 w-72 rounded-xl shadow-xl border border-gray-200 p-4 z-50"
+                  className="absolute right-0 mt-2 bg-white text-gray-800 w-72 rounded-xl shadow-xl border border-gray-200 p-4 z-50"
                 >
                   <h4 className="text-base font-semibold mb-2 border-b pb-1">Notifications</h4>
                   <ul className="space-y-3 text-sm max-h-60 overflow-y-auto">
@@ -198,20 +198,18 @@ const Navbar = () => {
                       <li className="text-center text-sm text-gray-500 py-2">No notifications</li>
                     )}
                   </ul>
-                  {notifications.length > 10 && (
-                    <div className="mt-2 text-center">
-                      <Link
-                        href={
-                          userRole
-                            ? `/dashboard/${userRole}/notifications`
-                            : "/notifications"
-                        }
-                        className="text-blue-600 hover:underline text-sm"
-                      >
-                        View All
-                      </Link>
-                    </div>
-                  )}
+                  <div className="mt-2 text-center">
+                    <Link
+                      href={
+                        userRole
+                          ? `/dashboard/${userRole}/notifications`
+                          : "/notifications"
+                      }
+                      className="text-blue-600 hover:underline text-sm"
+                    >
+                      View All
+                    </Link>
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- keep notification dropdown within Navbar and always show view all button
- always show view all button in dashboard header
- notify admins when a new user registers

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685cf641c8f48328937e3b2852d69b40