### PR TITLE
Improve group invite section

### DIFF
--- a/backend/src/modules/groups/groupUploadMiddleware.js
+++ b/backend/src/modules/groups/groupUploadMiddleware.js
@@ -1,0 +1,33 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const uploadDir = path.join(__dirname, '../../../uploads/groups');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const sanitizeName = (name) =>
+  name
+    .replace(/\s+/g, '-')
+    .replace(/[^a-zA-Z0-9+_.-]/g, '');
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    const base = sanitizeName(path.basename(file.originalname, ext));
+    cb(null, `${Date.now()}-${base}${ext}`);
+  },
+});
+
+const imageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
+const fileFilter = (_req, file, cb) => {
+  if (file.fieldname === 'cover_image') {
+    cb(null, imageTypes.includes(file.mimetype));
+  } else {
+    cb(null, false);
+  }
+};
+
+module.exports = multer({ storage, fileFilter, limits: { fileSize: 5 * 1024 * 1024 } }).single('cover_image');

--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -4,7 +4,7 @@ const service = require("./groups.service");
 const { v4: uuidv4 } = require("uuid");
 
 exports.createGroup = catchAsync(async (req, res) => {
-  const { name, description, visibility, requires_approval, cover_image } = req.body;
+  const { name, description, visibility, requires_approval } = req.body;
   const group = await service.createGroup({
     id: uuidv4(),
     creator_id: req.user.id,
@@ -12,7 +12,7 @@ exports.createGroup = catchAsync(async (req, res) => {
     description,
     visibility: visibility || "public",
     requires_approval: requires_approval || false,
-    cover_image,
+    cover_image: req.file ? `/uploads/groups/${req.file.filename}` : undefined,
   });
   await service.addMember(group.id, req.user.id, "admin");
   sendSuccess(res, group, "Group created");
@@ -29,7 +29,9 @@ exports.getGroup = catchAsync(async (req, res) => {
 });
 
 exports.updateGroup = catchAsync(async (req, res) => {
-  const updated = await service.updateGroup(req.params.id, req.body);
+  const data = { ...req.body };
+  if (req.file) data.cover_image = `/uploads/groups/${req.file.filename}`;
+  const updated = await service.updateGroup(req.params.id, data);
   sendSuccess(res, updated);
 });
 

--- a/backend/src/modules/groups/groups.routes.js
+++ b/backend/src/modules/groups/groups.routes.js
@@ -1,14 +1,15 @@
 const router = require("express").Router();
 const ctrl = require("./groups.controller");
 const { verifyToken } = require("../../middleware/auth/authMiddleware");
+const upload = require("./groupUploadMiddleware");
 
 router.get("/tags", ctrl.listTags);
 router.get("/my", verifyToken, ctrl.getMyGroups);
 router.post("/:id/join", verifyToken, ctrl.joinGroup);
-router.post("/", verifyToken, ctrl.createGroup);
+router.post("/", verifyToken, upload, ctrl.createGroup);
 router.get("/", ctrl.listGroups);
 router.get("/:id", ctrl.getGroup);
-router.patch("/:id", verifyToken, ctrl.updateGroup);
+router.patch("/:id", verifyToken, upload, ctrl.updateGroup);
 router.delete("/:id", verifyToken, ctrl.deleteGroup);
 
 module.exports = router;

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -22,7 +22,9 @@ const groupService = {
   },
 
   createGroup: async (payload) => {
-    const { data } = await api.post('/groups', payload);
+    const { data } = await api.post('/groups', payload, {
+      headers: payload instanceof FormData ? { 'Content-Type': 'multipart/form-data' } : {},
+    });
     return data?.data;
   },
 };


### PR DESCRIPTION
## Summary
- show selected users preview on group creation form
- rename "Send via" to "Notification methods" and clarify instructions
- support uploading a group avatar when creating or updating a group

## Testing
- `npm test` in `frontend` *(fails: jest not found)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a2d83fcc832888e9c061890ce212