### PR TITLE
Fix admin language creation syntax

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/languages/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/create.js
@@ -110,6 +110,7 @@ export default function CreateLanguagePage() {
         toast.error("Language code already exists.");
       } else {
         toast.error("Failed to add language");
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- close missing braces in the admin languages create page

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687c98419afc8328921592e85490eecb