### PR TITLE
Fix group details display

### DIFF
--- a/frontend/src/pages/dashboard/instructor/groups/[id].js
+++ b/frontend/src/pages/dashboard/instructor/groups/[id].js
@@ -110,8 +110,8 @@ export default function GroupDetailsPage() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold">{group.name}</h1>
-            {group.creator_id && (
-              <p className="text-sm text-gray-500">👑 Creator ID: {group.creator_id}</p>
+            {(group.creator || group.creator_id) && (
+              <p className="text-sm text-gray-500">👑 Creator: {group.creator || group.creator_id}</p>
             )}
           </div>
           <span className="text-sm text-gray-500">
@@ -224,7 +224,7 @@ export default function GroupDetailsPage() {
 
         {activeTab === 'members' && joinStatus === 'joined' && (
           <div className="space-y-4">
-            <GroupMembersList groupId={group.id} />
+            <GroupMembersList groupId={group.id} currentUserId={user?.id} />
           </div>
         )}
 

--- a/frontend/src/pages/dashboard/student/groups/[id].js
+++ b/frontend/src/pages/dashboard/student/groups/[id].js
@@ -101,8 +101,8 @@ export default function GroupDetailsPage() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold">{group.name}</h1>
-            {group.creator_id && (
-              <p className="text-sm text-gray-500">👑 Creator ID: {group.creator_id}</p>
+            {(group.creator || group.creator_id) && (
+              <p className="text-sm text-gray-500">👑 Creator: {group.creator || group.creator_id}</p>
             )}
           </div>
           <span className="text-sm text-gray-500">


### PR DESCRIPTION
## Summary
- show group creator name in instructor and student group pages
- pass `currentUserId` to group member list so management buttons work

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6864ecacf97c83288dcefe6ccf3d7891