### PR TITLE
Implement class scoring and certificate issuance

### DIFF
--- a/backend/src/migrations/20250706000000_create_class_scoring_policies_table.js
+++ b/backend/src/migrations/20250706000000_create_class_scoring_policies_table.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_scoring_policies', function(table) {
+    table.increments('id').primary();
+    table.uuid('class_id').references('id').inTable('online_classes').onDelete('CASCADE');
+    table.integer('assignment_weight').defaultTo(60);
+    table.integer('attendance_weight').defaultTo(40);
+    table.integer('final_exam_weight').defaultTo(0);
+    table.integer('pass_score').defaultTo(60);
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_scoring_policies');
+};

--- a/backend/src/migrations/20250706001000_create_student_class_scores_table.js
+++ b/backend/src/migrations/20250706001000_create_student_class_scores_table.js
@@ -1,0 +1,18 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('student_class_scores', function(table) {
+    table.increments('id').primary();
+    table.uuid('class_id').references('id').inTable('online_classes').onDelete('CASCADE');
+    table.uuid('student_id').references('id').inTable('users').onDelete('CASCADE');
+    table.integer('assignment_score').defaultTo(0);
+    table.integer('attendance_score').defaultTo(0);
+    table.integer('final_exam_score').defaultTo(0);
+    table.integer('total_score').defaultTo(0);
+    table.boolean('passed').defaultTo(false);
+    table.boolean('certificate_issued').defaultTo(false);
+    table.timestamp('issued_at');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('student_class_scores');
+};

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -24,6 +24,8 @@ router.use("/attendance", require("./attendance/classAttendance.routes"));
 // Reviews and comments
 router.use("/reviews", require("./reviews/classReview.routes"));
 router.use("/comments", require("./comments/classComment.routes"));
+// Final scoring and certificates
+router.use("/scores", require("./scores/classScore.routes"));
 
 router.post(
   "/admin",

--- a/backend/src/modules/classes/scores/__tests__/classScore.routes.test.js
+++ b/backend/src/modules/classes/scores/__tests__/classScore.routes.test.js
@@ -1,0 +1,60 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../../config/database', () => ({ raw: jest.fn(() => Promise.resolve()) }));
+
+jest.mock('../classScore.service', () => ({
+  setPolicy: jest.fn(),
+  calculateForClass: jest.fn(),
+  issueCertificate: jest.fn(),
+  calculateForStudent: jest.fn(),
+}));
+
+jest.mock('../../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'u1' };
+    next();
+  },
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+  isStudent: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../classScore.service');
+const routes = require('../../class.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/classes', routes);
+
+describe('class score routes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('set scoring policy', async () => {
+    service.setPolicy.mockResolvedValue({ id: 1 });
+    const res = await request(app).post('/classes/scores/policy/1').send({ pass_score: 70 });
+    expect(res.status).toBe(200);
+    expect(service.setPolicy).toHaveBeenCalled();
+  });
+
+  test('list scores', async () => {
+    service.calculateForClass.mockResolvedValue([]);
+    const res = await request(app).get('/classes/scores/instructor/1');
+    expect(res.status).toBe(200);
+    expect(service.calculateForClass).toHaveBeenCalled();
+  });
+
+  test('issue certificate', async () => {
+    service.issueCertificate.mockResolvedValue({ id: 'c1' });
+    const res = await request(app).post('/classes/scores/instructor/1/students/u1/issue');
+    expect(res.status).toBe(200);
+    expect(service.issueCertificate).toHaveBeenCalled();
+  });
+
+  test('get my score', async () => {
+    service.calculateForStudent.mockResolvedValue({ total_score: 80 });
+    const res = await request(app).get('/classes/scores/student/1');
+    expect(res.status).toBe(200);
+    expect(service.calculateForStudent).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/classes/scores/classScore.controller.js
+++ b/backend/src/modules/classes/scores/classScore.controller.js
@@ -1,0 +1,23 @@
+const catchAsync = require('../../../utils/catchAsync');
+const { sendSuccess } = require('../../../utils/response');
+const service = require('./classScore.service');
+
+exports.setPolicy = catchAsync(async (req, res) => {
+  const policy = await service.setPolicy(req.params.classId, req.body);
+  sendSuccess(res, policy, 'Scoring policy saved');
+});
+
+exports.listScores = catchAsync(async (req, res) => {
+  const scores = await service.calculateForClass(req.params.classId);
+  sendSuccess(res, scores);
+});
+
+exports.issueCertificate = catchAsync(async (req, res) => {
+  const cert = await service.issueCertificate(req.params.classId, req.params.studentId);
+  sendSuccess(res, cert, 'Certificate issued');
+});
+
+exports.getMyScore = catchAsync(async (req, res) => {
+  const score = await service.calculateForStudent(req.params.classId, req.user.id);
+  sendSuccess(res, score);
+});

--- a/backend/src/modules/classes/scores/classScore.routes.js
+++ b/backend/src/modules/classes/scores/classScore.routes.js
@@ -1,0 +1,10 @@
+const router = require('express').Router();
+const ctrl = require('./classScore.controller');
+const { verifyToken, isInstructorOrAdmin, isStudent } = require('../../../middleware/auth/authMiddleware');
+
+router.post('/policy/:classId', verifyToken, isInstructorOrAdmin, ctrl.setPolicy);
+router.get('/instructor/:classId', verifyToken, isInstructorOrAdmin, ctrl.listScores);
+router.post('/instructor/:classId/students/:studentId/issue', verifyToken, isInstructorOrAdmin, ctrl.issueCertificate);
+router.get('/student/:classId', verifyToken, isStudent, ctrl.getMyScore);
+
+module.exports = router;

--- a/backend/src/modules/classes/scores/classScore.service.js
+++ b/backend/src/modules/classes/scores/classScore.service.js
@@ -1,0 +1,121 @@
+const db = require('../../../config/database');
+const { v4: uuidv4 } = require('uuid');
+const { generateCode } = require('../../users/tutorials/certificate/certificate.service');
+
+const getPolicy = async (classId) => {
+  const existing = await db('class_scoring_policies').where({ class_id: classId }).first();
+  if (existing) return existing;
+  const [row] = await db('class_scoring_policies').insert({ class_id: classId }).returning('*');
+  return row;
+};
+
+const setPolicy = async (classId, data) => {
+  const existing = await db('class_scoring_policies').where({ class_id: classId }).first();
+  if (existing) {
+    const [row] = await db('class_scoring_policies').where({ class_id: classId }).update(data).returning('*');
+    return row;
+  }
+  const [row] = await db('class_scoring_policies').insert({ class_id: classId, ...data }).returning('*');
+  return row;
+};
+
+const saveStudentScore = async (classId, studentId, data) => {
+  const existing = await db('student_class_scores').where({ class_id: classId, student_id: studentId }).first();
+  if (existing) {
+    const [row] = await db('student_class_scores')
+      .where({ class_id: classId, student_id: studentId })
+      .update(data)
+      .returning('*');
+    return row;
+  }
+  const [row] = await db('student_class_scores')
+    .insert({ class_id: classId, student_id: studentId, ...data })
+    .returning('*');
+  return row;
+};
+
+const calculateForStudent = async (classId, studentId) => {
+  const policy = await getPolicy(classId);
+  const avgRes = await db('assignment_submissions as s')
+    .join('class_assignments as a', 's.assignment_id', 'a.id')
+    .where('a.class_id', classId)
+    .where('s.user_id', studentId)
+    .avg('s.grade as avg')
+    .first();
+  const assignmentAvg = parseFloat(avgRes?.avg) || 0;
+
+  const lessonIds = await db('class_lessons').where({ class_id: classId }).pluck('id');
+  const totalLessons = lessonIds.length;
+  let attendancePercent = 0;
+  if (totalLessons > 0) {
+    const countRes = await db('class_attendance')
+      .whereIn('lesson_id', lessonIds)
+      .andWhere({ user_id: studentId, attended: true })
+      .count('* as cnt')
+      .first();
+    attendancePercent = (parseInt(countRes.cnt, 10) / totalLessons) * 100;
+  }
+
+  const finalExamScore = 0;
+  const totalScore = Math.round(
+    assignmentAvg * (policy.assignment_weight / 100) +
+      attendancePercent * (policy.attendance_weight / 100) +
+      finalExamScore * (policy.final_exam_weight / 100),
+  );
+  const passed = totalScore >= policy.pass_score;
+
+  return saveStudentScore(classId, studentId, {
+    assignment_score: Math.round(assignmentAvg),
+    attendance_score: Math.round(attendancePercent),
+    final_exam_score: finalExamScore,
+    total_score: totalScore,
+    passed,
+  });
+};
+
+const calculateForClass = async (classId) => {
+  const enrollments = await db('class_enrollments').where({ class_id: classId });
+  const results = [];
+  for (const enr of enrollments) {
+    results.push(await calculateForStudent(classId, enr.user_id));
+  }
+  return results;
+};
+
+const getStudentScore = async (classId, studentId) => {
+  const row = await db('student_class_scores').where({ class_id: classId, student_id: studentId }).first();
+  return row;
+};
+
+const issueCertificate = async (classId, studentId) => {
+  let cert = await db('certificates').where({ class_id: classId, user_id: studentId }).first();
+  if (cert) return cert;
+
+  const score = await getStudentScore(classId, studentId);
+  if (!score || !score.passed) {
+    throw new Error('Student has not passed');
+  }
+  cert = {
+    id: uuidv4(),
+    user_id: studentId,
+    class_id: classId,
+    tutorial_id: null,
+    template_id: null,
+    certificate_code: generateCode().replace('TUT', 'CLS'),
+    status: 'issued',
+  };
+  await db('certificates').insert(cert);
+  await db('student_class_scores')
+    .where({ class_id: classId, student_id: studentId })
+    .update({ certificate_issued: true, issued_at: db.fn.now() });
+  return cert;
+};
+
+module.exports = {
+  getPolicy,
+  setPolicy,
+  calculateForClass,
+  calculateForStudent,
+  getStudentScore,
+  issueCertificate,
+};


### PR DESCRIPTION
## Summary
- add migrations for scoring policies and student class scores
- implement scoring logic with certificate issuance
- expose scoring endpoints under `/classes/scores`
- test class scoring routes

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_686321427f148328a55202e8e8c8c0b8