### PR TITLE
Connect tutorial analytics to backend

### DIFF
--- a/frontend/src/pages/api/tutorials/[id]/analytics.js
+++ b/frontend/src/pages/api/tutorials/[id]/analytics.js
@@ -1,0 +1,24 @@
+// pages/api/tutorials/[id]/analytics.js
+import axios from 'axios';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    const { data } = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/users/tutorials/admin/${id}/analytics`,
+      {
+        headers: req.headers.cookie ? { Cookie: req.headers.cookie } : {},
+        withCredentials: true,
+      }
+    );
+    if (!data?.data) {
+      return res.status(404).json({ error: 'Analytics not found' });
+    }
+    return res.status(200).json(data.data);
+  } catch (err) {
+    const status = err.response?.status || 500;
+    const message = err.response?.data?.message || 'Failed to fetch analytics';
+    return res.status(status).json({ error: message });
+  }
+}
+

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/analytics.js
@@ -2,7 +2,7 @@
 import { useRouter } from "next/router";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { useEffect, useState } from "react";
-import { fetchInstructorTutorialAnalytics } from "@/services/instructor/tutorialService";
+import axios from "axios";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
 
 export default function TutorialAnalyticsPage() {
@@ -12,8 +12,9 @@ export default function TutorialAnalyticsPage() {
 
   useEffect(() => {
     if (!id) return;
-    fetchInstructorTutorialAnalytics(id)
-      .then((data) => setStats(data))
+    axios
+      .get(`/api/tutorials/${id}/analytics`)
+      .then((res) => setStats(res.data))
       .catch(() => setStats(null));
   }, [id]);
 


### PR DESCRIPTION
## Summary
- create Next.js API route to proxy tutorial analytics to backend
- fetch analytics data from new API route instead of mock data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678b1f50488328a462168d2071aa73