### PR TITLE
Add tutorial scheduling fields

### DIFF
--- a/backend/src/migrations/20250702120000_add_start_end_dates_to_tutorials.js
+++ b/backend/src/migrations/20250702120000_add_start_end_dates_to_tutorials.js
@@ -1,0 +1,13 @@
+exports.up = async function (knex) {
+  await knex.schema.alterTable('tutorials', table => {
+    table.timestamp('start_date');
+    table.timestamp('end_date');
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable('tutorials', table => {
+    table.dropColumn('start_date');
+    table.dropColumn('end_date');
+  });
+};

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -40,6 +40,8 @@ exports.createTutorial = catchAsync(async (req, res) => {
     level,
     duration,
     price,
+    start_date,
+    end_date,
     status = "draft",
     chapters = [],
   } = req.body;
@@ -83,6 +85,8 @@ exports.createTutorial = catchAsync(async (req, res) => {
     level,
     duration: duration ? parseInt(duration) : null,
     price,
+    start_date: start_date ? new Date(start_date) : null,
+    end_date: end_date ? new Date(end_date) : null,
     instructor_id,
     status,
     moderation_status: status === "published" ? "Pending" : null,
@@ -130,6 +134,12 @@ exports.updateTutorial = catchAsync(async (req, res) => {
   const data = req.body;
   if (data.duration) {
     data.duration = parseInt(data.duration);
+  }
+  if (data.start_date) {
+    data.start_date = new Date(data.start_date);
+  }
+  if (data.end_date) {
+    data.end_date = new Date(data.end_date);
   }
   const roleDir = getRoleDir(req);
   if (req.files?.thumbnail) {

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -45,6 +45,8 @@ exports.create = z.object({
       ),
     cover_image: z.string().url().optional(),
     preview_video: z.string().url().optional(),
+    start_date: z.string().optional(),
+    end_date: z.string().optional(),
   }),
 });
 

--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -16,6 +16,7 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
     if (!tutorialData.level) newErrors.level = "Level is required.";
     if (!tutorialData.language) newErrors.language = "Tutorial language is required.";
     if (!tutorialData.isFree && (!tutorialData.price || isNaN(tutorialData.price))) newErrors.price = "Valid price is required.";
+    if (!tutorialData.startDate) newErrors.startDate = "Start date is required.";
 
     setErrors(newErrors);
 
@@ -63,6 +64,31 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
           placeholder="e.g., English, Arabic, French..."
         />
         {errors.language && <p className="text-red-500 text-sm mt-1">{errors.language}</p>}
+      </div>
+
+      {/* Start Date */}
+      <div>
+        <label className="font-semibold">Start Date *</label>
+        <input
+          type="date"
+          className="w-full p-2 border rounded mt-1"
+          value={tutorialData.startDate}
+          onChange={(e) => handleChange("startDate", e.target.value)}
+        />
+        {errors.startDate && (
+          <p className="text-red-500 text-sm mt-1">{errors.startDate}</p>
+        )}
+      </div>
+
+      {/* End Date */}
+      <div>
+        <label className="font-semibold">End Date</label>
+        <input
+          type="date"
+          className="w-full p-2 border rounded mt-1"
+          value={tutorialData.endDate}
+          onChange={(e) => handleChange("endDate", e.target.value)}
+        />
       </div>
 
       {/* Category */}

--- a/frontend/src/components/tutorials/create/ReviewStep.js
+++ b/frontend/src/components/tutorials/create/ReviewStep.js
@@ -35,6 +35,10 @@ export default function ReviewStep({
             {tutorialData.categoryName || tutorialData.category}
           </p>
           <p><strong>Level:</strong> {tutorialData.level}</p>
+          <p><strong>Start:</strong> {tutorialData.startDate}</p>
+          {tutorialData.endDate && (
+            <p><strong>End:</strong> {tutorialData.endDate}</p>
+          )}
           {tutorialData.tags.length > 0 && (
             <p><strong>Tags:</strong> {tutorialData.tags.join(", ")}</p>
           )}

--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -57,6 +57,8 @@ function EditTutorialPage() {
           chapters: mappedChapters,
           thumbnail: tutorial.thumbnail,
           preview: tutorial.preview,
+          startDate: tutorial.startDate || "",
+          endDate: tutorial.endDate || "",
           price: tutorial.price || "",
           isFree: tutorial.isFree,
         });
@@ -120,6 +122,12 @@ function EditTutorialPage() {
               formData.append("category_id", tutorialData.category);
               formData.append("level", tutorialData.level);
               formData.append("is_paid", (!tutorialData.isFree).toString());
+              if (tutorialData.startDate) {
+                formData.append("start_date", tutorialData.startDate);
+              }
+              if (tutorialData.endDate) {
+                formData.append("end_date", tutorialData.endDate);
+              }
               if (!tutorialData.isFree) {
                 formData.append("price", tutorialData.price);
               }

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -24,6 +24,8 @@ function CreateTutorialPage() {
     thumbnail: null,
     preview: null,
     language: "",
+    startDate: "",
+    endDate: "",
     price: "",
     isFree: false,
   });
@@ -64,6 +66,12 @@ function CreateTutorialPage() {
     formData.append("level", tutorialData.level);
     formData.append("status", status);
     formData.append("is_paid", (!tutorialData.isFree).toString());
+    if (tutorialData.startDate) {
+      formData.append("start_date", tutorialData.startDate);
+    }
+    if (tutorialData.endDate) {
+      formData.append("end_date", tutorialData.endDate);
+    }
     if (!tutorialData.isFree) {
       formData.append("price", tutorialData.price);
     }

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -33,6 +33,8 @@ export const fetchAllTutorials = async () => {
       : null,
     createdAt: t.created_at,
     updatedAt: t.updated_at,
+    startDate: t.start_date,
+    endDate: t.end_date,
     instructor: t.instructor_name,
     category: t.category_name,
     status: t.status === "published" ? "Published" : "Draft",
@@ -80,6 +82,7 @@ export const fetchTutorialById = async (id) => {
     category: t.category_id,
     categoryName: t.category_name,
     level: t.level,
+    language: t.language,
     tags: t.tags || [],
     thumbnail: t.thumbnail_url
       ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${t.thumbnail_url}`
@@ -89,6 +92,8 @@ export const fetchTutorialById = async (id) => {
       : null,
     price: t.price,
     isFree: !t.is_paid,
+    startDate: t.start_date,
+    endDate: t.end_date,
   };
 };
 


### PR DESCRIPTION
## Summary
- allow tutorials to have optional start and end dates
- show start/end date inputs during creation and editing
- display chosen dates in review step
- send new fields to backend and persist them
- add database migration for these timestamps

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fe046beb483289460a517f7602dc8