### PR TITLE
Add plan and subscription migrations

### DIFF
--- a/backend/src/migrations/20250712161220_create_plans_table.js
+++ b/backend/src/migrations/20250712161220_create_plans_table.js
@@ -1,0 +1,17 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('plans', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable();
+    table.string('slug').notNullable().unique();
+    table.decimal('price_monthly', 10, 2).defaultTo(0);
+    table.decimal('price_yearly', 10, 2).defaultTo(0);
+    table.string('currency').defaultTo('USD');
+    table.boolean('recommended').defaultTo(false);
+    table.boolean('active').defaultTo(true);
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('plans');
+};

--- a/backend/src/migrations/20250712161230_create_plan_features_table.js
+++ b/backend/src/migrations/20250712161230_create_plan_features_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('plan_features', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('plan_id').notNullable().references('id').inTable('plans').onDelete('CASCADE');
+    table.string('feature_key').notNullable();
+    table.string('value');
+    table.string('description');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('plan_features');
+};

--- a/backend/src/migrations/20250712161240_create_user_subscriptions_table.js
+++ b/backend/src/migrations/20250712161240_create_user_subscriptions_table.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('user_subscriptions', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('plan_id').notNullable().references('id').inTable('plans').onDelete('CASCADE');
+    table.timestamp('start_date').defaultTo(knex.fn.now());
+    table.timestamp('end_date');
+    table.string('status').defaultTo('active');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('user_subscriptions');
+};


### PR DESCRIPTION
## Summary
- add migrations for `plans`, `plan_features` and `user_subscriptions`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873900b88ec8328becc46757a9d09fe