### PR TITLE
Fix success redirect after password reset

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -213,6 +213,11 @@ exports.resetPassword = async ({ email, code, new_password }) => {
 
   if (!resetRecord) throw new AppError("Invalid or expired OTP", 400);
 
+  const samePassword = await bcrypt.compare(new_password, user.password_hash);
+  if (samePassword) {
+    throw new AppError("You already used this password before", 400);
+  }
+
   const hashed = await bcrypt.hash(new_password, SALT_ROUNDS);
   await db("users").where({ id: user.id }).update({ password_hash: hashed });
 

--- a/frontend/src/pages/auth/reset-password.js
+++ b/frontend/src/pages/auth/reset-password.js
@@ -62,9 +62,6 @@ export default function ResetPassword() {
     try {
       await resetPassword({ email, code, new_password: newPassword });
       toast.success("Password reset successful!");
-      // Clear stored verification data once password has been changed
-      localStorage.removeItem("otp_verified_email");
-      localStorage.removeItem("otp_verified_code");
       router.push("/auth/success-reset");
     } catch (err) {
       const msg = err?.response?.data?.message || "Password reset failed.";

--- a/frontend/src/pages/auth/success-reset.js
+++ b/frontend/src/pages/auth/success-reset.js
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { motion } from "framer-motion";
 import { FaCheckCircle } from "react-icons/fa";
-import { toast } from "react-toastify";
 
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
 
@@ -11,15 +10,9 @@ export default function SuccessReset() {
   const router = useRouter();
 
   useEffect(() => {
-    const verifiedEmail = localStorage.getItem("otp_verified_email");
-    if (!verifiedEmail) {
-      toast.info("Please complete the OTP verification first.");
-      router.replace("/auth/forgot-password");
-      return;
-    }
-
     localStorage.removeItem("otp_verified_email");
     localStorage.removeItem("otp_verified_code");
+
     const timer = setTimeout(() => {
       router.push("/auth/login");
     }, 4000);


### PR DESCRIPTION
## Summary
- ensure success page always transitions to login
- prevent reusing the same password when resetting

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6876831cf9688328aae01825dc416048