### PR TITLE
Use role-based layout for group creation

### DIFF
--- a/frontend/src/pages/groups/create.js
+++ b/frontend/src/pages/groups/create.js
@@ -17,7 +17,12 @@ export default function CreateGroupPage() {
 
   if (!hasHydrated || !user) return null;
 
-  const Layout = user.role === 'instructor' ? InstructorLayout : StudentLayout;
+  const layoutMap = {
+    instructor: InstructorLayout,
+    student: StudentLayout,
+  };
+
+  const Layout = layoutMap[user.role] || StudentLayout;
 
   return (
     <Layout>


### PR DESCRIPTION
## Summary
- add a layout map in `groups/create` page
- select layout based on user role

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864344121b88328a09ff7964d313254