### PR TITLE
Fix logo display on auth pages

### DIFF
--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -10,7 +10,6 @@ import { toast } from "react-toastify";
 import { motion } from "framer-motion";
 import Image from "next/image";
 
-import logo from "@/shared/assets/images/login/logo.png";
 import { API_BASE_URL } from "@/config/config";
 import useAppConfigStore from "@/store/appConfigStore";
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
@@ -140,7 +139,9 @@ export default function Login() {
       >
         <div className="w-24 h-24 rounded-full border-4 border-yellow-500 bg-gray-900 flex items-center justify-center mb-4 shadow-lg overflow-hidden">
           <Image
-            src={settings.logo_url ? `${API_BASE_URL}${settings.logo_url}` : logo}
+            src={settings.logo_url
+              ? `${API_BASE_URL}${settings.logo_url}`
+              : "/images/logo.png"}
             alt={(settings.appName || 'SkillBridge') + ' Logo'}
             width={80}
             height={80}

--- a/frontend/src/pages/auth/register.js
+++ b/frontend/src/pages/auth/register.js
@@ -10,7 +10,6 @@ import { FaEye, FaEyeSlash } from "react-icons/fa";
 import PhoneInput from "react-phone-number-input";
 import 'react-phone-number-input/style.css';
 
-import logo from "@/shared/assets/images/login/logo.png";
 import { API_BASE_URL } from "@/config/config";
 import useAppConfigStore from "@/store/appConfigStore";
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
@@ -86,7 +85,9 @@ export default function Register() {
       >
         <div className="w-24 h-24 rounded-full border-4 border-yellow-500 bg-gray-900 flex items-center justify-center mb-4 shadow-lg overflow-hidden">
           <Image
-            src={settings.logo_url ? `${API_BASE_URL}${settings.logo_url}` : logo}
+            src={settings.logo_url
+              ? `${API_BASE_URL}${settings.logo_url}`
+              : "/images/logo.png"}
             alt={(settings.appName || 'SkillBridge') + ' Logo'}
             width={80}
             height={80}


### PR DESCRIPTION
## Summary
- ensure auth logo uses /public path
- remove unused logo imports

## Testing
- `npm test` in `backend` *(passes)*
- `npm test` in `frontend` *(fails: network issue installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68775249bf3483288ff7e321a76013a6