### PR TITLE
Fix missing notice when no offer chat responses

### DIFF
--- a/frontend/src/pages/dashboard/instructor/offers/[id].js
+++ b/frontend/src/pages/dashboard/instructor/offers/[id].js
@@ -194,11 +194,13 @@ const OfferDetailsPage = () => {
       {/* Offer Discussion Section */}
       <div className="border-t pt-6 mb-10">
         <h3 className="text-lg font-semibold text-gray-700 mb-4">💬 Offer Discussion</h3>
-        <div className="space-y-4 max-h-64 overflow-y-auto pr-2 mb-4">
-          {messages.map((msg) => {
-            const isCurrentUser = msg.sender_id === currentUserId;
-            return (
-              <div key={msg.id} className={`flex ${isCurrentUser ? "justify-end" : "justify-start"}`}>
+        {response ? (
+          <>
+            <div className="space-y-4 max-h-64 overflow-y-auto pr-2 mb-4">
+              {messages.map((msg) => {
+              const isCurrentUser = msg.sender_id === currentUserId;
+              return (
+                <div key={msg.id} className={`flex ${isCurrentUser ? "justify-end" : "justify-start"}`}>
                 {!isCurrentUser && (
                   <ChatImage
                     src={getAvatarUrl(offer.avatar)}
@@ -296,12 +298,16 @@ const OfferDetailsPage = () => {
                 )}
               </div>
             );
-          })}
-        </div>
+              })}
+            </div>
 
-        <div className="mt-4">
-          <MessageInput sendMessage={handleSendMessage} />
-        </div>
+            <div className="mt-4">
+              <MessageInput sendMessage={handleSendMessage} />
+            </div>
+          </>
+        ) : (
+          <p className="text-gray-500">No responses yet. Messaging will be available once a student responds.</p>
+        )}
       </div>
 
       {/* Actions */}


### PR DESCRIPTION
## Summary
- show message input only when there are offer responses
- display a hint when no responses exist

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861a07c804c832899bb212cab946fef