### PR TITLE
Improve tutorial details display

### DIFF
--- a/frontend/src/components/tutorials/detail/RelatedTutorials.js
+++ b/frontend/src/components/tutorials/detail/RelatedTutorials.js
@@ -88,9 +88,18 @@ const RelatedTutorials = ({ tutorials = [] }) => {
             </div>
 
             <div className="p-4">
-              <h3 className="font-bold text-yellow-400 text-lg mb-1 truncate">
-                {tut.title}
-              </h3>
+              <div className="flex items-center gap-2 mb-1">
+                {tut.instructorAvatar && (
+                  <img
+                    src={tut.instructorAvatar}
+                    alt={tut.instructor}
+                    className="w-8 h-8 rounded-full object-cover"
+                  />
+                )}
+                <h3 className="font-bold text-yellow-400 text-lg truncate">
+                  {tut.title}
+                </h3>
+              </div>
               <p className="text-sm text-gray-300 truncate">
                 Instructor: {tut.instructor}
               </p>

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -241,6 +241,11 @@ export default function TutorialDetail() {
         </div>
 
         <TutorialHeader {...tutorial} />
+        <InstructorBio
+          name={tutorial.instructor}
+          avatarUrl={tutorial.instructorAvatar}
+          instructorBio={tutorial.instructorBio}
+        />
         <TutorialOverview description={tutorial.description} />
         <CourseProgress percentage={progressPercentage} />
 
@@ -268,7 +273,6 @@ export default function TutorialDetail() {
           </div>
         )}
 
-        <InstructorBio instructorBio={tutorial.instructorBio} />
         <ReviewsSection tutorialId={tutorial.id} canReview={isEnrolled} />
         <CommentsSection tutorialId={tutorial.id} canComment={isEnrolled} />
         <RelatedTutorials tutorials={related} />

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -10,6 +10,10 @@ const formatTutorial = (tut) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.preview_video}`
     : null,
   instructor: tut.instructor_name || tut.instructor,
+  instructorAvatar: tut.instructor_avatar
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.instructor_avatar}`
+    : null,
+  instructorBio: tut.instructor_bio || tut.instructorBio,
   rating: typeof tut.rating === "string" || typeof tut.rating === "number"
     ? parseFloat(tut.rating)
     : 0,


### PR DESCRIPTION
## Summary
- include instructor avatar and bio fields from backend
- show instructor info near the top of tutorial page
- display instructor avatar in the related tutorials grid

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68696a9648fc83288bf7b642d3e64eea