### PR TITLE
Fix success redirect after password reset

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -14,7 +14,7 @@ const messageService = require("../../messages/messages.service");
 const SALT_ROUNDS = 12;
 const ACCESS_EXPIRES_IN = "15m";
 const REFRESH_EXPIRES_IN = "7d";
-const OTP_EXPIRY_MINUTES = 10;
+const OTP_EXPIRY_MINUTES = 15;
 
 /**
  * Register a new user
@@ -212,6 +212,11 @@ exports.resetPassword = async ({ email, code, new_password }) => {
     .first();
 
   if (!resetRecord) throw new AppError("Invalid or expired OTP", 400);
+
+  const samePassword = await bcrypt.compare(new_password, user.password_hash);
+  if (samePassword) {
+    throw new AppError("You already used this password before", 400);
+  }
 
   const hashed = await bcrypt.hash(new_password, SALT_ROUNDS);
   await db("users").where({ id: user.id }).update({ password_hash: hashed });

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -31,14 +31,31 @@ exports.sendOtpEmail = async (to, otp) => {
   const cfg = (await emailConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  const fromEmail = (cfg.fromEmail || process.env.SMTP_USER || "").trim();
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "no-reply@eduskillbridge.net"
+  ).trim();
   const fromName = (cfg.fromName || process.env.SMTP_NAME || "SkillBridge").trim();
 
+  const footer =
+    '<p style="font-size:12px;color:#555;margin-top:20px">SkillBridge © 2025 • All rights reserved<br/>Visit us: <a href="https://eduskillbridge.net">https://eduskillbridge.net</a></p>';
   const mailOptions = {
     from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
     to,
     subject: "Your OTP for SkillBridge",
-    html: `<p>Your OTP code is: <strong>${otp}</strong></p>`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="https://eduskillbridge.net/logo.png" alt="SkillBridge" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>Your One-Time Password (OTP) for verifying your SkillBridge account is:</p>
+        <p style="font-size:24px"><strong>🔐 ${otp}</strong></p>
+        <p>This code is valid for 15 minutes. Please do not share it with anyone.</p>
+        <p>If you didn’t request this, please ignore this message or contact us at <a href="mailto:support@eduskillbridge.net">support@eduskillbridge.net</a>.</p>
+        <p>Thank you,<br/>The SkillBridge Team</p>
+        ${footer}
+      </div>`,
   };
 
   try {
@@ -54,14 +71,30 @@ exports.sendPasswordChangeEmail = async (to) => {
   const cfg = (await emailConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  const fromEmail = (cfg.fromEmail || process.env.SMTP_USER || "").trim();
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "no-reply@eduskillbridge.net"
+  ).trim();
   const fromName = (cfg.fromName || process.env.SMTP_NAME || "SkillBridge").trim();
 
+  const footer =
+    '<p style="font-size:12px;color:#555;margin-top:20px">SkillBridge © 2025 • All rights reserved<br/>Visit us: <a href="https://eduskillbridge.net">https://eduskillbridge.net</a></p>';
   const mailOptions = {
     from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
     to,
     subject: "Your SkillBridge password was changed",
-    html: `<p>Your password was changed successfully. If you didn't request this, please contact support immediately.</p>`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="https://eduskillbridge.net/logo.png" alt="SkillBridge" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>Your SkillBridge password was changed successfully.</p>
+        <p>If you did not request this change, please contact us <strong>immediately</strong> at <a href="mailto:support@eduskillbridge.net">support@eduskillbridge.net</a>.</p>
+        <p>For your security, we recommend regularly updating your password and not sharing it with others.</p>
+        <p>Thank you,<br/>The SkillBridge Team</p>
+        ${footer}
+      </div>`,
   };
 
   try {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,7 +24,8 @@ Follow these steps to run SkillBridge on a server or production host.
     ```
 
     To enable password recovery via email, provide SMTP settings or
-    configure them later through the `/api/email-config` endpoint. At a minimum
+    configure them later through the `/api/email-config` endpoint or the admin
+    dashboard at `/dashboard/admin/settings/email-config`. At a minimum
     the backend requires the following variables:
 
     ```bash
@@ -34,6 +35,9 @@ Follow these steps to run SkillBridge on a server or production host.
     SMTP_USER=your_smtp_username
     SMTP_PASS=your_smtp_password
     ```
+
+    The default templates include your logo and a footer. OTP codes expire
+    after **15 minutes**.
      
     This value is used for CORS and socket.io connections. If it still points to
     `http://localhost:3001` you may see `Network Error` or CORS errors when

--- a/frontend/src/pages/auth/reset-password.js
+++ b/frontend/src/pages/auth/reset-password.js
@@ -62,9 +62,6 @@ export default function ResetPassword() {
     try {
       await resetPassword({ email, code, new_password: newPassword });
       toast.success("Password reset successful!");
-      // Clear stored verification data once password has been changed
-      localStorage.removeItem("otp_verified_email");
-      localStorage.removeItem("otp_verified_code");
       router.push("/auth/success-reset");
     } catch (err) {
       const msg = err?.response?.data?.message || "Password reset failed.";

--- a/frontend/src/pages/auth/success-reset.js
+++ b/frontend/src/pages/auth/success-reset.js
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { motion } from "framer-motion";
 import { FaCheckCircle } from "react-icons/fa";
-import { toast } from "react-toastify";
 
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
 
@@ -11,15 +10,9 @@ export default function SuccessReset() {
   const router = useRouter();
 
   useEffect(() => {
-    const verifiedEmail = localStorage.getItem("otp_verified_email");
-    if (!verifiedEmail) {
-      toast.info("Please complete the OTP verification first.");
-      router.replace("/auth/forgot-password");
-      return;
-    }
-
     localStorage.removeItem("otp_verified_email");
     localStorage.removeItem("otp_verified_code");
+
     const timer = setTimeout(() => {
       router.push("/auth/login");
     }, 4000);


### PR DESCRIPTION
## Summary
- ensure success page always transitions to login
- prevent reusing the same password when resetting
- style password reset and change emails
- increase OTP validity to 15 minutes

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6876831cf9688328aae01825dc416048