### PR TITLE
Fix lesson upload field mismatch

### DIFF
--- a/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
+++ b/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
@@ -60,6 +60,17 @@ describe('Class lesson routes', () => {
     expect(service.createLesson).toHaveBeenCalled();
   });
 
+  test('create lesson with resource file', async () => {
+    service.createLesson.mockResolvedValue({ id: '1' });
+    const res = await request(app)
+      .post('/classes/lessons/class/abc')
+      .field('title', 'File Lesson')
+      .field('start_time', '2024-01-10T10:00:00Z')
+      .attach('resource', Buffer.from('test'), 'test.pdf');
+    expect(res.statusCode).toBe(200);
+    expect(service.createLesson).toHaveBeenCalled();
+  });
+
   test('update lesson', async () => {
     service.updateLesson.mockResolvedValue({ id: '1' });
     service.getById.mockResolvedValue({ id: '1', class_id: 'abc' });

--- a/backend/src/modules/classes/lessons/classLessonUploadMiddleware.js
+++ b/backend/src/modules/classes/lessons/classLessonUploadMiddleware.js
@@ -16,4 +16,19 @@ const storage = multer.diskStorage({
   },
 });
 
-module.exports = multer({ storage }).single('lesson_topic');
+const uploader = multer({ storage }).fields([
+  { name: 'lesson_topic', maxCount: 1 },
+  { name: 'resource', maxCount: 1 },
+]);
+
+module.exports = (req, res, next) => {
+  uploader(req, res, (err) => {
+    if (err) return next(err);
+    if (req.files?.lesson_topic?.[0]) {
+      req.file = req.files.lesson_topic[0];
+    } else if (req.files?.resource?.[0]) {
+      req.file = req.files.resource[0];
+    }
+    next();
+  });
+};


### PR DESCRIPTION
## Summary
- accept `resource` as an alternate field name when uploading lesson files
- test lesson creation using the `resource` field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d98646a888328b8cce31278384f85