### PR TITLE
Fix translation loading for admin class creation

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -762,7 +762,7 @@ import nextI18NextConfig from '../../../../../next-i18next.config.js';
 export async function getStaticProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+      ...(await serverSideTranslations(locale, ['common', 'dashboard'], nextI18NextConfig)),
     },
   };
 }


### PR DESCRIPTION
## Summary
- ensure admin class creation page loads common translations

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6880cd020bb88328a3b3d2c9b0279e32