### PR TITLE
Enable partial admin profile updates

### DIFF
--- a/backend/src/modules/users/admin/admin.validator.js
+++ b/backend/src/modules/users/admin/admin.validator.js
@@ -1,22 +1,26 @@
 const { z } = require("zod");
 
-exports.adminProfileSchema = z.object({
-  full_name: z.string().min(3),
-  phone: z.string().min(8),
-  gender: z.string().min(1),             // ✅ Added
-  date_of_birth: z.string().min(4),      // ✅ Added
-  avatar_url: z.string().optional(),     // ✅ Added (since PATCH is separate)
-  job_title: z.string().min(2),
-  department: z.string().min(2),
-  social_links: z
-    .array(
-      z.object({
-        platform: z.string().min(2),
-        url: z.string().url(),
-      })
-    )
-    .optional(),                         // ✅ Added
-});
+exports.adminProfileSchema = z
+  .object({
+    full_name: z.string().min(3).optional(),
+    phone: z.string().min(8).optional(),
+    gender: z.string().min(1).optional(), // ✅ Added
+    date_of_birth: z.string().min(4).optional(), // ✅ Added
+    avatar_url: z.string().optional(), // ✅ Added (since PATCH is separate)
+    job_title: z.string().min(2).optional(),
+    department: z.string().min(2).optional(),
+    social_links: z
+      .array(
+        z.object({
+          platform: z.string().min(2),
+          url: z.string().url(),
+        })
+      )
+      .optional(), // ✅ Added
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "No profile fields provided",
+  });
 
 exports.adminChangePasswordSchema = z.object({
   currentPassword: z.string().min(6),


### PR DESCRIPTION
## Summary
- allow optional fields in admin profile validator
- ignore undefined fields in admin profile controller
- adjust admin profile form to send only filled fields
- remove required asterisks in labels

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6863721e8b888328a7849aef0a5ad450