### PR TITLE
Fix unique group name

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -2,9 +2,13 @@ const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const service = require("./groups.service");
 const { v4: uuidv4 } = require("uuid");
+const AppError = require("../../utils/AppError");
 
 exports.createGroup = catchAsync(async (req, res) => {
   const { name, description, visibility, requires_approval } = req.body;
+  if (await service.findByName(name)) {
+    throw new AppError("Group name already exists", 409);
+  }
   const group = await service.createGroup({
     id: uuidv4(),
     creator_id: req.user.id,

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -1,6 +1,12 @@
 const db = require("../../config/database");
 const { v4: uuidv4 } = require("uuid");
 
+exports.findByName = async (name) => {
+  return db("groups")
+    .whereRaw("LOWER(name) = ?", [name.toLowerCase()])
+    .first();
+};
+
 exports.createGroup = async (data) => {
   const [row] = await db("groups").insert(data).returning("*");
   return row;


### PR DESCRIPTION
## Summary
- enforce unique group names when creating groups

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863e35203208328b10ed7e6d7c3a486