### PR TITLE
Improve system messages display

### DIFF
--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -15,6 +15,8 @@ exports.getUserMessages = async (userId) => {
     .del();
 
   return db("messages")
+    .select("messages.*", "users.full_name as sender_name")
+    .leftJoin("users", "messages.sender_id", "users.id")
     .where({ receiver_id: userId })
     .orderBy("sent_at", "desc");
 };

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -107,10 +107,21 @@ const MessagesPage = () => {
                 {messages.map((msg) => (
                   <li
                     key={msg.id}
-                    onClick={() => !msg.read && markMessageRead(msg.id)}
+                    onClick={() => {
+                      if (!msg.read) markMessageRead(msg.id);
+                      const user = users.find((u) => u.id === msg.sender_id);
+                      setSelectedChat(
+                        user || { id: msg.sender_id, name: msg.sender_name }
+                      );
+                    }}
                     className={`p-3 rounded-md cursor-pointer bg-gray-700 hover:bg-gray-600 transition flex justify-between ${msg.read ? "opacity-70" : ""}`}
                   >
-                    <span>{msg.message}</span>
+                    <span>
+                      <span className="font-semibold mr-1">
+                        {msg.sender_name || "System"}:
+                      </span>
+                      {msg.message}
+                    </span>
                     {!msg.read && (
                       <span className="text-xs text-red-400 ml-2">new</span>
                     )}


### PR DESCRIPTION
## Summary
- show sender name in system messages and open chat when clicked
- include sender info when fetching messages from backend

## Testing
- `npm test` (fails: jest not found)
- `npm run lint` in frontend (fails: cannot find package '@eslint/eslintrc')
- `npm test` in frontend (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_685edbb8029883289b47af96c1464c22