### PR TITLE
Enable admin-managed legal policy pages

### DIFF
--- a/backend/src/modules/policies/policies.controller.js
+++ b/backend/src/modules/policies/policies.controller.js
@@ -1,0 +1,13 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./policies.service");
+
+exports.getPolicies = catchAsync(async (_req, res) => {
+  const policies = await service.getPolicies();
+  sendSuccess(res, policies || {});
+});
+
+exports.updatePolicies = catchAsync(async (req, res) => {
+  const policies = await service.updatePolicies(req.body);
+  sendSuccess(res, policies, "Policies updated");
+});

--- a/backend/src/modules/policies/policies.routes.js
+++ b/backend/src/modules/policies/policies.routes.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./policies.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.getPolicies);
+router.use(verifyToken, isAdmin);
+router.put("/", controller.updatePolicies);
+
+module.exports = router;

--- a/backend/src/modules/policies/policies.service.js
+++ b/backend/src/modules/policies/policies.service.js
@@ -1,0 +1,26 @@
+const db = require("../../config/database");
+
+const SETTINGS_KEY = "policy_pages";
+
+exports.getPolicies = async () => {
+  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (!row) return {};
+  try {
+    return JSON.parse(row.value);
+  } catch (_err) {
+    return {};
+  }
+};
+
+exports.updatePolicies = async (policies) => {
+  const value = JSON.stringify(policies);
+  const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (existing) {
+    await db("settings")
+      .where({ key: SETTINGS_KEY })
+      .update({ value, updated_at: db.fn.now() });
+  } else {
+    await db("settings").insert({ key: SETTINGS_KEY, value });
+  }
+  return policies;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -78,6 +78,7 @@ app.use("/api/payments/config", require("./modules/paymentConfig/paymentConfig.r
 app.use("/api/social-login/config", require("./modules/socialLoginConfig/socialLoginConfig.routes"));
 app.use("/api/app-config", require("./modules/appConfig/appConfig.routes"));
 app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));
+app.use("/api/policies", require("./modules/policies/policies.routes"));
 app.use("/api/payouts/admin", require("./modules/payouts/payouts.routes"));
 app.use("/api/ads", require("./modules/ads/ads.routes"));
 app.use("/api/groups", require("./modules/groups/groups.routes"));

--- a/backend/tests/policiesRoutes.test.js
+++ b/backend/tests/policiesRoutes.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/policies/policies.service', () => ({
+  getPolicies: jest.fn(),
+  updatePolicies: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/policies/policies.service');
+const routes = require('../src/modules/policies/policies.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/policies', routes);
+
+describe('GET /api/policies', () => {
+  it('returns policies', async () => {
+    const mock = { test: { title: 'T' } };
+    service.getPolicies.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/policies');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getPolicies).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/policies', () => {
+  it('updates policies', async () => {
+    const payload = { test: { title: 'New' } };
+    service.updatePolicies.mockResolvedValue(payload);
+
+    const res = await request(app).put('/api/policies').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(payload);
+    expect(service.updatePolicies).toHaveBeenCalledWith(payload);
+  });
+});

--- a/frontend/src/pages/api/policies/index.js
+++ b/frontend/src/pages/api/policies/index.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+export default async function handler(req, res) {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const url = `${base}/policies`;
+  try {
+    const headers = req.headers.cookie ? { Cookie: req.headers.cookie } : {};
+    if (req.method === 'GET') {
+      const { data } = await axios.get(url, { headers, withCredentials: true });
+      return res.status(200).json(data.data || data);
+    }
+    if (req.method === 'PUT') {
+      const { data } = await axios.put(url, req.body, { headers, withCredentials: true });
+      return res.status(200).json(data.data);
+    }
+    res.setHeader('Allow', ['GET', 'PUT']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    const status = err.response?.status || 500;
+    const message = err.response?.data?.message || 'Failed to process request';
+    res.status(status).json({ error: message });
+  }
+}

--- a/frontend/src/pages/dashboard/admin/settings/policies/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/policies/index.js
@@ -1,31 +1,24 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import dynamic from "next/dynamic";
 import { FaSave, FaPlus } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { fetchPolicies, updatePolicies } from "@/services/admin/policiesService";
 
 // ReactQuill (lazy load to avoid SSR issues)
 const ReactQuill = dynamic(() => import("react-quill"), { ssr: false });
 import "react-quill/dist/quill.snow.css";
 
 const initialPolicies = {
-  "Privacy Policy": {
-    title: "Privacy Policy",
-    content: "<p>We respect your privacy...</p>",
-  },
-  "Terms & Conditions": {
-    title: "Terms & Conditions",
-    content: "<p>By using this platform...</p>",
-  },
-  "Refund Policy": {
-    title: "Refund Policy",
-    content: "<p>Refunds are only applicable...</p>",
-  },
+  "Privacy Policy": { title: "Privacy Policy", content: "" },
+  "Terms of Service": { title: "Terms of Service", content: "" },
+  "Delete Account": { title: "Delete Account", content: "" },
 };
 
 export default function AdminPoliciesPage() {
   const [policies, setPolicies] = useState(initialPolicies);
   const [activeTab, setActiveTab] = useState("Privacy Policy");
+  const [isLoading, setIsLoading] = useState(false);
 
   const [showAddModal, setShowAddModal] = useState(false);
   const [newPolicy, setNewPolicy] = useState({ title: "", content: "" });
@@ -41,9 +34,34 @@ export default function AdminPoliciesPage() {
     }));
   };
 
-  const handleSave = () => {
-    toast.success(`✅ ${activeTab} saved successfully!`);
-    // TODO: Save to backend API
+  useEffect(() => {
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const data = await fetchPolicies();
+        if (data && Object.keys(data).length) {
+          setPolicies({ ...initialPolicies, ...data });
+        }
+      } catch (err) {
+        toast.error("Failed to load policies");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    try {
+      const updated = await updatePolicies(policies);
+      setPolicies(updated);
+      toast.success(`✅ ${activeTab} saved successfully!`);
+    } catch (err) {
+      toast.error("Failed to save policies");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -103,9 +121,10 @@ export default function AdminPoliciesPage() {
             </button>
             <button
               onClick={handleSave}
-              className="bg-yellow-600 hover:bg-yellow-700 text-white font-semibold px-6 py-2 rounded-xl shadow transition-base flex items-center gap-2"
+              disabled={isLoading}
+              className={`bg-yellow-600 hover:bg-yellow-700 text-white font-semibold px-6 py-2 rounded-xl shadow transition-base flex items-center gap-2 ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
-              <FaSave /> Save {activeTab}
+              <FaSave /> {isLoading ? 'Saving...' : `Save ${activeTab}`}
             </button>
           </div>
         </div>

--- a/frontend/src/pages/delete-account.js
+++ b/frontend/src/pages/delete-account.js
@@ -1,27 +1,32 @@
+import { useEffect, useState } from 'react';
 import PageHead from '@/components/common/PageHead';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
+import { getPolicies } from '@/services/policiesService';
 
 export default function DeleteAccountPage() {
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await getPolicies();
+        setContent(data['Delete Account']?.content || '');
+      } catch (_err) {}
+    };
+    load();
+  }, []);
+
   return (
     <div className="bg-gray-900 text-white min-h-screen">
       <PageHead title="Delete Account" />
       <Navbar />
       <main className="max-w-3xl mx-auto px-4 py-16 space-y-6">
-        <h1 className="text-3xl font-bold text-yellow-500">Delete Your Account</h1>
-        <p>
-          We're sorry to see you go. If you'd like to delete your SkillBridge account and remove your personal data, follow these steps:
-        </p>
-        <ol className="list-decimal list-inside space-y-2">
-          <li>Log in and open your profile settings.</li>
-          <li>Click the "Delete Account" button at the bottom of the page.</li>
-          <li>Confirm when prompted to permanently remove your data.</li>
-        </ol>
-        <p>
-          If you can't access your account, email
-          {' '}<a href="mailto:support@skillbridge.com" className="text-yellow-300 underline">support@skillbridge.com</a>
-          {' '}and we'll assist with the deletion.
-        </p>
+        <h1 className="text-3xl font-bold text-yellow-500">Delete Account</h1>
+        <div
+          className="prose prose-sm max-w-none text-yellow-100"
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
       </main>
       <Footer />
     </div>

--- a/frontend/src/pages/privacy-policy.js
+++ b/frontend/src/pages/privacy-policy.js
@@ -1,23 +1,34 @@
+import { useEffect, useState } from 'react';
 import PageHead from '@/components/common/PageHead';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
+import { getPolicies } from '@/services/policiesService';
 
 export default function PrivacyPolicyPage() {
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await getPolicies();
+        setContent(data['Privacy Policy']?.content || '');
+      } catch (_err) {
+        /* ignore */
+      }
+    };
+    load();
+  }, []);
+
   return (
     <div className="bg-gray-900 text-white min-h-screen">
       <PageHead title="Privacy Policy" />
       <Navbar />
       <main className="max-w-3xl mx-auto px-4 py-16 space-y-6">
         <h1 className="text-3xl font-bold text-yellow-500">Privacy Policy</h1>
-        <p>
-          We respect your privacy and are committed to protecting your personal
-          information. This policy explains how we collect, use and safeguard
-          your data when you use our services.
-        </p>
-        <p>
-          By accessing SkillBridge you agree to this privacy policy. We may
-          update it from time to time, so please review it periodically.
-        </p>
+        <div
+          className="prose prose-sm max-w-none text-yellow-100"
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
       </main>
       <Footer />
     </div>

--- a/frontend/src/pages/terms.js
+++ b/frontend/src/pages/terms.js
@@ -1,22 +1,32 @@
+import { useEffect, useState } from 'react';
 import PageHead from '@/components/common/PageHead';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
+import { getPolicies } from '@/services/policiesService';
 
 export default function TermsPage() {
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await getPolicies();
+        setContent(data['Terms of Service']?.content || '');
+      } catch (_err) {}
+    };
+    load();
+  }, []);
+
   return (
     <div className="bg-gray-900 text-white min-h-screen">
       <PageHead title="Terms of Service" />
       <Navbar />
       <main className="max-w-3xl mx-auto px-4 py-16 space-y-6">
         <h1 className="text-3xl font-bold text-yellow-500">Terms of Service</h1>
-        <p>
-          These terms govern your use of SkillBridge. By accessing the platform
-          you agree to comply with them and any applicable laws.
-        </p>
-        <p>
-          We may modify these terms at any time. Continuing to use the service
-          means you accept the updated terms.
-        </p>
+        <div
+          className="prose prose-sm max-w-none text-yellow-100"
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
       </main>
       <Footer />
     </div>

--- a/frontend/src/services/admin/policiesService.js
+++ b/frontend/src/services/admin/policiesService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchPolicies = async () => {
+  const { data } = await api.get("/policies");
+  return data?.data ?? {};
+};
+
+export const updatePolicies = async (payload) => {
+  const { data } = await api.put("/policies", payload);
+  return data?.data;
+};

--- a/frontend/src/services/policiesService.js
+++ b/frontend/src/services/policiesService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const getPolicies = async () => {
+  const { data } = await api.get("/policies");
+  return data?.data ?? {};
+};


### PR DESCRIPTION
## Summary
- create `policies` module with service, controller and routes
- expose `/api/policies` in backend server
- add tests for the new routes
- add frontend API proxy and services for policies
- load and save policies from the admin dashboard
- render policy page contents dynamically on the main site

## Testing
- `npm run test` in `backend`
- `npm run test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd6ac056483289af84fe702d19b3f