### PR TITLE
Fix login API base URL defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
    ```bash
    cp backend/.env.example backend/.env
    # edit backend/.env and set your secrets
-   # FRONTEND_URL defaults to https://eduskillbridge.net
-   # change it if your frontend uses a different domain
+   # FRONTEND_URL defaults to http://localhost:3000
+   # set it to your frontend's domain if different
    ```
 
 2. Initialize the database (run migrations and seeds):
@@ -26,7 +26,7 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
    docker-compose up --build
    ```
 
-4. Visit `https://eduskillbridge.net` to access the frontend. The API is available at `https://eduskillbridge.net/api`.
+4. Visit `http://localhost:3000` to access the frontend when running locally. The API will be available at `http://localhost:5000/api`.
 
 For detailed instructions see [docs/installation.md](docs/installation.md).
 See [docs/deployment.md](docs/deployment.md) for tips on configuring environment variables when hosting the app.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,7 +6,8 @@ CLOUDINARY_API_KEY=your_key
 SMTP_HOST=smtp.mailtrap.io
 # Allow multiple origins separated by commas
 # Default frontend URL
-FRONTEND_URL=https://eduskillbridge.net
+# Default frontend URL
+FRONTEND_URL=http://localhost:3000
 # Example for multiple domains
 # FRONTEND_URL=https://eduskillbridge.net,http://147.93.121.45
 SESSION_SECRET=skillbridge_secret

--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -71,8 +71,8 @@ exports.createGroup = catchAsync(async (req, res) => {
           : role === "student"
             ? "student"
             : "admin";
-      // Use configured frontend URL or default to production domain
-      const host = process.env.FRONTEND_URL || "https://eduskillbridge.net";
+      // Use configured frontend URL or default to localhost for dev
+      const host = process.env.FRONTEND_URL || "http://localhost:3000";
       const groupLink = `${host}/dashboard/${rolePath}/groups/${group.id}`;
 
       const inviteLinkMsg = `${inviteMsg} ${groupLink}`;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,8 +12,8 @@ const session = require("express-session");
 const { passport, initStrategies } = require("./config/passport");
 require("dotenv").config(); // ✅ Load environment variables from .env file
 // Allow overriding the allowed origin via FRONTEND_URL env var.
-// Default to production domain when FRONTEND_URL is not set
-const FRONTEND_URL = process.env.FRONTEND_URL || "https://eduskillbridge.net";
+// Default to localhost when FRONTEND_URL is not set
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
 // Support multiple comma-separated origins (e.g. "https://example.com,http://1.2.3.4")
 const ALLOWED_ORIGINS = FRONTEND_URL.split(',').map((o) => o.trim());
 const db = require("./config/database");

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,7 @@ Follow these steps to run SkillBridge on a server or production host.
      specify multiple domains separated by commas. For example:
      
      ```bash
-    FRONTEND_URL=https://eduskillbridge.net
+    FRONTEND_URL=https://yourdomain.com
      ```
      
     This value is used for CORS and socket.io connections. If it still points to
@@ -22,11 +22,11 @@ Follow these steps to run SkillBridge on a server or production host.
    For example:
    
    ```bash
-   NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+   NEXT_PUBLIC_API_BASE_URL=https://yourdomain.com/api
    ```
    
-   Without this variable the frontend defaults to `https://eduskillbridge.net` which
-   will fail once the app is deployed.
+   Without this variable the frontend defaults to `/api` which may point to the
+   wrong server when deployed.
 
 After updating these files, rebuild the Docker images or restart the server so
 that the environment changes take effect.
@@ -36,7 +36,7 @@ that the environment changes take effect.
 If your uploads are served from the backend domain you should update the
 `remotePatterns` in `frontend/next.config.mjs` to include your production domain
 so Next.js can display those images. For example add an entry for
-`https://eduskillbridge.net`.
+`https://yourdomain.com`.
 
 ## Troubleshooting
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ Follow these steps to run SkillBridge on your local machine.
    ```bash
    cp backend/.env.example backend/.env
    # edit backend/.env and set your secrets
-   # FRONTEND_URL defaults to https://eduskillbridge.net
+   # FRONTEND_URL defaults to http://localhost:3000
    # change it if your frontend uses a different domain
    ```
 
@@ -47,8 +47,8 @@ Follow these steps to run SkillBridge on your local machine.
    docker-compose up --build
    ```
 
-   - Backend API: `https://eduskillbridge.net/api`
-   - Frontend: `https://eduskillbridge.net`
+   - Backend API: `http://localhost:5000/api`
+   - Frontend: `http://localhost:3000`
    - PostgreSQL: `localhost:5432`
    - pgAdmin: `http://localhost:5050`
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,2 @@
 # Example frontend environment file
-NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+NEXT_PUBLIC_API_BASE_URL=/api

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,7 +14,7 @@ pnpm dev
 bun dev
 ```
 
-Open [https://eduskillbridge.net](https://eduskillbridge.net) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result when running locally.
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -4,12 +4,12 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'eduskillbridge.net',
+        hostname: 'yourdomain.com',
         pathname: '/api/uploads/**', // Production domain
       },
       {
         protocol: 'https',
-        hostname: 'eduskillbridge.net',
+        hostname: 'yourdomain.com',
         pathname: '/uploads/**',
       },
       {

--- a/frontend/src/components/website/sections/InstructorBooking.js
+++ b/frontend/src/components/website/sections/InstructorBooking.js
@@ -17,7 +17,8 @@ import {
 } from "react-icons/fa6";
 import { FaSearch } from "react-icons/fa";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "https://eduskillbridge.net/api";
+// Use a relative API base URL by default so deployments work on any domain
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
 const defaultCategories = ["All"];
 const sortOptions = ["Highest Rated", "Most Experienced"];

--- a/frontend/src/config/config.js
+++ b/frontend/src/config/config.js
@@ -1,4 +1,5 @@
 // 📁 config.js
 // Default API URL should align with backend PORT (5000)
+// Default to a relative path so the frontend works on any domain by default
 export const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL || 'https://eduskillbridge.net/api';
+  process.env.NEXT_PUBLIC_API_BASE_URL || '/api';

--- a/frontend/src/hooks/useVideoCall.js
+++ b/frontend/src/hooks/useVideoCall.js
@@ -16,7 +16,8 @@ export default function useVideoCall(roomId, userName = "User", role = "particip
 
   useEffect(() => {
     socketRef.current = io(
-      process.env.NEXT_PUBLIC_API_URL || "https://eduskillbridge.net",
+      // Use current origin if NEXT_PUBLIC_API_URL isn't defined
+      process.env.NEXT_PUBLIC_API_URL || "",
     );
     const initMedia = async () => {
       const mediaStream = await navigator.mediaDevices.getUserMedia({

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -74,7 +74,7 @@ function MyApp({ Component, pageProps, router }) {
           {settings.favicon_url && (
             <link
               rel="icon"
-              href={`${process.env.NEXT_PUBLIC_API_BASE_URL || 'https://eduskillbridge.net/api'}${settings.favicon_url}`}
+              href={`${process.env.NEXT_PUBLIC_API_BASE_URL || '/api'}${settings.favicon_url}`}
             />
           )}
         </Head>

--- a/frontend/src/pages/instructors/[id].js
+++ b/frontend/src/pages/instructors/[id].js
@@ -23,8 +23,8 @@ export default function InstructorProfilePage() {
   const [showBooking, setShowBooking] = useState(false);
   const { user } = useAuthStore();
 
-  const API_BASE_URL =
-    process.env.NEXT_PUBLIC_API_BASE_URL || "https://eduskillbridge.net/api";
+  // Default to a relative path so the page works on any domain
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
   const openBooking = () => {
     if (!user || user.role?.toLowerCase() !== "student") {

--- a/frontend/src/pages/students/[id].js
+++ b/frontend/src/pages/students/[id].js
@@ -15,8 +15,8 @@ export default function PublicStudentProfile() {
   const [loading, setLoading] = useState(true);
   const { user } = useAuthStore();
 
-  const API_BASE_URL =
-    process.env.NEXT_PUBLIC_API_BASE_URL || "https://eduskillbridge.net/api";
+  // Default to a relative path so the page works on any domain
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
   useEffect(() => {
     if (!id) return;

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -7,13 +7,20 @@
 
 import axios from "axios";
 
-// Fallback to production domain when the env var is missing
-const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || "https://eduskillbridge.net/api";
+// If NEXT_PUBLIC_API_BASE_URL isn't provided, default to a relative path so
+// the frontend works regardless of the domain it's served from. This prevents
+// hard coded production URLs from causing CORS or redirect issues in other
+// environments.
+const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
 // Warn developers if the default domain URL is used in production
-if (typeof window !== "undefined" && !process.env.NEXT_PUBLIC_API_BASE_URL && window.location.hostname !== "eduskillbridge.net") {
+if (
+  typeof window !== "undefined" &&
+  !process.env.NEXT_PUBLIC_API_BASE_URL &&
+  window.location.hostname !== "localhost"
+) {
   console.warn(
-    "NEXT_PUBLIC_API_BASE_URL is not set. Using https://eduskillbridge.net/api which will fail in production if this domain is unavailable. Update frontend/.env.local"
+    "NEXT_PUBLIC_API_BASE_URL is not set. Using '/api'. Set this variable in frontend/.env.local to avoid unexpected network errors."
   );
 }
 

--- a/frontend/src/services/socketService.js
+++ b/frontend/src/services/socketService.js
@@ -1,6 +1,9 @@
 import { io } from "socket.io-client";
 
-const SOCKET_SERVER_URL = "https://eduskillbridge.net"; // Production socket URL
+// Allow overriding the socket server URL via env var, otherwise connect to the
+// same host that served the frontend.
+const SOCKET_SERVER_URL =
+  process.env.NEXT_PUBLIC_SOCKET_URL || "";
 
 const socket = io(SOCKET_SERVER_URL, {
   transports: ["websocket"],

--- a/frontend/src/shared/components/auth/SocialLogin.js
+++ b/frontend/src/shared/components/auth/SocialLogin.js
@@ -24,7 +24,9 @@ export default function SocialLogin() {
         {activeProviders.map(([key, p]) => {
           const Icon = iconMap[p.icon] || iconMap[key] || FaGoogle;
           const handleClick = () => {
-            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'https://eduskillbridge.net'}/api/auth/${key}`;
+            // Default to a relative path when NEXT_PUBLIC_API_BASE_URL isn't set
+            const base = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+            window.location.href = `${base}/api/auth/${key}`;
           };
           return (
             <motion.button

--- a/frontend/src/shared/components/auth/SocialRegister.js
+++ b/frontend/src/shared/components/auth/SocialRegister.js
@@ -25,7 +25,9 @@ export default function SocialRegister() {
         {activeProviders.map(([key, p]) => {
           const Icon = iconMap[p.icon] || iconMap[key] || FaGoogle;
           const handleClick = () => {
-            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'https://eduskillbridge.net'}/api/auth/${key}`;
+            // Default to relative path when API base URL isn't specified
+            const base = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+            window.location.href = `${base}/api/auth/${key}`;
           };
           return (
             <motion.button


### PR DESCRIPTION
## Summary
- remove hard-coded eduskillbridge.net URLs
- default API/SOCKET URLs to relative paths
- update docs with localhost examples

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf38fece88328835c39c3ae1dd812