### PR TITLE
Add authentication migrations

### DIFF
--- a/backend/src/migrations/20250709192110_create_users_table.js
+++ b/backend/src/migrations/20250709192110_create_users_table.js
@@ -2,8 +2,26 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = function(knex) {
-  
+exports.up = async function(knex) {
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+  return knex.schema.createTable('users', (table) => {
+    table
+      .uuid('id')
+      .primary()
+      .defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('full_name').notNullable();
+    table.string('email').notNullable().unique();
+    table.string('phone', 20).unique();
+    table.string('password_hash').notNullable();
+    table.string('role').notNullable();
+    table.string('avatar_url');
+    table.boolean('is_online').defaultTo(false);
+    table.string('status').defaultTo('pending');
+    table.boolean('profile_complete').defaultTo(false);
+    table.boolean('is_email_verified').defaultTo(false);
+    table.boolean('is_phone_verified').defaultTo(false);
+    table.timestamps(true, true);
+  });
 };
 
 /**
@@ -11,5 +29,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  
+  return knex.schema.dropTableIfExists('users');
 };

--- a/backend/src/migrations/20250709192133_create_verifications_table.js
+++ b/backend/src/migrations/20250709192133_create_verifications_table.js
@@ -3,7 +3,22 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-  
+  return knex.schema.createTable('verifications', (table) => {
+    table
+      .uuid('id')
+      .primary()
+      .defaultTo(knex.raw('uuid_generate_v4()'));
+    table
+      .uuid('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.enu('type', ['email', 'phone']).notNullable();
+    table.string('code', 10).notNullable();
+    table.timestamp('expires_at').notNullable();
+    table.boolean('verified').defaultTo(false);
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
 };
 
 /**
@@ -11,5 +26,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  
+  return knex.schema.dropTableIfExists('verifications');
 };

--- a/backend/src/migrations/20250709192143_create_social_accounts_table.js
+++ b/backend/src/migrations/20250709192143_create_social_accounts_table.js
@@ -3,7 +3,22 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-  
+  return knex.schema.createTable('social_accounts', (table) => {
+    table
+      .uuid('id')
+      .primary()
+      .defaultTo(knex.raw('uuid_generate_v4()'));
+    table
+      .uuid('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.string('provider').notNullable();
+    table.string('provider_id').notNullable();
+    table.string('email');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['provider', 'provider_id']);
+  });
 };
 
 /**
@@ -11,5 +26,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  
+  return knex.schema.dropTableIfExists('social_accounts');
 };

--- a/backend/src/migrations/20250709192200_create_password_resets_table.js
+++ b/backend/src/migrations/20250709192200_create_password_resets_table.js
@@ -3,7 +3,21 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-  
+  return knex.schema.createTable('password_resets', (table) => {
+    table
+      .uuid('id')
+      .primary()
+      .defaultTo(knex.raw('uuid_generate_v4()'));
+    table
+      .uuid('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.string('code', 10).notNullable();
+    table.timestamp('expires_at').notNullable();
+    table.boolean('used').defaultTo(false);
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
 };
 
 /**
@@ -11,5 +25,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  
+  return knex.schema.dropTableIfExists('password_resets');
 };

--- a/backend/src/migrations/20250709192209_create_roles_table.js
+++ b/backend/src/migrations/20250709192209_create_roles_table.js
@@ -3,7 +3,12 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-  
+  return knex.schema.createTable('roles', (table) => {
+    table.increments('id').primary();
+    table.string('name').notNullable().unique();
+    table.string('description');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
 };
 
 /**
@@ -11,5 +16,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  
+  return knex.schema.dropTableIfExists('roles');
 };

--- a/backend/src/migrations/20250709192217_create_permissions_table.js
+++ b/backend/src/migrations/20250709192217_create_permissions_table.js
@@ -3,7 +3,16 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-  
+  return knex.schema.createTable('permissions', (table) => {
+    table.increments('id').primary();
+    table.string('code').notNullable().unique();
+    table.string('description');
+    table
+      .uuid('created_by')
+      .references('id')
+      .inTable('users');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
 };
 
 /**
@@ -11,5 +20,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  
+  return knex.schema.dropTableIfExists('permissions');
 };

--- a/backend/src/migrations/20250709192225_create_role_permissions_table.js
+++ b/backend/src/migrations/20250709192225_create_role_permissions_table.js
@@ -3,7 +3,26 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-  
+  return knex.schema.createTable('role_permissions', (table) => {
+    table
+      .integer('role_id')
+      .unsigned()
+      .references('id')
+      .inTable('roles')
+      .onDelete('CASCADE');
+    table
+      .integer('permission_id')
+      .unsigned()
+      .references('id')
+      .inTable('permissions')
+      .onDelete('CASCADE');
+    table
+      .uuid('assigned_by')
+      .references('id')
+      .inTable('users');
+    table.timestamp('assigned_at').defaultTo(knex.fn.now());
+    table.primary(['role_id', 'permission_id']);
+  });
 };
 
 /**
@@ -11,5 +30,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  
+  return knex.schema.dropTableIfExists('role_permissions');
 };

--- a/backend/src/migrations/20250709192232_create_user_roles_table.js
+++ b/backend/src/migrations/20250709192232_create_user_roles_table.js
@@ -3,7 +3,20 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-  
+  return knex.schema.createTable('user_roles', (table) => {
+    table
+      .uuid('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table
+      .integer('role_id')
+      .unsigned()
+      .references('id')
+      .inTable('roles')
+      .onDelete('CASCADE');
+    table.primary(['user_id', 'role_id']);
+  });
 };
 
 /**
@@ -11,5 +24,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  
+  return knex.schema.dropTableIfExists('user_roles');
 };


### PR DESCRIPTION
## Summary
- implement DB migrations for auth tables
- include users, roles, permissions and supporting tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ec7bc54e483289381c25400806dbd