### PR TITLE
Fix instructor schedule page build error

### DIFF
--- a/frontend/src/pages/dashboard/instructor/schedule.js
+++ b/frontend/src/pages/dashboard/instructor/schedule.js
@@ -1,18 +1,16 @@
 import { useEffect, useState } from "react";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import CalendarView from "@/components/shared/CalendarView";
-import useScheduleStore from "@/store/schedule/scheduleStore";
+import { fetchInstructorScheduleEvents } from "@/services/instructor/classService";
 import useScheduleStore from "@/store/schedule/scheduleStore";
 
 export default function InstructorSchedule() {
-  const scheduleEvents = useScheduleStore((state) => state.events);
-  const [events, setEvents] = useState([]);
-
+  const { events, clear, addEvents } = useScheduleStore();
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const load = async () => {
       try {
-
         setLoading(true);
         const data = await fetchInstructorScheduleEvents();
         clear();
@@ -25,10 +23,6 @@ export default function InstructorSchedule() {
     };
     load();
   }, [clear, addEvents]);
-
-
-    setEvents([...confirmed, ...scheduleEvents]);
-  }, [scheduleEvents]);
 
 
   return (


### PR DESCRIPTION
## Summary
- repair instructor schedule page and resolve syntax error
- replace duplicate imports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9e72800c83289e1d5197c98634b9