### PR TITLE
Enable tutorial deletion via backend

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -3,9 +3,9 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { motion } from "framer-motion"; // Smooth animation
-import { FaEdit, FaCopy, FaDownload, FaRegEye, FaUsers, FaStar, FaRegComments } from "react-icons/fa";
+import { FaEdit, FaDownload, FaRegEye, FaUsers, FaStar, FaRegComments } from "react-icons/fa";
 import ProgressChecklistModal from '@/components/tutorials/ProgressChecklistModal';
-import { fetchInstructorTutorialById, submitTutorialForReview } from "@/services/instructor/tutorialService";
+import { fetchInstructorTutorialById, submitTutorialForReview, deleteInstructorTutorial } from "@/services/instructor/tutorialService";
 
 export default function ViewTutorialPage() {
   const router = useRouter();
@@ -75,13 +75,19 @@ export default function ViewTutorialPage() {
             📈 Analytics
           </button>
           <button
-            onClick={() => {
-              const copy = { ...tutorial, id: `copy-${Date.now()}` };
-              setTutorial(copy);
+            onClick={async () => {
+              if (!window.confirm('Are you sure you want to delete this tutorial?')) return;
+              try {
+                await deleteInstructorTutorial(tutorial.id);
+                router.push('/dashboard/instructor/tutorials');
+              } catch (err) {
+                console.error(err);
+                alert('Failed to delete tutorial');
+              }
             }}
-            className="bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-2 rounded-md font-semibold flex items-center gap-2"
+            className="bg-red-100 hover:bg-red-200 text-red-800 px-4 py-2 rounded-md font-semibold flex items-center gap-2"
           >
-            <FaCopy /> Duplicate
+            🗑 Delete
           </button>
           <button
             onClick={() => {

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -10,7 +10,6 @@ import {
   FaRegComments,
   FaStar,
   FaUsers,
-  FaCopy,
   FaDownload,
   FaSearch,
   FaFilter,
@@ -19,6 +18,7 @@ import {
 import {
   fetchInstructorTutorials,
   submitTutorialForReview,
+  deleteInstructorTutorial,
 } from "@/services/instructor/tutorialService";
 import ProgressChecklistModal from "@/components/tutorials/ProgressChecklistModal";
 
@@ -56,9 +56,14 @@ export default function InstructorTutorialsPage() {
     setStatusFilter(status);
   };
 
-  const handleDelete = (id) => {
-    if (window.confirm("Are you sure you want to delete this tutorial?")) {
+  const handleDelete = async (id) => {
+    if (!window.confirm("Are you sure you want to delete this tutorial?")) return;
+    try {
+      await deleteInstructorTutorial(id);
       setTutorials((prev) => prev.filter((tut) => tut.id !== id));
+    } catch (err) {
+      console.error(err);
+      alert("Failed to delete tutorial");
     }
   };
 
@@ -365,15 +370,6 @@ export default function InstructorTutorialsPage() {
                     </button>
                   )}
 
-                  <button
-                    onClick={() => {
-                      const copy = { ...tutorial, id: `copy-${Date.now()}` };
-                      setTutorials((prev) => [copy, ...prev]);
-                    }}
-                    className="bg-gray-100 hover:bg-gray-200 text-gray-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
-                  >
-                    <FaCopy className="mr-2" /> Duplicate
-                  </button>
 
                   <button
                     onClick={() => {

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -71,3 +71,10 @@ export const fetchInstructorTutorialAnalytics = async (id) => {
   const { data } = await api.get(`/users/tutorials/admin/${id}/analytics`);
   return data?.data ?? {};
 };
+
+// Permanently delete one of the instructor's tutorials
+// Used from the instructor dashboard tutorials list
+export const deleteInstructorTutorial = async (id) => {
+  const { data } = await api.delete(`/users/tutorials/admin/${id}`);
+  return data?.data ?? null;
+};


### PR DESCRIPTION
## Summary
- remove duplicate option from instructor tutorial pages
- add backend delete call on the tutorial view

## Testing
- `npm test --silent` in `frontend` *(fails: jest not found)*
- `npm test --silent` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867752ff39c8328bd344161953a0103