### PR TITLE
Filter inactive study groups on website

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -61,7 +61,8 @@ exports.createGroup = catchAsync(async (req, res) => {
 });
 
 exports.listGroups = catchAsync(async (req, res) => {
-  const data = await service.listGroups(req.query.search);
+  const { search, status = 'all' } = req.query;
+  const data = await service.listGroups({ search, status });
   sendSuccess(res, data);
 });
 

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -49,13 +49,14 @@ exports.getGroupTags = async (groupIds) => {
   return map;
 };
 
-exports.listGroups = async (search) => {
+exports.listGroups = async ({ search, status }) => {
   const rows = await db('groups as g')
     .leftJoin('users as u', 'g.creator_id', 'u.id')
     .leftJoin('categories as c', 'g.category_id', 'c.id')
     .leftJoin('group_members as gm', 'g.id', 'gm.group_id')
     .modify((qb) => {
       if (search) qb.whereILike('g.name', `%${search}%`);
+      if (status && status !== 'all') qb.andWhere('g.status', status);
     })
     .groupBy('g.id', 'u.full_name', 'c.name')
     .select(

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -41,10 +41,10 @@ const groupService = {
   },
 
   getPublicGroups: async (search) => {
-    const { data } = await api.get('/groups', { params: { search } });
+    const { data } = await api.get('/groups', { params: { search, status: 'active' } });
     const list = data?.data ?? [];
     const groups = Array.isArray(list) ? list.map(formatGroup) : list;
-    return groups.filter((g) => g.isPublic);
+    return groups.filter((g) => g.isPublic && g.status === 'active');
   },
 
   getAllGroups: async (search) => {


### PR DESCRIPTION
## Summary
- filter out inactive groups in frontend `groupService`
- accept optional `status` query in groups API
- support status filtering in `listGroups` service

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68645e71658883288f949865c0e0d424