### PR TITLE
Fix social login redirect

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -23,12 +23,17 @@ const isAdminRole = (roles = []) => {
  */
 const verifyToken = async (req, res, next) => {
   const authHeader = req.headers.authorization;
+  let token = null;
 
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return res.status(401).json({ message: "Missing or malformed token" });
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    token = authHeader.split(" ")[1];
+  } else if (req.cookies && req.cookies.token) {
+    token = req.cookies.token;
   }
 
-  const token = authHeader.split(" ")[1];
+  if (!token) {
+    return res.status(401).json({ message: "Missing or malformed token" });
+  }
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);

--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -16,8 +16,16 @@ exports.googleCallback = (req, res, next) => {
     }
     const { accessToken, refreshToken } = result;
     res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    const redirectUrl = `${frontendBase}/auth/social-success?token=${accessToken}`;
-    res.redirect(redirectUrl);
+    const tokenCookieOptions = {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Lax',
+    };
+    if (process.env.COOKIE_DOMAIN) {
+      tokenCookieOptions.domain = process.env.COOKIE_DOMAIN;
+    }
+    res.cookie('token', accessToken, tokenCookieOptions);
+    res.redirect(`${frontendBase}/website`);
   })(req, res, next);
 };
 

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -8,6 +8,8 @@ import "@/styles/globals.css";
 import "@/services/api/tokenInterceptor";
 import useAuthStore from "@/store/auth/authStore";
 import useAppConfigStore from "@/store/appConfigStore";
+import * as authService from "@/services/auth/authService";
+import { getFullProfile } from "@/services/profile/profileService";
 import Head from "next/head";
 import "@/styles/globals.css"; // or whatever your path is
 
@@ -40,6 +42,20 @@ function MyApp({ Component, pageProps, router }) {
         });
       }
     }
+  }, []);
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const { accessToken } = await authService.refreshAccessToken();
+        useAuthStore.setState({ accessToken });
+        const res = await getFullProfile();
+        useAuthStore.setState({ user: res.data });
+      } catch (_) {
+        // no active session
+      }
+    };
+    init();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/auth/social-success.js
+++ b/frontend/src/pages/auth/social-success.js
@@ -12,10 +12,12 @@ export default function SocialSuccess() {
     const token = router.query.token;
     if (!token) return;
     setToken(token);
-    getFullProfile().then((res) => {
-      setUser(res.data);
-      router.replace('/website');
-    }).catch(() => router.replace('/auth/login'));
+    getFullProfile()
+      .then((res) => {
+        setUser(res.data);
+        router.replace('/website');
+      })
+      .catch(() => router.replace('/auth/login'));
   }, [router.query.token]);
 
   return <p className="text-center mt-20">Signing in...</p>;


### PR DESCRIPTION
## Summary
- use COOKIE_DOMAIN env for Google token cookie
- restore `/auth/social-success` page for GitHub login

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68796260ab9083288df915845a6805c1