### PR TITLE
Fix admin settings logo sync

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/app/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/app/index.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchAppConfig, updateAppConfig, uploadAppLogo, uploadAppFavicon } from "@/services/admin/appConfigService";
+import useAppConfigStore from "@/store/appConfigStore";
 import { FaSave, FaUpload, FaImage, FaGlobe } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { API_BASE_URL } from "@/config/config";
@@ -21,13 +22,17 @@ export default function AppSettingsPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [logoPreview, setLogoPreview] = useState("");
   const [faviconPreview, setFaviconPreview] = useState("");
+  const updateConfigStore = useAppConfigStore((state) => state.update);
 
   useEffect(() => {
     const load = async () => {
       setIsLoading(true);
       try {
         const data = await fetchAppConfig();
-        if (data) setConfig({ ...defaultConfig, ...data });
+        if (data) {
+          setConfig({ ...defaultConfig, ...data });
+          updateConfigStore(data);
+        }
       } catch (err) {
         console.error("Failed to load app settings", err);
         toast.error("Failed to load settings");
@@ -70,7 +75,8 @@ export default function AppSettingsPage() {
   const handleSave = async () => {
     setIsLoading(true);
     try {
-      await updateAppConfig(config);
+      const updated = await updateAppConfig(config);
+      updateConfigStore(updated);
       toast.success("Settings saved successfully");
     } catch (err) {
       console.error("Failed to save settings", err);
@@ -86,6 +92,7 @@ export default function AppSettingsPage() {
     try {
       const data = await uploadAppLogo(logoFile);
       setConfig((prev) => ({ ...prev, ...data }));
+      updateConfigStore(data);
       setLogoFile(null);
       toast.success("Logo uploaded successfully");
     } catch (err) {
@@ -101,6 +108,7 @@ export default function AppSettingsPage() {
     try {
       const data = await uploadAppFavicon(faviconFile);
       setConfig((prev) => ({ ...prev, ...data }));
+      updateConfigStore(data);
       setFaviconFile(null);
       toast.success("Favicon uploaded successfully");
     } catch (err) {

--- a/frontend/src/store/appConfigStore.js
+++ b/frontend/src/store/appConfigStore.js
@@ -14,10 +14,12 @@ const useAppConfigStore = create(
         try {
           const data = await getAppConfig();
           set({ settings: data, loaded: true, loading: false });
-        } catch (err) {
+        } catch (_err) {
           set({ loaded: true, loading: false });
         }
       },
+      update: (newSettings) =>
+        set((state) => ({ settings: { ...state.settings, ...newSettings } })),
       clear: () => set({ settings: {}, loaded: false }),
     }),
     { name: "app-config" }


### PR DESCRIPTION
## Summary
- allow updating app config store values
- keep app config store in sync when saving settings or uploading logo/favicon

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687736cc18f88328bca4fc855c8764fd