### PR TITLE
Connect frontend with app settings

### DIFF
--- a/frontend/src/components/website/sections/Footer.js
+++ b/frontend/src/components/website/sections/Footer.js
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import GoogleAd from "@/components/shared/GoogleAd";
+import { API_BASE_URL } from "@/config/config";
+import useAppConfigStore from "@/store/appConfigStore";
 import { 
   FaFacebook, FaTwitter, FaLinkedin, FaInstagram, FaYoutube, 
   FaEnvelope, FaPhone, FaMapMarkerAlt, FaCcVisa, FaCcMastercard, 
@@ -11,6 +13,12 @@ import {
 const Footer = () => {
   const [showScroll, setShowScroll] = useState(false);
   const [email, setEmail] = useState("");
+  const settings = useAppConfigStore((state) => state.settings);
+  const fetchAppConfig = useAppConfigStore((state) => state.fetch);
+
+  useEffect(() => {
+    fetchAppConfig();
+  }, [fetchAppConfig]);
 
   useEffect(() => {
     const checkScrollTop = () => {
@@ -39,9 +47,9 @@ const Footer = () => {
             
             {/* About Section */}
             <div>
-              <h3 className="text-lg font-bold mb-4 text-yellow-400">About SkillBridge</h3>
+              <h3 className="text-lg font-bold mb-4 text-yellow-400">About {settings.appName || 'SkillBridge'}</h3>
               <p className="text-sm leading-relaxed">
-                SkillBridge connects learners with expert instructors worldwide.
+                {settings.metaDescription || 'SkillBridge connects learners with expert instructors worldwide.'}
               </p>
               <div className="flex space-x-4 mt-4">
                 {[{ href: "https://facebook.com", icon: <FaFacebook /> },
@@ -162,7 +170,7 @@ const Footer = () => {
 
         {/* Copyright Section */}
         <div className="text-center text-sm">
-          <p>&copy; {new Date().getFullYear()} SkillBridge. All rights reserved.</p>
+          <p>&copy; {new Date().getFullYear()} {settings.appName || 'SkillBridge'}. All rights reserved.</p>
           <div className="flex justify-center space-x-6 mt-2">
             <Link href="/privacy-policy" className="hover:text-yellow-300 transition">Privacy Policy</Link>
             <span>|</span>

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -28,6 +28,7 @@ import { API_BASE_URL } from "@/config/config";
 import useCartStore from "@/store/cart/cartStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import useAppConfigStore from "@/store/appConfigStore";
 
 // ✅ Assets
 import logo from "@/shared/assets/images/login/logo.png";
@@ -44,6 +45,8 @@ const Navbar = () => {
   const dropdownRef = useRef(null);
   const user = useAuthStore((state) => state.user);
   const logout = useAuthStore((state) => state.logout);
+  const appSettings = useAppConfigStore((state) => state.settings);
+  const fetchAppConfig = useAppConfigStore((state) => state.fetch);
 
   const { profile, fetchProfile, clearAdmin } = useAdminStore();
   const router = useRouter();
@@ -64,6 +67,10 @@ const Navbar = () => {
   const startMessagePolling = useMessageStore((state) => state.startPolling);
   const markMessageRead = useMessageStore((state) => state.markRead);
   const unreadMessages = messages.filter((m) => !m.read);
+
+  useEffect(() => {
+    fetchAppConfig();
+  }, [fetchAppConfig]);
 
   useEffect(() => {
     if (user?.role === "SuperAdmin" && !profile) fetchProfile();
@@ -155,13 +162,13 @@ const Navbar = () => {
 
       <div className="flex items-center space-x-6">
         <Link href="/">
-          <div className="w-14 h-14 rounded-full border-4 border-gray-800 flex items-center justify-center shadow-lg bg-gray-800 cursor-pointer">
-            <Image
-              src={logo}
-              alt="SkillBridge Logo"
+          <div className="w-14 h-14 rounded-full border-4 border-gray-800 flex items-center justify-center shadow-lg bg-gray-800 cursor-pointer overflow-hidden">
+            <img
+              src={appSettings.logo_url ? `${API_BASE_URL}${appSettings.logo_url}` : logo.src || logo}
+              alt={`${appSettings.appName || 'SkillBridge'} Logo`}
               width={45}
               height={45}
-              className="rounded-full"
+              className="rounded-full object-contain"
             />
           </div>
         </Link>

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -7,6 +7,8 @@ import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
 import "@/styles/globals.css";    
 import "@/services/api/tokenInterceptor";
 import useAuthStore from "@/store/auth/authStore";
+import useAppConfigStore from "@/store/appConfigStore";
+import Head from "next/head";
 import "@/styles/globals.css"; // or whatever your path is
 
 
@@ -22,7 +24,11 @@ function MyApp({ Component, pageProps, router }) {
   // Support for per-page layout pattern
   const getLayout = Component.getLayout || ((page) => page);
 
-    useEffect(() => {
+  const fetchConfig = useAppConfigStore((state) => state.fetch);
+  const configLoaded = useAppConfigStore((state) => state.loaded);
+  const settings = useAppConfigStore((state) => state.settings);
+
+  useEffect(() => {
     const local = localStorage.getItem("auth");
     if (local) {
       const parsed = JSON.parse(local)?.state;
@@ -36,6 +42,10 @@ function MyApp({ Component, pageProps, router }) {
     }
   }, []);
 
+  useEffect(() => {
+    if (!configLoaded) fetchConfig();
+  }, [configLoaded, fetchConfig]);
+
   return (
     <AnimatePresence mode="wait">
       {/* Motion wrapper for route transition */}
@@ -46,6 +56,18 @@ function MyApp({ Component, pageProps, router }) {
         exit={{ opacity: 0, y: 10 }}
         transition={{ duration: 0.3 }}
       >
+        <Head>
+          <title>{settings.siteTitle || 'SkillBridge'}</title>
+          {settings.metaDescription && (
+            <meta name="description" content={settings.metaDescription} />
+          )}
+          {settings.favicon_url && (
+            <link
+              rel="icon"
+              href={`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000'}${settings.favicon_url}`}
+            />
+          )}
+        </Head>
         {/* Render page with layout */}
         {getLayout(<Component {...pageProps} />)}
 

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -11,6 +11,8 @@ import { motion } from "framer-motion";
 import Image from "next/image";
 
 import logo from "@/shared/assets/images/login/logo.png";
+import { API_BASE_URL } from "@/config/config";
+import useAppConfigStore from "@/store/appConfigStore";
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
 import InputField from "@/shared/components/auth/InputField";
 import SocialLogin from "@/shared/components/auth/SocialLogin";
@@ -32,6 +34,8 @@ export default function Login() {
   const login = useAuthStore((state) => state.login);
   const hasHydrated = useAuthStore((state) => state.hasHydrated);
   const fetchNotifications = useNotificationStore((state) => state.fetch);
+  const settings = useAppConfigStore((state) => state.settings);
+  const fetchAppConfig = useAppConfigStore((state) => state.fetch);
 
   // ─────────────────────
   // 📝 Form setup
@@ -66,6 +70,10 @@ export default function Login() {
       router.replace("/website");
     }
   }, [hasHydrated, user]);
+
+  useEffect(() => {
+    fetchAppConfig();
+  }, [fetchAppConfig]);
 
   // ─────────────────────────────
   // 🔑 Handle form submission
@@ -123,11 +131,19 @@ export default function Login() {
         transition={{ duration: 0.3 }}
         className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-96 border border-gray-700 text-white flex flex-col items-center"
       >
-        <div className="w-24 h-24 rounded-full border-4 border-yellow-500 bg-gray-900 flex items-center justify-center mb-4 shadow-lg">
-          <Image src={logo} alt="SkillBridge Logo" width={80} height={80} priority className="rounded-full" />
+        <div className="w-24 h-24 rounded-full border-4 border-yellow-500 bg-gray-900 flex items-center justify-center mb-4 shadow-lg overflow-hidden">
+          <Image
+            src={settings.logo_url ? `${API_BASE_URL}${settings.logo_url}` : logo}
+            alt={(settings.appName || 'SkillBridge') + ' Logo'}
+            width={80}
+            height={80}
+            priority
+            className="rounded-full object-contain"
+          />
         </div>
-
-        <h2 className="text-2xl font-bold text-center text-yellow-400 mb-6">Welcome to SkillBridge 🎓</h2>
+        <h2 className="text-2xl font-bold text-center text-yellow-400 mb-6">
+          Welcome to {settings.appName || 'SkillBridge'} 🎓
+        </h2>
 
         {/* Login Form */}
         <form onSubmit={handleSubmit(onSubmit)} className="w-full">

--- a/frontend/src/pages/auth/register.js
+++ b/frontend/src/pages/auth/register.js
@@ -11,6 +11,8 @@ import PhoneInput from "react-phone-number-input";
 import 'react-phone-number-input/style.css';
 
 import logo from "@/shared/assets/images/login/logo.png";
+import { API_BASE_URL } from "@/config/config";
+import useAppConfigStore from "@/store/appConfigStore";
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
 import InputField from "@/shared/components/auth/InputField";
 import SocialRegister from "@/shared/components/auth/SocialRegister";
@@ -22,6 +24,8 @@ export default function Register() {
   const router = useRouter();
   const { register: registerUser, user, hasHydrated } = useAuthStore();
   const fetchNotifications = useNotificationStore((state) => state.fetch);
+  const settings = useAppConfigStore((state) => state.settings);
+  const fetchAppConfig = useAppConfigStore((state) => state.fetch);
 
   const {
     register,
@@ -48,6 +52,10 @@ export default function Register() {
     if (!hasHydrated) return;
     if (user) router.replace("/website");
   }, [user, hasHydrated]);
+
+  useEffect(() => {
+    fetchAppConfig();
+  }, [fetchAppConfig]);
 
   const onSubmit = async (data) => {
     try {
@@ -76,12 +84,19 @@ export default function Register() {
         transition={{ duration: 0.4 }}
         className="relative bg-gray-800/90 backdrop-blur-md rounded-xl shadow-2xl p-8 w-full max-w-md border border-yellow-500/40 text-white flex flex-col items-center"
       >
-        <div className="w-24 h-24 rounded-full border-4 border-yellow-500 bg-gray-900 flex items-center justify-center mb-4 shadow-lg">
-          <Image src={logo} alt="SkillBridge Logo" width={80} height={80} className="rounded-full" priority />
+        <div className="w-24 h-24 rounded-full border-4 border-yellow-500 bg-gray-900 flex items-center justify-center mb-4 shadow-lg overflow-hidden">
+          <Image
+            src={settings.logo_url ? `${API_BASE_URL}${settings.logo_url}` : logo}
+            alt={(settings.appName || 'SkillBridge') + ' Logo'}
+            width={80}
+            height={80}
+            className="rounded-full object-contain"
+            priority
+          />
         </div>
 
         <h2 className="text-2xl font-bold text-center text-yellow-400 mb-6">
-          Create an Account 🎓
+          Create an Account at {settings.appName || 'SkillBridge'} 🎓
         </h2>
 
         <div className="flex justify-between bg-gray-700 rounded-lg p-2 mb-4 w-full">

--- a/frontend/src/services/appConfigService.js
+++ b/frontend/src/services/appConfigService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const getAppConfig = async () => {
+  const { data } = await api.get("/app-config");
+  return data?.data ?? {};
+};

--- a/frontend/src/store/appConfigStore.js
+++ b/frontend/src/store/appConfigStore.js
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { getAppConfig } from "@/services/appConfigService";
+
+const useAppConfigStore = create(
+  persist(
+    (set, get) => ({
+      settings: {},
+      loading: false,
+      loaded: false,
+      fetch: async () => {
+        if (get().loading) return;
+        set({ loading: true });
+        try {
+          const data = await getAppConfig();
+          set({ settings: data, loaded: true, loading: false });
+        } catch (err) {
+          set({ loaded: true, loading: false });
+        }
+      },
+      clear: () => set({ settings: {}, loaded: false }),
+    }),
+    { name: "app-config" }
+  )
+);
+
+export default useAppConfigStore;


### PR DESCRIPTION
## Summary
- add service and Zustand store for `/api/app-config`
- load settings on app startup and expose via context
- use saved logo and name on login, register, navbar and footer
- set document title, description and favicon based on saved settings

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*
- `npm run lint --prefix frontend` *(fails: cannot find @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_685f1e1edf5c8328b3f1a284c047df7e