### PR TITLE
Implement social login toast feedback

### DIFF
--- a/frontend/src/pages/auth/social-success.js
+++ b/frontend/src/pages/auth/social-success.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { toast } from 'react-toastify';
 import useAuthStore from '@/store/auth/authStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import { getFullProfile } from '@/services/profile/profileService';
@@ -23,13 +24,15 @@ export default function SocialSuccess() {
         const res = await getFullProfile();
         setUser(res.data);
         fetchNotifications();
+        toast.success(t('login_successful'));
       } catch (err) {
         console.error('Failed to fetch profile after social login', err);
+        toast.error(t('login_failed'));
       }
       router.replace('/website');
     }
     finalize();
-  }, [router, setToken, setUser, fetchNotifications]);
+  }, [router, setToken, setUser, fetchNotifications, t]);
 
   return <p className="text-center mt-20">{t('signing_you_in')}</p>;
 }


### PR DESCRIPTION
## Summary
- show toast messages after social login completes
- update SocialSuccess to display success or failure

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687edf0770248328a34e9cf30d6d5b56