### PR TITLE
Fix password recovery flow

### DIFF
--- a/frontend/src/pages/auth/reset-password.js
+++ b/frontend/src/pages/auth/reset-password.js
@@ -62,6 +62,9 @@ export default function ResetPassword() {
     try {
       await resetPassword({ email, code, new_password: newPassword });
       toast.success("Password reset successful!");
+      // Clear stored verification data once password has been changed
+      localStorage.removeItem("otp_verified_email");
+      localStorage.removeItem("otp_verified_code");
       router.push("/auth/success-reset");
     } catch (err) {
       const msg = err?.response?.data?.message || "Password reset failed.";

--- a/frontend/src/pages/auth/success-reset.js
+++ b/frontend/src/pages/auth/success-reset.js
@@ -19,6 +19,12 @@ export default function SuccessReset() {
       toast.success("Password reset successful!");
       localStorage.removeItem("otp_verified_email");
       localStorage.removeItem("otp_verified_code");
+      // Automatically redirect user to login after short delay
+      const timer = setTimeout(() => {
+        router.push("/auth/login");
+      }, 4000);
+
+      return () => clearTimeout(timer);
     }
   }, [router]);
 


### PR DESCRIPTION
## Summary
- auto redirect to login after successful password reset
- clear OTP details when password is reset

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68761057a28883289436f47132f9bb6a