### PR TITLE
Fix display name warning in InputField

### DIFF
--- a/frontend/src/shared/components/auth/InputField.js
+++ b/frontend/src/shared/components/auth/InputField.js
@@ -34,4 +34,6 @@ const InputField = forwardRef(({ label, type, placeholder, ...rest }, ref) => {
   );
 });
 
+InputField.displayName = 'InputField';
+
 export default InputField;


### PR DESCRIPTION
## Summary
- add missing display name for `InputField`

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6880cc664b888328a6a51e58f8ae6939