### PR TITLE
Add privacy policy and terms pages

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -77,5 +77,12 @@ export const adminNavLinks = [
         ]
       }
     ]
+  },
+  {
+    title: 'Legal',
+    items: [
+      { label: 'Privacy Policy', href: '/privacy-policy', icon: FileSignature },
+      { label: 'Terms of Service', href: '/terms', icon: FileSignature }
+    ]
   }
 ];

--- a/frontend/src/pages/privacy-policy.js
+++ b/frontend/src/pages/privacy-policy.js
@@ -1,0 +1,25 @@
+import PageHead from '@/components/common/PageHead';
+import Navbar from '@/components/website/sections/Navbar';
+import Footer from '@/components/website/sections/Footer';
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="bg-gray-900 text-white min-h-screen">
+      <PageHead title="Privacy Policy" />
+      <Navbar />
+      <main className="max-w-3xl mx-auto px-4 py-16 space-y-6">
+        <h1 className="text-3xl font-bold text-yellow-500">Privacy Policy</h1>
+        <p>
+          We respect your privacy and are committed to protecting your personal
+          information. This policy explains how we collect, use and safeguard
+          your data when you use our services.
+        </p>
+        <p>
+          By accessing SkillBridge you agree to this privacy policy. We may
+          update it from time to time, so please review it periodically.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/pages/terms.js
+++ b/frontend/src/pages/terms.js
@@ -1,0 +1,24 @@
+import PageHead from '@/components/common/PageHead';
+import Navbar from '@/components/website/sections/Navbar';
+import Footer from '@/components/website/sections/Footer';
+
+export default function TermsPage() {
+  return (
+    <div className="bg-gray-900 text-white min-h-screen">
+      <PageHead title="Terms of Service" />
+      <Navbar />
+      <main className="max-w-3xl mx-auto px-4 py-16 space-y-6">
+        <h1 className="text-3xl font-bold text-yellow-500">Terms of Service</h1>
+        <p>
+          These terms govern your use of SkillBridge. By accessing the platform
+          you agree to comply with them and any applicable laws.
+        </p>
+        <p>
+          We may modify these terms at any time. Continuing to use the service
+          means you accept the updated terms.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/privacy-policy` and `/terms` pages to frontend
- link legal pages in admin sidebar navigation

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_687800b693b883288f9d1c1676fd716c