### PR TITLE
Add message notifications for new tutorials

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -155,6 +155,26 @@ exports.createTutorial = catchAsync(async (req, res) => {
     )
   );
 
+  // Send direct messages to admins about the new tutorial
+  if (admins.length) {
+    await Promise.all(
+      admins.map((admin) =>
+        messageService.createMessage({
+          sender_id: instructor_id,
+          receiver_id: admin.id,
+          message: `New tutorial \"${title}\" created by ${instructor.full_name} and awaiting your review`,
+        })
+      )
+    );
+  }
+
+  // Optional message to the instructor confirming creation
+  await messageService.createMessage({
+    sender_id: instructor_id,
+    receiver_id: instructor_id,
+    message: "Your tutorial was submitted and is pending review",
+  });
+
   sendSuccess(res, tutorial, "Tutorial with chapters created");
 });
 


### PR DESCRIPTION
## Summary
- send messages to admins and creator when a tutorial is created

## Testing
- `npm test --silent --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68699b37b2b08328bc9c13097571acfc