### PR TITLE
Replace img tags with Next.js Image in chat UI

### DIFF
--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 import { FaVideo, FaWhatsapp, FaEnvelope } from "react-icons/fa";
 import { API_BASE_URL } from "@/config/config";
+import ChatImage from "../shared/ChatImage";
 
 const ChatHeader = ({ selectedChat }) => {
   const router = useRouter();
@@ -42,10 +43,12 @@ const ChatHeader = ({ selectedChat }) => {
     <div className="flex justify-between items-center mb-4 border-b pb-2 border-gray-700">
       {/* Chat Name */}
       <h3 className="text-lg font-bold text-yellow-500 flex items-center gap-2">
-        <img
+        <ChatImage
           src={getAvatarUrl(selectedChat.profileImage)}
           alt="avatar"
           className="w-8 h-8 rounded-full border border-gray-500"
+          width={32}
+          height={32}
         />
         {selectedChat.groupName || selectedChat.name || "Unknown Chat"}
       </h3>

--- a/frontend/src/components/chat/ChatSidebar.js
+++ b/frontend/src/components/chat/ChatSidebar.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import ChatImage from "../shared/ChatImage";
 import { API_BASE_URL } from "@/config/config";
 import {
   FaPlus,
@@ -128,10 +129,12 @@ const ChatSidebar = ({
           >
             {/* Profile Picture */}
             <div className="relative">
-              <img
+              <ChatImage
                 src={getAvatarUrl(user.profileImage)}
                 alt={user.name}
                 className="w-10 h-10 rounded-full border-2 border-yellow-500"
+                width={40}
+                height={40}
               />
               <span
                 className={`absolute bottom-0 right-0 w-3 h-3 rounded-full border border-gray-800 ${
@@ -181,10 +184,12 @@ const ChatSidebar = ({
               className="flex items-center gap-3 p-3 rounded-lg cursor-pointer hover:bg-gray-700 transition"
               onClick={() => setSelectedChat(user)}
             >
-              <img
+              <ChatImage
                 src={getAvatarUrl(user.profileImage)}
                 alt={user.name}
                 className="w-10 h-10 rounded-full border-2 border-gray-500"
+                width={40}
+                height={40}
               />
               <p className="text-white font-semibold">{user.name}</p>
             </div>

--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import ChatImage from "../shared/ChatImage";
 import formatRelativeTime from "@/utils/relativeTime";
 import ChatHeader from "./ChatHeader";
 import MessageInput from "./MessageInput";
@@ -131,10 +132,12 @@ const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
           {pinnedMessages.map((msg, i) => (
             <div key={i} className="text-xs mt-1 border-l-4 border-yellow-400 pl-2">
               {isImage(msg.file_url || msg.message) ? (
-                <img
+                <ChatImage
                   src={getMediaUrl(msg.file_url || msg.message)}
                   alt="Pinned image"
                   className="max-w-xs rounded-md mt-1"
+                  width={200}
+                  height={200}
                 />
               ) : (
                 msg.message || msg.file_url?.split('/').pop()
@@ -160,12 +163,14 @@ const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
         key={index}
         className={`flex items-end gap-2 ${isYou ? "justify-end" : "justify-start"}`}
       >
-        <img
+        <ChatImage
           src={getAvatarUrl(
             isYou ? currentUser?.avatar_url : selectedChat.profileImage
           )}
           className="w-7 h-7 rounded-full border border-gray-500"
           alt="avatar"
+          width={28}
+          height={28}
         />
 
         <div
@@ -188,10 +193,12 @@ const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
           )}
           {msg.reply_file_url && isImage(msg.reply_file_url) && (
             <div className="mb-1 border-l-2 border-yellow-400 pl-2">
-              <img
+              <ChatImage
                 src={getMediaUrl(msg.reply_file_url)}
                 alt="reply"
                 className="max-w-xs rounded-md"
+                width={200}
+                height={200}
               />
             </div>
           )}
@@ -215,10 +222,12 @@ const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
 
           {msg.file_url && isImage(msg.file_url) && (
 
-            <img
+            <ChatImage
               src={getMediaUrl(msg.file_url)}
               alt="Sent image"
               className="max-w-xs rounded-md mt-1"
+              width={200}
+              height={200}
             />
           )}
           {msg.file_url && !isImage(msg.file_url) && (

--- a/frontend/src/components/chat/GroupMemberList.js
+++ b/frontend/src/components/chat/GroupMemberList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ChatImage from '../shared/ChatImage';
 
 const mockMembers = [
   {
@@ -36,10 +37,12 @@ export default function GroupMembersList({ members = mockMembers }) {
           className="flex items-center justify-between bg-white p-3 rounded shadow-sm border"
         >
           <div className="flex items-center gap-3">
-            <img
+            <ChatImage
               src={member.avatar}
               alt={member.name}
               className="w-10 h-10 rounded-full border"
+              width={40}
+              height={40}
             />
             <div>
               <p className="font-medium">{member.name}</p>

--- a/frontend/src/components/chat/GroupMembersManager.js
+++ b/frontend/src/components/chat/GroupMembersManager.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import ChatImage from '../shared/ChatImage';
 
 const initialMembers = [
   {
@@ -45,10 +46,12 @@ export default function GroupMembersManager() {
           className="flex items-center justify-between p-3 border rounded shadow-sm bg-white"
         >
           <div className="flex items-center gap-3">
-            <img
+            <ChatImage
               src={member.avatar}
               alt={member.name}
               className="w-10 h-10 rounded-full border"
+              width={40}
+              height={40}
             />
             <div>
               <p className="font-medium">{member.name}</p>

--- a/frontend/src/components/chat/MessageItem.js
+++ b/frontend/src/components/chat/MessageItem.js
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import ChatImage from "../shared/ChatImage";
 import {
   FaPlay,
   FaUserCircle,
@@ -39,10 +40,12 @@ const MessageItem = ({ message, onReply, onDelete, onPin }) => {
 
         {/* 📷 Image */}
         {message.image && (
-          <img
+          <ChatImage
             src={message.image}
             alt="Sent image"
             className="rounded-md mt-2 max-w-full object-cover"
+            width={300}
+            height={200}
           />
         )}
 

--- a/frontend/src/components/chat/PendingJoinRequests.js
+++ b/frontend/src/components/chat/PendingJoinRequests.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import ChatImage from '../shared/ChatImage';
 
 const mockPendingRequests = [
   {
@@ -40,10 +41,12 @@ export default function PendingJoinRequests({ onApprove, onReject }) {
             className="flex items-center justify-between p-3 border rounded shadow-sm bg-white"
           >
             <div className="flex items-center gap-3">
-              <img
+              <ChatImage
                 src={user.avatar}
                 alt={user.name}
                 className="w-10 h-10 rounded-full border"
+                width={40}
+                height={40}
               />
               <div>
                 <p className="font-medium">{user.name}</p>

--- a/frontend/src/components/shared/ChatImage.js
+++ b/frontend/src/components/shared/ChatImage.js
@@ -1,0 +1,12 @@
+import Image from 'next/image';
+
+const ChatImage = ({ src, alt, width = 40, height = 40, ...rest }) => {
+  const isExternal =
+    typeof src === 'string' &&
+    (src.startsWith('http') || src.startsWith('blob:') || src.startsWith('data:'));
+  return (
+    <Image src={src} alt={alt} width={width} height={height} unoptimized={isExternal} {...rest} />
+  );
+};
+
+export default ChatImage;

--- a/frontend/src/pages/messages/groupChat.js
+++ b/frontend/src/pages/messages/groupChat.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import Navbar from "@/components/website/sections/Navbar";
 import { getGroups, sendGroupMessage } from "@/services/groupService";
 import { motion } from "framer-motion";
+import ChatImage from "@/components/shared/ChatImage";
 import formatRelativeTime from "@/utils/relativeTime";
 import EmojiPicker from "emoji-picker-react";
 import MessageInput from "./MessageInput";
@@ -107,7 +108,15 @@ const GroupChatPage = () => {
                     <div>
                       <strong>{msg.sender}</strong>
                       <p>{msg.text}</p>
-                      {msg.file && <img src={msg.file} alt="Attachment" className="w-16 h-16 mt-2 rounded-lg" />}
+                      {msg.file && (
+                        <ChatImage
+                          src={msg.file}
+                          alt="Attachment"
+                          className="w-16 h-16 mt-2 rounded-lg"
+                          width={64}
+                          height={64}
+                        />
+                      )}
                       <p className="text-xs text-gray-400">{formatRelativeTime(msg.timestamp)}</p>
                     </div>
                   </motion.div>

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -6,6 +6,7 @@ import ChatWindow from "@/components/chat/ChatWindow";
 import ChatNotifications from "@/components/chat/ChatNotifications";
 import { getUsers, getGroups } from "@/services/messageService";
 import { FaSearch, FaCommentDots } from "react-icons/fa";
+import ChatImage from "@/components/shared/ChatImage";
 import useMessageStore from "@/store/messages/messageStore";
 
 const MessagesPage = () => {
@@ -159,10 +160,12 @@ const MessagesPage = () => {
                           className="flex items-center justify-between gap-3 p-3 hover:bg-gray-700 rounded-lg cursor-pointer transition"
                         >
                           <div className="flex items-center gap-3">
-                            <img
+                            <ChatImage
                               src={user.profileImage || "/images/default-avatar.png"}
                               alt={user.name || "User"}
                               className="w-10 h-10 rounded-full border border-yellow-500"
+                              width={40}
+                              height={40}
                             />
                             <div>
                               <p className="text-white font-semibold">{user.name || "Unknown User"}</p>


### PR DESCRIPTION
## Summary
- add `ChatImage` wrapper over `next/image`
- update chat components to use `ChatImage` instead of `<img>`
- ensure message pages also use `ChatImage`

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*
- `npm run lint --prefix frontend` *(fails: cannot find package '@eslint/eslintrc')*
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee5a82f288328b7d8d60139029a08