### PR TITLE
Fix categories migration

### DIFF
--- a/backend/src/migrations/20250518054957_create_categories_table.js
+++ b/backend/src/migrations/20250518054957_create_categories_table.js
@@ -2,10 +2,10 @@
 
 exports.up = function(knex) {
   return knex.schema.createTable('categories', function(table) {
-    table.increments('id').primary();
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
     table.string('name').notNullable().unique();
     table.text('description');
-    table.integer('parent_id').references('id').inTable('categories').onDelete('SET NULL');
+    table.uuid('parent_id').references('id').inTable('categories').onDelete('SET NULL');
     table.boolean('active').defaultTo(true);
     table.timestamp('created_at').defaultTo(knex.fn.now());
   });

--- a/backend/src/migrations/20250518055209_create_tutorials_table.js
+++ b/backend/src/migrations/20250518055209_create_tutorials_table.js
@@ -13,7 +13,7 @@ exports.up = function(knex) {
     table.enu('status', ['draft', 'published', 'archived']).defaultTo('draft');
     table.boolean('is_paid').defaultTo(false);
     table.decimal('price', 10, 2);
-    table.integer('category_id').references('id').inTable('categories').onDelete('SET NULL');
+    table.uuid('category_id').references('id').inTable('categories').onDelete('SET NULL');
     table.timestamp('created_at').defaultTo(knex.fn.now());
     table.timestamp('updated_at').defaultTo(knex.fn.now());
   });

--- a/backend/src/migrations/20250601131600_update_tutorial_category_id_to_uuid.js
+++ b/backend/src/migrations/20250601131600_update_tutorial_category_id_to_uuid.js
@@ -1,4 +1,10 @@
 exports.up = async function (knex) {
+  const info = await knex('tutorials').columnInfo('category_id');
+  if (info && info.type === 'uuid') {
+    // already migrated
+    return;
+  }
+
   // add temporary uuid column if it doesn't exist
   const hasTmp = await knex.schema.hasColumn('tutorials', 'category_id_tmp');
   if (!hasTmp) {
@@ -46,6 +52,11 @@ exports.up = async function (knex) {
 };
 
 exports.down = async function (knex) {
+  const info = await knex('tutorials').columnInfo('category_id');
+  if (info && info.type === 'integer') {
+    // already reverted
+    return;
+  }
   const hasTmp = await knex.schema.hasColumn('tutorials', 'category_id_tmp');
   if (!hasTmp) {
     await knex.schema.table('tutorials', (table) => {

--- a/backend/src/migrations/20250612154550_create_categories_table.js
+++ b/backend/src/migrations/20250612154550_create_categories_table.js
@@ -1,4 +1,6 @@
-exports.up = function(knex) {
+exports.up = async function(knex) {
+  const exists = await knex.schema.hasTable('categories');
+  if (exists) return;
   return knex.schema.createTable("categories", function (table) {
     table.uuid("id").primary();
     table.string("name").notNullable();
@@ -10,6 +12,8 @@ exports.up = function(knex) {
   });
 };
 
-exports.down = function(knex) {
+exports.down = async function(knex) {
+  const exists = await knex.schema.hasTable('categories');
+  if (!exists) return;
   return knex.schema.dropTable("categories");
 };


### PR DESCRIPTION
## Summary
- switch categories `id` to uuid
- switch tutorials `category_id` to uuid
- skip tutorial category migration when already updated
- make second categories migration idempotent

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_686ae59265ec8328af79752cb126ee7e