### PR TITLE
Add SEO config API and UI wiring

### DIFF
--- a/backend/src/modules/seoConfig/seoConfig.controller.js
+++ b/backend/src/modules/seoConfig/seoConfig.controller.js
@@ -1,0 +1,35 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./seoConfig.service");
+const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
+
+exports.getSettings = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings || {});
+});
+
+exports.updateSettings = catchAsync(async (req, res) => {
+  const settings = await service.updateSettings(req.body);
+  sendSuccess(res, settings, "Settings updated");
+
+  const admins = await userModel.findAdmins();
+  const senderId = req.user?.id;
+  await Promise.all(
+    admins.map((admin) =>
+      Promise.all([
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "seo_settings_updated",
+          message: "SEO settings were updated",
+        }),
+        messageService.createMessage({
+          sender_id: senderId || admin.id,
+          receiver_id: admin.id,
+          message: "SEO settings were updated",
+        }),
+      ])
+    )
+  );
+});

--- a/backend/src/modules/seoConfig/seoConfig.routes.js
+++ b/backend/src/modules/seoConfig/seoConfig.routes.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./seoConfig.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.getSettings);
+router.use(verifyToken, isAdmin);
+router.put("/", controller.updateSettings);
+
+module.exports = router;

--- a/backend/src/modules/seoConfig/seoConfig.service.js
+++ b/backend/src/modules/seoConfig/seoConfig.service.js
@@ -1,0 +1,26 @@
+const db = require("../../config/database");
+
+const SETTINGS_KEY = "seo_settings";
+
+exports.getSettings = async () => {
+  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (!row) return null;
+  try {
+    return JSON.parse(row.value);
+  } catch (_err) {
+    return null;
+  }
+};
+
+exports.updateSettings = async (settings) => {
+  const value = JSON.stringify(settings);
+  const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
+  if (existing) {
+    await db("settings")
+      .where({ key: SETTINGS_KEY })
+      .update({ value, updated_at: db.fn.now() });
+  } else {
+    await db("settings").insert({ key: SETTINGS_KEY, value });
+  }
+  return settings;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -80,6 +80,7 @@ app.use("/api/social-login/config", require("./modules/socialLoginConfig/socialL
 app.use("/api/app-config", require("./modules/appConfig/appConfig.routes"));
 app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));
 app.use("/api/contact-config", require("./modules/contactConfig/contactConfig.routes"));
+app.use("/api/seo-config", require("./modules/seoConfig/seoConfig.routes"));
 app.use("/api/policies", require("./modules/policies/policies.routes"));
 app.use("/api/payouts/admin", require("./modules/payouts/payouts.routes"));
 app.use("/api/ads", require("./modules/ads/ads.routes"));

--- a/backend/tests/seoConfigRoutes.test.js
+++ b/backend/tests/seoConfigRoutes.test.js
@@ -1,0 +1,55 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/seoConfig/seoConfig.service', () => ({
+  getSettings: jest.fn(),
+  updateSettings: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findAdmins: jest.fn(() => [{ id: 'admin1' }]),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'admin1' }; next(); },
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/seoConfig/seoConfig.service');
+const routes = require('../src/modules/seoConfig/seoConfig.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/seo-config', routes);
+
+describe('GET /api/seo-config', () => {
+  it('returns settings', async () => {
+    const mock = { globalSEO: {} };
+    service.getSettings.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/seo-config');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getSettings).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/seo-config', () => {
+  it('updates settings', async () => {
+    const payload = { globalSEO: { forceCanonical: true } };
+    service.updateSettings.mockResolvedValue(payload);
+
+    const res = await request(app).put('/api/seo-config').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(payload);
+    expect(service.updateSettings).toHaveBeenCalledWith(payload);
+  });
+});

--- a/frontend/src/pages/dashboard/admin/settings/seo/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/seo/index.js
@@ -1,6 +1,8 @@
 // pages/dashboard/admin/settings/seo/index.js
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { toast } from "react-toastify";
+import { fetchSEOConfig, updateSEOConfig } from "@/services/admin/seoConfigService";
 import { Tab } from "@headlessui/react";
 import { FaTags, FaSitemap, FaRobot, FaCog, FaTwitter, FaGlobe, FaEdit } from "react-icons/fa";
 
@@ -641,6 +643,32 @@ function AdvancedSEOSettings() {
     setRedirects(updated);
   };
 
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchSEOConfig();
+        if (data) {
+          if (data.globalSEO) setGlobalSEO((prev) => ({ ...prev, ...data.globalSEO }));
+          if (data.redirects) setRedirects(data.redirects);
+          if (data.jsonSchema) setJsonSchema(data.jsonSchema);
+        }
+      } catch (err) {
+        toast.error("Failed to load settings");
+      }
+    };
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSave = async () => {
+    try {
+      await updateSEOConfig({ globalSEO, redirects, jsonSchema });
+      toast.success("SEO settings saved!");
+    } catch (err) {
+      toast.error("Failed to save settings");
+    }
+  };
+
   return (
     <div className="space-y-10">
       {/* GLOBAL SEO CONTROLS */}
@@ -735,7 +763,10 @@ function AdvancedSEOSettings() {
 
       {/* SAVE BUTTONS */}
       <div>
-        <button className="bg-yellow-500 hover:bg-yellow-600 text-white px-6 py-2 rounded shadow">
+        <button
+          onClick={handleSave}
+          className="bg-yellow-500 hover:bg-yellow-600 text-white px-6 py-2 rounded shadow"
+        >
           💾 Save All Advanced Settings
         </button>
       </div>

--- a/frontend/src/services/admin/seoConfigService.js
+++ b/frontend/src/services/admin/seoConfigService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchSEOConfig = async () => {
+  const { data } = await api.get("/seo-config");
+  return data?.data ?? null;
+};
+
+export const updateSEOConfig = async (payload) => {
+  const { data } = await api.put("/seo-config", payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- implement backend seoConfig module with service, controller and routes
- expose `/api/seo-config` endpoint in server
- add jest tests for seoConfig routes
- add frontend service for SEO config
- wire SEO advanced settings UI to backend with toast feedback

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687d0d97b9e48328be46feffb993ce52