### PR TITLE
Fix group creation redirect for instructors and students

### DIFF
--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -139,10 +139,11 @@ export default function GroupForm() {
 
       const group = await groupService.createGroup(payload);
       toast.success('Group created successfully!');
+      const role = user?.role?.toLowerCase();
       const path =
-        user?.role === 'instructor'
+        role === 'instructor'
           ? '/dashboard/instructor/groups/my-groups'
-          : user?.role === 'student'
+          : role === 'student'
           ? '/dashboard/student/groups/my-groups'
           : '/dashboard/admin/groups';
       router.push(path);


### PR DESCRIPTION
## Summary
- fix role check when redirecting after group creation so the redirect works for all roles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68644f6802b8832884ec339124c9e382