### PR TITLE
Add blog post API and connect frontend

### DIFF
--- a/backend/src/migrations/20250722000000_create_blog_posts_table.js
+++ b/backend/src/migrations/20250722000000_create_blog_posts_table.js
@@ -1,0 +1,16 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('blog_posts', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('title').notNullable();
+    table.string('slug').notNullable().unique();
+    table.text('excerpt');
+    table.text('content');
+    table.string('image_url');
+    table.date('published_at');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('blog_posts');
+};

--- a/backend/src/modules/blog/blog.controller.js
+++ b/backend/src/modules/blog/blog.controller.js
@@ -1,0 +1,64 @@
+const { v4: uuidv4 } = require("uuid");
+const slugify = require("slugify");
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./blog.service");
+
+exports.createPost = catchAsync(async (req, res) => {
+  const { title, excerpt, content, published_at } = req.body;
+  if (!title) throw new AppError("Title is required", 400);
+  const slug = slugify(title, { lower: true, strict: true });
+  if (await service.findBySlug(slug)) throw new AppError("Post slug already exists", 409);
+
+  const post = await service.createPost({
+    id: uuidv4(),
+    title,
+    slug,
+    excerpt: excerpt || null,
+    content: content || null,
+    published_at: published_at || new Date(),
+    image_url: req.file ? `/uploads/blog/${req.file.filename}` : null,
+  });
+
+  sendSuccess(res, post, "Post created");
+});
+
+exports.getPosts = catchAsync(async (_req, res) => {
+  const posts = await service.getPosts();
+  sendSuccess(res, posts);
+});
+
+exports.getPost = catchAsync(async (req, res) => {
+  const post = await service.getPostById(req.params.id);
+  if (!post) throw new AppError("Post not found", 404);
+  sendSuccess(res, post);
+});
+
+exports.updatePost = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  const existing = await service.getPostById(id);
+  if (!existing) throw new AppError("Post not found", 404);
+
+  const { title, excerpt, content, published_at } = req.body;
+  const updates = { excerpt, content, published_at };
+
+  if (title) {
+    const slug = slugify(title, { lower: true, strict: true });
+    const slugExist = await service.findBySlug(slug);
+    if (slugExist && slugExist.id !== id) throw new AppError("Post slug already exists", 409);
+    updates.title = title;
+    updates.slug = slug;
+  }
+
+  if (req.file) updates.image_url = `/uploads/blog/${req.file.filename}`;
+
+  const updated = await service.updatePost(id, updates);
+  sendSuccess(res, updated, "Post updated");
+});
+
+exports.deletePost = catchAsync(async (req, res) => {
+  const count = await service.deletePost(req.params.id);
+  if (!count) throw new AppError("Post not found", 404);
+  sendSuccess(res, null, "Post deleted");
+});

--- a/backend/src/modules/blog/blog.routes.js
+++ b/backend/src/modules/blog/blog.routes.js
@@ -1,0 +1,12 @@
+const router = require("express").Router();
+const controller = require("./blog.controller");
+const upload = require("./blogUploadMiddleware");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.getPosts);
+router.get("/:id", controller.getPost);
+router.post("/", verifyToken, isAdmin, upload.single("image"), controller.createPost);
+router.put("/:id", verifyToken, isAdmin, upload.single("image"), controller.updatePost);
+router.delete("/:id", verifyToken, isAdmin, controller.deletePost);
+
+module.exports = router;

--- a/backend/src/modules/blog/blog.service.js
+++ b/backend/src/modules/blog/blog.service.js
@@ -1,0 +1,19 @@
+const db = require("../../config/database");
+
+exports.createPost = async (data) => {
+  const [row] = await db("blog_posts").insert(data).returning("*");
+  return row;
+};
+
+exports.getPosts = () => db("blog_posts").orderBy("published_at", "desc");
+
+exports.getPostById = (id) => db("blog_posts").where({ id }).first();
+
+exports.findBySlug = (slug) => db("blog_posts").where({ slug }).first();
+
+exports.updatePost = async (id, data) => {
+  const [row] = await db("blog_posts").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.deletePost = (id) => db("blog_posts").where({ id }).del();

--- a/backend/src/modules/blog/blogUploadMiddleware.js
+++ b/backend/src/modules/blog/blogUploadMiddleware.js
@@ -1,0 +1,23 @@
+const multer = require("multer");
+const path = require("path");
+const fs = require("fs");
+
+const allowed = ["image/jpeg", "image/png", "image/webp", "image/jpg"];
+const uploadDir = path.join(__dirname, "../../../uploads/blog");
+if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    const base = path.basename(file.originalname, ext).replace(/\s+/g, "-");
+    cb(null, `${Date.now()}-${base}${ext}`);
+  },
+});
+
+const fileFilter = (_req, file, cb) => {
+  if (allowed.includes(file.mimetype)) cb(null, true);
+  else cb(new Error("Invalid file type. Only images are allowed."), false);
+};
+
+module.exports = multer({ storage, fileFilter, limits: { fileSize: 2 * 1024 * 1024 } });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -93,6 +93,7 @@ app.use("/api/messages", require("./modules/messages/messages.routes"));
 app.use("/api/chat", require("./modules/chat/chat.routes"));
 app.use("/api/languages", require("./modules/languages/languages.routes"));
 app.use("/api/currencies", require("./modules/currencies/currencies.routes"));
+app.use("/api/blog", require("./modules/blog/blog.routes"));
 
 app.get("/", (req, res) => res.send("🚀 SkillBridge API is live."));
 

--- a/backend/tests/blogRoutes.test.js
+++ b/backend/tests/blogRoutes.test.js
@@ -1,0 +1,63 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/blog/blog.service', () => ({
+  createPost: jest.fn(),
+  getPosts: jest.fn(),
+  getPostById: jest.fn(),
+  findBySlug: jest.fn(),
+  updatePost: jest.fn(),
+  deletePost: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'user1' }; next(); },
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/blog/blog.service');
+const routes = require('../src/modules/blog/blog.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/blog', routes);
+
+describe('GET /api/blog', () => {
+  it('returns posts', async () => {
+    const mock = [{ id: '1' }];
+    service.getPosts.mockResolvedValue(mock);
+    const res = await request(app).get('/api/blog');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+  });
+});
+
+describe('POST /api/blog', () => {
+  it('creates post', async () => {
+    const payload = { title: 'Test' };
+    service.createPost.mockResolvedValue({ id: '1', ...payload });
+    const res = await request(app).post('/api/blog').send(payload);
+    expect(res.status).toBe(200);
+    expect(service.createPost).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/blog/:id', () => {
+  it('updates post', async () => {
+    const payload = { title: 'Up' };
+    service.getPostById.mockResolvedValue({ id: '1', title: 'Old' });
+    service.updatePost.mockResolvedValue({ id: '1', ...payload });
+    const res = await request(app).put('/api/blog/1').send(payload);
+    expect(res.status).toBe(200);
+    expect(service.updatePost).toHaveBeenCalledWith('1', expect.any(Object));
+  });
+});
+
+describe('DELETE /api/blog/:id', () => {
+  it('deletes post', async () => {
+    service.deletePost.mockResolvedValue(1);
+    const res = await request(app).delete('/api/blog/1');
+    expect(res.status).toBe(200);
+    expect(service.deletePost).toHaveBeenCalledWith('1');
+  });
+});

--- a/frontend/src/pages/blog/index.js
+++ b/frontend/src/pages/blog/index.js
@@ -2,27 +2,23 @@ import PageHead from '@/components/common/PageHead';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import Link from 'next/link';
-
-const mockPosts = [
-  {
-    id: 1,
-    title: '10 Tips to Improve Online Learning',
-    slug: '10-tips-to-improve-online-learning',
-    date: 'May 14, 2025',
-    excerpt: 'Discover how to stay motivated and succeed in online education with these 10 practical tips.',
-    image: 'https://source.unsplash.com/random/800x500?education',
-  },
-  {
-    id: 2,
-    title: 'How SkillBridge Uses AI for Smarter Tutoring',
-    slug: 'ai-powered-tutoring-skillbridge',
-    date: 'May 12, 2025',
-    excerpt: 'Learn how our AI-driven tools create adaptive learning experiences tailored to every student.',
-    image: 'https://source.unsplash.com/random/800x501?ai,learning',
-  },
-];
+import { useEffect, useState } from 'react';
+import { fetchBlogPosts } from '@/services/blogService';
 
 export default function BlogPage() {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const list = await fetchBlogPosts();
+        setPosts(list);
+      } catch (err) {
+        console.error('Failed to load posts', err);
+      }
+    };
+    load();
+  }, []);
   return (
     <>
       <PageHead title="Blog" />
@@ -36,12 +32,16 @@ export default function BlogPage() {
         </section>
 
         <section className="max-w-6xl mx-auto grid md:grid-cols-2 lg:grid-cols-3 gap-10 px-6 pb-24">
-          {mockPosts.map((post) => (
+          {posts.map((post) => (
             <div key={post.id} className="bg-gray-800 rounded-xl overflow-hidden shadow-lg hover:shadow-yellow-400/20 transition">
-              <img src={post.image} alt={post.title} className="w-full h-48 object-cover" />
+              {post.image && (
+                <img src={post.image} alt={post.title} className="w-full h-48 object-cover" />
+              )}
               <div className="p-6">
                 <h2 className="text-2xl font-semibold text-yellow-300">{post.title}</h2>
-                <p className="text-sm text-gray-400 mt-1">{post.date}</p>
+                {post.published_at && (
+                  <p className="text-sm text-gray-400 mt-1">{new Date(post.published_at).toLocaleDateString()}</p>
+                )}
                 <p className="text-gray-300 mt-3">{post.excerpt}</p>
                 <Link href={`/blog/${post.slug}`}>
                   <span className="text-indigo-400 hover:underline mt-4 inline-block">Read More →</span>

--- a/frontend/src/pages/dashboard/admin/settings/blog/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/blog/index.js
@@ -1,48 +1,98 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaPlus, FaTrash, FaEdit, FaSave, FaTimes } from "react-icons/fa";
+import {
+  fetchPosts,
+  createPost,
+  updatePost,
+  deletePost,
+} from "@/services/admin/blogService";
+import { toast } from "react-toastify";
 
 export default function AdminBlogManager() {
-  const [posts, setPosts] = useState([
-    {
-      id: 1,
-      title: "10 Tips to Improve Online Learning",
-      image: "https://source.unsplash.com/random/400x200?education",
-      excerpt: "Discover how to stay motivated and succeed in online education.",
-      date: "2025-05-14",
-    },
-  ]);
+  const [posts, setPosts] = useState([]);
 
   const [newPost, setNewPost] = useState({
     title: "",
     excerpt: "",
-    image: "",
     date: new Date().toISOString().split("T")[0],
+    imageFile: null,
+    preview: null,
   });
 
   const [editId, setEditId] = useState(null);
 
-  const handleAdd = () => {
-    if (!newPost.title || !newPost.excerpt || !newPost.image) return;
-    setPosts((prev) => [...prev, { ...newPost, id: Date.now() }]);
-    resetForm();
+  useEffect(() => {
+    loadPosts();
+  }, []);
+
+  const loadPosts = async () => {
+    try {
+      const list = await fetchPosts();
+      setPosts(list);
+    } catch (err) {
+      console.error('Failed to load posts', err);
+      toast.error('Failed to load posts');
+    }
   };
 
-  const handleDelete = (id) => {
-    setPosts((prev) => prev.filter((post) => post.id !== id));
+  const handleAdd = async () => {
+    if (!newPost.title || !newPost.excerpt || !newPost.imageFile) return;
+    try {
+      const form = new FormData();
+      form.append("title", newPost.title);
+      form.append("excerpt", newPost.excerpt);
+      form.append("published_at", newPost.date);
+      form.append("image", newPost.imageFile);
+      const saved = await createPost(form);
+      setPosts((prev) => [...prev, saved]);
+      resetForm();
+      toast.success("Post created");
+    } catch (err) {
+      console.error(err);
+      toast.error(err?.response?.data?.message || "Failed to create post");
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm("Delete this post?")) return;
+    try {
+      await deletePost(id);
+      setPosts((prev) => prev.filter((post) => post.id !== id));
+      toast.success("Post deleted");
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to delete post");
+    }
   };
 
   const handleEdit = (id) => {
     const post = posts.find((p) => p.id === id);
     setEditId(id);
-    setNewPost({ ...post });
+    setNewPost({
+      title: post.title,
+      excerpt: post.excerpt,
+      date: post.published_at ? post.published_at.split("T")[0] : new Date().toISOString().split("T")[0],
+      imageFile: null,
+      preview: post.image_url ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${post.image_url}` : null,
+    });
   };
 
-  const handleSave = () => {
-    setPosts((prev) =>
-      prev.map((p) => (p.id === editId ? { ...newPost, id: editId } : p))
-    );
-    resetForm();
+  const handleSave = async () => {
+    try {
+      const form = new FormData();
+      form.append("title", newPost.title);
+      form.append("excerpt", newPost.excerpt);
+      form.append("published_at", newPost.date);
+      if (newPost.imageFile) form.append("image", newPost.imageFile);
+      const updated = await updatePost(editId, form);
+      setPosts((prev) => prev.map((p) => (p.id === editId ? updated : p)));
+      resetForm();
+      toast.success("Post updated");
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to update post");
+    }
   };
 
   const handleCancel = () => {
@@ -51,7 +101,13 @@ export default function AdminBlogManager() {
 
   const resetForm = () => {
     setEditId(null);
-    setNewPost({ title: "", excerpt: "", image: "", date: new Date().toISOString().split("T")[0] });
+    setNewPost({
+      title: "",
+      excerpt: "",
+      date: new Date().toISOString().split("T")[0],
+      imageFile: null,
+      preview: null,
+    });
   };
 
   return (
@@ -78,14 +134,14 @@ export default function AdminBlogManager() {
                 const file = e.target.files[0];
                 if (file) {
                   const imageUrl = URL.createObjectURL(file);
-                  setNewPost((prev) => ({ ...prev, image: imageUrl }));
+                  setNewPost((prev) => ({ ...prev, imageFile: file, preview: imageUrl }));
                 }
               }}
               className="w-full border p-2 rounded"
             />
-            {newPost.image && (
+            {newPost.preview && (
               <div className="mt-2">
-                <img src={newPost.image} alt="Preview" className="rounded max-h-48 object-cover border" />
+                <img src={newPost.preview} alt="Preview" className="rounded max-h-48 object-cover border" />
               </div>
             )}
           </div>
@@ -124,10 +180,18 @@ export default function AdminBlogManager() {
         <div className="grid md:grid-cols-2 gap-6">
           {posts.map((post) => (
             <div key={post.id} className="bg-gray-100 rounded shadow overflow-hidden">
-              <img src={post.image} alt={post.title} className="w-full h-40 object-cover" />
+              {post.image_url && (
+                <img
+                  src={`${process.env.NEXT_PUBLIC_API_BASE_URL}${post.image_url}`}
+                  alt={post.title}
+                  className="w-full h-40 object-cover"
+                />
+              )}
               <div className="p-4">
                 <h3 className="font-semibold text-lg">{post.title}</h3>
-                <p className="text-sm text-gray-600 mb-2">{post.date}</p>
+                {post.published_at && (
+                  <p className="text-sm text-gray-600 mb-2">{post.published_at.split('T')[0]}</p>
+                )}
                 <p className="text-gray-700 text-sm mb-4">{post.excerpt}</p>
                 <div className="flex gap-2">
                   <button onClick={() => handleEdit(post.id)} className="bg-yellow-500 text-white px-3 py-1 rounded flex items-center gap-1">

--- a/frontend/src/services/admin/blogService.js
+++ b/frontend/src/services/admin/blogService.js
@@ -1,0 +1,24 @@
+import api from "@/services/api/api";
+
+export const fetchPosts = async () => {
+  const { data } = await api.get("/blog");
+  return data?.data ?? [];
+};
+
+export const createPost = async (payload) => {
+  const { data } = await api.post("/blog", payload, {
+    headers: payload instanceof FormData ? { "Content-Type": "multipart/form-data" } : {},
+  });
+  return data?.data;
+};
+
+export const updatePost = async (id, payload) => {
+  const { data } = await api.put(`/blog/${id}`, payload, {
+    headers: payload instanceof FormData ? { "Content-Type": "multipart/form-data" } : {},
+  });
+  return data?.data;
+};
+
+export const deletePost = async (id) => {
+  await api.delete(`/blog/${id}`);
+};

--- a/frontend/src/services/blogService.js
+++ b/frontend/src/services/blogService.js
@@ -1,0 +1,10 @@
+import api from "@/services/api/api";
+
+export const fetchBlogPosts = async () => {
+  const { data } = await api.get("/blog");
+  const posts = data?.data ?? [];
+  return posts.map((p) => ({
+    ...p,
+    image: p.image_url ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${p.image_url}` : null,
+  }));
+};


### PR DESCRIPTION
## Summary
- add migrations and module for blog posts
- wire blog routes into Express server
- implement admin and public services on the frontend
- load posts from backend on blog pages and admin blog settings
- include tests for new routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c071962208328bb90999780aa8ee5