### PR TITLE
Implement offers API and frontend integration

### DIFF
--- a/backend/src/modules/offers/offers.controller.js
+++ b/backend/src/modules/offers/offers.controller.js
@@ -1,0 +1,39 @@
+const { v4: uuidv4 } = require("uuid");
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./offers.service");
+
+exports.createOffer = catchAsync(async (req, res) => {
+  const { title, description, budget, timeframe } = req.body;
+  const data = {
+    id: uuidv4(),
+    student_id: req.user.id,
+    title,
+    description,
+    budget,
+    timeframe,
+    status: "open",
+  };
+  const offer = await service.createOffer(data);
+  sendSuccess(res, offer, "Offer created");
+});
+
+exports.getOffers = catchAsync(async (_req, res) => {
+  const offers = await service.getOffers();
+  sendSuccess(res, offers);
+});
+
+exports.getOfferById = catchAsync(async (req, res) => {
+  const offer = await service.getOfferById(req.params.id);
+  sendSuccess(res, offer);
+});
+
+exports.updateOffer = catchAsync(async (req, res) => {
+  const offer = await service.updateOffer(req.params.id, req.body);
+  sendSuccess(res, offer, "Offer updated");
+});
+
+exports.deleteOffer = catchAsync(async (req, res) => {
+  await service.deleteOffer(req.params.id);
+  sendSuccess(res, null, "Offer deleted");
+});

--- a/backend/src/modules/offers/offers.routes.js
+++ b/backend/src/modules/offers/offers.routes.js
@@ -1,0 +1,13 @@
+const router = require("express").Router();
+const controller = require("./offers.controller");
+const validate = require("../../middleware/validate");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
+const validator = require("./offers.validator");
+
+router.post("/", verifyToken, validate(validator.create), controller.createOffer);
+router.get("/", controller.getOffers);
+router.get("/:id", controller.getOfferById);
+router.put("/:id", verifyToken, validate(validator.update), controller.updateOffer);
+router.delete("/:id", verifyToken, controller.deleteOffer);
+
+module.exports = router;

--- a/backend/src/modules/offers/offers.service.js
+++ b/backend/src/modules/offers/offers.service.js
@@ -1,0 +1,23 @@
+const db = require("../../config/database");
+
+exports.createOffer = async (data) => {
+  const [row] = await db("offers").insert(data).returning("*");
+  return row;
+};
+
+exports.getOffers = () => {
+  return db("offers").orderBy("created_at", "desc");
+};
+
+exports.getOfferById = (id) => {
+  return db("offers").where({ id }).first();
+};
+
+exports.updateOffer = async (id, data) => {
+  const [row] = await db("offers").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.deleteOffer = (id) => {
+  return db("offers").where({ id }).del();
+};

--- a/backend/src/modules/offers/offers.validator.js
+++ b/backend/src/modules/offers/offers.validator.js
@@ -1,0 +1,20 @@
+const { z } = require("zod");
+
+exports.create = z.object({
+  body: z.object({
+    title: z.string().min(3),
+    description: z.string().optional(),
+    budget: z.string().optional(),
+    timeframe: z.string().optional(),
+  }),
+});
+
+exports.update = z.object({
+  body: z.object({
+    title: z.string().min(3).optional(),
+    description: z.string().optional(),
+    budget: z.string().optional(),
+    timeframe: z.string().optional(),
+    status: z.enum(["open", "closed", "cancelled"]).optional(),
+  }),
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -72,6 +72,7 @@ const cartRoutes = require("./modules/cart/cart.routes");
 const notificationRoutes = require("./modules/notifications/notifications.routes");
 const messageRoutes = require("./modules/messages/messages.routes");
 const chatRoutes = require("./modules/chat/chat.routes");
+const offersRoutes = require("./modules/offers/offers.routes");
 const socialLoginConfigRoutes = require("./modules/socialLoginConfig/socialLoginConfig.routes");
 const appConfigRoutes = require("./modules/appConfig/appConfig.routes");
 const errorHandler = require("./middleware/errorHandler");
@@ -144,6 +145,7 @@ app.use("/api/social-login/config", socialLoginConfigRoutes); // 🔑 Social log
 app.use("/api/app-config", appConfigRoutes); // 🛠️ Application settings
 app.use("/api/payouts/admin", payoutRoutes); // 🏦 Instructor payouts
 app.use("/api/ads", adsRoutes); // 📢 Advertisements
+app.use("/api/offers", offersRoutes); // 📚 Learning marketplace offers
 app.use("/api/instructors", publicInstructorRoutes); // 📚 Public instructor listing
 app.use("/api/cart", cartRoutes); // 🛒 Shopping cart
 app.use("/api/notifications", notificationRoutes); // 🔔 User notifications

--- a/frontend/src/components/website/sections/LearningMarketplace.js
+++ b/frontend/src/components/website/sections/LearningMarketplace.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import {
   FaUserGraduate,
@@ -9,15 +9,7 @@ import {
   FaPlus,
 } from "react-icons/fa";
 
-const mockOffers = Array.from({ length: 20 }, (_, i) => ({
-  id: i + 1,
-  type: i % 2 === 0 ? "student" : "instructor",
-  title: i % 2 === 0 ? "Need Chemistry Help" : "English Tutoring Available",
-  price: `$${100 + i * 5}`,
-  duration: `${1 + (i % 6)} months`,
-  tags: ["Flexible", "Urgent"].slice(0, (i % 2) + 1),
-  date: `${i + 1} days ago`,
-}));
+import { fetchOffers } from "@/services/offerService";
 
 const OfferBadge = ({ type }) => (
   <span
@@ -30,14 +22,34 @@ const OfferBadge = ({ type }) => (
 );
 
 const OffersIndex = () => {
+  const [offers, setOffers] = useState([]);
   const [visibleCount, setVisibleCount] = useState(6);
   const [showModal, setShowModal] = useState(false);
   const [pendingAction, setPendingAction] = useState(""); // "post" | "dashboard" | "detail"
   const [selectedOfferId, setSelectedOfferId] = useState(null);
   const router = useRouter();
 
-  const offersToShow = mockOffers.slice(0, visibleCount);
-  const allVisible = visibleCount >= mockOffers.length;
+  useEffect(() => {
+    fetchOffers()
+      .then((data) => {
+        const mapped = data.map((o) => ({
+          id: o.id,
+          type: "student",
+          title: o.title,
+          price: o.budget || "",
+          duration: o.timeframe || "",
+          tags: [],
+          date: o.created_at
+            ? new Date(o.created_at).toLocaleDateString()
+            : "",
+        }));
+        setOffers(mapped);
+      })
+      .catch(() => setOffers([]));
+  }, []);
+
+  const offersToShow = offers.slice(0, visibleCount);
+  const allVisible = visibleCount >= offers.length;
 
   const handleRoleSelection = (role) => {
     setShowModal(false);

--- a/frontend/src/pages/offers/new.js
+++ b/frontend/src/pages/offers/new.js
@@ -5,6 +5,7 @@ import Footer from "@/components/website/sections/Footer";
 import { FaTag } from "react-icons/fa";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { createOffer } from "@/services/offerService";
 
 const availableTags = ["Urgent", "LiveClass", "Discount", "Flexible", "OneOnOne"];
 
@@ -17,22 +18,20 @@ const CreateOffer = () => {
   const [description, setDescription] = useState("");
   const [tags, setTags] = useState([]);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    const newOffer = {
-      id: Date.now(),
-      offerType,
-      title,
-      duration,
-      price,
-      description,
-      tags,
-      date: new Date().toLocaleDateString()
-    };
-
-    console.log("Offer Created:", newOffer);
-    toast.success("🎉 Offer posted successfully!", { theme: "dark" });
-    setTimeout(() => router.push("/offers"), 1800);
+    try {
+      await createOffer({
+        title,
+        description,
+        budget: price,
+        timeframe: duration,
+      });
+      toast.success("🎉 Offer posted successfully!", { theme: "dark" });
+      setTimeout(() => router.push("/offers"), 1800);
+    } catch (err) {
+      toast.error("Failed to post offer", { theme: "dark" });
+    }
   };
 
   const toggleTag = (tag) => {

--- a/frontend/src/services/offerService.js
+++ b/frontend/src/services/offerService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchOffers = async () => {
+  const { data } = await api.get("/offers");
+  return data?.data ?? [];
+};
+
+export const createOffer = async (payload) => {
+  const { data } = await api.post("/offers", payload);
+  return data;
+};


### PR DESCRIPTION
## Summary
- add new `/api/offers` endpoints
- expose offers routes from the server
- fetch offers in `LearningMarketplace` section
- allow posting new offers through the new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff25707648328b74a2f4142776bfa