### PR TITLE
Limit instructor demo video uploads to 3MB

### DIFF
--- a/backend/src/modules/users/instructor/instructorUploadMiddleware.js
+++ b/backend/src/modules/users/instructor/instructorUploadMiddleware.js
@@ -48,7 +48,7 @@ const demoUpload = multer({
     if (file.mimetype.startsWith("video/")) cb(null, true);
     else cb(new Error("Only video files are allowed"), false);
   },
-  limits: { fileSize: 50 * 1024 * 1024 }, // 50MB
+  limits: { fileSize: 3 * 1024 * 1024 }, // 3MB
 });
 
 // ──────────────── Certificate Upload ────────────────

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -467,7 +467,7 @@ export default function InstructorProfileEdit() {
                   onChange={async (e) => {
                     const file = e.target.files[0];
                     if (!file) return;
-                    if (file.size > 100 * 1024 * 1024) return toast.error("Max size 100MB");
+                    if (file.size > 3 * 1024 * 1024) return toast.error("Max size 3MB");
                     setIsSubmitting(true);
                     try {
                       const res = await uploadInstructorDemo(user.id, file);


### PR DESCRIPTION
## Summary
- restrict instructor demo video upload to 3MB on the dashboard edit page
- enforce 3MB limit server-side for instructor demo upload
- update tests (no code changes needed) and ensure they pass

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881e08035e08328ae0f2d1a87c5d434