### PR TITLE
Enable GitHub social login

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "passport": "^0.7.0",
         "passport-apple": "^2.0.2",
         "passport-facebook": "^3.0.0",
+        "passport-github2": "^0.1.12",
         "passport-google-oauth20": "^2.0.0",
         "pg": "^8.16.3",
         "sharp": "^0.34.2",
@@ -5248,6 +5249,17 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-github2": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
+      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/passport-google-oauth20": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "passport-apple": "^2.0.2",
     "passport-facebook": "^3.0.0",
     "passport-google-oauth20": "^2.0.0",
+    "passport-github2": "^0.1.12",
     "pg": "^8.16.3",
     "sharp": "^0.34.2",
     "slugify": "^1.6.6",

--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -63,3 +63,23 @@ const { passport } = require('../../../config/passport');
 //     res.redirect(redirectUrl);
 //   })(req, res, next);
 // };
+
+// GitHub OAuth
+exports.githubAuth = passport.authenticate('github', { scope: ['user:email'] });
+
+exports.githubCallback = (req, res, next) => {
+  passport.authenticate('github', { session: false }, (err, result) => {
+    if (err || !result) {
+      return res.redirect(`${process.env.FRONTEND_URL || ''}/auth/login?error=social`);
+    }
+    const { accessToken, refreshToken } = result;
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
+    const redirectUrl = `${process.env.FRONTEND_URL || ''}/auth/social-success?token=${accessToken}`;
+    res.redirect(redirectUrl);
+  })(req, res, next);
+};

--- a/backend/src/modules/auth/routes/auth.routes.js
+++ b/backend/src/modules/auth/routes/auth.routes.js
@@ -94,5 +94,9 @@ router.post(
 // router.get("/apple", socialAuthController.appleAuth);
 // router.post("/apple/callback", socialAuthController.appleCallback);
 
+// GitHub routes
+router.get("/github", socialAuthController.githubAuth);
+router.get("/github/callback", socialAuthController.githubCallback);
+
 
 module.exports = router;

--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -1,13 +1,14 @@
 import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { toast } from "react-toastify";
-import { FaToggleOn, FaToggleOff, FaGoogle, FaFacebookF, FaApple } from "react-icons/fa";
+import { FaToggleOn, FaToggleOff, FaGoogle, FaFacebookF, FaApple, FaGithub } from "react-icons/fa";
 import { fetchSocialLoginConfig, updateSocialLoginConfig } from "@/services/admin/socialLoginConfigService";
 
 const availableIcons = {
   google: <FaGoogle />,
   facebook: <FaFacebookF />,
   apple: <FaApple />,
+  github: <FaGithub />,
 };
 
 const initialProviders = [
@@ -39,6 +40,15 @@ const initialProviders = [
     privateKey: "",
     label: "Sign in with Apple",
     icon: "apple"
+  },
+  {
+    name: "GitHub",
+    key: "github",
+    active: false,
+    clientId: "",
+    clientSecret: "",
+    label: "Sign in with GitHub",
+    icon: "github"
   }
 ];
 


### PR DESCRIPTION
## Summary
- support GitHub auth in backend passport configuration
- expose GitHub login endpoints
- implement GitHub handlers in social auth controller
- allow configuring GitHub in admin social login settings
- update packages with passport-github2

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877f58a29448328b39789d694b909c1