### PR TITLE
Create student_profiles table

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -34,6 +34,11 @@
 - **Foreign Keys**: `user_id → users(id)`
 - **Columns**: `user_id`, `code_hash`, `expires_at`, `used`, `created_at`
 
+### `student_profiles`
+- **Purpose**: Extra details for student accounts
+- **Primary Key**: `user_id (PK)`
+- **Foreign Keys**: `user_id → users(id)`
+
 
 ## Classes Tables
 

--- a/backend/src/migrations/20250719000000_create_student_profiles_table.js
+++ b/backend/src/migrations/20250719000000_create_student_profiles_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('student_profiles', function(table) {
+    table.uuid('user_id').primary().references('id').inTable('users').onDelete('CASCADE');
+    table.string('education_level');
+    table.text('topics');
+    table.text('learning_goals');
+    table.string('identity_doc_url');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('student_profiles');
+};


### PR DESCRIPTION
## Summary
- add missing `student_profiles` migration
- document student_profiles in database overview

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877677fb1fc83289a737e16c0f60558