### PR TITLE
Remove policy pages from admin sidebar

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -78,14 +78,5 @@ export const adminNavLinks = [
         ]
       }
     ]
-  },
-  {
-    title: 'Legal',
-    items: [
-      { label: 'Legal', href: '/legal', icon: FileSignature },
-      { label: 'Privacy Policy', href: '/privacy-policy', icon: FileSignature },
-      { label: 'Terms of Service', href: '/terms', icon: FileSignature },
-      { label: 'Delete Account', href: '/delete-account', icon: FileSignature }
-    ]
   }
 ];


### PR DESCRIPTION
## Summary
- remove Legal-related links from the admin sidebar navigation

## Testing
- `npm test` in `frontend`
- `npm run lint` in `frontend` *(fails: many existing lint errors)*
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_687bfdd158788328b3ed04352672ef4b