### PR TITLE
Add test for class creation options

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -13,7 +13,9 @@ jest.mock('../../../config/database', () => {
 jest.mock('../class.service', () => ({
   createClass: jest.fn(),
   getAllClasses: jest.fn(),
-  getClassesByInstructor: jest.fn()
+  getClassesByInstructor: jest.fn(),
+  togglePublishStatus: jest.fn(),
+  updateModeration: jest.fn()
 }));
 const service = require('../class.service');
 jest.mock('../../notifications/notifications.service', () => ({
@@ -67,6 +69,29 @@ describe('Class routes', () => {
     expect(notifications.createNotification).toHaveBeenCalledTimes(2);
   });
 
+  test('create class with options', async () => {
+    const payload = {
+      id: '2',
+      instructor_id: '2',
+      title: 'Free Class',
+      status: 'published',
+      price: 0,
+      allow_installments: true
+    };
+    service.createClass.mockResolvedValue(payload);
+    const res = await request(app)
+      .post('/classes/admin')
+      .send(payload);
+    expect(res.statusCode).toBe(200);
+    expect(service.createClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'published',
+        price: 0,
+        allow_installments: true
+      })
+    );
+  });
+
   test('get classes', async () => {
     const list = [{ id: '1', instructor_id: '2', title: 'Test Class' }];
     service.getAllClasses.mockResolvedValue(list);
@@ -83,5 +108,23 @@ describe('Class routes', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toEqual(list);
     expect(service.getClassesByInstructor).toHaveBeenCalled();
+  });
+
+  test('toggle class status', async () => {
+    const updated = { id: '1', status: 'published', moderation_status: 'Pending' };
+    service.togglePublishStatus.mockResolvedValue(updated);
+    const res = await request(app).patch('/classes/admin/1/status');
+    expect(res.statusCode).toBe(200);
+    expect(service.togglePublishStatus).toHaveBeenCalledWith('1');
+    expect(res.body.data).toEqual(updated);
+  });
+
+  test('approve class', async () => {
+    const approved = { id: '1', status: 'published', moderation_status: 'Approved' };
+    service.updateModeration.mockResolvedValue(approved);
+    const res = await request(app).patch('/classes/admin/1/approve');
+    expect(res.statusCode).toBe(200);
+    expect(service.updateModeration).toHaveBeenCalledWith('1', 'Approved');
+    expect(res.body.data).toEqual(approved);
   });
 });


### PR DESCRIPTION
## Summary
- ensure class creation handles free classes and installment options
- cover admin publishing actions in tests

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882225ebdb0832891cae4142814cea8