### PR TITLE
Restrict member actions to moderators

### DIFF
--- a/frontend/src/components/groups/GroupMembersList.js
+++ b/frontend/src/components/groups/GroupMembersList.js
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import groupService from '@/services/groupService';
 import { FaUserSlash, FaVolumeMute, FaUserShield } from 'react-icons/fa';
 
-export default function GroupMembersList({ groupId, currentUserId }) {
+export default function GroupMembersList({
+  groupId,
+  currentUserId,
+  currentUserRole,
+}) {
   const [members, setMembers] = useState([]);
 
   useEffect(() => {
@@ -52,13 +56,14 @@ export default function GroupMembersList({ groupId, currentUserId }) {
                 <span className="text-xs ml-2 text-gray-500">({member.role})</span>
                 {member.muted && <span className="ml-1 text-red-400">[Muted]</span>}
               </div>
-              {member.id !== currentUserId && (
-                <div className="flex gap-2">
-                  <button
-                    title="Kick"
-                    onClick={() => handleAction(member.id, 'kick')}
-                    className="text-red-500 hover:text-red-600"
-                  >
+              {member.id !== currentUserId &&
+                ['admin', 'moderator'].includes(currentUserRole) && (
+                  <div className="flex gap-2">
+                    <button
+                      title="Kick"
+                      onClick={() => handleAction(member.id, 'kick')}
+                      className="text-red-500 hover:text-red-600"
+                    >
                     <FaUserSlash />
                   </button>
                   <button
@@ -75,10 +80,10 @@ export default function GroupMembersList({ groupId, currentUserId }) {
                   >
                     <FaUserShield />
                   </button>
-                </div>
-              )}
-            </li>
-          ))}
+                  </div>
+                )}
+              </li>
+            ))}
       </ul>
     </div>
   );

--- a/frontend/src/pages/dashboard/instructor/groups/[id].js
+++ b/frontend/src/pages/dashboard/instructor/groups/[id].js
@@ -18,6 +18,7 @@ export default function GroupDetailsPage() {
   const [loading, setLoading] = useState(true);
   const [joinStatus, setJoinStatus] = useState('none');
   const [isAdmin, setIsAdmin] = useState(false);
+  const [currentUserRole, setCurrentUserRole] = useState(null);
   const [activeTab, setActiveTab] = useState('overview');
 
   const { user, hasHydrated } = useAuthStore();
@@ -45,20 +46,24 @@ export default function GroupDetailsPage() {
         const mem = await groupService.getGroupMembers(groupId);
         setMembers(mem);
 
+        let role = null;
         if (user) {
           if (String(user.id) === String(data.creator_id)) {
             setIsAdmin(true);
             setJoinStatus('joined');
+            role = 'admin';
           } else {
             const member = mem.find((m) => String(m.id) === String(user.id));
             if (member) {
               setJoinStatus('joined');
+              role = member.role;
               if (member.role === 'admin') setIsAdmin(true);
             } else {
               setJoinStatus('none');
             }
           }
         }
+        setCurrentUserRole(role);
       } catch (err) {
         toast.error('Failed to load group.');
         router.push('/dashboard/instructor/groups/explore');
@@ -235,7 +240,11 @@ export default function GroupDetailsPage() {
 
         {activeTab === 'members' && joinStatus === 'joined' && (
           <div className="space-y-4">
-            <GroupMembersList groupId={group.id} currentUserId={user?.id} />
+            <GroupMembersList
+              groupId={group.id}
+              currentUserId={user?.id}
+              currentUserRole={currentUserRole}
+            />
           </div>
         )}
 

--- a/frontend/src/pages/dashboard/student/groups/[id].js
+++ b/frontend/src/pages/dashboard/student/groups/[id].js
@@ -19,6 +19,7 @@ export default function GroupDetailsPage() {
   const [loading, setLoading] = useState(true);
   const [joinStatus, setJoinStatus] = useState('none');
   const [isAdmin, setIsAdmin] = useState(false);
+  const [currentUserRole, setCurrentUserRole] = useState(null);
   const [activeTab, setActiveTab] = useState('overview');
   const [members, setMembers] = useState([]);
   const [pendingCount, setPendingCount] = useState(0);
@@ -45,20 +46,24 @@ export default function GroupDetailsPage() {
         const mem = await groupService.getGroupMembers(groupId);
         setMembers(mem);
 
+        let role = null;
         if (user) {
           if (String(user.id) === String(data.creator_id)) {
             setIsAdmin(true);
             setJoinStatus('joined');
+            role = 'admin';
           } else {
             const member = mem.find((m) => String(m.id) === String(user.id));
             if (member) {
               setJoinStatus('joined');
+              role = member.role;
               if (member.role === 'admin') setIsAdmin(true);
             } else {
               setJoinStatus('none');
             }
           }
         }
+        setCurrentUserRole(role);
       } catch (err) {
         toast.error('Failed to load group.');
         router.push('/dashboard/student/groups/explore');
@@ -237,7 +242,11 @@ export default function GroupDetailsPage() {
 
         {activeTab === 'members' && joinStatus === 'joined' && (
           <div className="space-y-4">
-            <GroupMembersList groupId={group.id} currentUserId={user?.id} />
+            <GroupMembersList
+              groupId={group.id}
+              currentUserId={user?.id}
+              currentUserRole={currentUserRole}
+            />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- restrict kick/mute/promote actions in group member lists to admins or moderators
- pass current user role to group member list for student and instructor dashboards

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686534a8533883289e7fe63fa11d8505