### PR TITLE
Enable tutorial deletion via backend

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -19,6 +19,7 @@ import {
 import {
   fetchInstructorTutorials,
   submitTutorialForReview,
+  deleteInstructorTutorial,
 } from "@/services/instructor/tutorialService";
 import ProgressChecklistModal from "@/components/tutorials/ProgressChecklistModal";
 
@@ -56,9 +57,14 @@ export default function InstructorTutorialsPage() {
     setStatusFilter(status);
   };
 
-  const handleDelete = (id) => {
-    if (window.confirm("Are you sure you want to delete this tutorial?")) {
+  const handleDelete = async (id) => {
+    if (!window.confirm("Are you sure you want to delete this tutorial?")) return;
+    try {
+      await deleteInstructorTutorial(id);
       setTutorials((prev) => prev.filter((tut) => tut.id !== id));
+    } catch (err) {
+      console.error(err);
+      alert("Failed to delete tutorial");
     }
   };
 

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -71,3 +71,10 @@ export const fetchInstructorTutorialAnalytics = async (id) => {
   const { data } = await api.get(`/users/tutorials/admin/${id}/analytics`);
   return data?.data ?? {};
 };
+
+// Permanently delete one of the instructor's tutorials
+// Used from the instructor dashboard tutorials list
+export const deleteInstructorTutorial = async (id) => {
+  const { data } = await api.delete(`/users/tutorials/admin/${id}`);
+  return data?.data ?? null;
+};


### PR DESCRIPTION
## Summary
- add deleteInstructorTutorial to tutorial service
- call backend deletion from instructor tutorials list

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6867752ff39c8328bd344161953a0103