### PR TITLE
Allow custom redirect URL for social logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
 For detailed instructions see [docs/installation.md](docs/installation.md).
 See [docs/deployment.md](docs/deployment.md) for tips on configuring environment variables when hosting the app.
 New users can follow the [Student Registration Guide](docs/student-registration-guide.md) to learn how to sign up and enroll in classes.
+If Google sign-in fails with `redirect_uri_mismatch`, see [docs/social-login-setup.md](docs/social-login-setup.md) for the required OAuth callback URL.
 
 ## Booking API
 

--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -24,7 +24,7 @@ async function initStrategies() {
         {
           clientID: github.clientId || process.env.GITHUB_CLIENT_ID || '',
           clientSecret: github.clientSecret || process.env.GITHUB_CLIENT_SECRET || '',
-          callbackURL: '/api/auth/github/callback',
+          callbackURL: github.redirectUrl || '/api/auth/github/callback',
           scope: ['user:email'],
         },
         async (_accessToken, _refreshToken, profile, done) => {
@@ -55,7 +55,7 @@ async function initStrategies() {
         {
           clientID: google.clientId || process.env.GOOGLE_CLIENT_ID || '',
           clientSecret: google.clientSecret || process.env.GOOGLE_CLIENT_SECRET || '',
-          callbackURL: '/api/auth/google/callback',
+          callbackURL: google.redirectUrl || '/api/auth/google/callback',
         },
         async (_accessToken, _refreshToken, profile, done) => {
           try {

--- a/docs/social-login-setup.md
+++ b/docs/social-login-setup.md
@@ -1,0 +1,24 @@
+# Social Login Setup
+
+This guide explains how to configure OAuth providers like Google so users can sign in to SkillBridge using their existing accounts.
+
+## Google
+
+1. Open the **Google Cloud Console** and create OAuth 2.0 credentials.
+2. Add the following URI to the **Authorized redirect URIs** list:
+
+   ```
+   http://localhost:5000/api/auth/google/callback
+   ```
+
+   Replace `http://localhost:5000` with your production backend URL when deploying. For example:
+
+   ```
+   https://yourdomain.com/api/auth/google/callback
+   ```
+
+3. Copy the generated **Client ID** and **Client secret** and set them in `backend/.env` or through the admin dashboard under **Social Login Settings**.
+4. If the auto-generated redirect URL shown in the admin panel does not match the one configured in Google, enter the desired URL in the **Redirect URL** field for Google and save.
+5. Restart the backend so the new credentials take effect.
+
+If the redirect URI does not exactly match what is configured on Google, the login page will display **Error 400: redirect_uri_mismatch**.

--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -18,6 +18,7 @@ const initialProviders = [
     active: false,
     clientId: "",
     clientSecret: "",
+    redirectUrl: "",
     label: "Sign in with Google",
     icon: "google"
   },
@@ -27,6 +28,7 @@ const initialProviders = [
     active: false,
     clientId: "",
     clientSecret: "",
+    redirectUrl: "",
     label: "Sign in with Facebook",
     icon: "facebook"
   },
@@ -38,6 +40,7 @@ const initialProviders = [
     teamId: "",
     keyId: "",
     privateKey: "",
+    redirectUrl: "",
     label: "Sign in with Apple",
     icon: "apple"
   },
@@ -47,6 +50,7 @@ const initialProviders = [
     active: false,
     clientId: "",
     clientSecret: "",
+    redirectUrl: "",
     label: "Sign in with GitHub",
     icon: "github"
   }
@@ -88,6 +92,7 @@ export default function SocialLoginSettingsPage() {
                 teamId: saved.teamId || "",
                 keyId: saved.keyId || "",
                 privateKey: saved.privateKey || "",
+                redirectUrl: saved.redirectUrl || "",
                 label: saved.label || p.label,
                 icon: saved.icon || p.icon,
               };
@@ -158,6 +163,7 @@ export default function SocialLoginSettingsPage() {
           teamId: p.teamId,
           keyId: p.keyId,
           privateKey: p.privateKey,
+          redirectUrl: p.redirectUrl,
           label: p.label,
           icon: p.icon,
         };
@@ -193,6 +199,7 @@ export default function SocialLoginSettingsPage() {
           teamId: p.teamId,
           keyId: p.keyId,
           privateKey: p.privateKey,
+          redirectUrl: p.redirectUrl,
           label: p.label,
           icon: p.icon,
         };
@@ -213,9 +220,18 @@ export default function SocialLoginSettingsPage() {
     }
   };
 
-  const getRedirectUrl = (key) => {
-    const base = process.env.NEXT_PUBLIC_API_BASE_URL || window.location.origin;
-    return `${base.replace(/\/$/, '')}/api/auth/${key}/callback`;
+  const getDefaultRedirectUrl = (key) => {
+    let base = process.env.NEXT_PUBLIC_API_BASE_URL || window.location.origin;
+    base = base.replace(/\/$/, '');
+    if (base.endsWith('/api')) {
+      base = base.slice(0, -4);
+    }
+    return `${base}/api/auth/${key}/callback`;
+  };
+
+  const getRedirectUrl = (provider) => {
+    if (typeof provider === 'string') return getDefaultRedirectUrl(provider);
+    return provider.redirectUrl || getDefaultRedirectUrl(provider.key);
   };
 
 
@@ -340,16 +356,26 @@ export default function SocialLoginSettingsPage() {
                     </div>
                   </>
                 )}
-                <p className="text-xs text-gray-500 mt-1">
-                  Redirect URL: <code>{getRedirectUrl(provider.key)}</code>
-                  <button
-                    type="button"
-                    onClick={() => navigator.clipboard.writeText(getRedirectUrl(provider.key))}
-                    className="ml-2 text-blue-600 underline"
-                  >
-                    Copy
-                  </button>
-                </p>
+                <div>
+                  <label className="block text-sm font-medium">Redirect URL</label>
+                  <input
+                    type="text"
+                    className="w-full border rounded p-2"
+                    value={provider.redirectUrl}
+                    onChange={(e) => handleChange(index, "redirectUrl", e.target.value)}
+                    placeholder={getDefaultRedirectUrl(provider.key)}
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    Default: <code>{getDefaultRedirectUrl(provider.key)}</code>
+                    <button
+                      type="button"
+                      onClick={() => navigator.clipboard.writeText(getRedirectUrl(provider))}
+                      className="ml-2 text-blue-600 underline"
+                    >
+                      Copy
+                    </button>
+                  </p>
+                </div>
               </div>
 
               {provider.active && (


### PR DESCRIPTION
## Summary
- expose `redirectUrl` field for each provider in Social Login Settings
- use the custom `redirectUrl` in Passport strategies if provided
- document how admins can override the generated redirect URL

## Testing
- `npm test` *(backend)*
- ❌ `npm install` (frontend) *(failed: ECONNRESET)*


------
https://chatgpt.com/codex/tasks/task_e_68792ed02a4883289411b165e1cee142