### PR TITLE
Fix missing slug column in tags table

### DIFF
--- a/backend/src/migrations/20250713000000_add_slug_to_tags.js
+++ b/backend/src/migrations/20250713000000_add_slug_to_tags.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table('tags', function (table) {
+    table.string('slug').unique().notNullable().defaultTo('temp-slug');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('tags', function (table) {
+    table.dropColumn('slug');
+  });
+};


### PR DESCRIPTION
## Summary
- add a migration to introduce `slug` to the `tags` table

## Testing
- `npm install` within `backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68666df47e9c83288f8d227f2f4e7e93