### PR TITLE
Enable toast feedback in student offer chat

### DIFF
--- a/frontend/src/pages/dashboard/student/offers/[id].js
+++ b/frontend/src/pages/dashboard/student/offers/[id].js
@@ -9,6 +9,7 @@ import {
   FaComments,
   FaLink,
 } from "react-icons/fa";
+import { toast } from "react-toastify";
 import Link from "next/link";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import useAuthStore from "@/store/auth/authStore";
@@ -96,7 +97,10 @@ const OfferDetailsPage = () => {
   }, [offer]);
 
   const handleSendMessage = async ({ text, file, audio }) => {
-    if (!text && !file && !audio) return;
+    if (!text && !file && !audio) {
+      toast.error("Message is empty!");
+      return;
+    }
     try {
       const sent = await sendChatMessage(offer.userId, {
         text,
@@ -106,14 +110,20 @@ const OfferDetailsPage = () => {
       });
       setMessages((prev) => [...prev, sent]);
       setReplyTo(null);
-    } catch (_) {}
+      toast.success("Message sent!");
+    } catch (_) {
+      toast.error("Failed to send message");
+    }
   };
 
   const deleteMessage = async (msgId) => {
     try {
       await deleteChatMessage(msgId);
       setMessages((prev) => prev.filter((m) => m.id !== msgId));
-    } catch (_) {}
+      toast.info("Message deleted");
+    } catch (_) {
+      toast.error("Failed to delete message");
+    }
   };
 
   if (!offer) return <div className="p-6 text-gray-600">Loading offer details...</div>;


### PR DESCRIPTION
## Summary
- enable toast notifications in the student offer details page
  - display errors for empty messages
  - show success/failure feedback for sending or deleting messages

## Testing
- `npm test` *(fails: npm not installed)*
- `pytest -q` *(fails: pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861626c1c508328a15fc97352252dd6