### PR TITLE
Fix redirect when leaving group page

### DIFF
--- a/frontend/src/pages/dashboard/instructor/groups/[id].js
+++ b/frontend/src/pages/dashboard/instructor/groups/[id].js
@@ -26,6 +26,10 @@ export default function GroupDetailsPage() {
   const [pendingCount, setPendingCount] = useState(0);
 
   useEffect(() => {
+    // Avoid running when navigating away from this page. When the route
+    // changes, Next.js reuses the component briefly with the new query
+    // params, which previously caused a redirect to the group explore page.
+    if (router.pathname !== '/dashboard/instructor/groups/[id]') return;
     if (!router.isReady || !groupId || !hasHydrated) return;
 
     const load = async () => {


### PR DESCRIPTION
## Summary
- prevent redirect when clicking the group creator's profile
- ran frontend and backend tests

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6864f8a341c483289b7c7487d4f96d68