### PR TITLE
Enable group approval workflow

### DIFF
--- a/backend/src/migrations/20250709000000_add_status_to_groups.js
+++ b/backend/src/migrations/20250709000000_add_status_to_groups.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('groups', function(table) {
+    table.enu('status', ['pending', 'active', 'inactive', 'suspended']).defaultTo('pending').notNullable();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('groups', function(table) {
+    table.dropColumn('status');
+  });
+};

--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -23,6 +23,7 @@ exports.createGroup = catchAsync(async (req, res) => {
     category_id: category_id || null,
     max_size: max_size || null,
     timezone: timezone || null,
+    status: "pending",
   });
   if (req.body.tags) {
     const tags = Array.isArray(req.body.tags) ? req.body.tags : JSON.parse(req.body.tags);
@@ -55,7 +56,8 @@ exports.createGroup = catchAsync(async (req, res) => {
     ),
   ]);
 
-  sendSuccess(res, group, "Group created");
+  const full = await service.getGroupById(group.id);
+  sendSuccess(res, full, "Group created");
 });
 
 exports.listGroups = catchAsync(async (req, res) => {
@@ -70,6 +72,9 @@ exports.getGroup = catchAsync(async (req, res) => {
 
 exports.updateGroup = catchAsync(async (req, res) => {
   const data = { ...req.body };
+  if (data.status && !['active','inactive','suspended','pending'].includes(data.status)) {
+    throw new AppError('Invalid status', 400);
+  }
   if (req.file) data.cover_image = `/uploads/groups/${req.file.filename}`;
   const updated = await service.updateGroup(req.params.id, data);
   if (req.body.tags) {

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -50,18 +50,40 @@ exports.getGroupTags = async (groupIds) => {
 };
 
 exports.listGroups = async (search) => {
-  const groups = await db('groups')
+  const rows = await db('groups as g')
+    .leftJoin('users as u', 'g.creator_id', 'u.id')
+    .leftJoin('categories as c', 'g.category_id', 'c.id')
+    .leftJoin('group_members as gm', 'g.id', 'gm.group_id')
     .modify((qb) => {
-      if (search) qb.whereILike('name', `%${search}%`);
+      if (search) qb.whereILike('g.name', `%${search}%`);
     })
-    .select('*')
-    .orderBy('created_at', 'desc');
-  const tagsMap = await exports.getGroupTags(groups.map((g) => g.id));
-  return groups.map((g) => ({ ...g, tags: tagsMap[g.id] || [] }));
+    .groupBy('g.id', 'u.full_name', 'c.name')
+    .select(
+      'g.*',
+      db.raw("COALESCE(u.full_name, '') as creator_name"),
+      db.raw("COALESCE(c.name, '') as category"),
+      db.raw('COUNT(DISTINCT gm.id) as members_count')
+    )
+    .orderBy('g.created_at', 'desc');
+
+  const tagsMap = await exports.getGroupTags(rows.map((g) => g.id));
+  return rows.map((g) => ({ ...g, tags: tagsMap[g.id] || [] }));
 };
 
 exports.getGroupById = async (id) => {
-  const group = await db('groups').where({ id }).first();
+  const group = await db('groups as g')
+    .leftJoin('users as u', 'g.creator_id', 'u.id')
+    .leftJoin('categories as c', 'g.category_id', 'c.id')
+    .leftJoin('group_members as gm', 'g.id', 'gm.group_id')
+    .where('g.id', id)
+    .groupBy('g.id', 'u.full_name', 'c.name')
+    .select(
+      'g.*',
+      db.raw("COALESCE(u.full_name, '') as creator_name"),
+      db.raw("COALESCE(c.name, '') as category"),
+      db.raw('COUNT(DISTINCT gm.id) as members_count')
+    )
+    .first();
   if (!group) return null;
   const tagsMap = await exports.getGroupTags(id);
   return { ...group, tags: tagsMap[id] || [] };

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -18,8 +18,11 @@ const formatGroup = (g) => {
     isPublic: g.visibility ? g.visibility === 'public' : g.isPublic ?? true,
     createdAt: g.created_at ?? g.createdAt,
     categoryId: g.category_id ?? g.categoryId ?? null,
+    category: g.category ?? g.category_name ?? null,
     maxSize: g.max_size ?? g.maxSize ?? null,
     timezone: g.timezone ?? null,
+    creator: g.creator_name ?? g.creator ?? null,
+    status: g.status ?? 'active',
     tags,
   };
 };


### PR DESCRIPTION
## Summary
- add `status` column migration for groups
- default new groups to `pending` status
- expose creator name, category, members count & status in group services
- validate status updates and return full group in createGroup
- parse extra group fields on frontend

## Testing
- `npm test` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_6864586698f08328af10b8dbe3d4b1d7