### PR TITLE
Fix CORS private network header for login

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -128,18 +128,19 @@ app.use(
 })();
 app.use(passport.initialize());
 
-// 🌐 Allow frontend to communicate with backend (CORS)
-app.use(
-  cors({
-    origin: ALLOWED_ORIGINS,
-    credentials: true,
-  }),
-);
 // Allow Chrome private network access when frontend is hosted elsewhere
 app.use((req, res, next) => {
   res.setHeader("Access-Control-Allow-Private-Network", "true");
   next();
 });
+
+// 🌐 Allow frontend to communicate with backend (CORS)
+app.use(
+  cors({
+    origin: ALLOWED_ORIGINS,
+    credentials: true,
+  })
+);
 
 // 📋 HTTP request logger
 app.use(morgan("dev"));


### PR DESCRIPTION
## Summary
- ensure `Access-Control-Allow-Private-Network` header is included in CORS preflight responses

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b978602ac8328a8b8ff8cd34c2bf6