### PR TITLE
Add dashboard link to group invite notifications

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -54,43 +54,42 @@ exports.createGroup = catchAsync(async (req, res) => {
       : JSON.parse(invite_methods)
     : [];
 
-  const groupLink = `${process.env.FRONTEND_URL}/groups/${group.id}`;
-
   if (visibility === 'private' && inviteUserIds.length) {
 
     const inviteMsg = `${req.user.full_name} invited you to join the group "${name}".`;
-    const inviteLinkMsg = `${inviteMsg} ${groupLink}`;
 
     for (const uid of inviteUserIds) {
       const contact = await userModel.findContactInfo(uid);
       if (!contact) continue;
+
+      const role = (contact.role || '').toLowerCase();
+      const rolePath = role === 'instructor' ? 'instructor' : role === 'student' ? 'student' : 'admin';
+      const groupLink = `${process.env.FRONTEND_URL}/dashboard/${rolePath}/groups/${group.id}`;
+      const inviteLinkMsg = `${inviteMsg} ${groupLink}`;
+
       await Promise.all([
         notificationService.createNotification({
           user_id: uid,
           type: 'group_invite',
-          message: inviteMsg,
+          message: inviteLinkMsg,
         }),
         messageService.createMessage({
           sender_id: req.user.id,
           receiver_id: uid,
-          message: inviteMsg,
+          message: inviteLinkMsg,
         }),
       ]);
       if (inviteMethods.includes('email') && contact.email) {
         await mailService.sendMail({
           to: contact.email,
           subject: 'Group Invitation',
-
           html: `<p>${inviteMsg}</p><p><a href="${groupLink}">Join Group</a></p>`,
-
         });
       }
       if (inviteMethods.includes('whatsapp') && contact.phone) {
         await whatsappService.sendWhatsApp({
           to: contact.phone,
-
           message: inviteLinkMsg,
-
         });
       }
     }

--- a/backend/src/modules/users/user.model.js
+++ b/backend/src/modules/users/user.model.js
@@ -91,7 +91,7 @@ exports.findByPhone = async (phone) => {
 // Fetch minimal contact info for invites
 exports.findContactInfo = async (id) => {
   return db("users")
-    .select("id", "full_name", "email", "phone")
+    .select("id", "full_name", "email", "phone", "role")
     .where({ id })
     .first();
 };


### PR DESCRIPTION
## Summary
- include user role when fetching contact info for invites
- build invite messages with a role-based dashboard link

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6865813609b08328b2f492e43dbc07bf