### PR TITLE
Fix auth logo display

### DIFF
--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -8,9 +8,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { motion } from "framer-motion";
-import Image from "next/image";
 
-import logo from "@/shared/assets/images/login/logo.png";
 import { API_BASE_URL } from "@/config/config";
 import useAppConfigStore from "@/store/appConfigStore";
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
@@ -139,12 +137,13 @@ export default function Login() {
         className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-96 border border-gray-700 text-white flex flex-col items-center"
       >
         <div className="w-24 h-24 rounded-full border-4 border-yellow-500 bg-gray-900 flex items-center justify-center mb-4 shadow-lg overflow-hidden">
-          <Image
-            src={settings.logo_url ? `${API_BASE_URL}${settings.logo_url}` : logo}
+          <img
+            src={settings.logo_url
+              ? `${API_BASE_URL}${settings.logo_url}`
+              : "/images/logo.png"}
             alt={(settings.appName || 'SkillBridge') + ' Logo'}
             width={80}
             height={80}
-            priority
             className="rounded-full object-contain"
           />
         </div>

--- a/frontend/src/pages/auth/register.js
+++ b/frontend/src/pages/auth/register.js
@@ -5,12 +5,10 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { motion } from "framer-motion";
-import Image from "next/image";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
 import PhoneInput from "react-phone-number-input";
 import 'react-phone-number-input/style.css';
 
-import logo from "@/shared/assets/images/login/logo.png";
 import { API_BASE_URL } from "@/config/config";
 import useAppConfigStore from "@/store/appConfigStore";
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
@@ -85,13 +83,14 @@ export default function Register() {
         className="relative bg-gray-800/90 backdrop-blur-md rounded-xl shadow-2xl p-8 w-full max-w-md border border-yellow-500/40 text-white flex flex-col items-center"
       >
         <div className="w-24 h-24 rounded-full border-4 border-yellow-500 bg-gray-900 flex items-center justify-center mb-4 shadow-lg overflow-hidden">
-          <Image
-            src={settings.logo_url ? `${API_BASE_URL}${settings.logo_url}` : logo}
+          <img
+            src={settings.logo_url
+              ? `${API_BASE_URL}${settings.logo_url}`
+              : "/images/logo.png"}
             alt={(settings.appName || 'SkillBridge') + ' Logo'}
             width={80}
             height={80}
             className="rounded-full object-contain"
-            priority
           />
         </div>
 


### PR DESCRIPTION
## Summary
- render logo with `<img>` tag to avoid Next.js domain restrictions on login and register pages

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68775249bf3483288ff7e321a76013a6