### PR TITLE
Enable saving app settings

### DIFF
--- a/frontend/src/pages/api/app-config/index.js
+++ b/frontend/src/pages/api/app-config/index.js
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+export default async function handler(req, res) {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const url = `${base}/app-config`;
+  try {
+    const headers = req.headers.cookie ? { Cookie: req.headers.cookie } : {};
+    if (req.method === 'GET') {
+      const { data } = await axios.get(url, { headers, withCredentials: true });
+      return res.status(200).json(data.data || data);
+    }
+    if (req.method === 'PUT') {
+      const { data } = await axios.put(url, req.body, { headers, withCredentials: true });
+      return res.status(200).json(data.data);
+    }
+    res.setHeader('Allow', ['GET', 'PUT']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    const status = err.response?.status || 500;
+    const message = err.response?.data?.message || 'Failed to process request';
+    res.status(status).json({ error: message });
+  }
+}
+

--- a/frontend/src/pages/dashboard/admin/settings/app/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/app/index.js
@@ -61,6 +61,11 @@ export default function AppSettingsPage() {
     setConfig((prev) => ({ ...prev, [field]: value }));
   };
 
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await handleSave();
+  };
+
   const handleSave = async () => {
     setIsLoading(true);
     try {
@@ -106,19 +111,19 @@ export default function AppSettingsPage() {
 
   return (
     <AdminLayout title="App Settings">
-      <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <form onSubmit={handleSubmit} className="max-w-4xl mx-auto p-6 space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Application Settings</h1>
           <button
-            onClick={handleSave}
+            type="submit"
             disabled={isLoading}
             className={`inline-flex items-center gap-2 px-4 py-2 rounded-md transition-colors ${
-              isLoading 
-                ? "bg-gray-300 cursor-not-allowed" 
+              isLoading
+                ? "bg-gray-300 cursor-not-allowed"
                 : "bg-yellow-600 hover:bg-yellow-700 text-white"
             }`}
           >
-            <FaSave /> 
+            <FaSave />
             {isLoading ? "Saving..." : "Save Settings"}
           </button>
         </div>
@@ -286,7 +291,7 @@ export default function AppSettingsPage() {
             </div>
           </div>
         </div>
-      </div>
+      </form>
     </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- make admin app settings page submit via a form
- add API route to proxy `/app-config` requests to backend

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68769697847083289108c60d9d5bba72