### PR TITLE
Fix group creator links

### DIFF
--- a/frontend/src/pages/dashboard/instructor/groups/[id].js
+++ b/frontend/src/pages/dashboard/instructor/groups/[id].js
@@ -118,17 +118,22 @@ export default function GroupDetailsPage() {
 
               <p className="text-sm text-gray-500">
                 👑 Creator:{' '}
-                <Link
-                  href={
-                    group.creatorRole?.toLowerCase() === 'student'
+                {(() => {
+                  const role = group.creatorRole?.toLowerCase();
+                  const href =
+                    role === 'instructor'
+                      ? `/instructors/${group.creator_id}`
+                      : role === 'student'
                       ? `/students/${group.creator_id}`
-                      : `/instructors/${group.creator_id}`
-                  }
-
-                  className="text-blue-600 hover:underline"
-                >
-                  {group.creator || group.creator_id}
-                </Link>
+                      : null;
+                  return href ? (
+                    <Link href={href} className="text-blue-600 hover:underline">
+                      {group.creator || group.creator_id}
+                    </Link>
+                  ) : (
+                    <span>{group.creator || group.creator_id}</span>
+                  );
+                })()}
               </p>
 
             )}

--- a/frontend/src/pages/dashboard/student/groups/[id].js
+++ b/frontend/src/pages/dashboard/student/groups/[id].js
@@ -105,17 +105,22 @@ export default function GroupDetailsPage() {
 
               <p className="text-sm text-gray-500">
                 👑 Creator:{' '}
-                <Link
-                  href={
-                    group.creatorRole?.toLowerCase() === 'student'
+                {(() => {
+                  const role = group.creatorRole?.toLowerCase();
+                  const href =
+                    role === 'instructor'
+                      ? `/instructors/${group.creator_id}`
+                      : role === 'student'
                       ? `/students/${group.creator_id}`
-                      : `/instructors/${group.creator_id}`
-                  }
-
-                  className="text-blue-600 hover:underline"
-                >
-                  {group.creator || group.creator_id}
-                </Link>
+                      : null;
+                  return href ? (
+                    <Link href={href} className="text-blue-600 hover:underline">
+                      {group.creator || group.creator_id}
+                    </Link>
+                  ) : (
+                    <span>{group.creator || group.creator_id}</span>
+                  );
+                })()}
               </p>
 
             )}


### PR DESCRIPTION
## Summary
- handle unknown creator role when linking from group detail pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686502ac6dcc8328a72781d0fc7c4d04