### PR TITLE
Fix migrations path

### DIFF
--- a/backend/src/migrations/20250712143520_create_settings_table.js
+++ b/backend/src/migrations/20250712143520_create_settings_table.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('settings', function(table) {
+    table.string('key').primary();
+    table.text('value');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('settings');
+};

--- a/backend/src/migrations/20250712143530_create_online_classes_table.js
+++ b/backend/src/migrations/20250712143530_create_online_classes_table.js
@@ -1,0 +1,27 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('online_classes', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('instructor_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.string('title').notNullable();
+    table.string('slug').notNullable().unique();
+    table.text('description');
+    table.string('level');
+    table.string('cover_image');
+    table.date('start_date');
+    table.date('end_date');
+    table.uuid('category_id').references('id').inTable('categories').onDelete('SET NULL');
+    table.decimal('price', 10, 2);
+    table.integer('max_students');
+    table.string('language');
+    table.string('demo_video_url');
+    table.boolean('allow_installments').defaultTo(false);
+    table.enu('status', ['draft', 'published', 'archived']).defaultTo('draft');
+    table.enu('moderation_status', ['Pending', 'Approved', 'Rejected']).defaultTo('Pending');
+    table.text('rejection_reason');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('online_classes');
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -15,7 +15,9 @@ require("dotenv").config();
 // 🔄 Ensure DB schema is up to date
 (async () => {
   try {
-    await db.migrate.latest();
+    await db.migrate.latest({
+      directory: path.join(__dirname, "migrations"),
+    });
     console.log("✅ Database migrations up to date");
   } catch (err) {
     console.error("❌ Failed running migrations:", err.message);


### PR DESCRIPTION
## Summary
- configure Knex migrations to use `src/migrations`
- add migrations for `settings` and `online_classes` tables

## Testing
- `npm test -- -i`


------
https://chatgpt.com/codex/tasks/task_e_6872b61880d88328ab87659e299195b2