### PR TITLE
Show saved social login secrets in admin panel

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -368,7 +368,7 @@ export default function SocialLoginSettingsPage() {
                     placeholder={getDefaultRedirectUrl(provider.key)}
                   />
                   <p className="text-xs text-gray-500 mt-1">
-                    Default: <code>{getDefaultRedirectUrl(provider.key)}</code>
+                    Default: <code>{getDefaultRedirectUrl(provider.key)}</code>{" "}
                     <button
                       type="button"
                       onClick={() => navigator.clipboard.writeText(getRedirectUrl(provider))}

--- a/frontend/src/services/admin/socialLoginConfigService.js
+++ b/frontend/src/services/admin/socialLoginConfigService.js
@@ -1,7 +1,9 @@
 import api from "@/services/api/api";
 
 export const fetchSocialLoginConfig = async () => {
-  const { data } = await api.get("/social-login/config");
+  const { data } = await api.get("/social-login/config", {
+    params: { includeSecrets: true },
+  });
   return data?.data ?? null;
 };
 


### PR DESCRIPTION
## Summary
- request provider secrets when loading admin Social Login settings
- keep spacing so the Copy button doesn't touch the default URL

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_687acc6eaea883289883596b44488fc6