### PR TITLE
Fix email host whitespace

### DIFF
--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -4,15 +4,22 @@ const emailConfigService = require("../modules/emailConfig/emailConfig.service")
 
 async function createTransporter() {
   const cfg = (await emailConfigService.getSettings()) || {};
+
+  const host = (cfg.smtpHost || process.env.SMTP_HOST || "").trim();
+  const port = parseInt(cfg.smtpPort || process.env.SMTP_PORT, 10);
+  const user = (cfg.username || process.env.SMTP_USER || "").trim();
+  const pass = (cfg.password || process.env.SMTP_PASS || "").trim();
+
   return nodemailer.createTransport({
-    host: cfg.smtpHost || process.env.SMTP_HOST,
-    port: cfg.smtpPort || process.env.SMTP_PORT,
+    host,
+    port,
     secure:
-      cfg.encryption === "SSL" || cfg.encryption === "TLS" ||
+      cfg.encryption === "SSL" ||
+      cfg.encryption === "TLS" ||
       process.env.SMTP_SECURE === "true",
     auth: {
-      user: cfg.username || process.env.SMTP_USER,
-      pass: cfg.password || process.env.SMTP_PASS,
+      user,
+      pass,
     },
   });
 }


### PR DESCRIPTION
## Summary
- trim SMTP credentials when building the Nodemailer transport so leading/trailing whitespace doesn't cause DNS errors

## Testing
- `npm install`
- `npm test` *(fails: Jest worker encountered child process errors because database could not connect)*

------
https://chatgpt.com/codex/tasks/task_e_68752d6a1bf88328bb04a7dbae072246