### PR TITLE
Add migrations for integrations tables

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -72,6 +72,46 @@
 - **Primary Key**: `id`
 - **Foreign Keys**: `class_id, user_id`
 
+### `class_likes`
+- **Purpose**: Track class likes by students
+- **Primary Key**: `id`
+- **Foreign Keys**: `user_id, class_id`
+
+### `class_wishlist`
+- **Purpose**: Students' saved classes
+- **Primary Key**: `id`
+- **Foreign Keys**: `user_id, class_id`
+
+### `class_comments`
+- **Purpose**: Threaded class discussions
+- **Primary Key**: `id`
+- **Foreign Keys**: `class_id, user_id, parent_id`
+
+### `class_tags`
+- **Purpose**: Tag library for classes
+- **Primary Key**: `id`
+- **Foreign Keys**: `—`
+
+### `class_tag_map`
+- **Purpose**: Links classes to tags
+- **Primary Key**: `(class_id, tag_id)`
+- **Foreign Keys**: `class_id, tag_id`
+
+### `class_views`
+- **Purpose**: Track class page hits
+- **Primary Key**: `id`
+- **Foreign Keys**: `class_id, viewer_id`
+
+### `class_scoring_policies`
+- **Purpose**: Grading weights & pass mark
+- **Primary Key**: `class_id (PK)`
+- **Foreign Keys**: `class_id`
+
+### `student_class_scores`
+- **Purpose**: Aggregate scores per student
+- **Primary Key**: `id`
+- **Foreign Keys**: `class_id, student_id`
+
 
 ## Tutorials Tables
 

--- a/backend/src/migrations/20250712161010_create_ads_table.js
+++ b/backend/src/migrations/20250712161010_create_ads_table.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ads', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('title').notNullable();
+    table.text('description');
+    table.string('image_url').notNullable();
+    table.string('link_url');
+    table.uuid('created_by').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('ads');
+};

--- a/backend/src/migrations/20250712161020_create_ad_views_table.js
+++ b/backend/src/migrations/20250712161020_create_ad_views_table.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ad_views', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('ad_id').notNullable().references('id').inTable('ads').onDelete('CASCADE');
+    table.uuid('user_id').references('id').inTable('users').onDelete('CASCADE');
+    table.timestamp('viewed_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('ad_views');
+};

--- a/backend/src/migrations/20250712161030_create_ad_analytics_table.js
+++ b/backend/src/migrations/20250712161030_create_ad_analytics_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ad_analytics', function(table) {
+    table.uuid('ad_id').primary().references('id').inTable('ads').onDelete('CASCADE');
+    table.integer('views').defaultTo(0);
+    table.integer('clicks').defaultTo(0);
+    table.decimal('ctr', 8, 4).defaultTo(0);
+    table.integer('unique_viewers').defaultTo(0);
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('ad_analytics');
+};

--- a/backend/src/migrations/20250712161040_create_class_enrollments_table.js
+++ b/backend/src/migrations/20250712161040_create_class_enrollments_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_enrollments', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.string('status').defaultTo('enrolled');
+    table.timestamp('enrolled_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'class_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_enrollments');
+};

--- a/backend/src/migrations/20250712161050_create_class_likes_table.js
+++ b/backend/src/migrations/20250712161050_create_class_likes_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_likes', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'class_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_likes');
+};

--- a/backend/src/migrations/20250712161060_create_class_wishlist_table.js
+++ b/backend/src/migrations/20250712161060_create_class_wishlist_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_wishlist', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'class_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_wishlist');
+};

--- a/backend/src/migrations/20250712161070_create_integrations_table.js
+++ b/backend/src/migrations/20250712161070_create_integrations_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('integrations', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable();
+    table.string('provider').notNullable();
+    table.text('api_key');
+    table.jsonb('config').defaultTo('{}');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('integrations');
+};

--- a/backend/src/migrations/20250712161080_create_integration_logs_table.js
+++ b/backend/src/migrations/20250712161080_create_integration_logs_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('integration_logs', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('integration_id').notNullable().references('id').inTable('integrations').onDelete('CASCADE');
+    table.uuid('user_id').references('id').inTable('users').onDelete('SET NULL');
+    table.string('action');
+    table.jsonb('details');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('integration_logs');
+};

--- a/backend/src/migrations/20250712161100_create_class_lessons_table.js
+++ b/backend/src/migrations/20250712161100_create_class_lessons_table.js
@@ -1,0 +1,16 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_lessons', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.string('title').notNullable();
+    table.text('description');
+    table.timestamp('start_time');
+    table.integer('order');
+    table.string('topic_file_url');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_lessons');
+};

--- a/backend/src/migrations/20250712161110_create_class_attendance_table.js
+++ b/backend/src/migrations/20250712161110_create_class_attendance_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_attendance', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('lesson_id').notNullable().references('id').inTable('class_lessons').onDelete('CASCADE');
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.boolean('attended').defaultTo(false);
+    table.timestamp('timestamp').defaultTo(knex.fn.now());
+    table.unique(['lesson_id', 'user_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_attendance');
+};

--- a/backend/src/migrations/20250712161120_create_class_assignments_table.js
+++ b/backend/src/migrations/20250712161120_create_class_assignments_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_assignments', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.string('title').notNullable();
+    table.text('description');
+    table.date('due_date');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_assignments');
+};

--- a/backend/src/migrations/20250712161130_create_assignment_submissions_table.js
+++ b/backend/src/migrations/20250712161130_create_assignment_submissions_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('assignment_submissions', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('assignment_id').notNullable().references('id').inTable('class_assignments').onDelete('CASCADE');
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.string('file_url');
+    table.integer('grade');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('assignment_submissions');
+};

--- a/backend/src/migrations/20250712161140_create_class_reviews_table.js
+++ b/backend/src/migrations/20250712161140_create_class_reviews_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_reviews', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.integer('rating').notNullable();
+    table.text('comment');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_reviews');
+};

--- a/backend/src/migrations/20250712161150_create_class_comments_table.js
+++ b/backend/src/migrations/20250712161150_create_class_comments_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_comments', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.text('message').notNullable();
+    table.uuid('parent_id').references('id').inTable('class_comments').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_comments');
+};

--- a/backend/src/migrations/20250712161160_create_class_tags_table.js
+++ b/backend/src/migrations/20250712161160_create_class_tags_table.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_tags', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable();
+    table.string('slug').notNullable().unique();
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_tags');
+};

--- a/backend/src/migrations/20250712161170_create_class_tag_map_table.js
+++ b/backend/src/migrations/20250712161170_create_class_tag_map_table.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_tag_map', function(table) {
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.uuid('tag_id').notNullable().references('id').inTable('class_tags').onDelete('CASCADE');
+    table.primary(['class_id', 'tag_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_tag_map');
+};

--- a/backend/src/migrations/20250712161180_create_class_views_table.js
+++ b/backend/src/migrations/20250712161180_create_class_views_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_views', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.uuid('viewer_id').references('id').inTable('users').onDelete('SET NULL');
+    table.string('ip_address');
+    table.string('user_agent');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_views');
+};

--- a/backend/src/migrations/20250712161190_create_class_scoring_policies_table.js
+++ b/backend/src/migrations/20250712161190_create_class_scoring_policies_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_scoring_policies', function(table) {
+    table.uuid('class_id').primary().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.integer('assignment_weight').defaultTo(50);
+    table.integer('attendance_weight').defaultTo(30);
+    table.integer('final_exam_weight').defaultTo(20);
+    table.integer('pass_score').defaultTo(60);
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_scoring_policies');
+};

--- a/backend/src/migrations/20250712161200_create_student_class_scores_table.js
+++ b/backend/src/migrations/20250712161200_create_student_class_scores_table.js
@@ -1,0 +1,20 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('student_class_scores', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('class_id').notNullable().references('id').inTable('online_classes').onDelete('CASCADE');
+    table.uuid('student_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.integer('assignment_score');
+    table.integer('attendance_score');
+    table.integer('final_exam_score');
+    table.integer('total_score');
+    table.boolean('passed').defaultTo(false);
+    table.boolean('certificate_issued').defaultTo(false);
+    table.timestamp('issued_at');
+    table.timestamps(true, true);
+    table.unique(['class_id', 'student_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('student_class_scores');
+};


### PR DESCRIPTION
## Summary
- add migrations for `integrations` and `integration_logs` tables
- add migrations for OnlineClasses features like lessons, assignments, comments, and scoring policies

## Testing
- `npm install` in backend
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68735a2a83748328a05d9c133b567124