### PR TITLE
Improve registration flow

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -20,8 +20,8 @@ const refreshCookieOptions = {
  */
 exports.register = catchAsync(async (req, res, next) => {
   try {
-    const result = await authService.registerUser(req.body);
-    res.status(201).json(result);
+    const { user } = await authService.registerUser(req.body);
+    res.status(201).json({ message: "Registration successful", user });
   } catch (err) {
     console.error("🔥 Registration error caught:");
     console.error("Name:", err.name);
@@ -37,6 +37,11 @@ exports.register = catchAsync(async (req, res, next) => {
       if (err.detail.includes("users_phone_unique")) {
         return res.status(400).json({ error: "Phone number is already registered" });
       }
+    }
+
+    // Handle expected AppError instances thrown by the service
+    if (err instanceof AppError && err.isOperational) {
+      return res.status(err.statusCode).json({ error: err.message });
     }
 
     // ⛔ Unknown error — fallback to generic

--- a/backend/src/modules/users/user.model.js
+++ b/backend/src/modules/users/user.model.js
@@ -99,7 +99,7 @@ exports.findContactInfo = async (id) => {
 // Fetch Admin and SuperAdmin users
 exports.findAdmins = () => {
   return db("users")
-    .select("id")
+    .select("id", "email", "full_name")
     .whereIn("role", ["Admin", "SuperAdmin"]);
 };
 

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -8,7 +8,7 @@ import api from "@/services/api/api";
  * @param {Object} credentials - User credentials
  * @param {string} credentials.email
  * @param {string} credentials.password
- * @returns {Promise<{ accessToken: string, user: object }>}
+ * @returns {Promise<{ message: string, user: object }>}
  */
 export const loginUser = async ({ email, password }) => {
   try {
@@ -25,7 +25,7 @@ export const loginUser = async ({ email, password }) => {
  * 🧾 Register a new user account (Student, Instructor, Admin).
  * 
  * @param {Object} payload - Registration data
- * @returns {Promise<{ accessToken: string, user: object }>}
+ * @returns {Promise<{ message: string, user: object }>}
  */
 export const registerUser = async (payload) => {
   const res = await api.post("/auth/register", payload);

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -28,12 +28,7 @@ const useAuthStore = create(
       },
 
       register: async (data) => {
-        const { accessToken, user } = await authService.registerUser(data);
-        if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
-          user.avatar_url = null;
-        }
-        set({ accessToken, user });
-        return user;
+        await authService.registerUser(data);
       },
 
       logout: async () => {


### PR DESCRIPTION
## Summary
- stop auto-login on registration
- respond with success message instead of tokens
- update frontend store and service accordingly
- document register service return type

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68775b919da08328a423f070e9aeb2b6