### PR TITLE
Add progress bar to tutorial creation flow

### DIFF
--- a/frontend/src/components/tutorials/create/StepProgressBar.js
+++ b/frontend/src/components/tutorials/create/StepProgressBar.js
@@ -1,0 +1,36 @@
+import { FaCheck } from "react-icons/fa";
+
+export default function StepProgressBar({ steps = [], currentStep = 1, onStepClick }) {
+  const progress = ((currentStep - 1) / (steps.length - 1)) * 100;
+
+  return (
+    <div className="relative mb-12">
+      <div className="absolute top-4 left-0 w-full h-1 bg-gray-300 z-0 rounded" />
+      <div
+        className="absolute top-4 left-0 h-1 bg-yellow-500 z-0 rounded transition-all"
+        style={{ width: `${progress}%` }}
+      />
+      <div className="relative flex justify-between">
+        {steps.map((label, index) => {
+          const stepNumber = index + 1;
+          const isActive = stepNumber === currentStep;
+          const isCompleted = stepNumber < currentStep;
+          return (
+            <div
+              key={label}
+              className="flex flex-col items-center text-center flex-1 cursor-pointer"
+              onClick={() => onStepClick && onStepClick(stepNumber)}
+            >
+              <div
+                className={`w-8 h-8 flex items-center justify-center rounded-full font-bold text-white ${isActive ? "bg-yellow-500" : isCompleted ? "bg-green-500" : "bg-gray-400"}`}
+              >
+                {isCompleted ? <FaCheck /> : stepNumber}
+              </div>
+              <span className={`mt-2 text-sm ${isActive ? "text-yellow-600" : "text-gray-500"}`}>{label}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -9,6 +9,7 @@ import MediaStep from "@/components/tutorials/create/MediaStep";
 import ReviewStep from "@/components/tutorials/create/ReviewStep";
 import { createTutorial } from "@/services/admin/tutorialService";
 import { fetchAllCategories } from "@/services/admin/categoryService";
+import StepProgressBar from "@/components/tutorials/create/StepProgressBar";
 
 function CreateTutorialPage() {
   const [step, setStep] = useState(1);
@@ -116,20 +117,14 @@ function CreateTutorialPage() {
       <div className="p-8 bg-gray-100 min-h-screen max-w-4xl mx-auto">
         <h1 className="text-3xl font-bold text-gray-800 mb-8">🎬 Create New Tutorial</h1>
 
-        {/* Step Indicators */}
-        <div className="flex justify-between mb-12">
-          {["Basic Info", "Curriculum", "Media", "Pricing & Publish"].map((label, index) => (
-            <div key={index} className="flex flex-col items-center text-center">
-              <div className={`w-10 h-10 flex items-center justify-center rounded-full text-white font-bold
-                ${step === index + 1 ? "bg-yellow-500" : "bg-gray-400"}`}>
-                {index + 1}
-              </div>
-              <span className={`mt-2 text-sm ${step === index + 1 ? "text-yellow-500" : "text-gray-500"}`}>
-                {label}
-              </span>
-            </div>
-          ))}
-        </div>
+        {/* Step Progress */}
+        <StepProgressBar
+          steps={["Basic Info", "Curriculum", "Media", "Pricing & Publish"]}
+          currentStep={step}
+          onStepClick={(s) => {
+            if (s < step) setStep(s);
+          }}
+        />
 
         {/* Step Content */}
         <div className="bg-white p-8 rounded-lg shadow space-y-6">

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -8,6 +8,7 @@ import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
 import MediaStep from "@/components/tutorials/create/MediaStep";
 import ReviewStep from "@/components/tutorials/create/ReviewStep";
+import StepProgressBar from "@/components/tutorials/create/StepProgressBar";
 
 export default function CreateTutorialPage() {
   const [step, setStep] = useState(1);
@@ -112,20 +113,14 @@ export default function CreateTutorialPage() {
       <div className="p-8 bg-gray-100 min-h-screen">
         <h1 className="text-3xl font-bold text-gray-800 mb-8">🎬 Create New Tutorial</h1>
 
-        {/* Step Indicators */}
-        <div className="flex justify-between mb-12">
-          {["Basic Info", "Curriculum", "Media", "Pricing & Publish"].map((label, index) => (
-            <div key={index} className="flex flex-col items-center text-center">
-              <div className={`w-10 h-10 flex items-center justify-center rounded-full text-white font-bold
-                ${step === index + 1 ? "bg-yellow-500" : "bg-gray-400"}`}>
-                {index + 1}
-              </div>
-              <span className={`mt-2 text-sm ${step === index + 1 ? "text-yellow-500" : "text-gray-500"}`}>
-                {label}
-              </span>
-            </div>
-          ))}
-        </div>
+        {/* Step Progress */}
+        <StepProgressBar
+          steps={["Basic Info", "Curriculum", "Media", "Pricing & Publish"]}
+          currentStep={step}
+          onStepClick={(s) => {
+            if (s < step) setStep(s);
+          }}
+        />
 
         {/* Step Content */}
         <div className="bg-white p-8 rounded-lg shadow space-y-6">


### PR DESCRIPTION
## Summary
- add `StepProgressBar` component for creation wizard
- use progress bar in instructor and admin tutorial creation pages

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find ESLint packages)*

------
https://chatgpt.com/codex/tasks/task_e_68667b7d7470832885e4ef51e0d6f492