### PR TITLE
Fix duplicate CORS headers

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -10,11 +10,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-    # always send CORS headers so browsers see them even on errors
-    add_header 'Access-Control-Allow-Origin' 'https://eduskillbridge.net' always;
-    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-    add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
+    # CORS is handled by the backend so avoid duplicate headers
   }
 
   location ^~ /api/ {

--- a/nginx/conf.d/ssl.conf
+++ b/nginx/conf.d/ssl.conf
@@ -14,11 +14,7 @@ server {
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
-
-        # always send CORS headers so browsers see them even on errors
-        add_header 'Access-Control-Allow-Origin' 'https://eduskillbridge.net' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
+        # CORS is handled by the backend so avoid duplicate headers
     }
 
     location ^~ /api/ {


### PR DESCRIPTION
## Summary
- remove Access-Control headers from nginx configs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688172faa288832891bf23b8db887da6