### PR TITLE
Improve tutorial auth and progress handling

### DIFF
--- a/frontend/src/components/shared/CustomVideoPlayer.js
+++ b/frontend/src/components/shared/CustomVideoPlayer.js
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect } from "react";
 import { FaPlay, FaPause, FaStepBackward, FaStepForward, FaVolumeUp, FaVolumeMute, FaDownload, FaExpand } from "react-icons/fa";
 import { MdSpeed, MdReplay10, MdForward10 } from "react-icons/md";
 
-export default function CustomVideoPlayer({ videos = [], startTime = 0, onTimeUpdate, onEnded }) {
+export default function CustomVideoPlayer({ videos = [], startTime = 0, onTimeUpdate, onEnded, locked = false }) {
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -131,7 +131,7 @@ export default function CustomVideoPlayer({ videos = [], startTime = 0, onTimeUp
   };
 
   return (
-    <div 
+    <div
       ref={playerRef}
       className="relative bg-black rounded-lg border-2 border-yellow-500 overflow-hidden shadow-lg"
     >
@@ -144,6 +144,12 @@ export default function CustomVideoPlayer({ videos = [], startTime = 0, onTimeUp
         autoPlay={isPlaying}
         muted={isMuted}
       />
+
+      {locked && (
+        <div className="absolute inset-0 bg-black/70 flex items-center justify-center text-white text-center p-4">
+          <p>Login and enroll to watch full tutorial</p>
+        </div>
+      )}
 
       {/* Video Controls */}
       <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/90 to-transparent p-4">

--- a/frontend/src/components/tutorials/detail/ChapterList.js
+++ b/frontend/src/components/tutorials/detail/ChapterList.js
@@ -1,7 +1,12 @@
 // ✅ 1. ChapterList.js
-import { Play, CheckCircle } from "lucide-react";
-
-const ChapterList = ({ chapters = [], onSelect = () => {}, currentIndex = 0, completedChapters = [] }) => {
+import { Play, CheckCircle, Lock } from "lucide-react";
+const ChapterList = ({
+  chapters = [],
+  onSelect = () => {},
+  currentIndex = 0,
+  completedChapters = [],
+  isEnrolled = false,
+}) => {
   if (!chapters.length) return null;
 
   return (
@@ -11,19 +16,25 @@ const ChapterList = ({ chapters = [], onSelect = () => {}, currentIndex = 0, com
         {chapters.map((chapter, index) => {
           const isActive = index === currentIndex;
           const isCompleted = completedChapters.includes(index);
+          const locked = !isEnrolled && index > 0;
 
           return (
             <li
               key={index}
-              onClick={() => onSelect(index)}
-              className={`flex items-start gap-3 p-4 rounded-lg cursor-pointer transition border ${
-                isActive
-                  ? "bg-yellow-500 text-black border-yellow-400"
-                  : "bg-gray-800 hover:bg-gray-700 border-gray-700"
+              onClick={() => !locked && onSelect(index)}
+              title={locked ? "Enroll to unlock" : ""}
+              className={`flex items-start gap-3 p-4 rounded-lg transition border ${
+                locked
+                  ? "bg-gray-800 opacity-50 cursor-not-allowed border-gray-700"
+                  : isActive
+                  ? "bg-yellow-500 text-black border-yellow-400 cursor-pointer"
+                  : "bg-gray-800 hover:bg-gray-700 border-gray-700 cursor-pointer"
               }`}
             >
               <div className="mt-1">
-                {isCompleted ? (
+                {locked ? (
+                  <Lock className="text-gray-400 w-5 h-5" />
+                ) : isCompleted ? (
                   <CheckCircle className="text-green-400 w-5 h-5" />
                 ) : (
                   <Play className="text-yellow-400 w-5 h-5" />

--- a/frontend/src/components/tutorials/detail/EnrollBanner.js
+++ b/frontend/src/components/tutorials/detail/EnrollBanner.js
@@ -1,0 +1,13 @@
+const EnrollBanner = ({ onEnroll }) => (
+  <div className="bg-yellow-700/20 border border-yellow-600 text-yellow-300 p-4 rounded-lg flex items-center justify-between">
+    <p>Enroll to unlock all chapters and quizzes.</p>
+    <button
+      onClick={onEnroll}
+      className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded"
+    >
+      💳 Enroll Now
+    </button>
+  </div>
+);
+
+export default EnrollBanner;

--- a/frontend/src/components/tutorials/detail/LoginPrompt.js
+++ b/frontend/src/components/tutorials/detail/LoginPrompt.js
@@ -1,0 +1,18 @@
+import { useRouter } from "next/router";
+
+const LoginPrompt = () => {
+  const router = useRouter();
+  return (
+    <div className="bg-gray-900 text-white min-h-screen flex flex-col items-center justify-center gap-4">
+      <p className="text-xl">🚫 Please log in to view this tutorial.</p>
+      <button
+        onClick={() => router.push("/auth/login")}
+        className="bg-yellow-500 text-black px-6 py-2 rounded-full hover:bg-yellow-600"
+      >
+        Login Now
+      </button>
+    </div>
+  );
+};
+
+export default LoginPrompt;

--- a/frontend/src/hooks/useTutorialProgress.js
+++ b/frontend/src/hooks/useTutorialProgress.js
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+
+export default function useTutorialProgress(tutorialId) {
+  const [progress, setProgress] = useState({
+    completedChapters: [],
+    lastIndex: 0,
+    times: {},
+  });
+
+  useEffect(() => {
+    if (!tutorialId) return;
+    const stored = localStorage.getItem(`progress-tutorial-${tutorialId}`);
+    if (stored) {
+      try {
+        setProgress(JSON.parse(stored));
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [tutorialId]);
+
+  const persist = (data) => {
+    setProgress(data);
+    if (tutorialId) {
+      localStorage.setItem(
+        `progress-tutorial-${tutorialId}`,
+        JSON.stringify(data),
+      );
+    }
+  };
+
+  const saveTime = (chapterId, time) => {
+    persist({
+      ...progress,
+      times: { ...progress.times, [chapterId]: time },
+    });
+  };
+
+  const completeChapter = (index, chapterId) => {
+    const updated = Array.from(new Set([...progress.completedChapters, index]));
+    persist({ ...progress, completedChapters: updated, lastIndex: index });
+  };
+
+  const setIndex = (index) => {
+    persist({ ...progress, lastIndex: index });
+  };
+
+  const startTimeFor = (chapterId) => progress.times?.[chapterId] || 0;
+
+  return { progress, saveTime, completeChapter, setIndex, startTimeFor };
+}


### PR DESCRIPTION
## Summary
- add reusable `useTutorialProgress` hook
- lock chapters and video player when not enrolled
- show login prompt and enrollment banner
- restrict quiz and certificate access
- enhance share action with toast
- add dynamic metadata for tutorials

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68696fa6b33483289eb8a4f8679664de