### PR TITLE
Add email configuration module

### DIFF
--- a/backend/src/modules/emailConfig/emailConfig.controller.js
+++ b/backend/src/modules/emailConfig/emailConfig.controller.js
@@ -1,0 +1,13 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./emailConfig.service");
+
+exports.getSettings = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings || {});
+});
+
+exports.updateSettings = catchAsync(async (req, res) => {
+  const settings = await service.updateSettings(req.body);
+  sendSuccess(res, settings, "Settings updated");
+});

--- a/backend/src/modules/emailConfig/emailConfig.routes.js
+++ b/backend/src/modules/emailConfig/emailConfig.routes.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./emailConfig.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.getSettings);
+router.use(verifyToken, isAdmin);
+router.put("/", controller.updateSettings);
+
+module.exports = router;

--- a/backend/src/modules/emailConfig/emailConfig.service.js
+++ b/backend/src/modules/emailConfig/emailConfig.service.js
@@ -1,0 +1,26 @@
+const db = require("../../config/database");
+
+const SETTINGS_KEY = "email_settings";
+
+exports.getSettings = async () => {
+  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (!row) return null;
+  try {
+    return JSON.parse(row.value);
+  } catch (_err) {
+    return null;
+  }
+};
+
+exports.updateSettings = async (settings) => {
+  const value = JSON.stringify(settings);
+  const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (existing) {
+    await db("settings")
+      .where({ key: SETTINGS_KEY })
+      .update({ value, updated_at: db.fn.now() });
+  } else {
+    await db("settings").insert({ key: SETTINGS_KEY, value });
+  }
+  return settings;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -77,6 +77,7 @@ app.use("/api/payment-methods/admin", require("./modules/paymentMethods/paymentM
 app.use("/api/payments/config", require("./modules/paymentConfig/paymentConfig.routes"));
 app.use("/api/social-login/config", require("./modules/socialLoginConfig/socialLoginConfig.routes"));
 app.use("/api/app-config", require("./modules/appConfig/appConfig.routes"));
+app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));
 app.use("/api/payouts/admin", require("./modules/payouts/payouts.routes"));
 app.use("/api/ads", require("./modules/ads/ads.routes"));
 app.use("/api/groups", require("./modules/groups/groups.routes"));

--- a/backend/src/services/mailService.js
+++ b/backend/src/services/mailService.js
@@ -1,8 +1,23 @@
 
 // 📁 src/services/mailService.js
+const { getSettings } = require("../modules/emailConfig/emailConfig.service");
+const createTransporter = require("../utils/email").createTransporter;
+
 module.exports = {
-  sendMail: async ({ to, subject, html }) => {
-    // Integrate with SMTP, SendGrid, or Resend
-    console.log(`Sending email to ${to}`);
+  sendMail: async ({ to, subject, html, from }) => {
+    const cfg = (await getSettings()) || {};
+    const transporter = await createTransporter();
+    const mailOptions = {
+      from: from || cfg.fromEmail || process.env.SMTP_USER,
+      to,
+      subject,
+      html,
+    };
+    try {
+      await transporter.sendMail(mailOptions);
+      console.log(`Sending email to ${to}`);
+    } catch (err) {
+      console.error("Failed to send email", err);
+    }
   },
 };

--- a/backend/tests/emailConfigRoutes.test.js
+++ b/backend/tests/emailConfigRoutes.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/emailConfig/emailConfig.service', () => ({
+  getSettings: jest.fn(),
+  updateSettings: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/emailConfig/emailConfig.service');
+const routes = require('../src/modules/emailConfig/emailConfig.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/email-config', routes);
+
+describe('GET /api/email-config', () => {
+  it('returns settings', async () => {
+    const mock = { smtpHost: 'smtp.test.com' };
+    service.getSettings.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/email-config');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getSettings).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/email-config', () => {
+  it('updates settings', async () => {
+    const payload = { smtpHost: 'smtp.new.com' };
+    service.updateSettings.mockResolvedValue(payload);
+
+    const res = await request(app).put('/api/email-config').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(payload);
+    expect(service.updateSettings).toHaveBeenCalledWith(payload);
+  });
+});

--- a/frontend/src/pages/dashboard/admin/settings/email-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/email-config/index.js
@@ -1,34 +1,58 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import FormField from "@/components/ui/FormField";
 import FormSelect from "@/components/ui/FormSelect";
 import PasswordField from "@/components/ui/PasswordField";
 import { FaSave, FaEnvelopeOpenText } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { fetchEmailConfig, updateEmailConfig } from "@/services/admin/emailConfigService";
+
+const defaultConfig = {
+  fromName: "SkillBridge Admin",
+  fromEmail: "admin@skillbridge.com",
+  replyTo: "support@skillbridge.com",
+  smtpHost: "smtp.gmail.com",
+  smtpPort: 587,
+  encryption: "TLS",
+  username: "admin@skillbridge.com",
+  password: "",
+  method: "smtp",
+};
 
 export default function EmailConfigPage() {
-  const [form, setForm] = useState({
-    fromName: "SkillBridge Admin",
-    fromEmail: "admin@skillbridge.com",
-    replyTo: "support@skillbridge.com",
-    smtpHost: "smtp.gmail.com",
-    smtpPort: 587,
-    encryption: "TLS",
-    username: "admin@skillbridge.com",
-    password: "",
-    method: "smtp",
-  });
+  const [form, setForm] = useState(defaultConfig);
 
   const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchEmailConfig();
+        if (data) setForm({ ...defaultConfig, ...data });
+      } catch (err) {
+        toast.error("Failed to load settings");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setForm((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSave = () => {
-    toast.success("✅ Email configuration saved successfully!");
-    // TODO: connect to backend
+  const handleSave = async () => {
+    setLoading(true);
+    try {
+      await updateEmailConfig(form);
+      toast.success("✅ Email configuration saved successfully!");
+    } catch (err) {
+      toast.error("Failed to save settings");
+    } finally {
+      setLoading(false);
+    }
   };
 
   const sendTestEmail = () => {

--- a/frontend/src/services/admin/emailConfigService.js
+++ b/frontend/src/services/admin/emailConfigService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchEmailConfig = async () => {
+  const { data } = await api.get("/email-config");
+  return data?.data ?? null;
+};
+
+export const updateEmailConfig = async (payload) => {
+  const { data } = await api.put("/email-config", payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- implement email configuration service/controller/routes
- hook email config into main server
- update email utility and mail service to use saved settings
- create frontend service and connect admin email settings page
- add tests for email config routes

## Testing
- `npm --prefix backend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874f7461f708328a50a8776e3ab3d39