### PR TITLE
Fix tutorial tag table reference

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -124,7 +124,7 @@ exports.addTutorialTags = async (tutorialId, tagIds) => {
 
 exports.getTutorialTags = async (tutorialId) => {
   return db("tutorial_tag_map as m")
-    .join("tutorial_tags as t", "m.tag_id", "t.id")
+    .join("tags as t", "m.tag_id", "t.id")
     .where("m.tutorial_id", tutorialId)
     .select("t.id", "t.name", "t.slug");
 };

--- a/backend/src/modules/users/tutorials/tutorialTag.service.js
+++ b/backend/src/modules/users/tutorials/tutorialTag.service.js
@@ -1,22 +1,22 @@
 const db = require("../../../config/database");
 
 exports.getAllTags = async () => {
-  return db("tutorial_tags").select("*").orderBy("created_at", "desc");
+  return db("tags").select("*").orderBy("created_at", "desc");
 };
 
 exports.findByName = async (name) => {
-  return db("tutorial_tags")
+  return db("tags")
     .whereRaw("LOWER(name) = ?", [name.toLowerCase()])
     .first();
 };
 
 exports.createTag = async (data) => {
-  const [row] = await db("tutorial_tags").insert(data).returning("*");
+  const [row] = await db("tags").insert(data).returning("*");
   return row;
 };
 
 exports.searchTags = async (search, limit = 10) => {
-  return db("tutorial_tags")
+  return db("tags")
     .modify(query => {
       if (search) query.whereILike("name", `%${search}%`);
     })


### PR DESCRIPTION
## Summary
- fix tutorial tag service to use `tags` table
- join through `tags` table when fetching tags

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68666a1ef390832890fe7e88538f7431