### PR TITLE
Fix port configuration to match docs

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -309,7 +309,7 @@ io.on("connection", (socket) => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Default to port 5000 to match example env and docker-compose
-const PORT = process.env.PORT || 5002;
+const PORT = process.env.PORT || 5000;
 server.listen(PORT, () => {
   console.log(`✅ Server running on http://localhost:${PORT}`);
 });

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -5,19 +5,19 @@ const nextConfig = {
       {
         protocol: 'http',
         hostname: 'localhost',
-        port: '5002',
+        port: '5000',
         pathname: '/uploads/**', // legacy path
       },
       {
         protocol: 'http',
         hostname: 'localhost',
-        port: '5002',
+        port: '5000',
         pathname: '/api/uploads/**', // Allow images served via API
       },
       {
         protocol: 'http',
         hostname: 'localhost',
-        port: '5002',
+        port: '5000',
         pathname: '/api/uploads/**', // Development server
       },
       {


### PR DESCRIPTION
## Summary
- align backend default PORT with docker-compose
- update Next.js config for local image uploads

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_686bc0f324b08328bc8c082bfb930239