### PR TITLE
Fix video URLs with special characters

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -5,6 +5,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import Link from "next/link";
 import { fetchAdminClassById } from "@/services/admin/classService";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
+import { safeEncodeURI } from "@/utils/url";
 
 export default function AdminClassDetailPage() {
   const { id } = useRouter().query;
@@ -75,7 +76,7 @@ export default function AdminClassDetailPage() {
                   <h3 className="text-sm font-medium text-gray-700">Class Demo Video</h3>
                 </div>
                 <CustomVideoPlayer
-                  videos={[{ src: encodeURI(details.demo_video_url) }]}
+                  videos={[{ src: safeEncodeURI(details.demo_video_url) }]}
                 />
               </div>
             )}

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
@@ -4,6 +4,7 @@ import Link from "next/link";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { fetchInstructorClassById } from "@/services/instructor/classService";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
+import { safeEncodeURI } from "@/utils/url";
 
 export default function InstructorClassDetailPage() {
   const { id } = useRouter().query;
@@ -44,7 +45,7 @@ export default function InstructorClassDetailPage() {
           )}
           {details?.demo_video_url && (
             <div className="mt-4">
-              <CustomVideoPlayer videos={[{ src: encodeURI(details.demo_video_url) }]} />
+              <CustomVideoPlayer videos={[{ src: safeEncodeURI(details.demo_video_url) }]} />
             </div>
           )}
 

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -12,6 +12,7 @@ import {
   FaRegComments,
 } from "react-icons/fa";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
+import { safeEncodeURI } from "@/utils/url";
 import ProgressChecklistModal from '@/components/tutorials/ProgressChecklistModal';
 import { fetchInstructorTutorialById, submitTutorialForReview, deleteInstructorTutorial } from "@/services/instructor/tutorialService";
 
@@ -229,7 +230,7 @@ export default function ViewTutorialPage() {
           <h2 className="text-xl sm:text-2xl font-semibold text-gray-700 mb-2">Preview</h2>
           {tutorial.preview ? (
             <CustomVideoPlayer
-              videos={[{ src: encodeURI(tutorial.preview) }]}
+              videos={[{ src: safeEncodeURI(tutorial.preview) }]}
             />
           ) : (
             <div className="w-full h-48 bg-gray-200 rounded-lg flex items-center justify-center text-gray-500">

--- a/frontend/src/pages/instructors/[id].js
+++ b/frontend/src/pages/instructors/[id].js
@@ -12,6 +12,7 @@ import { fetchPublicInstructorById } from "@/services/public/instructorService";
 import { fetchPublishedClasses } from "@/services/classService";
 import { fetchPublishedTutorials } from "@/services/tutorialService";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
+import { safeEncodeURI } from "@/utils/url";
 
 export default function InstructorProfilePage() {
   const router = useRouter();
@@ -206,7 +207,7 @@ export default function InstructorProfilePage() {
               <div className="mb-6">
                 <h2 className="text-xl font-semibold text-gray-800 mb-3">Demo Video</h2>
                 <div className="rounded-lg overflow-hidden shadow-md">
-                  <CustomVideoPlayer videos={[{ src: encodeURI(instructor.demo_video_url) }]} />
+                  <CustomVideoPlayer videos={[{ src: safeEncodeURI(instructor.demo_video_url) }]} />
                 </div>
               </div>
             )}

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import CustomVideoPlayer from '@/components/shared/CustomVideoPlayer';
+import { safeEncodeURI } from '@/utils/url';
 import { FaFacebook, FaTwitter, FaWhatsapp, FaHeart, FaRegHeart, FaCalendarAlt, FaClock, FaTag, FaInfoCircle, FaUsers, FaDollarSign } from 'react-icons/fa';
 import {
   enrollInClass,
@@ -286,7 +287,7 @@ export default function ClassDetailsPage() {
         <div className="mb-10 rounded-xl overflow-hidden shadow-2xl border border-gray-700">
           {classInfo.demo_video_url ? (
             <CustomVideoPlayer
-              videos={[{ src: encodeURI(classInfo.demo_video_url) }]}
+              videos={[{ src: safeEncodeURI(classInfo.demo_video_url) }]}
               className="w-full"
             />
           ) : (

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -1,5 +1,6 @@
 import api from "@/services/api/api";
 import { toDateInput } from "@/utils/date";
+import { safeEncodeURI } from "@/utils/url";
 
 const formatClass = (cls) => ({
   ...cls,
@@ -7,7 +8,7 @@ const formatClass = (cls) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
     : null,
   demo_video_url: cls.demo_video_url
-    ? encodeURI(
+    ? safeEncodeURI(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
       )
     : null,

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -1,5 +1,6 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
+import { safeEncodeURI } from "@/utils/url";
 
 const formatClass = (cls) => ({
   ...cls,
@@ -7,7 +8,7 @@ const formatClass = (cls) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`
     : null,
   demo_video_url: cls.demo_video_url
-    ? encodeURI(
+    ? safeEncodeURI(
         `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.demo_video_url}`,
       )
     : null,

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -1,5 +1,6 @@
 import api from "@/services/api/api";
 import { toDateInput } from "@/utils/date";
+import { safeEncodeURI } from "@/utils/url";
 
 const formatClass = (cls) => ({
   ...cls,
@@ -7,7 +8,7 @@ const formatClass = (cls) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
     : null,
   demo_video_url: cls.demo_video_url
-    ? encodeURI(
+    ? safeEncodeURI(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
       )
     : null,

--- a/frontend/src/utils/url.js
+++ b/frontend/src/utils/url.js
@@ -1,0 +1,3 @@
+export function safeEncodeURI(url) {
+  return encodeURI(url).replace(/#/g, '%23');
+}


### PR DESCRIPTION
## Summary
- handle `#` in media filenames via `safeEncodeURI` utility
- use `safeEncodeURI` when constructing video URLs in services and pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68679485d7b88328ac161b9d86ed5d4c