### PR TITLE
Fix i18n translations for some pages

### DIFF
--- a/frontend/src/pages/profile/index.js
+++ b/frontend/src/pages/profile/index.js
@@ -2,6 +2,8 @@ import Navbar from "@/components/website/sections/Navbar";
 import { FaCog, FaLock } from "react-icons/fa";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
 
 const ProfilePage = () => {
   const { t } = useTranslation("common");
@@ -31,3 +33,11 @@ const ProfilePage = () => {
 };
 
 export default ProfilePage;
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/website/index.js
+++ b/frontend/src/pages/website/index.js
@@ -15,6 +15,8 @@ import Footer from "@/components/website/sections/Footer";
 import AITutoring from "@/components/website/sections/AITutoring";
 import IncompleteAlertModal from "@/components/auth/IncompleteAlertModal";
 import useAuthStore from "@/store/auth/authStore";
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
 
 
 export default function Home() {
@@ -94,4 +96,12 @@ export default function Home() {
       </div>
     </div>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common', 'website'], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- include `serverSideTranslations` on profile page
- load `common` and `website` namespaces for website home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e2b1202c483289304e11077580a4b