### PR TITLE
Add notifications for new tutorials

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -62,6 +62,10 @@ export default function CreateTutorialPage() {
   const prevStep = () => setStep((prev) => prev - 1);
 
   const submitTutorial = async (status) => {
+    if (tutorialData.chapters.some((ch) => !ch.videoUrl)) {
+      toast.error("Please upload a video for each lesson before submitting.");
+      return;
+    }
     const formData = new FormData();
     formData.append("title", tutorialData.title);
     formData.append("description", tutorialData.shortDescription);
@@ -94,7 +98,7 @@ export default function CreateTutorialPage() {
       toast.success(
         status === "draft"
           ? "Tutorial saved as draft!"
-          : "Tutorial submitted for approval!"
+          : "Tutorial submitted successfully! Waiting for admin approval."
       );
       localStorage.removeItem("tutorialDraft");
       router.push("/dashboard/instructor/tutorials");


### PR DESCRIPTION
## Summary
- notify instructor and admins when tutorials are created
- require chapter videos before submitting a tutorial
- improve success message after submitting a tutorial

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d97fe7288328bc701fdb9aa91a4a