### PR TITLE
Fix tutorial rating and instructor display

### DIFF
--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -10,6 +10,9 @@ const formatTutorial = (tut) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.preview_video}`
     : null,
   instructor: tut.instructor_name || tut.instructor,
+  rating: typeof tut.rating === "string" || typeof tut.rating === "number"
+    ? parseFloat(tut.rating)
+    : 0,
   tags: tut.tags || [],
   trending: Boolean(tut.trending),
 });


### PR DESCRIPTION
## Summary
- include instructor name and avg rating in featured tutorials
- parse rating in tutorial service to show rating in website

## Testing
- `cd backend && npx jest --runInBand`
- `cd frontend && npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6868381a49488328b79d6f34de201646