### PR TITLE
Add toast and notifications for currency actions

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/currency/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/create.js
@@ -1,6 +1,12 @@
 // pages/dashboard/admin/settings/currencies/create.js
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState } from "react";
+import { toast } from "react-toastify";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
+import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
 import { useSWRConfig } from "swr";
 import { useRouter } from "next/router";
 import { FaArrowLeft, FaSave } from "react-icons/fa";
@@ -10,6 +16,9 @@ import withAuthProtection from "@/hooks/withAuthProtection";
 function CreateCurrencyPage() {
   const router = useRouter();
   const { mutate } = useSWRConfig();
+  const user = useAuthStore((state) => state.user);
+  const refreshNotifications = useNotificationStore((state) => state.fetch);
+  const refreshMessages = useMessageStore((state) => state.fetch);
   const [form, setForm] = useState({
     label: "",
     code: "",
@@ -46,15 +55,25 @@ function CreateCurrencyPage() {
     try {
       await createCurrency(fd);
       mutate("/currencies");
+      toast.success("Currency saved!");
+      const message = `Currency "${form.label}" created.`;
+      await createNotification({
+        user_id: user.id,
+        type: "currency_created",
+        message,
+      });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
       router.push("/dashboard/admin/settings/currency");
     } catch (err) {
       console.error(err);
-      alert("Failed to save currency.");
+      const msg = err.response?.data?.message || "Failed to save currency.";
+      toast.error(msg);
     }
   };
 
   return (
-    <AdminLayout>
       <div className="p-6 max-w-2xl mx-auto">
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold flex items-center gap-2">
@@ -201,7 +220,6 @@ function CreateCurrencyPage() {
           </button>
         </form>
       </div>
-    </AdminLayout>
   );
 }
 


### PR DESCRIPTION
## Summary
- show toast on success/failure when managing currencies
- create admin notifications and chat messages for currency operations
- display backend error text in toasts if currency save fails

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687bcacbf6708328a689214a7e043a4c