### PR TITLE
Fix social links check in FinalReview

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/steps/FinalReview.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/FinalReview.js
@@ -98,8 +98,8 @@ const FinalReview = ({ formData = {}, prevStep = () => {} }) => {
       {/* ✅ Social Links */}
       <div className="mb-4">
         <h3 className="text-lg font-semibold">🔗 Social Links</h3>
-        <p><strong>LinkedIn:</strong> {formData.socialLinks.linkedin || "Not Provided"}</p>
-        <p><strong>Portfolio:</strong> {formData.socialLinks.portfolio || "Not Provided"}</p>
+        <p><strong>LinkedIn:</strong> {formData.socialLinks?.linkedin || "Not Provided"}</p>
+        <p><strong>Portfolio:</strong> {formData.socialLinks?.portfolio || "Not Provided"}</p>
       </div>
 
       {/* ✅ Demo Video Upload (For Instructors Only) */}

--- a/frontend/src/pages/profile/steps/FinalReview.js
+++ b/frontend/src/pages/profile/steps/FinalReview.js
@@ -98,8 +98,8 @@ const FinalReview = ({ formData, prevStep }) => {
       {/* ✅ Social Links */}
       <div className="mb-4">
         <h3 className="text-lg font-semibold">🔗 Social Links</h3>
-        <p><strong>LinkedIn:</strong> {formData.socialLinks.linkedin || "Not Provided"}</p>
-        <p><strong>Portfolio:</strong> {formData.socialLinks.portfolio || "Not Provided"}</p>
+        <p><strong>LinkedIn:</strong> {formData.socialLinks?.linkedin || "Not Provided"}</p>
+        <p><strong>Portfolio:</strong> {formData.socialLinks?.portfolio || "Not Provided"}</p>
       </div>
 
       {/* ✅ Demo Video Upload (For Instructors Only) */}


### PR DESCRIPTION
## Summary
- handle missing `socialLinks` object in instructor and generic FinalReview pages

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: 52 errors, 179 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686c3a50eb748328afd093e72a0a756e