### PR TITLE
Enhance instructor tutorial listing

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -34,16 +34,24 @@ exports.getTutorialById = async (id) => {
 };
 
 exports.getTutorialsByInstructor = async (instructorId) => {
-  return db("tutorials as t")
+  const tutorials = await db("tutorials as t")
     .leftJoin("categories as c", "t.category_id", "c.id")
+    .leftJoin("users as u", "t.instructor_id", "u.id")
     .select(
       "t.*",
       "c.name as category_name",
-      "c.image_url as category_image_url"
+      "c.image_url as category_image_url",
+      "u.full_name as instructor_name"
     )
     .where("t.instructor_id", instructorId)
     .whereNot("t.status", "archived")
     .orderBy("t.created_at", "desc");
+
+  for (const tut of tutorials) {
+    tut.tags = await exports.getTutorialTags(tut.id);
+  }
+
+  return tutorials;
 };
 
 exports.updateTutorial = async (id, data) => {

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -109,6 +109,37 @@ export default function InstructorTutorialsPage() {
                     Updated: {new Date(tutorial.updatedAt).toLocaleDateString()}
                   </p>
 
+                  <div className="flex items-center justify-between text-xs text-gray-600 mt-1">
+                    <a
+                      href={`/instructors/${tutorial.instructor_id}`}
+                      className="hover:underline text-blue-600"
+                    >
+                      {tutorial.instructor_name || tutorial.instructor}
+                    </a>
+                    <span className="font-semibold">
+                      {tutorial.price ? `$${tutorial.price}` : 'Free'}
+                    </span>
+                  </div>
+
+                  <p className="text-xs text-gray-500 mt-1">
+                    Language: {tutorial.language || 'N/A'}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Category: {tutorial.category_name || 'N/A'} • Level: {tutorial.level || 'N/A'}
+                  </p>
+                  {tutorial.tags && tutorial.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {tutorial.tags.map((tag) => (
+                        <span
+                          key={tag.id || tag}
+                          className="bg-gray-200 px-2 py-0.5 rounded-full text-[10px] text-gray-700"
+                        >
+                          {tag.name || tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
                   {/* Status Badge */}
                   <div className="mt-3">
                     <span


### PR DESCRIPTION
## Summary
- include tags and instructor name when fetching instructor tutorials
- show more tutorial metadata in instructor dashboard list

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686673bb58e0832890ccdbad860e6dfa