### PR TITLE
Add full group creation fields and public listing

### DIFF
--- a/backend/src/migrations/20250708000000_add_fields_to_groups.js
+++ b/backend/src/migrations/20250708000000_add_fields_to_groups.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.table('groups', function(table) {
+    table.uuid('category_id').references('id').inTable('categories').onDelete('SET NULL');
+    table.integer('max_size');
+    table.string('timezone');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('groups', function(table) {
+    table.dropColumn('category_id');
+    table.dropColumn('max_size');
+    table.dropColumn('timezone');
+  });
+};

--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -134,6 +134,8 @@ export default function GroupForm() {
       if (imageFile) payload.append('cover_image', imageFile);
       if (category) payload.append('category_id', category);
       if (tags.length) payload.append('tags', JSON.stringify(tags));
+      if (maxSize) payload.append('max_size', maxSize);
+      if (timezone) payload.append('timezone', timezone);
 
       const group = await groupService.createGroup(payload);
       toast.success('Group created successfully!');

--- a/frontend/src/components/website/sections/StudyGroups.js
+++ b/frontend/src/components/website/sections/StudyGroups.js
@@ -3,18 +3,34 @@ import { useRouter } from "next/router";
 import { motion } from "framer-motion";
 import { FaFilter, FaPlus } from "react-icons/fa";
 import groupService from "@/services/groupService";
+import useAuthStore from "@/store/auth/authStore";
 
 const StudyGroups = () => {
-  const [tags, setTags] = useState([]);
+  const [groups, setGroups] = useState([]);
   const [search, setSearch] = useState("");
+  const { user, hasHydrated } = useAuthStore();
   const router = useRouter();
 
   useEffect(() => {
-    groupService.getTags().then(setTags).catch(() => {});
-  }, []);
+    const load = async () => {
+      try {
+        const all = await groupService.getPublicGroups();
+        if (hasHydrated && user) {
+          const mine = await groupService.getMyGroups();
+          const myIds = new Set(mine.map((g) => g.id));
+          setGroups(all.filter((g) => !myIds.has(g.id)));
+        } else {
+          setGroups(all);
+        }
+      } catch {}
+    };
+    load();
+  }, [user, hasHydrated]);
 
-  const filtered = tags.filter((t) =>
-    t.name.toLowerCase().includes(search.toLowerCase())
+  const filtered = groups.filter(
+    (g) =>
+      g.name.toLowerCase().includes(search.toLowerCase()) ||
+      (g.tags || []).some((t) => t.toLowerCase().includes(search.toLowerCase()))
   );
 
   return (
@@ -42,20 +58,45 @@ const StudyGroups = () => {
             >
               <FaPlus /> Create Study Group
             </button>
+            <button
+              onClick={() => router.push('/groups/explore')}
+              className="ml-4 text-yellow-400 underline"
+            >
+              View All
+            </button>
           </div>
 
           {filtered.length === 0 ? (
-            <p className="text-gray-400">No matching categories found.</p>
+            <p className="text-gray-400">No groups found.</p>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filtered.map((tag) => (
-                <div
-                  key={tag.id}
-                  className="bg-gray-800 rounded-xl shadow-lg p-4 cursor-pointer hover:bg-yellow-500 transition"
-                  onClick={() => router.push(`/groups/explore?filter=${tag.slug}`)}
-                >
-                  <h3 className="text-xl font-semibold mb-1">{tag.name}</h3>
-                  <p className="text-sm text-yellow-300">{tag.group_count} groups</p>
+              {filtered.map((group) => (
+                <div key={group.id} className="p-4 bg-gray-800 rounded-xl shadow hover:shadow-lg transition space-y-2">
+                  <img
+                    src={group.cover_image || 'https://via.placeholder.com/150'}
+                    alt={group.name}
+                    className="w-full h-32 object-cover rounded-lg"
+                  />
+                  <div className="flex justify-between items-center">
+                    <h3 className="text-lg font-bold">{group.name}</h3>
+                    <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">
+                      {group.isPublic ? 'Public' : 'Private'}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-300 line-clamp-2">{group.description}</p>
+                  <div className="flex flex-wrap gap-2 text-xs">
+                    {(group.tags || []).map((tag) => (
+                      <span key={tag} className="bg-gray-700 text-yellow-300 px-2 py-0.5 rounded">
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
+                  <button
+                    onClick={() => router.push(`/dashboard/instructor/groups/${group.id}`)}
+                    className="text-sm text-yellow-400 underline"
+                  >
+                    View Details
+                  </button>
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/groups/explore.js
+++ b/frontend/src/pages/groups/explore.js
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Search } from 'lucide-react';
+import groupService from '@/services/groupService';
+import useAuthStore from '@/store/auth/authStore';
+
+export default function ExploreGroupsPage() {
+  const [groups, setGroups] = useState([]);
+  const [search, setSearch] = useState('');
+  const { user, hasHydrated } = useAuthStore();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const all = await groupService.getPublicGroups();
+        if (hasHydrated && user) {
+          const mine = await groupService.getMyGroups();
+          const myIds = new Set(mine.map((g) => g.id));
+          setGroups(all.filter((g) => !myIds.has(g.id)));
+        } else {
+          setGroups(all);
+        }
+      } catch {}
+    };
+    load();
+  }, [user, hasHydrated]);
+
+  const filtered = groups.filter(
+    (g) =>
+      g.name.toLowerCase().includes(search.toLowerCase()) ||
+      (g.tags || []).some((t) => t.toLowerCase().includes(search.toLowerCase()))
+  );
+
+  return (
+    <div className="max-w-6xl mx-auto p-4 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Explore Groups</h1>
+        <Link href="/groups/create" className="text-yellow-600 underline">
+          Create Group
+        </Link>
+      </div>
+      <div className="relative max-w-md">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search groups..."
+          className="w-full pl-8 pr-4 py-2 border rounded-lg"
+        />
+        <Search className="absolute left-2 top-2.5 text-gray-400" size={18} />
+      </div>
+      {filtered.length === 0 ? (
+        <p className="text-gray-500">No groups found.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+          {filtered.map((group) => (
+            <div key={group.id} className="p-4 bg-white rounded-xl shadow space-y-2 border">
+              <img
+                src={group.cover_image || 'https://via.placeholder.com/150'}
+                alt={group.name}
+                className="w-full h-32 object-cover rounded"
+              />
+              <div className="flex justify-between items-center">
+                <h2 className="text-lg font-bold">{group.name}</h2>
+                <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">
+                  {group.isPublic ? 'Public' : 'Private'}
+                </span>
+              </div>
+              <p className="text-sm text-gray-600 line-clamp-2">{group.description}</p>
+              <div className="flex flex-wrap gap-2 text-xs">
+                {(group.tags || []).map((tag) => (
+                  <span key={tag} className="bg-gray-100 text-gray-700 px-2 py-0.5 rounded">
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -35,9 +35,10 @@ const groupService = {
   },
 
   getPublicGroups: async (search) => {
-    const { data } = await api.get("/groups", { params: { search } });
+    const { data } = await api.get('/groups', { params: { search } });
     const list = data?.data ?? [];
-    return Array.isArray(list) ? list.map(formatGroup) : list;
+    const groups = Array.isArray(list) ? list.map(formatGroup) : list;
+    return groups.filter((g) => g.isPublic);
   },
 
   getGroupById: async (id) => {


### PR DESCRIPTION
## Summary
- store category, max size, timezone and tags when creating a group
- keep tags synced on update
- expose tags on group queries
- show public groups on the website home and allow exploring them
- filter only public groups on the client
- migration to add new group fields

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_68644a5565248328a7637ef65bd7942c