### PR TITLE
Add tutorial suspension feature

### DIFF
--- a/backend/src/migrations/20250715000000_add_suspended_status_to_tutorials.js
+++ b/backend/src/migrations/20250715000000_add_suspended_status_to_tutorials.js
@@ -1,0 +1,17 @@
+exports.up = async function(knex) {
+  await knex.raw(`
+    ALTER TABLE tutorials
+    DROP CONSTRAINT IF EXISTS tutorials_status_check,
+    ADD CONSTRAINT tutorials_status_check
+    CHECK (status IN ('draft','published','archived','suspended'))
+  `);
+};
+
+exports.down = async function(knex) {
+  await knex.raw(`
+    ALTER TABLE tutorials
+    DROP CONSTRAINT IF EXISTS tutorials_status_check,
+    ADD CONSTRAINT tutorials_status_check
+    CHECK (status IN ('draft','published','archived'))
+  `);
+};

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -55,6 +55,12 @@ router.patch(
   validate(tutorialValidator.reject),
   controller.rejectTutorial
 );
+router.patch(
+  "/admin/:id/suspend",
+  verifyToken,
+  isAdmin,
+  controller.suspendTutorial
+);
 
 /*
  * ✅ Tutorial chapters routes  

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -153,6 +153,10 @@ exports.togglePublishStatus = async (id) => {
   return db("tutorials").where({ id }).update({ status: newStatus });
 };
 
+exports.suspendTutorial = async (id) => {
+  return db("tutorials").where({ id }).update({ status: "suspended" });
+};
+
 exports.updateModeration = async (id, status, reason = null) => {
   return db("tutorials").where({ id }).update({
     moderation_status: status,

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -35,7 +35,12 @@ export const fetchAllTutorials = async () => {
     updatedAt: t.updated_at,
     instructor: t.instructor_name,
     category: t.category_name,
-    status: t.status === "published" ? "Published" : "Draft",
+    status:
+      t.status === "published"
+        ? "Published"
+        : t.status === "suspended"
+        ? "Suspended"
+        : "Draft",
     approvalStatus: t.moderation_status ?? "Pending",
     rating: t.rating,
     views: t.views,
@@ -65,6 +70,11 @@ export const approveTutorial = async (id) => {
 
 export const rejectTutorial = async (id, reason) => {
   const { data } = await api.patch(`/users/tutorials/admin/${id}/reject`, { reason });
+  return data?.data;
+};
+
+export const suspendTutorial = async (id) => {
+  const { data } = await api.patch(`/users/tutorials/admin/${id}/suspend`);
   return data?.data;
 };
 


### PR DESCRIPTION
## Summary
- allow `suspended` status for tutorials
- add backend support to suspend tutorials
- expose suspend endpoint
- update admin tutorial service and page
- show Suspend button and modal

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a4eb38948328820cdfefdfe92f96