### PR TITLE
Improve chat header avatar and message status

### DIFF
--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -1,8 +1,15 @@
 import { useRouter } from "next/router";
 import { FaVideo, FaWhatsapp, FaEnvelope } from "react-icons/fa";
+import { API_BASE_URL } from "@/config/config";
 
 const ChatHeader = ({ selectedChat }) => {
   const router = useRouter();
+
+  const getAvatarUrl = (url) => {
+    if (!url) return "/images/default-avatar.png";
+    if (url.startsWith("http") || url.startsWith("blob:")) return url;
+    return `${API_BASE_URL}${url}`;
+  };
 
   if (!selectedChat) {
     return <div className="text-gray-400 text-center p-4">No chat selected</div>;
@@ -35,6 +42,11 @@ const ChatHeader = ({ selectedChat }) => {
     <div className="flex justify-between items-center mb-4 border-b pb-2 border-gray-700">
       {/* Chat Name */}
       <h3 className="text-lg font-bold text-yellow-500 flex items-center gap-2">
+        <img
+          src={getAvatarUrl(selectedChat.profileImage)}
+          alt="avatar"
+          className="w-8 h-8 rounded-full border border-gray-500"
+        />
         {selectedChat.groupName || selectedChat.name || "Unknown Chat"}
       </h3>
 

--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import formatRelativeTime from "@/utils/relativeTime";
 import ChatHeader from "./ChatHeader";
 import MessageInput from "./MessageInput";
-import { FaCheckDouble, FaThumbtack, FaReply, FaTrash } from "react-icons/fa";
+import { FaCheck, FaCheckDouble, FaThumbtack, FaReply, FaTrash } from "react-icons/fa";
 import { API_BASE_URL } from "@/config/config";
 import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
@@ -130,9 +130,11 @@ const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
           <div className="flex justify-between items-center text-[10px] text-gray-300 mt-1">
             <span className="whitespace-nowrap">{formatRelativeTime(msg.sent_at)}</span>
             <div className="flex items-center gap-2 ml-2">
-              <FaCheckDouble
-                className={`${msg.read ? "text-blue-300" : "text-gray-400"}`}
-              />
+              {msg.read ? (
+                <FaCheckDouble className="text-blue-300" />
+              ) : (
+                <FaCheck className="text-gray-400" />
+              )}
               <button
                 onClick={() => togglePinMessage(msg)}
                 title="Pin"


### PR DESCRIPTION
## Summary
- show user avatars in chat header with fallback
- display single check for sent messages and double for read

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e94abfae48328bbe8fdc8a6fe9f0a