### PR TITLE
Fix view details routing based on user role

### DIFF
--- a/frontend/src/components/website/sections/StudyGroups.js
+++ b/frontend/src/components/website/sections/StudyGroups.js
@@ -92,7 +92,17 @@ const StudyGroups = () => {
                     ))}
                   </div>
                   <button
-                    onClick={() => router.push(`/dashboard/instructor/groups/${group.id}`)}
+                    onClick={() => {
+                      const role = user?.role?.toLowerCase();
+                      if (!role) {
+                        alert("You must register to continue.");
+                        return;
+                      }
+                      const target = ["admin", "superadmin"].includes(role)
+                        ? "admin"
+                        : role;
+                      router.push(`/dashboard/${target}/groups/${group.id}`);
+                    }}
                     className="text-sm text-yellow-400 underline"
                   >
                     View Details


### PR DESCRIPTION
## Summary
- route Study Groups view details to the correct dashboard for the logged in role

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864d847f49c8328a86a870d1d614699