### PR TITLE
Add instructor bio field and improve booking display

### DIFF
--- a/frontend/src/components/website/sections/InstructorBooking.js
+++ b/frontend/src/components/website/sections/InstructorBooking.js
@@ -179,18 +179,33 @@ export default function InstructorBooking() {
             whileHover={{ scale: 1.05 }}
             className="p-6 bg-gray-800 rounded-lg shadow-lg text-center flex flex-col items-center relative"
           >
-            {i.availableNow && (
-              <span className="absolute top-2 right-2 bg-green-500 text-xs px-2 py-1 rounded-full">Online</span>
-            )}
+            <span
+              className={`absolute top-2 right-2 text-xs px-2 py-1 rounded-full ${
+                i.availableNow ? 'bg-green-500' : 'bg-gray-600'
+              }`}
+            >
+              {i.availableNow ? 'Online' : 'Offline'}
+            </span>
             {i.verified && (
               <span className="absolute top-2 left-2 text-green-400 text-sm flex items-center gap-1">
                 <FaCircleCheck /> Verified
               </span>
             )}
             <img src={i.avatar} className="w-20 h-20 rounded-full border-2 border-yellow-500 mb-3" alt={i.name} />
-            <h3 className="text-xl font-semibold cursor-pointer hover:underline" onClick={() => router.push(`/instructors/${i.id}`)}>{i.name}</h3>
-            <p className="text-gray-300 text-sm">{i.expertise}</p>
-            <p className="text-gray-400 text-sm">{i.experience}</p>
+            <h3
+              className="text-xl font-semibold cursor-pointer hover:underline"
+              onClick={() => router.push(`/instructors/${i.id}`)}
+            >
+              {i.name}
+            </h3>
+            <div className="flex flex-wrap justify-center gap-2 mt-2 text-sm text-gray-300">
+              {(Array.isArray(i.expertise) ? i.expertise : [i.expertise]).map((exp, idx) => (
+                <span key={idx} className="bg-gray-700 px-2 py-1 rounded">
+                  {exp}
+                </span>
+              ))}
+            </div>
+            <p className="text-gray-400 text-sm mt-1">{i.experience}</p>
             <div className="flex items-center justify-center gap-1 mt-2">
               {Array.from({ length: 5 }).map((_, idx) => (
                 <FaStar
@@ -199,13 +214,6 @@ export default function InstructorBooking() {
                 />
               ))}
               <span className="text-sm text-gray-300">({i.rating})</span>
-            </div>
-            <div className="flex flex-wrap justify-center gap-2 mt-2">
-              {i.tags.map((tag, idx) => (
-                <span key={idx} className="bg-yellow-700 text-xs px-2 py-1 rounded-full text-white">
-                  {tag}
-                </span>
-              ))}
             </div>
             <div className="flex gap-3 mt-4">
               <button

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -40,6 +40,12 @@ const instructorProfileSchema = z.object({
   pricing_amount: z.number().min(0, "Amount must be positive").optional(),
   pricing_currency: z.string().optional(),
   expertise: z.array(z.string()).optional(),
+  bio: z
+    .string()
+    .optional()
+    .refine((val) => !val || val.split(/\s+/).filter(Boolean).length <= 150, {
+      message: "Bio must be 150 words or fewer",
+    }),
   socialLinks: z
     .record(z.union([z.literal(""), z.string().url("Must be a valid URL")]))
     .optional(),
@@ -79,6 +85,7 @@ export default function InstructorProfileEdit() {
     pricing_amount: undefined,
     pricing_currency: "USD",
     expertise: [],
+    bio: "",
     socialLinks: {},
     certificates: [],
     avatarPreview: null,
@@ -140,6 +147,7 @@ export default function InstructorProfileEdit() {
           pricing_amount,
           pricing_currency,
           expertise: instructor?.expertise || [],
+          bio: instructor?.bio || "",
           socialLinks: socialMap,
           certificates: certificates || [],
           avatarPreview: avatar_url ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${avatar_url}` : null,
@@ -283,6 +291,7 @@ export default function InstructorProfileEdit() {
         gender: formData.gender,
         date_of_birth: formData.date_of_birth,
         experience: formData.experience,
+        bio: formData.bio,
         availability: formData.availability ? "available" : "unavailable",
         pricing,
         expertise: formData.expertise,
@@ -308,6 +317,7 @@ export default function InstructorProfileEdit() {
         ...prev,
         expertise: fresh.instructor?.expertise || [],
         experience: fresh.instructor?.experience || 0,
+        bio: fresh.instructor?.bio || "",
         availability: fresh.instructor?.availability === "available",
         pricing_amount: fresh.instructor?.pricing
           ? (() => {
@@ -520,13 +530,25 @@ export default function InstructorProfileEdit() {
                 onChange={(e) => setFormData({ ...formData, date_of_birth: e.target.value })}
                 className={`w-full px-4 py-2 border ${errors.date_of_birth ? 'border-red-500' : 'border-gray-300'} rounded-md focus:ring-yellow-500 focus:border-yellow-500`}
               />
-              {errors.date_of_birth && <p className="text-sm text-red-600 mt-1">{errors.date_of_birth}</p>}
-            </div>
-          </div>
+          {errors.date_of_birth && <p className="text-sm text-red-600 mt-1">{errors.date_of_birth}</p>}
+        </div>
+      </div>
 
-          <h2 className="text-xl font-semibold text-gray-800 border-b pb-2 mt-8">
-            Professional Information
-          </h2>
+      <div className="mt-6">
+        <label className="block text-sm font-medium mb-1">Bio (max 150 words)</label>
+        <textarea
+          name="bio"
+          value={formData.bio}
+          onChange={(e) => setFormData({ ...formData, bio: e.target.value })}
+          rows={4}
+          className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-yellow-500 focus:border-yellow-500"
+        />
+        {errors.bio && <p className="text-sm text-red-600 mt-1">{errors.bio}</p>}
+      </div>
+
+      <h2 className="text-xl font-semibold text-gray-800 border-b pb-2 mt-8">
+        Professional Information
+      </h2>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>

--- a/frontend/src/pages/instructors/[id].js
+++ b/frontend/src/pages/instructors/[id].js
@@ -114,6 +114,9 @@ export default function InstructorProfilePage() {
           <p className="text-gray-700">
             {instructor.expertise} {instructor.experience ? `· ${instructor.experience}` : ""}
           </p>
+          {instructor.bio && (
+            <p className="text-gray-700 mt-2 whitespace-pre-line">{instructor.bio}</p>
+          )}
           {instructor.pricing && (
             <p className="text-gray-700 mt-2">Pricing: {instructor.pricing}</p>
           )}


### PR DESCRIPTION
## Summary
- style instructor expertise tags and show offline status
- display instructor bio on profile page
- add bio support to instructor profile editing form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d106552448328bb81ba85d8963c2d