### PR TITLE
Fix profile redirect logic

### DIFF
--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -83,8 +83,9 @@ const Navbar = () => {
         admin: "/dashboard/admin/profile/edit",
         instructor: "/dashboard/instructor/profile/edit",
         student: "/dashboard/student/profile/edit",
+        superadmin: "/dashboard/admin/profile/edit",
       };
-      const rolePath = profilePaths[userRole] || "/auth/login";
+      const rolePath = profilePaths[userRole] || "/website";
       if (router.pathname !== rolePath) {
         router.replace(rolePath);
         toast.info("Please complete your profile to continue.");

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -63,6 +63,7 @@ export default function Login() {
         admin: "/dashboard/admin/profile/edit",
         instructor: "/dashboard/instructor/profile/edit",
         student: "/dashboard/student/profile/edit",
+        superadmin: "/dashboard/admin/profile/edit",
       };
       const rolePath = profilePaths[user.role?.toLowerCase()] || "/website";
       router.replace(rolePath);
@@ -89,6 +90,7 @@ export default function Login() {
       admin: "/dashboard/admin/profile/edit",
       instructor: "/dashboard/instructor/profile/edit",
       student: "/dashboard/student/profile/edit",
+      superadmin: "/dashboard/admin/profile/edit",
     };
 
     const targetPath =


### PR DESCRIPTION
## Summary
- fix role path defaults in website navbar
- handle `superadmin` role during login and profile checks

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68749c72d4e4832897db2e5d8ac99fa9