### PR TITLE
Add bulk status actions in admin groups

### DIFF
--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -47,8 +47,8 @@ const groupService = {
     return groups.filter((g) => g.isPublic && g.status === 'active');
   },
 
-  getAllGroups: async (search) => {
-    const { data } = await api.get('/groups', { params: { search } });
+  getAllGroups: async (search, status) => {
+    const { data } = await api.get('/groups', { params: { search, status } });
     const list = data?.data ?? [];
     return Array.isArray(list) ? list.map(formatGroup) : list;
   },


### PR DESCRIPTION
## Summary
- allow filtering server-side via new parameters to getAllGroups
- update admin groups page to fetch when filter/search changes
- add bulk status change buttons and sync status updates
- ensure group state updates across filters and actions
- tweak button colors for deactivate action

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686463aec63c8328a97bf7f3c9773a74