### PR TITLE
Fix admin groups create path

### DIFF
--- a/frontend/src/pages/dashboard/admin/groups/create.js
+++ b/frontend/src/pages/dashboard/admin/groups/create.js
@@ -1,0 +1,16 @@
+import GroupForm from '@/components/groups/GroupForm';
+import AdminLayout from '@/components/layouts/AdminLayout';
+import withAuthProtection from '@/hooks/withAuthProtection';
+
+function CreateGroupPage() {
+  return (
+    <AdminLayout>
+      <div className="p-4 max-w-3xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Create a New Group</h1>
+        <GroupForm />
+      </div>
+    </AdminLayout>
+  );
+}
+
+export default withAuthProtection(CreateGroupPage, ['admin', 'superadmin']);

--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -257,15 +257,21 @@ export default function AdminGroupsIndex() {
             <option value="suspended">🚫 Suspended</option>
           </select>
 
-          <select
-            value={sortOption}
-            onChange={(e) => setSortOption(e.target.value)}
-            className="p-2 border rounded-md"
-          >
-            <option value="newest">📅 Newest</option>
-            <option value="oldest">📆 Oldest</option>
-            <option value="members">👥 Most Members</option>
-          </select>
+        <select
+          value={sortOption}
+          onChange={(e) => setSortOption(e.target.value)}
+          className="p-2 border rounded-md"
+        >
+          <option value="newest">📅 Newest</option>
+          <option value="oldest">📆 Oldest</option>
+          <option value="members">👥 Most Members</option>
+        </select>
+
+        <Link href="/dashboard/admin/groups/create">
+          <button className="ml-auto border px-4 py-2 rounded text-sm bg-yellow-400 text-white hover:bg-yellow-500">
+            + Create Group
+          </button>
+        </Link>
 
           {selectedGroups.length > 0 && (
             <button

--- a/frontend/src/services/profile/userService.js
+++ b/frontend/src/services/profile/userService.js
@@ -7,13 +7,10 @@ const mockUsers = [
   { id: 'u4', name: 'Lina Ahmed', email: 'lina.ahmed@example.com' },
 ];
 
-// ✅ Mock: Search Users by name/email
-const searchUsers = async (query) => {
-  return mockUsers.filter(
-    (user) =>
-      user.name.toLowerCase().includes(query.toLowerCase()) ||
-      user.email.toLowerCase().includes(query.toLowerCase())
-  );
+// 🔍 Search users via backend
+const searchUsers = async (query = "") => {
+  const { data } = await api.get("/chat/users", { params: { q: query } });
+  return data?.data || [];
 };
 
 // ✅ Submit full profile to backend


### PR DESCRIPTION
## Summary
- add missing page for /dashboard/admin/groups/create
- show a 'Create Group' button on the admin groups index
- load categories, tags, and users from backend when creating a group

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686386bc425483288e0b2103ed9b26f8