### PR TITLE
Fix CORS origin handling

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -136,12 +136,9 @@ app.use((req, res, next) => {
 });
 
 // 🌐 Allow frontend to communicate with backend (CORS)
-// 🌐 Allow frontend to communicate with backend (CORS)
-const allowedOrigins = [
-  'http://localhost:3000',
-  'http://147.93.121.45:3000',
-  'https://eduskillbridge.net',
-];
+// Use the ALLOWED_ORIGINS derived from the FRONTEND_URL env var
+// This ensures CORS automatically works for any domains configured in .env
+const allowedOrigins = ALLOWED_ORIGINS;
 
 app.use((req, res, next) => {
   const origin = req.headers.origin;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,8 @@ Follow these steps to run SkillBridge on a server or production host.
      specify multiple domains separated by commas. For example:
      
      ```bash
-    FRONTEND_URL=https://yourdomain.com
+    # Example using SkillBridge's VPS domain and IP
+    FRONTEND_URL=https://eduskillbridge.net,http://147.93.121.45
      ```
      
     This value is used for CORS and socket.io connections. If it still points to
@@ -22,7 +23,8 @@ Follow these steps to run SkillBridge on a server or production host.
    For example:
    
    ```bash
-   NEXT_PUBLIC_API_BASE_URL=https://yourdomain.com/api
+   # Point the frontend to your backend including the /api prefix
+   NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
    ```
    
    Without this variable the frontend defaults to `/api` which may point to the


### PR DESCRIPTION
## Summary
- update backend CORS middleware to use origins from `FRONTEND_URL`
- clarify deployment docs with example domain and IP configuration

## Testing
- `npm install` in `backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d0fb851708328a7ca243e571ed425