### PR TITLE
Add notifications migration

### DIFF
--- a/backend/src/migrations/20250707063300_create_notifications_table.js
+++ b/backend/src/migrations/20250707063300_create_notifications_table.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('notifications', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('user_id').references('id').inTable('users').onDelete('CASCADE');
+    table.string('type').notNullable();
+    table.text('message').notNullable();
+    table.boolean('read').defaultTo(false);
+    table.timestamp('read_at');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('notifications');
+};


### PR DESCRIPTION
## Summary
- add missing knex migration for notifications table

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_686bcfaa80a08328a43ece9a0017c564