### PR TITLE
Improve Google social login flow

### DIFF
--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -29,14 +29,16 @@ async function initStrategies() {
         },
         async (_accessToken, _refreshToken, profile, done) => {
           try {
-            const { id, displayName, username, emails } = profile;
+            const { id, displayName, username, emails, photos } = profile;
             const email = emails && emails[0] && emails[0].value;
             const fullName = displayName || username;
+            const avatarUrl = photos && photos[0] && photos[0].value;
             const result = await socialAuthService.loginOrRegister({
               provider: 'github',
               providerId: id,
               email,
               fullName,
+              avatarUrl,
             });
             return done(null, result);
           } catch (err) {
@@ -59,13 +61,15 @@ async function initStrategies() {
         },
         async (_accessToken, _refreshToken, profile, done) => {
           try {
-            const { id, displayName, emails } = profile;
+            const { id, displayName, emails, photos } = profile;
             const email = emails && emails[0] && emails[0].value;
+            const avatarUrl = photos && photos[0] && photos[0].value;
             const result = await socialAuthService.loginOrRegister({
               provider: 'google',
               providerId: id,
               email,
               fullName: displayName,
+              avatarUrl,
             });
             return done(null, result);
           } catch (err) {

--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -16,14 +16,8 @@ exports.googleCallback = (req, res, next) => {
     }
     const { accessToken, refreshToken } = result;
     res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    res.cookie('token', accessToken, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'Lax',
-      ...(process.env.COOKIE_DOMAIN ? { domain: process.env.COOKIE_DOMAIN } : {}),
-    });
-    const host = req.get('origin') || frontendBase;
-    res.redirect(`${host}/website`);
+    const redirectUrl = `${frontendBase}/website?token=${accessToken}`;
+    res.redirect(redirectUrl);
   })(req, res, next);
 };
 

--- a/backend/src/modules/auth/services/socialAuth.service.js
+++ b/backend/src/modules/auth/services/socialAuth.service.js
@@ -4,7 +4,13 @@ const { generateAccessToken, generateRefreshToken } = require("./auth.service");
 
 const SALT_ROUNDS = 12;
 
-exports.loginOrRegister = async ({ provider, providerId, email, fullName }) => {
+exports.loginOrRegister = async ({
+  provider,
+  providerId,
+  email,
+  fullName,
+  avatarUrl,
+}) => {
   let account = await userModel.findBySocialAccount(provider, providerId);
   let user;
 
@@ -30,10 +36,14 @@ exports.loginOrRegister = async ({ provider, providerId, email, fullName }) => {
         is_email_verified: !!email,
         is_phone_verified: false,
         profile_complete: false,
+        avatar_url: avatarUrl || null,
         created_at: new Date(),
         updated_at: new Date(),
       });
       user = newUser;
+    } else if (avatarUrl && !user.avatar_url) {
+      await userModel.updateUser(user.id, { avatar_url: avatarUrl });
+      user.avatar_url = avatarUrl;
     }
     await userModel.addSocialAccount(user.id, provider, providerId, email);
   }


### PR DESCRIPTION
## Summary
- support avatar URLs during social login
- pass avatar through Google and GitHub strategies
- redirect Google login with token parameter for frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa97bee308328a2fd05b8cf451968