### PR TITLE
Fix rating star rendering

### DIFF
--- a/frontend/src/components/tutorials/detail/RelatedTutorials.js
+++ b/frontend/src/components/tutorials/detail/RelatedTutorials.js
@@ -13,11 +13,12 @@ const mockProgress = {
 };
 
 const getStars = (rating) => {
-  const full = Math.floor(rating);
-  const half = rating % 1 >= 0.5;
+  const safeRating = Number.isFinite(rating) && rating > 0 ? rating : 0;
+  const full = Math.floor(safeRating);
+  const half = safeRating % 1 >= 0.5;
   return (
     <>
-      {Array(full).fill().map((_, i) => (
+      {Array.from({ length: full }).map((_, i) => (
         <FaStar key={i} className="text-yellow-400 text-sm" />
       ))}
       {half && <FaStar className="text-yellow-300 opacity-50 text-sm" />}

--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -22,11 +22,12 @@ const categoryTabs = [
 ];
 
 const getStars = (rating) => {
-  const full = Math.floor(rating);
-  const half = rating % 1 >= 0.5;
+  const safeRating = Number.isFinite(rating) && rating > 0 ? rating : 0;
+  const full = Math.floor(safeRating);
+  const half = safeRating % 1 >= 0.5;
   return (
     <>
-      {Array(full).fill().map((_, i) => (
+      {Array.from({ length: full }).map((_, i) => (
         <FaStar key={i} className="text-yellow-400" />
       ))}
       {half && <FaStar className="text-yellow-300 opacity-50" />}


### PR DESCRIPTION
## Summary
- ensure rating stars use safe values in landing tutorials and related tutorials

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686783d9631c8328b6e764fd147e0920