### PR TITLE
Connect admin offers to backend

### DIFF
--- a/backend/src/modules/offers/offers.service.js
+++ b/backend/src/modules/offers/offers.service.js
@@ -6,11 +6,28 @@ exports.createOffer = async (data) => {
 };
 
 exports.getOffers = () => {
-  return db("offers").orderBy("created_at", "desc");
+  return db("offers as o")
+    .join("users as u", "o.student_id", "u.id")
+    .select(
+      "o.*",
+      "u.full_name as student_name",
+      "u.role as student_role",
+      "u.avatar_url as student_avatar"
+    )
+    .orderBy("o.created_at", "desc");
 };
 
 exports.getOfferById = (id) => {
-  return db("offers").where({ id }).first();
+  return db("offers as o")
+    .join("users as u", "o.student_id", "u.id")
+    .select(
+      "o.*",
+      "u.full_name as student_name",
+      "u.role as student_role",
+      "u.avatar_url as student_avatar"
+    )
+    .where("o.id", id)
+    .first();
 };
 
 exports.updateOffer = async (id, data) => {

--- a/frontend/src/pages/dashboard/admin/offers/[id].js
+++ b/frontend/src/pages/dashboard/admin/offers/[id].js
@@ -13,6 +13,7 @@ import {
 } from "react-icons/fa";
 import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import { fetchOfferById } from "@/services/admin/offerService";
 
 const AdminOfferDetails = () => {
   const router = useRouter();
@@ -24,25 +25,25 @@ const AdminOfferDetails = () => {
   useEffect(() => {
     if (!id) return;
 
-    const mockOffers = Array.from({ length: 12 }, (_, i) => ({
-      id: `${i + 1}`,
-      userId: i % 2 === 0 ? "student1" : "instructor1",
-      type: i % 2 === 0 ? "student" : "instructor",
-      title: i % 2 === 0 ? `Need Help with Subject ${i + 1}` : `Offering Course ${i + 1}`,
-      price: `$${100 + i * 10}`,
-      duration: `${1 + i % 6} months`,
-      tags: ["Flexible", "LiveClass"].slice(0, (i % 2) + 1),
-      date: `${i + 1} days ago`,
-      description: i % 2 === 0
-        ? "Looking for weekly physics help."
-        : "Offering structured weekend math classes.",
-      status: i % 3 === 0 ? "Pending" : "Active",
-      email: `user${i}@example.com`,
-      phone: `+96650000000${i}`,
-    }));
-
-    const found = mockOffers.find((o) => o.id === id);
-    setOffer(found);
+    fetchOfferById(id)
+      .then((o) => {
+        if (!o) return setOffer(null);
+        setOffer({
+          id: o.id,
+          userId: o.student_id,
+          type: o.student_role?.toLowerCase() === "instructor" ? "instructor" : "student",
+          title: o.title,
+          price: o.budget || "",
+          duration: o.timeframe || "",
+          tags: [],
+          date: o.created_at ? new Date(o.created_at).toLocaleDateString() : "",
+          description: o.description || "",
+          status: o.status,
+          email: o.email || "",
+          phone: o.phone || "",
+        });
+      })
+      .catch(() => setOffer(null));
 
     setMessages([
       {

--- a/frontend/src/services/admin/offerService.js
+++ b/frontend/src/services/admin/offerService.js
@@ -1,0 +1,20 @@
+import api from "@/services/api/api";
+
+export const fetchOffers = async () => {
+  const { data } = await api.get("/offers");
+  return data?.data ?? [];
+};
+
+export const fetchOfferById = async (id) => {
+  const { data } = await api.get(`/offers/${id}`);
+  return data?.data ?? null;
+};
+
+export const updateOffer = async (id, payload) => {
+  const { data } = await api.put(`/offers/${id}`, payload);
+  return data?.data;
+};
+
+export const deleteOffer = async (id) => {
+  await api.delete(`/offers/${id}`);
+};


### PR DESCRIPTION
## Summary
- include student info in offers queries
- add admin offer service on frontend
- load offers from backend for admin dashboard
- fetch offer details from backend for admin

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860e4d38dec8328aac60d11715def1e