### PR TITLE
Fix certificate deletion path

### DIFF
--- a/frontend/src/services/instructor/instructorService.js
+++ b/frontend/src/services/instructor/instructorService.js
@@ -55,7 +55,9 @@ export const uploadCertificateFile = async (formData) => {
 
 // 🔹 Delete certificate by ID
 export const deleteCertificateFile = async (certificateId) => {
-  const res = await api.delete(`/instructor/certificates/${certificateId}`);
+  const res = await api.delete(
+    `/users/instructor/certificates/${certificateId}`,
+  );
   return res.data;
 };
 


### PR DESCRIPTION
## Summary
- correct API path for deleting instructor certificates

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685d0bc69fc083289f1e9d1fd4bda5c6