### PR TITLE
Fix message discussion state for offers

### DIFF
--- a/frontend/src/pages/dashboard/instructor/offers/[id].js
+++ b/frontend/src/pages/dashboard/instructor/offers/[id].js
@@ -107,12 +107,19 @@ const OfferDetailsPage = () => {
     if (!offer) return;
     fetchResponses(offer.id)
       .then((resps) => {
-        if (!resps.length) return;
+        if (!resps.length) {
+          setResponse(null);
+          setMessages([]);
+          return;
+        }
         const resp = resps[0];
         setResponse(resp);
         return fetchResponseMessages(offer.id, resp.id).then(setMessages);
       })
-      .catch(() => setMessages([]));
+      .catch(() => {
+        setResponse(null);
+        setMessages([]);
+      });
   }, [offer]);
   const handleSendMessage = async ({ text, file, audio }) => {
     if (!text?.trim() || !response) return;
@@ -122,6 +129,7 @@ const OfferDetailsPage = () => {
     try {
       const sent = await sendResponseMessage(offer.id, response.id, text.trim());
       setMessages((prev) => [...prev, sent]);
+      toast.success("Message sent!", { theme: "colored" });
     } catch (_) {
       toast.error("Failed to send message", { theme: "colored" });
     }

--- a/frontend/src/pages/dashboard/student/offers/[id].js
+++ b/frontend/src/pages/dashboard/student/offers/[id].js
@@ -88,12 +88,19 @@ const OfferDetailsPage = () => {
     if (!offer) return;
     fetchResponses(offer.id)
       .then((resps) => {
-        if (!resps.length) return;
+        if (!resps.length) {
+          setResponse(null);
+          setMessages([]);
+          return;
+        }
         const resp = resps[0];
         setResponse(resp);
         return fetchResponseMessages(offer.id, resp.id).then(setMessages);
       })
-      .catch(() => setMessages([]));
+      .catch(() => {
+        setResponse(null);
+        setMessages([]);
+      });
   }, [offer]);
 
   const handleSendMessage = async ({ text, file, audio }) => {
@@ -105,7 +112,6 @@ const OfferDetailsPage = () => {
     try {
       const sent = await sendResponseMessage(offer.id, response.id, text.trim());
       setMessages((prev) => [...prev, sent]);
-      setReplyTo(null);
       toast.success("Message sent!");
     } catch (_) {
       toast.error("Failed to send message");


### PR DESCRIPTION
## Summary
- reset messages and response when an offer has no responses
- show success toast on instructor dashboard message send
- remove unused call to `setReplyTo` on student offer page

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68619a7b9cdc83288563c24a66fa6a22