### PR TITLE
Fix API routing after Google OAuth

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 // 📁 .env.example
-PORT=5000
+# Default API port. Docker Compose and nginx expect 5002.
+PORT=5002
 DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge
 JWT_SECRET=your_jwt_secret
 CLOUDINARY_API_KEY=your_key

--- a/docs/social-login-setup.md
+++ b/docs/social-login-setup.md
@@ -26,6 +26,8 @@ If the redirect URI does not exactly match what is configured on Google, the log
 
 If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, verify the frontend's `NEXT_PUBLIC_API_BASE_URL` points to your backend URL including the `/api` prefix. Without this variable the login and register buttons default to `/api/auth/*` which only works when the frontend and backend share the same host. Both buttons now append `?origin=` with the current site origin so the API can redirect back correctly even when `FRONTEND_URL` is not configured.
 
+If requests to `/api/*` still return a Next.js 404 page, confirm your reverse proxy forwards the `/api` path to the backend container. The provided `nginx/conf.d` configs use `location ^~ /api/` to proxy to `backend:5002` without rewriting the prefix. Restart nginx after updating the configuration.
+
 
 
 If the authentication completes but you land on a 404 page, check that the backend's

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  server_name eduskillbridge.net;
+  server_name eduskillbridge.net www.eduskillbridge.net;
 
   location / {
     proxy_pass http://frontend:3000;
@@ -10,8 +10,9 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
-  location /api/ {
-    proxy_pass http://backend:5002/;  # ✅ Use internal Docker name (backend)
+  location ^~ /api/ {
+    # forward API requests without rewriting the path
+    proxy_pass http://backend:5002;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/conf.d/ssl.conf
+++ b/nginx/conf.d/ssl.conf
@@ -6,11 +6,20 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/eduskillbridge.net/privkey.pem;
 
     location / {
-        proxy_pass http://eduskillbridgenet_frontend_1:3000;
+        proxy_pass http://frontend:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+    }
+
+    location ^~ /api/ {
+        # forward API requests without rewriting the path
+        proxy_pass http://backend:5002;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,24 +1,6 @@
 events {}
 
 http {
-  server {
-    listen 80;
-    server_name eduskillbridge.net www.eduskillbridge.net;
-
-    location /api/ {
-      proxy_pass http://backend:5002/;
-      proxy_http_version 1.1;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
-    location / {
-      proxy_pass http://frontend:3000/;
-      proxy_http_version 1.1;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-  }
+    # Load virtual hosts from the conf.d directory
+    include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Summary
- ensure nginx uses `location ^~ /api/` to proxy without rewriting the path
- mention proxy requirement in social login guide
- clarify default backend port in env example

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687fdbb7061c83289a254b35cea786bb