### PR TITLE
Connect instructor assignment pages to backend

### DIFF
--- a/frontend/src/pages/dashboard/instructor/assignments/[classId]/index.js
+++ b/frontend/src/pages/dashboard/instructor/assignments/[classId]/index.js
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import Link from 'next/link';
 import { FaEdit, FaTrashAlt, FaEye, FaPlusCircle } from 'react-icons/fa';
+import { fetchClassAssignments } from '@/services/classService';
+import { deleteClassAssignment } from '@/services/instructor/classService';
 
 export default function ClassAssignmentsPage() {
   const router = useRouter();
@@ -19,30 +21,25 @@ export default function ClassAssignmentsPage() {
 
   useEffect(() => {
     if (mounted && classId) {
-      // Mock assignments for specific class
-      setAssignments([
-        {
-          id: 'a1',
-          title: 'Hooks Deep Dive',
-          dueDate: '2025-06-10T23:59:00Z',
-          type: 'MCQ',
-          status: 'Active',
-        },
-        {
-          id: 'a2',
-          title: 'State Management Mini Project',
-          dueDate: '2025-06-20T23:59:00Z',
-          type: 'Text',
-          status: 'Draft',
-        },
-      ]);
+      const load = async () => {
+        try {
+          const list = await fetchClassAssignments(classId);
+          setAssignments(list);
+        } catch (err) {
+          console.error('Failed to load assignments', err);
+        }
+      };
+      load();
     }
   }, [mounted, classId]);
 
-  const handleDelete = (id) => {
-    if (confirm('Are you sure you want to delete this assignment?')) {
+  const handleDelete = async (id) => {
+    if (!confirm('Are you sure you want to delete this assignment?')) return;
+    try {
+      await deleteClassAssignment(id);
       setAssignments((prev) => prev.filter((a) => a.id !== id));
-      alert('🗑️ Assignment deleted (mock)!');
+    } catch (err) {
+      console.error('Failed to delete assignment', err);
     }
   };
 
@@ -80,9 +77,9 @@ export default function ClassAssignmentsPage() {
                 {assignments.map((a) => (
                   <tr key={a.id} className="border-t">
                     <td className="p-3">{a.title}</td>
-                    <td className="p-3">{new Date(a.dueDate).toLocaleString()}</td>
-                    <td className="p-3">{a.type}</td>
-                    <td className="p-3">{a.status}</td>
+                    <td className="p-3">{a.due_date ? new Date(a.due_date).toLocaleString() : ''}</td>
+                    <td className="p-3">{a.type || '-'}</td>
+                    <td className="p-3">{a.status || '-'}</td>
                     <td className="p-3 flex gap-2">
                       <Link href={`/dashboard/instructor/assignments/view/${a.id}`} className="text-gray-600 hover:text-gray-800">
                         <FaEye />

--- a/frontend/src/pages/dashboard/instructor/assignments/index.js
+++ b/frontend/src/pages/dashboard/instructor/assignments/index.js
@@ -3,17 +3,27 @@ import { useEffect, useState } from 'react';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import Link from 'next/link';
 import { FaPlus, FaEye, FaEdit, FaTrashAlt } from 'react-icons/fa';
+import { fetchInstructorClasses } from '@/services/instructor/classService';
+import { fetchClassAssignments } from '@/services/classService';
 
 export default function InstructorAssignmentsAll() {
   const [assignments, setAssignments] = useState([]);
 
   useEffect(() => {
-    // Mock assignments fetch
-    setAssignments([
-      { id: 'a1', title: 'React Basics Quiz', dueDate: '2025-05-20', type: 'MCQ', status: 'Active', classId: 'react-bootcamp' },
-      { id: 'a2', title: 'JSX Mini Project', dueDate: '2025-05-25', type: 'Text', status: 'Draft', classId: 'react-bootcamp' },
-      { id: 'a3', title: 'Java Basics', dueDate: '2025-06-01', type: 'MCQ', status: 'Active', classId: 'java-crash-course' },
-    ]);
+    const load = async () => {
+      try {
+        const classes = await fetchInstructorClasses();
+        const all = [];
+        for (const cls of classes) {
+          const list = await fetchClassAssignments(cls.id);
+          list.forEach((a) => all.push({ ...a, classId: cls.id }));
+        }
+        setAssignments(all);
+      } catch (err) {
+        console.error('Failed to load assignments', err);
+      }
+    };
+    load();
   }, []);
 
   return (
@@ -47,9 +57,9 @@ export default function InstructorAssignmentsAll() {
                       {a.classId}
                     </Link>
                   </td>
-                  <td className="p-3">{a.dueDate}</td>
-                  <td className="p-3">{a.type}</td>
-                  <td className="p-3">{a.status}</td>
+                  <td className="p-3">{a.due_date ? new Date(a.due_date).toLocaleString() : ''}</td>
+                  <td className="p-3">{a.type || '-'}</td>
+                  <td className="p-3">{a.status || '-'}</td>
                   <td className="p-3 flex gap-2">
                     <Link href={`/dashboard/instructor/assignments/view/${a.id}`} className="text-blue-600 hover:text-blue-800"><FaEye /></Link>
                     <Link href={`/dashboard/instructor/assignments/edit/${a.id}`} className="text-gray-600 hover:text-gray-800"><FaEdit /></Link>


### PR DESCRIPTION
## Summary
- load instructor assignment list from backend instead of using mock data
- fetch assignments for specific classes from backend
- allow deleting class assignments via API

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_686307a7596883288b0946641d3898ed