### PR TITLE
Add offer message delete API

### DIFF
--- a/backend/src/modules/offers/offerMessages.service.js
+++ b/backend/src/modules/offers/offerMessages.service.js
@@ -32,3 +32,8 @@ exports.getMessages = (responseId) => {
     .where("m.response_id", responseId)
     .orderBy("m.sent_at", "asc");
 };
+
+exports.deleteMessage = async (id) => {
+  const [row] = await db("offer_messages").where({ id }).del().returning("*");
+  return row;
+};

--- a/backend/src/modules/offers/offerResponses.controller.js
+++ b/backend/src/modules/offers/offerResponses.controller.js
@@ -61,3 +61,16 @@ exports.sendMessage = catchAsync(async (req, res) => {
 
   sendSuccess(res, msg, "Message sent");
 });
+
+exports.deleteMessage = catchAsync(async (req, res) => {
+  const { responseId, messageId } = req.params;
+  const msg = await messageService.getMessageById(messageId);
+  if (!msg || msg.response_id !== responseId) {
+    throw new AppError("Message not found", 404);
+  }
+  if (msg.sender_id !== req.user.id) {
+    throw new AppError("Not authorized", 403);
+  }
+  await messageService.deleteMessage(messageId);
+  sendSuccess(res, null, "Message deleted");
+});

--- a/backend/src/modules/offers/offerResponses.routes.js
+++ b/backend/src/modules/offers/offerResponses.routes.js
@@ -9,5 +9,6 @@ router.get("/", controller.listResponses);
 
 router.get("/:responseId/messages", controller.getMessages);
 router.post("/:responseId/messages", controller.sendMessage);
+router.delete("/:responseId/messages/:messageId", controller.deleteMessage);
 
 module.exports = router;

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -50,3 +50,18 @@ The backend exposes a REST API under the `/api` prefix. Below is a brief outline
 ## Health Check
 
 `GET /` – returns a simple message confirming that the API is running.
+
+## Offers
+
+`/api/offers`
+
+- `GET /api/offers` – list open offers
+- `POST /api/offers` – create a new offer (auth required)
+- `GET /api/offers/:id` – view offer details
+- `PUT /api/offers/:id` – update an existing offer
+- `DELETE /api/offers/:id` – remove an offer
+- `GET /api/offers/:offerId/responses` – list responses for an offer
+- `POST /api/offers/:offerId/responses` – create a response
+- `GET /api/offers/:offerId/responses/:responseId/messages` – list offer messages
+- `POST /api/offers/:offerId/responses/:responseId/messages` – send a message
+- `DELETE /api/offers/:offerId/responses/:responseId/messages/:messageId` – delete a message you sent

--- a/frontend/src/pages/offers/[id].js
+++ b/frontend/src/pages/offers/[id].js
@@ -11,6 +11,7 @@ import {
   fetchResponses,
   fetchMessages as fetchResponseMessages,
   sendMessage as sendResponseMessage,
+  deleteMessage as deleteResponseMessage,
 } from "@/services/offerResponseService";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -53,6 +54,7 @@ const OfferDetailsPage = () => {
               msgs.map((m) => ({
                 id: m.id,
                 sender: m.sender_name,
+                senderId: m.sender_id,
                 text: m.message,
                 time: m.sent_at,
               }))
@@ -77,6 +79,7 @@ const OfferDetailsPage = () => {
       const msg = {
         id: sent.id,
         sender: user?.full_name || "You",
+        senderId: user?.id,
         text: sent.message,
         time: sent.sent_at,
       };
@@ -90,6 +93,13 @@ const OfferDetailsPage = () => {
       e.preventDefault();
       handleSend();
     }
+  };
+
+  const handleDeleteMessage = async (msgId) => {
+    try {
+      await deleteResponseMessage(id, response.id, msgId);
+      setMessages((prev) => prev.filter((m) => m.id !== msgId));
+    } catch (_) {}
   };
 
   const renderDealActions = () => {
@@ -195,7 +205,17 @@ const OfferDetailsPage = () => {
                     <span className="font-bold">{msg.sender}</span>
                     <span>{dayjs(msg.time).fromNow()}</span>
                   </div>
-                  <span>{msg.text}</span>
+                  <div className="flex justify-between items-start">
+                    <span>{msg.text}</span>
+                    {msg.senderId === user?.id && (
+                      <button
+                        onClick={() => handleDeleteMessage(msg.id)}
+                        className="text-red-400 text-xs hover:text-red-500"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
                 </div>
               ))}
             </div>

--- a/frontend/src/services/offerResponseService.js
+++ b/frontend/src/services/offerResponseService.js
@@ -24,3 +24,10 @@ export const sendMessage = async (offerId, responseId, message, replyTo) => {
   );
   return data?.data ?? data;
 };
+
+export const deleteMessage = async (offerId, responseId, messageId) => {
+  const { data } = await api.delete(
+    `/offers/${offerId}/responses/${responseId}/messages/${messageId}`
+  );
+  return data?.data ?? data;
+};


### PR DESCRIPTION
## Summary
- allow deleting offer messages on the backend
- document offer endpoints
- expose delete endpoint in offer response routes
- add deleteMessage API helper for offers
- support deleting messages in offer details page

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_686240b29c488328a5b56270f40ee270