### PR TITLE
Implement language management

### DIFF
--- a/backend/src/migrations/20250720000000_create_languages_table.js
+++ b/backend/src/migrations/20250720000000_create_languages_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('languages', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.string('code').notNullable().unique();
+    table.string('name').notNullable();
+    table.boolean('is_default').notNullable().defaultTo(false);
+    table.boolean('is_active').notNullable().defaultTo(true);
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('languages');
+};

--- a/backend/src/modules/languages/languages.controller.js
+++ b/backend/src/modules/languages/languages.controller.js
@@ -1,0 +1,23 @@
+const service = require("./languages.service");
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+
+exports.createLanguage = catchAsync(async (req, res) => {
+  const lang = await service.create(req.body);
+  sendSuccess(res, lang, "Language created");
+});
+
+exports.listLanguages = catchAsync(async (_req, res) => {
+  const langs = await service.list();
+  sendSuccess(res, langs);
+});
+
+exports.updateLanguage = catchAsync(async (req, res) => {
+  const lang = await service.update(req.params.id, req.body);
+  sendSuccess(res, lang, "Language updated");
+});
+
+exports.deleteLanguage = catchAsync(async (req, res) => {
+  await service.remove(req.params.id);
+  sendSuccess(res, null, "Language deleted");
+});

--- a/backend/src/modules/languages/languages.routes.js
+++ b/backend/src/modules/languages/languages.routes.js
@@ -1,0 +1,10 @@
+const router = require("express").Router();
+const controller = require("./languages.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.listLanguages);
+router.post("/", verifyToken, isAdmin, controller.createLanguage);
+router.put("/:id", verifyToken, isAdmin, controller.updateLanguage);
+router.delete("/:id", verifyToken, isAdmin, controller.deleteLanguage);
+
+module.exports = router;

--- a/backend/src/modules/languages/languages.service.js
+++ b/backend/src/modules/languages/languages.service.js
@@ -1,0 +1,27 @@
+const db = require("../../config/database");
+
+exports.create = async (data) => {
+  return db.transaction(async (trx) => {
+    if (data.is_default) {
+      await trx("languages").update({ is_default: false });
+    }
+    const [row] = await trx("languages").insert(data).returning("*");
+    return row;
+  });
+};
+
+exports.list = () => {
+  return db("languages").select("*").orderBy("name");
+};
+
+exports.update = async (id, data) => {
+  return db.transaction(async (trx) => {
+    if (data.is_default) {
+      await trx("languages").update({ is_default: false });
+    }
+    const [row] = await trx("languages").where({ id }).update(data).returning("*");
+    return row;
+  });
+};
+
+exports.remove = (id) => db("languages").where({ id }).del();

--- a/backend/src/seeds/03_languages_seed.js
+++ b/backend/src/seeds/03_languages_seed.js
@@ -1,0 +1,19 @@
+exports.seed = async function (knex) {
+  await knex('languages').del();
+  await knex('languages').insert([
+    {
+      id: knex.raw('gen_random_uuid()'),
+      code: 'en',
+      name: 'English',
+      is_default: true,
+      is_active: true,
+    },
+    {
+      id: knex.raw('gen_random_uuid()'),
+      code: 'ar',
+      name: 'العربية',
+      is_default: false,
+      is_active: true,
+    },
+  ]);
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -89,6 +89,7 @@ app.use("/api/cart", require("./modules/cart/cart.routes"));
 app.use("/api/notifications", require("./modules/notifications/notifications.routes"));
 app.use("/api/messages", require("./modules/messages/messages.routes"));
 app.use("/api/chat", require("./modules/chat/chat.routes"));
+app.use("/api/languages", require("./modules/languages/languages.routes"));
 
 app.get("/", (req, res) => res.send("🚀 SkillBridge API is live."));
 

--- a/backend/src/utils/language.js
+++ b/backend/src/utils/language.js
@@ -1,0 +1,8 @@
+const db = require("../config/database");
+
+const getDefaultLanguage = async () => {
+  const [lang] = await db("languages").where({ is_default: true });
+  return lang?.code || "en";
+};
+
+module.exports = { getDefaultLanguage };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,7 +77,8 @@
     "typewriter-effect": "^2.21.0",
     "uuid": "^11.1.0",
     "zod": "^3.25.28",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "swr": "^2.2.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/components/shared/LanguageSwitcher.js
+++ b/frontend/src/components/shared/LanguageSwitcher.js
@@ -1,0 +1,24 @@
+import useSWR from "swr";
+import { useTranslation } from "react-i18next";
+import api from "@/services/api/api";
+
+const fetcher = url => api.get(url).then(res => res.data.data);
+
+export default function LanguageSwitcher({ changeLang }) {
+  const { i18n } = useTranslation();
+  const { data: langs } = useSWR("/languages", fetcher);
+
+  return (
+    <select
+      onChange={(e) => changeLang(e.target.value)}
+      value={i18n.language}
+      className="border p-1 rounded"
+    >
+      {langs?.filter((l) => l.is_active).map((lang) => (
+        <option key={lang.code} value={lang.code}>
+          {lang.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/pages/dashboard/admin/settings/languages/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/index.js
@@ -1,267 +1,69 @@
-// Updated Language Manager with enhancements
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { useState, useMemo } from "react";
 import Link from "next/link";
+import useSWR from "swr";
+import api from "@/services/api/api";
 import { useRouter } from "next/router";
-import {
-    Globe,
-    Star,
-    Pencil,
-    Upload,
-    Trash,
-    Download,
-} from "lucide-react";
 
-const mockLanguages = [
-    { id: 1, label: "English", code: "en", direction: "ltr", active: true, default: true, translationProgress: 100, lastUpdated: "2025-05-12" },
-    { id: 2, label: "Arabic", code: "ar", direction: "rtl", active: true, default: false, translationProgress: 90, lastUpdated: "2025-05-10" },
-    { id: 3, label: "French", code: "fr", direction: "ltr", active: false, default: false, translationProgress: 70, lastUpdated: "2025-05-08" },
-];
+const fetcher = url => api.get(url).then(res => res.data.data);
 
-export default function LanguageManagerPage() {
-    const router = useRouter();
-    const [languages, setLanguages] = useState(mockLanguages);
-    const [search, setSearch] = useState("");
-    const [filter, setFilter] = useState("all");
-    const [selectedIds, setSelectedIds] = useState([]);
+export default function LanguagesPage() {
+  const router = useRouter();
+  const { data: languages, mutate } = useSWR("/languages", fetcher);
 
-    const filteredLanguages = useMemo(() => {
-        return languages.filter((lang) => {
-            const matchSearch = lang.label.toLowerCase().includes(search.toLowerCase()) || lang.code.toLowerCase().includes(search.toLowerCase());
-            const matchFilter =
-                filter === "all" ||
-                (filter === "active" && lang.active) ||
-                (filter === "inactive" && !lang.active);
-            return matchSearch && matchFilter;
-        });
-    }, [languages, search, filter]);
+  const toggleActive = async (lang) => {
+    await api.put(`/languages/${lang.id}`, { ...lang, is_active: !lang.is_active });
+    mutate();
+  };
 
-    const toggleActive = (id) => {
-        setLanguages((prev) =>
-            prev.map((lang) =>
-                lang.id === id ? (lang.default ? (alert("Cannot deactivate default language"), lang) : { ...lang, active: !lang.active }) : lang
-            )
-        );
-    };
+  const setDefault = async (lang) => {
+    await api.put(`/languages/${lang.id}`, { ...lang, is_default: true });
+    mutate();
+  };
 
-    const setDefault = (id) => {
-        setLanguages((prev) => prev.map((lang) => ({ ...lang, default: lang.id === id })));
-    };
+  const remove = async (id) => {
+    if (confirm("Delete language?")) {
+      await api.delete(`/languages/${id}`);
+      mutate();
+    }
+  };
 
-    const handleDelete = (id) => {
-        const lang = languages.find((l) => l.id === id);
-        if (lang.default) return alert("Cannot delete default language");
-        if (confirm(`Delete language \"${lang.label}\"?`)) {
-            setLanguages((prev) => prev.filter((l) => l.id !== id));
-        }
-    };
-
-    const handleEdit = (code) => router.push(`/dashboard/admin/settings/languages/edit/${code}`);
-
-    const handleUpload = (code) => alert(`Upload for: ${code}`);
-
-    const handleExport = (code) => alert(`Exporting ${code}.zip`);
-
-    const toggleSelect = (id) => {
-        setSelectedIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]));
-    };
-
-    const selectAll = () => {
-        setSelectedIds(filteredLanguages.map((lang) => lang.id));
-    };
-
-    const clearAll = () => setSelectedIds([]);
-
-    const bulkDelete = () => {
-        const nonDefaultIds = selectedIds.filter((id) => {
-            const lang = languages.find((l) => l.id === id);
-            return lang && !lang.default;
-        });
-        setLanguages((prev) => prev.filter((l) => !nonDefaultIds.includes(l.id)));
-        clearAll();
-    };
-
-    return (
-        <AdminLayout>
-            <div className="p-6">
-                <div className="flex justify-between items-center mb-4">
-                    <h1 className="text-2xl font-bold flex items-center gap-2">
-                        <Globe className="w-6 h-6" /> Language Manager
-                    </h1>
-                    <Link href="/dashboard/admin/settings/languages/create">
-                        <button className="bg-yellow-500 text-white px-4 py-2 rounded shadow">+ Add Language</button>
-                    </Link>
-                </div>
-
-                <div className="flex items-center justify-between mb-4">
-                    <div className="flex gap-2">
-                        <input
-                            type="text"
-                            placeholder="Search..."
-                            className="border p-2 rounded"
-                            value={search}
-                            onChange={(e) => setSearch(e.target.value)}
-                        />
-                        <select
-                            className="border p-2 rounded"
-                            value={filter}
-                            onChange={(e) => setFilter(e.target.value)}
-                        >
-                            <option value="all">All</option>
-                            <option value="active">Active</option>
-                            <option value="inactive">Inactive</option>
-                        </select>
-                    </div>
-
-                    {selectedIds.length > 0 && (
-                        <div className="flex gap-2 items-center">
-                            <span className="text-sm text-gray-600">Selected: {selectedIds.length}</span>
-                            <button
-                                onClick={bulkDelete}
-                                className="bg-red-500 text-white px-3 py-1 rounded text-sm"
-                            >
-                                Delete Selected
-                            </button>
-                            <button
-                                onClick={clearAll}
-                                className="text-sm text-gray-500 hover:text-black"
-                            >
-                                Clear
-                            </button>
-                        </div>
-                    )}
-                </div>
-
-                <div className="overflow-x-auto">
-                    <table className="min-w-full bg-white border rounded shadow text-sm">
-                        <thead className="bg-gray-100 text-left">
-                            <tr>
-                                <th className="p-3 text-center">
-                                    <input
-                                        type="checkbox"
-                                        onChange={(e) => (e.target.checked ? selectAll() : clearAll())}
-                                        checked={selectedIds.length === filteredLanguages.length && filteredLanguages.length > 0}
-                                    />
-                                </th>
-                                <th className="p-3">Language</th>
-                                <th className="p-3">Code</th>
-                                <th className="p-3 text-center">Direction</th>
-                                <th className="p-3 text-center">Status</th>
-                                <th className="p-3 text-center">Default</th>
-                                <th className="p-3">Progress</th>
-                                <th className="p-3 text-center">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {filteredLanguages.map((lang) => (
-                                <tr key={lang.id} className="border-t hover:bg-gray-50 transition">
-                                    <td className="p-3 text-center">
-                                        <input
-                                            type="checkbox"
-                                            checked={selectedIds.includes(lang.id)}
-                                            onChange={() => toggleSelect(lang.id)}
-                                        />
-                                    </td>
-                                    <td className="p-3 flex flex-col gap-1">
-                                        <div className="flex items-center gap-2">
-                                            <img
-                                                src={
-                                                    lang.code === "en"
-                                                        ? "https://wiki2.railml.org/images/b/b8/UK_flag.png"
-                                                        : lang.code === "ar"
-                                                            ? "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Flag_of_Saudi_Arabia.svg/1280px-Flag_of_Saudi_Arabia.svg.png"
-                                                            : lang.code === "fr"
-                                                                ? "https://upload.wikimedia.org/wikipedia/commons/6/62/Flag_of_France.png"
-                                                                : `/flags/${lang.code}.png`
-                                                }
-                                                onError={(e) => (e.target.src = "/flags/default.png")}
-                                                alt={`${lang.label} flag`}
-                                                className="w-5 h-3 rounded-sm border object-cover"
-                                            />
-                                            {lang.label}
-                                            {lang.translationProgress < 100 && (
-                                                <span className="text-red-500 text-xs ml-2">⚠ Incomplete</span>
-                                            )}
-                                        </div>
-                                        <div className="text-xs text-gray-400">Updated: {lang.lastUpdated}</div>
-                                    </td>
-                                    <td className="p-3">{lang.code}</td>
-                                    <td className="p-3 text-center">
-                                        <span
-                                            className={`px-2 py-1 rounded text-xs font-semibold ${lang.direction === "rtl"
-                                                ? "bg-blue-100 text-blue-700"
-                                                : "bg-green-100 text-green-700"
-                                                }`}
-                                        >
-                                            {lang.direction.toUpperCase()}
-                                        </span>
-                                    </td>
-                                    <td className="p-3 text-center">
-                                        <button
-                                            onClick={() => toggleActive(lang.id)}
-                                            className={`px-2 py-1 text-xs font-medium rounded ${lang.active ? "bg-green-200 text-green-800" : "bg-red-200 text-red-800"
-                                                }`}
-                                        >
-                                            {lang.active ? "Active" : "Inactive"}
-                                        </button>
-                                    </td>
-                                    <td className="p-3 text-center">
-                                        <button onClick={() => setDefault(lang.id)} title="Set as default">
-                                            <Star
-                                                className={`w-5 h-5 mx-auto transition ${lang.default ? "text-yellow-500 fill-yellow-500" : "text-gray-400"
-                                                    }`}
-                                            />
-                                        </button>
-                                    </td>
-                                    <td className="p-3">
-                                        <div className="w-full bg-gray-200 rounded-full h-2">
-                                            <div
-                                                className="bg-yellow-500 h-2 rounded-full"
-                                                style={{ width: `${lang.translationProgress}%` }}
-                                            ></div>
-                                        </div>
-                                        <div className="text-xs text-right mt-1">
-                                            {lang.translationProgress}%
-                                        </div>
-                                    </td>
-                                    <td className="p-3 text-center">
-                                        <div className="flex justify-center gap-2">
-                                            <button
-                                                title="Edit"
-                                                className="text-blue-600"
-                                                onClick={() => handleEdit(lang.code)}
-                                            >
-                                                <Pencil size={16} />
-                                            </button>
-                                            <button
-                                                title="Upload"
-                                                className="text-green-600"
-                                                onClick={() => handleUpload(lang.code)}
-                                            >
-                                                <Upload size={16} />
-                                            </button>
-                                            <button
-                                                title="Export"
-                                                className="text-gray-600"
-                                                onClick={() => handleExport(lang.code)}
-                                            >
-                                                <Download size={16} />
-                                            </button>
-                                            <button
-                                                title="Delete"
-                                                className="text-red-600"
-                                                onClick={() => handleDelete(lang.id)}
-                                            >
-                                                <Trash size={16} />
-                                            </button>
-                                        </div>
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </AdminLayout>
-    );
+  return (
+    <AdminLayout>
+      <div className="p-6">
+        <div className="flex justify-between mb-4">
+          <h1 className="text-2xl font-bold">Languages</h1>
+          <Link href="/dashboard/admin/settings/languages/create" className="bg-yellow-500 text-white px-4 py-2 rounded">+ Add Language</Link>
+        </div>
+        <table className="min-w-full bg-white border rounded">
+          <thead className="bg-gray-100 text-left">
+            <tr>
+              <th className="p-3">Name</th>
+              <th className="p-3">Code</th>
+              <th className="p-3">Default</th>
+              <th className="p-3">Active</th>
+              <th className="p-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {languages?.map((lang) => (
+              <tr key={lang.id} className="border-t">
+                <td className="p-3">{lang.name}</td>
+                <td className="p-3">{lang.code}</td>
+                <td className="p-3 text-center">
+                  <input type="radio" checked={lang.is_default} onChange={() => setDefault(lang)} />
+                </td>
+                <td className="p-3 text-center">
+                  <input type="checkbox" checked={lang.is_active} onChange={() => toggleActive(lang)} />
+                </td>
+                <td className="p-3 space-x-2">
+                  <button onClick={() => router.push(`/dashboard/admin/settings/languages/edit/${lang.code}`)} className="text-blue-600">Edit</button>
+                  <button onClick={() => remove(lang.id)} className="text-red-600">Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </AdminLayout>
+  );
 }

--- a/frontend/src/services/languageService.js
+++ b/frontend/src/services/languageService.js
@@ -1,0 +1,20 @@
+import api from "@/services/api/api";
+
+export const getLanguages = async () => {
+  const { data } = await api.get("/languages");
+  return data.data;
+};
+
+export const createLanguage = async (payload) => {
+  const { data } = await api.post("/languages", payload);
+  return data.data;
+};
+
+export const updateLanguage = async (id, payload) => {
+  const { data } = await api.put(`/languages/${id}`, payload);
+  return data.data;
+};
+
+export const deleteLanguage = async (id) => {
+  await api.delete(`/languages/${id}`);
+};


### PR DESCRIPTION
## Summary
- create migration and seed for `languages` table
- implement CRUD API for languages
- expose `getDefaultLanguage` helper
- register new routes in the backend server
- add SWR powered admin languages page
- add language switcher component and service
- update frontend dependencies

## Testing
- `npm test` within `backend` *(fails: jest not found)*
- `npm test` within `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad5d7b148832889748fd6dd82195e