### PR TITLE
Fix notification links and show relative time

### DIFF
--- a/frontend/src/components/chat/ChatNotifications.js
+++ b/frontend/src/components/chat/ChatNotifications.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { FaEnvelopeOpenText, FaUsers, FaBell } from "react-icons/fa";
 import { getNotifications } from "@/services/notificationService";
+import formatRelativeTime from "@/utils/relativeTime";
 
 const ChatNotifications = ({ users = [], groups = [], setSelectedChat, userId = 1 }) => {
   const [systemNotifs, setSystemNotifs] = useState([]);
@@ -42,7 +43,7 @@ const ChatNotifications = ({ users = [], groups = [], setSelectedChat, userId = 
             {systemNotifs.map((n) => (
               <li key={n.id} className="bg-gray-700 p-3 rounded-lg border-l-4 border-yellow-500">
                 <div className="text-sm">{n.message}</div>
-                <div className="text-xs text-gray-400">{new Date(n.timestamp).toLocaleString()}</div>
+                <div className="text-xs text-gray-400">{formatRelativeTime(n.timestamp)}</div>
               </li>
             ))}
           </ul>

--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import formatRelativeTime from "@/utils/relativeTime";
 import ChatHeader from "./ChatHeader";
 import MessageInput from "./MessageInput";
 import { FaCheckDouble, FaThumbtack, FaReply, FaTrash } from "react-icons/fa";
@@ -36,7 +37,10 @@ const ChatWindow = ({ selectedChat, onStartVideoCall }) => {
       setReplyingTo(null);
     }
 
-    setMessages((prev) => [...prev, { ...newMessage, timestamp: new Date().toLocaleTimeString() }]);
+    setMessages((prev) => [
+      ...prev,
+      { ...newMessage, timestamp: new Date().toISOString() },
+    ]);
     setTyping(false);
     toast.success("Message sent!");
   };
@@ -122,7 +126,7 @@ const ChatWindow = ({ selectedChat, onStartVideoCall }) => {
 
           {/* Meta info + actions */}
           <div className="flex justify-between items-center text-[10px] text-gray-300 mt-1">
-            <span className="whitespace-nowrap">{msg.timestamp}</span>
+            <span className="whitespace-nowrap">{formatRelativeTime(msg.timestamp)}</span>
             <div className="flex items-center gap-2 ml-2">
               <FaCheckDouble
                 className={`${

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -270,7 +270,9 @@ const Navbar = () => {
                     <Link
                       href={
                         userRole
-                          ? `/dashboard/${userRole}/notifications`
+                          ? userRole === "superadmin"
+                            ? "/dashboard/admin/notifications"
+                            : `/dashboard/${userRole}/notifications`
                           : "/notifications"
                       }
                       className="text-blue-600 hover:underline text-sm"

--- a/frontend/src/pages/dashboard/admin/notifications/index.js
+++ b/frontend/src/pages/dashboard/admin/notifications/index.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import formatRelativeTime from '@/utils/relativeTime';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaBell, FaCalendarAlt, FaChalkboardTeacher, FaCheckCircle, FaTimes } from 'react-icons/fa';
 import useNotificationStore from '@/store/notifications/notificationStore';
@@ -82,7 +83,7 @@ export default function AdminNotificationsPage() {
                   <div>
                     <p className="text-sm mb-1 leading-relaxed font-medium">{note.message}</p>
                     <p className="text-xs text-gray-500 flex items-center gap-1">
-                      <FaCalendarAlt /> {new Date(note.date).toLocaleString()}
+                      <FaCalendarAlt /> {formatRelativeTime(note.date)}
                     </p>
                   </div>
                 </div>

--- a/frontend/src/pages/dashboard/instructor/notifications/index.js
+++ b/frontend/src/pages/dashboard/instructor/notifications/index.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import formatRelativeTime from '@/utils/relativeTime';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { FaBell, FaCalendarAlt, FaChalkboardTeacher, FaCheckCircle, FaTimes } from 'react-icons/fa';
 import useNotificationStore from '@/store/notifications/notificationStore';
@@ -82,7 +83,7 @@ export default function InstructorNotificationsPage() {
                   <div>
                     <p className="text-sm mb-1 leading-relaxed font-medium">{note.message}</p>
                     <p className="text-xs text-gray-500 flex items-center gap-1">
-                      <FaCalendarAlt /> {new Date(note.date).toLocaleString()}
+                      <FaCalendarAlt /> {formatRelativeTime(note.date)}
                     </p>
                   </div>
                 </div>

--- a/frontend/src/pages/dashboard/student/notifications/index.js
+++ b/frontend/src/pages/dashboard/student/notifications/index.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import formatRelativeTime from '@/utils/relativeTime';
 import StudentLayout from '@/components/layouts/StudentLayout';
 import { FaBell, FaCalendarAlt, FaChalkboardTeacher, FaCheckCircle, FaTimes } from 'react-icons/fa';
 import useNotificationStore from '@/store/notifications/notificationStore';
@@ -82,7 +83,7 @@ export default function StudentNotificationsPage() {
                   <div>
                     <p className="text-sm mb-1 leading-relaxed font-medium">{note.message}</p>
                     <p className="text-xs text-gray-500 flex items-center gap-1">
-                      <FaCalendarAlt /> {new Date(note.date).toLocaleString()}
+                      <FaCalendarAlt /> {formatRelativeTime(note.date)}
                     </p>
                   </div>
                 </div>

--- a/frontend/src/pages/messages/group.js
+++ b/frontend/src/pages/messages/group.js
@@ -1,6 +1,7 @@
 import Navbar from "@/components/website/sections/Navbar";
 import { useState } from "react";
 import { motion } from "framer-motion";
+import formatRelativeTime from "@/utils/relativeTime";
 import { FaUsers, FaPlus, FaComments, FaPaperPlane } from "react-icons/fa";
 
 const GroupChat = () => {
@@ -50,7 +51,7 @@ const GroupChat = () => {
                 >
                   <p className="text-yellow-400 font-semibold">{msg.sender}</p>
                   <p>{msg.text}</p>
-                  <p className="text-sm text-gray-400">{new Date(msg.timestamp).toLocaleTimeString()}</p>
+                  <p className="text-sm text-gray-400">{formatRelativeTime(msg.timestamp)}</p>
                 </motion.div>
               ))
             )}

--- a/frontend/src/pages/messages/groupChat.js
+++ b/frontend/src/pages/messages/groupChat.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import Navbar from "@/components/website/sections/Navbar";
 import { getGroups, sendGroupMessage } from "@/services/groupService";
 import { motion } from "framer-motion";
+import formatRelativeTime from "@/utils/relativeTime";
 import EmojiPicker from "emoji-picker-react";
 import MessageInput from "./MessageInput";
 
@@ -107,7 +108,7 @@ const GroupChatPage = () => {
                       <strong>{msg.sender}</strong>
                       <p>{msg.text}</p>
                       {msg.file && <img src={msg.file} alt="Attachment" className="w-16 h-16 mt-2 rounded-lg" />}
-                      <p className="text-xs text-gray-400">{new Date(msg.timestamp).toLocaleString()}</p>
+                      <p className="text-xs text-gray-400">{formatRelativeTime(msg.timestamp)}</p>
                     </div>
                   </motion.div>
                 ))}

--- a/frontend/src/utils/relativeTime.js
+++ b/frontend/src/utils/relativeTime.js
@@ -1,0 +1,22 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
+
+export default function formatRelativeTime(dateString) {
+  if (!dateString) return '';
+  const date = dayjs(dateString);
+  if (!date.isValid()) return 'Invalid date';
+  const now = dayjs();
+  const diffMinutes = now.diff(date, 'minute');
+  const diffHours = now.diff(date, 'hour');
+  const diffDays = now.diff(date, 'day');
+  const diffWeeks = now.diff(date, 'week');
+
+  if (diffMinutes < 1) return 'just now';
+  if (diffHours < 1) return `${diffMinutes} minute${diffMinutes !== 1 ? 's' : ''} ago`;
+  if (diffDays < 1) return `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
+  if (diffWeeks < 1) return `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`;
+  if (diffWeeks < 4) return `${diffWeeks} week${diffWeeks !== 1 ? 's' : ''} ago`;
+  return date.format('YYYY-MM-DD');
+}


### PR DESCRIPTION
## Summary
- add `formatRelativeTime` util using dayjs
- use relative timestamps in chat notifications and messages
- update notification pages to display relative times
- fix navbar notification link for superadmin

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbfac67b88328bcc424cee3c1cb0f