### PR TITLE
Notify instructors on admin actions

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -284,31 +284,31 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
                   <button title="Approve Class"
                     onClick={() => handleStatusChange(cls.id, 'approve')}
                     className="bg-green-500 hover:bg-green-600 text-white text-xs px-2 py-1 rounded shadow">
-                    <FaCheck />
+                    <FaCheck className="w-4 h-4" />
                   </button>
                   <button title="Reject Class"
                     onClick={() => { setModalClass(cls); setModalType('reject'); setRejectionReason(''); }}
                     className="bg-red-500 hover:bg-red-600 text-white text-xs px-2 py-1 rounded shadow">
-                    <FaTimes />
+                    <FaTimes className="w-4 h-4" />
                   </button>
                   <Link href={`/dashboard/admin/online-classes/edit/${cls.id}`} title="Manage Class">
                     <button className="bg-blue-500 hover:bg-blue-600 text-white text-xs px-2 py-1 rounded shadow">
-                      <FaEdit />
+                      <FaEdit className="w-4 h-4" />
                     </button>
                   </Link>
                   <button title="Delete Class"
                     onClick={() => { setModalClass(cls); setModalType('delete'); }}
                     className="bg-gray-600 hover:bg-gray-700 text-white text-xs px-2 py-1 rounded shadow">
-                    <FaTrash />
+                    <FaTrash className="w-4 h-4" />
                   </button>
                   <Link href={`/dashboard/admin/online-classes/${cls.id}/students`} title="View Enrolled Students">
                     <button className="bg-indigo-500 hover:bg-indigo-600 text-white text-xs px-2 py-1 rounded shadow">
-                      <FaUserGraduate />
+                      <FaUserGraduate className="w-4 h-4" />
                     </button>
                   </Link>
                   <Link href={`/dashboard/admin/online-classes/${cls.id}`} title="View Class Details">
                     <button className="bg-yellow-500 hover:bg-yellow-600 text-white text-xs px-2 py-1 rounded shadow">
-                      <FaCalendarAlt />
+                      <FaCalendarAlt className="w-4 h-4" />
                     </button>
                   </Link>
                   <Link href={`/dashboard/admin/online-classes/${cls.id}/analytics`}>
@@ -316,7 +316,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
                       title="View Analytics"
                       className="bg-purple-500 hover:bg-yellow-600 text-white text-xs px-2 py-1 rounded shadow"
                     >
-                      <FaChartBar /> Analytics
+                      <FaChartBar className="w-4 h-4" /> Analytics
                     </button>
                   </Link>
 

--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -511,7 +511,7 @@ function CreateOnlineClass() {
                         }}
                         className="text-red-600 text-sm flex items-center gap-1 hover:underline"
                       >
-                        <FaTrash /> Remove
+                        <FaTrash className="w-4 h-4" /> Remove
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- send notifications to instructors when admins update, change status or reject classes
- standardize admin online class action icon sizes

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_685d858f3b6c8328b97f73c334887a2d