### PR TITLE
Improve deployment docs and warn about missing API URL

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,3 +37,13 @@ If your uploads are served from the backend domain you should also update the
 `remotePatterns` in `frontend/next.config.mjs` to include your production domain
 or IP so that Next.js can display those images. For example add entries for
 `https://eduskillbridge.net` and `http://147.93.121.45`.
+
+## Troubleshooting
+
+### Login page requests `http://localhost:5000`
+
+If you deploy the frontend and see network errors pointing to
+`http://localhost:5000/api` it means the build did not have
+`NEXT_PUBLIC_API_BASE_URL` set.  Update `frontend/.env.local` with the correct
+backend URL and rebuild/restart the frontend container so the new value is
+picked up.

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -7,9 +7,18 @@
 
 import axios from "axios";
 
+// Fallback to localhost when the env var is missing
+const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+
+// Warn developers if the default localhost URL is used in production
+if (typeof window !== "undefined" && !process.env.NEXT_PUBLIC_API_BASE_URL && window.location.hostname !== "localhost") {
+  console.warn(
+    "NEXT_PUBLIC_API_BASE_URL is not set. Using http://localhost:5000/api which will fail in production. Update frontend/.env.local"
+  );
+}
+
 const api = axios.create({
-  // Default to port 5000 to mirror backend configuration
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api",
+  baseURL,
   withCredentials: true, // ✅ KEEP this to send cookies with requests
 });
 


### PR DESCRIPTION
## Summary
- document common localhost URL issue after deployment
- warn in frontend console if NEXT_PUBLIC_API_BASE_URL is missing

## Testing
- `npm test` in `backend`
- `npm run lint` in `frontend` *(fails: 52 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b8cf88d148328b4e9af4121566e8d