### PR TITLE
Fix login reCAPTCHA verification

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -57,14 +57,13 @@ exports.register = catchAsync(async (req, res, next) => {
  * @access Public
  */
 exports.login = catchAsync(async (req, res) => {
-  // TODO: Re-enable reCAPTCHA verification once login issues are resolved
-  // const cfg = await socialLoginConfigService.getSettings();
-  // if (cfg?.recaptcha?.active) {
-  //   const valid = await recaptchaService.verify(req.body.recaptchaToken, req.ip);
-  //   if (!valid) {
-  //     throw new AppError('Failed reCAPTCHA verification', 400);
-  //   }
-  // }
+  const cfg = await socialLoginConfigService.getSettings();
+  if (cfg?.recaptcha?.active) {
+    const valid = await recaptchaService.verify(req.body.recaptchaToken, req.ip);
+    if (!valid) {
+      throw new AppError('Failed reCAPTCHA verification', 400);
+    }
+  }
   const { accessToken, refreshToken, user } = await authService.loginUser(req.body);
   res
     .cookie("refreshToken", refreshToken, refreshCookieOptions)


### PR DESCRIPTION
## Summary
- enforce reCAPTCHA check in the login controller so authentication fails when verification fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bf13a6a088328993d7c3b790585b3