### PR TITLE
Update instructor class features

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
@@ -91,6 +91,12 @@ export default function InstructorClassDetailPage() {
             >
               🚀 Manage Class
             </Link>
+            <Link
+              href={`/dashboard/instructor/online-classes/${id}/edit`}
+              className="bg-gray-700 text-white px-4 py-2 rounded shadow hover:bg-gray-800 text-sm"
+            >
+              ✏️ Edit Class
+            </Link>
           </div>
         </div>
       )}

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/edit.js
@@ -1,0 +1,68 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import InstructorLayout from '@/components/layouts/InstructorLayout';
+import FloatingInput from '@/components/shared/FloatingInput';
+import { fetchInstructorClassById, updateInstructorClass } from '@/services/instructor/classService';
+
+export default function EditInstructorClass() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [formData, setFormData] = useState({ title: '', start_date: '', end_date: '' });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchInstructorClassById(id);
+        if (data) {
+          setFormData({
+            title: data.title || '',
+            start_date: data.start_date || '',
+            end_date: data.end_date || '',
+          });
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!id) return;
+    const payload = new FormData();
+    payload.append('title', formData.title);
+    if (formData.start_date) payload.append('start_date', formData.start_date);
+    if (formData.end_date) payload.append('end_date', formData.end_date);
+    await updateInstructorClass(id, payload);
+    router.push(`/dashboard/instructor/online-classes/${id}/details`);
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Edit Class</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4 max-w-lg">
+          <FloatingInput label="Title" name="title" value={formData.title} onChange={handleChange} />
+          <FloatingInput label="Start Date" type="date" name="start_date" value={formData.start_date} onChange={handleChange} />
+          <FloatingInput label="End Date" type="date" name="end_date" value={formData.end_date} onChange={handleChange} />
+          <button type="submit" className="bg-yellow-500 text-black px-4 py-2 rounded">Save</button>
+        </form>
+      )}
+    </div>
+  );
+}
+
+EditInstructorClass.getLayout = function getLayout(page) {
+  return <InstructorLayout>{page}</InstructorLayout>;
+};

--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -14,6 +14,7 @@ import { fetchAllCategories } from '@/services/instructor/categoryService';
 import { createInstructorClass, createClassLesson } from '@/services/instructor/classService';
 import { fetchClassTags } from '@/services/instructor/classTagService';
 import useAuthStore from '@/store/auth/authStore';
+import useScheduleStore from '@/store/schedule/scheduleStore';
 import FloatingInput from '@/components/shared/FloatingInput';
 
 const ReactQuill = dynamic(() => import('react-quill'), {
@@ -25,6 +26,7 @@ import 'react-quill/dist/quill.snow.css';
 function CreateOnlineClass() {
   const router = useRouter();
   const { user } = useAuthStore();
+  const addEvents = useScheduleStore((state) => state.addEvents);
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     title: '',
@@ -234,6 +236,20 @@ function CreateOnlineClass() {
             return createClassLesson(newClass.id, lessonData).catch(() => null);
           })
         );
+
+        const events = [
+          {
+            id: `class-${newClass.id}`,
+            title: `Class: ${newClass.title}`,
+            start: formData.startDate || newClass.start_date,
+          },
+          ...formData.lessons.map((l, idx) => ({
+            id: `lesson-${newClass.id}-${idx}`,
+            title: `Lesson: ${l.title}`,
+            start: l.start_time,
+          })),
+        ];
+        addEvents(events);
 
         toast.success('Class created successfully');
         router.push('/dashboard/instructor/online-classes');

--- a/frontend/src/pages/dashboard/instructor/online-classes/index.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/index.js
@@ -4,6 +4,7 @@ import {
   FaCalendarAlt,
   FaChalkboardTeacher,
   FaClock,
+  FaVideo,
 } from "react-icons/fa";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { fetchInstructorClasses } from "@/services/instructor/classService";
@@ -149,9 +150,15 @@ export default function MyClasses() {
               </div>
               <Link
                 href={`/dashboard/instructor/online-classes/${cls.id}`}
-                className="block bg-yellow-500 text-black text-center py-2 px-4 rounded hover:bg-yellow-600 font-semibold"
+                className="block bg-yellow-500 text-black text-center py-2 px-4 rounded hover:bg-yellow-600 font-semibold flex items-center justify-center gap-2"
               >
-                Manage Class
+                {cls.scheduleStatus === 'Ongoing' ? (
+                  <>
+                    <FaVideo /> Go To Class
+                  </>
+                ) : (
+                  'Manage Class'
+                )}
               </Link>
               <Link
                 href={`/dashboard/instructor/online-classes/${cls.id}/details`}

--- a/frontend/src/pages/dashboard/instructor/schedule.js
+++ b/frontend/src/pages/dashboard/instructor/schedule.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import CalendarView from "@/components/shared/CalendarView";
+import useScheduleStore from "@/store/schedule/scheduleStore";
 
 const mockBookings = [
   {
@@ -92,6 +93,7 @@ const mockBookings = [
 
 
 export default function InstructorSchedule() {
+  const scheduleEvents = useScheduleStore((state) => state.events);
   const [events, setEvents] = useState([]);
 
   useEffect(() => {
@@ -107,8 +109,8 @@ export default function InstructorSchedule() {
         }
       }));
 
-    setEvents(confirmed);
-  }, []);
+    setEvents([...confirmed, ...scheduleEvents]);
+  }, [scheduleEvents]);
 
   return (
     <InstructorLayout>
@@ -116,7 +118,13 @@ export default function InstructorSchedule() {
         title="My Teaching Schedule"
         events={events}
         onEventClick={(info) => {
-          alert(`📚 ${info.event.extendedProps.subject}\n👤 Student: ${info.event.extendedProps.student}`);
+          const sub = info.event.extendedProps?.subject;
+          const student = info.event.extendedProps?.student;
+          if (sub && student) {
+            alert(`📚 ${sub}\n👤 Student: ${student}`);
+          } else {
+            alert(info.event.title);
+          }
         }}
       />
     </InstructorLayout>

--- a/frontend/src/store/schedule/scheduleStore.js
+++ b/frontend/src/store/schedule/scheduleStore.js
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+const useScheduleStore = create(
+  persist(
+    (set, get) => ({
+      events: [],
+      addEvents: (items) =>
+        set((state) => ({ events: [...state.events, ...items] })),
+      clear: () => set({ events: [] }),
+    }),
+    { name: "schedule-store" }
+  )
+);
+
+export default useScheduleStore;


### PR DESCRIPTION
## Summary
- track schedule data in a new zustand store
- sync class creation with the schedule
- show "Go To Class" when a class is ongoing
- allow editing classes from the details page
- add an edit page for instructor classes

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d958441f883288673e5fb58f4d334