### PR TITLE
Fix missing offer chat messages

### DIFF
--- a/frontend/src/pages/dashboard/instructor/offers/[id].js
+++ b/frontend/src/pages/dashboard/instructor/offers/[id].js
@@ -132,6 +132,20 @@ const OfferDetailsPage = () => {
         setMessages([]);
       });
   }, [offer]);
+
+  useEffect(() => {
+    if (!offer || !response) return;
+
+    const loadMessages = () => {
+      fetchResponseMessages(offer.id, response.id)
+        .then(setMessages)
+        .catch(() => {});
+    };
+
+    loadMessages();
+    const interval = setInterval(loadMessages, 10000);
+    return () => clearInterval(interval);
+  }, [offer, response]);
   const handleSendMessage = async ({ text, file, audio }) => {
     if (!text?.trim()) return;
     if (file || audio) {

--- a/frontend/src/pages/dashboard/student/offers/[id].js
+++ b/frontend/src/pages/dashboard/student/offers/[id].js
@@ -119,6 +119,20 @@ const OfferDetailsPage = () => {
       });
   }, [offer]);
 
+  useEffect(() => {
+    if (!offer || !response) return;
+
+    const loadMessages = () => {
+      fetchResponseMessages(offer.id, response.id)
+        .then(setMessages)
+        .catch(() => {});
+    };
+
+    loadMessages();
+    const interval = setInterval(loadMessages, 10000);
+    return () => clearInterval(interval);
+  }, [offer, response]);
+
   const handleSendMessage = async ({ text, file, audio }) => {
     if (!text?.trim()) return;
     if (file || audio) {


### PR DESCRIPTION
## Summary
- add polling for instructor offer message page
- add polling for student offer message page

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68627ce787108328a6f0adf24a28683b