### PR TITLE
Update offers list for open status

### DIFF
--- a/backend/src/modules/offers/offers.service.js
+++ b/backend/src/modules/offers/offers.service.js
@@ -14,6 +14,7 @@ exports.getOffers = () => {
       "u.role as student_role",
       "u.avatar_url as student_avatar"
     )
+    .where("o.status", "open")
     .orderBy("o.created_at", "desc");
 };
 

--- a/frontend/src/components/website/sections/LearningMarketplace.js
+++ b/frontend/src/components/website/sections/LearningMarketplace.js
@@ -33,7 +33,10 @@ const OffersIndex = () => {
       .then((data) => {
         const mapped = data.map((o) => ({
           id: o.id,
-          type: "student",
+          type:
+            o.student_role?.toLowerCase() === "instructor"
+              ? "instructor"
+              : "student",
           title: o.title,
           price: o.budget || "",
           duration: o.timeframe || "",


### PR DESCRIPTION
## Summary
- filter offers by status 'open' in backend service
- display whether each offer is from a student or instructor on the main website

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_686162e956808328ba6ec99e5992e524