### PR TITLE
Fix instructor offer messaging

### DIFF
--- a/frontend/src/pages/dashboard/instructor/offers/[id].js
+++ b/frontend/src/pages/dashboard/instructor/offers/[id].js
@@ -112,7 +112,10 @@ const OfferDetailsPage = () => {
           setMessages([]);
           return;
         }
-        const resp = resps[0];
+        const myResp = resps.find(
+          (r) => r.instructor_id === currentUserId
+        );
+        const resp = myResp || resps[0];
         setResponse(resp);
         return fetchResponseMessages(offer.id, resp.id).then(setMessages);
       })


### PR DESCRIPTION
## Summary
- show the current instructor's response thread when viewing an offer

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_68619deaaf6c8328afed0da4105c2c2f