### PR TITLE
Add features to instructor tutorial page

### DIFF
--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -50,6 +50,14 @@ export const fetchInstructorTutorialById = async (id) => {
     ...formatBase(tut),
     status: mapStatus(tut),
     updatedAt: tut.updated_at,
+    createdAt: tut.created_at,
+    views: tut.views || 0,
+    rating: tut.rating || 0,
+    enrollments: tut.enrollments || 0,
+    comments: tut.comment_count || 0,
+    watchTime: tut.watch_time || 0,
+    rejection_reason: tut.rejection_reason,
+    progress: tut.progress,
     chapters,
   };
 };


### PR DESCRIPTION
## Summary
- enhance fetchInstructorTutorialById with analytics fields
- add created date, analytics stats, submission button and rejection reason to view page
- add export/duplicate/checklist actions with modal

## Testing
- `npm test` *(fails: jest not found)*
- `cd frontend && npm test` *(fails: jest not found)*
- `cd backend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676bc73dfc8328a51e2d81d65e1bf7