### PR TITLE
Fix category images in admin dashboard

### DIFF
--- a/frontend/src/pages/dashboard/admin/categories/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/categories/edit/[id].js
@@ -5,6 +5,7 @@ import { ArrowLeftCircle, Upload } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
+import { API_BASE_URL } from "@/config/config";
 import {
   fetchCategoryTree,
   fetchCategoryById,
@@ -44,7 +45,10 @@ function EditCategory() {
           setName(category.name);
           setParentId(category.parent_id || "");
           setStatus(category.status);
-          if (category.image_url) setPreview(category.image_url);
+          if (category.image_url) {
+            const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+            setPreview(`${base}${category.image_url}`);
+          }
         }
       } catch (err) {
         console.error("Failed to load category", err);

--- a/frontend/src/pages/dashboard/admin/categories/index.js
+++ b/frontend/src/pages/dashboard/admin/categories/index.js
@@ -8,6 +8,7 @@ import {
   deleteCategory,
   updateCategoryStatus,
 } from "@/services/admin/categoryService";
+import { API_BASE_URL } from "@/config/config";
 import { toast } from "react-toastify";
 
 function AdminCategoryIndex() {
@@ -80,9 +81,12 @@ function AdminCategoryIndex() {
     }
   };
 
-  const getImage = (src) =>
-    src ? `${process.env.NEXT_PUBLIC_API_BASE_URL}/${src.replace(/^\/+/, "")}` :
-    "https://via.placeholder.com/80x80?text=No+Image";
+  const getImage = (src) => {
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+    return src
+      ? `${base}/${src.replace(/^\/+/, "")}`
+      : "https://via.placeholder.com/80x80?text=No+Image";
+  };
 
   const buildTree = (list, parentId = null) =>
     list


### PR DESCRIPTION
## Summary
- ensure admin category pages resolve image paths using API_BASE_URL
- show existing category images on edit page

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68662ce0ea508328b3f65d24a1de039e