### PR TITLE
Fix dynamic Next.js pages build

### DIFF
--- a/frontend/src/pages/community/question/[id].js
+++ b/frontend/src/pages/community/question/[id].js
@@ -29,7 +29,7 @@ export default QuestionDetails;
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/dashboard/admin/profile/orders/[id].js
+++ b/frontend/src/pages/dashboard/admin/profile/orders/[id].js
@@ -118,7 +118,7 @@ export default OrderDetailsPage;
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/dashboard/course/[id].js
+++ b/frontend/src/pages/dashboard/course/[id].js
@@ -276,7 +276,7 @@ export default CourseDashboard;
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/dashboard/instructor/profile/orders/[id].js
+++ b/frontend/src/pages/dashboard/instructor/profile/orders/[id].js
@@ -118,7 +118,7 @@ export default OrderDetailsPage;
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/dashboard/student/profile/orders/[id].js
+++ b/frontend/src/pages/dashboard/student/profile/orders/[id].js
@@ -118,7 +118,7 @@ export default OrderDetailsPage;
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/offers/[id].js
+++ b/frontend/src/pages/offers/[id].js
@@ -252,7 +252,7 @@ export default OfferDetailsPage;
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -487,7 +487,7 @@ export default function ClassDetailsPage() {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/payments/[id].js
+++ b/frontend/src/pages/payments/[id].js
@@ -178,7 +178,7 @@ export default function CheckoutPage() {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/payments/invoice/[id].js
+++ b/frontend/src/pages/payments/invoice/[id].js
@@ -113,7 +113,7 @@ export default function InvoicePage() {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/profile/orders/[id].js
+++ b/frontend/src/pages/profile/orders/[id].js
@@ -118,7 +118,7 @@ export default OrderDetailsPage;
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/promotions/[id].js
+++ b/frontend/src/pages/promotions/[id].js
@@ -137,7 +137,7 @@ export default function PromotionPage() {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/support/articles/[id].js
+++ b/frontend/src/pages/support/articles/[id].js
@@ -49,7 +49,7 @@ export default function ArticlePage() {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/support/categories/[slug].js
+++ b/frontend/src/pages/support/categories/[slug].js
@@ -66,7 +66,7 @@ export default function SupportCategoryPage() {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/support/tickets/[id].js
+++ b/frontend/src/pages/support/tickets/[id].js
@@ -85,7 +85,7 @@ export default function TicketDetailPage() {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -306,7 +306,7 @@ export default function TutorialDetail() {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),


### PR DESCRIPTION
## Summary
- use `getServerSideProps` for dynamic pages
- update multiple dynamic routes

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687ec76c45048328b315e5b0f3e7775c