### PR TITLE
Add verify OTP route tests

### DIFF
--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,6 +1,23 @@
 // 📁 src/middleware/errorHandler.js
 module.exports = (err, req, res, next) => {
-  const status = err.statusCode || 500;
+  let origins = process.env.FRONTEND_URL || "http://localhost:3000";
+  if (origins.startsWith("FRONTEND_URL=")) origins = origins.replace(/^FRONTEND_URL=/, "");
+  const ALLOWED_ORIGINS = origins.split(',').map(o => o.trim());
+
+  const origin = req.headers.origin;
+  if (ALLOWED_ORIGINS.includes(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+  }
+  res.setHeader("Access-Control-Allow-Credentials", "true");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+  const status =
+    typeof err.statusCode === "number"
+      ? err.statusCode
+      : typeof err.status === "number"
+      ? err.status
+      : 500;
   const message = err.message || "Internal Server Error";
 
   console.error(`❌ ${status} - ${message}`);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -144,30 +144,7 @@ app.post("/api/video-calls/:roomId/messages", (req, res) => {
   res.status(201).json(message);
 });
 
-// ✅ Final fallback CORS headers in case route errors skip the first middleware
-// Final fallback CORS headers on errors
-app.use((err, req, res, next) => {
-  const origin = req.headers.origin;
-  if (ALLOWED_ORIGINS.includes(origin)) {
-    res.setHeader("Access-Control-Allow-Origin", origin);
-  }
-  res.setHeader("Access-Control-Allow-Credentials", "true");
-  res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-
-  console.error("❌", err.message);
-  const status = err.statusCode || err.status || 500;
-  res.status(status).json({ message: err.message || "Internal Server Error" });
-});
-
-
-
 app.use(require("./middleware/errorHandler"));
-app.use((err, req, res, next) => {
-  console.error("❌", err.message);
-  const status = err.statusCode || err.status || 500;
-  res.status(status).json({ message: err.message || "Internal Server Error" });
-});
 
 const PORT = process.env.PORT || 5002;
 

--- a/backend/tests/authVerifyOtpRoutes.test.js
+++ b/backend/tests/authVerifyOtpRoutes.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database', () => ({
+  raw: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../src/modules/auth/services/auth.service', () => ({
+  verifyOtp: jest.fn(),
+}));
+
+const service = require('../src/modules/auth/services/auth.service');
+const routes = require('../src/modules/auth/routes/auth.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/auth', routes);
+
+const errorHandler = require('../src/middleware/errorHandler');
+app.use(errorHandler);
+
+describe('POST /api/auth/verify-otp', () => {
+  it('returns valid true for correct OTP', async () => {
+    service.verifyOtp.mockResolvedValue(true);
+    const res = await request(app)
+      .post('/api/auth/verify-otp')
+      .send({ email: 'test@example.com', code: '123456' });
+    expect(res.status).toBe(200);
+    expect(service.verifyOtp).toHaveBeenCalledWith({ email: 'test@example.com', code: '123456' });
+    expect(res.body.valid).toBe(true);
+  });
+
+  it('returns error for wrong OTP', async () => {
+    const AppError = require('../src/utils/AppError');
+    service.verifyOtp.mockRejectedValue(new AppError('Invalid or expired OTP', 400));
+    const res = await request(app)
+      .post('/api/auth/verify-otp')
+      .send({ email: 'test@example.com', code: '000000' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/invalid/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration tests for `/api/auth/verify-otp`
- ensure fallback error handler sends CORS headers and numeric status

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_687645abb6788328b09e5960c9eea9cd