### PR TITLE
Implement offer type and status toggle

### DIFF
--- a/backend/src/migrations/20250702120000_add_offer_type_to_offers.js
+++ b/backend/src/migrations/20250702120000_add_offer_type_to_offers.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('offers', function(table) {
+    table.enu('offer_type', ['class', 'tutorial']).defaultTo('class');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('offers', function(table) {
+    table.dropColumn('offer_type');
+  });
+};

--- a/backend/src/modules/offers/offers.controller.js
+++ b/backend/src/modules/offers/offers.controller.js
@@ -9,7 +9,7 @@ const messageService = require("../messages/messages.service");
 const slugify = require("slugify");
 
 exports.createOffer = catchAsync(async (req, res) => {
-  const { tags: rawTags, title, description, budget, timeframe } = req.body;
+  const { tags: rawTags, title, description, budget, timeframe, offer_type } = req.body;
   const data = {
     id: uuidv4(),
     student_id: req.user.id,
@@ -17,6 +17,7 @@ exports.createOffer = catchAsync(async (req, res) => {
     description,
     budget,
     timeframe,
+    offer_type,
     status: "open",
   };
   const tags = rawTags ? JSON.parse(rawTags) : [];

--- a/backend/src/modules/offers/offers.validator.js
+++ b/backend/src/modules/offers/offers.validator.js
@@ -6,6 +6,7 @@ exports.create = z.object({
     description: z.string().optional(),
     budget: z.string().optional(),
     timeframe: z.string().optional(),
+    offer_type: z.enum(["class", "tutorial"]),
     tags: z.string().optional(),
   }),
 });
@@ -17,6 +18,7 @@ exports.update = z.object({
     budget: z.string().optional(),
     timeframe: z.string().optional(),
     tags: z.string().optional(),
+    offer_type: z.enum(["class", "tutorial"]).optional(),
     status: z.enum(["open", "closed", "cancelled"]).optional(),
   }),
 });

--- a/frontend/src/pages/dashboard/instructor/offers/[id].js
+++ b/frontend/src/pages/dashboard/instructor/offers/[id].js
@@ -15,6 +15,7 @@ import Link from "next/link";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import useAuthStore from "@/store/auth/authStore";
 import { fetchOfferById } from "@/services/offerService";
+import { updateOffer } from "@/services/admin/offerService";
 import { getConversation, sendChatMessage } from "@/services/messageService";
 import MessageInput from "@/components/chat/MessageInput";
 import formatRelativeTime from "@/utils/relativeTime";
@@ -52,6 +53,15 @@ const OfferDetailsPage = () => {
   const [messages, setMessages] = useState([]);
   const [replyTo, setReplyTo] = useState(null);
 
+  const toggleStatus = async () => {
+    if (!offer) return;
+    const newStatus = offer.status === "open" ? "closed" : "open";
+    setOffer((prev) => ({ ...prev, status: newStatus }));
+    try {
+      await updateOffer(offer.id, { status: newStatus });
+    } catch (_) {}
+  };
+
   useEffect(() => {
     if (!id) return;
 
@@ -67,6 +77,7 @@ const OfferDetailsPage = () => {
             o.student_role?.toLowerCase() === "instructor"
               ? "instructor"
               : "student",
+          offerType: o.offer_type,
           title: o.title,
           price: o.budget || "",
           duration: o.timeframe || "",
@@ -127,8 +138,11 @@ const OfferDetailsPage = () => {
         </span>
       </div>
 
-      <div className="flex justify-between text-sm text-gray-500 mb-6">
+      <div className="flex flex-wrap justify-between text-sm text-gray-500 mb-6 gap-2">
         <p>Posted: {offer.date}</p>
+        <span className="bg-gray-100 px-2 py-1 rounded-full text-xs text-gray-700">
+          Type: {offer.offerType}
+        </span>
         <span className="bg-gray-100 px-2 py-1 rounded-full text-xs text-gray-700">
           Status: {offer.status}
         </span>
@@ -317,6 +331,12 @@ const OfferDetailsPage = () => {
                 <FaEdit /> Edit
               </button>
             </Link>
+            <button
+              onClick={toggleStatus}
+              className="flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg font-semibold transition"
+            >
+              {offer.status === "open" ? "Close" : "Open"} Offer
+            </button>
             <button
               onClick={() => {
                 if (confirm("Are you sure you want to delete this offer?")) {

--- a/frontend/src/pages/dashboard/instructor/offers/index.js
+++ b/frontend/src/pages/dashboard/instructor/offers/index.js
@@ -31,6 +31,7 @@ const InstructorOfferDashboard = () => {
             o.student_role?.toLowerCase() === "instructor"
               ? "instructor"
               : "student",
+          offerType: o.offer_type,
           title: o.title,
           price: o.budget || "",
           duration: o.timeframe || "",

--- a/frontend/src/pages/dashboard/instructor/offers/new.js
+++ b/frontend/src/pages/dashboard/instructor/offers/new.js
@@ -9,6 +9,7 @@ const NewOfferPage = () => {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [form, setForm] = useState({
+    offerType: "class",
     title: "",
     price: "",
     duration: "",
@@ -58,6 +59,7 @@ const NewOfferPage = () => {
 
     try {
       const payload = {
+        offer_type: form.offerType,
         title: form.title,
         description: form.description,
         budget: form.price,
@@ -91,6 +93,19 @@ const NewOfferPage = () => {
             placeholder="e.g. I will teach advanced math"
             className="w-full border border-gray-300 rounded-lg px-4 py-3 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all"
           />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Offer Type</label>
+          <select
+            name="offerType"
+            value={form.offerType}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded-lg px-4 py-3 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all"
+          >
+            <option value="class">Class</option>
+            <option value="tutorial">Tutorial</option>
+          </select>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- add DB migration for `offer_type`
- validate and store offer type in the backend
- capture offer type on instructor offer form
- display type on offer details and map in listings
- allow instructors to open or close their own offer

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686106a7c308832886d9b0685a8595db