### PR TITLE
Allow instructors to view their tutorials in any status

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -141,6 +141,11 @@ exports.getAllTutorials = async (req, res) => {
   sendSuccess(res, tutorials);
 };
 
+exports.getMyTutorials = catchAsync(async (req, res) => {
+  const tutorials = await service.getTutorialsByInstructor(req.user.id);
+  sendSuccess(res, tutorials);
+});
+
 
 exports.getTutorialById = catchAsync(async (req, res) => {
   const tutorial = await service.getTutorialById(req.params.id);

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -22,6 +22,7 @@ router.post(
 );
 
 router.get("/admin", verifyToken, isInstructorOrAdmin, controller.getAllTutorials);
+router.get("/admin/my", verifyToken, isInstructorOrAdmin, controller.getMyTutorials);
 router.get("/admin/:id", verifyToken, isInstructorOrAdmin, controller.getTutorialById);
 
 router.put(

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -33,6 +33,19 @@ exports.getTutorialById = async (id) => {
     );
 };
 
+exports.getTutorialsByInstructor = async (instructorId) => {
+  return db("tutorials as t")
+    .leftJoin("categories as c", "t.category_id", "c.id")
+    .select(
+      "t.*",
+      "c.name as category_name",
+      "c.image_url as category_image_url"
+    )
+    .where("t.instructor_id", instructorId)
+    .whereNot("t.status", "archived")
+    .orderBy("t.created_at", "desc");
+};
+
 exports.updateTutorial = async (id, data) => {
   const [updated] = await db("tutorials").where({ id }).update(data).returning("*");
   return updated;

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -6,7 +6,7 @@ import BasicInfoStep from '@/components/tutorials/create/BasicInfoStep';
 import CurriculumStep from '@/components/tutorials/create/CurriculumStep';
 import MediaStep from '@/components/tutorials/create/MediaStep';
 import ReviewStep from '@/components/tutorials/create/ReviewStep';
-import { fetchTutorialDetails } from "@/services/tutorialService";
+import { fetchInstructorTutorialById } from "@/services/instructor/tutorialService";
 
 export default function EditTutorialPage() {
   const router = useRouter();
@@ -32,7 +32,7 @@ export default function EditTutorialPage() {
 
     const load = async () => {
       try {
-        const data = await fetchTutorialDetails(id);
+        const data = await fetchInstructorTutorialById(id);
         const formatted = data?.data || data || null;
         if (formatted) {
           setTutorialData({

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { motion } from "framer-motion"; // Smooth animation
-import { fetchTutorialDetails } from "@/services/tutorialService";
+import { fetchInstructorTutorialById } from "@/services/instructor/tutorialService";
 
 export default function ViewTutorialPage() {
   const router = useRouter();
@@ -17,7 +17,7 @@ export default function ViewTutorialPage() {
     if (!id) return;
     const load = async () => {
       try {
-        const data = await fetchTutorialDetails(id);
+        const data = await fetchInstructorTutorialById(id);
         setTutorial(data?.data || data || null);
       } catch (err) {
         console.error(err);

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { FaPlus, FaEdit, FaEye, FaTrash } from "react-icons/fa";
-import { fetchPublishedTutorials } from "@/services/tutorialService";
+import { fetchInstructorTutorials } from "@/services/instructor/tutorialService";
 
 export default function InstructorTutorialsPage() {
   const router = useRouter();
@@ -15,7 +15,7 @@ export default function InstructorTutorialsPage() {
   useEffect(() => {
     const load = async () => {
       try {
-        const data = await fetchPublishedTutorials();
+        const data = await fetchInstructorTutorials();
         setTutorials(data?.data || data || []);
       } catch (err) {
         console.error(err);

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -1,0 +1,49 @@
+import api from "@/services/api/api";
+import { API_BASE_URL } from "@/config/config";
+
+const formatBase = (tut) => ({
+  ...tut,
+  thumbnail: tut.thumbnail_url
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.thumbnail_url}`
+    : null,
+  preview: tut.preview_video
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.preview_video}`
+    : null,
+  instructor: tut.instructor_name || tut.instructor,
+  tags: tut.tags || [],
+});
+
+const mapStatus = (tut) =>
+  tut.status === "draft"
+    ? "Draft"
+    : tut.moderation_status === "Approved"
+    ? "Approved"
+    : tut.moderation_status === "Rejected"
+    ? "Rejected"
+    : "Submitted";
+
+export const fetchInstructorTutorials = async () => {
+  const { data } = await api.get("/users/tutorials/admin/my");
+  const list = data?.data ?? [];
+  return list.map((t) => ({
+    ...formatBase(t),
+    status: mapStatus(t),
+    updatedAt: t.updated_at,
+  }));
+};
+
+export const fetchInstructorTutorialById = async (id) => {
+  const { data } = await api.get(`/users/tutorials/admin/${id}`);
+  const tut = data?.data;
+  if (!tut) return null;
+  const { data: chData } = await api.get(
+    `/users/tutorials/chapters/tutorial/${id}`
+  );
+  const chapters = chData?.data || [];
+  return {
+    ...formatBase(tut),
+    status: mapStatus(tut),
+    updatedAt: tut.updated_at,
+    chapters,
+  };
+};


### PR DESCRIPTION
## Summary
- add service method to fetch tutorials by instructor
- expose `/admin/my` route for tutorials
- expose controller handler to list instructor tutorials
- add instructor tutorial service on frontend
- use new service for instructor tutorial pages

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68667089cc588328b149ab353c2a2d48