### PR TITLE
Fix spacing next to redirect URL copy button

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -368,7 +368,7 @@ export default function SocialLoginSettingsPage() {
                     placeholder={getDefaultRedirectUrl(provider.key)}
                   />
                   <p className="text-xs text-gray-500 mt-1">
-                    Default: <code>{getDefaultRedirectUrl(provider.key)}</code>
+                    Default: <code>{getDefaultRedirectUrl(provider.key)}</code>{" "}
                     <button
                       type="button"
                       onClick={() => navigator.clipboard.writeText(getRedirectUrl(provider))}


### PR DESCRIPTION
## Summary
- ensure the social login settings page doesn't concatenate `Copy` with the default redirect URL

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_687acc6eaea883289883596b44488fc6