### PR TITLE
Configure env examples for production

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,12 +4,9 @@ DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge
 JWT_SECRET=your_jwt_secret
 CLOUDINARY_API_KEY=your_key
 SMTP_HOST=smtp.mailtrap.io
-# Allow multiple origins separated by commas
-# Default frontend URL
-# Default frontend URL
-FRONTEND_URL=http://localhost:3000
-# Example for multiple domains
-# FRONTEND_URL=https://eduskillbridge.net,http://147.93.121.45
+# Allowed frontend origins separated by commas
+# Configure this to match your production domain and server IP
+FRONTEND_URL=https://eduskillbridge.net,http://147.93.121.45
 SESSION_SECRET=skillbridge_secret
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,3 @@
-# Example frontend environment file
-NEXT_PUBLIC_API_BASE_URL=/api
+# Example frontend environment file for production
+# Point the frontend to your API including the /api prefix
+NEXT_PUBLIC_API_BASE_URL=http://147.93.121.45/api


### PR DESCRIPTION
## Summary
- set FRONTEND_URL to use eduskillbridge VPS in backend `.env.example`
- point `NEXT_PUBLIC_API_BASE_URL` to the live API in frontend `.env.local.example`

## Testing
- `npm test` (fails: jest not found)

------
https://chatgpt.com/codex/tasks/task_e_686d20b2f06c832895f0e4e551c75af9