### PR TITLE
Fix forgot password flow

### DIFF
--- a/frontend/src/pages/auth/forgot-password.js
+++ b/frontend/src/pages/auth/forgot-password.js
@@ -26,7 +26,7 @@ export default function ForgotPassword() {
     } catch (err) {
 
       if (err?.response?.status === 404) {
-        toast.error("This email does not exist.");
+        toast.error("This account does not exist. Please register.");
       } else {
         const msg =
           err?.response?.data?.message ||

--- a/frontend/src/pages/auth/reset-password.js
+++ b/frontend/src/pages/auth/reset-password.js
@@ -48,8 +48,6 @@ export default function ResetPassword() {
 
     try {
       await resetPassword({ email, code, new_password: newPassword });
-      localStorage.removeItem("otp_verified_email");
-      localStorage.removeItem("otp_verified_code");
       toast.success("Password reset successful!");
       router.push("/auth/success-reset");
     } catch (err) {

--- a/frontend/src/pages/auth/success-reset.js
+++ b/frontend/src/pages/auth/success-reset.js
@@ -17,7 +17,8 @@ export default function SuccessReset() {
       router.replace("/auth/forgot-password");
     } else {
       toast.success("Password reset successful!");
-      localStorage.removeItem("otp_verified_email"); // Clean up
+      localStorage.removeItem("otp_verified_email");
+      localStorage.removeItem("otp_verified_code");
     }
   }, [router]);
 

--- a/frontend/src/pages/auth/verify-otp.js
+++ b/frontend/src/pages/auth/verify-otp.js
@@ -72,7 +72,7 @@ export default function VerifyOTP() {
           router.push("/auth/reset-password");
         }, 500);
       } else {
-        toast.error("Invalid OTP code.");
+        toast.error("Wrong OTP code.");
       }
     } catch (err) {
       const msg = err?.response?.data?.message || "Verification failed.";


### PR DESCRIPTION
## Summary
- tweak text for unknown email
- clarify error when OTP is wrong
- retain verification info until success page
- clean up verification data on success

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6876022244d8832898c219e9b2ddcd1a