### PR TITLE
Enable reply threads in offer discussions

### DIFF
--- a/backend/src/migrations/20250705000000_add_reply_to_offer_messages.js
+++ b/backend/src/migrations/20250705000000_add_reply_to_offer_messages.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('offer_messages', function(table) {
+    table.uuid('reply_to_id').references('id').inTable('offer_messages').onDelete('SET NULL');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('offer_messages', function(table) {
+    table.dropColumn('reply_to_id');
+  });
+};

--- a/backend/src/modules/offers/offerMessages.service.js
+++ b/backend/src/modules/offers/offerMessages.service.js
@@ -5,13 +5,29 @@ exports.createMessage = async (data) => {
   return row;
 };
 
-exports.getMessages = (responseId) => {
-  return db("offer_messages as m")
-    .join("users as u", "m.sender_id", "u.id")
+exports.getMessageById = (id) => {
+  return db({ m: "offer_messages" })
+    .leftJoin({ r: "offer_messages" }, "m.reply_to_id", "r.id")
+    .join({ u: "users" }, "m.sender_id", "u.id")
     .select(
       "m.*",
       "u.full_name as sender_name",
-      "u.avatar_url as sender_avatar"
+      "u.avatar_url as sender_avatar",
+      db.raw("r.message as reply_message")
+    )
+    .where("m.id", id)
+    .first();
+};
+
+exports.getMessages = (responseId) => {
+  return db({ m: "offer_messages" })
+    .leftJoin({ r: "offer_messages" }, "m.reply_to_id", "r.id")
+    .join({ u: "users" }, "m.sender_id", "u.id")
+    .select(
+      "m.*",
+      "u.full_name as sender_name",
+      "u.avatar_url as sender_avatar",
+      db.raw("r.message as reply_message")
     )
     .where("m.response_id", responseId)
     .orderBy("m.sent_at", "asc");

--- a/backend/src/modules/offers/offerResponses.controller.js
+++ b/backend/src/modules/offers/offerResponses.controller.js
@@ -33,7 +33,7 @@ exports.getMessages = catchAsync(async (req, res) => {
 
 exports.sendMessage = catchAsync(async (req, res) => {
   const { responseId } = req.params;
-  const { message } = req.body || {};
+  const { message, replyTo } = req.body || {};
   if (!message || !message.trim()) {
     throw new AppError("Message required", 400);
   }
@@ -42,10 +42,12 @@ exports.sendMessage = catchAsync(async (req, res) => {
   if (req.user.id !== resp.instructor_id && req.user.id !== resp.student_id) {
     throw new AppError("Not authorized", 403);
   }
-  const msg = await messageService.createMessage({
+  const created = await messageService.createMessage({
     response_id: responseId,
     sender_id: req.user.id,
     message: message.trim(),
+    reply_to_id: replyTo || null,
   });
+  const msg = await messageService.getMessageById(created.id);
   sendSuccess(res, msg, "Message sent");
 });

--- a/frontend/src/pages/dashboard/instructor/offers/[id].js
+++ b/frontend/src/pages/dashboard/instructor/offers/[id].js
@@ -57,6 +57,7 @@ const OfferDetailsPage = () => {
   const [offer, setOffer] = useState(null);
   const [response, setResponse] = useState(null);
   const [messages, setMessages] = useState([]);
+  const [replyTo, setReplyTo] = useState(null);
 
   const toggleStatus = async () => {
     if (!offer) return;
@@ -130,8 +131,14 @@ const OfferDetailsPage = () => {
       toast.error("Attachments not supported for offer messages", { theme: "colored" });
     }
     try {
-      const sent = await sendResponseMessage(offer.id, response.id, text.trim());
+      const sent = await sendResponseMessage(
+        offer.id,
+        response.id,
+        text.trim(),
+        replyTo?.id
+      );
       setMessages((prev) => [...prev, sent]);
+      setReplyTo(null);
       toast.success("Message sent!", { theme: "colored" });
     } catch (_) {
       toast.error("Failed to send message", { theme: "colored" });
@@ -282,7 +289,10 @@ const OfferDetailsPage = () => {
                   </div>
                   <div className={`flex items-center text-xs text-gray-400 mt-1 ${isCurrentUser ? "justify-end" : "justify-start"}`}>
                     <span>{formatRelativeTime(msg.sent_at)}</span>
-                    <button disabled className="ml-2 text-gray-400 cursor-not-allowed">
+                    <button
+                      onClick={() => setReplyTo(msg)}
+                      className="ml-2 text-blue-600 hover:underline"
+                    >
                       Reply
                     </button>
                   </div>
@@ -302,7 +312,11 @@ const OfferDetailsPage = () => {
             </div>
 
             <div className="mt-4">
-              <MessageInput sendMessage={handleSendMessage} />
+              <MessageInput
+                sendMessage={handleSendMessage}
+                replyTo={replyTo}
+                onCancelReply={() => setReplyTo(null)}
+              />
             </div>
           </>
         ) : (

--- a/frontend/src/pages/dashboard/student/offers/[id].js
+++ b/frontend/src/pages/dashboard/student/offers/[id].js
@@ -55,6 +55,7 @@ const OfferDetailsPage = () => {
   const [offer, setOffer] = useState(null);
   const [response, setResponse] = useState(null);
   const [messages, setMessages] = useState([]);
+  const [replyTo, setReplyTo] = useState(null);
 
   useEffect(() => {
     if (!id) return;
@@ -110,8 +111,14 @@ const OfferDetailsPage = () => {
       toast.error("Attachments not supported for offer messages");
     }
     try {
-      const sent = await sendResponseMessage(offer.id, response.id, text.trim());
+      const sent = await sendResponseMessage(
+        offer.id,
+        response.id,
+        text.trim(),
+        replyTo?.id
+      );
       setMessages((prev) => [...prev, sent]);
+      setReplyTo(null);
       toast.success("Message sent!");
     } catch (_) {
       toast.error("Failed to send message");
@@ -235,7 +242,10 @@ const OfferDetailsPage = () => {
                   </div>
                   <div className={`flex items-center text-xs text-gray-400 mt-1 ${isCurrentUser ? "justify-end" : "justify-start"}`}>
                     <span>{formatRelativeTime(msg.sent_at)}</span>
-                    <button disabled className="ml-2 text-gray-400 cursor-not-allowed">
+                    <button
+                      onClick={() => setReplyTo(msg)}
+                      className="ml-2 text-blue-600 hover:underline"
+                    >
                       Reply
                     </button>
                   </div>
@@ -255,7 +265,11 @@ const OfferDetailsPage = () => {
             </div>
 
             <div className="mt-4">
-              <MessageInput sendMessage={handleSendMessage} />
+              <MessageInput
+                sendMessage={handleSendMessage}
+                replyTo={replyTo}
+                onCancelReply={() => setReplyTo(null)}
+              />
             </div>
           </>
         ) : (

--- a/frontend/src/services/offerResponseService.js
+++ b/frontend/src/services/offerResponseService.js
@@ -15,7 +15,12 @@ export const fetchMessages = async (offerId, responseId) => {
   return data?.data ?? [];
 };
 
-export const sendMessage = async (offerId, responseId, message) => {
-  const { data } = await api.post(`/offers/${offerId}/responses/${responseId}/messages`, { message });
+export const sendMessage = async (offerId, responseId, message, replyTo) => {
+  const payload = { message };
+  if (replyTo) payload.replyTo = replyTo;
+  const { data } = await api.post(
+    `/offers/${offerId}/responses/${responseId}/messages`,
+    payload
+  );
   return data?.data ?? data;
 };


### PR DESCRIPTION
## Summary
- add migration for reply_to_id on offer_messages
- support fetching single offer message with reply info
- extend sendMessage controller to return reply details
- allow sending reply id from frontend service
- enable reply threads in instructor & student offer pages

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686229141e108328b3fa6b1a76d4e25d