### PR TITLE
Add admin-configurable social login

### DIFF
--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.controller.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.controller.js
@@ -1,0 +1,13 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./socialLoginConfig.service");
+
+exports.getSettings = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings || {});
+});
+
+exports.updateSettings = catchAsync(async (req, res) => {
+  const settings = await service.updateSettings(req.body);
+  sendSuccess(res, settings, "Settings updated");
+});

--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.routes.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.routes.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./socialLoginConfig.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.getSettings);
+router.use(verifyToken, isAdmin);
+router.put("/", controller.updateSettings);
+
+module.exports = router;

--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.service.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.service.js
@@ -1,0 +1,26 @@
+const db = require("../../config/database");
+
+const SETTINGS_KEY = "social_login_settings";
+
+exports.getSettings = async () => {
+  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (!row) return null;
+  try {
+    return JSON.parse(row.value);
+  } catch (_err) {
+    return null;
+  }
+};
+
+exports.updateSettings = async (settings) => {
+  const value = JSON.stringify(settings);
+  const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (existing) {
+    await db("settings")
+      .where({ key: SETTINGS_KEY })
+      .update({ value, updated_at: db.fn.now() });
+  } else {
+    await db("settings").insert({ key: SETTINGS_KEY, value });
+  }
+  return settings;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -71,6 +71,7 @@ const publicInstructorRoutes = require("./modules/instructors/instructor.routes"
 const cartRoutes = require("./modules/cart/cart.routes");
 const notificationRoutes = require("./modules/notifications/notifications.routes");
 const messageRoutes = require("./modules/messages/messages.routes");
+const socialLoginConfigRoutes = require("./modules/socialLoginConfig/socialLoginConfig.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -137,6 +138,7 @@ app.use("/api/payment-methods", paymentMethodsPublicRoutes); // 💳 Public paym
 app.use("/api/payments/admin", paymentRoutes); // 💵 Payments management
 app.use("/api/payment-methods/admin", paymentMethodRoutes); // 💳 Payment methods
 app.use("/api/payments/config", paymentConfigRoutes); // ⚙️ Payment settings
+app.use("/api/social-login/config", socialLoginConfigRoutes); // 🔑 Social login settings
 app.use("/api/payouts/admin", payoutRoutes); // 🏦 Instructor payouts
 app.use("/api/ads", adsRoutes); // 📢 Advertisements
 app.use("/api/instructors", publicInstructorRoutes); // 📚 Public instructor listing

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -178,8 +178,6 @@ export default function Login() {
           </motion.button>
         </form>
 
-        <div className="mt-4 text-center text-gray-500 text-sm">or continue with</div>
-
         <SocialLogin />
 
         <p className="text-center mt-6 text-gray-400 text-sm">

--- a/frontend/src/pages/auth/register.js
+++ b/frontend/src/pages/auth/register.js
@@ -171,7 +171,6 @@ export default function Register() {
         </motion.button>
 
         {/* ✅ Social Login + Footer */}
-        <div className="mt-6 text-center text-gray-400 text-sm">or continue with</div>
         <SocialRegister />
 
         <p className="text-center mt-6 text-gray-400 text-sm">

--- a/frontend/src/services/admin/socialLoginConfigService.js
+++ b/frontend/src/services/admin/socialLoginConfigService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchSocialLoginConfig = async () => {
+  const { data } = await api.get("/social-login/config");
+  return data?.data ?? null;
+};
+
+export const updateSocialLoginConfig = async (payload) => {
+  const { data } = await api.put("/social-login/config", payload);
+  return data?.data;
+};

--- a/frontend/src/services/socialLoginService.js
+++ b/frontend/src/services/socialLoginService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const fetchSocialLoginConfig = async () => {
+  const { data } = await api.get("/social-login/config");
+  return data?.data ?? null;
+};

--- a/frontend/src/shared/components/auth/SocialLogin.js
+++ b/frontend/src/shared/components/auth/SocialLogin.js
@@ -1,30 +1,40 @@
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaGoogle, FaFacebook, FaApple } from "react-icons/fa";
+import { fetchSocialLoginConfig } from "@/services/socialLoginService";
+
+const iconMap = { google: FaGoogle, facebook: FaFacebook, apple: FaApple };
 
 export default function SocialLogin() {
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    fetchSocialLoginConfig().then(setConfig).catch(() => {});
+  }, []);
+
+  if (!config?.enabled) return null;
+
+  const activeProviders = Object.entries(config.providers || {}).filter(([, p]) => p.active);
+  if (activeProviders.length === 0) return null;
+
   return (
-    <div className="mt-4 flex space-x-4">
-      <motion.button
-        whileHover={{ scale: 1.1 }}
-        transition={{ duration: 0.3 }}
-        className="w-14 h-14 flex items-center justify-center bg-yellow-500 text-white rounded-full hover:bg-yellow-600 transition"
-      >
-        <FaGoogle size={28} />
-      </motion.button>
-      <motion.button
-        whileHover={{ scale: 1.1 }}
-        transition={{ duration: 0.3 }}
-        className="w-14 h-14 flex items-center justify-center bg-yellow-500 text-white rounded-full hover:bg-yellow-600 transition"
-      >
-        <FaFacebook size={28} />
-      </motion.button>
-      <motion.button
-        whileHover={{ scale: 1.1 }}
-        transition={{ duration: 0.3 }}
-        className="w-14 h-14 flex items-center justify-center bg-yellow-500 text-white rounded-full hover:bg-yellow-600 transition"
-      >
-        <FaApple size={28} />
-      </motion.button>
-    </div>
+    <>
+      <div className="mt-4 text-center text-gray-500 text-sm">or continue with</div>
+      <div className="mt-2 flex space-x-4 justify-center">
+        {activeProviders.map(([key, p]) => {
+          const Icon = iconMap[p.icon] || iconMap[key] || FaGoogle;
+          return (
+            <motion.button
+              key={key}
+              whileHover={{ scale: 1.1 }}
+              transition={{ duration: 0.3 }}
+              className="w-14 h-14 flex items-center justify-center bg-yellow-500 text-white rounded-full hover:bg-yellow-600 transition"
+            >
+              <Icon size={28} />
+            </motion.button>
+          );
+        })}
+      </div>
+    </>
   );
 }

--- a/frontend/src/shared/components/auth/SocialRegister.js
+++ b/frontend/src/shared/components/auth/SocialRegister.js
@@ -1,31 +1,40 @@
 // 📁 src/shared/components/auth/SocialRegister.js
+import { useState, useEffect } from "react";
 import { FaGoogle, FaFacebook, FaApple } from "react-icons/fa";
 import { motion } from "framer-motion";
+import { fetchSocialLoginConfig } from "@/services/socialLoginService";
 
-const providers = [
-  { name: "Google", icon: FaGoogle },
-  { name: "Facebook", icon: FaFacebook },
-  { name: "Apple", icon: FaApple },
-];
+const iconMap = { google: FaGoogle, facebook: FaFacebook, apple: FaApple };
 
 export default function SocialRegister() {
-  const handleSocialClick = (provider) => {
-    console.log(`🔐 Sign up with ${provider}`);
-    alert(`Simulate OAuth with ${provider}`);
-  };
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    fetchSocialLoginConfig().then(setConfig).catch(() => {});
+  }, []);
+
+  if (!config?.enabled) return null;
+
+  const activeProviders = Object.entries(config.providers || {}).filter(([, p]) => p.active);
+  if (activeProviders.length === 0) return null;
 
   return (
-    <div className="mt-4 flex space-x-4 w-full justify-center">
-      {providers.map(({ name, icon: Icon }) => (
-        <motion.button
-          key={name}
-          whileHover={{ scale: 1.1 }}
-          className="w-14 h-14 flex items-center justify-center bg-yellow-500 text-white rounded-full hover:bg-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-400 transition"
-          onClick={() => handleSocialClick(name)}
-        >
-          <Icon size={28} />
-        </motion.button>
-      ))}
-    </div>
+    <>
+      <div className="mt-6 text-center text-gray-400 text-sm">or continue with</div>
+      <div className="mt-2 flex space-x-4 w-full justify-center">
+        {activeProviders.map(([key, p]) => {
+          const Icon = iconMap[p.icon] || iconMap[key] || FaGoogle;
+          return (
+            <motion.button
+              key={key}
+              whileHover={{ scale: 1.1 }}
+              className="w-14 h-14 flex items-center justify-center bg-yellow-500 text-white rounded-full hover:bg-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-400 transition"
+            >
+              <Icon size={28} />
+            </motion.button>
+          );
+        })}
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add social login config API
- show social login buttons based on saved settings
- allow admins to configure social login providers

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*
- `npm run lint` in `frontend` *(fails: cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_685dbe2162c88328bd9d72a956243798