### PR TITLE
Fix Next.js build failure

### DIFF
--- a/frontend/src/pages/dashboard/admin/categories/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/categories/edit/[id].js
@@ -7,8 +7,6 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { API_BASE_URL } from "@/config/config";
 import { useTranslation } from "next-i18next";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import {
   fetchCategoryTree,
   fetchCategoryById,


### PR DESCRIPTION
## Summary
- remove unused `serverSideTranslations` import that broke Next.js build

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f7665ccb88328bb3e6960b1c80468