### PR TITLE
Allow overriding refresh cookie security

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,14 @@ SMTP_PASS=your_smtp_password
 FRONTEND_URL=https://eduskillbridge.net
 COOKIE_DOMAIN=.eduskillbridge.net
 
+# Optional overrides for cookie security
+# Set COOKIE_SECURE=false to allow HTTP when NODE_ENV=production
+# Set COOKIE_SAMESITE=None when using different subdomains
+# COOKIE_SECURE defaults to true in production and false otherwise
+# COOKIE_SAMESITE defaults to Lax in development and None in production
+COOKIE_SECURE=false
+COOKIE_SAMESITE=None
+
 SESSION_SECRET=skillbridge_secret
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret

--- a/backend/src/utils/cookie.js
+++ b/backend/src/utils/cookie.js
@@ -10,8 +10,15 @@
 
 const refreshCookieOptions = {
   httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
+  // Allow overriding cookie security via environment variables. This makes
+  // local HTTPS-less development possible even when NODE_ENV is "production".
+  secure:
+    typeof process.env.COOKIE_SECURE !== 'undefined'
+      ? process.env.COOKIE_SECURE === 'true'
+      : process.env.NODE_ENV === 'production',
+  sameSite:
+    process.env.COOKIE_SAMESITE ||
+    (process.env.NODE_ENV === 'production' ? 'None' : 'Lax'),
   maxAge: 7 * 24 * 60 * 60 * 1000,
 };
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,8 +20,16 @@ Follow these steps to run SkillBridge on a server or production host.
     `COOKIE_DOMAIN` so the authentication cookie can be shared. Example:
 
     ```bash
-    COOKIE_DOMAIN=.eduskillbridge.net
-    ```
+   COOKIE_DOMAIN=.eduskillbridge.net
+   ```
+
+   When running over plain HTTP but using different subdomains (e.g. staging
+   environments), also add:
+
+   ```bash
+   COOKIE_SECURE=false
+   COOKIE_SAMESITE=None
+   ```
 
     To enable password recovery via email, provide SMTP settings or
     configure them later through the `/api/email-config` endpoint or the admin
@@ -149,5 +157,12 @@ matches the deployed domain exactly and restart the backend.  The
 backend including the `/api` prefix. When the frontend and API are on
 different subdomains, set `COOKIE_DOMAIN` in `backend/.env` to the shared
 base domain (e.g. `.eduskillbridge.net`) so the authentication cookie is
-available to both sites.
+available to both sites. If the site uses HTTP, also set:
+
+```bash
+COOKIE_SECURE=false
+COOKIE_SAMESITE=None
+```
+
+This ensures the refresh token cookie is sent across subdomains without HTTPS.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,6 +31,10 @@ Follow these steps to run SkillBridge on your local machine.
    token cookie is delivered over plain HTTP. Using `NODE_ENV=production` without
    HTTPS will result in `401` errors when refreshing the session.
 
+   If you need `SameSite=None` for cross-subdomain cookies while still using
+   plain HTTP (e.g. staging environments), set `COOKIE_SECURE=false` and
+   `COOKIE_SAMESITE=None` in `backend/.env`.
+
 3. (Optional) Install dependencies for manual development:
 
    ```bash

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,3 +1,5 @@
-# Example frontend environment file for production
-# Point the frontend to your API including the /api prefix
-NEXT_PUBLIC_API_BASE_URL=https://api.eduskillbridge.net/api
+# Example frontend environment file
+# Point the frontend to your API including the /api prefix.
+# For local development this can be http://localhost:5000/api
+# When deploying to production replace it with your live API URL.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api


### PR DESCRIPTION
## Summary
- allow setting `COOKIE_SECURE` and `COOKIE_SAMESITE` to override default cookie options
- document the new variables in installation and deployment docs
- update example env files with the overrides and local API URL example

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_687c967dda088328b49d251da018bcfe