### PR TITLE
Add short delay after login toast

### DIFF
--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -97,8 +97,10 @@ export default function Login() {
         ? profilePaths[loggedInUser.role?.toLowerCase()] || "/website"
         : "/website";
 
-    // 🚀 Redirect immediately after a successful login
-    router.push(targetPath);
+    // 🚀 Redirect after a short delay so the toast is visible
+    setTimeout(() => {
+      router.push(targetPath);
+    }, 500);
   } catch (err) {
     console.error("❌ login onSubmit error", err);
     let msg =


### PR DESCRIPTION
## Summary
- delay redirect on login success so toast is visible

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6877588257d4832893f8059501b58a2a