### PR TITLE
Fix dynamic page titles

### DIFF
--- a/frontend/src/components/common/PageHead.js
+++ b/frontend/src/components/common/PageHead.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Head from 'next/head';
+import useAppConfigStore from '@/store/appConfigStore';
+
+export default function PageHead({ title }) {
+  const appName = useAppConfigStore((state) => state.settings.appName) || 'SkillBridge';
+  return (
+    <Head>
+      <title>{`${appName} | ${title}`}</title>
+    </Head>
+  );
+}

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -46,6 +46,16 @@ function MyApp({ Component, pageProps, router }) {
     if (!configLoaded) fetchConfig();
   }, [configLoaded, fetchConfig]);
 
+  const getPageTitle = () => {
+    const slug = router.pathname.split('/').pop();
+    if (!slug || slug === 'index') return 'Home';
+    if (slug.startsWith('[')) return slug.slice(1, -1);
+    return slug.replace(/-/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
+  };
+
+  const appName = settings.appName || 'SkillBridge';
+  const defaultTitle = `${appName} | ${getPageTitle()}`;
+
   return (
     <AnimatePresence mode="wait">
       {/* Motion wrapper for route transition */}
@@ -57,7 +67,7 @@ function MyApp({ Component, pageProps, router }) {
         transition={{ duration: 0.3 }}
       >
         <Head>
-          <title>{settings.siteTitle || 'SkillBridge'}</title>
+          <title>{defaultTitle}</title>
           {settings.metaDescription && (
             <meta name="description" content={settings.metaDescription} />
           )}

--- a/frontend/src/pages/about/index.js
+++ b/frontend/src/pages/about/index.js
@@ -1,13 +1,11 @@
-import Head from 'next/head';
+import PageHead from '@/components/common/PageHead';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 
 export default function AboutUsPage() {
   return (
     <>
-      <Head>
-        <title>About Us – SkillBridge</title>
-      </Head>
+      <PageHead title="About Us" />
       <Navbar />
       <section className="bg-black text-white text-center py-24">
         <h1 className="text-4xl font-bold mb-4">Empowering Global Learning</h1>

--- a/frontend/src/pages/blog/index.js
+++ b/frontend/src/pages/blog/index.js
@@ -1,4 +1,4 @@
-import Head from 'next/head';
+import PageHead from '@/components/common/PageHead';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import Link from 'next/link';
@@ -25,9 +25,7 @@ const mockPosts = [
 export default function BlogPage() {
   return (
     <>
-      <Head>
-        <title>Blog – SkillBridge</title>
-      </Head>
+      <PageHead title="Blog" />
 
       <div className="bg-gray-900 text-white min-h-screen">
         <Navbar />

--- a/frontend/src/pages/contact/index.js
+++ b/frontend/src/pages/contact/index.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 
@@ -29,9 +29,7 @@ export default function ContactPage() {
 
   return (
     <>
-      <Head>
-        <title>Contact Us - SkillBridge</title>
-      </Head>
+      <PageHead title="Contact Us" />
 
       <div className="bg-gray-900 min-h-screen text-white">
         <Navbar />

--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -2,7 +2,7 @@
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useEffect, useState } from "react";
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import { fetchAdById, fetchAdAnalytics } from "@/services/admin/adService";
 import {
   LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid,
@@ -37,9 +37,7 @@ export default function AdAnalyticsPage() {
 
   return (
     <AdminLayout>
-      <Head>
-        <title>Ad Analytics - {ad.title}</title>
-      </Head>
+      <PageHead title={`Ad Analytics - ${ad.title}`} />
   
       <div className="p-4 sm:p-6 space-y-8 max-w-screen-xl mx-auto">
         {/* Header */}

--- a/frontend/src/pages/dashboard/admin/support/index.js
+++ b/frontend/src/pages/dashboard/admin/support/index.js
@@ -1,13 +1,11 @@
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import Link from "next/link";
 
 export default function AdminSupportHome() {
   return (
     <AdminLayout>
-      <Head>
-        <title>Support - Admin Dashboard | SkillBridge</title>
-      </Head>
+      <PageHead title="Support - Admin Dashboard" />
       <div className="px-6 py-10">
         <h1 className="text-3xl font-bold text-gray-900 mb-8">Support Dashboard</h1>
 

--- a/frontend/src/pages/dashboard/admin/support/tickets/[id].js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/[id].js
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState } from "react";
 
@@ -57,9 +57,7 @@ export default function AdminTicketDetail() {
 
   return (
     <AdminLayout>
-      <Head>
-        <title>Ticket {id} - Admin | SkillBridge</title>
-      </Head>
+      <PageHead title={`Ticket ${id} - Admin`} />
       <div className="px-6 py-10">
         <div className="flex items-center justify-between mb-2">
           <h1 className="text-2xl font-bold text-gray-900">{mockThread.subject}</h1>

--- a/frontend/src/pages/dashboard/admin/support/tickets/index.js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/index.js
@@ -1,4 +1,4 @@
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import Link from "next/link";
 
@@ -26,9 +26,7 @@ const mockTickets = [
 export default function AdminSupportTicketsPage() {
     return (
         <AdminLayout>
-            <Head>
-                <title>Support Tickets - Admin | SkillBridge</title>
-            </Head>
+            <PageHead title="Support Tickets - Admin" />
             <div className="px-6 py-10">
                 <h1 className="text-2xl font-bold text-gray-900 mb-6">All Support Tickets</h1>
 

--- a/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
@@ -2,7 +2,7 @@
 import { useRouter } from "next/router";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { useEffect, useState } from "react";
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import { fetchAdById } from "@/services/admin/adService";
 import {
   LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid,
@@ -61,9 +61,7 @@ export default function InstructorAdAnalyticsPage() {
 
   return (
     <InstructorLayout>
-      <Head>
-        <title>Ad Analytics - {ad.title}</title>
-      </Head>
+      <PageHead title={`Ad Analytics - ${ad.title}`} />
 
       <div className="p-4 sm:p-6 space-y-8 max-w-screen-xl mx-auto">
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">

--- a/frontend/src/pages/dashboard/instructor/support/index.js
+++ b/frontend/src/pages/dashboard/instructor/support/index.js
@@ -1,13 +1,11 @@
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Link from "next/link";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 
 export default function StudentSupportHome() {
   return (
     <InstructorLayout>
-      <Head>
-        <title>Support - Dashboard | SkillBridge</title>
-      </Head>
+      <PageHead title="Support - Dashboard" />
       <div className="px-6 py-10">
         <h1 className="text-3xl font-bold text-gray-900 mb-8">Support Center</h1>
 

--- a/frontend/src/pages/dashboard/instructor/support/my-tickets.js
+++ b/frontend/src/pages/dashboard/instructor/support/my-tickets.js
@@ -1,4 +1,4 @@
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Link from "next/link";
 import StudentLayout from "@/components/layouts/StudentLayout";
 
@@ -22,9 +22,7 @@ const mockTickets = [
 export default function MyTicketsPage() {
   return (
     <StudentLayout>
-      <Head>
-        <title>My Tickets - Dashboard | SkillBridge</title>
-      </Head>
+      <PageHead title="My Tickets - Dashboard" />
       <div className="px-6 py-10">
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold text-gray-900">My Support Tickets</h1>

--- a/frontend/src/pages/dashboard/student/support/index.js
+++ b/frontend/src/pages/dashboard/student/support/index.js
@@ -1,13 +1,11 @@
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Link from "next/link";
 import StudentLayout from "@/components/layouts/StudentLayout";
 
 export default function StudentSupportHome() {
   return (
     <StudentLayout>
-      <Head>
-        <title>Support - Dashboard | SkillBridge</title>
-      </Head>
+      <PageHead title="Support - Dashboard" />
       <div className="px-6 py-10">
         <h1 className="text-3xl font-bold text-gray-900 mb-8">Support Center</h1>
 

--- a/frontend/src/pages/dashboard/student/support/my-tickets.js
+++ b/frontend/src/pages/dashboard/student/support/my-tickets.js
@@ -1,4 +1,4 @@
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Link from "next/link";
 import StudentLayout from "@/components/layouts/StudentLayout";
 
@@ -22,9 +22,7 @@ const mockTickets = [
 export default function MyTicketsPage() {
   return (
     <StudentLayout>
-      <Head>
-        <title>My Tickets - Dashboard | SkillBridge</title>
-      </Head>
+      <PageHead title="My Tickets - Dashboard" />
       <div className="px-6 py-10">
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold text-gray-900">My Support Tickets</h1>

--- a/frontend/src/pages/faqs/index.js
+++ b/frontend/src/pages/faqs/index.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Head from 'next/head';
+import PageHead from '@/components/common/PageHead';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
@@ -28,9 +28,7 @@ export default function FaqPage() {
 
   return (
     <>
-      <Head>
-        <title>FAQs – SkillBridge</title>
-      </Head>
+      <PageHead title="FAQs" />
 
       <div className="bg-gray-900 min-h-screen text-white">
         <Navbar />

--- a/frontend/src/pages/offers/[id].js
+++ b/frontend/src/pages/offers/[id].js
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import Link from "next/link";
+import PageHead from "@/components/common/PageHead";
 import Head from "next/head";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -133,8 +134,8 @@ const OfferDetailsPage = () => {
 
   return (
     <div className="bg-gray-950 text-white min-h-screen">
+      <PageHead title={`${offer.title} – Offer`} />
       <Head>
-        <title>{offer.title} – SkillBridge Offer</title>
         <meta name="description" content={`Offer details: ${offer.description}`} />
       </Head>
       <Navbar />

--- a/frontend/src/pages/promotions/[id].js
+++ b/frontend/src/pages/promotions/[id].js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import Image from "next/image";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
+import PageHead from "@/components/common/PageHead";
 import Head from "next/head";
 import Link from "next/link";
 
@@ -66,8 +67,8 @@ export default function PromotionPage() {
 
   return (
     <>
+      <PageHead title={`${promotion.title} - Offer`} />
       <Head>
-        <title>{promotion.title} - Offer</title>
         <meta name="description" content={promotion.description} />
         <meta property="og:image" content={promotion.image} />
       </Head>

--- a/frontend/src/pages/promotions/index.js
+++ b/frontend/src/pages/promotions/index.js
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import Link from "next/link";
+import PageHead from "@/components/common/PageHead";
 import Head from "next/head";
 
 const mockPromotions = {
@@ -72,8 +73,8 @@ const PromotionsPage = () => {
 
   return (
     <>
+      <PageHead title={`${promotion.title} - Special Offer`} />
       <Head>
-        <title>{promotion.title} - Special Offer</title>
         <meta name="description" content={promotion.description} />
         {/* SEO & Social Media Metadata */}
         <meta property="og:title" content={promotion.title} />

--- a/frontend/src/pages/support/articles/[id].js
+++ b/frontend/src/pages/support/articles/[id].js
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Link from "next/link";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
@@ -28,9 +28,7 @@ export default function ArticlePage() {
 
   return (
     <div className="bg-gray-900 text-white min-h-screen">
-      <Head>
-        <title>{article ? `${article.title} - Support` : 'Loading...'} | SkillBridge</title>
-      </Head>
+      <PageHead title={article ? `${article.title} - Support` : 'Loading...'} />
       <Navbar />
       <main className="max-w-4xl mx-auto px-4 py-24">
         {article ? (

--- a/frontend/src/pages/support/categories/[slug].js
+++ b/frontend/src/pages/support/categories/[slug].js
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Link from "next/link";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
@@ -35,9 +35,7 @@ export default function SupportCategoryPage() {
 
   return (
     <div className="bg-gray-900 text-white min-h-screen">
-      <Head>
-        <title>{category ? `${category.title} - Support` : 'Loading...'} | SkillBridge</title>
-      </Head>
+      <PageHead title={category ? `${category.title} - Support` : 'Loading...'} />
       <Navbar />
       <main className="max-w-4xl mx-auto px-4 py-20">
         {category ? (

--- a/frontend/src/pages/support/index.js
+++ b/frontend/src/pages/support/index.js
@@ -1,4 +1,4 @@
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Link from "next/link";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
@@ -6,9 +6,7 @@ import Footer from "@/components/website/sections/Footer";
 export default function WebsiteSupportHome() {
   return (
     <div className="bg-gray-900 text-white min-h-screen">
-      <Head>
-        <title>Support - SkillBridge</title>
-      </Head>
+      <PageHead title="Support" />
       <Navbar />
       <main className="max-w-4xl mx-auto px-4 py-20 text-center">
         <h1 className="text-4xl font-bold text-yellow-500 mb-6">Welcome to the Support Center</h1>

--- a/frontend/src/pages/support/submit.js
+++ b/frontend/src/pages/support/submit.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 
@@ -25,9 +25,7 @@ export default function SubmitTicketPage() {
 
   return (
     <div className="bg-gray-900 text-white min-h-screen">
-      <Head>
-        <title>Submit a Support Ticket - SkillBridge</title>
-      </Head>
+      <PageHead title="Submit a Support Ticket" />
       <Navbar />
       <main className="max-w-3xl mx-auto px-4 py-20">
         <h1 className="text-3xl font-bold text-yellow-500 mb-6">Submit a Support Ticket</h1>

--- a/frontend/src/pages/support/ticket-status.js
+++ b/frontend/src/pages/support/ticket-status.js
@@ -1,4 +1,4 @@
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 
@@ -23,9 +23,7 @@ const mockTickets = [
 export default function TicketStatusPage() {
   return (
     <div className="bg-gray-900 text-white min-h-screen">
-      <Head>
-        <title>My Support Tickets - SkillBridge</title>
-      </Head>
+      <PageHead title="My Support Tickets" />
       <Navbar />
       <main className="max-w-5xl mx-auto px-4 py-20">
         <h1 className="text-3xl font-bold text-yellow-500 mb-8 text-center">My Support Tickets</h1>

--- a/frontend/src/pages/support/tickets/[id].js
+++ b/frontend/src/pages/support/tickets/[id].js
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import Head from "next/head";
+import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import { useState } from "react";
@@ -39,9 +39,7 @@ export default function TicketDetailPage() {
 
   return (
     <div className="bg-gray-900 text-white min-h-screen">
-      <Head>
-        <title>Ticket {id} - Support | SkillBridge</title>
-      </Head>
+      <PageHead title={`Ticket ${id} - Support`} />
       <Navbar />
       <main className="max-w-4xl mx-auto px-4 py-20">
         <h1 className="text-2xl font-bold text-yellow-500 mb-4">{mockThread.subject}</h1>


### PR DESCRIPTION
## Summary
- add `PageHead` component for consistent titles
- derive page names automatically in `_app.js`
- update pages to use the new helper

## Testing
- `npm test --silent` in `frontend` *(fails: jest not found)*
- `npm test --silent` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2186f76c8328b782bc0ad2b8048b