### PR TITLE
Add currency flag display and exchange rate controls

### DIFF
--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -32,8 +32,10 @@ import useMessageStore from "@/store/messages/messageStore";
 import LinkText from "@/components/shared/LinkText";
 import useAppConfigStore from "@/store/appConfigStore";
 import api from "@/services/api/api";
+import { getCurrencies } from "@/services/currencyService";
 
 const fetcher = (url) => api.get(url).then((res) => res.data.data);
+const currencyFetcher = () => getCurrencies();
 
 // ✅ Assets
 import logo from "@/shared/assets/images/login/logo.png";
@@ -76,7 +78,9 @@ const Navbar = () => {
 
   const { i18n, t } = useTranslation("common");
   const { data: langs } = useSWR("/languages", fetcher);
+  const { data: currencies } = useSWR("/currencies", currencyFetcher);
   const currentLang = langs?.find((l) => l.code === i18n.language);
+  const currentCurrency = currencies?.find((c) => c.is_default) || currencies?.[0];
   const changeLang = async (lng) => {
     try {
       await i18n.changeLanguage(lng);
@@ -346,6 +350,20 @@ const Navbar = () => {
             <FaLanguage className="text-xl" />
           )}
         </motion.button>
+
+        {currentCurrency && (
+          <div className="flex items-center gap-1 text-sm">
+            <img
+              src={`https://flagcdn.com/24x18/${currentCurrency.code
+                .slice(0, 2)
+                .toLowerCase()}.png`}
+              onError={(e) => (e.target.src = "/flags/default.png")}
+              alt={currentCurrency.code}
+              className="w-5 h-3 border rounded"
+            />
+            <span className="font-semibold">{currentCurrency.code}</span>
+          </div>
+        )}
 
         {user && (
           <Link

--- a/frontend/src/pages/dashboard/admin/settings/currency/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/index.js
@@ -110,10 +110,51 @@ function CurrencyManagerPage() {
     }
   };
 
+  const refreshRate = async (id) => {
+    const currency = currencies.find((c) => c.id === id);
+    if (!currency) return;
+    try {
+      const res = await fetch(
+        `https://api.exchangerate.host/latest?base=USD&symbols=${currency.code}`
+      );
+      const data = await res.json();
+      const rate = data?.rates?.[currency.code];
+      if (!rate) throw new Error("Rate not found");
+      await updateCurrency(id, { exchange_rate: rate, last_updated: new Date().toISOString() });
+      mutate();
+      toast.success("Rate refreshed");
+      const message = `Currency "${currency.label}" rate refreshed.`;
+      notify("currency_rate_refreshed", message);
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to refresh rate");
+    }
+  };
+
+  const changeRate = async (id) => {
+    const currency = currencies.find((c) => c.id === id);
+    if (!currency) return;
+    const input = prompt("Enter new exchange rate", currency.exchange_rate);
+    if (!input) return;
+    const value = parseFloat(input);
+    if (isNaN(value) || value <= 0) return alert("Invalid rate");
+    try {
+      await updateCurrency(id, { exchange_rate: value });
+      mutate();
+      toast.success("Exchange rate updated");
+      const message = `Currency "${currency.label}" rate set to ${value}.`;
+      notify("currency_rate_updated", message);
+    } catch (err) {
+      console.error(err);
+      const msg = err.response?.data?.message || "Failed to update";
+      toast.error(msg);
+    }
+  };
+
   const deleteCurrency = async (id) => {
     const currency = currencies.find((c) => c.id === id);
     if (currency?.is_default) return alert("Cannot delete default currency.");
-    if (confirm(`Delete currency: ${currency.label}?`)) {
+    if (window.confirm(`Delete currency: ${currency.label}?`)) {
       try {
         await deleteCurrencyApi(id);
         mutate();
@@ -266,7 +307,13 @@ function CurrencyManagerPage() {
                 </td>
                 <td className="p-3">{c.code}</td>
                 <td className="p-3">{c.symbol}</td>
-                <td className="p-3">{Number(c.exchange_rate).toFixed(2)}</td>
+                <td
+                  className="p-3 cursor-pointer"
+                  onClick={() => changeRate(c.id)}
+                  title="Click to edit"
+                >
+                  {Number(c.exchange_rate).toFixed(2)}
+                </td>
                 <td className="p-3 text-center">
                   <button
                     onClick={() => toggleAutoUpdate(c.id)}
@@ -300,7 +347,7 @@ function CurrencyManagerPage() {
                     <button
                       title="Refresh Rate"
                       className="text-blue-500"
-                      onClick={() => alert(`Refresh rate for ${c.code}`)}
+                      onClick={() => refreshRate(c.id)}
                     >
                       <FaSync />
                     </button>

--- a/frontend/src/services/currencyService.js
+++ b/frontend/src/services/currencyService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const getCurrencies = async () => {
+  const { data } = await api.get("/currencies");
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- show selected currency flag and code in Navbar
- fetch currencies via new `currencyService`
- refresh exchange rate from exchangerate.host
- allow editing exchange rate inline with admin notification
- confirm before deleting currency entries

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_687f29c783148328a91d7aa5a26ca2e1