### PR TITLE
Fix social login redirect host

### DIFF
--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -16,7 +16,7 @@ exports.googleCallback = (req, res, next) => {
     }
     const { accessToken, refreshToken } = result;
     res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    const host = req.get('origin') || frontendBase;
+    const host = req.query.origin || req.get('origin') || frontendBase;
     const redirectUrl = `${host}/auth/social-success?token=${accessToken}`;
     res.redirect(redirectUrl);
   })(req, res, next);
@@ -72,7 +72,7 @@ exports.githubCallback = (req, res, next) => {
     }
     const { accessToken, refreshToken } = result;
     res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    const host = req.get('origin') || frontendBase;
+    const host = req.query.origin || req.get('origin') || frontendBase;
     const redirectUrl = `${host}/auth/social-success?token=${accessToken}`;
     res.redirect(redirectUrl);
   })(req, res, next);

--- a/docs/social-login-setup.md
+++ b/docs/social-login-setup.md
@@ -23,7 +23,7 @@ This guide explains how to configure OAuth providers like Google so users can si
 
 If the redirect URI does not exactly match what is configured on Google, the login page will display **Error 400: redirect_uri_mismatch**.
 
-If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, make sure the frontend's `NEXT_PUBLIC_API_BASE_URL` is set to your backend URL including the `/api` prefix. Without this variable the social login buttons default to `/api/auth/*`.
+If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, verify the frontend's `NEXT_PUBLIC_API_BASE_URL` points to your backend URL including the `/api` prefix. Without this variable the login and register buttons default to `/api/auth/*` which only works when the frontend and backend share the same host. Both buttons now append `?origin=` with the current site origin so the API can redirect back correctly even when `FRONTEND_URL` is not configured.
 
 
 If the authentication completes but you land on a 404 page, check that the backend's

--- a/frontend/src/shared/components/auth/SocialLogin.js
+++ b/frontend/src/shared/components/auth/SocialLogin.js
@@ -28,7 +28,9 @@ export default function SocialLogin() {
           const handleClick = () => {
             // Align with API service defaulting to '/api' when env is missing
             const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-            window.location.href = `${base}/auth/${key}`;
+            const origin = window.location.origin;
+            const url = `${base}/auth/${key}?origin=${encodeURIComponent(origin)}`;
+            window.location.href = url;
           };
           return (
             <motion.button

--- a/frontend/src/shared/components/auth/SocialRegister.js
+++ b/frontend/src/shared/components/auth/SocialRegister.js
@@ -31,7 +31,9 @@ export default function SocialRegister() {
           const handleClick = () => {
             // Align with API service defaulting to '/api' when env is missing
             const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-            window.location.href = `${base}/auth/${key}`;
+            const origin = window.location.origin;
+            const url = `${base}/auth/${key}?origin=${encodeURIComponent(origin)}`;
+            window.location.href = url;
           };
           return (
             <motion.button


### PR DESCRIPTION
## Summary
- redirect back to the origin that started OAuth
- send origin parameter when starting social login
- send origin when starting social register
- document origin-based redirect logic

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_687ac4137a788328b8290c40699be817