### PR TITLE
Add migrations for online classes interactions

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -72,6 +72,16 @@
 - **Primary Key**: `id`
 - **Foreign Keys**: `class_id, user_id`
 
+### `class_likes`
+- **Purpose**: Track class likes by students
+- **Primary Key**: `id`
+- **Foreign Keys**: `user_id, class_id`
+
+### `class_wishlist`
+- **Purpose**: Students' saved classes
+- **Primary Key**: `id`
+- **Foreign Keys**: `user_id, class_id`
+
 
 ## Tutorials Tables
 

--- a/backend/src/migrations/20250712161010_create_ads_table.js
+++ b/backend/src/migrations/20250712161010_create_ads_table.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ads', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('title').notNullable();
+    table.text('description');
+    table.string('image_url').notNullable();
+    table.string('link_url');
+    table.uuid('created_by').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('ads');
+};

--- a/backend/src/migrations/20250712161020_create_ad_views_table.js
+++ b/backend/src/migrations/20250712161020_create_ad_views_table.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ad_views', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('ad_id').notNullable().references('id').inTable('ads').onDelete('CASCADE');
+    table.uuid('user_id').references('id').inTable('users').onDelete('CASCADE');
+    table.timestamp('viewed_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('ad_views');
+};

--- a/backend/src/migrations/20250712161030_create_ad_analytics_table.js
+++ b/backend/src/migrations/20250712161030_create_ad_analytics_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ad_analytics', function(table) {
+    table.uuid('ad_id').primary().references('id').inTable('ads').onDelete('CASCADE');
+    table.integer('views').defaultTo(0);
+    table.integer('clicks').defaultTo(0);
+    table.decimal('ctr', 8, 4).defaultTo(0);
+    table.integer('unique_viewers').defaultTo(0);
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('ad_analytics');
+};

--- a/backend/src/migrations/20250712161040_create_class_enrollments_table.js
+++ b/backend/src/migrations/20250712161040_create_class_enrollments_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_enrollments', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.string('status').defaultTo('enrolled');
+    table.timestamp('enrolled_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'class_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_enrollments');
+};

--- a/backend/src/migrations/20250712161050_create_class_likes_table.js
+++ b/backend/src/migrations/20250712161050_create_class_likes_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_likes', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'class_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_likes');
+};

--- a/backend/src/migrations/20250712161060_create_class_wishlist_table.js
+++ b/backend/src/migrations/20250712161060_create_class_wishlist_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_wishlist', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'class_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_wishlist');
+};


### PR DESCRIPTION
## Summary
- add migrations for class enrollments, likes, and wishlist tables
- document new tables in schema overview

## Testing
- `npm install` in backend
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68735a2a83748328a05d9c133b567124