### PR TITLE
Allow comments for any offer

### DIFF
--- a/frontend/src/pages/dashboard/instructor/offers/[id].js
+++ b/frontend/src/pages/dashboard/instructor/offers/[id].js
@@ -117,9 +117,15 @@ const OfferDetailsPage = () => {
         const myResp = resps.find(
           (r) => r.instructor_id === currentUserId
         );
-        const resp = myResp || resps[0];
-        setResponse(resp);
-        return fetchResponseMessages(offer.id, resp.id).then(setMessages);
+
+        if (myResp) {
+          setResponse(myResp);
+          return fetchResponseMessages(offer.id, myResp.id).then(setMessages);
+        }
+
+        // No response from the current instructor yet
+        setResponse(null);
+        setMessages([]);
       })
       .catch(() => {
         setResponse(null);

--- a/frontend/src/pages/dashboard/student/offers/[id].js
+++ b/frontend/src/pages/dashboard/student/offers/[id].js
@@ -95,10 +95,23 @@ const OfferDetailsPage = () => {
           setMessages([]);
           return;
         }
+
         const myResp = resps.find((r) => r.instructor_id === currentUserId);
-        const resp = myResp || resps[0];
-        setResponse(resp);
-        return fetchResponseMessages(offer.id, resp.id).then(setMessages);
+
+        if (myResp) {
+          setResponse(myResp);
+          return fetchResponseMessages(offer.id, myResp.id).then(setMessages);
+        }
+
+        if (offer.userId === currentUserId) {
+          const firstResp = resps[0];
+          setResponse(firstResp);
+          return fetchResponseMessages(offer.id, firstResp.id).then(setMessages);
+        }
+
+        // User is neither the instructor who responded nor the offer owner
+        setResponse(null);
+        setMessages([]);
       })
       .catch(() => {
         setResponse(null);


### PR DESCRIPTION
## Summary
- fix offer discussion logic so each user can create their own response
- student/instructor pages now check for current user's response before using existing ones

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686257a7cc0483288d0b77af68a84c6e