### PR TITLE
Fix OTP reset flow

### DIFF
--- a/backend/tests/authForgotPasswordRoutes.test.js
+++ b/backend/tests/authForgotPasswordRoutes.test.js
@@ -1,6 +1,10 @@
 const request = require('supertest');
 const express = require('express');
 
+jest.mock('../src/config/database', () => ({
+  raw: jest.fn(() => Promise.resolve()),
+}));
+
 jest.mock('../src/modules/auth/services/auth.service', () => ({
   generateOtp: jest.fn(),
 }));

--- a/frontend/src/pages/auth/forgot-password.js
+++ b/frontend/src/pages/auth/forgot-password.js
@@ -24,7 +24,10 @@ export default function ForgotPassword() {
       toast.success("OTP sent successfully!");
       router.push({ pathname: "/auth/verify-otp", query: { email } });
     } catch (err) {
-      const msg = err?.response?.data?.error || "Failed to send OTP.";
+      const msg =
+        err?.response?.data?.message ||
+        err?.response?.data?.error ||
+        "Failed to send OTP.";
       toast.error(msg);
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
## Summary
- show backend error messages on Forgot Password form
- mock database in password reset route tests to avoid DB connection
- clean up dependencies and run tests

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687553ad750c83289ed3137f91baa1bf