### PR TITLE
Fix currency page error handling

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -59,7 +59,7 @@ export const adminNavLinks = [
         dropdown: [
           { label: 'Language Manager', href: '/dashboard/admin/settings/languages', icon: Globe },
           { label: 'Language Config', href: '/dashboard/admin/settings/language-config', icon: Globe },
-          { label: 'Currency Manager ', href: '/dashboard/admin/settings/currency', icon: DollarSign },
+          { label: 'Currency Manager', href: '/dashboard/admin/settings/currency', icon: DollarSign },
           { label: 'Social Logins', href: '/dashboard/admin/settings/social_login', icon: Network },
           { label: 'Email Config', href: '/dashboard/admin/settings/email-config', icon: Mail },
           { label: 'Messages Config', href: '/dashboard/admin/settings/messages-config', icon: MessageCircle },

--- a/frontend/src/pages/dashboard/admin/settings/currency/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/index.js
@@ -37,7 +37,11 @@ const useAdminNotice = () => {
   };
 };
 function CurrencyManagerPage() {
-  const { data: currencies = [], mutate } = useSWR("/currencies", fetcher);
+  const {
+    data: currencies = [],
+    error,
+    mutate,
+  } = useSWR("/currencies", fetcher);
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState("all");
   const [selectedIds, setSelectedIds] = useState([]);
@@ -152,6 +156,17 @@ function CurrencyManagerPage() {
       toast.error(msg);
     }
   };
+
+  if (error) {
+    return (
+      <AdminLayout>
+        <div className="p-6">
+          <h1 className="text-2xl font-bold mb-4">💱 Currency Manager</h1>
+          <p className="text-red-600">Failed to load currencies.</p>
+        </div>
+      </AdminLayout>
+    );
+  }
 
   return (
       <div className="p-6">


### PR DESCRIPTION
## Summary
- tidy up sidebar label
- add error handling to currency admin page

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f26846d288328a6cac976e4bd1c05