### PR TITLE
Add forgot-password endpoint

### DIFF
--- a/backend/src/modules/auth/routes/auth.routes.js
+++ b/backend/src/modules/auth/routes/auth.routes.js
@@ -44,6 +44,18 @@ router.post("/logout", authController.logout);
 router.post("/request-reset", limitAuthRequests, validate(authValidation.otpRequestSchema), authController.requestReset);
 
 /**
+ * @route   POST /auth/forgot-password
+ * @desc    Alias for requesting a password reset OTP via email
+ * @access  Public
+ */
+router.post(
+  "/forgot-password",
+  limitAuthRequests,
+  validate(authValidation.otpRequestSchema),
+  authController.requestReset
+);
+
+/**
  * @route   POST /auth/verify-otp
  * @desc    Verify submitted OTP code
  * @access  Public

--- a/backend/tests/authForgotPasswordRoutes.test.js
+++ b/backend/tests/authForgotPasswordRoutes.test.js
@@ -1,0 +1,26 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/auth/services/auth.service', () => ({
+  generateOtp: jest.fn(),
+}));
+
+const service = require('../src/modules/auth/services/auth.service');
+const routes = require('../src/modules/auth/routes/auth.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/auth', routes);
+
+describe('POST /api/auth/forgot-password', () => {
+  it('invokes generateOtp and returns message', async () => {
+    service.generateOtp.mockResolvedValue();
+    const res = await request(app)
+      .post('/api/auth/forgot-password')
+      .send({ email: 'test@example.com' });
+    expect(res.status).toBe(200);
+    expect(service.generateOtp).toHaveBeenCalledWith('test@example.com');
+    expect(res.body.message).toBeDefined();
+  });
+});
+

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -11,6 +11,7 @@ The backend exposes a REST API under the `/api` prefix. Below is a brief outline
 - `POST /refresh` – refresh an access token
 - `POST /logout` – clear the refresh token
 - `POST /request-reset` – send a password reset OTP
+- `POST /forgot-password` – alternative endpoint to request a reset OTP
 - `POST /verify-otp` – verify the reset code
 - `POST /reset-password` – update the password
 


### PR DESCRIPTION
## Summary
- support POST `/auth/forgot-password` to request a reset OTP via email
- document the new endpoint
- cover new route with a Jest test

## Testing
- `npm install --prefix backend`
- `npx jest --runInBand --prefix backend` *(fails: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_687526aa10108328ad0315252a747e20