### PR TITLE
Add migration for tutorial moderation

### DIFF
--- a/backend/src/migrations/20250714055130_add_moderation_to_tutorials.js
+++ b/backend/src/migrations/20250714055130_add_moderation_to_tutorials.js
@@ -1,0 +1,19 @@
+exports.up = async function(knex) {
+  const hasStatus = await knex.schema.hasColumn('tutorials', 'moderation_status');
+  const hasReason = await knex.schema.hasColumn('tutorials', 'rejection_reason');
+  if (!hasStatus || !hasReason) {
+    await knex.schema.alterTable('tutorials', table => {
+      if (!hasStatus) table.enu('moderation_status', ['Pending', 'Approved', 'Rejected']).defaultTo('Pending');
+      if (!hasReason) table.text('rejection_reason');
+    });
+    await knex.raw("ALTER TABLE tutorials DROP CONSTRAINT IF EXISTS tutorials_moderation_status_check");
+    await knex.raw("ALTER TABLE tutorials ADD CONSTRAINT tutorials_moderation_status_check CHECK (moderation_status IS NULL OR moderation_status IN ('Pending','Approved','Rejected'))");
+  }
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('tutorials', table => {
+    table.dropColumn('moderation_status');
+    table.dropColumn('rejection_reason');
+  });
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -24,7 +24,6 @@ require("dotenv").config();
     process.exit(1);
   }
 })();
-// ─── Database Migration for Online Classes Moderation ───
 const app = express();
 const server = http.createServer(app);
 
@@ -35,23 +34,6 @@ if (FRONTEND_URL.startsWith("FRONTEND_URL=")) {
 }
 const ALLOWED_ORIGINS = FRONTEND_URL.split(',').map(o => o.trim());
 
-(async () => {
-  try {
-    const hasStatus = await db.schema.hasColumn("online_classes", "moderation_status");
-    const hasReason = await db.schema.hasColumn("online_classes", "rejection_reason");
-    if (!hasStatus || !hasReason) {
-      await db.schema.alterTable("online_classes", table => {
-        if (!hasStatus) table.enu("moderation_status", ["Pending", "Approved", "Rejected"]).defaultTo("Pending");
-        if (!hasReason) table.text("rejection_reason");
-      });
-      await db.raw("ALTER TABLE online_classes DROP CONSTRAINT IF EXISTS online_classes_moderation_status_check");
-      await db.raw("ALTER TABLE online_classes ADD CONSTRAINT online_classes_moderation_status_check CHECK (moderation_status IS NULL OR moderation_status IN ('Pending','Approved','Rejected'))");
-      console.log("ℹ️ Ensured online_classes has moderation_status and rejection_reason columns");
-    }
-  } catch (err) {
-    console.error("Error ensuring moderation columns:", err);
-  }
-})();
 
 app.disable("etag");
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- add migration ensuring `tutorials` table has `moderation_status` and `rejection_reason`
- remove runtime DB alteration for online classes in server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874bc51d3548328b497336b5a9a6099