### PR TITLE
Fix Google social login 404

### DIFF
--- a/docs/social-login-setup.md
+++ b/docs/social-login-setup.md
@@ -22,3 +22,5 @@ This guide explains how to configure OAuth providers like Google so users can si
 5. Restart the backend so the new credentials take effect.
 
 If the redirect URI does not exactly match what is configured on Google, the login page will display **Error 400: redirect_uri_mismatch**.
+
+If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, make sure the frontend's `NEXT_PUBLIC_API_BASE_URL` is set to your backend URL including the `/api` prefix. Without this variable the social login buttons default to `/api/auth/*`.

--- a/frontend/src/shared/components/auth/SocialLogin.js
+++ b/frontend/src/shared/components/auth/SocialLogin.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaGoogle, FaFacebook, FaApple } from "react-icons/fa";
 import { fetchSocialLoginConfig } from "@/services/socialLoginService";
+import { API_BASE_URL } from "@/config/config";
 
 const iconMap = { google: FaGoogle, facebook: FaFacebook, apple: FaApple };
 const unifiedButtonStyle =
@@ -25,8 +26,8 @@ export default function SocialLogin() {
         {activeProviders.map(([key, p]) => {
           const Icon = iconMap[p.icon] || iconMap[key] || FaGoogle;
           const handleClick = () => {
-            // Default to a relative path when NEXT_PUBLIC_API_BASE_URL isn't set
-            const base = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+            // Align with API service defaulting to '/api' when env is missing
+            const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
             window.location.href = `${base}/auth/${key}`;
           };
           return (


### PR DESCRIPTION
## Summary
- use API base URL constant in `<SocialLogin>` to build OAuth URLs
- document setting `NEXT_PUBLIC_API_BASE_URL` when Google login returns 404

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687950b5ef0883289f7515253613010b