### PR TITLE
Add lesson count and auto tag creation to tutorial flow

### DIFF
--- a/backend/src/migrations/20250712000000_add_unique_title_to_tutorials.js
+++ b/backend/src/migrations/20250712000000_add_unique_title_to_tutorials.js
@@ -1,0 +1,12 @@
+// 📁 20250712000000_add_unique_title_to_tutorials.js
+exports.up = function(knex) {
+  return knex.schema.alterTable('tutorials', function(table) {
+    table.unique('title');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('tutorials', function(table) {
+    table.dropUnique('title');
+  });
+};

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -18,6 +18,8 @@ export default function CreateTutorialPage() {
     category: "",
     categoryName: "",
     level: "",
+    language: "",
+    lessonCount: 1,
     tags: [],
     chapters: [],
     thumbnail: null,
@@ -32,7 +34,13 @@ export default function CreateTutorialPage() {
     const savedDraft = localStorage.getItem("tutorialDraft");
     if (savedDraft) {
       const draft = JSON.parse(savedDraft);
-      setTutorialData({ ...draft, thumbnail: null, preview: null });
+      setTutorialData({
+        ...draft,
+        thumbnail: null,
+        preview: null,
+        language: draft.language || "",
+        lessonCount: draft.lessonCount || 1,
+      });
     }
 
     const loadCategories = async () => {
@@ -58,6 +66,7 @@ export default function CreateTutorialPage() {
     formData.append("description", tutorialData.shortDescription);
     formData.append("category_id", tutorialData.category);
     formData.append("level", tutorialData.level);
+    formData.append("language", tutorialData.language);
     formData.append("status", status);
     formData.append("is_paid", (!tutorialData.isFree).toString());
     if (!tutorialData.isFree) {


### PR DESCRIPTION
## Summary
- allow instructors to set a lesson count when creating tutorials
- pre-fill curriculum step based on chosen lesson count
- automatically create new tutorial tags on the fly
- ensure tutorial titles are unique at the DB level

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6866392ed4c88328b86ffc83d1f712c5