### PR TITLE
Add role-aware group creation page

### DIFF
--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { X, Mail, Bell, MessageSquare, Smartphone, Send, Image as ImageIcon, Tag, Users } from 'lucide-react';
 import { toast } from 'react-toastify';
+import groupService from '@/services/groupService';
 
 const allUsers = [
   { id: 'u1', name: 'Ali Hassan', email: 'ali@example.com', phone: '+966500000001', avatar: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTcUATNS9SzcJCCPuJ9OqlGynFYfxy2bOYVaw&s' },
@@ -83,14 +84,24 @@ export default function GroupForm() {
     );
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     setIsSubmitting(true);
-    setTimeout(() => {
-      console.log({ groupName, description, type, category, tags, maxSize, timezone, invitedUsers, inviteMethods });
+    try {
+      await groupService.createGroup({
+        name: groupName,
+        description,
+        visibility: type || 'public',
+        requires_approval: false,
+        cover_image: null,
+      });
       toast.success('Group created successfully!');
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to create group');
+    } finally {
       setIsSubmitting(false);
-    }, 1000);
+    }
   };
 
   const handleSendInvites = () => {

--- a/frontend/src/pages/groups/create.js
+++ b/frontend/src/pages/groups/create.js
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import useAuthStore from '@/store/auth/authStore';
+import GroupForm from '@/components/groups/GroupForm';
+import InstructorLayout from '@/components/layouts/InstructorLayout';
+import StudentLayout from '@/components/layouts/StudentLayout';
+
+export default function CreateGroupPage() {
+  const router = useRouter();
+  const { user, hasHydrated } = useAuthStore();
+
+  useEffect(() => {
+    if (hasHydrated && !user) {
+      router.push('/auth/login?returnTo=/groups/create');
+    }
+  }, [user, hasHydrated, router]);
+
+  if (!hasHydrated || !user) return null;
+
+  const Layout = user.role === 'instructor' ? InstructorLayout : StudentLayout;
+
+  return (
+    <Layout>
+      <div className="p-4 max-w-3xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Create a New Group</h1>
+        <GroupForm />
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -20,6 +20,11 @@ const groupService = {
     const { data } = await api.post(`/groups/${groupId}/join`);
     return data?.data;
   },
+
+  createGroup: async (payload) => {
+    const { data } = await api.post('/groups', payload);
+    return data?.data;
+  },
 };
 
 export default groupService;


### PR DESCRIPTION
## Summary
- add `/groups/create` page that chooses layout based on logged in user's role
- hook GroupForm to backend API via new `createGroup` function
- include group service import and handle API errors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` in frontend *(fails: jest not found)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686382a577bc8328ac66d27f439ad437