### PR TITLE
Fix private network access login issue

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -135,6 +135,11 @@ app.use(
     credentials: true,
   }),
 );
+// Allow Chrome private network access when frontend is hosted elsewhere
+app.use((req, res, next) => {
+  res.setHeader("Access-Control-Allow-Private-Network", "true");
+  next();
+});
 
 // 📋 HTTP request logger
 app.use(morgan("dev"));


### PR DESCRIPTION
## Summary
- add `Access-Control-Allow-Private-Network` header in backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b8b7ef4c8832886d20bb5798c307d