### PR TITLE
Fix message polling dependencies

### DIFF
--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -18,9 +18,17 @@ const MessagesPage = () => {
   const searchInputRef = useRef(null);
 
   const messages = useMessageStore((state) => state.items);
-  const fetchMessages = useMessageStore((state) => state.fetch);
-  const startPolling = useMessageStore((state) => state.startPolling);
+  const fetchMessagesStore = useMessageStore((state) => state.fetch);
+  const startPollingStore = useMessageStore((state) => state.startPolling);
   const markMessageRead = useMessageStore((state) => state.markRead);
+
+  const fetchMessages = useCallback(() => {
+    fetchMessagesStore();
+  }, [fetchMessagesStore]);
+
+  const startPolling = useCallback(() => {
+    startPollingStore();
+  }, [startPollingStore]);
 
   const router = useRouter();
 
@@ -41,7 +49,7 @@ const MessagesPage = () => {
 
     const interval = setInterval(fetchUsersList, 30000);
     return () => clearInterval(interval);
-  }, []);
+  }, [fetchUsersList, fetchMessages, startPolling]);
 
   useEffect(() => {
     setUsers((prev) => adjustCounts(prev));


### PR DESCRIPTION
## Summary
- memoize `fetchMessages` and `startPolling` handlers
- include polling callbacks in sidebar refresh effect

## Testing
- `npm test` in `frontend` *(fails: jest not found)*
- `npm test` in `backend` *(fails: jest not found)*
- `npm run lint` in `frontend` *(fails: cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_685ee5a6a6dc832886e199ccfd8c5a04