### PR TITLE
Add profile update notification feature

### DIFF
--- a/backend/src/modules/notifications/notifications.service.js
+++ b/backend/src/modules/notifications/notifications.service.js
@@ -7,8 +7,15 @@ exports.createNotification = async ({ user_id, type, message }) => {
   return row;
 };
 
-exports.getUserNotifications = (userId) => {
-  return db("notifications").where({ user_id: userId }).orderBy("created_at", "desc");
+exports.getUserNotifications = async (userId) => {
+  const threshold = new Date(Date.now() - 60 * 60 * 1000);
+  await db("notifications")
+    .where({ read: true })
+    .andWhere("read_at", "<", threshold)
+    .del();
+  return db("notifications")
+    .where({ user_id: userId })
+    .orderBy("created_at", "desc");
 };
 
 exports.markAsRead = async (id, userId) => {

--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -6,6 +6,7 @@ const db = require("../../../config/database");
 const fs = require("fs");
 const path = require("path");
 const instructorService = require("./instructor.service");
+const notificationService = require("../../notifications/notifications.service");
 
 
 /**
@@ -150,6 +151,11 @@ exports.updateProfile = async (req, res) => {
     );
 
     const updated = await instructorService.getInstructorProfile(userId);
+    await notificationService.createNotification({
+      user_id: userId,
+      type: "profile_update",
+      message: "Your profile was updated successfully",
+    });
     res.json(updated);
   } catch (err) {
     console.error("Profile update error:", err);

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import { z } from "zod";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
 import {
   getInstructorProfile,
   updateInstructorProfile,
@@ -62,6 +63,7 @@ const currencyOptions = [
 export default function InstructorProfileEdit() {
   const router = useRouter();
   const { user, hasHydrated } = useAuthStore();
+  const fetchNotifications = useNotificationStore((state) => state.fetch);
 
   const [formData, setFormData] = useState({
     full_name: "",
@@ -263,6 +265,7 @@ export default function InstructorProfileEdit() {
       }));
 
       toast.success("Profile updated successfully!");
+      await fetchNotifications();
       router.push("/dashboard/instructor");
     } catch (err) {
       toast.error(err.message || "Failed to update profile");

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { toast } from "react-toastify";
 import { getNotifications, markNotificationAsRead } from "@/services/notificationService";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
 
 const useNotificationStore = create((set, get) => ({
   items: [],
@@ -14,7 +14,7 @@ const useNotificationStore = create((set, get) => ({
     try {
       const data = await getNotifications();
       const filtered = data.filter(
-        (n) => !(n.read && n.read_at && new Date() - new Date(n.read_at) > DAY_MS)
+        (n) => !(n.read && n.read_at && new Date() - new Date(n.read_at) > HOUR_MS)
       );
       const prevUnread = get().items.filter((n) => !n.read).length;
       const unread = filtered.filter((n) => !n.read).length;
@@ -48,11 +48,11 @@ const useNotificationStore = create((set, get) => ({
               n.id === id &&
               n.read &&
               n.read_at &&
-              new Date() - new Date(n.read_at) >= DAY_MS
+              new Date() - new Date(n.read_at) >= HOUR_MS
             )
         ),
       }));
-    }, DAY_MS);
+    }, HOUR_MS);
   },
 
   startPolling: () => {


### PR DESCRIPTION
## Summary
- notify instructors when profile is updated
- auto-cleanup read notifications after one hour
- refresh notifications after profile update
- reduce notification lifespan in store to one hour

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d0393a3788328802b83df114bb014