### PR TITLE
Remove nested AdminLayout in currency pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/currency/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/create.js
@@ -54,7 +54,6 @@ function CreateCurrencyPage() {
   };
 
   return (
-    <AdminLayout>
       <div className="p-6 max-w-2xl mx-auto">
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold flex items-center gap-2">
@@ -201,7 +200,6 @@ function CreateCurrencyPage() {
           </button>
         </form>
       </div>
-    </AdminLayout>
   );
 }
 

--- a/frontend/src/pages/dashboard/admin/settings/currency/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/index.js
@@ -80,7 +80,6 @@ function CurrencyManagerPage() {
   };
 
   return (
-    <AdminLayout>
       <div className="p-6">
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-2xl font-bold">💱 Currency Manager</h1>
@@ -230,7 +229,6 @@ function CurrencyManagerPage() {
           </tbody>
         </table>
       </div>
-    </AdminLayout>
   );
 }
 


### PR DESCRIPTION
## Summary
- avoid deprecated double `AdminLayout` usage in currency settings pages

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687bcacbf6708328a689214a7e043a4c