### PR TITLE
Update tutorial detail with assignments

### DIFF
--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -73,3 +73,9 @@ export const postTutorialComment = async (tutorialId, payload) => {
   const { data } = await api.post(`/users/tutorials/comments/${tutorialId}`, payload);
   return data;
 };
+
+// Fetch assignments linked to a tutorial
+export const fetchTutorialAssignments = async (tutorialId) => {
+  const res = await api.get(`/users/tutorials/assignments/${tutorialId}`);
+  return res.data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- fetch tutorial-specific assignments
- show assignment link after passing quiz on tutorial detail page
- display "Free" or price in tutorial header

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68697c336a7483289bfe1697d8bed92e