### PR TITLE
Add dashboard link to navbar

### DIFF
--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -17,6 +17,7 @@ import {
   FaUserPlus,
   FaHeart,
   FaThumbsUp,
+  FaTachometerAlt,
 } from "react-icons/fa";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
@@ -299,6 +300,19 @@ const Navbar = () => {
         >
           <FaLanguage />
         </motion.button>
+
+        {user && (
+          <Link
+            href={
+              userRole === "superadmin" || userRole === "admin"
+                ? "/dashboard/admin"
+                : `/dashboard/${userRole}`
+            }
+            className="flex items-center gap-2 font-semibold hover:underline"
+          >
+            <FaTachometerAlt /> Dashboard
+          </Link>
+        )}
 
         {user ? (
           <>


### PR DESCRIPTION
## Summary
- link to dashboard from website navbar for logged in users

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f13fc02e4832892d4b9f0c19e8bf4