### PR TITLE
Fix default API port

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -308,7 +308,7 @@ io.on("connection", (socket) => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Default to port 5000 to match example env and docker-compose
-const PORT = process.env.PORT || 5002;
+const PORT = process.env.PORT || 5000;
 server.listen(PORT, () => {
   console.log(`✅ Server running on http://localhost:${PORT}`);
 });

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -17,7 +17,7 @@ const nextConfig = {
       {
         protocol: 'http',
         hostname: 'localhost',
-        port: '5002',
+        port: '5000',
         pathname: '/api/uploads/**', // Development server
       },
       {


### PR DESCRIPTION
## Summary
- correct default server port to 5000
- update next.js config to match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb6004d748328af2a1d39e7638196