### PR TITLE
Add video progress persistence

### DIFF
--- a/frontend/src/components/shared/CustomVideoPlayer.js
+++ b/frontend/src/components/shared/CustomVideoPlayer.js
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect } from "react";
 import { FaPlay, FaPause, FaStepBackward, FaStepForward, FaVolumeUp, FaVolumeMute, FaDownload, FaExpand } from "react-icons/fa";
 import { MdSpeed, MdReplay10, MdForward10 } from "react-icons/md";
 
-export default function CustomVideoPlayer({ videos = [] }) {
+export default function CustomVideoPlayer({ videos = [], startTime = 0, onTimeUpdate }) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [volume, setVolume] = useState(0.7);
@@ -19,22 +19,34 @@ export default function CustomVideoPlayer({ videos = [] }) {
     const video = videoRef.current;
     if (!video) return;
 
+    const handleLoaded = () => {
+      if (startTime > 0) {
+        video.currentTime = startTime;
+        setProgress((startTime / video.duration) * 100);
+      }
+    };
+
     const handleTimeUpdate = () => {
       setProgress((video.currentTime / video.duration) * 100);
+      if (onTimeUpdate) {
+        onTimeUpdate(video.currentTime, currentIndex);
+      }
     };
 
     const handleEnded = () => {
       setIsPlaying(false);
     };
 
+    video.addEventListener('loadedmetadata', handleLoaded);
     video.addEventListener('timeupdate', handleTimeUpdate);
     video.addEventListener('ended', handleEnded);
 
     return () => {
+      video.removeEventListener('loadedmetadata', handleLoaded);
       video.removeEventListener('timeupdate', handleTimeUpdate);
       video.removeEventListener('ended', handleEnded);
     };
-  }, [currentVideo]);
+  }, [currentVideo, startTime, onTimeUpdate]);
 
   const togglePlay = () => {
     if (isPlaying) {


### PR DESCRIPTION
## Summary
- let CustomVideoPlayer accept `startTime` and `onTimeUpdate`
- save chapter progress in localStorage and resume playback on return

## Testing
- `npm test --silent` in `frontend` *(fails: jest not found)*
- `npm test --silent` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690440193083288140e32788a7b5c9