### PR TITLE
Implement class publication and notifications

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -16,6 +16,9 @@ jest.mock('../class.service', () => ({
   getClassesByInstructor: jest.fn()
 }));
 const service = require('../class.service');
+jest.mock('../../notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
 // Mock enrollment service to avoid DB calls when routes are loaded
 jest.mock('../enrollments/classEnrollment.service', () => ({
   findEnrollment: jest.fn(),
@@ -52,7 +55,7 @@ describe('Class routes', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toEqual(data);
     expect(service.createClass).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 'draft' })
+      expect.objectContaining({ status: 'published' })
     );
   });
 

--- a/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
+++ b/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
@@ -16,8 +16,13 @@ jest.mock('../classLesson.service', () => ({
   createLesson: jest.fn(),
   updateLesson: jest.fn(),
   deleteLesson: jest.fn(),
+  getById: jest.fn(),
 }));
 const service = require('../classLesson.service');
+jest.mock('../../class.service', () => ({
+  getClassById: jest.fn(() => ({ start_date: '2024-01-01', end_date: '2024-01-31' }))
+}));
+const classService = require('../../class.service');
 
 jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
@@ -50,16 +55,17 @@ describe('Class lesson routes', () => {
     service.createLesson.mockResolvedValue({ id: '1' });
     const res = await request(app)
       .post('/classes/lessons/class/abc')
-      .send({ title: 'New Lesson' });
+      .send({ title: 'New Lesson', start_time: '2024-01-10T10:00:00Z' });
     expect(res.statusCode).toBe(200);
     expect(service.createLesson).toHaveBeenCalled();
   });
 
   test('update lesson', async () => {
     service.updateLesson.mockResolvedValue({ id: '1' });
+    service.getById.mockResolvedValue({ id: '1', class_id: 'abc' });
     const res = await request(app)
       .put('/classes/lessons/1')
-      .send({ title: 'Edit' });
+      .send({ title: 'Edit', start_time: '2024-01-20T10:00:00Z' });
     expect(res.statusCode).toBe(200);
     expect(service.updateLesson).toHaveBeenCalled();
   });

--- a/backend/src/modules/classes/lessons/classLesson.controller.js
+++ b/backend/src/modules/classes/lessons/classLesson.controller.js
@@ -2,6 +2,8 @@ const { v4: uuidv4 } = require("uuid");
 const catchAsync = require("../../../utils/catchAsync");
 const { sendSuccess } = require("../../../utils/response");
 const service = require("./classLesson.service");
+const classService = require("../class.service");
+const AppError = require("../../../utils/AppError");
 
 exports.getLessonsByClass = catchAsync(async (req, res) => {
   const lessons = await service.getByClass(req.params.classId);
@@ -9,6 +11,16 @@ exports.getLessonsByClass = catchAsync(async (req, res) => {
 });
 
 exports.createLesson = catchAsync(async (req, res) => {
+  const cls = await classService.getClassById(req.params.classId);
+  if (!cls) throw new AppError("Class not found", 404);
+  if (!req.body.start_time) throw new AppError("start_time is required", 400);
+  const start = new Date(req.body.start_time);
+  if (
+    (cls.start_date && start < new Date(cls.start_date)) ||
+    (cls.end_date && start > new Date(cls.end_date))
+  ) {
+    throw new AppError("Lesson start_time must be within class date range", 400);
+  }
   const data = {
     ...req.body,
     id: uuidv4(),
@@ -19,6 +31,17 @@ exports.createLesson = catchAsync(async (req, res) => {
 });
 
 exports.updateLesson = catchAsync(async (req, res) => {
+  if (req.body.start_time) {
+    const existing = await service.getById(req.params.lessonId);
+    const cls = await classService.getClassById(existing.class_id);
+    const start = new Date(req.body.start_time);
+    if (
+      (cls.start_date && start < new Date(cls.start_date)) ||
+      (cls.end_date && start > new Date(cls.end_date))
+    ) {
+      throw new AppError("Lesson start_time must be within class date range", 400);
+    }
+  }
   const lesson = await service.updateLesson(req.params.lessonId, req.body);
   sendSuccess(res, lesson, "Lesson updated");
 });

--- a/backend/src/modules/classes/lessons/classLesson.service.js
+++ b/backend/src/modules/classes/lessons/classLesson.service.js
@@ -9,6 +9,10 @@ exports.createLesson = async (data) => {
   return row;
 };
 
+exports.getById = async (id) => {
+  return db("class_lessons").where({ id }).first();
+};
+
 exports.updateLesson = async (id, data) => {
   const [row] = await db("class_lessons").where({ id }).update(data).returning("*");
   return row;


### PR DESCRIPTION
## Summary
- let instructors mark classes as published when creating
- notify instructors on class creation, approval, and deletion
- validate lesson start times and provide helper to fetch lessons
- update associated tests

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685d367374048328b4813c845a6aec37