### PR TITLE
Improve message center search

### DIFF
--- a/frontend/src/components/chat/ChatSidebar.js
+++ b/frontend/src/components/chat/ChatSidebar.js
@@ -20,7 +20,7 @@ const ChatSidebar = ({
   const [sortedUsers, setSortedUsers] = useState([]);
   const [sortedGroups, setSortedGroups] = useState([]);
   const [searchTerm, setSearchTerm] = useState("");
-  const [searchFilter, setSearchFilter] = useState("name");
+  const [searchFilter, setSearchFilter] = useState("all");
   const [pinnedChats, setPinnedChats] = useState([]);
 
   // ✅ Sort users by online status & last active
@@ -40,7 +40,13 @@ const ChatSidebar = ({
   const filteredUsers = sortedUsers.filter((user) => {
     const term = searchTerm.toLowerCase().trim();
     if (!term) return true;
-    return user.name?.toLowerCase().includes(term);
+
+    const fields = [];
+    if (searchFilter === "name" || searchFilter === "all") fields.push(user.name);
+    if (searchFilter === "email" || searchFilter === "all") fields.push(user.email);
+    if (searchFilter === "phone" || searchFilter === "all") fields.push(user.phone);
+
+    return fields.some((f) => f && f.toLowerCase().includes(term));
   });
 
   // ✅ Function to Pin/Unpin Chats
@@ -62,12 +68,22 @@ const ChatSidebar = ({
           <FaSearch className="text-gray-400 absolute left-3" />
           <input
             type="text"
-            placeholder="Search users..."
+            placeholder="Search by name, email or phone"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="pl-10 pr-3 py-2 bg-gray-700 text-white w-full rounded-md focus:outline-none"
           />
         </div>
+        <select
+          className="bg-gray-700 text-white p-2 rounded-md focus:outline-none"
+          value={searchFilter}
+          onChange={(e) => setSearchFilter(e.target.value)}
+        >
+          <option value="all">All</option>
+          <option value="name">Name</option>
+          <option value="email">Email</option>
+          <option value="phone">Phone</option>
+        </select>
       </div>
 
       {/* 📌 Pinned Chats */}
@@ -141,6 +157,9 @@ const ChatSidebar = ({
             </button>
           </div>
         ))}
+        {filteredUsers.length === 0 && (
+          <p className="text-gray-400 text-center">No chats found.</p>
+        )}
       </div>
 
       {/* 🟢 Suggested Users */}

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import Navbar from "@/components/website/sections/Navbar";
 import ChatSidebar from "@/components/chat/ChatSidebar";
@@ -15,6 +15,7 @@ const MessagesPage = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [filteredGroups, setFilteredGroups] = useState([]);
+  const searchInputRef = useRef(null);
 
   const messages = useMessageStore((state) => state.items);
   const fetchMessages = useMessageStore((state) => state.fetch);
@@ -73,6 +74,7 @@ const MessagesPage = () => {
         <div className="flex items-center bg-gray-700 p-3 rounded-lg mb-6">
           <FaSearch className="text-gray-400 mr-2" />
           <input
+            ref={searchInputRef}
             type="text"
             placeholder="Search users, groups..."
             value={searchTerm}
@@ -99,6 +101,19 @@ const MessagesPage = () => {
                   </li>
                 ))}
               </ul>
+            </div>
+          )}
+          {messages.length === 0 && !selectedChat && (
+            <div className="text-center">
+              <button
+                className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600"
+                onClick={() => {
+                  setSearchTerm("");
+                  searchInputRef.current?.focus();
+                }}
+              >
+                Start New Message
+              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- add search filter dropdown in chat sidebar
- support searching by email or phone
- show message if no chats found
- allow starting a new chat from the messages page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd10bc1308328a13b98fcfa0eb1b0