### PR TITLE
Fix language switcher

### DIFF
--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -83,6 +83,9 @@ const Navbar = () => {
       if (typeof window !== "undefined") {
         localStorage.setItem("lng", lng);
       }
+      // Reload the current route with the selected locale so that
+      // server-side translations are properly loaded
+      await router.push(router.asPath, router.asPath, { locale: lng });
       mutate("/languages");
       const selected = langs?.find((l) => l.code === lng);
       toast.success(


### PR DESCRIPTION
## Summary
- reload the page with the selected locale when switching languages so translations update

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_687ed46d5d3c832884b90134bfd6db2a