### PR TITLE
Add message deletion and visibility fixes

### DIFF
--- a/frontend/src/pages/dashboard/instructor/offers/[id].js
+++ b/frontend/src/pages/dashboard/instructor/offers/[id].js
@@ -22,6 +22,7 @@ import {
   fetchResponses,
   fetchMessages as fetchResponseMessages,
   sendMessage as sendResponseMessage,
+  deleteMessage as deleteResponseMessage,
 } from "@/services/offerResponseService";
 import MessageInput from "@/components/chat/MessageInput";
 import formatRelativeTime from "@/utils/relativeTime";
@@ -123,7 +124,13 @@ const OfferDetailsPage = () => {
           return fetchResponseMessages(offer.id, myResp.id).then(setMessages);
         }
 
-        // No response from the current instructor yet
+        if (offer.userId === currentUserId) {
+          const firstResp = resps[0];
+          setResponse(firstResp);
+          return fetchResponseMessages(offer.id, firstResp.id).then(setMessages);
+        }
+
+        // No response associated with current instructor
         setResponse(null);
         setMessages([]);
       })
@@ -139,9 +146,13 @@ const OfferDetailsPage = () => {
     }
     try {
       let resp = response;
-      if (!resp) {
+      if (
+        !resp ||
+        (resp.instructor_id !== currentUserId && offer.userId !== currentUserId)
+      ) {
         resp = await createResponse(offer.id, {});
         setResponse(resp);
+        setMessages([]);
       }
       const sent = await sendResponseMessage(
         offer.id,
@@ -154,6 +165,16 @@ const OfferDetailsPage = () => {
       toast.success("Message sent!", { theme: "colored" });
     } catch (_) {
       toast.error("Failed to send message", { theme: "colored" });
+    }
+  };
+
+  const handleDeleteMessage = async (msgId) => {
+    try {
+      await deleteResponseMessage(offer.id, response.id, msgId);
+      setMessages((prev) => prev.filter((m) => m.id !== msgId));
+      toast.info("Message deleted.");
+    } catch (_) {
+      toast.error("Failed to delete message", { theme: "colored" });
     }
   };
 
@@ -306,6 +327,14 @@ const OfferDetailsPage = () => {
                     >
                       Reply
                     </button>
+                    {isCurrentUser && (
+                      <button
+                        onClick={() => handleDeleteMessage(msg.id)}
+                        className="ml-2 text-red-600 hover:underline"
+                      >
+                        Delete
+                      </button>
+                    )}
                   </div>
                 </div>
                 {isCurrentUser && (

--- a/frontend/src/pages/dashboard/student/offers/[id].js
+++ b/frontend/src/pages/dashboard/student/offers/[id].js
@@ -19,6 +19,7 @@ import {
   fetchMessages as fetchResponseMessages,
   sendMessage as sendResponseMessage,
   createResponse,
+  deleteMessage as deleteResponseMessage,
 } from "@/services/offerResponseService";
 import MessageInput from "@/components/chat/MessageInput";
 import formatRelativeTime from "@/utils/relativeTime";
@@ -148,6 +149,16 @@ const OfferDetailsPage = () => {
     }
   };
 
+  const handleDeleteMessage = async (msgId) => {
+    try {
+      await deleteResponseMessage(offer.id, response.id, msgId);
+      setMessages((prev) => prev.filter((m) => m.id !== msgId));
+      toast.info("Message deleted.");
+    } catch (_) {
+      toast.error("Failed to delete message");
+    }
+  };
+
   if (!offer) return <div className="p-6 text-gray-600">Loading offer details...</div>;
 
   const isMyRequest = offer.userId === currentUserId && offer.type === "student";
@@ -270,6 +281,14 @@ const OfferDetailsPage = () => {
                     >
                       Reply
                     </button>
+                    {isCurrentUser && (
+                      <button
+                        onClick={() => handleDeleteMessage(msg.id)}
+                        className="ml-2 text-red-600 hover:underline"
+                      >
+                        Delete
+                      </button>
+                    )}
                   </div>
                 </div>
                 {isCurrentUser && (


### PR DESCRIPTION
## Summary
- show responses for offer owners on instructor view
- create a new response when sending messages across roles
- allow deleting discussion messages in instructor and student offer pages

## Testing
- `npm test --silent --prefix backend` *(fails: jest not found)*
- `npm test --silent --prefix frontend` *(fails: jest not found)*
- `npm run lint --silent --prefix frontend` *(fails: cannot find @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_6862777e49f483289b357966890f6a73