### PR TITLE
Fix success redirect after password reset

### DIFF
--- a/frontend/src/pages/auth/reset-password.js
+++ b/frontend/src/pages/auth/reset-password.js
@@ -62,9 +62,6 @@ export default function ResetPassword() {
     try {
       await resetPassword({ email, code, new_password: newPassword });
       toast.success("Password reset successful!");
-      // Clear stored verification data once password has been changed
-      localStorage.removeItem("otp_verified_email");
-      localStorage.removeItem("otp_verified_code");
       router.push("/auth/success-reset");
     } catch (err) {
       const msg = err?.response?.data?.message || "Password reset failed.";


### PR DESCRIPTION
## Summary
- ensure password reset flow keeps verification info until success page

## Testing
- `npm test --silent` in `frontend`
- `npm install --silent && npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6876831cf9688328aae01825dc416048