### PR TITLE
Fix dashboard translation hook

### DIFF
--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import useAuthStore from "@/store/auth/authStore";
 import { getRecommendedCourses } from "@/services/aiCourseRecommendation";
+import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../next-i18next.config.js";
 
@@ -33,6 +34,7 @@ const enrolledCourses = allCourses.slice(0, 3); // Mocked enrolled courses
 const recommendedCourses = getRecommendedCourses(enrolledCourses, allCourses);
 
 const DashboardPage = () => {
+  const { t } = useTranslation('dashboard');
   const { user } = useAuthStore();
   const router = useRouter();
 
@@ -98,7 +100,7 @@ export default DashboardPage;
 export async function getStaticProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["common"], nextI18NextConfig)),
+      ...(await serverSideTranslations(locale, ["common", "dashboard"], nextI18NextConfig)),
     },
   };
 }


### PR DESCRIPTION
## Summary
- use `useTranslation` hook in dashboard
- preload dashboard locales for translations

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880c81026f4832896d40a3ebb88fd97