### PR TITLE
Fix admin profile edit page

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { z } from "zod";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import {
   FaSpinner,
   FaChevronDown,
@@ -259,19 +260,15 @@ export default function ProfileEditTemplate() {
 
 
   if (!hasHydrated || loadingProfile) {
-
     return (
-      <AdminLayout>
-        <div className="flex justify-center items-center h-64">
-          <FaSpinner className="animate-spin text-4xl text-yellow-600" />
-        </div>
-      </AdminLayout>
+      <div className="flex justify-center items-center h-64">
+        <FaSpinner className="animate-spin text-4xl text-yellow-600" />
+      </div>
     );
   }
 
   return (
-    <AdminLayout>
-      <div className="max-w-5xl mx-auto p-6">
+    <div className="max-w-5xl mx-auto p-6">
         <h1 className="text-3xl font-bold text-gray-900 mb-6">Profile Edit</h1>
         <div className="space-y-6">
           {/* Avatar Upload */}
@@ -498,6 +495,18 @@ export default function ProfileEditTemplate() {
           </div>
         </div>
       )}
-    </AdminLayout>
   );
 }
+
+ProfileEditTemplate.getLayout = function getLayout(page) {
+  return <AdminLayout>{page}</AdminLayout>;
+};
+
+const ProtectedProfileEdit = withAuthProtection(ProfileEditTemplate, [
+  "admin",
+  "superadmin",
+]);
+
+ProtectedProfileEdit.getLayout = ProfileEditTemplate.getLayout;
+
+export default ProtectedProfileEdit;


### PR DESCRIPTION
## Summary
- add missing authentication wrapper for admin profile editing
- use AdminLayout via getLayout instead of inline

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6877cff57aa883288ddd8ee4ac2010b2