### PR TITLE
Update verification refresh logic

### DIFF
--- a/frontend/src/components/profile/steps/Verification.js
+++ b/frontend/src/components/profile/steps/Verification.js
@@ -11,7 +11,7 @@ import {
 } from "@/services/verificationService";
 
 const Verification = ({ onNext, onBack }) => {
-  const { user } = useAuthStore();
+  const { user, refreshUser } = useAuthStore();
   const [emailVerified, setEmailVerified] = useState(user?.is_email_verified || false);
   const [phoneVerified, setPhoneVerified] = useState(user?.is_phone_verified || false);
   const [emailOTP, setEmailOTP] = useState("");
@@ -52,6 +52,9 @@ const Verification = ({ onNext, onBack }) => {
       }
       if (type === "email") setEmailVerified(true);
       if (type === "phone") setPhoneVerified(true);
+
+      // 🔄 Refresh stored user data after verification
+      await refreshUser();
 
       const emailNow = type === "email" ? true : emailVerified;
       const phoneNow = type === "phone" ? true : phoneVerified;

--- a/frontend/src/pages/dashboard/instructor/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/Verification.js
@@ -14,7 +14,7 @@ import {
 
 const Verification = ({ onBack = () => {} }) => {
   const router = useRouter();
-  const { user } = useAuthStore();
+  const { user, refreshUser } = useAuthStore();
   const [emailVerified, setEmailVerified] = useState(user?.is_email_verified || false);
   const [phoneVerified, setPhoneVerified] = useState(user?.is_phone_verified || false);
   const [emailOTP, setEmailOTP] = useState("");
@@ -65,6 +65,8 @@ const Verification = ({ onBack = () => {} }) => {
       }
       if (type === "email") setEmailVerified(true);
       if (type === "phone") setPhoneVerified(true);
+
+      await refreshUser();
 
       const emailNow = type === "email" ? true : emailVerified;
       const phoneNow = type === "phone" ? true : phoneVerified;

--- a/frontend/src/pages/dashboard/student/profile/steps/FinalReview.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/FinalReview.js
@@ -6,7 +6,7 @@ import useAuthStore from "@/store/auth/authStore"; // ✅ Get logged-in user inf
 
 const FinalReview = ({ formData = {} }) => {
   const router = useRouter();
-  const { user } = useAuthStore(); // ✅ access user.id
+  const { user, refreshUser } = useAuthStore(); // ✅ access user.id
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async () => {
@@ -29,6 +29,7 @@ const FinalReview = ({ formData = {} }) => {
 
       // 1. Submit JSON profile data
       await updateProfile(payload);
+      await refreshUser();
 
       // 2. Upload demo video (instructor only)
       const demoVideo = formData.instructorDetails?.demo_video;

--- a/frontend/src/pages/dashboard/student/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/Verification.js
@@ -17,7 +17,7 @@ import StudentLayout from "@/components/layouts/StudentLayout";
 const Verification = ({ prevStep = () => {} }) => {
   const router = useRouter();
 
-  const { user } = useAuthStore();
+  const { user, refreshUser } = useAuthStore();
   const [emailVerified, setEmailVerified] = useState(user?.is_email_verified || false);
   const [phoneVerified, setPhoneVerified] = useState(user?.is_phone_verified || false);
   const [emailOTP, setEmailOTP] = useState("");
@@ -62,6 +62,8 @@ const Verification = ({ prevStep = () => {} }) => {
         toast.success(`${type === "email" ? "Email" : "Phone"} verified`);
       }
       type === "email" ? setEmailVerified(true) : setPhoneVerified(true);
+
+      await refreshUser();
 
       const emailNow = type === "email" ? true : emailVerified;
       const phoneNow = type === "phone" ? true : phoneVerified;

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import * as authService from "@/services/auth/authService";
+import { getFullProfile } from "@/services/profile/profileService";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 
@@ -25,6 +26,20 @@ const useAuthStore = create(
         }
         set({ accessToken, user });
         return user;
+      },
+
+      refreshUser: async () => {
+        try {
+          const res = await getFullProfile();
+          const fresh = res.data;
+          if (fresh.avatar_url?.startsWith("blob:") || fresh.avatar_url === "null") {
+            fresh.avatar_url = null;
+          }
+          set({ user: fresh });
+          return fresh;
+        } catch (err) {
+          console.error("❌ refreshUser error", err);
+        }
       },
 
       register: async (data) => {


### PR DESCRIPTION
## Summary
- refresh auth store from server via `refreshUser`
- update verification steps to update auth store after confirming OTP
- refresh profile info after completing profile form

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687797e69edc83288e01e253a7882612