### PR TITLE
Add Student class with enrollment workflow

### DIFF
--- a/backend/src/modules/users/student/student.class.js
+++ b/backend/src/modules/users/student/student.class.js
@@ -1,0 +1,76 @@
+const classService = require("../../classes/class.service");
+const wishlistService = require("../../classes/wishlist/classWishlist.service");
+const cartService = require("../../cart/cart.service");
+const enrollmentService = require("../../classes/enrollments/classEnrollment.service");
+const paymentsService = require("../../payments/payments.service");
+
+class Student {
+  constructor(userId) {
+    this.userId = userId;
+  }
+
+  async discoverClasses() {
+    return classService.getPublishedClasses();
+  }
+
+  async viewClassDetails(classId) {
+    return classService.getPublicClassDetails(classId);
+  }
+
+  async addToWishlist(classId) {
+    return wishlistService.add(this.userId, classId);
+  }
+
+  async removeFromWishlist(classId) {
+    return wishlistService.remove(this.userId, classId);
+  }
+
+  async listWishlist() {
+    return wishlistService.listByUser(this.userId);
+  }
+
+  addToCart(classId, quantity = 1) {
+    return cartService.add({ id: classId, quantity });
+  }
+
+  viewCart() {
+    return cartService.list();
+  }
+
+  removeFromCart(classId) {
+    return cartService.remove(classId);
+  }
+
+  async listEnrolledClasses() {
+    return enrollmentService.getByUser(this.userId);
+  }
+
+  async checkout(paymentMethodId) {
+    const cartItems = cartService.list();
+    const results = [];
+    for (const item of cartItems) {
+      const cls = await classService.getClassById(item.id);
+      if (!cls) continue;
+      await enrollmentService.createEnrollment({
+        id: undefined,
+        user_id: this.userId,
+        class_id: item.id,
+        status: "enrolled",
+      });
+      const payment = await paymentsService.create({
+        user_id: this.userId,
+        method_id: paymentMethodId,
+        item_type: "class",
+        item_id: item.id,
+        amount: cls.price || 0,
+        status: "paid",
+        paid_at: new Date(),
+      });
+      cartService.remove(item.id);
+      results.push({ enrollment: item.id, payment });
+    }
+    return results;
+  }
+}
+
+module.exports = Student;

--- a/backend/tests/studentClass.test.js
+++ b/backend/tests/studentClass.test.js
@@ -1,0 +1,63 @@
+const Student = require('../src/modules/users/student/student.class');
+
+jest.mock('../src/modules/classes/class.service', () => ({
+  getPublishedClasses: jest.fn(() => Promise.resolve([])),
+  getPublicClassDetails: jest.fn((id) => Promise.resolve({ id, price: 10 })),
+  getClassById: jest.fn((id) => Promise.resolve({ id, price: 10 }))
+}));
+
+jest.mock('../src/modules/classes/wishlist/classWishlist.service', () => ({
+  add: jest.fn(() => Promise.resolve({})),
+  remove: jest.fn(() => Promise.resolve()),
+  listByUser: jest.fn(() => Promise.resolve([]))
+}));
+
+jest.mock('../src/modules/cart/cart.service', () => {
+  const cart = [];
+  return {
+    list: jest.fn(() => cart),
+    add: jest.fn((item) => { cart.push(item); return item; }),
+    remove: jest.fn((id) => {
+      const idx = cart.findIndex(c => c.id === id);
+      if (idx !== -1) cart.splice(idx,1);
+    })
+  };
+});
+
+jest.mock('../src/modules/classes/enrollments/classEnrollment.service', () => ({
+  getByUser: jest.fn(() => Promise.resolve([])),
+  createEnrollment: jest.fn(() => Promise.resolve({}))
+}));
+
+jest.mock('../src/modules/payments/payments.service', () => ({
+  create: jest.fn(() => Promise.resolve({ id: 'p1' }))
+}));
+
+const classService = require('../src/modules/classes/class.service');
+const wishlistService = require('../src/modules/classes/wishlist/classWishlist.service');
+const cartService = require('../src/modules/cart/cart.service');
+const enrollmentService = require('../src/modules/classes/enrollments/classEnrollment.service');
+const paymentsService = require('../src/modules/payments/payments.service');
+
+describe('Student class', () => {
+  const student = new Student('user1');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cartService.list().length = 0;
+  });
+
+  test('discoverClasses calls class service', async () => {
+    await student.discoverClasses();
+    expect(classService.getPublishedClasses).toHaveBeenCalled();
+  });
+
+  test('checkout enrolls and pays', async () => {
+    student.addToCart('c1');
+    const result = await student.checkout(1);
+    expect(enrollmentService.createEnrollment).toHaveBeenCalled();
+    expect(paymentsService.create).toHaveBeenCalled();
+    expect(result.length).toBe(1);
+    expect(cartService.list().length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- read docs about the student enrollment workflow
- implement a `Student` class to encapsulate enrollment actions
- add tests for the new class

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685f006c4f1c8328bc5d52919b4c3266