### PR TITLE
Implement registration emails

### DIFF
--- a/backend/src/modules/users/user.model.js
+++ b/backend/src/modules/users/user.model.js
@@ -99,7 +99,7 @@ exports.findContactInfo = async (id) => {
 // Fetch Admin and SuperAdmin users
 exports.findAdmins = () => {
   return db("users")
-    .select("id")
+    .select("id", "email", "full_name")
     .whereIn("role", ["Admin", "SuperAdmin"]);
 };
 


### PR DESCRIPTION
## Summary
- extend email utility with welcome and admin notifications
- include admin email and name in `findAdmins`
- send welcome and admin notification emails after user registration

## Testing
- `npx --yes jest` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68775b919da08328a423f070e9aeb2b6