### PR TITLE
Fix error handler status codes

### DIFF
--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,6 +1,11 @@
 // 📁 src/middleware/errorHandler.js
 module.exports = (err, req, res, next) => {
-  const status = err.statusCode || 500;
+  const status =
+    typeof err.statusCode === "number"
+      ? err.statusCode
+      : typeof err.status === "number"
+      ? err.status
+      : 500;
   const message = err.message || "Internal Server Error";
 
   console.error(`❌ ${status} - ${message}`);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -156,7 +156,12 @@ app.use((err, req, res, next) => {
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
 
   console.error("❌", err.message);
-  const status = err.statusCode || err.status || 500;
+  const status =
+    typeof err.statusCode === "number"
+      ? err.statusCode
+      : typeof err.status === "number"
+      ? err.status
+      : 500;
   res.status(status).json({ message: err.message || "Internal Server Error" });
 });
 
@@ -165,7 +170,12 @@ app.use((err, req, res, next) => {
 app.use(require("./middleware/errorHandler"));
 app.use((err, req, res, next) => {
   console.error("❌", err.message);
-  const status = err.statusCode || err.status || 500;
+  const status =
+    typeof err.statusCode === "number"
+      ? err.statusCode
+      : typeof err.status === "number"
+      ? err.status
+      : 500;
   res.status(status).json({ message: err.message || "Internal Server Error" });
 });
 


### PR DESCRIPTION
## Summary
- avoid invalid HTTP status codes in server error handlers
- guard middleware/errorHandler against non-numeric status codes

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_687645abb6788328b09e5960c9eea9cd