### PR TITLE
Add class student roster endpoints

### DIFF
--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const controller = require("./class.controller");
 const tagsController = require("./classTag.controller");
+const enrollmentCtrl = require("./enrollments/classEnrollment.controller");
 const validate = require("../../middleware/validate");
 const validator = require("./class.validator");
 const upload = require("./classUploadMiddleware");
@@ -56,6 +57,18 @@ router.get(
   verifyToken,
   isInstructorOrAdmin,
   controller.getClassAnalytics
+);
+router.get(
+  "/admin/:id/students",
+  verifyToken,
+  isInstructorOrAdmin,
+  enrollmentCtrl.getStudentsByClass
+);
+router.get(
+  "/admin/:classId/students/:studentId",
+  verifyToken,
+  isInstructorOrAdmin,
+  enrollmentCtrl.getStudent
 );
 router.put(
   "/admin/:id",

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -17,7 +17,9 @@ jest.mock('../classEnrollment.service', () => ({
   findEnrollment: jest.fn(),
   createEnrollment: jest.fn(),
   markCompleted: jest.fn(),
-  getByUser: jest.fn()
+  getByUser: jest.fn(),
+  getByClass: jest.fn(),
+  getStudent: jest.fn()
 }));
 const service = require('../classEnrollment.service');
 
@@ -56,5 +58,23 @@ describe('Class enrollment routes', () => {
     const res = await request(app).get('/classes/enroll/my');
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toEqual(list);
+  });
+
+  test('list students in class', async () => {
+    const list = [{ id: 'stu' }];
+    service.getByClass.mockResolvedValue(list);
+    const res = await request(app).get('/classes/admin/abc/students');
+    expect(res.statusCode).toBe(200);
+    expect(service.getByClass).toHaveBeenCalledWith('abc');
+    expect(res.body.data).toEqual(list);
+  });
+
+  test('get student details', async () => {
+    const student = { id: 'stu' };
+    service.getStudent.mockResolvedValue(student);
+    const res = await request(app).get('/classes/admin/abc/students/def');
+    expect(res.statusCode).toBe(200);
+    expect(service.getStudent).toHaveBeenCalledWith('abc', 'def');
+    expect(res.body.data).toEqual(student);
   });
 });

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -24,3 +24,14 @@ exports.getMyEnrollments = catchAsync(async (req, res) => {
   const data = await service.getByUser(req.user.id);
   sendSuccess(res, data);
 });
+
+exports.getStudentsByClass = catchAsync(async (req, res) => {
+  const data = await service.getByClass(req.params.id);
+  sendSuccess(res, data);
+});
+
+exports.getStudent = catchAsync(async (req, res) => {
+  const { classId, studentId } = req.params;
+  const data = await service.getStudent(classId, studentId);
+  sendSuccess(res, data);
+});

--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -27,3 +27,33 @@ exports.getByUser = async (user_id) => {
       "u.full_name as instructor"
     );
 };
+
+// List all students enrolled in a class
+exports.getByClass = async (class_id) => {
+  return db("class_enrollments as ce")
+    .join("users as u", "ce.user_id", "u.id")
+    .where("ce.class_id", class_id)
+    .select(
+      "u.id",
+      "u.full_name",
+      "u.email",
+      "ce.status",
+      "ce.enrolled_at"
+    )
+    .orderBy("ce.enrolled_at");
+};
+
+// Get a single student's enrollment details in a class
+exports.getStudent = async (class_id, user_id) => {
+  return db("class_enrollments as ce")
+    .join("users as u", "ce.user_id", "u.id")
+    .where({ "ce.class_id": class_id, "ce.user_id": user_id })
+    .select(
+      "u.id",
+      "u.full_name",
+      "u.email",
+      "ce.status",
+      "ce.enrolled_at"
+    )
+    .first();
+};

--- a/frontend/src/pages/api/classes/[classId]/students/index.js
+++ b/frontend/src/pages/api/classes/[classId]/students/index.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+export default async function handler(req, res) {
+  const { classId } = req.query;
+  try {
+    const { data } = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/classes/admin/${classId}/students`
+    );
+    return res.status(200).json(data.data || data);
+  } catch (err) {
+    const status = err.response?.status || 500;
+    const message = err.response?.data?.message || 'Failed to fetch students';
+    res.status(status).json({ error: message });
+  }
+}

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
@@ -2,6 +2,7 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import { fetchClassStudent } from "@/services/admin/classService";
 
 export default function ManageStudentInClassPage() {
   const { id, studentId } = useRouter().query;
@@ -11,11 +12,9 @@ export default function ManageStudentInClassPage() {
 
   useEffect(() => {
     if (!id || !studentId) return;
-    async function fetchStudent() {
+    async function load() {
       try {
-        const res = await fetch(`/api/classes/${id}/students/${studentId}`);
-        if (!res.ok) throw new Error("Failed to fetch");
-        const data = await res.json();
+        const data = await fetchClassStudent(id, studentId);
         setStudent(data);
       } catch (err) {
         console.error(err);
@@ -23,7 +22,7 @@ export default function ManageStudentInClassPage() {
         setLoading(false);
       }
     }
-    fetchStudent();
+    load();
   }, [id, studentId]);
 
   if (loading) {

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
@@ -1,0 +1,76 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { fetchClassStudents } from "@/services/admin/classService";
+
+export default function ClassStudentsPage() {
+  const { id } = useRouter().query;
+  const [students, setStudents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    async function load() {
+      setLoading(true);
+      try {
+        const list = await fetchClassStudents(id);
+        setStudents(list);
+      } catch (err) {
+        console.error(err);
+        setError("Failed to load students");
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold text-gray-800">Enrolled Students</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : error ? (
+        <p className="text-red-600">{error}</p>
+      ) : students.length === 0 ? (
+        <p>No students enrolled.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full table-auto border-collapse border border-gray-300">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="border p-2 text-left">Name</th>
+                <th className="border p-2 text-left">Email</th>
+                <th className="border p-2">Status</th>
+                <th className="border p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {students.map((stu) => (
+                <tr key={stu.id} className="bg-white">
+                  <td className="border p-2">{stu.full_name}</td>
+                  <td className="border p-2">{stu.email}</td>
+                  <td className="border p-2 text-center">{stu.status}</td>
+                  <td className="border p-2 text-center">
+                    <Link
+                      href={`/dashboard/admin/online-classes/${id}/students/${stu.id}`}
+                      className="text-blue-600 hover:underline text-sm"
+                    >
+                      View
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+ClassStudentsPage.getLayout = function getLayout(page) {
+  return <AdminLayout>{page}</AdminLayout>;
+};

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -85,3 +85,15 @@ export const rejectAdminClass = async (id, reason) => {
   const { data } = await api.patch(`/users/classes/admin/${id}/reject`, { reason });
   return data?.data;
 };
+
+export const fetchClassStudents = async (id) => {
+  const { data } = await api.get(`/users/classes/admin/${id}/students`);
+  return data?.data ?? [];
+};
+
+export const fetchClassStudent = async (classId, studentId) => {
+  const { data } = await api.get(
+    `/users/classes/admin/${classId}/students/${studentId}`
+  );
+  return data?.data ?? null;
+};


### PR DESCRIPTION
## Summary
- expand enrollment service with queries for class rosters
- add controller handlers for these student queries
- register new admin routes `/admin/:id/students` and `/admin/:classId/students/:studentId`
- add frontend API route and service helpers to fetch class students
- implement admin pages to list enrolled students and view details

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685f282f6d14832886f731a7423e24f0