### PR TITLE
Add admin promotion controls in group members list

### DIFF
--- a/frontend/src/components/groups/GroupMembersList.js
+++ b/frontend/src/components/groups/GroupMembersList.js
@@ -35,7 +35,7 @@ export default function GroupMembersList({
       case "unmute":
         return { muted: false };
       case "promote":
-        return { role: "moderator" };
+        return { role: "admin" };
       case "demote":
         return { role: "member" };
       case "disable":
@@ -106,14 +106,14 @@ export default function GroupMembersList({
                     </button>
                     <button
                       title={
-                        member.role === "moderator"
-                          ? "Demote"
-                          : "Promote to Moderator"
+                        member.role === "admin"
+                          ? "Demote to Member"
+                          : "Make Admin"
                       }
                       onClick={() =>
                         handleAction(
                           member.id,
-                          member.role === "moderator" ? "demote" : "promote",
+                          member.role === "admin" ? "demote" : "promote",
                         )
                       }
                       className="text-blue-500 hover:text-blue-600"


### PR DESCRIPTION
## Summary
- enable promoting/demoting members to admin on group member tab

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68663555127c83288fefdbac9c480eb3