### PR TITLE
Add test for class creation options

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -67,6 +67,29 @@ describe('Class routes', () => {
     expect(notifications.createNotification).toHaveBeenCalledTimes(2);
   });
 
+  test('create class with options', async () => {
+    const payload = {
+      id: '2',
+      instructor_id: '2',
+      title: 'Free Class',
+      status: 'published',
+      price: 0,
+      allow_installments: true
+    };
+    service.createClass.mockResolvedValue(payload);
+    const res = await request(app)
+      .post('/classes/admin')
+      .send(payload);
+    expect(res.statusCode).toBe(200);
+    expect(service.createClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'published',
+        price: 0,
+        allow_installments: true
+      })
+    );
+  });
+
   test('get classes', async () => {
     const list = [{ id: '1', instructor_id: '2', title: 'Test Class' }];
     service.getAllClasses.mockResolvedValue(list);


### PR DESCRIPTION
## Summary
- ensure class creation handles free classes and installment options

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882225ebdb0832891cae4142814cea8