### PR TITLE
Implement backend fetch for group page

### DIFF
--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -30,6 +30,11 @@ const groupService = {
     return Array.isArray(list) ? list.map(formatGroup) : list;
   },
 
+  getGroupById: async (id) => {
+    const { data } = await api.get(`/groups/${id}`);
+    return data?.data ? formatGroup(data.data) : null;
+  },
+
   joinGroup: async (groupId) => {
     const { data } = await api.post(`/groups/${groupId}/join`);
     return data?.data;


### PR DESCRIPTION
## Summary
- add `getGroupById` helper to `groupService`
- fetch group details from backend in student group page
- use `groupService.joinGroup` when joining a group

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6863cb0766fc8328bc9d93b8d28a54fe