### PR TITLE
Fix login logo on localhost

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -10,6 +10,12 @@ const nextConfig = {
         pathname: '/**',
       },
       {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '5002',
+        pathname: '/**',
+      },
+      {
         protocol: 'https',
         hostname: 'eduskillbridge.net',
         pathname: '/api/uploads/**', // Production domain


### PR DESCRIPTION
## Summary
- allow images from `localhost:5002` so the login page can load the logo during local development

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6876b8f9d0048328b1e0c0a7d9947fcd