### PR TITLE
Fix missing dashboard link

### DIFF
--- a/frontend/src/components/shared/SidebarMenu.js
+++ b/frontend/src/components/shared/SidebarMenu.js
@@ -6,7 +6,8 @@ import { useTranslation } from "next-i18next";
 import {
   FaBookOpen, FaChalkboardTeacher, FaGraduationCap, FaUsers,
   FaCalendarAlt, FaPlus, FaChartLine, FaTimes, FaUserShield,
-  FaBullhorn, FaQuestionCircle, FaFileAlt, FaEnvelope
+  FaBullhorn, FaQuestionCircle, FaFileAlt, FaEnvelope,
+  FaTachometerAlt
 } from "react-icons/fa";
 import useAuthStore from "@/store/auth/authStore";
 
@@ -78,7 +79,11 @@ const SidebarMenu = ({ isOpen, onClose, showAds }) => {
     },
   };
 
-  const currentDashboard = dashboardConfig[userRole];
+  const currentDashboard = dashboardConfig[userRole] || {
+    href: "/dashboard",
+    label: t("dashboard"),
+    icon: <FaTachometerAlt />,
+  };
 
   return (
     <AnimatePresence>

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -365,19 +365,18 @@ const Navbar = () => {
           </div>
         )}
 
-        {user && (
           <Link
             href={
               userRole === "superadmin" || userRole === "admin"
                 ? "/dashboard/admin"
-                : `/dashboard/${userRole}`
+                : userRole
+                ? `/dashboard/${userRole}`
+                : "/dashboard"
             }
             className="flex items-center gap-2 font-semibold hover:underline"
           >
             <FaTachometerAlt /> {t('dashboard')}
           </Link>
-        )}
-
         {user ? (
           <>
             <motion.button


### PR DESCRIPTION
## Summary
- always show the dashboard link in the Navbar and Sidebar
- when no user role is available, link to `/dashboard`

## Testing
- `npm test` in `backend` *(fails: npm not installed)*
- `npm test` in `frontend` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6880a00a5b1883289b7c95c578558843