### PR TITLE
Fix currency exchange rate formatting

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/currency/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/index.js
@@ -251,7 +251,7 @@ function CurrencyManagerPage() {
                 </td>
                 <td className="p-3">{c.code}</td>
                 <td className="p-3">{c.symbol}</td>
-                <td className="p-3">{c.exchange_rate.toFixed(2)}</td>
+                <td className="p-3">{Number(c.exchange_rate).toFixed(2)}</td>
                 <td className="p-3 text-center">
                   <button
                     onClick={() => toggleAutoUpdate(c.id)}


### PR DESCRIPTION
## Summary
- parse numeric value when displaying exchange rates

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687edf2b25b48328ad9598f5896af97b