### PR TITLE
Persist uploaded branding assets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - db
     volumes:
       - ./backend/src:/app/src  # ✅ This makes migrations show up locally
+      - ./backend/uploads:/app/uploads  # persist uploaded logos and media
 
   frontend:
     build: ./frontend

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -68,6 +68,21 @@ Follow these steps to run SkillBridge on a server or production host.
 After updating these files, rebuild the Docker images or restart the server so
 that the environment changes take effect.
 
+## Preserve uploaded media
+
+The admin panel lets you upload a logo and favicon under
+`/dashboard/admin/settings/app`. These files are stored inside the backend
+container under `/app/uploads`. To keep them after a container restart, mount the
+`backend/uploads` folder from the host. In `docker-compose.yml` add:
+
+```yaml
+  backend:
+    volumes:
+      - ./backend/uploads:/app/uploads
+```
+
+This ensures custom branding files persist across deployments.
+
 ## Next.js image domains
 
 If your uploads are served from the backend domain you should update the


### PR DESCRIPTION
## Summary
- persist backend uploads using a host volume
- document how to keep custom logos and favicons

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68773c9bd78c8328bc8e66ba2de27f9e