### PR TITLE
Add basic chat messaging

### DIFF
--- a/backend/src/modules/chat/chat.controller.js
+++ b/backend/src/modules/chat/chat.controller.js
@@ -1,0 +1,30 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
+const service = require("./chat.service");
+
+exports.searchUsers = catchAsync(async (req, res) => {
+  const term = req.query.q || "";
+  const users = await service.searchUsers(term);
+  sendSuccess(res, users);
+});
+
+exports.getConversation = catchAsync(async (req, res) => {
+  const otherId = req.params.userId;
+  const convo = await service.getConversation(req.user.id, otherId);
+  sendSuccess(res, convo);
+});
+
+exports.sendMessage = catchAsync(async (req, res) => {
+  const otherId = req.params.userId;
+  const { message } = req.body || {};
+  if (!message || !message.trim()) {
+    throw new AppError("Message required", 400);
+  }
+  const msg = await service.sendMessage({
+    sender_id: req.user.id,
+    receiver_id: otherId,
+    message: message.trim(),
+  });
+  sendSuccess(res, msg, "Message sent");
+});

--- a/backend/src/modules/chat/chat.routes.js
+++ b/backend/src/modules/chat/chat.routes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./chat.controller");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken);
+
+router.get("/users", controller.searchUsers);
+router.get("/:userId", controller.getConversation);
+router.post("/:userId", controller.sendMessage);
+
+module.exports = router;

--- a/backend/src/modules/chat/chat.service.js
+++ b/backend/src/modules/chat/chat.service.js
@@ -1,0 +1,37 @@
+const db = require("../../config/database");
+
+exports.searchUsers = async (term) => {
+  return db("users")
+    .select(
+      "id",
+      db.raw("COALESCE(full_name, '') as name"),
+      "email",
+      "phone",
+      db.raw("COALESCE(avatar_url, '') as profileImage")
+    )
+    .modify((query) => {
+      if (term) {
+        const t = `%${term}%`;
+        query.where("full_name", "ilike", t)
+          .orWhere("email", "ilike", t)
+          .orWhere("phone", "ilike", t);
+      }
+    })
+    .limit(20);
+};
+
+exports.getConversation = async (userId, otherId) => {
+  return db("messages")
+    .where(function () {
+      this.where({ sender_id: userId, receiver_id: otherId })
+        .orWhere({ sender_id: otherId, receiver_id: userId });
+    })
+    .orderBy("sent_at");
+};
+
+exports.sendMessage = async ({ sender_id, receiver_id, message }) => {
+  const [row] = await db("messages")
+    .insert({ sender_id, receiver_id, message })
+    .returning("*");
+  return row;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -71,6 +71,7 @@ const publicInstructorRoutes = require("./modules/instructors/instructor.routes"
 const cartRoutes = require("./modules/cart/cart.routes");
 const notificationRoutes = require("./modules/notifications/notifications.routes");
 const messageRoutes = require("./modules/messages/messages.routes");
+const chatRoutes = require("./modules/chat/chat.routes");
 const socialLoginConfigRoutes = require("./modules/socialLoginConfig/socialLoginConfig.routes");
 const errorHandler = require("./middleware/errorHandler");
 
@@ -145,6 +146,7 @@ app.use("/api/instructors", publicInstructorRoutes); // 📚 Public instructor l
 app.use("/api/cart", cartRoutes); // 🛒 Shopping cart
 app.use("/api/notifications", notificationRoutes); // 🔔 User notifications
 app.use("/api/messages", messageRoutes); // 💬 User messages
+app.use("/api/chat", chatRoutes); // 💬 Direct chat
 
 // 🩺 Health check (for CI/CD or uptime monitoring)
 app.get("/", (req, res) => {

--- a/frontend/src/components/chat/MessageInput.js
+++ b/frontend/src/components/chat/MessageInput.js
@@ -22,16 +22,7 @@ const MessageInput = ({ sendMessage, replyTo, onCancelReply }) => {
   const handleSend = () => {
     if (!message.trim() && !file && !audioBlob) return;
 
-    const newMessage = {
-      text: message,
-      sender: "You",
-      timestamp: new Date().toLocaleTimeString(),
-      status: "sent",
-      image: file ? URL.createObjectURL(file) : null,
-      audio: audioBlob ? URL.createObjectURL(audioBlob) : null,
-      replyTo: replyTo?.text || null,
-    };
-
+    const newMessage = { text: message };
     sendMessage(newMessage);
     setMessage("");
     setFile(null);

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -22,3 +22,13 @@ export const markMessageAsRead = async (id) => {
   return res.data.data || res.data;
 
 };
+
+export const getConversation = async (userId) => {
+  const res = await api.get(`/chat/${userId}`);
+  return res.data.data || res.data;
+};
+
+export const sendChatMessage = async (userId, message) => {
+  const res = await api.post(`/chat/${userId}`, { message });
+  return res.data.data || res.data;
+};


### PR DESCRIPTION
## Summary
- implement `/api/chat` backend module for direct user messages
- expose chat routes via server
- add conversation APIs to frontend service
- fetch/send chat messages from `ChatWindow`
- update `MessageInput` for server messaging

## Testing
- `npm test --prefix backend` *(fails: command not found)*
- `npm test --prefix frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e82090a148328820bab2ea987eb74