### PR TITLE
Remove unused start and end date fields

### DIFF
--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -16,7 +16,6 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
     if (!tutorialData.level) newErrors.level = "Level is required.";
     if (!tutorialData.language) newErrors.language = "Tutorial language is required.";
     if (!tutorialData.isFree && (!tutorialData.price || isNaN(tutorialData.price))) newErrors.price = "Valid price is required.";
-    if (!tutorialData.startDate) newErrors.startDate = "Start date is required.";
 
     setErrors(newErrors);
 
@@ -64,31 +63,6 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
           placeholder="e.g., English, Arabic, French..."
         />
         {errors.language && <p className="text-red-500 text-sm mt-1">{errors.language}</p>}
-      </div>
-
-      {/* Start Date */}
-      <div>
-        <label className="font-semibold">Start Date *</label>
-        <input
-          type="date"
-          className="w-full p-2 border rounded mt-1"
-          value={tutorialData.startDate}
-          onChange={(e) => handleChange("startDate", e.target.value)}
-        />
-        {errors.startDate && (
-          <p className="text-red-500 text-sm mt-1">{errors.startDate}</p>
-        )}
-      </div>
-
-      {/* End Date */}
-      <div>
-        <label className="font-semibold">End Date</label>
-        <input
-          type="date"
-          className="w-full p-2 border rounded mt-1"
-          value={tutorialData.endDate}
-          onChange={(e) => handleChange("endDate", e.target.value)}
-        />
       </div>
 
       {/* Category */}

--- a/frontend/src/components/tutorials/create/ReviewStep.js
+++ b/frontend/src/components/tutorials/create/ReviewStep.js
@@ -35,10 +35,6 @@ export default function ReviewStep({
             {tutorialData.categoryName || tutorialData.category}
           </p>
           <p><strong>Level:</strong> {tutorialData.level}</p>
-          <p><strong>Start:</strong> {tutorialData.startDate}</p>
-          {tutorialData.endDate && (
-            <p><strong>End:</strong> {tutorialData.endDate}</p>
-          )}
           {tutorialData.tags.length > 0 && (
             <p><strong>Tags:</strong> {tutorialData.tags.join(", ")}</p>
           )}

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -24,8 +24,6 @@ function CreateTutorialPage() {
     thumbnail: null,
     preview: null,
     language: "",
-    startDate: "",
-    endDate: "",
     price: "",
     isFree: false,
   });
@@ -66,12 +64,6 @@ function CreateTutorialPage() {
     formData.append("level", tutorialData.level);
     formData.append("status", status);
     formData.append("is_paid", (!tutorialData.isFree).toString());
-    if (tutorialData.startDate) {
-      formData.append("start_date", tutorialData.startDate);
-    }
-    if (tutorialData.endDate) {
-      formData.append("end_date", tutorialData.endDate);
-    }
     if (!tutorialData.isFree) {
       formData.append("price", tutorialData.price);
     }


### PR DESCRIPTION
## Summary
- remove start/end date validation and inputs from tutorial creation form
- strip start/end date data from admin tutorial submission

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
- `npm run lint` in `frontend` *(fails: 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ff0d23f2c8328843d5bcb7026d009