### PR TITLE
Fix 403 on enrolled class fetch

### DIFF
--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -44,8 +44,15 @@ export const markClassCompleted = async (id) => {
 };
 
 export const fetchMyEnrolledClasses = async () => {
-  const { data } = await api.get("/users/classes/enroll/my");
-  return data?.data ?? [];
+  try {
+    const { data } = await api.get("/users/classes/enroll/my");
+    return data?.data ?? [];
+  } catch (err) {
+    if (err.response && [401, 403].includes(err.response.status)) {
+      return [];
+    }
+    throw err;
+  }
 };
 
 export const fetchClassLessons = async (classId) => {


### PR DESCRIPTION
## Summary
- prevent crashes when fetching enrolled classes for unauthorized users

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685eff12bd088328bd35b493d4a5a438