### PR TITLE
Implement basic chat alerts

### DIFF
--- a/backend/src/modules/chat/chat.controller.js
+++ b/backend/src/modules/chat/chat.controller.js
@@ -5,7 +5,7 @@ const service = require("./chat.service");
 
 exports.searchUsers = catchAsync(async (req, res) => {
   const term = req.query.q || "";
-  const users = await service.searchUsers(term);
+  const users = await service.searchUsers(req.user.id, term);
   sendSuccess(res, users);
 });
 

--- a/backend/src/modules/chat/chat.service.js
+++ b/backend/src/modules/chat/chat.service.js
@@ -1,26 +1,41 @@
 const db = require("../../config/database");
 
-exports.searchUsers = async (term) => {
+exports.searchUsers = async (currentUserId, term) => {
+  const subquery = db("messages")
+    .select("sender_id")
+    .count("id as count")
+    .where({ receiver_id: currentUserId, read: false })
+    .groupBy("sender_id")
+    .as("unread");
+
   return db("users")
     .select(
-      "id",
-      db.raw("COALESCE(full_name, '') as name"),
-      "email",
-      "phone",
-      db.raw("COALESCE(avatar_url, '') as profileImage")
+      "users.id",
+      db.raw("COALESCE(users.full_name, '') as name"),
+      "users.email",
+      "users.phone",
+      db.raw("COALESCE(users.avatar_url, '') as profileImage"),
+      db.raw("COALESCE(unread.count, 0) as unreadMessages")
     )
+    .leftJoin(subquery, "users.id", "unread.sender_id")
     .modify((query) => {
       if (term) {
         const t = `%${term}%`;
-        query.where("full_name", "ilike", t)
-          .orWhere("email", "ilike", t)
-          .orWhere("phone", "ilike", t);
+        query
+          .where("users.full_name", "ilike", t)
+          .orWhere("users.email", "ilike", t)
+          .orWhere("users.phone", "ilike", t);
       }
     })
+    .whereNot("users.id", currentUserId)
     .limit(20);
 };
 
 exports.getConversation = async (userId, otherId) => {
+  await db("messages")
+    .where({ sender_id: otherId, receiver_id: userId, read: false })
+    .update({ read: true, read_at: new Date() });
+
   return db("messages")
     .where(function () {
       this.where({ sender_id: userId, receiver_id: otherId })

--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -8,7 +8,7 @@ import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
 import { getConversation, sendChatMessage } from "@/services/messageService";
 
-const ChatWindow = ({ selectedChat, onStartVideoCall }) => {
+const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
   const currentUser = useAuthStore((state) => state.user);
   const [messages, setMessages] = useState([]);
   const [typing, setTyping] = useState(false);
@@ -26,16 +26,9 @@ const ChatWindow = ({ selectedChat, onStartVideoCall }) => {
   useEffect(() => {
     if (selectedChat) {
       getConversation(selectedChat.id)
-        .then(setMessages)
+        .then((msgs) => setMessages(msgs))
         .catch(() => setMessages([]));
-    }
-  }, [selectedChat]);
-
-  useEffect(() => {
-    if (selectedChat) {
-      getConversation(selectedChat.id)
-        .then(setMessages)
-        .catch(() => setMessages([]));
+      if (refreshUsers) refreshUsers();
     }
   }, [selectedChat]);
 
@@ -114,26 +107,22 @@ const ChatWindow = ({ selectedChat, onStartVideoCall }) => {
         key={index}
         className={`flex items-end gap-2 ${isYou ? "justify-end" : "justify-start"}`}
       >
-        {!isYou && (
-          <img
-
-            src={getAvatarUrl(selectedChat.profileImage)}
-
-            className="w-7 h-7 rounded-full border border-gray-500"
-            alt="avatar"
-          />
-        )}
+        <img
+          src={getAvatarUrl(
+            isYou ? currentUser?.avatar_url : selectedChat.profileImage
+          )}
+          className="w-7 h-7 rounded-full border border-gray-500"
+          alt="avatar"
+        />
 
         <div
           className={`px-3 py-2 rounded-lg shadow-sm max-w-sm text-sm ${
             isYou ? "bg-blue-600 text-white" : "bg-gray-600 text-white"
           }`}
         >
-          {!isYou && (
-            <div className="text-[11px] font-semibold text-gray-300 mb-1">
-              {selectedChat.name}
-            </div>
-          )}
+          <div className="text-[11px] font-semibold text-gray-300 mb-1">
+            {isYou ? currentUser?.full_name || "You" : selectedChat.name}
+          </div>
 
           <p className="text-[13px] leading-snug break-words">{msg.message}</p>
 

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -24,8 +24,11 @@ const MessagesPage = () => {
 
   const router = useRouter();
 
-  useEffect(() => {
+  const fetchUsersList = () =>
     getUsers().then(setUsers).catch(() => setUsers([]));
+
+  useEffect(() => {
+    fetchUsersList();
     getGroups().then(setGroups).catch(() => setGroups([]));
     fetchMessages();
     startPolling();
@@ -204,7 +207,7 @@ const MessagesPage = () => {
               setSelectedChat={setSelectedChat}
               selectedChat={selectedChat}
             />
-            <ChatWindow selectedChat={selectedChat} />
+            <ChatWindow selectedChat={selectedChat} refreshUsers={fetchUsersList} />
           </main>
         )}
       </div>


### PR DESCRIPTION
## Summary
- show unread message count from backend
- mark chat messages as read when opening a conversation
- refresh user list after loading a chat
- show avatars and sender names for all chat messages

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_685e8e8324588328a53ed72cc93dce2b