### PR TITLE
Fix dashboard link routing

### DIFF
--- a/frontend/src/components/shared/SidebarMenu.js
+++ b/frontend/src/components/shared/SidebarMenu.js
@@ -6,7 +6,8 @@ import { useTranslation } from "next-i18next";
 import {
   FaBookOpen, FaChalkboardTeacher, FaGraduationCap, FaUsers,
   FaCalendarAlt, FaPlus, FaChartLine, FaTimes, FaUserShield,
-  FaBullhorn, FaQuestionCircle, FaFileAlt, FaEnvelope
+  FaBullhorn, FaQuestionCircle, FaFileAlt, FaEnvelope,
+  FaTachometerAlt
 } from "react-icons/fa";
 import useAuthStore from "@/store/auth/authStore";
 

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -365,7 +365,7 @@ const Navbar = () => {
           </div>
         )}
 
-        {user && (
+        {userRole && (
           <Link
             href={
               userRole === "superadmin" || userRole === "admin"
@@ -377,7 +377,6 @@ const Navbar = () => {
             <FaTachometerAlt /> {t('dashboard')}
           </Link>
         )}
-
         {user ? (
           <>
             <motion.button

--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import AIRecommendations from "@/components/dashboard/AIRecommendations";
 import { motion } from "framer-motion";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import useAuthStore from "@/store/auth/authStore";
 import { getRecommendedCourses } from "@/services/aiCourseRecommendation";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../next-i18next.config.js";
@@ -31,6 +33,16 @@ const enrolledCourses = allCourses.slice(0, 3); // Mocked enrolled courses
 const recommendedCourses = getRecommendedCourses(enrolledCourses, allCourses);
 
 const DashboardPage = () => {
+  const { user } = useAuthStore();
+  const router = useRouter();
+
+  useEffect(() => {
+    const role = user?.role?.toLowerCase();
+    if (!role) return;
+    if (role === "admin" || role === "superadmin") router.replace("/dashboard/admin");
+    else router.replace(`/dashboard/${role}`);
+  }, [user, router]);
+
   return (
     <div className="flex flex-col min-h-screen bg-gray-900 text-white">
       <Navbar />

--- a/frontend/src/pages/dashboard/instructor/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/Verification.js
@@ -26,7 +26,7 @@ const Verification = ({ onBack = () => {} }) => {
   useEffect(() => {
     if (emailVerified && phoneVerified) {
       toast.success("Both email and phone verified. Redirecting to dashboard...");
-      const t = setTimeout(() => router.push("/dashboard"), 1500);
+      const t = setTimeout(() => router.push("/dashboard/instructor"), 1500);
       return () => clearTimeout(t);
     }
   }, []);
@@ -72,7 +72,7 @@ const Verification = ({ onBack = () => {} }) => {
       const phoneNow = type === "phone" ? true : phoneVerified;
       if (emailNow && phoneNow) {
         toast.success("Both email and phone verified. Redirecting to dashboard...");
-        setTimeout(() => router.push("/dashboard"), 1500);
+        setTimeout(() => router.push("/dashboard/instructor"), 1500);
       }
       setShowOtpModal(null);
       toast.success(`${type === "email" ? "Email" : "Phone"} verified`);

--- a/frontend/src/pages/dashboard/student/profile/steps/FinalReview.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/FinalReview.js
@@ -41,7 +41,7 @@ const FinalReview = ({ formData = {} }) => {
       }
 
       toast.success("Profile completed successfully!");
-      router.push("/dashboard");
+      router.push("/dashboard/student");
     } catch (err) {
       console.error("Profile submission failed:", err);
       toast.error(err.message || "Failed to complete profile");

--- a/frontend/src/pages/dashboard/student/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/Verification.js
@@ -28,7 +28,7 @@ const Verification = ({ prevStep = () => {} }) => {
   useEffect(() => {
     if (emailVerified && phoneVerified) {
       toast.success("Both email and phone verified. Redirecting to dashboard...");
-      const t = setTimeout(() => router.push("/dashboard"), 1500);
+      const t = setTimeout(() => router.push("/dashboard/student"), 1500);
       return () => clearTimeout(t);
     }
   }, []);
@@ -69,7 +69,7 @@ const Verification = ({ prevStep = () => {} }) => {
       const phoneNow = type === "phone" ? true : phoneVerified;
       if (emailNow && phoneNow) {
         toast.success("Both email and phone verified. Redirecting to dashboard...");
-        setTimeout(() => router.push("/dashboard"), 1500);
+        setTimeout(() => router.push("/dashboard/student"), 1500);
       }
     } catch (err) {
       const msg = err?.response?.data?.message || "Invalid or expired OTP";


### PR DESCRIPTION
## Summary
- redirect generic `/dashboard` to role-based dashboard
- use role-specific paths after profile verification steps

## Testing
- ❌ `npm test` in `backend` (jest not found)
- ❌ `npm test` in `frontend` (jest not found)


------
https://chatgpt.com/codex/tasks/task_e_6880a00a5b1883289b7c95c578558843