### PR TITLE
Stop notification polling on logout

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -37,12 +37,14 @@ export default function Header() {
   const fetchNotifications = useNotificationStore((state) => state.fetch);
 
   const startPolling = useNotificationStore((state) => state.startPolling);
+  const stopPolling = useNotificationStore((state) => state.stopPolling);
 
   const markRead = useNotificationStore((state) => state.markRead);
   const unreadCount = notifications.filter((n) => !n.read).length;
   const messages = useMessageStore((state) => state.items);
   const fetchMessages = useMessageStore((state) => state.fetch);
   const startMessagePolling = useMessageStore((state) => state.startPolling);
+  const stopMessagePolling = useMessageStore((state) => state.stopPolling);
   const markMessageRead = useMessageStore((state) => state.markRead);
   const unreadMessageCount = messages.filter((m) => !m.read).length;
   const router = useRouter();
@@ -55,6 +57,13 @@ export default function Header() {
   const handleLogout = async () => {
     try {
       await logout();
+      stopPolling();
+      stopMessagePolling();
+      console.log(
+        'Polling after logout:',
+        useNotificationStore.getState().poller,
+        useMessageStore.getState().poller
+      );
       toast.success("You’ve been logged out. See you soon!");
 
       // ⏳ Delay before redirecting to login
@@ -103,6 +112,19 @@ export default function Header() {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [user]);
+
+  // Stop polling when component unmounts
+  useEffect(() => {
+    return () => {
+      stopPolling();
+      stopMessagePolling();
+      console.log(
+        'Polling after unmount:',
+        useNotificationStore.getState().poller,
+        useMessageStore.getState().poller
+      );
+    };
+  }, []);
 
   useEffect(() => {
     if (user) {

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import * as authService from "@/services/auth/authService";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
 
 const useAuthStore = create(
   persist(
@@ -37,6 +39,16 @@ const useAuthStore = create(
         try {
           await authService.logoutUser();
         } catch (_) {}
+        // Stop polling intervals when logging out
+        const notifStop = useNotificationStore.getState().stopPolling;
+        const msgStop = useMessageStore.getState().stopPolling;
+        notifStop?.();
+        msgStop?.();
+        console.log(
+          'Polling after logout:',
+          useNotificationStore.getState().poller,
+          useMessageStore.getState().poller
+        );
         localStorage.removeItem("auth");
         set({ accessToken: null, user: null });
       },


### PR DESCRIPTION
## Summary
- stop polling of notifications and messages when logging out
- ensure polling stopped on component unmount

## Testing
- `npm test --silent`
- `npm run lint` *(fails: 47 errors, 179 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685ee5bc54348328b4f7d1022c08c8ed