### PR TITLE
Fix Student class checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ Endpoints for creating and managing live classes are served under `/api/users/cl
 - Fields for a class include `title`, `description`, `start_date`, `end_date`, `price`, `max_students`, `language` and a unique `slug` for public URLs.
 
 For an overview of the student purchase and enrollment process see [docs/student-enrollment-workflow.md](docs/student-enrollment-workflow.md).
+
+## Student helper class
+
+The backend contains a small utility class `Student` located at
+`backend/src/modules/users/student/student.class.js`. It can be used in tests or
+scripts to simulate common student actions such as discovering classes, adding
+items to the cart and completing checkout. The `checkout` method now generates a
+unique enrollment ID for each class and returns both the created enrollment and
+payment record.
+

--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -5,8 +5,8 @@ exports.findEnrollment = async (user_id, class_id) => {
 };
 
 exports.createEnrollment = async (data) => {
-  await db("class_enrollments").insert(data);
-  return data;
+  const [row] = await db("class_enrollments").insert(data).returning("*");
+  return row;
 };
 
 exports.markCompleted = async (user_id, class_id) => {

--- a/backend/src/modules/users/student/student.class.js
+++ b/backend/src/modules/users/student/student.class.js
@@ -3,6 +3,7 @@ const wishlistService = require("../../classes/wishlist/classWishlist.service");
 const cartService = require("../../cart/cart.service");
 const enrollmentService = require("../../classes/enrollments/classEnrollment.service");
 const paymentsService = require("../../payments/payments.service");
+const { v4: uuidv4 } = require("uuid");
 
 class Student {
   constructor(userId) {
@@ -51,8 +52,8 @@ class Student {
     for (const item of cartItems) {
       const cls = await classService.getClassById(item.id);
       if (!cls) continue;
-      await enrollmentService.createEnrollment({
-        id: undefined,
+      const enrollment = await enrollmentService.createEnrollment({
+        id: uuidv4(),
         user_id: this.userId,
         class_id: item.id,
         status: "enrolled",
@@ -67,7 +68,7 @@ class Student {
         paid_at: new Date(),
       });
       cartService.remove(item.id);
-      results.push({ enrollment: item.id, payment });
+      results.push({ enrollment, payment });
     }
     return results;
   }


### PR DESCRIPTION
## Summary
- generate an enrollment id during Student checkout and collect the created enrollment
- return the inserted enrollment row from `createEnrollment`
- document the Student helper class in the README

## Testing
- `cd backend && npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685f0391aecc8328ab5c61d112cbd20f