### PR TITLE
Fix instructor tutorial analytics API path

### DIFF
--- a/frontend/src/pages/api/tutorials/[id]/analytics.js
+++ b/frontend/src/pages/api/tutorials/[id]/analytics.js
@@ -5,7 +5,7 @@ export default async function handler(req, res) {
   const { id } = req.query;
   try {
     const { data } = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/users/tutorials/admin/${id}/analytics`,
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/users/tutorials/admin/${id}/analytics`,
       {
         headers: req.headers.cookie ? { Cookie: req.headers.cookie } : {},
         withCredentials: true,


### PR DESCRIPTION
## Summary
- fix tutorial analytics API route URL so it uses `/api`
- keep existing analytics page logic

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68678f7983708328811658c2081d6b01