### PR TITLE
Fix group creation form

### DIFF
--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -28,7 +28,7 @@ export default function GroupForm() {
     const loadInitial = async () => {
       try {
         const cats = await fetchAllCategories();
-        setAvailableCategories(cats || []);
+        setAvailableCategories(cats?.data || cats || []);
       } catch (err) {
         console.error('Failed to load categories', err);
       }
@@ -105,7 +105,7 @@ export default function GroupForm() {
         name: groupName,
         description,
         visibility: type || 'public',
-        requires_approval: false,
+        requires_approval: type === 'public',
         cover_image: null,
         category_id: category || null,
         tags,

--- a/frontend/src/services/profile/userService.js
+++ b/frontend/src/services/profile/userService.js
@@ -1,12 +1,5 @@
 import api from "../api/api";
 
-const mockUsers = [
-  { id: 'u1', name: 'Ali Hassan', email: 'ali@example.com' },
-  { id: 'u2', name: 'Sarah Youssef', email: 'sarah@example.com' },
-  { id: 'u3', name: 'Mohammed Fathy', email: 'm.fathy@example.com' },
-  { id: 'u4', name: 'Lina Ahmed', email: 'lina.ahmed@example.com' },
-];
-
 // 🔍 Search users via backend
 const searchUsers = async (query = "") => {
   const { data } = await api.get("/chat/users", { params: { q: query } });
@@ -28,30 +21,10 @@ const uploadDemoVideo = async (userId, file) => {
 };
 
 
-// ✅ Mock: Get User Profile
-const getUserProfile = async (userId) => {
-  return mockUsers.find((u) => u.id === userId);
-};
-
-// ✅ Mock: Update User Profile
-const updateUserProfile = async (userId, userData) => {
-  console.log(`Updating user ${userId}`, userData);
-  return { ...userData, id: userId };
-};
-
-// ✅ Mock: Change Password
-const changePassword = async (userId, passwordData) => {
-  console.log(`Changing password for ${userId}`, passwordData);
-  return true;
-};
-
 const userService = {
-  getUserProfile,
-  updateUserProfile,
-  changePassword,
   searchUsers,
   completeUserProfile,
-  uploadDemoVideo
+  uploadDemoVideo,
 };
 
 export default userService;


### PR DESCRIPTION
## Summary
- remove unused mock data from user profile service
- set requires approval flag based on group privacy in form
- fetch categories properly when creating groups

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68638baeec7483289e62e33d6e35b49f