### PR TITLE
Implement study groups API and integrate frontend

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -1,0 +1,54 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./groups.service");
+const { v4: uuidv4 } = require("uuid");
+
+exports.createGroup = catchAsync(async (req, res) => {
+  const { name, description, visibility, requires_approval, cover_image } = req.body;
+  const group = await service.createGroup({
+    id: uuidv4(),
+    creator_id: req.user.id,
+    name,
+    description,
+    visibility: visibility || "public",
+    requires_approval: requires_approval || false,
+    cover_image,
+  });
+  await service.addMember(group.id, req.user.id, "admin");
+  sendSuccess(res, group, "Group created");
+});
+
+exports.listGroups = catchAsync(async (req, res) => {
+  const data = await service.listGroups(req.query.search);
+  sendSuccess(res, data);
+});
+
+exports.getGroup = catchAsync(async (req, res) => {
+  const group = await service.getGroupById(req.params.id);
+  sendSuccess(res, group);
+});
+
+exports.updateGroup = catchAsync(async (req, res) => {
+  const updated = await service.updateGroup(req.params.id, req.body);
+  sendSuccess(res, updated);
+});
+
+exports.deleteGroup = catchAsync(async (req, res) => {
+  await service.deleteGroup(req.params.id);
+  sendSuccess(res, null, "Deleted");
+});
+
+exports.getMyGroups = catchAsync(async (req, res) => {
+  const data = await service.getUserGroups(req.user.id);
+  sendSuccess(res, data);
+});
+
+exports.joinGroup = catchAsync(async (req, res) => {
+  const reqRow = await service.requestJoin(req.params.id, req.user.id);
+  sendSuccess(res, reqRow, "Request sent");
+});
+
+exports.listTags = catchAsync(async (_req, res) => {
+  const data = await service.listTags();
+  sendSuccess(res, data);
+});

--- a/backend/src/modules/groups/groups.routes.js
+++ b/backend/src/modules/groups/groups.routes.js
@@ -1,0 +1,14 @@
+const router = require("express").Router();
+const ctrl = require("./groups.controller");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
+
+router.get("/tags", ctrl.listTags);
+router.get("/my", verifyToken, ctrl.getMyGroups);
+router.post("/:id/join", verifyToken, ctrl.joinGroup);
+router.post("/", verifyToken, ctrl.createGroup);
+router.get("/", ctrl.listGroups);
+router.get("/:id", ctrl.getGroup);
+router.patch("/:id", verifyToken, ctrl.updateGroup);
+router.delete("/:id", verifyToken, ctrl.deleteGroup);
+
+module.exports = router;

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -1,0 +1,64 @@
+const db = require("../../config/database");
+const { v4: uuidv4 } = require("uuid");
+
+exports.createGroup = async (data) => {
+  const [row] = await db("groups").insert(data).returning("*");
+  return row;
+};
+
+exports.listGroups = async (search) => {
+  return db("groups")
+    .modify((qb) => {
+      if (search) qb.whereILike("name", `%${search}%`);
+    })
+    .select("*")
+    .orderBy("created_at", "desc");
+};
+
+exports.getGroupById = (id) => db("groups").where({ id }).first();
+
+exports.updateGroup = async (id, data) => {
+  const [row] = await db("groups").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.deleteGroup = (id) => db("groups").where({ id }).del();
+
+exports.addMember = async (groupId, userId, role = "admin") => {
+  const [row] = await db("group_members")
+    .insert({ id: uuidv4(), group_id: groupId, user_id: userId, role })
+    .returning("*");
+  return row;
+};
+
+exports.requestJoin = async (groupId, userId) => {
+  const [row] = await db("group_join_requests")
+    .insert({ id: uuidv4(), group_id: groupId, user_id: userId })
+    .onConflict(["group_id", "user_id"]).merge({ status: "pending", responded_at: null })
+    .returning("*");
+  return row;
+};
+
+exports.getUserGroups = async (userId) => {
+  const memberQuery = db("group_members as gm")
+    .join("groups as g", "gm.group_id", "g.id")
+    .select("g.*", "gm.role")
+    .where("gm.user_id", userId);
+
+  const pendingQuery = db("group_join_requests as gj")
+    .join("groups as g", "gj.group_id", "g.id")
+    .select("g.*", db.raw("'pending' as role"))
+    .where("gj.user_id", userId)
+    .andWhere("gj.status", "pending");
+
+  return memberQuery.unionAll(pendingQuery);
+};
+
+exports.listTags = async () => {
+  return db("group_tags as t")
+    .leftJoin("group_tag_map as m", "t.id", "m.tag_id")
+    .groupBy("t.id")
+    .select("t.id", "t.name", "t.slug", db.raw("COUNT(m.group_id) as group_count"))
+    .where("t.active", true)
+    .orderBy("t.name");
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -74,6 +74,7 @@ const cartRoutes = require("./modules/cart/cart.routes");
 const notificationRoutes = require("./modules/notifications/notifications.routes");
 const messageRoutes = require("./modules/messages/messages.routes");
 const chatRoutes = require("./modules/chat/chat.routes");
+const groupRoutes = require("./modules/groups/groups.routes");
 const offersRoutes = require("./modules/offers/offers.routes");
 const offerResponseRoutes = require("./modules/offers/offerResponses.routes");
 const socialLoginConfigRoutes = require("./modules/socialLoginConfig/socialLoginConfig.routes");
@@ -165,6 +166,7 @@ app.use("/api/social-login/config", socialLoginConfigRoutes); // 🔑 Social log
 app.use("/api/app-config", appConfigRoutes); // 🛠️ Application settings
 app.use("/api/payouts/admin", payoutRoutes); // 🏦 Instructor payouts
 app.use("/api/ads", adsRoutes); // 📢 Advertisements
+app.use("/api/groups", groupRoutes); // 📚 Study groups
 app.use("/api/offers", offersRoutes); // 📚 Learning marketplace offers
 app.use("/api/offers/:offerId/responses", offerResponseRoutes); // 💬 Offer negotiations
 app.use("/api/instructors", publicInstructorRoutes); // 📚 Public instructor listing

--- a/frontend/src/components/website/sections/StudyGroups.js
+++ b/frontend/src/components/website/sections/StudyGroups.js
@@ -1,52 +1,20 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { motion, AnimatePresence } from "framer-motion";
-import { FaChevronDown, FaFilter, FaPlus } from "react-icons/fa";
+import { motion } from "framer-motion";
+import { FaFilter, FaPlus } from "react-icons/fa";
+import groupService from "@/services/groupService";
 
-const categories = [
-  {
-    id: 1,
-    name: "Medicine & Healthcare",
-    icon: "🏥",
-    image: "https://i.pinimg.com/736x/5e/6b/1c/5e6b1c6a633aeeaa013312b69c89ab11.jpg",
-    children: [
-      { name: "Nursing", count: 7 },
-      { name: "Dentistry", count: 3 },
-    ]
-  },
-  {
-    id: 2,
-    name: "Engineering & Technology",
-    icon: "⚙️",
-    image: "https://static.vecteezy.com/system/resources/previews/002/949/141/non_2x/programming-code-coding-or-hacker-background-vector.jpg",
-    children: [
-      { name: "Python", count: 5 },
-      { name: "Web Development", count: 4 }
-    ]
-  },
-  {
-    id: 3,
-    name: "Business & Finance",
-    icon: "💼",
-    image: "https://img.freepik.com/free-vector/marketing-strategy-planning-analysis-business-vision-concept_1150-39773.jpg",
-    children: [
-      { name: "Finance", count: 6 },
-      { name: "Marketing", count: 5 }
-    ]
-  }
-];
-
-const GroupLandingPage = () => {
-  const [expanded, setExpanded] = useState(null);
+const StudyGroups = () => {
+  const [tags, setTags] = useState([]);
   const [search, setSearch] = useState("");
-  const [showAll, setShowAll] = useState(false);
   const router = useRouter();
 
-  const toggle = (i) => setExpanded(expanded === i ? null : i);
+  useEffect(() => {
+    groupService.getTags().then(setTags).catch(() => {});
+  }, []);
 
-  const filtered = categories.filter(cat =>
-    cat.name.toLowerCase().includes(search.toLowerCase()) ||
-    cat.children.some(sub => sub.name.toLowerCase().includes(search.toLowerCase()))
+  const filtered = tags.filter((t) =>
+    t.name.toLowerCase().includes(search.toLowerCase())
   );
 
   return (
@@ -56,11 +24,10 @@ const GroupLandingPage = () => {
           <h2 className="text-4xl font-bold mb-6 text-yellow-400">📚 Study Groups</h2>
           <p className="text-lg text-gray-300 mb-8">Explore fields and connect with focused learning communities.</p>
 
-          {/* 🔍 Search */}
           <div className="relative max-w-xl mx-auto mb-8">
             <input
               type="text"
-              placeholder="Search by category or topic..."
+              placeholder="Search by category..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="w-full p-3 pl-10 rounded-lg border border-gray-600 focus:ring-2 focus:ring-yellow-500 focus:outline-none text-gray-900"
@@ -68,7 +35,6 @@ const GroupLandingPage = () => {
             <FaFilter className="absolute left-3 top-4 text-gray-500" />
           </div>
 
-          {/* ➕ Create Button */}
           <div className="mb-10 flex justify-center">
             <button
               onClick={() => router.push("/groups/create")}
@@ -78,70 +44,21 @@ const GroupLandingPage = () => {
             </button>
           </div>
 
-          {/* ❌ No Match */}
           {filtered.length === 0 ? (
             <p className="text-gray-400">No matching categories found.</p>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filtered.slice(0, showAll ? filtered.length : 3).map((cat, i) => (
-                <motion.div
-                  key={cat.id}
-                  whileHover={{ scale: 1.03 }}
-                  onClick={() => toggle(i)}
-                  className="bg-gray-800 rounded-xl shadow-lg cursor-pointer transition duration-300 hover:shadow-2xl hover:bg-yellow-500 overflow-hidden"
+              {filtered.map((tag) => (
+                <div
+                  key={tag.id}
+                  className="bg-gray-800 rounded-xl shadow-lg p-4 cursor-pointer hover:bg-yellow-500 transition"
+                  onClick={() => router.push(`/groups/explore?filter=${tag.slug}`)}
                 >
-                  <img
-                    src={cat.image}
-                    alt={cat.name}
-                    className="h-36 w-full object-cover"
-                  />
-                  <div className="p-4 text-center">
-                    <h3 className="text-xl font-semibold">{cat.icon} {cat.name}</h3>
-                    <p className="text-sm text-yellow-300 mt-1">{cat.children.length} Subcategories</p>
-                  </div>
-
-                  <AnimatePresence>
-                    {expanded === i && (
-                      <motion.div
-                        initial={{ opacity: 0, height: 0 }}
-                        animate={{ opacity: 1, height: "auto" }}
-                        exit={{ opacity: 0, height: 0 }}
-                        className="bg-gray-700 px-4 py-3 text-left text-sm text-gray-200"
-                      >
-                        {cat.children.map((child, j) => (
-                          <motion.p
-                            key={j}
-                            className="py-1 hover:text-yellow-400 transition cursor-pointer"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              router.push(`/groups/explore?filter=${encodeURIComponent(child.name)}`);
-                            }}
-                          >
-                            • {child.name}{" "}
-                            <span className="text-xs text-gray-400">({child.count} groups)</span>
-                          </motion.p>
-                        ))}
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
-
-                  <FaChevronDown
-                    className={`mt-2 mb-4 mx-auto text-gray-400 transition-transform ${expanded === i ? "rotate-180" : ""}`}
-                  />
-                </motion.div>
+                  <h3 className="text-xl font-semibold mb-1">{tag.name}</h3>
+                  <p className="text-sm text-yellow-300">{tag.group_count} groups</p>
+                </div>
               ))}
             </div>
-          )}
-
-          {/* 🔽 Show More */}
-          {!showAll && filtered.length > 3 && (
-            <motion.button
-              onClick={() => setShowAll(true)}
-              className="mt-10 px-6 py-3 bg-yellow-500 text-gray-900 rounded-lg font-semibold hover:bg-yellow-600 transition shadow-lg"
-              whileHover={{ scale: 1.05 }}
-            >
-              Show More Groups
-            </motion.button>
           )}
         </div>
       </section>
@@ -149,4 +66,4 @@ const GroupLandingPage = () => {
   );
 };
 
-export default GroupLandingPage;
+export default StudyGroups;

--- a/frontend/src/pages/dashboard/instructor/groups/my-groups.js
+++ b/frontend/src/pages/dashboard/instructor/groups/my-groups.js
@@ -2,71 +2,11 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import toast from 'react-hot-toast';
+import groupService from '@/services/groupService';
 
-const allGroups = [
-  {
-    id: 'g1',
-    name: 'Frontend Wizards',
-    description: 'React, Vue, and modern UI lovers',
-    image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTuDDsrSKJXvX7_7I1l6XQMy6BlvfVGqDrdcQ&s',
-    createdAt: '2025-01-01',
-  },
-  {
-    id: 'g2',
-    name: 'AI Pioneers',
-    description: 'Discuss machine learning and AI trends',
-    image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTuDDsrSKJXvX7_7I1l6XQMy6BlvfVGqDrdcQ&s',
-    createdAt: '2025-02-10',
-  },
-  {
-    id: 'g3',
-    name: 'Design Guild',
-    description: 'Figma, UX, and UI talks',
-    image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTuDDsrSKJXvX7_7I1l6XQMy6BlvfVGqDrdcQ&s',
-    createdAt: '2024-12-05',
-  },
-  {
-    id: 'g4',
-    name: 'Fullstack Ninjas',
-    description: 'Talk everything backend and frontend',
-    image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQEysO5CaN4Jbgy9r--if2Whh32rFsiEkowTA&s',
-    createdAt: '2025-03-01',
-  },
-  {
-    id: 'g5',
-    name: 'Crypto Coders',
-    description: 'Blockchain, Web3, and decentralization',
-    image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQEysO5CaN4Jbgy9r--if2Whh32rFsiEkowTA&s',
-    createdAt: '2024-11-20',
-  },
-  {
-    id: 'g6',
-    name: 'Math Masters',
-    description: 'Solving equations and proofs together',
-    image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQEysO5CaN4Jbgy9r--if2Whh32rFsiEkowTA&s',
-    createdAt: '2024-10-10',
-  },
-  {
-    id: 'g7',
-    name: 'Cyber Security Squad',
-    description: 'Pen testing, exploits and more',
-    image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQEysO5CaN4Jbgy9r--if2Whh32rFsiEkowTA&s',
-    createdAt: '2025-03-15',
-  },
-];
-
-const initialStudentGroups = [
-  { groupId: 'g1', role: 'admin' },
-  { groupId: 'g2', role: 'member' },
-  { groupId: 'g3', role: 'pending' },
-  { groupId: 'g4', role: 'admin' },
-  { groupId: 'g5', role: 'member' },
-  { groupId: 'g6', role: 'pending' },
-  { groupId: 'g7', role: 'member' },
-];
 
 export default function MyGroupsPage() {
-  const [studentGroups, setStudentGroups] = useState(initialStudentGroups);
+  const [groups, setGroups] = useState([]);
   const [filteredGroups, setFilteredGroups] = useState([]);
   const [activeTab, setActiveTab] = useState('all');
   const [sortBy, setSortBy] = useState('newest');
@@ -75,24 +15,23 @@ export default function MyGroupsPage() {
   const tabs = ['all', 'admin', 'member', 'pending'];
 
   useEffect(() => {
-    const enriched = studentGroups.map((sg) => {
-      const group = allGroups.find((g) => g.id === sg.groupId);
-      return { ...group, role: sg.role };
-    });
+    groupService.getMyGroups().then(setGroups).catch(() => toast.error('Failed to load groups'));
+  }, []);
 
-    let filtered = activeTab === 'all' ? enriched : enriched.filter((g) => g.role === activeTab);
+  useEffect(() => {
+    let filtered = activeTab === 'all' ? groups : groups.filter((g) => g.role === activeTab);
 
     if (sortBy === 'newest') {
-      filtered.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+      filtered.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
     } else if (sortBy === 'az') {
       filtered.sort((a, b) => a.name.localeCompare(b.name));
     }
 
     setFilteredGroups(filtered);
-  }, [studentGroups, activeTab, sortBy]);
+  }, [groups, activeTab, sortBy]);
 
   const cancelJoinRequest = (groupId) => {
-    setStudentGroups((prev) => prev.filter((g) => g.groupId !== groupId));
+    setGroups((prev) => prev.filter((g) => g.id !== groupId));
     toast.success('Join request cancelled.');
   };
 
@@ -114,9 +53,12 @@ export default function MyGroupsPage() {
           {group.role === 'pending' && '⏳ Pending'}
         </span>
       </div>
-      <img src={group.image} alt={group.name} className="w-full h-32 object-cover rounded" />
+      <img
+        src={group.cover_image || group.image}
+        alt={group.name}
+        className="w-full h-32 object-cover rounded"
+      />
       <p className="text-sm text-gray-600">{group.description}</p>
-      <p className="text-xs text-gray-400">🕒 Last updated: 2d ago</p>
 
       <div className="flex -space-x-2 pt-1">
         {[...Array(3)].map((_, i) => (

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -1,174 +1,24 @@
-// ---------------------------------------------
-// ✅ MOCK DATA
-// ---------------------------------------------
-
-const currentUserId = 'u1'; // Simulate logged-in user (Ali Hassan)
-
-const mockGroup = {
-  id: '12345',
-  name: 'Frontend Developers',
-  description: 'Public group for frontend discussions.',
-  isPublic: true,
-};
-
-let mockRequests = [
-  {
-    id: 'req1',
-    user: { id: 'u1', name: 'Ali Hassan' },
-    group: { id: '12345', name: 'Frontend Developers' },
-  },
-];
-
-let groupMembersMock = [
-  { id: 'u3', name: 'You', role: 'admin', muted: false },
-  { id: 'u1', name: 'Ali Hassan', role: 'member', muted: false },
-  { id: 'u2', name: 'Sarah Youssef', role: 'moderator', muted: false },
-];
-
-let groupPermissions = {
-  admin: { message: true, upload: true, video: true, invite: true },
-  moderator: { message: true, upload: true, video: true, invite: false },
-  member: { message: true, upload: false, video: false, invite: false },
-};
-
-const allGroupsMock = [
-  {
-    id: '12345',
-    name: 'Frontend Developers',
-    description: 'Public group for frontend discussions.',
-    isPublic: true,
-  },
-  {
-    id: 'g2',
-    name: 'AI Builders',
-    description: 'Discuss machine learning & AI',
-    isPublic: true,
-  },
-  {
-    id: 'g3',
-    name: 'Private Research Team',
-    description: 'Private team for internal collaboration',
-    isPublic: false,
-  },
-];
-
-// ---------------------------------------------
-// ✅ SERVICE METHODS
-// ---------------------------------------------
+import api from "@/services/api/api";
 
 const groupService = {
-  // ✅ Get specific group by ID
-  getGroupById: async (id) => {
-    return allGroupsMock.find((g) => g.id === id) || null;
-  },
-
-  // ✅ Get all groups (public + private)
-  getAllGroups: async () => {
-    return allGroupsMock;
-  },
-
-  // ✅ Filtered public groups
-  getPublicGroups: async () => {
-    return allGroupsMock.filter((g) => g.isPublic);
-  },
-
-  // ✅ Send join request
-  sendJoinRequest: async (groupId) => {
-    console.log(`Join request sent to group ${groupId}`);
-    const group = allGroupsMock.find((g) => g.id === groupId);
-    if (!group) return false;
-
-    mockRequests.push({
-      id: `req-${Date.now()}`,
-      user: { id: currentUserId, name: 'Test User' },
-      group,
-    });
-
-    return true;
-  },
-
-  // ✅ Admin sees join requests
-  getJoinRequestsForAdmin: async () => {
-    return mockRequests;
-  },
-
-  // ✅ Admin approves or rejects request
-  respondToJoinRequest: async (requestId, action) => {
-    const request = mockRequests.find((r) => r.id === requestId);
-
-    if (action === 'approve' && request) {
-      groupMembersMock.push({
-        id: request.user.id,
-        name: request.user.name,
-        role: 'member',
-        muted: false,
-      });
-    }
-
-    mockRequests = mockRequests.filter((r) => r.id !== requestId);
-    console.log(`Request ${requestId} was ${action}`);
-    return true;
-  },
-
-  // ✅ Get logged-in user's joined groups
   getMyGroups: async () => {
-    return groupMembersMock
-      .filter((m) => m.id === currentUserId && !m.removed)
-      .map((m) => {
-        const group = allGroupsMock.find((g) => g.id === '12345'); // Simplified
-        return {
-          ...group,
-          role: m.role,
-          status: 'joined',
-        };
-      });
+    const { data } = await api.get("/groups/my");
+    return data?.data ?? [];
   },
 
-  // ✅ Get user's pending join requests
-  getMyJoinRequests: async () => {
-    return mockRequests
-      .filter((r) => r.user.id === currentUserId)
-      .map((r) => ({
-        ...r.group,
-        status: 'pending',
-      }));
+  getTags: async () => {
+    const { data } = await api.get("/groups/tags");
+    return data?.data ?? [];
   },
 
-  // ✅ Get members of a group
-  getGroupMembers: async (groupId) => {
-    return groupMembersMock.filter((m) => !m.removed);
+  getPublicGroups: async (search) => {
+    const { data } = await api.get("/groups", { params: { search } });
+    return data?.data ?? [];
   },
 
-  // ✅ Manage member (kick, mute, promote, etc.)
-  manageMember: async (groupId, memberId, action) => {
-    console.log(`Performing ${action} on member ${memberId} in group ${groupId}`);
-
-    groupMembersMock = groupMembersMock.map((m) => {
-      if (m.id === memberId) {
-        switch (action) {
-          case 'kick': return { ...m, removed: true };
-          case 'mute': return { ...m, muted: true };
-          case 'unmute': return { ...m, muted: false };
-          case 'promote': return { ...m, role: 'moderator' };
-          case 'demote': return { ...m, role: 'member' };
-          default: return m;
-        }
-      }
-      return m;
-    });
-
-    return true;
-  },
-
-  // ✅ Permissions
-  getGroupPermissions: async (groupId) => {
-    return groupPermissions;
-  },
-
-  updateGroupPermissions: async (groupId, updatedPermissions) => {
-    groupPermissions = updatedPermissions;
-    console.log(`Permissions for group ${groupId} updated`, updatedPermissions);
-    return true;
+  joinGroup: async (groupId) => {
+    const { data } = await api.post(`/groups/${groupId}/join`);
+    return data?.data;
   },
 };
 


### PR DESCRIPTION
## Summary
- add backend groups module with CRUD operations
- expose new `/api/groups` endpoints via server
- update StudyGroups section to load categories from backend
- update instructor "My Groups" page to fetch data from API
- rewrite groupService to use axios

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686380458c648328ae96bfe4af60ddd6