### PR TITLE
Fix tag display on group explore pages

### DIFF
--- a/frontend/src/pages/dashboard/instructor/groups/explore.js
+++ b/frontend/src/pages/dashboard/instructor/groups/explore.js
@@ -128,16 +128,18 @@ export default function ExploreGroupsPage() {
         <div className="flex flex-wrap gap-2 pt-2">
           {tags.map((tag) => (
             <button
-              key={tag}
-              onClick={() => setSelectedTag(tag === selectedTag ? '' : tag)}
+              key={tag.id || tag.slug || tag.name}
+              onClick={() =>
+                setSelectedTag(tag.name === selectedTag ? '' : tag.name)
+              }
               className={`px-3 py-1 text-sm rounded-full border ${
-                selectedTag === tag
+                selectedTag === tag.name
                   ? 'bg-yellow-600 text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
               }`}
-              aria-label={`Filter by tag ${tag}`}
+              aria-label={`Filter by tag ${tag.name}`}
             >
-              #{tag}
+              #{tag.name}
             </button>
           ))}
         </div>

--- a/frontend/src/pages/dashboard/student/groups/explore.js
+++ b/frontend/src/pages/dashboard/student/groups/explore.js
@@ -106,16 +106,18 @@ export default function ExploreGroupsPage() {
         <div className="flex flex-wrap gap-2 pt-2">
           {tags.map((tag) => (
             <button
-              key={tag}
-              onClick={() => setSelectedTag(tag === selectedTag ? '' : tag)}
+              key={tag.id || tag.slug || tag.name}
+              onClick={() =>
+                setSelectedTag(tag.name === selectedTag ? '' : tag.name)
+              }
               className={`px-3 py-1 text-sm rounded-full border ${
-                selectedTag === tag
+                selectedTag === tag.name
                   ? 'bg-yellow-600 text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
               }`}
-              aria-label={`Filter by tag ${tag}`}
+              aria-label={`Filter by tag ${tag.name}`}
             >
-              #{tag}
+              #{tag.name}
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- update instructor/student group explore pages to render tag objects properly

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_686475e0eba08328a65138c405e0cc02