### PR TITLE
Fix login redirect freeze

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -51,3 +51,16 @@ If you deploy the frontend and see network errors pointing to
 `NEXT_PUBLIC_API_BASE_URL` set.  Update `frontend/.env.local` with the correct
 backend URL and rebuild/restart the frontend container so the new value is
 picked up.
+
+### CORS errors when logging in
+
+If the browser console shows messages like `No 'Access-Control-Allow-Origin'` or
+`ERR_NETWORK` during login, your backend is rejecting the frontend's origin.
+Edit `backend/.env` and ensure the `FRONTEND_URL` variable lists the exact
+domain of your deployed site, for example:
+
+```bash
+FRONTEND_URL=https://eduskillbridge.net
+```
+
+Restart the backend so the updated CORS settings take effect.

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -96,17 +96,20 @@ export default function Login() {
         ? profilePaths[loggedInUser.role?.toLowerCase()] || "/website"
         : "/website";
 
-    // ⏳ Delay before redirecting (e.g., 1.2 seconds)
-    setTimeout(() => {
-      router.push(targetPath);
-    }, 1200);
+    // 🚀 Redirect immediately after a successful login
+    router.push(targetPath);
   } catch (err) {
     console.error("❌ login onSubmit error", err);
-    const msg =
+    let msg =
       err?.response?.data?.message ||
       err?.response?.data?.error ||
       err?.message ||
       "Login failed. Please try again.";
+
+    if (err.code === "ERR_NETWORK") {
+      msg =
+        "Network error: please check your connection or server configuration.";
+    }
 
     toast.error(msg);
     setValue("password", "");


### PR DESCRIPTION
## Summary
- redirect immediately after login
- add clearer message on network error
- document how to resolve CORS login failures

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872c307b0f88328bfba4be4647f4bc6