### PR TITLE
Fetch groups from backend

### DIFF
--- a/frontend/src/pages/dashboard/student/groups/explore.js
+++ b/frontend/src/pages/dashboard/student/groups/explore.js
@@ -3,61 +3,8 @@ import Link from 'next/link';
 import { Search } from 'lucide-react';
 import StudentLayout from '@/components/layouts/StudentLayout';
 import toast from 'react-hot-toast';
+import groupService from '@/services/groupService';
 
-const mockGroups = [
-  {
-    id: 'g1',
-    name: 'Frontend Wizards',
-    description: 'React, Vue, and modern UI lovers',
-    tags: ['React', 'Tailwind'],
-    isPublic: true,
-    membersCount: 128,
-    createdAt: '2024-12-01',
-    image: 'https://d1ymz67w5raq8g.cloudfront.net/Pictures/480xAny/8/9/2/108892_eic0515_cpd_f1_630m.jpg',
-  },
-  {
-    id: 'g2',
-    name: 'AI Pioneers',
-    description: 'Discuss machine learning and AI trends',
-    tags: ['AI', 'ML'],
-    isPublic: true,
-    membersCount: 210,
-    createdAt: '2025-01-15',
-    image: 'https://d1ymz67w5raq8g.cloudfront.net/Pictures/480xAny/8/9/2/108892_eic0515_cpd_f1_630m.jpg',
-  },
-  {
-    id: 'g3',
-    name: 'Design Guild',
-    description: 'Figma, UX, and UI talks',
-    tags: ['Figma', 'Design'],
-    isPublic: true,
-    membersCount: 90,
-    createdAt: '2024-11-20',
-    image: 'https://d1ymz67w5raq8g.cloudfront.net/Pictures/480xAny/8/9/2/108892_eic0515_cpd_f1_630m.jpg',
-  },
-  {
-    id: 'g4',
-    name: 'Fullstack Ninjas',
-    description: 'Talk everything backend and frontend',
-    tags: ['Node.js', 'React'],
-    isPublic: true,
-    membersCount: 150,
-    createdAt: '2025-02-10',
-    image: 'https://d1ymz67w5raq8g.cloudfront.net/Pictures/480xAny/8/9/2/108892_eic0515_cpd_f1_630m.jpg',
-  },
-  {
-    id: 'g5',
-    name: 'Crypto Coders',
-    description: 'Blockchain, Web3, and decentralization',
-    tags: ['Crypto', 'Blockchain'],
-    isPublic: true,
-    membersCount: 70,
-    createdAt: '2024-10-30',
-    image: 'https://d1ymz67w5raq8g.cloudfront.net/Pictures/480xAny/8/9/2/108892_eic0515_cpd_f1_630m.jpg',
-  }
-];
-
-const popularTags = ['React', 'AI', 'Design', 'Tailwind', 'ML', 'Figma'];
 
 export default function ExploreGroupsPage() {
   const [groups, setGroups] = useState([]);
@@ -66,10 +13,20 @@ export default function ExploreGroupsPage() {
   const [selectedTag, setSelectedTag] = useState('');
   const [sortBy, setSortBy] = useState('newest');
   const [joinRequests, setJoinRequests] = useState([]);
+  const [tags, setTags] = useState([]);
 
   useEffect(() => {
-    setGroups(mockGroups);
-    setFilteredGroups(mockGroups);
+    const fetchData = async () => {
+      try {
+        const list = await groupService.getPublicGroups();
+        setGroups(list);
+        setFilteredGroups(list);
+      } catch (err) {
+        toast.error('Failed to load groups');
+      }
+    };
+    fetchData();
+    groupService.getTags().then(setTags).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -78,12 +35,14 @@ export default function ExploreGroupsPage() {
     if (searchTerm) {
       filtered = filtered.filter((g) =>
         g.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        g.tags.some((tag) => tag.toLowerCase().includes(searchTerm.toLowerCase()))
+        (g.tags || []).some((tag) =>
+          tag.toLowerCase().includes(searchTerm.toLowerCase())
+        )
       );
     }
 
     if (selectedTag) {
-      filtered = filtered.filter((g) => g.tags.includes(selectedTag));
+      filtered = filtered.filter((g) => (g.tags || []).includes(selectedTag));
     }
 
     if (sortBy === 'newest') {
@@ -145,7 +104,7 @@ export default function ExploreGroupsPage() {
 
         {/* Tag Filters */}
         <div className="flex flex-wrap gap-2 pt-2">
-          {popularTags.map((tag) => (
+          {tags.map((tag) => (
             <button
               key={tag}
               onClick={() => setSelectedTag(tag === selectedTag ? '' : tag)}
@@ -194,7 +153,7 @@ export default function ExploreGroupsPage() {
 
                 {/* Tag list */}
                 <div className="flex flex-wrap gap-2 text-sm">
-                  {group.tags.length > 0 ? group.tags.map((tag) => (
+                  {Array.isArray(group.tags) && group.tags.length > 0 ? group.tags.map((tag) => (
                     <span key={tag} className="bg-gray-100 text-gray-700 px-2 py-0.5 rounded">
                       #{tag}
                     </span>

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -4,10 +4,20 @@ import { API_BASE_URL } from "@/config/config";
 
 const formatGroup = (g) => {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+  const tags = g.tags
+    ? Array.isArray(g.tags)
+      ? g.tags
+      : typeof g.tags === 'string'
+        ? JSON.parse(g.tags)
+        : []
+    : [];
   return {
     ...g,
     cover_image: g.cover_image ? `${base}${g.cover_image}` : g.cover_image,
     membersCount: g.members_count ?? g.membersCount ?? 0,
+    isPublic: g.visibility ? g.visibility === 'public' : g.isPublic ?? true,
+    createdAt: g.created_at ?? g.createdAt,
+    tags,
   };
 };
 


### PR DESCRIPTION
## Summary
- make explore page load groups from backend
- load available tags from backend
- remove placeholder data
- fix runtime error when group has no tags

## Testing
- `npm test` in `frontend` *(fails: jest not found)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686439c389a88328b4d57a0d2f4e43b2