### PR TITLE
Implement social login toast feedback

### DIFF
--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -1,7 +1,7 @@
 // ───────────────────────────────────────
 // 📁 frontend/src/pages/auth/login.js
 //  ──────────────────────────────────────
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
@@ -13,8 +13,8 @@ import useAppConfigStore from "@/store/appConfigStore";
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
 import InputField from "@/shared/components/auth/InputField";
 import SocialLogin from "@/shared/components/auth/SocialLogin";
-// import ReCAPTCHA from "react-google-recaptcha";
-// import { fetchSocialLoginConfig } from "@/services/socialLoginService";
+import ReCAPTCHA from "react-google-recaptcha";
+import { fetchSocialLoginConfig } from "@/services/socialLoginService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import { useTranslation } from "next-i18next";
@@ -35,9 +35,9 @@ export default function Login() {
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const settings = useAppConfigStore((state) => state.settings);
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
-  // const [recaptchaCfg, setRecaptchaCfg] = useState(null);
-  // const [cfgLoading, setCfgLoading] = useState(true);
-  // const recaptchaRef = useRef(null);
+  const [recaptchaCfg, setRecaptchaCfg] = useState(null);
+  const [cfgLoading, setCfgLoading] = useState(true);
+  const recaptchaRef = useRef(null);
 
   // ─────────────────────
   // 📝 Form setup
@@ -78,12 +78,12 @@ export default function Login() {
     fetchAppConfig();
   }, [fetchAppConfig]);
 
-  // useEffect(() => {
-  //   fetchSocialLoginConfig()
-  //     .then(setRecaptchaCfg)
-  //     .catch(() => {})
-  //     .finally(() => setCfgLoading(false));
-  // }, []);
+  useEffect(() => {
+    fetchSocialLoginConfig()
+      .then(setRecaptchaCfg)
+      .catch(() => {})
+      .finally(() => setCfgLoading(false));
+  }, []);
 
   // ─────────────────────────────
   // 🔑 Handle form submission
@@ -91,18 +91,18 @@ export default function Login() {
   const onSubmit = async (data) => {
   try {
     console.log("➡️ login onSubmit", data.email);
-    // const cfg = recaptchaCfg;
-    // if (!cfg && cfgLoading) {
-    //   cfg = await fetchSocialLoginConfig().catch(() => null);
-    //   setRecaptchaCfg(cfg);
-    //   setCfgLoading(false);
-    // }
-    // let token;
-    // if (cfg?.recaptcha?.active && recaptchaRef.current) {
-    //   token = await recaptchaRef.current.executeAsync();
-    //   recaptchaRef.current.reset();
-    // }
-    const loggedInUser = await login({ ...data });
+    let cfg = recaptchaCfg;
+    if (!cfg && cfgLoading) {
+      cfg = await fetchSocialLoginConfig().catch(() => null);
+      setRecaptchaCfg(cfg);
+      setCfgLoading(false);
+    }
+    let token;
+    if (cfg?.recaptcha?.active && recaptchaRef.current) {
+      token = await recaptchaRef.current.executeAsync();
+      recaptchaRef.current.reset();
+    }
+    const loggedInUser = await login({ ...data, recaptchaToken: token });
     toast.success(t("login_successful"));
     fetchNotifications();
 
@@ -241,15 +241,14 @@ export default function Login() {
         </p>
       </motion.div>
 
-      {/*
-        reCAPTCHA temporarily disabled
+      {recaptchaCfg?.recaptcha?.active && (
         <ReCAPTCHA
           sitekey={recaptchaCfg.recaptcha.siteKey}
           size="invisible"
           badge="bottomleft"
           ref={recaptchaRef}
         />
-      */}
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/auth/social-success.js
+++ b/frontend/src/pages/auth/social-success.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { toast } from 'react-toastify';
 import useAuthStore from '@/store/auth/authStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import { getFullProfile } from '@/services/profile/profileService';
@@ -23,13 +24,15 @@ export default function SocialSuccess() {
         const res = await getFullProfile();
         setUser(res.data);
         fetchNotifications();
+        toast.success(t('login_successful'));
       } catch (err) {
         console.error('Failed to fetch profile after social login', err);
+        toast.error(t('login_failed'));
       }
       router.replace('/website');
     }
     finalize();
-  }, [router, setToken, setUser, fetchNotifications]);
+  }, [router, setToken, setUser, fetchNotifications, t]);
 
   return <p className="text-center mt-20">{t('signing_you_in')}</p>;
 }


### PR DESCRIPTION
## Summary
- show toast messages after social login completes
- fetch social login config on Login page and use reCAPTCHA when enabled

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687edf0770248328a34e9cf30d6d5b56