### PR TITLE
Fix StudyGroups listing

### DIFF
--- a/frontend/src/components/website/sections/StudyGroups.js
+++ b/frontend/src/components/website/sections/StudyGroups.js
@@ -8,24 +8,18 @@ import useAuthStore from "@/store/auth/authStore";
 const StudyGroups = () => {
   const [groups, setGroups] = useState([]);
   const [search, setSearch] = useState("");
-  const { user, hasHydrated } = useAuthStore();
+  const { user } = useAuthStore();
   const router = useRouter();
 
   useEffect(() => {
     const load = async () => {
       try {
         const all = await groupService.getPublicGroups();
-        if (hasHydrated && user) {
-          const mine = await groupService.getMyGroups();
-          const myIds = new Set(mine.map((g) => g.id));
-          setGroups(all.filter((g) => !myIds.has(g.id)));
-        } else {
-          setGroups(all);
-        }
+        setGroups(all);
       } catch {}
     };
     load();
-  }, [user, hasHydrated]);
+  }, []);
 
   const filtered = groups.filter(
     (g) =>
@@ -174,14 +168,10 @@ const StudyGroups = () => {
 
                   <button
                     onClick={() => {
-                      if (!user) {
-                        alert("Please sign in to view group details");
-                        return;
-                      }
-                      const role = user?.role?.toLowerCase();
+                      const role = user?.role?.toLowerCase() || "student";
                       const target = ["admin", "superadmin"].includes(role)
                         ? "admin"
-                        : role || "guest";
+                        : role;
                       router.push(`/dashboard/${target}/groups/${group.id}`);
                     }}
                     className="w-full py-2.5 text-center bg-gray-700 hover:bg-gray-600 text-amber-400 rounded-lg font-medium transition-colors"

--- a/frontend/src/pages/groups/explore.js
+++ b/frontend/src/pages/groups/explore.js
@@ -7,23 +7,17 @@ import useAuthStore from '@/store/auth/authStore';
 export default function ExploreGroupsPage() {
   const [groups, setGroups] = useState([]);
   const [search, setSearch] = useState('');
-  const { user, hasHydrated } = useAuthStore();
+  const { user } = useAuthStore();
 
   useEffect(() => {
     const load = async () => {
       try {
         const all = await groupService.getPublicGroups();
-        if (hasHydrated && user) {
-          const mine = await groupService.getMyGroups();
-          const myIds = new Set(mine.map((g) => g.id));
-          setGroups(all.filter((g) => !myIds.has(g.id)));
-        } else {
-          setGroups(all);
-        }
+        setGroups(all);
       } catch {}
     };
     load();
-  }, [user, hasHydrated]);
+  }, []);
 
   const filtered = groups.filter(
     (g) =>
@@ -53,29 +47,37 @@ export default function ExploreGroupsPage() {
         <p className="text-gray-500">No groups found.</p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-          {filtered.map((group) => (
-            <div key={group.id} className="p-4 bg-white rounded-xl shadow space-y-2 border">
-              <img
-                src={group.cover_image || 'https://via.placeholder.com/150'}
-                alt={group.name}
-                className="w-full h-32 object-cover rounded"
-              />
-              <div className="flex justify-between items-center">
-                <h2 className="text-lg font-bold">{group.name}</h2>
-                <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">
-                  {group.isPublic ? 'Public' : 'Private'}
-                </span>
-              </div>
-              <p className="text-sm text-gray-600 line-clamp-2">{group.description}</p>
-              <div className="flex flex-wrap gap-2 text-xs">
-                {(group.tags || []).map((tag) => (
-                  <span key={tag} className="bg-gray-100 text-gray-700 px-2 py-0.5 rounded">
-                    #{tag}
+          {filtered.map((group) => {
+            const role = user?.role?.toLowerCase() || 'student';
+            const target = ['admin', 'superadmin'].includes(role) ? 'admin' : role;
+            return (
+              <Link
+                key={group.id}
+                href={`/dashboard/${target}/groups/${group.id}`}
+                className="p-4 bg-white rounded-xl shadow space-y-2 border hover:shadow-md block"
+              >
+                <img
+                  src={group.cover_image || 'https://via.placeholder.com/150'}
+                  alt={group.name}
+                  className="w-full h-32 object-cover rounded"
+                />
+                <div className="flex justify-between items-center">
+                  <h2 className="text-lg font-bold">{group.name}</h2>
+                  <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">
+                    {group.isPublic ? 'Public' : 'Private'}
                   </span>
-                ))}
-              </div>
-            </div>
-          ))}
+                </div>
+                <p className="text-sm text-gray-600 line-clamp-2">{group.description}</p>
+                <div className="flex flex-wrap gap-2 text-xs">
+                  {(group.tags || []).map((tag) => (
+                    <span key={tag} className="bg-gray-100 text-gray-700 px-2 py-0.5 rounded">
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- display all study groups on the website
- enable linking to group details from main site and explore page

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `backend` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686572c566a88328b1f2394bf74f80dc