### PR TITLE
Fix tutorial create error

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -41,8 +41,6 @@ exports.createTutorial = catchAsync(async (req, res) => {
     level,
     duration,
     price,
-    start_date,
-    end_date,
     status = "draft",
     tags: rawTags,
     chapters = [],
@@ -87,8 +85,6 @@ exports.createTutorial = catchAsync(async (req, res) => {
     level,
     duration: duration ? parseInt(duration) : null,
     price,
-    start_date: start_date ? new Date(start_date) : null,
-    end_date: end_date ? new Date(end_date) : null,
     instructor_id,
     status,
     moderation_status: status === "published" ? "Pending" : null,
@@ -157,12 +153,6 @@ exports.updateTutorial = catchAsync(async (req, res) => {
   const { tags: rawTags, ...data } = req.body;
   if (data.duration) {
     data.duration = parseInt(data.duration);
-  }
-  if (data.start_date) {
-    data.start_date = new Date(data.start_date);
-  }
-  if (data.end_date) {
-    data.end_date = new Date(data.end_date);
   }
   const roleDir = getRoleDir(req);
   if (req.files?.thumbnail) {

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -45,8 +45,6 @@ exports.create = z.object({
       ),
     cover_image: z.string().url().optional(),
     preview_video: z.string().url().optional(),
-    start_date: z.string().optional(),
-    end_date: z.string().optional(),
   }),
 });
 

--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -30,7 +30,29 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
   }, [tagInput, tutorialData.tags]);
 
   const handleChange = (field, value) => {
-    setTutorialData((prev) => ({ ...prev, [field]: value }));
+    if (field === "lessonCount") {
+      const count = parseInt(value, 10);
+      setTutorialData((prev) => {
+        const lessons = isNaN(count) || count <= 0 ? 0 : count;
+        let chapters = prev.chapters || [];
+        if (chapters.length > lessons) {
+          chapters = chapters.slice(0, lessons);
+        } else if (chapters.length < lessons) {
+          chapters = chapters.concat(
+            Array.from({ length: lessons - chapters.length }, () => ({
+              title: "",
+              duration: "",
+              video: null,
+              videoUrl: "",
+              preview: false,
+            }))
+          );
+        }
+        return { ...prev, lessonCount: value, chapters };
+      });
+    } else {
+      setTutorialData((prev) => ({ ...prev, [field]: value }));
+    }
   };
 
   const addTag = (tag) => {
@@ -209,19 +231,28 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
               </span>
             ))}
           </div>
-          <input
-            type="text"
-            value={tagInput}
-            onChange={(e) => setTagInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                addTag(tagInput);
-              }
-            }}
-            placeholder="Add tags..."
-            className="w-full p-2 border rounded mt-1"
-          />
+          <div className="flex gap-2 mt-1">
+            <input
+              type="text"
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addTag(tagInput);
+                }
+              }}
+              placeholder="Add tags..."
+              className="flex-1 p-2 border rounded"
+            />
+            <button
+              type="button"
+              onClick={() => addTag(tagInput)}
+              className="px-3 py-2 bg-yellow-500 text-white rounded"
+            >
+              Add
+            </button>
+          </div>
           {tagSuggestions.length > 0 && tagInput && (
             <div className="absolute z-10 mt-1 w-full rounded-md bg-white shadow-lg">
               {tagSuggestions.map((t) => (

--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -28,7 +28,11 @@ function EditTutorialPage() {
 
     const draft = localStorage.getItem(`editTutorialDraft-${id}`);
     if (draft) {
-      setTutorialData(JSON.parse(draft));
+      const parsed = JSON.parse(draft);
+      setTutorialData({
+        ...parsed,
+        lessonCount: parsed.lessonCount || parsed.chapters?.length || 1,
+      });
       return;
     }
 
@@ -53,12 +57,11 @@ function EditTutorialPage() {
           categoryName: tutorial.categoryName,
           level: tutorial.level,
           language: tutorial.language || "",
+          lessonCount: mappedChapters.length,
           tags: tutorial.tags || [],
           chapters: mappedChapters,
           thumbnail: tutorial.thumbnail,
           preview: tutorial.preview,
-          startDate: tutorial.startDate || "",
-          endDate: tutorial.endDate || "",
           price: tutorial.price || "",
           isFree: tutorial.isFree,
         });
@@ -122,12 +125,6 @@ function EditTutorialPage() {
               formData.append("category_id", tutorialData.category);
               formData.append("level", tutorialData.level);
               formData.append("is_paid", (!tutorialData.isFree).toString());
-              if (tutorialData.startDate) {
-                formData.append("start_date", tutorialData.startDate);
-              }
-              if (tutorialData.endDate) {
-                formData.append("end_date", tutorialData.endDate);
-              }
               if (!tutorialData.isFree) {
                 formData.append("price", tutorialData.price);
               }

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -19,6 +19,7 @@ function CreateTutorialPage() {
     category: "",
     categoryName: "",
     level: "",
+    lessonCount: 1,
     tags: [],
     chapters: [],
     thumbnail: null,
@@ -34,7 +35,12 @@ function CreateTutorialPage() {
     const savedDraft = localStorage.getItem("tutorialDraft");
     if (savedDraft) {
       const draft = JSON.parse(savedDraft);
-      setTutorialData({ ...draft, thumbnail: null, preview: null });
+      setTutorialData({
+        ...draft,
+        thumbnail: null,
+        preview: null,
+        lessonCount: draft.lessonCount || draft.chapters?.length || 1,
+      });
     }
 
     const loadCategories = async () => {

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -21,7 +21,11 @@ export default function EditTutorialPage() {
     if (!id) return;
     const draft = localStorage.getItem(`editTutorialDraft-${id}`);
     if (draft) {
-      setTutorialData(JSON.parse(draft));
+      const parsed = JSON.parse(draft);
+      setTutorialData({
+        ...parsed,
+        lessonCount: parsed.lessonCount || parsed.chapters?.length || 1,
+      });
       setLoading(false);
       return;
     }
@@ -29,7 +33,15 @@ export default function EditTutorialPage() {
     const load = async () => {
       try {
         const data = await fetchTutorialDetails(id);
-        setTutorialData(data?.data || data || null);
+        const formatted = data?.data || data || null;
+        if (formatted) {
+          setTutorialData({
+            ...formatted,
+            lessonCount: formatted.chapters?.length || 1,
+          });
+        } else {
+          setTutorialData(null);
+        }
       } catch (err) {
         console.error(err);
         setError("Failed to load tutorial");

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -33,8 +33,6 @@ export const fetchAllTutorials = async () => {
       : null,
     createdAt: t.created_at,
     updatedAt: t.updated_at,
-    startDate: t.start_date,
-    endDate: t.end_date,
     instructor: t.instructor_name,
     category: t.category_name,
     status: t.status === "published" ? "Published" : "Draft",
@@ -92,8 +90,6 @@ export const fetchTutorialById = async (id) => {
       : null,
     price: t.price,
     isFree: !t.is_paid,
-    startDate: t.start_date,
-    endDate: t.end_date,
   };
 };
 


### PR DESCRIPTION
## Summary
- remove unused date fields from tutorial validation and controller
- update admin tutorial service and edit form to stop sending date fields
- dynamically create chapters based on the lesson count value
- add button beside tag input to manually insert tags

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686647e69ee0832883e3e53ecebd0275