### PR TITLE
Implement FAQ backend and integrate admin page

### DIFF
--- a/backend/src/migrations/20250722000000_create_faqs_table.js
+++ b/backend/src/migrations/20250722000000_create_faqs_table.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('faqs', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.string('question').notNullable();
+    table.text('answer').notNullable();
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('faqs');
+};

--- a/backend/src/modules/faqs/faqs.controller.js
+++ b/backend/src/modules/faqs/faqs.controller.js
@@ -1,0 +1,25 @@
+const service = require("./faqs.service");
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
+
+exports.listFaqs = catchAsync(async (_req, res) => {
+  const faqs = await service.list();
+  sendSuccess(res, faqs);
+});
+
+exports.createFaq = catchAsync(async (req, res) => {
+  const faq = await service.create(req.body);
+  sendSuccess(res, faq, "FAQ created");
+});
+
+exports.updateFaq = catchAsync(async (req, res) => {
+  const faq = await service.update(req.params.id, req.body);
+  if (!faq) throw new AppError("FAQ not found", 404);
+  sendSuccess(res, faq, "FAQ updated");
+});
+
+exports.deleteFaq = catchAsync(async (req, res) => {
+  await service.remove(req.params.id);
+  sendSuccess(res, null, "FAQ deleted");
+});

--- a/backend/src/modules/faqs/faqs.routes.js
+++ b/backend/src/modules/faqs/faqs.routes.js
@@ -1,0 +1,10 @@
+const router = require('express').Router();
+const controller = require('./faqs.controller');
+const { verifyToken, isAdmin } = require('../../middleware/auth/authMiddleware');
+
+router.get('/', controller.listFaqs);
+router.post('/', verifyToken, isAdmin, controller.createFaq);
+router.put('/:id', verifyToken, isAdmin, controller.updateFaq);
+router.delete('/:id', verifyToken, isAdmin, controller.deleteFaq);
+
+module.exports = router;

--- a/backend/src/modules/faqs/faqs.service.js
+++ b/backend/src/modules/faqs/faqs.service.js
@@ -1,0 +1,24 @@
+const db = require("../../config/database");
+
+exports.create = async (data) => {
+  const [row] = await db("faqs").insert(data).returning("*");
+  return row;
+};
+
+exports.list = () => {
+  return db("faqs").select("*").orderBy("created_at", "desc");
+};
+
+exports.getById = (id) => {
+  return db("faqs").where({ id }).first();
+};
+
+exports.update = async (id, data) => {
+  const [row] = await db("faqs")
+    .where({ id })
+    .update({ ...data, updated_at: db.fn.now() })
+    .returning("*");
+  return row;
+};
+
+exports.remove = (id) => db("faqs").where({ id }).del();

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -93,6 +93,7 @@ app.use("/api/messages", require("./modules/messages/messages.routes"));
 app.use("/api/chat", require("./modules/chat/chat.routes"));
 app.use("/api/languages", require("./modules/languages/languages.routes"));
 app.use("/api/currencies", require("./modules/currencies/currencies.routes"));
+app.use("/api/faqs", require("./modules/faqs/faqs.routes"));
 
 app.get("/", (req, res) => res.send("🚀 SkillBridge API is live."));
 

--- a/frontend/src/pages/dashboard/admin/settings/faqs/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/faqs/index.js
@@ -1,23 +1,26 @@
 import { useState } from "react";
+import useSWR from "swr";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaPlus, FaTrash, FaEdit, FaSave, FaTimes } from "react-icons/fa";
+import api from "@/services/api/api";
+
+const fetcher = (url) => api.get(url).then((res) => res.data.data);
 
 export default function AdminFaqsPage() {
-  const [faqs, setFaqs] = useState([
-    { id: 1, question: "What is SkillBridge?", answer: "SkillBridge is an online learning platform." },
-    { id: 2, question: "Do I receive a certificate?", answer: "Yes, certificates are issued automatically upon course completion." },
-  ]);
+  const { data: faqs = [], mutate } = useSWR("/faqs", fetcher);
   const [newFaq, setNewFaq] = useState({ question: "", answer: "" });
   const [editId, setEditId] = useState(null);
 
-  const handleAdd = () => {
+  const handleAdd = async () => {
     if (!newFaq.question.trim() || !newFaq.answer.trim()) return;
-    setFaqs((prev) => [...prev, { ...newFaq, id: Date.now() }]);
+    await api.post("/faqs", newFaq);
+    mutate();
     setNewFaq({ question: "", answer: "" });
   };
 
-  const handleDelete = (id) => {
-    setFaqs((prev) => prev.filter((f) => f.id !== id));
+  const handleDelete = async (id) => {
+    await api.delete(`/faqs/${id}`);
+    mutate();
   };
 
   const handleEdit = (id) => {
@@ -26,10 +29,9 @@ export default function AdminFaqsPage() {
     setNewFaq({ question: faq.question, answer: faq.answer });
   };
 
-  const handleSave = () => {
-    setFaqs((prev) =>
-      prev.map((faq) => (faq.id === editId ? { ...faq, ...newFaq } : faq))
-    );
+  const handleSave = async () => {
+    await api.put(`/faqs/${editId}`, newFaq);
+    mutate();
     setEditId(null);
     setNewFaq({ question: "", answer: "" });
   };


### PR DESCRIPTION
## Summary
- add `faqs` database table and API endpoints
- register FAQ routes in the backend server
- connect admin FAQ UI to backend using SWR

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_687c07401a448328995b3ae95b29f47d