### PR TITLE
Use eduskillbridge domain for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
    ```bash
    cp backend/.env.example backend/.env
    # edit backend/.env and set your secrets
-   # FRONTEND_URL defaults to http://localhost:3001 for Docker Compose
-   # change it if your frontend uses a different port
+   # FRONTEND_URL defaults to https://eduskillbridge.net
+   # change it if your frontend uses a different domain
    ```
 
 2. Initialize the database (run migrations and seeds):
@@ -26,7 +26,7 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
    docker-compose up --build
    ```
 
-4. Visit `http://localhost:3001` to access the frontend. The API is available at `http://localhost:5000`.
+4. Visit `https://eduskillbridge.net` to access the frontend. The API is available at `https://eduskillbridge.net/api`.
 
 For detailed instructions see [docs/installation.md](docs/installation.md).
 See [docs/deployment.md](docs/deployment.md) for tips on configuring environment variables when hosting the app.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,9 +5,9 @@ JWT_SECRET=your_jwt_secret
 CLOUDINARY_API_KEY=your_key
 SMTP_HOST=smtp.mailtrap.io
 # Allow multiple origins separated by commas
-# Default frontend port in docker-compose
-FRONTEND_URL=http://localhost:3001
-# Example for production with multiple domains
+# Default frontend URL
+FRONTEND_URL=https://eduskillbridge.net
+# Example for multiple domains
 # FRONTEND_URL=https://eduskillbridge.net,http://147.93.121.45
 SESSION_SECRET=skillbridge_secret
 GOOGLE_CLIENT_ID=your_google_client_id

--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -71,8 +71,8 @@ exports.createGroup = catchAsync(async (req, res) => {
           : role === "student"
             ? "student"
             : "admin";
-      // Default to port 3001 so invite links work in docker-compose dev setup
-      const host = process.env.FRONTEND_URL || "http://localhost:3001";
+      // Use configured frontend URL or default to production domain
+      const host = process.env.FRONTEND_URL || "https://eduskillbridge.net";
       const groupLink = `${host}/dashboard/${rolePath}/groups/${group.id}`;
 
       const inviteLinkMsg = `${inviteMsg} ${groupLink}`;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,8 +12,8 @@ const session = require("express-session");
 const { passport, initStrategies } = require("./config/passport");
 require("dotenv").config(); // ✅ Load environment variables from .env file
 // Allow overriding the allowed origin via FRONTEND_URL env var.
-// Default to port 3001 when FRONTEND_URL is not set to match docker-compose
-const FRONTEND_URL = process.env.FRONTEND_URL || "http://147.93.121.45:3001";
+// Default to production domain when FRONTEND_URL is not set
+const FRONTEND_URL = process.env.FRONTEND_URL || "https://eduskillbridge.net";
 // Support multiple comma-separated origins (e.g. "https://example.com,http://1.2.3.4")
 const ALLOWED_ORIGINS = FRONTEND_URL.split(',').map((o) => o.trim());
 const db = require("./config/database");
@@ -311,5 +311,5 @@ io.on("connection", (socket) => {
 // Default to port 5000 to match example env and docker-compose
 const PORT = process.env.PORT || 5000;
 server.listen(PORT, () => {
-  console.log(`✅ Server running on http://147.93.121.45:${PORT}`);
+  console.log(`✅ Server running on port ${PORT}`);
 });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,7 @@ Follow these steps to run SkillBridge on a server or production host.
      specify multiple domains separated by commas. For example:
      
      ```bash
-     FRONTEND_URL=https://eduskillbridge.net,http://147.93.121.45
+    FRONTEND_URL=https://eduskillbridge.net
      ```
      
     This value is used for CORS and socket.io connections. If it still points to
@@ -25,7 +25,7 @@ Follow these steps to run SkillBridge on a server or production host.
    NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
    ```
    
-   Without this variable the frontend defaults to `http://localhost:5000` which
+   Without this variable the frontend defaults to `https://eduskillbridge.net` which
    will fail once the app is deployed.
 
 After updating these files, rebuild the Docker images or restart the server so
@@ -33,10 +33,10 @@ that the environment changes take effect.
 
 ## Next.js image domains
 
-If your uploads are served from the backend domain you should also update the
+If your uploads are served from the backend domain you should update the
 `remotePatterns` in `frontend/next.config.mjs` to include your production domain
-or IP so that Next.js can display those images. For example add entries for
-`https://eduskillbridge.net` and `http://147.93.121.45`.
+so Next.js can display those images. For example add an entry for
+`https://eduskillbridge.net`.
 
 ## Troubleshooting
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,8 +22,8 @@ Follow these steps to run SkillBridge on your local machine.
    ```bash
    cp backend/.env.example backend/.env
    # edit backend/.env and set your secrets
-   # FRONTEND_URL defaults to http://localhost:3001
-   # change it if your frontend runs on another port
+   # FRONTEND_URL defaults to https://eduskillbridge.net
+   # change it if your frontend uses a different domain
    ```
 
 3. (Optional) Install dependencies for manual development:
@@ -47,8 +47,8 @@ Follow these steps to run SkillBridge on your local machine.
    docker-compose up --build
    ```
 
-   - Backend API: `http://localhost:5000`
-   - Frontend: `http://localhost:3001`
+   - Backend API: `https://eduskillbridge.net/api`
+   - Frontend: `https://eduskillbridge.net`
    - PostgreSQL: `localhost:5432`
    - pgAdmin: `http://localhost:5050`
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,4 +1,2 @@
 # Example frontend environment file
-NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api
-# For production:
-# NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,7 +14,7 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [https://eduskillbridge.net](https://eduskillbridge.net) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -3,24 +3,6 @@ const nextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '5000',
-        pathname: '/uploads/**', // legacy path
-      },
-      {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '5000',
-        pathname: '/api/uploads/**', // Allow images served via API
-      },
-      {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '5000',
-        pathname: '/api/uploads/**', // Development server
-      },
-      {
         protocol: 'https',
         hostname: 'eduskillbridge.net',
         pathname: '/api/uploads/**', // Production domain

--- a/frontend/src/components/website/sections/InstructorBooking.js
+++ b/frontend/src/components/website/sections/InstructorBooking.js
@@ -17,7 +17,7 @@ import {
 } from "react-icons/fa6";
 import { FaSearch } from "react-icons/fa";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "https://eduskillbridge.net/api";
 
 const defaultCategories = ["All"];
 const sortOptions = ["Highest Rated", "Most Experienced"];

--- a/frontend/src/config/config.js
+++ b/frontend/src/config/config.js
@@ -1,3 +1,4 @@
 // 📁 config.js
 // Default API URL should align with backend PORT (5000)
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://147.93.121.45:5002';
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || 'https://eduskillbridge.net/api';

--- a/frontend/src/hooks/useVideoCall.js
+++ b/frontend/src/hooks/useVideoCall.js
@@ -16,7 +16,7 @@ export default function useVideoCall(roomId, userName = "User", role = "particip
 
   useEffect(() => {
     socketRef.current = io(
-      process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000",
+      process.env.NEXT_PUBLIC_API_URL || "https://eduskillbridge.net",
     );
     const initMedia = async () => {
       const mediaStream = await navigator.mediaDevices.getUserMedia({

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -74,7 +74,7 @@ function MyApp({ Component, pageProps, router }) {
           {settings.favicon_url && (
             <link
               rel="icon"
-              href={`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://147.93.121.45:5002'}${settings.favicon_url}`}
+              href={`${process.env.NEXT_PUBLIC_API_BASE_URL || 'https://eduskillbridge.net/api'}${settings.favicon_url}`}
             />
           )}
         </Head>

--- a/frontend/src/pages/instructors/[id].js
+++ b/frontend/src/pages/instructors/[id].js
@@ -24,7 +24,7 @@ export default function InstructorProfilePage() {
   const { user } = useAuthStore();
 
   const API_BASE_URL =
-    process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+    process.env.NEXT_PUBLIC_API_BASE_URL || "https://eduskillbridge.net/api";
 
   const openBooking = () => {
     if (!user || user.role?.toLowerCase() !== "student") {

--- a/frontend/src/pages/students/[id].js
+++ b/frontend/src/pages/students/[id].js
@@ -16,7 +16,7 @@ export default function PublicStudentProfile() {
   const { user } = useAuthStore();
 
   const API_BASE_URL =
-    process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+    process.env.NEXT_PUBLIC_API_BASE_URL || "https://eduskillbridge.net/api";
 
   useEffect(() => {
     if (!id) return;

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -7,13 +7,13 @@
 
 import axios from "axios";
 
-// Fallback to localhost when the env var is missing
-const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://147.93.121.45:5002/api";
+// Fallback to production domain when the env var is missing
+const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || "https://eduskillbridge.net/api";
 
-// Warn developers if the default localhost URL is used in production
-if (typeof window !== "undefined" && !process.env.NEXT_PUBLIC_API_BASE_URL && window.location.hostname !== "147.93.121.45") {
+// Warn developers if the default domain URL is used in production
+if (typeof window !== "undefined" && !process.env.NEXT_PUBLIC_API_BASE_URL && window.location.hostname !== "eduskillbridge.net") {
   console.warn(
-    "NEXT_PUBLIC_API_BASE_URL is not set. Using http://147.93.121.45:5002/api which will fail in production. Update frontend/.env.local"
+    "NEXT_PUBLIC_API_BASE_URL is not set. Using https://eduskillbridge.net/api which will fail in production if this domain is unavailable. Update frontend/.env.local"
   );
 }
 

--- a/frontend/src/services/socketService.js
+++ b/frontend/src/services/socketService.js
@@ -1,6 +1,6 @@
 import { io } from "socket.io-client";
 
-const SOCKET_SERVER_URL = "http://localhost:4000"; // Change this when backend is ready
+const SOCKET_SERVER_URL = "https://eduskillbridge.net"; // Production socket URL
 
 const socket = io(SOCKET_SERVER_URL, {
   transports: ["websocket"],

--- a/frontend/src/shared/components/auth/SocialLogin.js
+++ b/frontend/src/shared/components/auth/SocialLogin.js
@@ -24,7 +24,7 @@ export default function SocialLogin() {
         {activeProviders.map(([key, p]) => {
           const Icon = iconMap[p.icon] || iconMap[key] || FaGoogle;
           const handleClick = () => {
-            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000'}/api/auth/${key}`;
+            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'https://eduskillbridge.net'}/api/auth/${key}`;
           };
           return (
             <motion.button

--- a/frontend/src/shared/components/auth/SocialRegister.js
+++ b/frontend/src/shared/components/auth/SocialRegister.js
@@ -25,7 +25,7 @@ export default function SocialRegister() {
         {activeProviders.map(([key, p]) => {
           const Icon = iconMap[p.icon] || iconMap[key] || FaGoogle;
           const handleClick = () => {
-            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000'}/api/auth/${key}`;
+            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'https://eduskillbridge.net'}/api/auth/${key}`;
           };
           return (
             <motion.button


### PR DESCRIPTION
## Summary
- use eduskillbridge.net domain as default in backend and frontend
- show favicon link from production domain
- update deployment docs with new URL guidance

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc6d226348328a9d8ea3e52914f92