### PR TITLE
Add i18n getStaticProps to pages

### DIFF
--- a/frontend/src/pages/about/index.js
+++ b/frontend/src/pages/about/index.js
@@ -57,3 +57,14 @@ export default function AboutUsPage() {
     </>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/blog/index.js
+++ b/frontend/src/pages/blog/index.js
@@ -56,3 +56,14 @@ export default function BlogPage() {
     </>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/cart/index.js
+++ b/frontend/src/pages/cart/index.js
@@ -200,3 +200,14 @@ const CartPage = () => {
 };
 
 export default CartPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -183,3 +183,14 @@ const AskQuestionPage = () => {
 };
 
 export default AskQuestionPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/community/index.js
+++ b/frontend/src/pages/community/index.js
@@ -101,3 +101,14 @@ const CommunityPage = () => {
 };
 
 export default CommunityPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/community/my-questions.js
+++ b/frontend/src/pages/community/my-questions.js
@@ -29,3 +29,13 @@ const MyQuestions = () => {
   );
 };
 export default MyQuestions;
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/community/question/[id].js
+++ b/frontend/src/pages/community/question/[id].js
@@ -26,3 +26,13 @@ const QuestionDetails = () => {
   );
 };
 export default QuestionDetails;
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/community/question/details.js
+++ b/frontend/src/pages/community/question/details.js
@@ -149,3 +149,14 @@ const QuestionDetails = () => {
 };
 
 export default QuestionDetails;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/contact/index.js
+++ b/frontend/src/pages/contact/index.js
@@ -117,3 +117,14 @@ export default function ContactPage() {
     </>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/admin/profile/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/profile/certificates/index.js
@@ -37,3 +37,14 @@ const Certificates = () => {
 };
 
 export default Certificates;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/admin/profile/change-password.js
+++ b/frontend/src/pages/dashboard/admin/profile/change-password.js
@@ -166,3 +166,14 @@ const ChangePasswordPage = ({ prevStep }) => {
 };
 
 export default ChangePasswordPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/admin/profile/orders/[id].js
+++ b/frontend/src/pages/dashboard/admin/profile/orders/[id].js
@@ -114,3 +114,14 @@ const OrderStatusIcon = ({ status }) => {
 };
 
 export default OrderDetailsPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/admin/profile/orders/index.js
+++ b/frontend/src/pages/dashboard/admin/profile/orders/index.js
@@ -160,3 +160,14 @@ const OrderStatusIcon = ({ status }) => {
 };
 
 export default OrdersPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/admin/profile/security-settings/index.js
+++ b/frontend/src/pages/dashboard/admin/profile/security-settings/index.js
@@ -45,3 +45,14 @@ const SecuritySettings = () => {
 };
 
 export default SecuritySettings;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/course/[id].js
+++ b/frontend/src/pages/dashboard/course/[id].js
@@ -272,3 +272,14 @@ const CourseDashboard = () => {
 };
 
 export default CourseDashboard;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/instructor/profile/certificates/index.js
+++ b/frontend/src/pages/dashboard/instructor/profile/certificates/index.js
@@ -37,3 +37,14 @@ const Certificates = () => {
 };
 
 export default Certificates;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/instructor/profile/change-password.js
+++ b/frontend/src/pages/dashboard/instructor/profile/change-password.js
@@ -166,3 +166,14 @@ const ChangePasswordPage = ({ prevStep }) => {
 };
 
 export default ChangePasswordPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/instructor/profile/index.js
+++ b/frontend/src/pages/dashboard/instructor/profile/index.js
@@ -29,3 +29,14 @@ const ProfilePage = () => {
 };
 
 export default ProfilePage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/instructor/profile/orders/[id].js
+++ b/frontend/src/pages/dashboard/instructor/profile/orders/[id].js
@@ -114,3 +114,14 @@ const OrderStatusIcon = ({ status }) => {
 };
 
 export default OrderDetailsPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/instructor/profile/orders/index.js
+++ b/frontend/src/pages/dashboard/instructor/profile/orders/index.js
@@ -160,3 +160,14 @@ const OrderStatusIcon = ({ status }) => {
 };
 
 export default OrdersPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/instructor/profile/security-settings/index.js
+++ b/frontend/src/pages/dashboard/instructor/profile/security-settings/index.js
@@ -45,3 +45,14 @@ const SecuritySettings = () => {
 };
 
 export default SecuritySettings;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/student/profile/certificates/index.js
+++ b/frontend/src/pages/dashboard/student/profile/certificates/index.js
@@ -37,3 +37,14 @@ const Certificates = () => {
 };
 
 export default Certificates;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/student/profile/change-password.js
+++ b/frontend/src/pages/dashboard/student/profile/change-password.js
@@ -131,3 +131,14 @@ const ChangePasswordPage = ({ prevStep }) => {
 };
 
 export default ChangePasswordPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/student/profile/orders/[id].js
+++ b/frontend/src/pages/dashboard/student/profile/orders/[id].js
@@ -114,3 +114,14 @@ const OrderStatusIcon = ({ status }) => {
 };
 
 export default OrderDetailsPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/student/profile/orders/index.js
+++ b/frontend/src/pages/dashboard/student/profile/orders/index.js
@@ -160,3 +160,14 @@ const OrderStatusIcon = ({ status }) => {
 };
 
 export default OrdersPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/student/profile/security-settings/index.js
+++ b/frontend/src/pages/dashboard/student/profile/security-settings/index.js
@@ -45,3 +45,14 @@ const SecuritySettings = () => {
 };
 
 export default SecuritySettings;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/delete-account.js
+++ b/frontend/src/pages/delete-account.js
@@ -32,3 +32,14 @@ export default function DeleteAccountPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/faqs/index.js
+++ b/frontend/src/pages/faqs/index.js
@@ -78,3 +78,14 @@ export default function FaqPage() {
     </>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/legal.js
+++ b/frontend/src/pages/legal.js
@@ -33,3 +33,14 @@ export default function LegalPage() {
   );
 }
 
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/likes/index.js
+++ b/frontend/src/pages/likes/index.js
@@ -30,3 +30,14 @@ export default function LikesPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/messages/chat.js
+++ b/frontend/src/pages/messages/chat.js
@@ -26,3 +26,14 @@ const ChatPage = () => {
 };
 
 export default ChatPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/messages/group.js
+++ b/frontend/src/pages/messages/group.js
@@ -82,3 +82,14 @@ const GroupChat = () => {
 };
 
 export default GroupChat;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/messages/groupChat.js
+++ b/frontend/src/pages/messages/groupChat.js
@@ -135,3 +135,14 @@ const GroupChatPage = () => {
 };
 
 export default GroupChatPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -251,3 +251,13 @@ const MessagesPage = () => {
 };
 
 export default MessagesPage;
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/notifications/index.js
+++ b/frontend/src/pages/notifications/index.js
@@ -103,3 +103,14 @@ const NotificationsPage = () => {
 };
 
 export default NotificationsPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/offers/[id].js
+++ b/frontend/src/pages/offers/[id].js
@@ -249,3 +249,13 @@ const OfferDetailsPage = () => {
 };
 
 export default OfferDetailsPage;
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/offers/index.js
+++ b/frontend/src/pages/offers/index.js
@@ -205,3 +205,14 @@ const OffersPage = () => {
 };
 
 export default OffersPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/offers/new.js
+++ b/frontend/src/pages/offers/new.js
@@ -153,3 +153,13 @@ const CreateOffer = () => {
 
 export default CreateOffer;
 1
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -484,3 +484,13 @@ export default function ClassDetailsPage() {
     </div>
   );
 }
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/online-classes/index.js
+++ b/frontend/src/pages/online-classes/index.js
@@ -105,3 +105,14 @@ export default function OnlineClassesPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/payments/[id].js
+++ b/frontend/src/pages/payments/[id].js
@@ -174,3 +174,14 @@ export default function CheckoutPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -206,3 +206,14 @@ export default function CheckoutPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/payments/index.js
+++ b/frontend/src/pages/payments/index.js
@@ -173,3 +173,14 @@ export default function PaymentsPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/payments/invoice/[id].js
+++ b/frontend/src/pages/payments/invoice/[id].js
@@ -110,3 +110,13 @@ export default function InvoicePage() {
     </div>
   );
 }
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/payments/success.js
+++ b/frontend/src/pages/payments/success.js
@@ -83,3 +83,14 @@ export default function PaymentSuccessPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/privacy-policy.js
+++ b/frontend/src/pages/privacy-policy.js
@@ -34,3 +34,14 @@ export default function PrivacyPolicyPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/profile/certificates/index.js
+++ b/frontend/src/pages/profile/certificates/index.js
@@ -37,3 +37,14 @@ const Certificates = () => {
 };
 
 export default Certificates;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/profile/change-password.js
+++ b/frontend/src/pages/profile/change-password.js
@@ -174,3 +174,14 @@ const ChangePasswordPage = ({ prevStep }) => {
 };
 
 export default ChangePasswordPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/profile/edit.js
+++ b/frontend/src/pages/profile/edit.js
@@ -112,3 +112,14 @@ const ProfileEdit = () => {
 };
 
 export default ProfileEdit;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/profile/orders/[id].js
+++ b/frontend/src/pages/profile/orders/[id].js
@@ -114,3 +114,14 @@ const OrderStatusIcon = ({ status }) => {
 };
 
 export default OrderDetailsPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/profile/orders/index.js
+++ b/frontend/src/pages/profile/orders/index.js
@@ -160,3 +160,14 @@ const OrderStatusIcon = ({ status }) => {
 };
 
 export default OrdersPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/profile/security-settings/index.js
+++ b/frontend/src/pages/profile/security-settings/index.js
@@ -45,3 +45,14 @@ const SecuritySettings = () => {
 };
 
 export default SecuritySettings;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/promotions/[id].js
+++ b/frontend/src/pages/promotions/[id].js
@@ -133,3 +133,14 @@ export default function PromotionPage() {
     </>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/promotions/index.js
+++ b/frontend/src/pages/promotions/index.js
@@ -151,3 +151,14 @@ const PromotionsPage = () => {
 };
 
 export default PromotionsPage;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/recordings/index.js
+++ b/frontend/src/pages/recordings/index.js
@@ -28,3 +28,13 @@ const RecordingsPage = () => {
   );
 };
 export default RecordingsPage;
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/support/articles/[id].js
+++ b/frontend/src/pages/support/articles/[id].js
@@ -45,3 +45,14 @@ export default function ArticlePage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/support/categories/[slug].js
+++ b/frontend/src/pages/support/categories/[slug].js
@@ -62,3 +62,14 @@ export default function SupportCategoryPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/support/index.js
+++ b/frontend/src/pages/support/index.js
@@ -40,3 +40,13 @@ export default function WebsiteSupportHome() {
     </div>
   );
 }
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/support/submit.js
+++ b/frontend/src/pages/support/submit.js
@@ -102,3 +102,14 @@ export default function SubmitTicketPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/support/ticket-status.js
+++ b/frontend/src/pages/support/ticket-status.js
@@ -80,3 +80,14 @@ export default function TicketStatusPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/support/tickets/[id].js
+++ b/frontend/src/pages/support/tickets/[id].js
@@ -81,3 +81,14 @@ export default function TicketDetailPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/terms.js
+++ b/frontend/src/pages/terms.js
@@ -32,3 +32,14 @@ export default function TermsPage() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -302,3 +302,14 @@ export default function TutorialDetail() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -425,3 +425,14 @@ const TutorialsSection = () => {
 };
 
 export default TutorialsSection;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/video-player-demo.js
+++ b/frontend/src/pages/video-player-demo.js
@@ -22,3 +22,14 @@ export default function VideoPlayerDemo() {
     </div>
   );
 }
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/wishlist/index.js
+++ b/frontend/src/pages/wishlist/index.js
@@ -32,3 +32,14 @@ const Wishlist = () => {
 };
 
 export default Wishlist;
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add `getStaticProps` with `serverSideTranslations` in contact page
- enable same localization setup for other pages using Navbar or other translatable components

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ebbf82ab88328a4494595b82d9d31