### PR TITLE
Fix Nginx config loading and proxy paths

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -11,7 +11,8 @@ server {
   }
 
   location /api/ {
-    proxy_pass http://backend:5002/;  # ✅ Use internal Docker name (backend)
+    # keep the /api prefix when forwarding to the backend
+    proxy_pass http://backend:5002;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/conf.d/ssl.conf
+++ b/nginx/conf.d/ssl.conf
@@ -6,11 +6,20 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/eduskillbridge.net/privkey.pem;
 
     location / {
-        proxy_pass http://eduskillbridgenet_frontend_1:3000;
+        proxy_pass http://frontend:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api/ {
+        # keep the /api prefix when forwarding to the backend
+        proxy_pass http://backend:5002;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,24 +1,6 @@
 events {}
 
 http {
-  server {
-    listen 80;
-    server_name eduskillbridge.net www.eduskillbridge.net;
-
-    location /api/ {
-      proxy_pass http://backend:5002/;
-      proxy_http_version 1.1;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
-    location / {
-      proxy_pass http://frontend:3000/;
-      proxy_http_version 1.1;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-  }
+    # Load virtual hosts from the conf.d directory
+    include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Summary
- load virtual host configs from `conf.d` in `nginx.conf`
- keep the `/api` prefix when forwarding to backend over HTTP

## Testing
- `npm test --silent` *(no tests defined)*
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_687fdbb7061c83289a254b35cea786bb