### PR TITLE
Implement basic Google social login

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,3 +5,6 @@ JWT_SECRET=your_jwt_secret
 CLOUDINARY_API_KEY=your_key
 SMTP_HOST=smtp.mailtrap.io
 FRONTEND_URL=http://localhost:3000
+SESSION_SECRET=skillbridge_secret
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
+        "express-session": "^1.17.3",
         "fluent-ffmpeg": "^2.1.3",
         "json2csv": "^6.0.0-alpha.2",
         "jsonwebtoken": "^9.0.2",
@@ -23,6 +24,8 @@
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.2",
         "nodemailer": "^7.0.3",
+        "passport": "^0.7.0",
+        "passport-google-oauth20": "^2.0.0",
         "pg": "^8.16.0",
         "sharp": "^0.34.2",
         "slugify": "^1.6.6",
@@ -1856,6 +1859,15 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -2986,6 +2998,40 @@
       "peerDependencies": {
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -4986,6 +5032,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5145,6 +5197,64 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5185,6 +5295,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/pg": {
       "version": "8.16.0",
@@ -5461,6 +5576,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -6433,6 +6557,24 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
       "license": "MIT"
     },
     "node_modules/undefsafe": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,7 +34,10 @@
     "winston": "^3.17.0",
     "yamljs": "^0.3.0",
     "zod": "^3.25.20",
-    "socket.io": "^4.7.2"
+    "socket.io": "^4.7.2",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
+    "express-session": "^1.17.3"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -1,0 +1,30 @@
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const socialAuthService = require('../modules/auth/services/socialAuth.service');
+
+passport.use(
+  new GoogleStrategy(
+    {
+      clientID: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+      callbackURL: '/api/auth/google/callback',
+    },
+    async (_accessToken, _refreshToken, profile, done) => {
+      try {
+        const { id, displayName, emails } = profile;
+        const email = emails && emails[0] && emails[0].value;
+        const result = await socialAuthService.loginOrRegister({
+          provider: 'google',
+          providerId: id,
+          email,
+          fullName: displayName,
+        });
+        return done(null, result);
+      } catch (err) {
+        return done(err);
+      }
+    }
+  )
+);
+
+module.exports = passport;

--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -1,0 +1,24 @@
+const passport = require('../../config/passport');
+
+// Initiates Google OAuth
+exports.googleAuth = passport.authenticate('google', {
+  scope: ['profile', 'email'],
+});
+
+// Callback after Google OAuth
+exports.googleCallback = (req, res, next) => {
+  passport.authenticate('google', { session: false }, (err, result) => {
+    if (err || !result) {
+      return res.redirect(`${process.env.FRONTEND_URL || ''}/auth/login?error=social`);
+    }
+    const { accessToken, refreshToken } = result;
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
+    const redirectUrl = `${process.env.FRONTEND_URL || ''}/auth/social-success?token=${accessToken}`;
+    res.redirect(redirectUrl);
+  })(req, res, next);
+};

--- a/backend/src/modules/auth/routes/auth.routes.js
+++ b/backend/src/modules/auth/routes/auth.routes.js
@@ -3,6 +3,7 @@ const express = require("express");
 const router = express.Router();
 
 const authController = require("../controllers/auth.controller");
+const socialAuthController = require("../controllers/socialAuth.controller");
 const validate = require("../../../middleware/validate");
 const authValidation = require("../validators/auth.validator");
 const { limitAuthRequests } = require("../../../middleware/rateLimiter");
@@ -55,5 +56,12 @@ router.post("/verify-otp", validate(authValidation.otpVerifySchema), authControl
  * @access  Public
  */
 router.post("/reset-password", validate(authValidation.resetPasswordSchema), authController.resetPassword);
+
+// ─────────────────────────────────────────────────────────────
+// Social login routes
+// ─────────────────────────────────────────────────────────────
+
+router.get("/google", socialAuthController.googleAuth);
+router.get("/google/callback", socialAuthController.googleCallback);
 
 module.exports = router;

--- a/backend/src/modules/auth/services/socialAuth.service.js
+++ b/backend/src/modules/auth/services/socialAuth.service.js
@@ -1,0 +1,47 @@
+const bcrypt = require("bcrypt");
+const userModel = require("../../users/user.model");
+const { generateAccessToken, generateRefreshToken } = require("./auth.service");
+
+const SALT_ROUNDS = 12;
+
+exports.loginOrRegister = async ({ provider, providerId, email, fullName }) => {
+  let account = await userModel.findBySocialAccount(provider, providerId);
+  let user;
+
+  if (account) {
+    user = await userModel.findById(account.user_id);
+  } else {
+    // if email matches existing user, link account
+    if (email) {
+      const existing = await userModel.findByEmail(email);
+      if (existing) {
+        user = existing;
+      }
+    }
+    if (!user) {
+      const hashed = await bcrypt.hash(providerId, SALT_ROUNDS);
+      const [newUser] = await userModel.insertUser({
+        full_name: fullName || "User",
+        email: email || `${providerId}@${provider}.local`,
+        phone: null,
+        password_hash: hashed,
+        role: "Student",
+        status: "active",
+        is_email_verified: !!email,
+        is_phone_verified: false,
+        profile_complete: false,
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+      user = newUser;
+    }
+    await userModel.addSocialAccount(user.id, provider, providerId, email);
+  }
+
+  const roles = await userModel.getUserRoles(user.id);
+  const tokenRoles = roles.length ? roles : [user.role];
+  const accessToken = generateAccessToken({ id: user.id, role: tokenRoles[0], roles: tokenRoles });
+  const refreshToken = generateRefreshToken({ id: user.id });
+
+  return { accessToken, refreshToken, user: { ...user, roles } };
+};

--- a/backend/src/modules/users/user.model.js
+++ b/backend/src/modules/users/user.model.js
@@ -158,3 +158,23 @@ exports.setUserRoles = async (userId, roleIds) => {
   }
   return exports.getUserRoles(userId);
 };
+
+// ─────────────────────────────────────────────────────────────
+// Social Accounts Helpers
+// ─────────────────────────────────────────────────────────────
+
+exports.findBySocialAccount = (provider, providerId) => {
+  return db("social_accounts")
+    .where({ provider, provider_id: providerId })
+    .first();
+};
+
+exports.addSocialAccount = (userId, provider, providerId, email) => {
+  return db("social_accounts").insert({
+    user_id: userId,
+    provider,
+    provider_id: providerId,
+    email,
+    created_at: new Date(),
+  });
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -8,6 +8,8 @@ const cors = require("cors");
 const morgan = require("morgan");
 const cookieParser = require("cookie-parser");
 const { Server } = require("socket.io");
+const session = require("express-session");
+const passport = require("./config/passport");
 require("dotenv").config(); // ✅ Load environment variables from .env file
 // Allow overriding the allowed origin via FRONTEND_URL env var.
 const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
@@ -103,6 +105,16 @@ app.use(express.json({ limit: "10mb" }));
 
 // 🍪 Parse cookies from incoming requests
 app.use(cookieParser());
+
+// 🔐 Session and Passport setup for social login
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || "skillbridge",
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+app.use(passport.initialize());
 
 // 🌐 Allow frontend to communicate with backend (CORS)
 app.use(

--- a/frontend/src/pages/auth/social-success.js
+++ b/frontend/src/pages/auth/social-success.js
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import useAuthStore from '@/store/auth/authStore';
+import { getFullProfile } from '@/services/profile/profileService';
+
+export default function SocialSuccess() {
+  const router = useRouter();
+  const setToken = useAuthStore((s) => s.setToken);
+  const setUser = useAuthStore((s) => s.setUser);
+
+  useEffect(() => {
+    const token = router.query.token;
+    if (!token) return;
+    setToken(token);
+    getFullProfile().then((res) => {
+      setUser(res.data);
+      router.replace('/website');
+    }).catch(() => router.replace('/auth/login'));
+  }, [router.query.token]);
+
+  return <p className="text-center mt-20">Signing in...</p>;
+}

--- a/frontend/src/shared/components/auth/SocialLogin.js
+++ b/frontend/src/shared/components/auth/SocialLogin.js
@@ -23,9 +23,13 @@ export default function SocialLogin() {
       <div className="mt-2 flex space-x-4 justify-center">
         {activeProviders.map(([key, p]) => {
           const Icon = iconMap[p.icon] || iconMap[key] || FaGoogle;
+          const handleClick = () => {
+            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000'}/api/auth/${key}`;
+          };
           return (
             <motion.button
               key={key}
+              onClick={handleClick}
               whileHover={{ scale: 1.1 }}
               transition={{ duration: 0.3 }}
               className="w-14 h-14 flex items-center justify-center bg-yellow-500 text-white rounded-full hover:bg-yellow-600 transition"

--- a/frontend/src/shared/components/auth/SocialRegister.js
+++ b/frontend/src/shared/components/auth/SocialRegister.js
@@ -24,9 +24,13 @@ export default function SocialRegister() {
       <div className="mt-2 flex space-x-4 w-full justify-center">
         {activeProviders.map(([key, p]) => {
           const Icon = iconMap[p.icon] || iconMap[key] || FaGoogle;
+          const handleClick = () => {
+            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000'}/api/auth/${key}`;
+          };
           return (
             <motion.button
               key={key}
+              onClick={handleClick}
               whileHover={{ scale: 1.1 }}
               className="w-14 h-14 flex items-center justify-center bg-yellow-500 text-white rounded-full hover:bg-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-400 transition"
             >


### PR DESCRIPTION
## Summary
- add `passport` and `passport-google-oauth20` to backend
- implement Google OAuth strategy and session setup
- expose `/api/auth/google` routes and redirect callback
- store social accounts for users
- update login/register buttons to start social login
- handle token on new `/auth/social-success` page

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861712cbef88328ac1a880810dc4ec0