### PR TITLE
Fix hydration mismatch and clean up logs

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -65,11 +65,6 @@ export default function Header() {
       await logout();
       stopPolling();
       stopMessagePolling();
-      console.log(
-        'Polling after logout:',
-        useNotificationStore.getState().poller,
-        useMessageStore.getState().poller
-      );
       toast.success(t('logged_out'));
 
       // ⏳ Delay before redirecting to login
@@ -124,11 +119,6 @@ export default function Header() {
     return () => {
       stopPolling();
       stopMessagePolling();
-      console.log(
-        'Polling after unmount:',
-        useNotificationStore.getState().poller,
-        useMessageStore.getState().poller
-      );
     };
   }, []);
 

--- a/frontend/src/shared/assets/BackgroundAnimation.js
+++ b/frontend/src/shared/assets/BackgroundAnimation.js
@@ -1,16 +1,36 @@
 import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
 
+/**
+ * Floating star background animation.
+ *
+ * This component previously generated random positions during the
+ * initial render which caused hydration mismatches between the
+ * server and client. The random values are now generated after the
+ * component mounts on the client to avoid this issue.
+ */
 export default function BackgroundAnimation() {
+  const [stars, setStars] = useState([]);
+
+  useEffect(() => {
+    const arr = [...Array(10)].map(() => ({
+      top: `${Math.random() * 100}vh`,
+      left: `${Math.random() * 100}vw`,
+      duration: `${Math.random() * 5 + 5}s`,
+    }));
+    setStars(arr);
+  }, []);
+
   return (
     <div className="absolute inset-0 overflow-hidden">
-      {[...Array(10)].map((_, i) => (
+      {stars.map((style, i) => (
         <motion.div
           key={i}
           className="absolute text-white opacity-30 animate-float"
           style={{
-            top: `${Math.random() * 100}vh`,
-            left: `${Math.random() * 100}vw`,
-            animationDuration: `${Math.random() * 5 + 5}s`,
+            top: style.top,
+            left: style.left,
+            animationDuration: style.duration,
           }}
         >
           ✨

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -77,11 +77,6 @@ const useAuthStore = create(
         const msgStop = useMessageStore.getState().stopPolling;
         notifStop?.();
         msgStop?.();
-        console.log(
-          'Polling after logout:',
-          useNotificationStore.getState().poller,
-          useMessageStore.getState().poller
-        );
         localStorage.removeItem("auth");
         set({ accessToken: null, user: null });
       },


### PR DESCRIPTION
## Summary
- avoid server/client mismatch for `BackgroundAnimation`
- remove leftover debug logs in dashboard header
- remove logout polling logs from auth store

## Testing
- `npm test --silent` in `backend`
- `npm run lint --silent` *(fails: React hook rule violation and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687fe9fca9c883288cfedcb2fe3964ab