### PR TITLE
Fix social_login page

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -222,8 +222,11 @@ export default function SocialLoginSettingsPage() {
 
 
   const getDefaultRedirectUrl = (key) => {
-    let base = process.env.NEXT_PUBLIC_API_BASE_URL || window.location.origin;
-    base = base.replace(/\/$/, '');
+    let base = process.env.NEXT_PUBLIC_API_BASE_URL;
+    if (!base && typeof window !== 'undefined') {
+      base = window.location.origin;
+    }
+    base = (base || '').replace(/\/$/, '');
     if (base.endsWith('/api')) {
       base = base.slice(0, -4);
     }


### PR DESCRIPTION
## Summary
- handle environments without `window` in `social_login` to avoid build errors

## Testing
- `npm run build` in `frontend`
- `npm test` in `frontend`
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cabf31fc8832888e0e0ee0dc8ae2e