### PR TITLE
Set Arabic as default locale

### DIFF
--- a/frontend/next-i18next.config.js
+++ b/frontend/next-i18next.config.js
@@ -4,7 +4,7 @@ module.exports = {
   i18n: {
     // Supported languages with available translations
     locales: ["en", "fr", "ar", "de", "es"],
-    defaultLocale: "en",
+    defaultLocale: "ar",
     localeDetection: false,
   },
   // Fallback to English if a translation is missing


### PR DESCRIPTION
## Summary
- default to Arabic in i18n config

## Testing
- `npm test --silent` in `frontend`
- `npm run lint --silent` *(fails: 52 errors)*
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_687d18f373288328a3e2696761b9c655