### PR TITLE
Connect popup announcements to backend

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -338,6 +338,11 @@
 - **Primary Key**: `page (PK)`
 - **Foreign Keys**: `—`
 
+### `popup_announcements`
+- **Purpose**: Time-based pop-up messages
+- **Primary Key**: `id`
+- **Foreign Keys**: `author_id`
+
 
 ## Plans Tables
 

--- a/backend/src/migrations/20250723000000_create_popup_announcements_table.js
+++ b/backend/src/migrations/20250723000000_create_popup_announcements_table.js
@@ -1,0 +1,22 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('popup_announcements', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.string('title').notNullable();
+    table.text('message').notNullable();
+    table.string('audience').notNullable().defaultTo('all');
+    table.jsonb('pages');
+    table.timestamp('start_date');
+    table.timestamp('end_date');
+    table.string('position').defaultTo('center');
+    table.string('theme').defaultTo('yellow');
+    table.boolean('once_per_session').defaultTo(true);
+    table.boolean('active').defaultTo(true);
+    table.uuid('author_id').references('id').inTable('users').onDelete('SET NULL');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('popup_announcements');
+};

--- a/backend/src/modules/popupAnnouncements/popupAnnouncements.controller.js
+++ b/backend/src/modules/popupAnnouncements/popupAnnouncements.controller.js
@@ -1,0 +1,74 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
+const service = require("./popupAnnouncements.service");
+const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
+
+exports.list = catchAsync(async (_req, res) => {
+  const data = await service.getAll();
+  sendSuccess(res, data);
+});
+
+exports.create = catchAsync(async (req, res) => {
+  const {
+    title,
+    message,
+    audience = "all",
+    pages = [],
+    start_date,
+    end_date,
+    position = "center",
+    theme = "yellow",
+    once_per_session = true,
+    active = true,
+  } = req.body || {};
+  if (!title || !message) throw new AppError("Title and message required", 400);
+  const payload = {
+    title,
+    message,
+    audience,
+    pages: JSON.stringify(pages),
+    start_date,
+    end_date,
+    position,
+    theme,
+    once_per_session,
+    active,
+    author_id: req.user.id,
+    created_at: new Date(),
+  };
+  const ann = await service.create(payload);
+  sendSuccess(res, ann, "Announcement created");
+
+  const admins = await userModel.findAdmins();
+  const senderId = req.user?.id;
+  await Promise.all(
+    admins.map((admin) =>
+      Promise.all([
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "popup_announcement_created",
+          message: `New popup announcement: ${title}`,
+        }),
+        messageService.createMessage({
+          sender_id: senderId || admin.id,
+          receiver_id: admin.id,
+          message: `New popup announcement: ${title}`,
+        }),
+      ])
+    )
+  );
+});
+
+exports.update = catchAsync(async (req, res) => {
+  const ann = await service.update(req.params.id, req.body);
+  if (!ann) throw new AppError("Announcement not found", 404);
+  sendSuccess(res, ann, "Announcement updated");
+});
+
+exports.remove = catchAsync(async (req, res) => {
+  await service.remove(req.params.id);
+  sendSuccess(res, null, "Announcement deleted");
+});

--- a/backend/src/modules/popupAnnouncements/popupAnnouncements.routes.js
+++ b/backend/src/modules/popupAnnouncements/popupAnnouncements.routes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./popupAnnouncements.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.list);
+router.use(verifyToken, isAdmin);
+router.post("/", controller.create);
+router.patch("/:id", controller.update);
+router.delete("/:id", controller.remove);
+
+module.exports = router;

--- a/backend/src/modules/popupAnnouncements/popupAnnouncements.service.js
+++ b/backend/src/modules/popupAnnouncements/popupAnnouncements.service.js
@@ -1,0 +1,19 @@
+const db = require("../../config/database");
+
+exports.getAll = async () => {
+  return db("popup_announcements").select("*").orderBy("created_at", "desc");
+};
+
+exports.create = async (data) => {
+  const [row] = await db("popup_announcements").insert(data).returning("*");
+  return row;
+};
+
+exports.update = async (id, data) => {
+  const [row] = await db("popup_announcements").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.remove = async (id) => {
+  return db("popup_announcements").where({ id }).del();
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -81,6 +81,7 @@ app.use("/api/app-config", require("./modules/appConfig/appConfig.routes"));
 app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));
 app.use("/api/contact-config", require("./modules/contactConfig/contactConfig.routes"));
 app.use("/api/seo-config", require("./modules/seoConfig/seoConfig.routes"));
+app.use("/api/popup-announcements", require("./modules/popupAnnouncements/popupAnnouncements.routes"));
 app.use("/api/policies", require("./modules/policies/policies.routes"));
 app.use("/api/payouts/admin", require("./modules/payouts/payouts.routes"));
 app.use("/api/ads", require("./modules/ads/ads.routes"));

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
@@ -2,10 +2,36 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState } from "react";
 import dynamic from "next/dynamic";
 import { FaSave, FaEye } from "react-icons/fa";
+import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
+import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
+import { createPopupAnnouncement } from "@/services/admin/popupAnnouncementService";
 
 const RichTextEditor = dynamic(() => import("react-quill"), { ssr: false });
 
+const useAdminNotice = () => {
+  const user = useAuthStore((s) => s.user);
+  const refreshNotifications = useNotificationStore((s) => s.fetch);
+  const refreshMessages = useMessageStore((s) => s.fetch);
+  return async (type, message) => {
+    try {
+      await createNotification({ user_id: user.id, type, message });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+};
+
 export default function CreateAnnouncementForm() {
+  const router = useRouter();
+  const notify = useAdminNotice();
   const [form, setForm] = useState({
     title: "",
     message: "",
@@ -32,12 +58,30 @@ export default function CreateAnnouncementForm() {
     handleChange("pages", updated);
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!form.title || !form.message || !form.start || !form.end) return;
-    alert("✅ Announcement saved!");
-    console.log("📤 Submitted:", form);
-    // POST to API here
+    const payload = {
+      title: form.title,
+      message: form.message,
+      audience: form.audience,
+      pages: form.pages,
+      start_date: form.start,
+      end_date: form.end,
+      position: form.position,
+      theme: form.theme,
+      once_per_session: form.oncePerSession,
+      active: form.active,
+    };
+    try {
+      await createPopupAnnouncement(payload);
+      toast.success("Announcement saved!");
+      notify("popup_created", `Popup announcement "${form.title}" created.`);
+      router.push("/dashboard/admin/settings/popup-announcement");
+    } catch (err) {
+      console.error(err);
+      toast.error(err.response?.data?.message || "Failed to save");
+    }
   };
 
   return (

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/index.js
@@ -1,42 +1,56 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaPlus, FaEdit, FaTrash, FaEye, FaToggleOn, FaToggleOff } from "react-icons/fa";
-import { useState } from "react";
-
-const mockAnnouncements = [
-  {
-    id: 1,
-    title: "🚧 Maintenance Tonight",
-    status: true,
-    audience: "All Visitors",
-    pages: "All Pages",
-    start: "2025-05-16 20:00",
-    end: "2025-05-17 02:00",
-  },
-  {
-    id: 2,
-    title: "🎉 Promo for Students",
-    status: false,
-    audience: "Students Only",
-    pages: "/courses",
-    start: "2025-05-18 00:00",
-    end: "2025-05-20 23:59",
-  },
-];
+import { useState, useEffect } from "react";
+import {
+  fetchPopupAnnouncements,
+  updatePopupAnnouncement,
+  deletePopupAnnouncement,
+} from "@/services/admin/popupAnnouncementService";
 
 export default function PopupAnnouncementsIndex() {
-  const [announcements, setAnnouncements] = useState(mockAnnouncements);
+  const [announcements, setAnnouncements] = useState([]);
 
-  const toggleStatus = (id) => {
-    setAnnouncements((prev) =>
-      prev.map((a) =>
-        a.id === id ? { ...a, status: !a.status } : a
-      )
-    );
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchPopupAnnouncements();
+        const formatted = (data || []).map((a) => ({
+          ...a,
+          status: a.active,
+          audience: a.audience,
+          pages: Array.isArray(a.pages) ? a.pages.join(', ') : a.pages,
+          start: a.start_date,
+          end: a.end_date,
+        }));
+        setAnnouncements(formatted);
+      } catch (err) {
+        console.error('Failed to load announcements', err);
+      }
+    };
+    load();
+  }, []);
+
+  const toggleStatus = async (id) => {
+    const ann = announcements.find((a) => a.id === id);
+    if (!ann) return;
+    try {
+      const updated = await updatePopupAnnouncement(id, { active: !ann.status });
+      setAnnouncements((prev) =>
+        prev.map((a) => (a.id === id ? { ...a, status: updated.active } : a))
+      );
+    } catch (err) {
+      console.error('Failed to update', err);
+    }
   };
 
-  const deleteAnnouncement = (id) => {
+  const deleteAnnouncement = async (id) => {
     if (confirm("Are you sure you want to delete this announcement?")) {
-      setAnnouncements((prev) => prev.filter((a) => a.id !== id));
+      try {
+        await deletePopupAnnouncement(id);
+        setAnnouncements((prev) => prev.filter((a) => a.id !== id));
+      } catch (err) {
+        console.error('Failed to delete', err);
+      }
     }
   };
 

--- a/frontend/src/services/admin/popupAnnouncementService.js
+++ b/frontend/src/services/admin/popupAnnouncementService.js
@@ -1,0 +1,21 @@
+import api from "@/services/api/api";
+
+export const fetchPopupAnnouncements = async () => {
+  const { data } = await api.get('/popup-announcements');
+  return data?.data ?? [];
+};
+
+export const createPopupAnnouncement = async (payload) => {
+  const { data } = await api.post('/popup-announcements', payload);
+  return data?.data;
+};
+
+export const updatePopupAnnouncement = async (id, payload) => {
+  const { data } = await api.patch(`/popup-announcements/${id}`, payload);
+  return data?.data;
+};
+
+export const deletePopupAnnouncement = async (id) => {
+  await api.delete(`/popup-announcements/${id}`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- add DB table and backend module for popup announcements
- expose `/api/popup-announcements` routes
- save popup announcements with notifications and messages
- add service for frontend usage
- fetch and manage popup announcements from admin UI
- update DB schema docs

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687ebf22ff9483289450bfea4029a83b