### PR TITLE
Fix dashboard i18n and include role in profile

### DIFF
--- a/backend/src/modules/users/profile.controller.js
+++ b/backend/src/modules/users/profile.controller.js
@@ -140,6 +140,7 @@ exports.getFullProfile = async (req, res) => {
         'full_name',
         'email',
         'phone',
+        'role',
         'gender',
         'date_of_birth',
         'avatar_url',
@@ -185,7 +186,12 @@ exports.getFullProfile = async (req, res) => {
       .where({ user_id: userId })
       .select('platform', 'url');
 
-    res.json({ ...user, ...roleData, social_links: socialLinks });
+    res.json({
+      ...user,
+      roles: req.user.roles,
+      ...roleData,
+      social_links: socialLinks,
+    });
   } catch (err) {
     console.error('Full profile fetch error:', err);
     res.status(500).json({ error: 'Failed to fetch profile' });

--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import useAuthStore from "@/store/auth/authStore";
 import { getRecommendedCourses } from "@/services/aiCourseRecommendation";
+import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../next-i18next.config.js";
 
@@ -33,6 +34,7 @@ const enrolledCourses = allCourses.slice(0, 3); // Mocked enrolled courses
 const recommendedCourses = getRecommendedCourses(enrolledCourses, allCourses);
 
 const DashboardPage = () => {
+  const { t } = useTranslation('dashboard');
   const { user } = useAuthStore();
   const router = useRouter();
 
@@ -98,7 +100,7 @@ export default DashboardPage;
 export async function getStaticProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["common"], nextI18NextConfig)),
+      ...(await serverSideTranslations(locale, ["common", "dashboard"], nextI18NextConfig)),
     },
   };
 }


### PR DESCRIPTION
## Summary
- use `useTranslation` in dashboard page
- preload the `dashboard` namespace
- return `role` and `roles` in full profile API

## Testing
- `cd backend && npm install && npm test`
- `cd ../frontend && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880c81026f4832896d40a3ebb88fd97