### PR TITLE
Add missing admin profile migration

### DIFF
--- a/backend/src/migrations/20250714055050_create_admin_profiles_table.js
+++ b/backend/src/migrations/20250714055050_create_admin_profiles_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('admin_profiles', function(table) {
+    table.uuid('user_id').primary().references('id').inTable('users').onDelete('CASCADE');
+    table.string('job_title');
+    table.string('department');
+    table.string('identity_doc_url');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('admin_profiles');
+};

--- a/backend/src/migrations/20250714055100_create_group_tables.js
+++ b/backend/src/migrations/20250714055100_create_group_tables.js
@@ -1,0 +1,67 @@
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('groups', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.uuid('creator_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      table.string('name').notNullable();
+      table.text('description');
+      table.string('visibility').defaultTo('public');
+      table.boolean('requires_approval').defaultTo(false);
+      table.string('cover_image');
+      table.uuid('category_id').references('id').inTable('categories').onDelete('SET NULL');
+      table.integer('max_size');
+      table.string('timezone');
+      table.string('status').defaultTo('pending');
+      table.jsonb('permissions');
+      table.timestamps(true, true);
+    })
+    .createTable('group_members', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.uuid('group_id').notNullable().references('id').inTable('groups').onDelete('CASCADE');
+      table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      table.string('role').defaultTo('member');
+      table.boolean('disabled').defaultTo(false);
+      table.timestamps(true, true);
+      table.unique(['group_id', 'user_id']);
+    })
+    .createTable('group_join_requests', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.uuid('group_id').notNullable().references('id').inTable('groups').onDelete('CASCADE');
+      table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      table.string('status').defaultTo('pending');
+      table.timestamp('requested_at').defaultTo(knex.fn.now());
+      table.timestamp('responded_at');
+      table.unique(['group_id', 'user_id']);
+    })
+    .createTable('group_messages', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.uuid('group_id').notNullable().references('id').inTable('groups').onDelete('CASCADE');
+      table.uuid('sender_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      table.text('content');
+      table.string('file_url');
+      table.string('audio_url');
+      table.timestamp('sent_at').defaultTo(knex.fn.now());
+    })
+    .createTable('group_tags', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.string('name').notNullable().unique();
+      table.string('slug').notNullable().unique();
+      table.boolean('active').defaultTo(true);
+      table.timestamps(true, true);
+    })
+    .createTable('group_tag_map', function(table) {
+      table.uuid('group_id').notNullable().references('id').inTable('groups').onDelete('CASCADE');
+      table.uuid('tag_id').notNullable().references('id').inTable('group_tags').onDelete('CASCADE');
+      table.primary(['group_id', 'tag_id']);
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .dropTableIfExists('group_tag_map')
+    .dropTableIfExists('group_tags')
+    .dropTableIfExists('group_messages')
+    .dropTableIfExists('group_join_requests')
+    .dropTableIfExists('group_members')
+    .dropTableIfExists('groups');
+};

--- a/backend/src/migrations/20250714055110_create_tutorial_reviews_table.js
+++ b/backend/src/migrations/20250714055110_create_tutorial_reviews_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_reviews', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.integer('rating').notNullable();
+    table.text('comment');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_reviews');
+};

--- a/backend/src/migrations/20250714055120_create_offers_tables.js
+++ b/backend/src/migrations/20250714055120_create_offers_tables.js
@@ -1,0 +1,52 @@
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('offers', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.uuid('student_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      table.string('title').notNullable();
+      table.text('description');
+      table.decimal('budget', 10, 2);
+      table.string('timeframe');
+      table.string('offer_type');
+      table.string('status').defaultTo('open');
+      table.timestamps(true, true);
+    })
+    .createTable('offer_responses', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.uuid('offer_id').notNullable().references('id').inTable('offers').onDelete('CASCADE');
+      table.uuid('instructor_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      table.decimal('proposed_price', 10, 2);
+      table.string('estimated_time');
+      table.text('notes');
+      table.string('status').defaultTo('pending');
+      table.timestamp('responded_at').defaultTo(knex.fn.now());
+    })
+    .createTable('offer_messages', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.uuid('response_id').notNullable().references('id').inTable('offer_responses').onDelete('CASCADE');
+      table.uuid('sender_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      table.text('message');
+      table.uuid('reply_to_id').references('id').inTable('offer_messages').onDelete('SET NULL');
+      table.timestamp('sent_at').defaultTo(knex.fn.now());
+    })
+    .createTable('offer_tags', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.string('name').notNullable().unique();
+      table.string('slug').notNullable().unique();
+      table.timestamps(true, true);
+    })
+    .createTable('offer_tag_map', function(table) {
+      table.uuid('offer_id').notNullable().references('id').inTable('offers').onDelete('CASCADE');
+      table.uuid('tag_id').notNullable().references('id').inTable('offer_tags').onDelete('CASCADE');
+      table.primary(['offer_id', 'tag_id']);
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .dropTableIfExists('offer_tag_map')
+    .dropTableIfExists('offer_tags')
+    .dropTableIfExists('offer_messages')
+    .dropTableIfExists('offer_responses')
+    .dropTableIfExists('offers');
+};

--- a/backend/src/seeds/seed_superadmin_user.js
+++ b/backend/src/seeds/seed_superadmin_user.js
@@ -35,6 +35,15 @@ exports.seed = async function(knex) {
     })
     .returning("id");
 
+  // Create matching admin profile
+  await knex("admin_profiles").insert({
+    user_id: superAdminUserId.id || superAdminUserId,
+    job_title: "Super Administrator",
+    department: "Management",
+    created_at: knex.fn.now(),
+    updated_at: knex.fn.now(),
+  });
+
   // 🔗 Link user to role (if using a many-to-many system)
   await knex("user_roles").insert({
     user_id: superAdminUserId.id || superAdminUserId,


### PR DESCRIPTION
## Summary
- create admin_profiles table
- seed a profile for the default SuperAdmin user
- add migrations for groups, offers, and tutorial reviews

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874ad0b36288328a2edaa41a5e4f2c8