### PR TITLE
Fix refresh token cookie handling

### DIFF
--- a/backend/src/utils/cookie.js
+++ b/backend/src/utils/cookie.js
@@ -1,7 +1,17 @@
+// ---------------------------------------------------------------------------
+// Cookie options for the refresh token
+//
+// In production the cookie must be `Secure` and `SameSite=None` so it can be
+// shared across subdomains. During local development this would prevent the
+// cookie from being sent over plain HTTP, causing 401 errors when attempting to
+// refresh the session.  Use `NODE_ENV` to automatically disable the `Secure`
+// flag and relax `SameSite` when not running in production.
+// ---------------------------------------------------------------------------
+
 const refreshCookieOptions = {
   httpOnly: true,
-  secure: true,
-  sameSite: 'None',
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
   maxAge: 7 * 24 * 60 * 60 * 1000,
 };
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,11 +20,16 @@ Follow these steps to run SkillBridge on your local machine.
 2. Configure environment variables for the backend:
 
    ```bash
-   cp backend/.env.example backend/.env
-   # edit backend/.env and set your secrets
-   # FRONTEND_URL defaults to http://localhost:3000
-   # change it if your frontend uses a different domain
-   ```
+  cp backend/.env.example backend/.env
+  # edit backend/.env and set your secrets
+  # FRONTEND_URL defaults to http://localhost:3000
+  # change it if your frontend uses a different domain
+  ```
+
+   The backend determines cookie security based on `NODE_ENV`. When running
+   locally leave `NODE_ENV` unset (defaults to `development`) so the refresh
+   token cookie is delivered over plain HTTP. Using `NODE_ENV=production` without
+   HTTPS will result in `401` errors when refreshing the session.
 
 3. (Optional) Install dependencies for manual development:
 


### PR DESCRIPTION
## Summary
- make refresh token cookie security depend on `NODE_ENV`
- document how `NODE_ENV` affects cookies during installation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bfa04698c8328bd8c12efd7f87890