### PR TITLE
Fix Google social login redirect

### DIFF
--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -17,7 +17,7 @@ exports.googleCallback = (req, res, next) => {
     const { accessToken, refreshToken } = result;
     res.cookie('refreshToken', refreshToken, refreshCookieOptions);
     const host = req.get('origin') || frontendBase;
-    const redirectUrl = `${host}/website?token=${accessToken}`;
+    const redirectUrl = `${host}/auth/social-success?token=${accessToken}`;
     res.redirect(redirectUrl);
   })(req, res, next);
 };


### PR DESCRIPTION
## Summary
- correct Google OAuth callback to redirect to `/auth/social-success`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab5d11ac08328976372a900fc6ed8