### PR TITLE
Add chat polling for new message alerts

### DIFF
--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -24,13 +24,21 @@ const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
   };
 
   useEffect(() => {
-    if (selectedChat) {
+    let interval;
+    const fetchConvo = () => {
+      if (!selectedChat) return;
       getConversation(selectedChat.id)
         .then((msgs) => setMessages(msgs))
         .catch(() => setMessages([]));
       if (refreshUsers) refreshUsers();
+    };
+
+    fetchConvo();
+    if (selectedChat) {
+      interval = setInterval(fetchConvo, 10000);
     }
-  }, [selectedChat]);
+    return () => clearInterval(interval);
+  }, [selectedChat, refreshUsers]);
 
   useEffect(() => {
     if (chatRef.current) {
@@ -56,6 +64,7 @@ const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
       setMessages((prev) => [...prev, sent]);
       setTyping(false);
       toast.success("Message sent!");
+      if (refreshUsers) refreshUsers();
     } catch (_) {
       toast.error("Failed to send message");
     }

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -32,6 +32,9 @@ const MessagesPage = () => {
     getGroups().then(setGroups).catch(() => setGroups([]));
     fetchMessages();
     startPolling();
+
+    const interval = setInterval(fetchUsersList, 30000);
+    return () => clearInterval(interval);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- poll chat users list regularly to update unread counts
- refresh conversation periodically when a chat is open
- refresh user list after sending chat messages

## Testing
- `npm test` in `frontend`
- `npm run lint` in `frontend` *(fails: 47 errors)*
- `npm test` in `backend`
- `npm run lint` in `backend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e983d33d48328b0f49bf970387dcd