### PR TITLE
Add missing admin profile migration

### DIFF
--- a/backend/src/migrations/20250714055050_create_admin_profiles_table.js
+++ b/backend/src/migrations/20250714055050_create_admin_profiles_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('admin_profiles', function(table) {
+    table.uuid('user_id').primary().references('id').inTable('users').onDelete('CASCADE');
+    table.string('job_title');
+    table.string('department');
+    table.string('identity_doc_url');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('admin_profiles');
+};

--- a/backend/src/seeds/seed_superadmin_user.js
+++ b/backend/src/seeds/seed_superadmin_user.js
@@ -35,6 +35,15 @@ exports.seed = async function(knex) {
     })
     .returning("id");
 
+  // Create matching admin profile
+  await knex("admin_profiles").insert({
+    user_id: superAdminUserId.id || superAdminUserId,
+    job_title: "Super Administrator",
+    department: "Management",
+    created_at: knex.fn.now(),
+    updated_at: knex.fn.now(),
+  });
+
   // 🔗 Link user to role (if using a many-to-many system)
   await knex("user_roles").insert({
     user_id: superAdminUserId.id || superAdminUserId,


### PR DESCRIPTION
## Summary
- create `admin_profiles` table
- seed a profile for the default SuperAdmin user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874ad0b36288328a2edaa41a5e4f2c8