### PR TITLE
Add data deletion page

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -82,7 +82,8 @@ export const adminNavLinks = [
     title: 'Legal',
     items: [
       { label: 'Privacy Policy', href: '/privacy-policy', icon: FileSignature },
-      { label: 'Terms of Service', href: '/terms', icon: FileSignature }
+      { label: 'Terms of Service', href: '/terms', icon: FileSignature },
+      { label: 'Delete Account', href: '/delete-account', icon: FileSignature }
     ]
   }
 ];

--- a/frontend/src/components/website/sections/Footer.js
+++ b/frontend/src/components/website/sections/Footer.js
@@ -175,6 +175,8 @@ const Footer = () => {
             <Link href="/privacy-policy" className="hover:text-yellow-300 transition">Privacy Policy</Link>
             <span>|</span>
             <Link href="/terms" className="hover:text-yellow-300 transition">Terms of Service</Link>
+            <span>|</span>
+            <Link href="/delete-account" className="hover:text-yellow-300 transition">Delete Account</Link>
           </div>
         </div>
 

--- a/frontend/src/pages/delete-account.js
+++ b/frontend/src/pages/delete-account.js
@@ -1,0 +1,29 @@
+import PageHead from '@/components/common/PageHead';
+import Navbar from '@/components/website/sections/Navbar';
+import Footer from '@/components/website/sections/Footer';
+
+export default function DeleteAccountPage() {
+  return (
+    <div className="bg-gray-900 text-white min-h-screen">
+      <PageHead title="Delete Account" />
+      <Navbar />
+      <main className="max-w-3xl mx-auto px-4 py-16 space-y-6">
+        <h1 className="text-3xl font-bold text-yellow-500">Delete Your Account</h1>
+        <p>
+          We're sorry to see you go. If you'd like to delete your SkillBridge account and remove your personal data, follow these steps:
+        </p>
+        <ol className="list-decimal list-inside space-y-2">
+          <li>Log in and open your profile settings.</li>
+          <li>Click the "Delete Account" button at the bottom of the page.</li>
+          <li>Confirm when prompted to permanently remove your data.</li>
+        </ol>
+        <p>
+          If you can't access your account, email
+          {' '}<a href="mailto:support@skillbridge.com" className="text-yellow-300 underline">support@skillbridge.com</a>
+          {' '}and we'll assist with the deletion.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/delete-account` static page with instructions
- link to new page from Footer and admin sidebar

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_687803976abc832895d5e6d1c5a78f17