### PR TITLE
Sanitize social login config

### DIFF
--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.controller.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.controller.js
@@ -3,9 +3,33 @@ const { sendSuccess } = require("../../utils/response");
 const service = require("./socialLoginConfig.service");
 const { initStrategies } = require("../../config/passport");
 
-exports.getSettings = catchAsync(async (_req, res) => {
+// Determine if the current user has admin-level access
+const isAdminRole = (roles = []) => {
+  const arr = Array.isArray(roles) ? roles : [roles];
+  return arr
+    .map((r) => r.toLowerCase().replace(/\s+/g, ""))
+    .some((r) => ["admin", "superadmin"].includes(r));
+};
+
+// Remove secrets from the returned settings for non-admin requests
+const sanitize = (settings, req) => {
+  if (isAdminRole(req.user?.roles || req.user?.role)) return settings;
+  const cloned = JSON.parse(JSON.stringify(settings || {}));
+
+  if (cloned.providers) {
+    for (const key of Object.keys(cloned.providers)) {
+      delete cloned.providers[key]?.clientSecret;
+    }
+  }
+  if (cloned.recaptcha) {
+    delete cloned.recaptcha.secretKey;
+  }
+  return cloned;
+};
+
+exports.getSettings = catchAsync(async (req, res) => {
   const settings = await service.getSettings();
-  sendSuccess(res, settings || {});
+  sendSuccess(res, sanitize(settings || {}, req));
 });
 
 exports.updateSettings = catchAsync(async (req, res) => {
@@ -15,5 +39,5 @@ exports.updateSettings = catchAsync(async (req, res) => {
   } catch (err) {
     console.error("Failed to reinitialize passport strategies", err);
   }
-  sendSuccess(res, settings, "Settings updated");
+  sendSuccess(res, sanitize(settings, req), "Settings updated");
 });

--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.routes.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.routes.js
@@ -3,11 +3,22 @@ const router = express.Router();
 const controller = require("./socialLoginConfig.controller");
 const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
 
+// Middleware that verifies the user when secrets are requested
+const maybeAuth = (req, res, next) => {
+  if (req.query.includeSecrets) {
+    return verifyToken(req, res, (err) => {
+      if (err) return;
+      return isAdmin(req, res, next);
+    });
+  }
+  next();
+};
+
 // Log incoming GET requests to debug potential auth or DB issues
-router.get("/", (req, res, next) => {
+router.get("/", maybeAuth, (req, res, next) => {
   console.log("[socialLoginConfig] GET /api/social-login/config", {
     user: req.user,
-    authHeader: req.headers.authorization,
+    includeSecrets: req.query.includeSecrets,
   });
   controller.getSettings(req, res, next);
 });

--- a/backend/tests/socialLoginConfigRoutes.test.js
+++ b/backend/tests/socialLoginConfigRoutes.test.js
@@ -24,13 +24,19 @@ app.use(express.json());
 app.use('/api/social-login/config', routes);
 
 describe('GET /api/social-login/config', () => {
-  it('returns settings', async () => {
-    const mock = { enabled: true };
+  it('returns sanitized settings', async () => {
+    const mock = {
+      providers: { google: { clientId: 'id', clientSecret: 'secret' } },
+      recaptcha: { siteKey: 'site', secretKey: 'priv' },
+    };
     service.getSettings.mockResolvedValue(mock);
 
     const res = await request(app).get('/api/social-login/config');
     expect(res.status).toBe(200);
-    expect(res.body.data).toEqual(mock);
+    expect(res.body.data).toEqual({
+      providers: { google: { clientId: 'id' } },
+      recaptcha: { siteKey: 'site' },
+    });
     expect(service.getSettings).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- sanitize social login responses for non-admins
- only log requested secrets flag for social login route
- adjust test to expect sanitized config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab93b83e08328b3c19a653091a0e9