### PR TITLE
Add application config settings

### DIFF
--- a/backend/src/modules/appConfig/appConfig.controller.js
+++ b/backend/src/modules/appConfig/appConfig.controller.js
@@ -1,0 +1,13 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./appConfig.service");
+
+exports.getSettings = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings || {});
+});
+
+exports.updateSettings = catchAsync(async (req, res) => {
+  const settings = await service.updateSettings(req.body);
+  sendSuccess(res, settings, "Settings updated");
+});

--- a/backend/src/modules/appConfig/appConfig.routes.js
+++ b/backend/src/modules/appConfig/appConfig.routes.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./appConfig.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.getSettings);
+router.use(verifyToken, isAdmin);
+router.put("/", controller.updateSettings);
+
+module.exports = router;

--- a/backend/src/modules/appConfig/appConfig.service.js
+++ b/backend/src/modules/appConfig/appConfig.service.js
@@ -1,0 +1,26 @@
+const db = require("../../config/database");
+
+const SETTINGS_KEY = "app_settings";
+
+exports.getSettings = async () => {
+  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (!row) return {};
+  try {
+    return JSON.parse(row.value);
+  } catch (_err) {
+    return {};
+  }
+};
+
+exports.updateSettings = async (settings) => {
+  const value = JSON.stringify(settings);
+  const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (existing) {
+    await db("settings")
+      .where({ key: SETTINGS_KEY })
+      .update({ value, updated_at: db.fn.now() });
+  } else {
+    await db("settings").insert({ key: SETTINGS_KEY, value });
+  }
+  return settings;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -73,6 +73,7 @@ const notificationRoutes = require("./modules/notifications/notifications.routes
 const messageRoutes = require("./modules/messages/messages.routes");
 const chatRoutes = require("./modules/chat/chat.routes");
 const socialLoginConfigRoutes = require("./modules/socialLoginConfig/socialLoginConfig.routes");
+const appConfigRoutes = require("./modules/appConfig/appConfig.routes");
 const errorHandler = require("./middleware/errorHandler");
 
 const app = express();
@@ -140,6 +141,7 @@ app.use("/api/payments/admin", paymentRoutes); // 💵 Payments management
 app.use("/api/payment-methods/admin", paymentMethodRoutes); // 💳 Payment methods
 app.use("/api/payments/config", paymentConfigRoutes); // ⚙️ Payment settings
 app.use("/api/social-login/config", socialLoginConfigRoutes); // 🔑 Social login settings
+app.use("/api/app-config", appConfigRoutes); // 🛠️ Application settings
 app.use("/api/payouts/admin", payoutRoutes); // 🏦 Instructor payouts
 app.use("/api/ads", adsRoutes); // 📢 Advertisements
 app.use("/api/instructors", publicInstructorRoutes); // 📚 Public instructor listing

--- a/backend/tests/appConfigRoutes.test.js
+++ b/backend/tests/appConfigRoutes.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/appConfig/appConfig.service', () => ({
+  getSettings: jest.fn(),
+  updateSettings: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/appConfig/appConfig.service');
+const routes = require('../src/modules/appConfig/appConfig.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/app-config', routes);
+
+describe('GET /api/app-config', () => {
+  it('returns settings', async () => {
+    const mock = { appName: 'SkillBridge' };
+    service.getSettings.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/app-config');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getSettings).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/app-config', () => {
+  it('updates settings', async () => {
+    const payload = { appName: 'New Name' };
+    service.updateSettings.mockResolvedValue(payload);
+
+    const res = await request(app).put('/api/app-config').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(payload);
+    expect(service.updateSettings).toHaveBeenCalledWith(payload);
+  });
+});

--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -66,7 +66,7 @@ export const adminNavLinks = [
           { label: 'Contact Info', href: '/dashboard/admin/settings/contact', icon: Contact },
           { label: 'Blogs', href: '/dashboard/admin/settings/blog', icon: BookMarked },
           { label: 'FAQs', href: '/dashboard/admin/settings/faqs', icon: HelpCircle },
-
+          { label: 'App Settings', href: '/dashboard/admin/settings/app', icon: Settings },
 
           { label: 'Footer Settings', href: '/dashboard/admin/settings/footer', icon: FileSignature },
 

--- a/frontend/src/pages/dashboard/admin/settings/app/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/app/index.js
@@ -1,0 +1,73 @@
+import { useState, useEffect } from "react";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { fetchAppConfig, updateAppConfig } from "@/services/admin/appConfigService";
+import { FaSave } from "react-icons/fa";
+import { toast } from "react-toastify";
+
+const defaultConfig = { appName: "", siteTitle: "" };
+
+export default function AppSettingsPage() {
+  const [config, setConfig] = useState(defaultConfig);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchAppConfig();
+        if (data) setConfig({ ...defaultConfig, ...data });
+      } catch (err) {
+        console.error("Failed to load app settings", err);
+      }
+    };
+    load();
+  }, []);
+
+  const handleChange = (field, value) => {
+    setConfig((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSave = async () => {
+    try {
+      await updateAppConfig(config);
+      toast.success("Settings saved");
+    } catch (err) {
+      console.error("Failed to save settings", err);
+      toast.error("Failed to save settings");
+    }
+  };
+
+  return (
+    <AdminLayout title="App Settings">
+      <div className="max-w-xl mx-auto p-6 space-y-6">
+        <h1 className="text-2xl font-bold text-gray-800">App Settings</h1>
+        <div className="bg-white p-4 rounded-lg shadow space-y-4">
+          <div>
+            <label className="block font-semibold mb-1">Application Name</label>
+            <input
+              type="text"
+              className="w-full border rounded p-2"
+              value={config.appName}
+              onChange={(e) => handleChange("appName", e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block font-semibold mb-1">Site Title</label>
+            <input
+              type="text"
+              className="w-full border rounded p-2"
+              value={config.siteTitle}
+              onChange={(e) => handleChange("siteTitle", e.target.value)}
+            />
+          </div>
+          <div className="text-right">
+            <button
+              onClick={handleSave}
+              className="inline-flex items-center gap-2 bg-yellow-600 text-white px-4 py-2 rounded hover:bg-yellow-700"
+            >
+              <FaSave /> Save Settings
+            </button>
+          </div>
+        </div>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/frontend/src/services/admin/appConfigService.js
+++ b/frontend/src/services/admin/appConfigService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchAppConfig = async () => {
+  const { data } = await api.get("/app-config");
+  return data?.data ?? {};
+};
+
+export const updateAppConfig = async (payload) => {
+  const { data } = await api.put("/app-config", payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- add appConfig module on backend for storing global app settings
- expose `/api/app-config` routes
- include tests for new routes
- add frontend service and admin page for editing app name & site title
- add page link in admin sidebar

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685f1522211483289b12db38df96e51e