### PR TITLE
Update instructor tutorials dashboard

### DIFF
--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -29,6 +29,12 @@ export const fetchInstructorTutorials = async () => {
     ...formatBase(t),
     status: mapStatus(t),
     updatedAt: t.updated_at,
+    createdAt: t.created_at,
+    views: t.views || 0,
+    rating: t.rating || 0,
+    enrollments: t.enrollments || 0,
+    comments: t.comment_count || 0,
+    watchTime: t.watch_time || 0,
   }));
 };
 
@@ -46,4 +52,9 @@ export const fetchInstructorTutorialById = async (id) => {
     updatedAt: tut.updated_at,
     chapters,
   };
+};
+
+export const submitTutorialForReview = async (id) => {
+  const { data } = await api.patch(`/users/tutorials/admin/${id}/status`);
+  return data?.data;
 };


### PR DESCRIPTION
## Summary
- enhance instructor tutorial service with metrics and submission endpoint
- add analytics, sorting and extra controls to instructor tutorials page

## Testing
- `npm --prefix frontend run lint` *(fails: cannot find package '@eslint/eslintrc')*
- `npm --prefix frontend test` *(fails: jest not found)*
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867670ecb5483288d39bd528b94728c