### PR TITLE
Use custom player on instructor class details

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { fetchInstructorClassById } from "@/services/instructor/classService";
+import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
 
 export default function InstructorClassDetailPage() {
   const { id } = useRouter().query;
@@ -42,9 +43,9 @@ export default function InstructorClassDetailPage() {
             <img src={details.cover_image} alt="Class Cover" className="w-full h-64 object-cover rounded-lg" />
           )}
           {details?.demo_video_url && (
-            <video controls className="w-full mt-4 rounded-lg">
-              <source src={encodeURI(details.demo_video_url)} />
-            </video>
+            <div className="mt-4">
+              <CustomVideoPlayer videos={[{ src: encodeURI(details.demo_video_url) }]} />
+            </div>
           )}
 
           <div className="space-y-1 flex items-center gap-4">


### PR DESCRIPTION
## Summary
- use `CustomVideoPlayer` on instructor class details page

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685d959f75f88328ae46f3df9ee1a1a3