### PR TITLE
Add social redirect page and loginWithToken

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -53,6 +53,8 @@ function MyApp({ Component, pageProps, router }) {
   }, []);
 
   useEffect(() => {
+    if (router.pathname.startsWith('/auth')) return;
+
     const init = async () => {
       try {
         const { accessToken } = await authService.refreshAccessToken();
@@ -64,7 +66,7 @@ function MyApp({ Component, pageProps, router }) {
       }
     };
     init();
-  }, []);
+  }, [router.pathname]);
 
   useEffect(() => {
     if (!configLoaded) fetchConfig();

--- a/frontend/src/pages/auth/social-redirect.js
+++ b/frontend/src/pages/auth/social-redirect.js
@@ -1,0 +1,19 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import useAuthStore from "@/store/auth/authStore";
+
+export default function SocialRedirect() {
+  const router = useRouter();
+  const { token } = router.query;
+  const loginWithToken = useAuthStore((state) => state.loginWithToken);
+
+  useEffect(() => {
+    if (token) {
+      loginWithToken(token).finally(() => {
+        router.replace("/website");
+      });
+    }
+  }, [token, loginWithToken, router]);
+
+  return <p>Signing you in...</p>;
+}

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -28,6 +28,28 @@ const useAuthStore = create(
         return user;
       },
 
+      /**
+       * Log in using an already issued access token.
+       * Stores the token, fetches the profile and notifications.
+       */
+      loginWithToken: async (token) => {
+        set({ accessToken: token });
+        try {
+          const res = await getFullProfile();
+          let user = res.data;
+          if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
+            user.avatar_url = null;
+          }
+          set({ user });
+          const fetchNotifications = useNotificationStore.getState().fetch;
+          fetchNotifications?.();
+          return user;
+        } catch (err) {
+          console.error("❌ loginWithToken error", err);
+          set({ accessToken: null, user: null });
+        }
+      },
+
       refreshUser: async () => {
         try {
           const res = await getFullProfile();


### PR DESCRIPTION
## Summary
- add `loginWithToken` method to Zustand auth store
- handle Google callback via new `/auth/social-redirect` page
- skip automatic token refresh when visiting auth pages

## Testing
- `cd frontend && npm test` *(fails: jest not found)*
- `cd ../backend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd5ca197c8328a329cd34dde29a55