### PR TITLE
Implement full profile API endpoint

### DIFF
--- a/backend/src/modules/users/user.routes.js
+++ b/backend/src/modules/users/user.routes.js
@@ -6,6 +6,8 @@
 
 const express = require("express");
 const router = express.Router();
+const profileController = require("./profile.controller");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
 
 // ==============================================
 // 🔁 GLOBAL FEATURES (public or shared access)
@@ -34,6 +36,11 @@ router.use("/tutorials", tutorialRoutes);
  */
 const classRoutes = require("../classes/class.routes");
 router.use("/classes", classRoutes);
+
+// ---------------------------------------------------------------------------
+// Profile helpers for current authenticated user
+// ---------------------------------------------------------------------------
+router.get("/me/full-profile", verifyToken, profileController.getFullProfile);
 
 
 // ==============================================


### PR DESCRIPTION
## Summary
- add `getFullProfile` controller for retrieving the authenticated user's entire profile
- expose `/api/users/me/full-profile` route

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687be8c600a8832890b5d90ddc2385b9