### PR TITLE
Handle 401 globally

### DIFF
--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -93,6 +93,14 @@ api.interceptors.response.use(
       } finally {
         isRefreshing = false;
       }
+    } else if (error.response?.status === 401 && originalRequest._retry && !isAuthRoute) {
+      authStore.logout();
+      toast.info("You have been logged out.");
+      toast.error("Session expired. Please log in again.");
+      if (typeof window !== "undefined") {
+        Router.push("/auth/login");
+      }
+      return Promise.reject(error);
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
## Summary
- trigger logout and redirect to `/auth/login` for any 401 after token refresh attempt

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687c7b2488f08328abe862b12ca822cf