### PR TITLE
Enhance language editing

### DIFF
--- a/backend/src/modules/languages/languages.controller.js
+++ b/backend/src/modules/languages/languages.controller.js
@@ -4,6 +4,9 @@ const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
 const fs = require("fs");
 const path = require("path");
+const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
 
 exports.createLanguage = catchAsync(async (req, res) => {
   const data = { ...req.body };
@@ -34,6 +37,25 @@ exports.updateLanguage = catchAsync(async (req, res) => {
   }
 
   const lang = await service.update(req.params.id, data);
+  const admins = await userModel.findAdmins();
+  await Promise.all(
+    admins.map((admin) =>
+      notificationService.createNotification({
+        user_id: admin.id,
+        type: "language_updated",
+        message: `Language ${lang.name} was updated`,
+      })
+    )
+  );
+  await Promise.all(
+    admins.map((admin) =>
+      messageService.createMessage({
+        sender_id: req.user.id,
+        receiver_id: admin.id,
+        message: `Language ${lang.name} was updated`,
+      })
+    )
+  );
   sendSuccess(res, lang, "Language updated");
 });
 

--- a/frontend/src/pages/dashboard/admin/settings/languages/edit/[code].js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/edit/[code].js
@@ -2,6 +2,7 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { getLanguages, updateLanguage } from "@/services/languageService";
+import { toast } from "react-toastify";
 import { mutate } from "swr";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import Link from "next/link";
@@ -28,7 +29,21 @@ export default function EditLanguagePage() {
   const [language, setLanguage] = useState(null);
   const [iconFile, setIconFile] = useState(null);
   const [iconUploading, setIconUploading] = useState(false);
+  const [langForm, setLangForm] = useState({
+    name: "",
+    code: "",
+    is_default: false,
+    is_active: true,
+  });
   const [newKeys, setNewKeys] = useState({});
+
+  const handleLangFormChange = (e) => {
+    const { name, type, value, checked } = e.target;
+    setLangForm((prev) => ({
+      ...prev,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  };
 
   useEffect(() => {
     if (!code) return;
@@ -38,6 +53,14 @@ export default function EditLanguagePage() {
         const langs = await getLanguages();
         const lang = langs.find((l) => l.code === code);
         setLanguage(lang);
+        if (lang) {
+          setLangForm({
+            name: lang.name,
+            code: lang.code,
+            is_default: lang.is_default,
+            is_active: lang.is_active,
+          });
+        }
         const data = await fetchTranslations(code);
         setTranslations(data);
       } catch (err) {
@@ -89,11 +112,11 @@ const handleIconChange = (file) => {
       const updated = await updateLanguage(language.id, fd);
       setLanguage(updated);
       setIconFile(null);
-      alert("Icon uploaded");
+      toast.success("Icon uploaded");
       mutate("/languages");
     } catch (err) {
       console.error(err);
-      alert("Failed to upload icon");
+      toast.error("Failed to upload icon");
     } finally {
       setIconUploading(false);
     }
@@ -102,6 +125,9 @@ const handleIconChange = (file) => {
   const handleSave = async () => {
     setLoading(true);
     try {
+      if (language?.id) {
+        await updateLanguage(language.id, langForm);
+      }
       for (const ns of namespaces) {
         await fetch(`/api/translations/${code}/${ns}`, {
           method: "PUT",
@@ -109,11 +135,11 @@ const handleIconChange = (file) => {
           body: JSON.stringify(translations[ns] || {}),
         });
       }
-      alert("Translations saved");
+      toast.success("Language updated");
       mutate("/languages");
     } catch (err) {
       console.error(err);
-      alert("Failed to save translations");
+      toast.error("Failed to save language");
     } finally {
       setLoading(false);
     }
@@ -141,17 +167,58 @@ const handleIconChange = (file) => {
               e.preventDefault();
               handleSave();
             }}
-            className="space-y-8"
+            className="space-y-8 md:space-y-0 md:grid md:grid-cols-2 md:gap-6"
           >
             {language && (
-              <div className="bg-white shadow rounded p-4">
-                <label className="block font-semibold mb-1">Language Icon</label>
-                <input
-                  type="file"
-                  accept="image/*"
-                  onChange={(e) => handleIconChange(e.target.files[0])}
-                  className="border p-2 rounded w-full"
-                />
+              <>
+                <div className="bg-white shadow rounded p-4 flex flex-col gap-4">
+                  <div>
+                    <label className="block font-semibold mb-1">Language Name</label>
+                    <input
+                      type="text"
+                      name="name"
+                      value={langForm.name}
+                      onChange={handleLangFormChange}
+                      className="border p-2 rounded w-full"
+                    />
+                  </div>
+                  <div>
+                    <label className="block font-semibold mb-1">Language Code</label>
+                    <input
+                      type="text"
+                      name="code"
+                      value={langForm.code}
+                      onChange={handleLangFormChange}
+                      className="border p-2 rounded w-full"
+                    />
+                  </div>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name="is_default"
+                      checked={langForm.is_default}
+                      onChange={handleLangFormChange}
+                    />
+                    <span className="text-sm">Set as Default</span>
+                  </label>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name="is_active"
+                      checked={langForm.is_active}
+                      onChange={handleLangFormChange}
+                    />
+                    <span className="text-sm">Active</span>
+                  </label>
+                </div>
+                <div className="bg-white shadow rounded p-4">
+                  <label className="block font-semibold mb-1">Language Icon</label>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) => handleIconChange(e.target.files[0])}
+                    className="border p-2 rounded w-full"
+                  />
                 {(iconFile || language.icon_url) && (
                   <img
                     src={iconFile ? URL.createObjectURL(iconFile) : `${process.env.NEXT_PUBLIC_API_BASE_URL}${language.icon_url}`}
@@ -167,7 +234,8 @@ const handleIconChange = (file) => {
                 >
                   <FaUpload /> {iconUploading ? "Uploading..." : "Upload"}
                 </button>
-              </div>
+                </div>
+              </>
             )}
             {namespaces.map((ns) => (
               <div key={ns} className="bg-white shadow rounded p-4">


### PR DESCRIPTION
## Summary
- support updating language details from the edit page
- show toast notifications instead of alerts
- notify admins when a language is updated
- improve edit page layout with responsive grid

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bf6b9b0448328b95d735e71a7133b