### PR TITLE
Add i18n settings to next config

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,3 +1,5 @@
+import nextI18NextConfig from './next-i18next.config.js';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
@@ -37,6 +39,7 @@ const nextConfig = {
       },
     ],
   },
+  i18n: nextI18NextConfig.i18n,
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- load `next-i18next.config.js` in `next.config.mjs`
- export `i18n` settings for Next.js

## Testing
- `npm test`
- `npm run build` *(fails: ./src/pages/dashboard/admin/settings/languages/create.js: Expression expected)*

------
https://chatgpt.com/codex/tasks/task_e_687ce12f42b8832881ab6911a2486e12