### PR TITLE
Add chat attachments

### DIFF
--- a/backend/src/migrations/20250630120600_add_file_fields_to_messages.js
+++ b/backend/src/migrations/20250630120600_add_file_fields_to_messages.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.table('messages', function(table) {
+    table.string('file_url');
+    table.string('audio_url');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('messages', function(table) {
+    table.dropColumn('file_url');
+    table.dropColumn('audio_url');
+  });
+};

--- a/backend/src/modules/chat/chat.controller.js
+++ b/backend/src/modules/chat/chat.controller.js
@@ -18,13 +18,23 @@ exports.getConversation = catchAsync(async (req, res) => {
 exports.sendMessage = catchAsync(async (req, res) => {
   const otherId = req.params.userId;
   const { message } = req.body || {};
-  if (!message || !message.trim()) {
-    throw new AppError("Message required", 400);
+
+  const file = req.files?.file?.[0];
+  const audio = req.files?.audio?.[0];
+
+  if (!message && !file && !audio) {
+    throw new AppError("Message or attachment required", 400);
   }
+
+  const fileUrl = file ? `/uploads/chat/${file.filename}` : null;
+  const audioUrl = audio ? `/uploads/chat/${audio.filename}` : null;
+
   const msg = await service.sendMessage({
     sender_id: req.user.id,
     receiver_id: otherId,
-    message: message.trim(),
+    message: message ? message.trim() : "",
+    file_url: fileUrl,
+    audio_url: audioUrl,
   });
   sendSuccess(res, msg, "Message sent");
 });

--- a/backend/src/modules/chat/chat.routes.js
+++ b/backend/src/modules/chat/chat.routes.js
@@ -2,11 +2,12 @@ const express = require("express");
 const router = express.Router();
 const controller = require("./chat.controller");
 const { verifyToken } = require("../../middleware/auth/authMiddleware");
+const upload = require("./chatUpload.middleware");
 
 router.use(verifyToken);
 
 router.get("/users", controller.searchUsers);
 router.get("/:userId", controller.getConversation);
-router.post("/:userId", controller.sendMessage);
+router.post("/:userId", upload, controller.sendMessage);
 
 module.exports = router;

--- a/backend/src/modules/chat/chat.service.js
+++ b/backend/src/modules/chat/chat.service.js
@@ -44,9 +44,9 @@ exports.getConversation = async (userId, otherId) => {
     .orderBy("sent_at");
 };
 
-exports.sendMessage = async ({ sender_id, receiver_id, message }) => {
+exports.sendMessage = async ({ sender_id, receiver_id, message, file_url, audio_url }) => {
   const [row] = await db("messages")
-    .insert({ sender_id, receiver_id, message })
+    .insert({ sender_id, receiver_id, message, file_url, audio_url })
     .returning("*");
   return row;
 };

--- a/backend/src/modules/chat/chatUpload.middleware.js
+++ b/backend/src/modules/chat/chatUpload.middleware.js
@@ -1,0 +1,21 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const uploadDir = path.join(__dirname, '../../../uploads/chat');
+if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    cb(null, `${Date.now()}-${Math.round(Math.random()*1e9)}${ext}`);
+  }
+});
+
+const upload = multer({ storage });
+
+module.exports = upload.fields([
+  { name: 'file', maxCount: 1 },
+  { name: 'audio', maxCount: 1 }
+]);

--- a/frontend/src/components/chat/MessageInput.js
+++ b/frontend/src/components/chat/MessageInput.js
@@ -22,7 +22,11 @@ const MessageInput = ({ sendMessage, replyTo, onCancelReply }) => {
   const handleSend = () => {
     if (!message.trim() && !file && !audioBlob) return;
 
-    const newMessage = { text: message };
+    const newMessage = {
+      text: message.trim(),
+      file,
+      audio: audioBlob ? new File([audioBlob], `record-${Date.now()}.webm`) : null,
+    };
     sendMessage(newMessage);
     setMessage("");
     setFile(null);

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -28,7 +28,13 @@ export const getConversation = async (userId) => {
   return res.data.data || res.data;
 };
 
-export const sendChatMessage = async (userId, message) => {
-  const res = await api.post(`/chat/${userId}`, { message });
+export const sendChatMessage = async (userId, { text, file, audio }) => {
+  const form = new FormData();
+  if (text) form.append("message", text);
+  if (file) form.append("file", file);
+  if (audio) form.append("audio", audio);
+  const res = await api.post(`/chat/${userId}`, form, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
   return res.data.data || res.data;
 };


### PR DESCRIPTION
## Summary
- allow chat messages to include files and audio
- store attachments on the backend
- migrate DB to hold file and audio URLs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ea5b71d18832898429d67115b25ad