### PR TITLE
Improve group chat UI and real-time updates

### DIFF
--- a/frontend/src/components/chat/ChatGroupHeader.js
+++ b/frontend/src/components/chat/ChatGroupHeader.js
@@ -1,8 +1,9 @@
-export default function ChatGroupHeader({ groupId }) {
-    return (
-      <div className="pb-2 border-b mb-2">
-        <h2 className="text-lg font-bold">Group Chat: {groupId}</h2>
-      </div>
-    );
-  }
+export default function ChatGroupHeader({ groupName, groupId }) {
+  const title = groupName || groupId;
+  return (
+    <div className="pb-2 border-b mb-2">
+      <h2 className="text-lg font-bold">Group Chat: {title}</h2>
+    </div>
+  );
+}
   

--- a/frontend/src/components/chat/GroupChat.js
+++ b/frontend/src/components/chat/GroupChat.js
@@ -6,14 +6,29 @@ import ChatGroupHeader from './ChatGroupHeader';
 import groupService from '@/services/groupService';
 
 
-export default function GroupChat({ groupId }) {
+export default function GroupChat({ groupId, groupName }) {
   const [messages, setMessages] = useState([]);
   const [typing, setTyping] = useState(false);
   const [replyTo, setReplyTo] = useState(null);
 
   useEffect(() => {
     if (!groupId) return;
-    groupService.getGroupMessages(groupId).then(setMessages).catch(() => {});
+    let isMounted = true;
+
+    const fetchMessages = async () => {
+      try {
+        const msgs = await groupService.getGroupMessages(groupId);
+        if (isMounted) setMessages(msgs);
+      } catch (_) {}
+    };
+
+    fetchMessages();
+    const interval = setInterval(fetchMessages, 5000);
+
+    return () => {
+      isMounted = false;
+      clearInterval(interval);
+    };
   }, [groupId]);
 
   const sendMessage = async (newMessage) => {
@@ -59,7 +74,7 @@ export default function GroupChat({ groupId }) {
 
   return (
     <div className="space-y-4">
-      <ChatGroupHeader groupId={groupId} />
+      <ChatGroupHeader groupId={groupId} groupName={groupName} />
 
       <div className="h-64 overflow-y-auto bg-gray-100 dark:bg-gray-800 border rounded p-3">
         <MessageList

--- a/frontend/src/components/chat/MessageItem.js
+++ b/frontend/src/components/chat/MessageItem.js
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import ChatImage from "../shared/ChatImage";
 import formatRelativeTime from "@/utils/relativeTime";
 import { API_BASE_URL } from "@/config/config";
+import useAuthStore from "@/store/auth/authStore";
 import {
   FaPlay,
   FaCheckDouble,
@@ -11,7 +12,8 @@ import {
 } from "react-icons/fa";
 
 const MessageItem = ({ message, onReply, onDelete, onPin }) => {
-  const isSender = message.sender === "You";
+  const currentUserId = useAuthStore((state) => state.user?.id);
+  const isSender = message.senderId === currentUserId || message.sender === "You";
 
   const getMediaUrl = (url) => {
     if (!url) return null;
@@ -101,9 +103,7 @@ const MessageItem = ({ message, onReply, onDelete, onPin }) => {
         {/* ⏰ Timestamp + Seen */}
         <div className="flex items-center justify-end mt-1 text-xs text-gray-300 gap-1">
           <span>{formatRelativeTime(message.timestamp)}</span>
-          {isSender && message.status === "seen" && (
-            <FaCheckDouble className="text-blue-300" title="Seen" />
-          )}
+          {isSender && <FaCheckDouble className="text-blue-300" title="Sent" />}
         </div>
       </div>
     </motion.div>

--- a/frontend/src/pages/dashboard/instructor/groups/[id].js
+++ b/frontend/src/pages/dashboard/instructor/groups/[id].js
@@ -212,7 +212,7 @@ export default function GroupDetailsPage() {
 
         {activeTab === 'chat' && joinStatus === 'joined' && (
           <>
-            <GroupChat groupId={group.id} />
+            <GroupChat groupId={group.id} groupName={group.name} />
               <div className="mt-6">
                 <h2 className="text-sm font-medium mb-1">
                   👥 Members ({members.length})

--- a/frontend/src/pages/dashboard/student/groups/[id].js
+++ b/frontend/src/pages/dashboard/student/groups/[id].js
@@ -214,7 +214,7 @@ export default function GroupDetailsPage() {
 
         {activeTab === 'chat' && joinStatus === 'joined' && (
           <>
-            <GroupChat groupId={group.id} />
+            <GroupChat groupId={group.id} groupName={group.name} />
             <div className="mt-6">
               <h2 className="text-sm font-medium mb-1">
                 👥 Members ({members.length})


### PR DESCRIPTION
## Summary
- show group name in chat header instead of ID
- poll for new group messages every 5 seconds
- align group messages by sender with avatar and check mark
- pass group name into group chat component

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6865297a709483289359cf269f7d331b