### PR TITLE
Fix tutorial analytics fallback

### DIFF
--- a/frontend/src/pages/api/tutorials/[id]/analytics.js
+++ b/frontend/src/pages/api/tutorials/[id]/analytics.js
@@ -1,6 +1,13 @@
 // pages/api/tutorials/[id]/analytics.js
 import axios from 'axios';
 
+const EMPTY_ANALYTICS = {
+  totalStudents: 0,
+  completed: 0,
+  totalRevenue: 0,
+  registrationTrend: [],
+};
+
 export default async function handler(req, res) {
   const { id } = req.query;
   try {
@@ -12,13 +19,11 @@ export default async function handler(req, res) {
       }
     );
     if (!data?.data) {
-      return res.status(404).json({ error: 'Analytics not found' });
+      return res.status(200).json(EMPTY_ANALYTICS);
     }
     return res.status(200).json(data.data);
   } catch (err) {
-    const status = err.response?.status || 500;
-    const message = err.response?.data?.message || 'Failed to fetch analytics';
-    return res.status(status).json({ error: message });
+    return res.status(200).json(EMPTY_ANALYTICS);
   }
 }
 

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/analytics.js
@@ -5,6 +5,13 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
 
+const EMPTY_STATS = {
+  totalStudents: 0,
+  completed: 0,
+  totalRevenue: 0,
+  registrationTrend: [],
+};
+
 export default function TutorialAnalyticsPage() {
   const router = useRouter();
   const { id } = router.query;
@@ -15,7 +22,7 @@ export default function TutorialAnalyticsPage() {
     axios
       .get(`/api/tutorials/${id}/analytics`)
       .then((res) => setStats(res.data))
-      .catch(() => setStats(null));
+      .catch(() => setStats(EMPTY_STATS));
   }, [id]);
 
   if (!stats) {


### PR DESCRIPTION
## Summary
- ensure instructor tutorial analytics API returns zeros when backend data is missing
- show zeroed analytics instead of empty page when fetch fails

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_686957bd85288328b11a126ce5ee735a