### PR TITLE
Add phone OTP default and profile completion notification

### DIFF
--- a/backend/src/modules/users/profile.controller.js
+++ b/backend/src/modules/users/profile.controller.js
@@ -1,5 +1,7 @@
 const userModel = require("./user.model");
 const db = require("../../config/database");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
 
 /**
  * PATCH /users/profile
@@ -87,6 +89,25 @@ exports.updateProfile = async (req, res) => {
 
     if (profileComplete) {
       await userModel.updateUser(userId, { profile_complete: true });
+
+      // Notify user profile completion
+      await notificationService.createNotification({
+        user_id: userId,
+        type: "profile",
+        message:
+          "Your profile is complete! You can now use the platform and all its features.",
+      });
+
+      const admins = await userModel.findAdmins();
+      const firstAdmin = admins[0];
+      if (firstAdmin) {
+        await messageService.createMessage({
+          sender_id: firstAdmin.id,
+          receiver_id: userId,
+          message:
+            "Your profile is complete! You can now use the platform and all its features.",
+        });
+      }
     }
 
     // ─────────────────────────────────────────────────────

--- a/backend/src/modules/verify/verify.service.js
+++ b/backend/src/modules/verify/verify.service.js
@@ -1,10 +1,11 @@
 const db = require("../../config/database");
 const { v4: uuidv4 } = require("uuid");
 
-const generateCode = () => Math.floor(100000 + Math.random() * 900000).toString();
+const generateCode = () =>
+  Math.floor(100000 + Math.random() * 900000).toString();
 
 exports.sendOtp = async (userId, type) => {
-  const code = generateCode();
+  const code = type === "phone" ? "123456" : generateCode();
   const expires = new Date(Date.now() + 10 * 60 * 1000); // 10 min
 
   await db("verifications").insert({


### PR DESCRIPTION
## Summary
- use a static OTP for phone verification until SMS provider is ready
- notify and message users once their profile is completed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68776a9e3bfc8328b0ca54b3f3ed88b0