### PR TITLE
Add public student profile page

### DIFF
--- a/backend/src/modules/students/student.controller.js
+++ b/backend/src/modules/students/student.controller.js
@@ -1,0 +1,20 @@
+const service = require("./student.service");
+const { sendSuccess } = require("../../utils/response");
+
+exports.list = async (_req, res) => {
+  const data = await service.getPublicStudents();
+  sendSuccess(res, data, "Students fetched");
+};
+
+exports.getById = async (req, res) => {
+  const { id } = req.params;
+  if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
+    return res.status(400).json({ message: "Invalid student id" });
+  }
+
+  const student = await service.getPublicStudent(id);
+  if (!student) {
+    return res.status(404).json({ message: "Student not found" });
+  }
+  sendSuccess(res, student);
+};

--- a/backend/src/modules/students/student.routes.js
+++ b/backend/src/modules/students/student.routes.js
@@ -1,0 +1,7 @@
+const router = require("express").Router();
+const controller = require("./student.controller");
+
+router.get("/", controller.list);
+router.get("/:id", controller.getById);
+
+module.exports = router;

--- a/backend/src/modules/students/student.service.js
+++ b/backend/src/modules/students/student.service.js
@@ -1,0 +1,37 @@
+const db = require("../../config/database");
+
+exports.getPublicStudents = async () => {
+  return db("users")
+    .join("student_profiles", "users.id", "student_profiles.user_id")
+    .whereRaw("LOWER(users.role) = ?", ["student"])
+    .andWhere({ "users.status": "active" })
+    .select(
+      "users.id",
+      "users.full_name",
+      "users.avatar_url",
+      "users.is_online",
+      "student_profiles.education_level",
+      "student_profiles.topics",
+      "student_profiles.learning_goals"
+    )
+    .orderBy("users.created_at", "desc");
+};
+
+exports.getPublicStudent = async (id) => {
+  return db("users")
+    .join("student_profiles", "users.id", "student_profiles.user_id")
+    .where({ "users.id": id })
+    .andWhereRaw("LOWER(users.role) = ?", ["student"])
+    .first(
+      "users.id",
+      "users.full_name",
+      "users.avatar_url",
+      "users.is_online",
+      "users.email",
+      "users.phone",
+      "users.created_at",
+      "student_profiles.education_level",
+      "student_profiles.topics",
+      "student_profiles.learning_goals"
+    );
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -70,6 +70,7 @@ const paymentConfigRoutes = require("./modules/paymentConfig/paymentConfig.route
 const payoutRoutes = require("./modules/payouts/payouts.routes");
 const adsRoutes = require("./modules/ads/ads.routes");
 const publicInstructorRoutes = require("./modules/instructors/instructor.routes");
+const publicStudentRoutes = require("./modules/students/student.routes");
 const cartRoutes = require("./modules/cart/cart.routes");
 const notificationRoutes = require("./modules/notifications/notifications.routes");
 const messageRoutes = require("./modules/messages/messages.routes");
@@ -170,6 +171,7 @@ app.use("/api/groups", groupRoutes); // 📚 Study groups
 app.use("/api/offers", offersRoutes); // 📚 Learning marketplace offers
 app.use("/api/offers/:offerId/responses", offerResponseRoutes); // 💬 Offer negotiations
 app.use("/api/instructors", publicInstructorRoutes); // 📚 Public instructor listing
+app.use("/api/students", publicStudentRoutes); // 🎓 Public student listing
 app.use("/api/cart", cartRoutes); // 🛒 Shopping cart
 app.use("/api/notifications", notificationRoutes); // 🔔 User notifications
 app.use("/api/messages", messageRoutes); // 💬 User messages

--- a/frontend/src/pages/students/[id].js
+++ b/frontend/src/pages/students/[id].js
@@ -1,21 +1,146 @@
-import { useRouter } from 'next/router';
-import Navbar from '@/components/website/sections/Navbar';
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import useAuthStore from "@/store/auth/authStore";
+import StudentLayout from "@/components/layouts/StudentLayout";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import { FaComments } from "react-icons/fa";
+import { IoMdTime } from "react-icons/io";
+import { fetchPublicStudentById } from "@/services/public/studentService";
 
 export default function PublicStudentProfile() {
   const router = useRouter();
   const { id } = router.query;
+  const [student, setStudent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const { user } = useAuthStore();
+
+  const API_BASE_URL =
+    process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      try {
+        setLoading(true);
+        const data = await fetchPublicStudentById(id);
+        const formatted = {
+          ...data,
+          avatar_url: data?.avatar_url
+            ? `${API_BASE_URL}${data.avatar_url}`
+            : "/images/profile/user.png",
+        };
+        setStudent(formatted);
+      } catch (err) {
+        console.error("Failed to load student", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  if (loading) return (
+    <div className="flex justify-center items-center h-64">
+      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-yellow-500"></div>
+    </div>
+  );
+
+  if (!student) return (
+    <div className="text-center py-10">
+      <h2 className="text-xl font-semibold text-gray-700">Student not found</h2>
+      <p className="text-gray-500 mt-2">The requested student profile does not exist</p>
+    </div>
+  );
+
+  const joinDate = student.created_at
+    ? new Date(student.created_at).toLocaleDateString()
+    : null;
+
+  const role = user?.role?.toLowerCase();
+  let Layout = StudentLayout;
+  if (role === "instructor") {
+    Layout = InstructorLayout;
+  } else if (role === "admin" || role === "superadmin") {
+    Layout = AdminLayout;
+  }
 
   return (
-    <div>
-      <Navbar />
-      <main className="max-w-4xl mx-auto p-6">
-        <h1 className="text-2xl font-bold mb-4">Student Profile</h1>
-        {id ? (
-          <p className="text-gray-700">Profile for student ID: {id}</p>
-        ) : (
-          <p className="text-gray-500">Loading...</p>
-        )}
-      </main>
-    </div>
+    <Layout>
+      <section className="py-8 px-4 sm:px-6 max-w-4xl mx-auto">
+        <div className="bg-white rounded-xl shadow-lg overflow-hidden">
+          <div className="bg-gradient-to-r from-yellow-400 to-yellow-500 h-32 relative">
+            <div className="absolute -bottom-16 left-1/2 transform -translate-x-1/2">
+              <img
+                src={student.avatar_url}
+                className="w-32 h-32 rounded-full border-4 border-white shadow-lg"
+                alt={student.full_name}
+              />
+            </div>
+          </div>
+          <div className="pt-20 pb-6 px-6">
+            <div className="text-center mb-6">
+              <h1 className="text-2xl font-bold text-gray-800">{student.full_name}</h1>
+              {joinDate && (
+                <div className="flex items-center justify-center mt-2 text-gray-600">
+                  <IoMdTime className="mr-2 text-yellow-500" />
+                  <span>Joined {joinDate}</span>
+                </div>
+              )}
+            </div>
+            <div className="border-t border-gray-200 my-4"></div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+              {student.email && (
+                <div className="bg-gray-50 p-3 rounded-lg">
+                  <h3 className="text-sm font-medium text-gray-500 mb-1">Email</h3>
+                  <p className="text-gray-800">{student.email}</p>
+                </div>
+              )}
+              {student.phone && (
+                <div className="bg-gray-50 p-3 rounded-lg">
+                  <h3 className="text-sm font-medium text-gray-500 mb-1">Phone</h3>
+                  <p className="text-gray-800">{student.phone}</p>
+                </div>
+              )}
+              {student.education_level && (
+                <div className="bg-gray-50 p-3 rounded-lg">
+                  <h3 className="text-sm font-medium text-gray-500 mb-1">Education Level</h3>
+                  <p className="text-gray-800">{student.education_level}</p>
+                </div>
+              )}
+            </div>
+            {Array.isArray(student.topics) && student.topics.length > 0 && (
+              <div className="mb-6">
+                <h2 className="text-xl font-semibold text-gray-800 mb-3">Topics of Interest</h2>
+                <div className="flex flex-wrap gap-2">
+                  {student.topics.map((topic, idx) => (
+                    <span
+                      key={idx}
+                      className="inline-block bg-yellow-100 text-yellow-800 text-sm font-semibold px-3 py-1 rounded-full"
+                    >
+                      {topic}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {student.learning_goals && (
+              <div className="mb-6">
+                <h2 className="text-xl font-semibold text-gray-800 mb-3">Learning Goals</h2>
+                <p className="text-gray-600 whitespace-pre-line">{student.learning_goals}</p>
+              </div>
+            )}
+            <div className="flex justify-center mt-8">
+              <button
+                onClick={() => router.push(`/messages?userId=${student.id}`)}
+                className="flex items-center justify-center gap-2 bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-lg font-medium transition-all shadow-md hover:shadow-lg"
+              >
+                <FaComments /> Chat Now
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
   );
 }

--- a/frontend/src/services/public/studentService.js
+++ b/frontend/src/services/public/studentService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchPublicStudents = async () => {
+  const { data } = await api.get("/students");
+  return data?.data ?? [];
+};
+
+export const fetchPublicStudentById = async (id) => {
+  const { data } = await api.get(`/students/${id}`);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- support fetching public student info via new API endpoints
- show student profile page in the same style as instructor profile

## Testing
- `npm test` in frontend *(fails: jest not found)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fa66891083289d69786a4d996673