### PR TITLE
Enable basic group member management

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -54,3 +54,14 @@ exports.listTags = catchAsync(async (_req, res) => {
   const data = await service.listTags();
   sendSuccess(res, data);
 });
+exports.listMembers = catchAsync(async (req, res) => {
+  const members = await service.listMembers(req.params.id);
+  sendSuccess(res, members);
+});
+
+exports.manageMember = catchAsync(async (req, res) => {
+  const { memberId } = req.params;
+  const { action } = req.body;
+  const result = await service.manageMember(req.params.id, memberId, action);
+  sendSuccess(res, result);
+});

--- a/backend/src/modules/groups/groups.routes.js
+++ b/backend/src/modules/groups/groups.routes.js
@@ -6,6 +6,8 @@ const upload = require("./groupUploadMiddleware");
 router.get("/tags", ctrl.listTags);
 router.get("/my", verifyToken, ctrl.getMyGroups);
 router.post("/:id/join", verifyToken, ctrl.joinGroup);
+router.get("/:id/members", verifyToken, ctrl.listMembers);
+router.post("/:id/members/:memberId/manage", verifyToken, ctrl.manageMember);
 router.post("/", verifyToken, upload, ctrl.createGroup);
 router.get("/", ctrl.listGroups);
 router.get("/:id", ctrl.getGroup);

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -46,6 +46,22 @@ const groupService = {
     });
     return data?.data ? formatGroup(data.data) : null;
   },
+
+  getGroupMembers: async (groupId) => {
+    const { data } = await api.get(`/groups/${groupId}/members`);
+    const list = data?.data ?? [];
+    return list.map((m) => ({
+      id: m.user_id,
+      name: m.name,
+      avatar: m.avatar,
+      role: m.role,
+    }));
+  },
+
+  manageMember: async (groupId, memberId, action) => {
+    const { data } = await api.post(`/groups/${groupId}/members/${memberId}/manage`, { action });
+    return data?.data;
+  },
 };
 
 export default groupService;


### PR DESCRIPTION
## Summary
- expose backend endpoints to manage group members
- add frontend service calls for member management

## Testing
- `npm test --if-present` in `backend`
- `npm test --if-present` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6863d1aaa7e08328a152b880f571028d