### PR TITLE
Fix forgot password flow

### DIFF
--- a/frontend/src/pages/auth/forgot-password.js
+++ b/frontend/src/pages/auth/forgot-password.js
@@ -22,11 +22,12 @@ export default function ForgotPassword() {
     try {
       await authService.requestPasswordReset(email);
       toast.success("OTP sent successfully!");
+      localStorage.setItem("otp_email", email);
       router.push({ pathname: "/auth/verify-otp", query: { email } });
     } catch (err) {
 
       if (err?.response?.status === 404) {
-        toast.error("This email does not exist.");
+        toast.error("This account does not exist. Please register.");
       } else {
         const msg =
           err?.response?.data?.message ||

--- a/frontend/src/pages/auth/reset-password.js
+++ b/frontend/src/pages/auth/reset-password.js
@@ -18,17 +18,24 @@ export default function ResetPassword() {
   const [code, setCode] = useState("");
 
   useEffect(() => {
-    const verifiedEmail = localStorage.getItem("otp_verified_email");
-    const verifiedCode = localStorage.getItem("otp_verified_code");
+    const queryEmail = router.query.email;
+    const queryCode = router.query.code;
+    const storedEmail = localStorage.getItem("otp_verified_email");
+    const storedCode = localStorage.getItem("otp_verified_code");
 
-    if (!verifiedEmail || !verifiedCode) {
+    if (queryEmail && queryCode) {
+      localStorage.setItem("otp_verified_email", queryEmail);
+      localStorage.setItem("otp_verified_code", queryCode);
+      setEmail(queryEmail);
+      setCode(queryCode);
+    } else if (storedEmail && storedCode) {
+      setEmail(storedEmail);
+      setCode(storedCode);
+    } else {
       toast.error("Missing OTP verification. Please try again.");
       router.replace("/auth/forgot-password");
-    } else {
-      setEmail(verifiedEmail);
-      setCode(verifiedCode);
     }
-  }, [router]);
+  }, [router.query]);
 
   const isStrongPassword =
     newPassword.length >= 8 &&
@@ -48,8 +55,6 @@ export default function ResetPassword() {
 
     try {
       await resetPassword({ email, code, new_password: newPassword });
-      localStorage.removeItem("otp_verified_email");
-      localStorage.removeItem("otp_verified_code");
       toast.success("Password reset successful!");
       router.push("/auth/success-reset");
     } catch (err) {

--- a/frontend/src/pages/auth/success-reset.js
+++ b/frontend/src/pages/auth/success-reset.js
@@ -17,7 +17,8 @@ export default function SuccessReset() {
       router.replace("/auth/forgot-password");
     } else {
       toast.success("Password reset successful!");
-      localStorage.removeItem("otp_verified_email"); // Clean up
+      localStorage.removeItem("otp_verified_email");
+      localStorage.removeItem("otp_verified_code");
     }
   }, [router]);
 

--- a/frontend/src/pages/auth/verify-otp.js
+++ b/frontend/src/pages/auth/verify-otp.js
@@ -69,10 +69,13 @@ export default function VerifyOTP() {
 
         setIsVerified(true);
         setTimeout(() => {
-          router.push("/auth/reset-password");
+          router.push({
+            pathname: "/auth/reset-password",
+            query: { email, code },
+          });
         }, 500);
       } else {
-        toast.error("Invalid OTP code.");
+        toast.error("Wrong OTP code.");
       }
     } catch (err) {
       const msg = err?.response?.data?.message || "Verification failed.";


### PR DESCRIPTION
## Summary
- store OTP email so verify page works after redirect
- pass email & code to reset-password page via query params
- load OTP details from query or localStorage

## Testing
- `npm test --silent --prefix frontend`
- `npm test --silent --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6876022244d8832898c219e9b2ddcd1a