### PR TITLE
Fix migration exports

### DIFF
--- a/backend/src/migrations/20250518061700_create_certificates_table.js
+++ b/backend/src/migrations/20250518061700_create_certificates_table.js
@@ -13,10 +13,8 @@ exports.up = function (knex) {
     table.timestamp("issued_at").defaultTo(knex.fn.now());
     table.timestamps(true, true);
   });
-  return true;
 };
 
-exports.down = async function (knex) {
-  await knex.schema.dropTableIfExists("certificates");
-  return true;
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists("certificates");
 };

--- a/backend/src/migrations/20250518061706_create_certificate_actions_log_table.js
+++ b/backend/src/migrations/20250518061706_create_certificate_actions_log_table.js
@@ -11,7 +11,6 @@ exports.up = function (knex) {
     table.text('notes');
     table.timestamp('performed_at').defaultTo(knex.fn.now());
   });
-  return true;
 };
 
 


### PR DESCRIPTION
## Summary
- simplify migration functions for certificates table
- simplify certificate actions log migration

## Testing
- `yes | npx knex migrate:latest --knexfile backend/knexfile.js` *(fails: No local knex install found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad0a548488328afc47bc0845c4330