### PR TITLE
Fix tutorial create error

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -41,8 +41,6 @@ exports.createTutorial = catchAsync(async (req, res) => {
     level,
     duration,
     price,
-    start_date,
-    end_date,
     status = "draft",
     tags: rawTags,
     chapters = [],
@@ -87,8 +85,6 @@ exports.createTutorial = catchAsync(async (req, res) => {
     level,
     duration: duration ? parseInt(duration) : null,
     price,
-    start_date: start_date ? new Date(start_date) : null,
-    end_date: end_date ? new Date(end_date) : null,
     instructor_id,
     status,
     moderation_status: status === "published" ? "Pending" : null,
@@ -157,12 +153,6 @@ exports.updateTutorial = catchAsync(async (req, res) => {
   const { tags: rawTags, ...data } = req.body;
   if (data.duration) {
     data.duration = parseInt(data.duration);
-  }
-  if (data.start_date) {
-    data.start_date = new Date(data.start_date);
-  }
-  if (data.end_date) {
-    data.end_date = new Date(data.end_date);
   }
   const roleDir = getRoleDir(req);
   if (req.files?.thumbnail) {

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -45,8 +45,6 @@ exports.create = z.object({
       ),
     cover_image: z.string().url().optional(),
     preview_video: z.string().url().optional(),
-    start_date: z.string().optional(),
-    end_date: z.string().optional(),
   }),
 });
 

--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -57,8 +57,6 @@ function EditTutorialPage() {
           chapters: mappedChapters,
           thumbnail: tutorial.thumbnail,
           preview: tutorial.preview,
-          startDate: tutorial.startDate || "",
-          endDate: tutorial.endDate || "",
           price: tutorial.price || "",
           isFree: tutorial.isFree,
         });
@@ -122,12 +120,6 @@ function EditTutorialPage() {
               formData.append("category_id", tutorialData.category);
               formData.append("level", tutorialData.level);
               formData.append("is_paid", (!tutorialData.isFree).toString());
-              if (tutorialData.startDate) {
-                formData.append("start_date", tutorialData.startDate);
-              }
-              if (tutorialData.endDate) {
-                formData.append("end_date", tutorialData.endDate);
-              }
               if (!tutorialData.isFree) {
                 formData.append("price", tutorialData.price);
               }

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -33,8 +33,6 @@ export const fetchAllTutorials = async () => {
       : null,
     createdAt: t.created_at,
     updatedAt: t.updated_at,
-    startDate: t.start_date,
-    endDate: t.end_date,
     instructor: t.instructor_name,
     category: t.category_name,
     status: t.status === "published" ? "Published" : "Draft",
@@ -92,8 +90,6 @@ export const fetchTutorialById = async (id) => {
       : null,
     price: t.price,
     isFree: !t.is_paid,
-    startDate: t.start_date,
-    endDate: t.end_date,
   };
 };
 


### PR DESCRIPTION
## Summary
- remove unused date fields from tutorial validation and controller
- update admin tutorial service and edit form to stop sending date fields

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_686647e69ee0832883e3e53ecebd0275