### PR TITLE
Add messages config module

### DIFF
--- a/backend/src/modules/messagesConfig/messagesConfig.controller.js
+++ b/backend/src/modules/messagesConfig/messagesConfig.controller.js
@@ -1,0 +1,13 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./messagesConfig.service");
+
+exports.getSettings = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings || {});
+});
+
+exports.updateSettings = catchAsync(async (req, res) => {
+  const settings = await service.updateSettings(req.body);
+  sendSuccess(res, settings, "Settings updated");
+});

--- a/backend/src/modules/messagesConfig/messagesConfig.routes.js
+++ b/backend/src/modules/messagesConfig/messagesConfig.routes.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./messagesConfig.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.get("/", controller.getSettings);
+router.put("/", controller.updateSettings);
+
+module.exports = router;

--- a/backend/src/modules/messagesConfig/messagesConfig.service.js
+++ b/backend/src/modules/messagesConfig/messagesConfig.service.js
@@ -1,0 +1,26 @@
+const db = require("../../config/database");
+
+const SETTINGS_KEY = "messages_settings";
+
+exports.getSettings = async () => {
+  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (!row) return null;
+  try {
+    return JSON.parse(row.value);
+  } catch (_err) {
+    return null;
+  }
+};
+
+exports.updateSettings = async (settings) => {
+  const value = JSON.stringify(settings);
+  const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (existing) {
+    await db("settings")
+      .where({ key: SETTINGS_KEY })
+      .update({ value, updated_at: db.fn.now() });
+  } else {
+    await db("settings").insert({ key: SETTINGS_KEY, value });
+  }
+  return settings;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -75,6 +75,7 @@ app.use("/api/payment-methods", require("./modules/paymentMethods/paymentMethods
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
 app.use("/api/payment-methods/admin", require("./modules/paymentMethods/paymentMethods.routes"));
 app.use("/api/payments/config", require("./modules/paymentConfig/paymentConfig.routes"));
+app.use("/api/messages/config", require("./modules/messagesConfig/messagesConfig.routes"));
 app.use("/api/social-login/config", require("./modules/socialLoginConfig/socialLoginConfig.routes"));
 app.use("/api/app-config", require("./modules/appConfig/appConfig.routes"));
 app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));

--- a/backend/tests/messagesConfigRoutes.test.js
+++ b/backend/tests/messagesConfigRoutes.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/messagesConfig/messagesConfig.service', () => ({
+  getSettings: jest.fn(),
+  updateSettings: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/messagesConfig/messagesConfig.service');
+const routes = require('../src/modules/messagesConfig/messagesConfig.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/messages/config', routes);
+
+describe('GET /api/messages/config', () => {
+  it('returns settings', async () => {
+    const mock = { providers: [] };
+    service.getSettings.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/messages/config');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getSettings).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/messages/config', () => {
+  it('updates settings', async () => {
+    const payload = { providers: [{ name: "Twilio" }] };
+    service.updateSettings.mockResolvedValue(payload);
+
+    const res = await request(app).put('/api/messages/config').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(payload);
+    expect(service.updateSettings).toHaveBeenCalledWith(payload);
+  });
+});

--- a/frontend/src/pages/dashboard/admin/settings/messages-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/messages-config/index.js
@@ -1,8 +1,9 @@
 // pages/dashboard/admin/settings/messages-config.js
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaToggleOn, FaToggleOff, FaSave } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { fetchMessagesConfig, updateMessagesConfig } from "@/services/admin/messagesConfigService";
 
 const initialProviders = [
   {
@@ -50,6 +51,24 @@ const initialProviders = [
 
 export default function MessageServiceConfig() {
   const [providers, setProviders] = useState(initialProviders);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchMessagesConfig();
+        if (data && Array.isArray(data.providers)) {
+          setProviders(data.providers);
+        }
+      } catch (err) {
+        toast.error("Failed to load settings");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
 
   // Separate groups
   const smsProviders = providers.filter(p => p.type === "Gateway");
@@ -70,7 +89,15 @@ export default function MessageServiceConfig() {
   };
 
   const handleSaveProvider = (index) => {
-    toast.success(`${providers[index].name} settings saved!`, { theme: "colored" });
+    const save = async () => {
+      try {
+        await updateMessagesConfig({ providers });
+        toast.success(`${providers[index].name} settings saved!`, { theme: "colored" });
+      } catch (err) {
+        toast.error("Failed to save settings");
+      }
+    };
+    save();
   };
 
   return (

--- a/frontend/src/services/admin/messagesConfigService.js
+++ b/frontend/src/services/admin/messagesConfigService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchMessagesConfig = async () => {
+  const { data } = await api.get("/messages/config");
+  return data?.data ?? null;
+};
+
+export const updateMessagesConfig = async (payload) => {
+  const { data } = await api.put("/messages/config", payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- add backend module for messages config with CRUD endpoints
- register route `/api/messages/config`
- add Jest tests for the new backend routes
- add frontend admin service and update messages config page to load and save settings

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_687c013b45088328b4648209033ed532