### PR TITLE
Handle CORS trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
    cp backend/.env.example backend/.env
    # edit backend/.env and set your secrets
    # FRONTEND_URL defaults to http://localhost:3000
-   # set it to your frontend's domain if different
+   # set it to your frontend's domain if different and omit any trailing slash
    # When using docker-compose make sure the value does
    # not include an extra "FRONTEND_URL=" prefix.
    ```

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -2,7 +2,7 @@
 module.exports = (err, req, res, next) => {
   let origins = process.env.FRONTEND_URL || "http://localhost:3000";
   if (origins.startsWith("FRONTEND_URL=")) origins = origins.replace(/^FRONTEND_URL=/, "");
-  const ALLOWED_ORIGINS = origins.split(',').map(o => o.trim());
+  const ALLOWED_ORIGINS = origins.split(',').map(o => o.trim().replace(/\/$/, ""));
 
   const origin = req.headers.origin;
   if (ALLOWED_ORIGINS.includes(origin)) {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -23,7 +23,8 @@ let FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
 if (FRONTEND_URL.startsWith("FRONTEND_URL=")) {
   FRONTEND_URL = FRONTEND_URL.replace(/^FRONTEND_URL=/, "");
 }
-const ALLOWED_ORIGINS = FRONTEND_URL.split(',').map(o => o.trim());
+const ALLOWED_ORIGINS = FRONTEND_URL.split(',')
+  .map(o => o.trim().replace(/\/$/, ""));
 
 
 app.disable("etag");

--- a/backend/src/utils/frontend.js
+++ b/backend/src/utils/frontend.js
@@ -2,5 +2,5 @@ let url = process.env.FRONTEND_URL || 'http://localhost:3000';
 if (url.startsWith('FRONTEND_URL=')) {
   url = url.replace(/^FRONTEND_URL=/, '');
 }
-const frontendBase = url.split(',')[0].trim();
+const frontendBase = url.split(',')[0].trim().replace(/\/$/, '');
 module.exports = { frontendBase };

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -131,7 +131,7 @@ picked up.
 If the browser console shows messages like `No 'Access-Control-Allow-Origin'` or
 `ERR_NETWORK` during login, your backend is rejecting the frontend's origin.
 Edit `backend/.env` and ensure the `FRONTEND_URL` variable lists the exact
-domain of your deployed site, for example:
+domain of your deployed site without a trailing slash, for example:
 
 ```bash
 FRONTEND_URL=https://eduskillbridge.net


### PR DESCRIPTION
## Summary
- trim trailing slashes from `FRONTEND_URL` values
- document that `FRONTEND_URL` should not have a trailing slash

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6880d1ebf5d88328a8e32c8eb27e49d2