### PR TITLE
Fix social login redirect

### DIFF
--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -19,8 +19,8 @@ exports.googleCallback = (req, res, next) => {
     res.cookie('token', accessToken, {
       httpOnly: true,
       secure: true,
-      domain: '.eduskillbridge.net',
       sameSite: 'Lax',
+      ...(process.env.COOKIE_DOMAIN ? { domain: process.env.COOKIE_DOMAIN } : {}),
     });
     res.redirect(`${frontendBase}/website`);
   })(req, res, next);

--- a/docs/social-login-setup.md
+++ b/docs/social-login-setup.md
@@ -24,3 +24,16 @@ This guide explains how to configure OAuth providers like Google so users can si
 If the redirect URI does not exactly match what is configured on Google, the login page will display **Error 400: redirect_uri_mismatch**.
 
 If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, make sure the frontend's `NEXT_PUBLIC_API_BASE_URL` is set to your backend URL including the `/api` prefix. Without this variable the social login buttons default to `/api/auth/*`.
+
+## GitHub
+
+1. On GitHub open **Settings → Developer settings → OAuth Apps** and create a new OAuth App.
+2. Set the **Authorization callback URL** to:
+   ```
+   http://localhost:5000/api/auth/github/callback
+   ```
+   Replace `http://localhost:5000` with your backend URL when deployed.
+3. Enter the generated **Client ID** and **Client Secret** in `backend/.env` or the admin panel under **Social Login Settings**.
+4. Save the settings and restart the backend so the GitHub strategy is initialized.
+
+After completing these steps the **Sign in with GitHub** button should redirect back to `/auth/social-success` and automatically log the user in.

--- a/frontend/src/pages/auth/social-success.js
+++ b/frontend/src/pages/auth/social-success.js
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import useAuthStore from '@/store/auth/authStore';
+import useNotificationStore from '@/store/notifications/notificationStore';
+import { getFullProfile } from '@/services/profile/profileService';
+
+export default function SocialSuccess() {
+  const router = useRouter();
+  const setToken = useAuthStore((state) => state.setToken);
+  const setUser = useAuthStore((state) => state.setUser);
+  const fetchNotifications = useNotificationStore((state) => state.fetch);
+
+  useEffect(() => {
+    const { token } = router.query;
+    if (!token) return;
+    async function finalize() {
+      setToken(token);
+      try {
+        const res = await getFullProfile();
+        setUser(res.data);
+        fetchNotifications();
+      } catch (err) {
+        console.error('Failed to fetch profile after social login', err);
+      }
+      router.replace('/website');
+    }
+    finalize();
+  }, [router, setToken, setUser, fetchNotifications]);
+
+  return <p className="text-center mt-20">Signing you in...</p>;
+}

--- a/frontend/src/shared/components/auth/SocialLogin.js
+++ b/frontend/src/shared/components/auth/SocialLogin.js
@@ -1,10 +1,10 @@
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
-import { FaGoogle, FaFacebook, FaApple } from "react-icons/fa";
+import { FaGoogle, FaFacebook, FaApple, FaGithub } from "react-icons/fa";
 import { fetchSocialLoginConfig } from "@/services/socialLoginService";
 import { API_BASE_URL } from "@/config/config";
 
-const iconMap = { google: FaGoogle, facebook: FaFacebook, apple: FaApple };
+const iconMap = { google: FaGoogle, facebook: FaFacebook, apple: FaApple, github: FaGithub };
 const unifiedButtonStyle =
   "w-12 h-12 flex items-center justify-center rounded-full bg-yellow-500 text-white hover:bg-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-400";
 


### PR DESCRIPTION
## Summary
- set token cookie using COOKIE_DOMAIN if present
- add GitHub icon to social login buttons
- handle auth/social-success redirect on frontend
- document GitHub OAuth setup

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687a98d9421483289e46e3a375ef3d97