### PR TITLE
Fix login schema duplication

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/languages/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/create.js
@@ -264,4 +264,3 @@ export default function CreateLanguagePage() {
     </AdminLayout>
   );
 }
-}

--- a/frontend/src/utils/auth/validationSchemas.js
+++ b/frontend/src/utils/auth/validationSchemas.js
@@ -1,7 +1,7 @@
 // 📁 src/utils/validationSchemas.js
 import { z } from "zod";
-
 // These helpers generate validation schemas using i18n translations
+// 🔐 Login Schema
 export const loginSchema = (t) =>
   z.object({
     email: z.string().email({ message: t("invalid_email_address") }),
@@ -10,13 +10,6 @@ export const loginSchema = (t) =>
       .min(6, { message: t("password_min_6_characters") }),
     recaptchaToken: z.string().optional(),
   });
-
-// 🔐 Login Schema
-export const loginSchema = z.object({
-  email: z.string().email({ message: "Invalid email address" }),
-  password: z.string().min(6, { message: "Password must be at least 6 characters" }),
-  recaptchaToken: z.string().optional(),
-});
 
 // 🧾 Register Schema
 export const registerSchema = (t) =>


### PR DESCRIPTION
## Summary
- remove duplicate login schema definition
- correct closing brace in languages create page

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_687d2a5d34ec832883be5151cd1ecab9