### PR TITLE
Fix login email case sensitivity

### DIFF
--- a/backend/src/modules/users/user.model.js
+++ b/backend/src/modules/users/user.model.js
@@ -81,7 +81,8 @@ exports.findById = (id) => {
  * 📧 Find one user by email (used for login, registration, and OTP)
  */
 exports.findByEmail = (email) => {
-  return db("users").where({ email }).first();
+  const normalized = email.trim().toLowerCase();
+  return db("users").whereRaw("LOWER(email) = ?", [normalized]).first();
 };
 
 exports.findByPhone = async (phone) => {


### PR DESCRIPTION
## Summary
- normalize emails before querying user record
- add case-insensitive lookup for `findByEmail`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bb6b409a48328bb22ef99cf750f01