### PR TITLE
Fix HTTPS proxy path for /api

### DIFF
--- a/nginx/conf.d/ssl.conf
+++ b/nginx/conf.d/ssl.conf
@@ -6,11 +6,19 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/eduskillbridge.net/privkey.pem;
 
     location / {
-        proxy_pass http://eduskillbridgenet_frontend_1:3000;
+        proxy_pass http://frontend:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api/ {
+        proxy_pass http://backend:5002/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }


### PR DESCRIPTION
## Summary
- proxy `/api` requests to backend in `ssl.conf`
- use docker service names for HTTPS proxy

## Testing
- `node --version`
- `npm --version`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fdbb7061c83289a254b35cea786bb