### PR TITLE
Add migration for missing user columns

### DIFF
--- a/backend/src/migrations/20250714053830_add_missing_columns_to_users.js
+++ b/backend/src/migrations/20250714053830_add_missing_columns_to_users.js
@@ -1,0 +1,29 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('users', function (table) {
+    table.string('gender');
+    table.date('date_of_birth');
+    table.boolean('is_email_verified').defaultTo(false);
+    table.boolean('is_phone_verified').defaultTo(false);
+    table.boolean('profile_complete').defaultTo(false);
+    table.string('avatar_url');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('users', function (table) {
+    table.dropColumn('gender');
+    table.dropColumn('date_of_birth');
+    table.dropColumn('is_email_verified');
+    table.dropColumn('is_phone_verified');
+    table.dropColumn('profile_complete');
+    table.dropColumn('avatar_url');
+  });
+};


### PR DESCRIPTION
## Summary
- add migration to restore user profile columns

## Testing
- `npx knex migrate:latest` *(fails: ECONNREFUSED)*
- `docker restart skillbridge_backend_1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874970640548328883419a31a4c14e6