### PR TITLE
Enable Facebook OAuth

### DIFF
--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -1,8 +1,8 @@
 const passport = require('passport');
 // Google login strategy
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
-// Facebook login is disabled until production deployment
-// const FacebookStrategy = require('passport-facebook').Strategy;
+// Facebook login strategy
+const FacebookStrategy = require('passport-facebook').Strategy;
 // Apple login is disabled until production deployment
 // const AppleStrategy = require('passport-apple').Strategy;
 const GitHubStrategy = require('passport-github2').Strategy;
@@ -80,36 +80,37 @@ async function initStrategies() {
     );
   }
 
-  // Facebook login is temporarily disabled until the project is deployed
-  // const facebook = providers.facebook || {};
-  // if (facebook.active && (facebook.clientId || process.env.FACEBOOK_CLIENT_ID)) {
-  //   passport.use(
-  //     'facebook',
-  //     new FacebookStrategy(
-  //       {
-  //         clientID: facebook.clientId || process.env.FACEBOOK_CLIENT_ID || '',
-  //         clientSecret: facebook.clientSecret || process.env.FACEBOOK_CLIENT_SECRET || '',
-  //         callbackURL: '/api/auth/facebook/callback',
-  //         profileFields: ['id', 'displayName', 'email'],
-  //       },
-  //       async (_accessToken, _refreshToken, profile, done) => {
-  //         try {
-  //           const { id, displayName, emails } = profile;
-  //           const email = emails && emails[0] && emails[0].value;
-  //           const result = await socialAuthService.loginOrRegister({
-  //             provider: 'facebook',
-  //             providerId: id,
-  //             email,
-  //             fullName: displayName,
-  //           });
-  //           return done(null, result);
-  //         } catch (err) {
-  //           return done(err);
-  //         }
-  //       }
-  //     )
-  //   );
-  // }
+  const facebook = providers.facebook || {};
+  if (facebook.active && (facebook.clientId || process.env.FACEBOOK_CLIENT_ID)) {
+    passport.use(
+      'facebook',
+      new FacebookStrategy(
+        {
+          clientID: facebook.clientId || process.env.FACEBOOK_CLIENT_ID || '',
+          clientSecret: facebook.clientSecret || process.env.FACEBOOK_CLIENT_SECRET || '',
+          callbackURL: facebook.redirectUrl || '/api/auth/facebook/callback',
+          profileFields: ['id', 'displayName', 'emails', 'photos'],
+        },
+        async (_accessToken, _refreshToken, profile, done) => {
+          try {
+            const { id, displayName, emails, photos } = profile;
+            const email = emails && emails[0] && emails[0].value;
+            const avatarUrl = photos && photos[0] && photos[0].value;
+            const result = await socialAuthService.loginOrRegister({
+              provider: 'facebook',
+              providerId: id,
+              email,
+              fullName: displayName,
+              avatarUrl,
+            });
+            return done(null, result);
+          } catch (err) {
+            return done(err);
+          }
+        }
+      )
+    );
+  }
 
   // Apple login is temporarily disabled until the project is deployed
   // const apple = providers.apple || {};


### PR DESCRIPTION
## Summary
- configure Facebook passport strategy

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687ab944be988328890bca5f14d1a4b4