### PR TITLE
Remove branding from dashboard header

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -19,8 +19,6 @@ import { toggleInstructorStatus } from "@/services/instructor/instructorService"
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import useAppConfigStore from "@/store/appConfigStore";
-import { API_BASE_URL } from "@/config/config";
-import logo from "@/shared/assets/images/login/logo.png";
 
 export default function Header() {
   const user = useAuthStore((state) => state.user);
@@ -149,16 +147,6 @@ export default function Header() {
   return (
     <header className="bg-white dark:bg-gray-900 shadow-sm px-6 py-4 flex justify-between items-center sticky top-0 z-30">
       <div className="flex items-center gap-4">
-        <div className="flex items-center gap-2">
-          <img
-            src={appSettings.logo_url ? `${API_BASE_URL}${appSettings.logo_url}` : logo.src || logo}
-            alt={`${appSettings.appName || 'SkillBridge'} Logo`}
-            className="w-10 h-10 rounded-full object-contain shadow"
-          />
-          <span className="hidden sm:block text-xl font-extrabold text-yellow-500">
-            {appSettings.appName || 'SkillBridge'}
-          </span>
-        </div>
         <h1 className="text-2xl font-bold text-gray-800 dark:text-white tracking-tight">
           {getPageTitle()}
         </h1>


### PR DESCRIPTION
## Summary
- clean up dashboard header by removing app name and logo

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685f290de25c8328ba5e8b637c9a0e97