### PR TITLE
Restrict active i18n languages

### DIFF
--- a/frontend/next-i18next.config.js
+++ b/frontend/next-i18next.config.js
@@ -1,6 +1,9 @@
 module.exports = {
     i18n: {
-      locales: ["en", "fr", "ar", "de", "es"], // ✅ Supported Languages
+      // Only English and Arabic are currently active. The remaining
+      // languages are commented out until translations are completed.
+      locales: ["en", "ar"], // Supported Languages
+      // locales: ["en", "fr", "ar", "de", "es"],
       defaultLocale: "en",
       localeDetection: false,
     },


### PR DESCRIPTION
## Summary
- only enable English and Arabic locales in `next-i18next.config.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bda1bbebc8328a0c49103808ea6df