### PR TITLE
Add tutorial analytics metrics

### DIFF
--- a/backend/src/migrations/20250714000000_create_tutorial_views_table.js
+++ b/backend/src/migrations/20250714000000_create_tutorial_views_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_views', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.uuid('viewer_id').references('id').inTable('users').onDelete('SET NULL');
+    table.string('ip_address');
+    table.string('user_agent');
+    table.timestamp('viewed_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_views');
+};

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -352,6 +352,16 @@ exports.getPublishedTutorials = catchAsync(async (req, res) => {
 exports.getPublicTutorialDetails = catchAsync(async (req, res) => {
   const tutorial = await service.getPublicTutorialDetails(req.params.id);
 
+  if (tutorial) {
+    await service.recordTutorialView(
+      req.params.id,
+      req.user?.id,
+      req.ip,
+      req.headers["user-agent"]
+    );
+    tutorial.views = await service.getTutorialViewCount(req.params.id);
+  }
+
   analyticsService.logEvent(req.user?.id || null, 'view_tutorial', {
     tutorialId: req.params.id,
   });


### PR DESCRIPTION
## Summary
- track tutorial views with new table
- compute views, enrollments, rating and comment counts for instructor dashboard
- record tutorial views when tutorials are viewed

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68699507f6e083289abfdaa728495d28