### PR TITLE
Add admin notifications on language config update

### DIFF
--- a/backend/src/modules/appConfig/appConfig.controller.js
+++ b/backend/src/modules/appConfig/appConfig.controller.js
@@ -4,6 +4,9 @@ const AppError = require("../../utils/AppError");
 const fs = require("fs");
 const path = require("path");
 const service = require("./appConfig.service");
+const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
 
 exports.getSettings = catchAsync(async (_req, res) => {
   const settings = await service.getSettings();
@@ -13,6 +16,25 @@ exports.getSettings = catchAsync(async (_req, res) => {
 exports.updateSettings = catchAsync(async (req, res) => {
   const settings = await service.updateSettings(req.body);
   sendSuccess(res, settings, "Settings updated");
+
+  const admins = await userModel.findAdmins();
+  const senderId = req.user?.id;
+  await Promise.all(
+    admins.map((admin) =>
+      Promise.all([
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "app_settings_updated",
+          message: "Application settings were updated",
+        }),
+        messageService.createMessage({
+          sender_id: senderId || admin.id,
+          receiver_id: admin.id,
+          message: "Application settings were updated",
+        }),
+      ])
+    )
+  );
 });
 
 exports.uploadLogo = catchAsync(async (req, res) => {

--- a/backend/tests/appConfigRoutes.test.js
+++ b/backend/tests/appConfigRoutes.test.js
@@ -6,8 +6,23 @@ jest.mock('../src/modules/appConfig/appConfig.service', () => ({
   updateSettings: jest.fn(),
 }));
 
+jest.mock('../src/modules/users/user.model', () => ({
+  findAdmins: jest.fn(() => [{ id: 'admin1' }]),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
-  verifyToken: (_req, _res, next) => next(),
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'admin1' };
+    next();
+  },
   isAdmin: (_req, _res, next) => next(),
 }));
 


### PR DESCRIPTION
## Summary
- notify admins when app settings change in backend
- update tests for new notification behavior

## Testing
- `cd backend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c90a033a88328adf6815b73b1bb3b