### PR TITLE
Fix missing categories migration

### DIFF
--- a/backend/src/migrations/20250709192341_create_categories_table.js
+++ b/backend/src/migrations/20250709192341_create_categories_table.js
@@ -2,8 +2,24 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = function(knex) {
-  
+exports.up = async function(knex) {
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+  return knex.schema.createTable('categories', (table) => {
+    table
+      .uuid('id')
+      .primary()
+      .defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable();
+    table.string('slug').notNullable().unique();
+    table.string('status').defaultTo('active');
+    table
+      .uuid('parent_id')
+      .references('id')
+      .inTable('categories')
+      .onDelete('SET NULL');
+    table.string('image_url');
+    table.timestamps(true, true);
+  });
 };
 
 /**
@@ -11,5 +27,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  
+  return knex.schema.dropTableIfExists('categories');
 };


### PR DESCRIPTION
## Summary
- define `categories` table in migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ed043bea08328a3d5c4e395b4516b