### PR TITLE
Fix tutorial listing progress bar and thumbnail

### DIFF
--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -259,7 +259,7 @@ const TutorialsSection = () => {
                       )}
                     </div>
 
-                    {enrolled && progressPercent > 0 && (
+                    {enrolled && (
                       <div className="w-full bg-gray-700 h-2 rounded-full relative mt-2">
                         <div className="absolute right-1 -top-4 text-xs text-gray-400">
                           {Math.round(progressPercent)}%

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -3,9 +3,12 @@ import { API_BASE_URL } from "@/config/config";
 
 const formatTutorial = (tut) => ({
   ...tut,
-  thumbnail: tut.thumbnail_url
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.thumbnail_url}`
-    : null,
+  thumbnail:
+    tut.thumbnail_url || tut.cover_image
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${
+          tut.thumbnail_url || tut.cover_image
+        }`
+      : null,
   preview: tut.preview_video
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.preview_video}`
     : null,


### PR DESCRIPTION
## Summary
- support old `cover_image` field when formatting tutorials
- always show progress bar for enrolled tutorials on the tutorials list page

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68698c2f171c8328952d8b9f667b4063