### PR TITLE
Remove instructor profile URL validation

### DIFF
--- a/backend/src/modules/users/instructor/instructor.service.js
+++ b/backend/src/modules/users/instructor/instructor.service.js
@@ -5,15 +5,6 @@
 
 const db = require("../../../config/database");
 
-// ✅ Utility to validate URL (basic)
-const isValidUrl = (url) => {
-  try {
-    new URL(url);
-    return true;
-  } catch (_) {
-    return false;
-  }
-};
 
 // 🔹 Get full instructor profile (user + instructor + social + certificates)
 const getInstructorProfile = async (userId) => {
@@ -78,7 +69,7 @@ const updateInstructorProfile = async (userId, userData, instructorData, socialL
     // ✅ Replace social links
     await trx("user_social_links").where({ user_id: userId }).del();
     for (const link of socialLinks) {
-      if (link.url && isValidUrl(link.url)) {
+      if (link.url) {
         await trx("user_social_links").insert({
           user_id: userId,
           platform: link.platform,

--- a/backend/src/modules/users/instructor/instructor.validator.js
+++ b/backend/src/modules/users/instructor/instructor.validator.js
@@ -31,7 +31,6 @@ const updateInstructorProfileSchema = z.object({
 
   demo_video_url: z
     .string()
-    .url("Must be a valid URL")
     .optional()
     .nullable(),
 
@@ -39,7 +38,7 @@ const updateInstructorProfileSchema = z.object({
     .array(
       z.object({
         platform: z.string().min(2),
-        url: z.string().url("Must be a valid URL"),
+        url: z.string(),
       })
     )
     .optional()

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -70,7 +70,7 @@ const instructorProfileSchema = z.object({
       message: "bio_max_words",
     }),
   socialLinks: z
-    .record(z.string().url("url_invalid"))
+    .record(z.string())
     .optional(),
 });
 


### PR DESCRIPTION
## Summary
- allow free-form text for social links on the instructor profile edit page
- relax backend instructor profile schema to accept any URL string
- drop URL validation logic from instructor service

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6881e5b964408328a838682b2b4a80c8