### PR TITLE
Fix OTP email from name and add password change notification

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -3,7 +3,7 @@ const jwt = require("jsonwebtoken");
 const { v4: uuidv4 } = require("uuid");
 const userModel = require("../../users/user.model");
 const db = require("../../../config/database");
-const { sendOtpEmail } = require("../../../utils/email");
+const { sendOtpEmail, sendPasswordChangeEmail } = require("../../../utils/email");
 const AppError = require("../../../utils/AppError");
 const notificationService = require("../../notifications/notifications.service");
 const messageService = require("../../messages/messages.service");
@@ -217,6 +217,8 @@ exports.resetPassword = async ({ email, code, new_password }) => {
   await db("users").where({ id: user.id }).update({ password_hash: hashed });
 
   await db("password_resets").where({ id: resetRecord.id }).update({ used: true });
+
+  await sendPasswordChangeEmail(user.email);
 
   await notificationService.createNotification({
     user_id: user.id,

--- a/backend/src/services/mailService.js
+++ b/backend/src/services/mailService.js
@@ -7,8 +7,12 @@ module.exports = {
   sendMail: async ({ to, subject, html, from }) => {
     const cfg = (await getSettings()) || {};
     const transporter = await createTransporter();
+
+    const fromEmail = (cfg.fromEmail || process.env.SMTP_USER || "").trim();
+    const fromName = (cfg.fromName || process.env.SMTP_NAME || "SkillBridge").trim();
+
     const mailOptions = {
-      from: from || cfg.fromEmail || process.env.SMTP_USER,
+      from: from || `${fromName} <${fromEmail}>`,
       to,
       subject,
       html,

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -4,15 +4,22 @@ const emailConfigService = require("../modules/emailConfig/emailConfig.service")
 
 async function createTransporter() {
   const cfg = (await emailConfigService.getSettings()) || {};
+
+  const host = (cfg.smtpHost || process.env.SMTP_HOST || "").trim();
+  const port = parseInt(cfg.smtpPort || process.env.SMTP_PORT, 10);
+  const user = (cfg.username || process.env.SMTP_USER || "").trim();
+  const pass = (cfg.password || process.env.SMTP_PASS || "").trim();
+
   return nodemailer.createTransport({
-    host: cfg.smtpHost || process.env.SMTP_HOST,
-    port: cfg.smtpPort || process.env.SMTP_PORT,
+    host,
+    port,
     secure:
-      cfg.encryption === "SSL" || cfg.encryption === "TLS" ||
+      cfg.encryption === "SSL" ||
+      cfg.encryption === "TLS" ||
       process.env.SMTP_SECURE === "true",
     auth: {
-      user: cfg.username || process.env.SMTP_USER,
-      pass: cfg.password || process.env.SMTP_PASS,
+      user,
+      pass,
     },
   });
 }
@@ -23,8 +30,12 @@ exports.createTransporter = createTransporter;
 exports.sendOtpEmail = async (to, otp) => {
   const cfg = (await emailConfigService.getSettings()) || {};
   const transporter = await createTransporter();
+
+  const fromEmail = (cfg.fromEmail || process.env.SMTP_USER || "").trim();
+  const fromName = (cfg.fromName || process.env.SMTP_NAME || "SkillBridge").trim();
+
   const mailOptions = {
-    from: cfg.fromEmail || process.env.SMTP_USER,
+    from: `${fromName} <${fromEmail}>`,
     to,
     subject: "Your OTP for SkillBridge",
     html: `<p>Your OTP code is: <strong>${otp}</strong></p>`,
@@ -35,5 +46,28 @@ exports.sendOtpEmail = async (to, otp) => {
     console.log(`OTP sent to ${to}`);
   } catch (error) {
     console.error("Error sending email: ", error);
+  }
+};
+
+// Notify user of successful password change
+exports.sendPasswordChangeEmail = async (to) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  const fromEmail = (cfg.fromEmail || process.env.SMTP_USER || "").trim();
+  const fromName = (cfg.fromName || process.env.SMTP_NAME || "SkillBridge").trim();
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    to,
+    subject: "Your SkillBridge password was changed",
+    html: `<p>Your password was changed successfully. If you didn't request this, please contact support immediately.</p>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Password change notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending password change email: ", error);
   }
 };


### PR DESCRIPTION
## Summary
- ensure OTP emails include configured sender name
- send email after password reset confirmation
- default from name in generic mail service

## Testing
- `npm install`
- `npm test` *(fails: Database connection error in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68752d6a1bf88328bb04a7dbae072246