### PR TITLE
Fix certificate migrations

### DIFF
--- a/backend/src/migrations/20250518060827_create_certificate_templates_table.js
+++ b/backend/src/migrations/20250518060827_create_certificate_templates_table.js
@@ -1,0 +1,20 @@
+// \ud83d\udc81 migrations/YYYYMMDD_create_certificate_templates_table.js
+
+exports.up = function(knex) {
+  return knex.schema.createTable('certificate_templates', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.string('name').notNullable();
+    table.string('type').defaultTo('Completion'); // Completion, Excellence, etc.
+    table.string('font_family').defaultTo('Georgia, serif');
+    table.string('title_font').defaultTo("'Great Vibes', cursive");
+    table.string('border_color').defaultTo('#FACC15');
+    table.string('logo');         // logo image URL
+    table.string('background');   // background image URL
+    table.boolean('show_qr').defaultTo(true);
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('certificate_templates');
+};

--- a/backend/src/migrations/20250518060936_create_certificates_table.js
+++ b/backend/src/migrations/20250518060936_create_certificates_table.js
@@ -1,0 +1,20 @@
+// \ud83d\udc81 migrations/YYYYMMDD_create_certificates_table.js
+
+exports.up = function(knex) {
+  return knex.schema.createTable('certificates', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('class_id').references('id').inTable('online_classes').onDelete('SET NULL');
+    table.uuid('tutorial_id').references('id').inTable('tutorials').onDelete('SET NULL');
+    table.uuid('template_id').references('id').inTable('certificate_templates').onDelete('SET NULL');
+    table.string('certificate_code').notNullable().unique();
+    table.enu('status', ['issued', 'revoked', 'pending']).defaultTo('issued');
+    table.timestamp('issued_at').defaultTo(knex.fn.now());
+    table.timestamp('revoked_at');
+    table.text('reason'); // optional reason for revocation
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('certificates');
+};


### PR DESCRIPTION
## Summary
- restore missing `certificate_templates` migration
- restore `certificates` migration and run it after templates are created

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa60e1b0c8328bd9391322b1d2c66