### PR TITLE
Enable group message deletion and sender labels

### DIFF
--- a/backend/src/modules/groups/groupMessages.controller.js
+++ b/backend/src/modules/groups/groupMessages.controller.js
@@ -36,3 +36,10 @@ exports.sendMessage = catchAsync(async (req, res) => {
   const full = await msgService.getMessageById(created.id);
   sendSuccess(res, full, "Message sent");
 });
+
+exports.deleteMessage = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  const deleted = await msgService.deleteMessage(req.user.id, id);
+  if (!deleted) throw new AppError("Message not found", 404);
+  sendSuccess(res, deleted, "Message deleted");
+});

--- a/backend/src/modules/groups/groupMessages.service.js
+++ b/backend/src/modules/groups/groupMessages.service.js
@@ -28,3 +28,11 @@ exports.listMessages = (groupId) => {
     .where("m.group_id", groupId)
     .orderBy("m.sent_at", "asc");
 };
+
+exports.deleteMessage = async (userId, id) => {
+  const [row] = await db("group_messages")
+    .where({ id, sender_id: userId })
+    .del()
+    .returning("*");
+  return row;
+};

--- a/backend/src/modules/groups/groups.routes.js
+++ b/backend/src/modules/groups/groups.routes.js
@@ -16,6 +16,7 @@ router.get("/:id/permissions", verifyToken, ctrl.getGroupPermissions);
 router.put("/:id/permissions", verifyToken, ctrl.updateGroupPermissions);
 router.get("/:id/messages", verifyToken, msgCtrl.getMessages);
 router.post("/:id/messages", verifyToken, msgUpload, msgCtrl.sendMessage);
+router.delete("/messages/:id", verifyToken, msgCtrl.deleteMessage);
 
 router.post("/", verifyToken, upload, ctrl.createGroup);
 router.get("/", ctrl.listGroups);

--- a/frontend/src/components/chat/GroupChat.js
+++ b/frontend/src/components/chat/GroupChat.js
@@ -4,6 +4,7 @@ import MessageList from './MessageList';
 import TypingIndicator from './TypingIndicator';
 import ChatGroupHeader from './ChatGroupHeader';
 import groupService from '@/services/groupService';
+import toast from 'react-hot-toast';
 
 
 export default function GroupChat({ groupId, groupName }) {
@@ -58,8 +59,14 @@ export default function GroupChat({ groupId, groupName }) {
     } catch (_) {}
   };
 
-  const handleDelete = (id) => {
-    setMessages((prev) => prev.filter((msg) => msg.id !== id));
+  const handleDelete = async (id) => {
+    try {
+      await groupService.deleteGroupMessage(id);
+      setMessages((prev) => prev.filter((msg) => msg.id !== id));
+      toast.success('Message deleted');
+    } catch (_) {
+      toast.error('Failed to delete message');
+    }
   };
 
   const handlePin = (id) => {

--- a/frontend/src/components/chat/MessageItem.js
+++ b/frontend/src/components/chat/MessageItem.js
@@ -28,7 +28,7 @@ const MessageItem = ({ message, onReply, onDelete, onPin }) => {
 
   return (
     <motion.div
-      className={`flex items-start gap-3 my-2 ${isSender ? "justify-end" : "justify-start"}`}
+      className={`flex items-start gap-3 my-2 ${isSender ? "flex-row-reverse justify-start" : "justify-start"}`}
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
@@ -45,9 +45,13 @@ const MessageItem = ({ message, onReply, onDelete, onPin }) => {
       {/* Message Bubble */}
       <div
         className={`relative group p-3 rounded-lg max-w-xs shadow-md ${
-          isSender ? "bg-yellow-500 text-gray-900 ml-auto" : "bg-gray-700 text-white"
+          isSender ? "bg-yellow-500 text-gray-900" : "bg-gray-700 text-white"
         }`}
       >
+        {/* Sender Name */}
+        <div className="text-xs font-semibold mb-1">
+          {isSender ? 'You' : message.sender}
+        </div>
         {/* 📌 Reply Preview */}
         {message.replyTo && (
           <div className="text-sm italic text-yellow-300 mb-2 border-l-4 border-yellow-400 pl-2">

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -131,6 +131,11 @@ const groupService = {
     return data?.data;
   },
 
+  deleteGroupMessage: async (messageId) => {
+    const { data } = await api.delete(`/groups/messages/${messageId}`);
+    return data?.data ?? data;
+  },
+
   deleteGroup: async (id) => {
     await api.delete(`/groups/${id}`);
     return true;


### PR DESCRIPTION
## Summary
- add endpoint for deleting group messages in backend
- expose deleteGroupMessage in the frontend service
- show sender name on each message bubble
- allow deleting group messages with backend call
- fix avatar alignment for sent messages so it appears on the right

## Testing
- `npm --prefix backend test` *(fails: jest not found)*
- `npm --prefix frontend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652b094e1c832894609d67581507ed