### PR TITLE
Fix i18n translations for some pages

### DIFF
--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -5,11 +5,23 @@ import AIRecommendations from "@/components/dashboard/AIRecommendations";
 import { motion } from "framer-motion";
 import Link from "next/link";
 import { getRecommendedCourses } from "@/services/aiCourseRecommendation";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../next-i18next.config.js";
 
 const allCourses = [
   { id: 1, title: "Mastering React.js", category: "JavaScript", progress: 80 },
-  { id: 2, title: "Full Stack with Node.js", category: "JavaScript", progress: 50 },
-  { id: 3, title: "AI & Machine Learning Basics", category: "AI", progress: 20 },
+  {
+    id: 2,
+    title: "Full Stack with Node.js",
+    category: "JavaScript",
+    progress: 50,
+  },
+  {
+    id: 3,
+    title: "AI & Machine Learning Basics",
+    category: "AI",
+    progress: 20,
+  },
   { id: 4, title: "Advanced JavaScript", category: "JavaScript" },
   { id: 5, title: "Python for Data Science", category: "Data Science" },
   { id: 6, title: "Blockchain & NFTs", category: "Blockchain" },
@@ -40,7 +52,9 @@ const DashboardPage = () => {
               className="bg-gray-800 p-4 rounded-lg shadow-lg"
               whileHover={{ scale: 1.05 }}
             >
-              <h3 className="text-xl font-semibold text-yellow-400">{course.title}</h3>
+              <h3 className="text-xl font-semibold text-yellow-400">
+                {course.title}
+              </h3>
               <p className="text-gray-300">Progress: {course.progress}%</p>
               <div className="w-full bg-gray-700 rounded-lg overflow-hidden mt-2">
                 <motion.div
@@ -69,3 +83,11 @@ const DashboardPage = () => {
 };
 
 export default DashboardPage;
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common"], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/profile/index.js
+++ b/frontend/src/pages/profile/index.js
@@ -2,6 +2,8 @@ import Navbar from "@/components/website/sections/Navbar";
 import { FaCog, FaLock } from "react-icons/fa";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
 
 const ProfilePage = () => {
   const { t } = useTranslation("common");
@@ -31,3 +33,11 @@ const ProfilePage = () => {
 };
 
 export default ProfilePage;
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/website/index.js
+++ b/frontend/src/pages/website/index.js
@@ -15,6 +15,8 @@ import Footer from "@/components/website/sections/Footer";
 import AITutoring from "@/components/website/sections/AITutoring";
 import IncompleteAlertModal from "@/components/auth/IncompleteAlertModal";
 import useAuthStore from "@/store/auth/authStore";
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
 
 
 export default function Home() {
@@ -94,4 +96,12 @@ export default function Home() {
       </div>
     </div>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common', 'website'], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- include `serverSideTranslations` on profile page
- load `common` and `website` namespaces for website home page
- load common translations for dashboard page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e2b1202c483289304e11077580a4b