### PR TITLE
Fix message attachment/audio sending

### DIFF
--- a/frontend/src/components/chat/MessageInput.js
+++ b/frontend/src/components/chat/MessageInput.js
@@ -22,8 +22,11 @@ const MessageInput = ({ sendMessage, replyTo, onCancelReply }) => {
   const handleSend = () => {
     if (!message.trim() && !file && !audioBlob) return;
 
-
-    const newMessage = { text: message, replyTo };
+    const newMessage = {
+      text: message.trim(),
+      file,
+      audio: audioBlob,
+    };
 
     sendMessage(newMessage);
     setMessage("");


### PR DESCRIPTION
## Summary
- ensure uploaded files and audio recordings are sent from the chat input

## Testing
- `npm test --silent`
- `npm run lint` *(fails: 47 errors, 165 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685ef45938b883289373e79a0c2da890