### PR TITLE
Update env examples & ensure user columns

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 // 📁 .env.example
-PORT=5000
+# API server port (matches default in server.js)
+PORT=5002
 DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge
 JWT_SECRET=your_jwt_secret
 CLOUDINARY_API_KEY=your_key

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -55,6 +55,45 @@ const db = require("./config/database");
   }
 })();
 
+// Ensure essential user profile columns exist
+(async () => {
+  try {
+    const needsPhone = !(await db.schema.hasColumn("users", "is_phone_verified"));
+    const needsProfile = !(await db.schema.hasColumn("users", "profile_complete"));
+    const needsOnline = !(await db.schema.hasColumn("users", "is_online"));
+    const needsGender = !(await db.schema.hasColumn("users", "gender"));
+    const needsDob = !(await db.schema.hasColumn("users", "date_of_birth"));
+    const needsJob = !(await db.schema.hasColumn("users", "job_title"));
+    const needsDept = !(await db.schema.hasColumn("users", "department"));
+    const needsIdDoc = !(await db.schema.hasColumn("users", "identity_doc_url"));
+
+    if (
+      needsPhone ||
+      needsProfile ||
+      needsOnline ||
+      needsGender ||
+      needsDob ||
+      needsJob ||
+      needsDept ||
+      needsIdDoc
+    ) {
+      await db.schema.alterTable("users", (table) => {
+        if (needsPhone) table.boolean("is_phone_verified").defaultTo(false);
+        if (needsProfile) table.boolean("profile_complete").defaultTo(false);
+        if (needsOnline) table.boolean("is_online").defaultTo(false);
+        if (needsGender) table.string("gender");
+        if (needsDob) table.string("date_of_birth");
+        if (needsJob) table.string("job_title");
+        if (needsDept) table.string("department");
+        if (needsIdDoc) table.text("identity_doc_url");
+      });
+      console.log("ℹ️ Ensured users table has profile and verification columns");
+    }
+  } catch (err) {
+    console.error("Error ensuring users columns:", err);
+  }
+})();
+
 // ───── Import Route Modules ─────
 const authRoutes = require("./modules/auth/routes/auth.routes");
 const userRoutes = require("./modules/users/user.routes");

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,7 @@ Follow these steps to run SkillBridge on a server or production host.
 ## Configure environment variables
 
 1. **Backend** – copy `backend/.env.example` to `backend/.env` and set:
-   - `PORT` – typically `5000` unless changed.
+   - `PORT` – set to the port your API runs on (the examples use `5002`).
    - `FRONTEND_URL` – set this to the full URL of your frontend. You can
      specify multiple domains separated by commas. For example:
      
@@ -19,12 +19,12 @@ Follow these steps to run SkillBridge on a server or production host.
     logging in from the deployed site.
 
 2. **Frontend** – create a `.env.local` file inside `frontend` and set
-   `NEXT_PUBLIC_API_BASE_URL` to your backend URL including the `/api` prefix.
+   `NEXT_PUBLIC_API_BASE_URL` to your backend URL including the `/api` prefix and port.
    For example:
    
    ```bash
    # Point the frontend to your backend including the /api prefix
-   NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+   NEXT_PUBLIC_API_BASE_URL=http://147.93.121.45:5002/api
    ```
    
    Without this variable the frontend defaults to `/api` which may point to the

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,3 +1,4 @@
 # Example frontend environment file for production
 # Point the frontend to your API including the /api prefix
-NEXT_PUBLIC_API_BASE_URL=http://147.93.121.45/api
+# Backend API base URL including the /api prefix and port
+NEXT_PUBLIC_API_BASE_URL=http://147.93.121.45:5002/api


### PR DESCRIPTION
## Summary
- update backend and frontend environment examples for the production server
- document port in deployment guide and show example API URL with port
- ensure required columns exist on the `users` table at server start

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_686d7fd6efe08328976c9aa890ca482c