### PR TITLE
Add logging for auth login requests

### DIFF
--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -80,6 +80,7 @@ export default function Login() {
   // ─────────────────────────────
   const onSubmit = async (data) => {
   try {
+    console.log("➡️ login onSubmit", data.email);
     const loggedInUser = await login(data);
     toast.success("Login successful");
     fetchNotifications();
@@ -100,6 +101,7 @@ export default function Login() {
       router.push(targetPath);
     }, 1200);
   } catch (err) {
+    console.error("❌ login onSubmit error", err);
     const msg =
       err?.response?.data?.message ||
       err?.response?.data?.error ||

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -11,8 +11,14 @@ import api from "@/services/api/api";
  * @returns {Promise<{ accessToken: string, user: object }>}
  */
 export const loginUser = async ({ email, password }) => {
-  const res = await api.post("/auth/login", { email, password });
-  return res.data;
+  try {
+    console.log("🔐 loginUser requesting", api.defaults.baseURL + "/auth/login");
+    const res = await api.post("/auth/login", { email, password });
+    return res.data;
+  } catch (err) {
+    console.error("❌ loginUser error", err?.response || err);
+    throw err;
+  }
 };
 
 /**

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -18,6 +18,7 @@ const useAuthStore = create(
       isAuthenticated: () => !!get().accessToken && !!get().user,
 
       login: async (credentials) => {
+        console.log("🔑 authStore.login", credentials.email);
         const { accessToken, user } = await authService.loginUser(credentials);
         if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
           user.avatar_url = null;


### PR DESCRIPTION
## Summary
- log base URL and errors for `loginUser` service call
- log login input email in `authStore` and login page
- log caught errors on login page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bae16fa388328b99e13eef06a2726