### PR TITLE
Update database name to eduSkillbridge

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,6 @@
 // 📁 .env.example
 PORT=5000
-DATABASE_URL=postgres://user:password@localhost:5432/skillbridge_db
+DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge
 JWT_SECRET=your_jwt_secret
 CLOUDINARY_API_KEY=your_key
 SMTP_HOST=smtp.mailtrap.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "5000:5000"
     environment:
-      - DATABASE_URL=postgres://postgres:your_db_password@db:5432/skillbridge_db
+      - DATABASE_URL=postgres://postgres:your_db_password@db:5432/eduSkillbridge
     depends_on:
       - db
 
@@ -21,7 +21,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: your_db_password
-      POSTGRES_DB: skillbridge_db
+      POSTGRES_DB: eduSkillbridge
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
## Summary
- change default DB name to `eduSkillbridge` in docker-compose
- update `.env.example` with new connection string

## Testing
- `npm install` in `backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ada2298ec83289dc1ea25373cce3f