### PR TITLE
Add global switch to toggle all social login providers

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -79,7 +79,11 @@ export default function SocialLoginSettingsPage() {
     load();
   }, []);
 
-  const toggleGlobal = () => setGlobalActive(!globalActive);
+  const toggleGlobal = () => {
+    const newState = !globalActive;
+    setGlobalActive(newState);
+    setProviders((prev) => prev.map((p) => ({ ...p, active: newState })));
+  };
   const toggleRecaptcha = () => setRecaptchaActive(!recaptchaActive);
 
   const toggleProvider = (index) => {


### PR DESCRIPTION
## Summary
- update admin Social Login settings so global switch toggles all providers

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6860fe119c588328bb4c3c2d5d75bf56