### PR TITLE
Ensure instructor calendar loads real class data

### DIFF
--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -35,7 +35,9 @@ const computeScheduleStatus = (start, end) => {
 };
 
 export const fetchInstructorClasses = async () => {
-  const { data } = await api.get("/users/classes/admin");
+  // Fetch only classes belonging to the current instructor
+  // using the dedicated "/admin/my" endpoint
+  const { data } = await api.get("/users/classes/admin/my");
   const list = data?.data ?? [];
   return list.map(formatClass);
 };


### PR DESCRIPTION
## Summary
- fetch instructor classes from `/users/classes/admin/my` so calendar uses real data

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6860cfc6c2b48328a166b057987ddd1e