### PR TITLE
Fix tutorial curriculum display

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -195,13 +195,19 @@ export default function ViewTutorialPage() {
                 transition={{ duration: 0.4 }}
               >
                 {tutorial.chapters.map((chapter, index) => (
-                  <div key={index} className="p-4 bg-gray-50 rounded-lg shadow-sm">
-                    <h3 className="font-semibold text-gray-800">{chapter.title}</h3>
-                    <ul className="mt-2 list-disc list-inside text-gray-600 text-sm sm:text-base">
-                      {chapter.lessons.map((lesson, idx) => (
-                        <li key={idx}>{lesson}</li>
-                      ))}
-                    </ul>
+                  <div
+                    key={index}
+                    className="p-4 bg-gray-50 rounded-lg shadow-sm space-y-1"
+                  >
+                    <h3 className="font-semibold text-gray-800">
+                      {chapter.title}
+                      {chapter.duration ? ` (${chapter.duration} min)` : ""}
+                    </h3>
+                    {chapter.content && (
+                      <p className="text-gray-600 text-sm sm:text-base">
+                        {chapter.content}
+                      </p>
+                    )}
                   </div>
                 ))}
               </motion.div>


### PR DESCRIPTION
## Summary
- show tutorial chapter details correctly on instructor tutorial view page

## Testing
- `npm --prefix frontend test --silent`
- `npm --prefix backend test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6867856a1f148328a6f99f0acc07c4b8