### PR TITLE
Fix dashboard link when user role missing

### DIFF
--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -365,7 +365,7 @@ const Navbar = () => {
           </div>
         )}
 
-        {user && (
+        {user && userRole && (
           <Link
             href={
               userRole === "superadmin" || userRole === "admin"


### PR DESCRIPTION
## Summary
- prevent Navbar dashboard link from rendering with undefined role
- ensure dashboard link only appears when user role is known

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6880a00a5b1883289b7c95c578558843