### PR TITLE
Implement language creation enhancements

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/languages/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/create.js
@@ -3,6 +3,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
+import { toast } from "react-toastify";
 import { createLanguage } from "@/services/languageService";
 
 const predefinedNamespaces = ["auth", "website", "dashboard"];
@@ -69,7 +70,7 @@ export default function CreateLanguagePage() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (existingCodes.includes(form.code.toLowerCase())) {
-      alert("Language code already exists.");
+      toast.error("Language code already exists.");
       return;
     }
     const fd = new FormData();
@@ -78,9 +79,21 @@ export default function CreateLanguagePage() {
     fd.append("is_active", form.active);
     fd.append("is_default", form.default);
     if (form.icon) fd.append("icon", form.icon);
-
-    await createLanguage(fd);
-    router.push("/dashboard/admin/settings/languages");
+    try {
+      await createLanguage(fd);
+      for (const ns of predefinedNamespaces) {
+        await fetch(`/api/translations/${form.code}/${ns}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(jsonPreviews[ns] || {}),
+        });
+      }
+      toast.success("Language added");
+      router.push("/dashboard/admin/settings/languages");
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to add language");
+    }
   };
 
   return (
@@ -96,7 +109,10 @@ export default function CreateLanguagePage() {
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-6 bg-white p-6 shadow rounded">
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-6 bg-white p-6 shadow rounded md:grid md:grid-cols-2 md:gap-6 md:space-y-0"
+        >
           <div>
             <label className="block font-semibold mb-1">Language Name</label>
             <input
@@ -160,7 +176,7 @@ export default function CreateLanguagePage() {
             </select>
           </div>
 
-          <div>
+          <div className="col-span-2">
             <label className="block font-semibold mb-1">Description (optional)</label>
             <textarea
               name="description"
@@ -171,7 +187,7 @@ export default function CreateLanguagePage() {
             />
           </div>
 
-          <div>
+          <div className="col-span-2">
             <p className="font-semibold mb-2">Upload Translations by Namespace</p>
             {predefinedNamespaces.map((ns) => (
               <div key={ns} className="mb-4">
@@ -197,7 +213,7 @@ export default function CreateLanguagePage() {
             {error && <div className="text-red-600 text-sm mt-2">{error}</div>}
           </div>
 
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-4 col-span-2">
             <label className="flex items-center gap-2">
               <input
                 type="checkbox"
@@ -221,7 +237,7 @@ export default function CreateLanguagePage() {
 
           <button
             type="submit"
-            className="bg-yellow-500 text-white px-4 py-2 rounded flex items-center gap-2"
+            className="bg-yellow-500 text-white px-4 py-2 rounded flex items-center gap-2 col-span-2 justify-center"
           >
             <FaSave /> Save Language
           </button>


### PR DESCRIPTION
## Summary
- use toast notifications in new language form
- save translation files during language creation
- tweak styles for responsive layout

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_687c85955a5c83288bb6c874529ace4c