### PR TITLE
Fix dashboard link when user role missing

### DIFF
--- a/frontend/src/components/shared/SidebarMenu.js
+++ b/frontend/src/components/shared/SidebarMenu.js
@@ -6,7 +6,8 @@ import { useTranslation } from "next-i18next";
 import {
   FaBookOpen, FaChalkboardTeacher, FaGraduationCap, FaUsers,
   FaCalendarAlt, FaPlus, FaChartLine, FaTimes, FaUserShield,
-  FaBullhorn, FaQuestionCircle, FaFileAlt, FaEnvelope
+  FaBullhorn, FaQuestionCircle, FaFileAlt, FaEnvelope,
+  FaTachometerAlt
 } from "react-icons/fa";
 import useAuthStore from "@/store/auth/authStore";
 
@@ -78,7 +79,13 @@ const SidebarMenu = ({ isOpen, onClose, showAds }) => {
     },
   };
 
-  const currentDashboard = dashboardConfig[userRole];
+  const currentDashboard = user
+    ? dashboardConfig[userRole] || {
+        href: "/dashboard",
+        label: t("dashboard"),
+        icon: <FaTachometerAlt />,
+      }
+    : null;
 
   return (
     <AnimatePresence>

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -370,7 +370,9 @@ const Navbar = () => {
             href={
               userRole === "superadmin" || userRole === "admin"
                 ? "/dashboard/admin"
-                : `/dashboard/${userRole}`
+                : userRole
+                ? `/dashboard/${userRole}`
+                : "/dashboard"
             }
             className="flex items-center gap-2 font-semibold hover:underline"
           >


### PR DESCRIPTION
## Summary
- prevent Navbar dashboard link default to undefined path
- show dashboard link in sidebar with default when role missing

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6880a00a5b1883289b7c95c578558843