### PR TITLE
Add class student roster endpoints

### DIFF
--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const controller = require("./class.controller");
 const tagsController = require("./classTag.controller");
+const enrollmentCtrl = require("./enrollments/classEnrollment.controller");
 const validate = require("../../middleware/validate");
 const validator = require("./class.validator");
 const upload = require("./classUploadMiddleware");
@@ -56,6 +57,18 @@ router.get(
   verifyToken,
   isInstructorOrAdmin,
   controller.getClassAnalytics
+);
+router.get(
+  "/admin/:id/students",
+  verifyToken,
+  isInstructorOrAdmin,
+  enrollmentCtrl.getStudentsByClass
+);
+router.get(
+  "/admin/:classId/students/:studentId",
+  verifyToken,
+  isInstructorOrAdmin,
+  enrollmentCtrl.getStudent
 );
 router.put(
   "/admin/:id",

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -17,7 +17,9 @@ jest.mock('../classEnrollment.service', () => ({
   findEnrollment: jest.fn(),
   createEnrollment: jest.fn(),
   markCompleted: jest.fn(),
-  getByUser: jest.fn()
+  getByUser: jest.fn(),
+  getByClass: jest.fn(),
+  getStudent: jest.fn()
 }));
 const service = require('../classEnrollment.service');
 
@@ -56,5 +58,23 @@ describe('Class enrollment routes', () => {
     const res = await request(app).get('/classes/enroll/my');
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toEqual(list);
+  });
+
+  test('list students in class', async () => {
+    const list = [{ id: 'stu' }];
+    service.getByClass.mockResolvedValue(list);
+    const res = await request(app).get('/classes/admin/abc/students');
+    expect(res.statusCode).toBe(200);
+    expect(service.getByClass).toHaveBeenCalledWith('abc');
+    expect(res.body.data).toEqual(list);
+  });
+
+  test('get student details', async () => {
+    const student = { id: 'stu' };
+    service.getStudent.mockResolvedValue(student);
+    const res = await request(app).get('/classes/admin/abc/students/def');
+    expect(res.statusCode).toBe(200);
+    expect(service.getStudent).toHaveBeenCalledWith('abc', 'def');
+    expect(res.body.data).toEqual(student);
   });
 });

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -24,3 +24,14 @@ exports.getMyEnrollments = catchAsync(async (req, res) => {
   const data = await service.getByUser(req.user.id);
   sendSuccess(res, data);
 });
+
+exports.getStudentsByClass = catchAsync(async (req, res) => {
+  const data = await service.getByClass(req.params.id);
+  sendSuccess(res, data);
+});
+
+exports.getStudent = catchAsync(async (req, res) => {
+  const { classId, studentId } = req.params;
+  const data = await service.getStudent(classId, studentId);
+  sendSuccess(res, data);
+});

--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -27,3 +27,33 @@ exports.getByUser = async (user_id) => {
       "u.full_name as instructor"
     );
 };
+
+// List all students enrolled in a class
+exports.getByClass = async (class_id) => {
+  return db("class_enrollments as ce")
+    .join("users as u", "ce.user_id", "u.id")
+    .where("ce.class_id", class_id)
+    .select(
+      "u.id",
+      "u.full_name",
+      "u.email",
+      "ce.status",
+      "ce.enrolled_at"
+    )
+    .orderBy("ce.enrolled_at");
+};
+
+// Get a single student's enrollment details in a class
+exports.getStudent = async (class_id, user_id) => {
+  return db("class_enrollments as ce")
+    .join("users as u", "ce.user_id", "u.id")
+    .where({ "ce.class_id": class_id, "ce.user_id": user_id })
+    .select(
+      "u.id",
+      "u.full_name",
+      "u.email",
+      "ce.status",
+      "ce.enrolled_at"
+    )
+    .first();
+};


### PR DESCRIPTION
## Summary
- expand enrollment service with queries for class rosters
- add controller functions for listing students
- expose new admin routes to fetch students
- cover routes with tests

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685f282f6d14832886f731a7423e24f0