### PR TITLE
Improve social login settings

### DIFF
--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.controller.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.controller.js
@@ -2,6 +2,9 @@ const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const service = require("./socialLoginConfig.service");
 const { initStrategies } = require("../../config/passport");
+const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
 
 // Determine if the current user has admin-level access
 const isAdminRole = (roles = []) => {
@@ -40,4 +43,23 @@ exports.updateSettings = catchAsync(async (req, res) => {
     console.error("Failed to reinitialize passport strategies", err);
   }
   sendSuccess(res, sanitize(settings, req), "Settings updated");
+
+  const admins = await userModel.findAdmins();
+  const senderId = req.user?.id;
+  await Promise.all(
+    admins.map((admin) =>
+      Promise.all([
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "social_login_settings_updated",
+          message: "Social login settings were updated",
+        }),
+        messageService.createMessage({
+          sender_id: senderId || admin.id,
+          receiver_id: admin.id,
+          message: "Social login settings were updated",
+        }),
+      ])
+    )
+  );
 });

--- a/backend/tests/socialLoginConfigRoutes.test.js
+++ b/backend/tests/socialLoginConfigRoutes.test.js
@@ -6,13 +6,28 @@ jest.mock('../src/modules/socialLoginConfig/socialLoginConfig.service', () => ({
   updateSettings: jest.fn(),
 }));
 
+jest.mock('../src/modules/users/user.model', () => ({
+  findAdmins: jest.fn(() => [{ id: 'admin1' }]),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
 jest.mock('../src/config/passport', () => ({
   initStrategies: jest.fn(),
   passport: {},
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
-  verifyToken: (_req, _res, next) => next(),
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'admin1' };
+    next();
+  },
   isAdmin: (_req, _res, next) => next(),
 }));
 

--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -3,12 +3,35 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { toast } from "react-toastify";
 import { FaToggleOn, FaToggleOff, FaGoogle, FaFacebookF, FaApple, FaGithub } from "react-icons/fa";
 import { fetchSocialLoginConfig, updateSocialLoginConfig } from "@/services/admin/socialLoginConfigService";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
+import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
 
 const availableIcons = {
   google: <FaGoogle />,
   facebook: <FaFacebookF />,
   apple: <FaApple />,
   github: <FaGithub />,
+};
+
+const useAdminNotice = () => {
+  const user = useAuthStore((state) => state.user);
+  const refreshNotifications = useNotificationStore((state) => state.fetch);
+  const refreshMessages = useMessageStore((state) => state.fetch);
+  return async (type, message) => {
+    try {
+      await createNotification({ user_id: user.id, type, message });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
+    } catch (err) {
+      console.error(err);
+      const msg = err.response?.data?.message || "Failed to send notification";
+      toast.error(msg);
+    }
+  };
 };
 
 const initialProviders = [
@@ -70,6 +93,7 @@ export default function SocialLoginSettingsPage() {
   const [recaptchaSiteKey, setRecaptchaSiteKey] = useState("");
   const [recaptchaSecretKey, setRecaptchaSecretKey] = useState("");
   const [customIcons, setCustomIcons] = useState({});
+  const notify = useAdminNotice();
 
   useEffect(() => {
     const load = async () => {
@@ -109,24 +133,92 @@ export default function SocialLoginSettingsPage() {
     load();
   }, []);
 
-  const toggleGlobal = () => {
+  const toggleGlobal = async () => {
     const newState = !globalActive;
+    const updatedProviders = providers.map((p) => ({
+      ...p,
+      active: newState && providerHasCredentials(p),
+    }));
     setGlobalActive(newState);
-    setProviders((prev) =>
-      prev.map((p) => ({
-        ...p,
-        active: newState && providerHasCredentials(p),
-      }))
-    );
+    setProviders(updatedProviders);
+    const payload = {
+      enabled: newState,
+      providers: updatedProviders.reduce((acc, p) => {
+        acc[p.key] = {
+          active: p.active,
+          clientId: p.clientId,
+          clientSecret: p.clientSecret,
+          teamId: p.teamId,
+          keyId: p.keyId,
+          privateKey: p.privateKey,
+          redirectUrl: p.redirectUrl,
+          label: p.label,
+          icon: p.icon,
+        };
+        return acc;
+      }, {}),
+      recaptcha: {
+        active: recaptchaActive,
+        siteKey: recaptchaSiteKey,
+        secretKey: recaptchaSecretKey,
+      },
+    };
+    try {
+      await updateSocialLoginConfig(payload);
+      toast.success(`Social login ${newState ? "enabled" : "disabled"}`);
+      notify(
+        "social_login_settings_updated",
+        `Social login ${newState ? "enabled" : "disabled"}`
+      );
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Failed to update settings");
+    }
   };
   const toggleRecaptcha = () => setRecaptchaActive(!recaptchaActive);
 
-  const toggleProvider = (index) => {
-    setProviders((prev) => {
-      const updated = [...prev];
-      updated[index].active = !updated[index].active;
-      return updated;
-    });
+  const toggleProvider = async (index) => {
+    const updated = providers.map((p, i) =>
+      i === index ? { ...p, active: !p.active } : p
+    );
+    setProviders(updated);
+    const adjusted = updated.map((p) => ({
+      ...p,
+      active: p.active || providerHasCredentials(p),
+    }));
+    const payload = {
+      enabled: globalActive,
+      providers: adjusted.reduce((acc, p) => {
+        acc[p.key] = {
+          active: p.active,
+          clientId: p.clientId,
+          clientSecret: p.clientSecret,
+          teamId: p.teamId,
+          keyId: p.keyId,
+          privateKey: p.privateKey,
+          redirectUrl: p.redirectUrl,
+          label: p.label,
+          icon: p.icon,
+        };
+        return acc;
+      }, {}),
+      recaptcha: {
+        active: recaptchaActive,
+        siteKey: recaptchaSiteKey,
+        secretKey: recaptchaSecretKey,
+      },
+    };
+    try {
+      await updateSocialLoginConfig(payload);
+      setProviders(adjusted);
+      const status = adjusted[index].active ? "enabled" : "disabled";
+      toast.success(`${adjusted[index].name} ${status}`);
+      notify(
+        "social_provider_updated",
+        `${adjusted[index].name} ${status}`
+      );
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Failed to update settings");
+    }
   };
 
   const handleChange = (index, field, value) => {
@@ -179,6 +271,7 @@ export default function SocialLoginSettingsPage() {
       await updateSocialLoginConfig(payload);
       setProviders(adjusted);
       toast.success("Settings saved");
+      notify("social_login_settings_updated", "Social login settings updated");
     } catch (err) {
       toast.error(err?.response?.data?.message || "Failed to save settings");
     }
@@ -215,6 +308,10 @@ export default function SocialLoginSettingsPage() {
       await updateSocialLoginConfig(payload);
       setProviders(adjusted);
       toast.success(`${providers[index].name} settings saved`);
+      notify(
+        "social_provider_updated",
+        `${providers[index].name} settings updated`
+      );
     } catch (err) {
       toast.error(err?.response?.data?.message || "Failed to save settings");
     }
@@ -370,16 +467,6 @@ export default function SocialLoginSettingsPage() {
                     onChange={(e) => handleChange(index, "redirectUrl", e.target.value)}
                     placeholder={getDefaultRedirectUrl(provider.key)}
                   />
-                  <p className="text-xs text-gray-500 mt-1">
-                    Default: <code>{getDefaultRedirectUrl(provider.key)}</code>{" "}
-                    <button
-                      type="button"
-                      onClick={() => navigator.clipboard.writeText(getRedirectUrl(provider))}
-                      className="ml-2 text-blue-600 underline"
-                    >
-                      Copy
-                    </button>
-                  </p>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- support admin notifications when social login settings update
- show admin toast+notifications in UI when saving providers
- auto-save toggle actions
- clean redirect URL field

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687ebc9f05c08328bd9e06751080c194