### PR TITLE
Fix OTP reset flow

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -161,7 +161,7 @@ exports.verifyRefreshToken = (token) => {
  */
 exports.generateOtp = async (email) => {
   const user = await userModel.findByEmail(email);
-  if (!user) throw new AppError("User not found", 404);
+  if (!user) throw new AppError("Email not found", 404);
 
   const code = Math.floor(100000 + Math.random() * 900000).toString();
   const expires = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60000);

--- a/backend/tests/authForgotPasswordRoutes.test.js
+++ b/backend/tests/authForgotPasswordRoutes.test.js
@@ -1,6 +1,10 @@
 const request = require('supertest');
 const express = require('express');
 
+jest.mock('../src/config/database', () => ({
+  raw: jest.fn(() => Promise.resolve()),
+}));
+
 jest.mock('../src/modules/auth/services/auth.service', () => ({
   generateOtp: jest.fn(),
 }));

--- a/frontend/src/pages/auth/forgot-password.js
+++ b/frontend/src/pages/auth/forgot-password.js
@@ -24,8 +24,15 @@ export default function ForgotPassword() {
       toast.success("OTP sent successfully!");
       router.push({ pathname: "/auth/verify-otp", query: { email } });
     } catch (err) {
-      const msg = err?.response?.data?.error || "Failed to send OTP.";
-      toast.error(msg);
+      if (err?.response?.status === 404) {
+        toast.error("This email does not exist.");
+      } else {
+        const msg =
+          err?.response?.data?.message ||
+          err?.response?.data?.error ||
+          "Failed to send OTP.";
+        toast.error(msg);
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/src/pages/auth/verify-otp.js
+++ b/frontend/src/pages/auth/verify-otp.js
@@ -68,7 +68,7 @@ export default function VerifyOTP() {
         localStorage.setItem("otp_verified_code", code);
 
         setIsVerified(true);
-        setTimeout(() => router.push("/auth/reset-password"), 2000);
+        router.push("/auth/reset-password");
       } else {
         toast.error("Invalid OTP code.");
       }


### PR DESCRIPTION
## Summary
- show backend error messages on Forgot Password form
- mock database in password reset route tests to avoid DB connection
- clean up dependencies and run tests

------
https://chatgpt.com/codex/tasks/task_e_687553ad750c83289ed3137f91baa1bf