### PR TITLE
Add contact settings module

### DIFF
--- a/backend/src/modules/contactConfig/contactConfig.controller.js
+++ b/backend/src/modules/contactConfig/contactConfig.controller.js
@@ -1,0 +1,35 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./contactConfig.service");
+const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
+
+exports.getSettings = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings || {});
+});
+
+exports.updateSettings = catchAsync(async (req, res) => {
+  const settings = await service.updateSettings(req.body);
+  sendSuccess(res, settings, "Settings updated");
+
+  const admins = await userModel.findAdmins();
+  const senderId = req.user?.id;
+  await Promise.all(
+    admins.map((admin) =>
+      Promise.all([
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "contact_settings_updated",
+          message: "Contact settings were updated",
+        }),
+        messageService.createMessage({
+          sender_id: senderId || admin.id,
+          receiver_id: admin.id,
+          message: "Contact settings were updated",
+        }),
+      ])
+    )
+  );
+});

--- a/backend/src/modules/contactConfig/contactConfig.routes.js
+++ b/backend/src/modules/contactConfig/contactConfig.routes.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./contactConfig.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.getSettings);
+router.use(verifyToken, isAdmin);
+router.put("/", controller.updateSettings);
+
+module.exports = router;

--- a/backend/src/modules/contactConfig/contactConfig.service.js
+++ b/backend/src/modules/contactConfig/contactConfig.service.js
@@ -1,0 +1,26 @@
+const db = require("../../config/database");
+
+const SETTINGS_KEY = "contact_settings";
+
+exports.getSettings = async () => {
+  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (!row) return null;
+  try {
+    return JSON.parse(row.value);
+  } catch (_err) {
+    return null;
+  }
+};
+
+exports.updateSettings = async (settings) => {
+  const value = JSON.stringify(settings);
+  const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (existing) {
+    await db("settings")
+      .where({ key: SETTINGS_KEY })
+      .update({ value, updated_at: db.fn.now() });
+  } else {
+    await db("settings").insert({ key: SETTINGS_KEY, value });
+  }
+  return settings;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -79,6 +79,7 @@ app.use("/api/messages/config", require("./modules/messagesConfig/messagesConfig
 app.use("/api/social-login/config", require("./modules/socialLoginConfig/socialLoginConfig.routes"));
 app.use("/api/app-config", require("./modules/appConfig/appConfig.routes"));
 app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));
+app.use("/api/contact-config", require("./modules/contactConfig/contactConfig.routes"));
 app.use("/api/policies", require("./modules/policies/policies.routes"));
 app.use("/api/payouts/admin", require("./modules/payouts/payouts.routes"));
 app.use("/api/ads", require("./modules/ads/ads.routes"));

--- a/backend/tests/contactConfigRoutes.test.js
+++ b/backend/tests/contactConfigRoutes.test.js
@@ -1,0 +1,55 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/contactConfig/contactConfig.service', () => ({
+  getSettings: jest.fn(),
+  updateSettings: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findAdmins: jest.fn(() => [{ id: 'admin1' }]),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'admin1' }; next(); },
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/contactConfig/contactConfig.service');
+const routes = require('../src/modules/contactConfig/contactConfig.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/contact-config', routes);
+
+describe('GET /api/contact-config', () => {
+  it('returns settings', async () => {
+    const mock = { email: 'a@test.com' };
+    service.getSettings.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/contact-config');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getSettings).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/contact-config', () => {
+  it('updates settings', async () => {
+    const payload = { email: 'b@test.com' };
+    service.updateSettings.mockResolvedValue(payload);
+
+    const res = await request(app).put('/api/contact-config').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(payload);
+    expect(service.updateSettings).toHaveBeenCalledWith(payload);
+  });
+});

--- a/frontend/src/pages/dashboard/admin/settings/contact/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/contact/index.js
@@ -1,7 +1,9 @@
 // pages/dashboard/admin/settings/contact.js
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSave } from "react-icons/fa";
+import { toast } from "react-toastify";
+import { fetchContactConfig, updateContactConfig } from "@/services/admin/contactConfigService";
 
 const initialConfig = {
     "email": "support@skillbridge.com",
@@ -16,14 +18,37 @@ const initialConfig = {
 
 export default function AdminContactSettings() {
     const [config, setConfig] = useState(initialConfig);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const load = async () => {
+            setLoading(true);
+            try {
+                const data = await fetchContactConfig();
+                if (data) setConfig({ ...initialConfig, ...data });
+            } catch (err) {
+                toast.error("Failed to load settings");
+            } finally {
+                setLoading(false);
+            }
+        };
+        load();
+    }, []);
 
     const handleChange = (field, value) => {
         setConfig((prev) => ({ ...prev, [field]: value }));
     };
 
-    const handleSave = () => {
-        // Replace with actual API call later
-        alert("Contact settings saved!");
+    const handleSave = async () => {
+        setLoading(true);
+        try {
+            await updateContactConfig(config);
+            toast.success("Contact settings saved!");
+        } catch (err) {
+            toast.error("Failed to save settings");
+        } finally {
+            setLoading(false);
+        }
     };
 
     return (
@@ -101,9 +126,10 @@ export default function AdminContactSettings() {
                     <div className="text-right">
                         <button
                             onClick={handleSave}
-                            className="inline-flex items-center gap-2 bg-yellow-600 text-white px-6 py-2 rounded-lg shadow hover:bg-blue-700 transition"
+                            disabled={loading}
+                            className={`inline-flex items-center gap-2 px-6 py-2 rounded-lg shadow transition ${loading ? "bg-gray-300 cursor-not-allowed" : "bg-yellow-600 text-white hover:bg-yellow-700"}`}
                         >
-                            <FaSave /> Save Settings
+                            <FaSave /> {loading ? "Saving..." : "Save Settings"}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/services/admin/contactConfigService.js
+++ b/frontend/src/services/admin/contactConfigService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchContactConfig = async () => {
+  const { data } = await api.get("/contact-config");
+  return data?.data ?? {};
+};
+
+export const updateContactConfig = async (payload) => {
+  const { data } = await api.put("/contact-config", payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- add contact config module on backend
- notify admins when contact settings change
- expose `/api/contact-config` route
- add API tests for the new route
- connect admin contact settings page to backend
- show toast messages when saving

## Testing
- `cd backend && npm test --silent`
- `cd frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687c06e91794832899c246e726ce5284