### PR TITLE
Add back button for instructor class page

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id].js
@@ -48,6 +48,12 @@ export default function InstructorClassRoom() {
     <div className="bg-gray-900 min-h-screen text-white px-6 py-8">
       {/* Header */}
       <div className="mb-6">
+        <button
+          onClick={() => router.back()}
+          className="text-sm text-blue-400 hover:underline mb-2"
+        >
+          &larr; Back
+        </button>
         <h1 className="text-2xl font-bold text-yellow-400">{classData.title}</h1>
         <p className="text-sm text-gray-400">Instructor: {classData.instructor}</p>
         {classData.start_date && (


### PR DESCRIPTION
## Summary
- add a back button to return to the previous page in instructor class room

## Testing
- `npm test` (fails: jest not found)
- `npm test` in backend (fails: jest not found)

------
https://chatgpt.com/codex/tasks/task_e_685fba1fba2c8328a10265be494e7ef8