### PR TITLE
Fix OTP check when requesting password reset

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -1,6 +1,7 @@
 const authService = require("../services/auth.service");
 const userModel = require("../../users/user.model");
 const catchAsync = require("../../../utils/catchAsync");
+const AppError = require("../../../utils/AppError");
 
 // 🔧 Cookie options used in login and logout
 const refreshCookieOptions = {
@@ -102,6 +103,12 @@ exports.logout = catchAsync(async (req, res) => {
  */
 exports.requestReset = catchAsync(async (req, res) => {
   const { email } = req.body;
+  // Ensure the email exists before attempting to send an OTP
+  const userExists = await userModel.findByEmail(email);
+  if (!userExists) {
+    throw new AppError("Email not found", 404);
+  }
+
   await authService.generateOtp(email);
   res.json({ message: "OTP sent to email" });
 });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -156,7 +156,8 @@ app.use((err, req, res, next) => {
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
 
   console.error("❌", err.message);
-  res.status(err.status || 500).json({ message: err.message || "Internal Server Error" });
+  const status = err.statusCode || err.status || 500;
+  res.status(status).json({ message: err.message || "Internal Server Error" });
 });
 
 
@@ -164,7 +165,8 @@ app.use((err, req, res, next) => {
 app.use(require("./middleware/errorHandler"));
 app.use((err, req, res, next) => {
   console.error("❌", err.message);
-  res.status(err.status || 500).json({ message: err.message || "Internal Server Error" });
+  const status = err.statusCode || err.status || 500;
+  res.status(status).json({ message: err.message || "Internal Server Error" });
 });
 
 const PORT = process.env.PORT || 5002;

--- a/backend/tests/authForgotPasswordRoutes.test.js
+++ b/backend/tests/authForgotPasswordRoutes.test.js
@@ -9,16 +9,24 @@ jest.mock('../src/modules/auth/services/auth.service', () => ({
   generateOtp: jest.fn(),
 }));
 
+jest.mock('../src/modules/users/user.model', () => ({
+  findByEmail: jest.fn(),
+}));
+
 const service = require('../src/modules/auth/services/auth.service');
+const userModel = require('../src/modules/users/user.model');
 const routes = require('../src/modules/auth/routes/auth.routes');
 
 const app = express();
 app.use(express.json());
 app.use('/api/auth', routes);
 
+const errorHandler = require('../src/middleware/errorHandler');
+app.use(errorHandler);
 describe('POST /api/auth/forgot-password', () => {
   it('invokes generateOtp and returns message', async () => {
     service.generateOtp.mockResolvedValue();
+    userModel.findByEmail.mockResolvedValue({ id: 1, email: 'test@example.com' });
     const res = await request(app)
       .post('/api/auth/forgot-password')
       .send({ email: 'test@example.com' });
@@ -26,5 +34,13 @@ describe('POST /api/auth/forgot-password', () => {
     expect(service.generateOtp).toHaveBeenCalledWith('test@example.com');
     expect(res.body.message).toBeDefined();
   });
-});
 
+  it('returns 404 for unknown email', async () => {
+    userModel.findByEmail.mockResolvedValue(null);
+    const res = await request(app)
+      .post('/api/auth/forgot-password')
+      .send({ email: 'missing@example.com' });
+    expect(res.status).toBe(404);
+    expect(res.body.message).toMatch(/not found/i);
+  });
+});

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -83,6 +83,7 @@ FRONTEND_URL=https://eduskillbridge.net
 ```
 
 Restart the backend so the updated CORS settings take effect.
+If CORS errors occur when requesting a password reset, ensure the FRONTEND_URL contains your frontend's domain. The API only sends CORS headers for domains listed there.
 
 ### Home page shows "Failed to load tutorials" or "Failed to load categories"
 


### PR DESCRIPTION
## Summary
- validate email existence before generating password reset OTP
- update forgot password tests with missing-user case
- clarify CORS troubleshooting instructions
- fix global error handler to respect `statusCode`

## Testing
- `cd backend && npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876398aedbc8328b991d6326adf7a67