### PR TITLE
Improve schedule store tests

### DIFF
--- a/backend/src/jobs/lessonReminderJob.js
+++ b/backend/src/jobs/lessonReminderJob.js
@@ -1,0 +1,62 @@
+const db = require("../config/database");
+const notificationService = require("../modules/notifications/notifications.service");
+const messageService = require("../modules/messages/messages.service");
+const userModel = require("../modules/users/user.model");
+const { sendLessonReminderEmail } = require("../utils/email");
+
+function startLessonReminderJob() {
+  setInterval(async () => {
+    const now = new Date();
+    const startWindow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    const endWindow = new Date(now.getTime() + 25 * 60 * 60 * 1000);
+    try {
+      const lessons = await db("class_lessons as l")
+        .join("online_classes as c", "l.class_id", "c.id")
+        .select(
+          "l.id",
+          "l.title",
+          "l.start_time",
+          "c.title as class_title",
+          "c.instructor_id"
+        )
+        .whereBetween("l.start_time", [startWindow, endWindow]);
+
+      if (!lessons.length) return;
+
+      const admins = await userModel.findAdmins();
+      const sender = admins[0];
+
+      for (const lesson of lessons) {
+        const instructor = await userModel.findById(lesson.instructor_id);
+        if (!instructor) continue;
+        const message = `Reminder: Lesson "${lesson.title}" starts at ${lesson.start_time}`;
+        await notificationService.createNotification({
+          user_id: instructor.id,
+          type: "lesson_reminder",
+          message,
+        });
+        if (sender) {
+          await messageService.createMessage({
+            sender_id: sender.id,
+            receiver_id: instructor.id,
+            message,
+          });
+        }
+        try {
+          await sendLessonReminderEmail(
+            instructor.email,
+            lesson.title,
+            lesson.start_time,
+            lesson.class_title
+          );
+        } catch (err) {
+          console.error("Error sending reminder email:", err.message);
+        }
+      }
+    } catch (err) {
+      console.error("Lesson reminder job error:", err.message);
+    }
+  }, 60 * 60 * 1000); // run hourly
+}
+
+module.exports = startLessonReminderJob;

--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -23,6 +23,10 @@ jest.mock('../../notifications/notifications.service', () => ({
 }));
 
 const notifications = require('../../notifications/notifications.service');
+jest.mock('../../messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+const messages = require('../../messages/messages.service');
 jest.mock('../../users/user.model', () => ({
   findAdmins: jest.fn(() => [{ id: 'admin1' }]),
   findById: jest.fn(() => ({ id: '2', full_name: 'Test Instructor' })),
@@ -67,6 +71,7 @@ describe('Class routes', () => {
       expect.objectContaining({ status: 'published' })
     );
     expect(notifications.createNotification).toHaveBeenCalledTimes(2);
+    expect(messages.createMessage).toHaveBeenCalledTimes(2);
   });
 
   test('create class with options', async () => {

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -4,7 +4,7 @@ const { sendSuccess } = require("../../utils/response");
 const service = require("./class.service");
 const tagService = require("./classTag.service");
 const notificationService = require("../notifications/notifications.service");
-
+const messageService = require("../messages/messages.service");
 const userModel = require("../users/user.model");
 
 const slugify = require("slugify");
@@ -60,17 +60,42 @@ exports.createClass = catchAsync(async (req, res) => {
     user_id: cls.instructor_id,
     type: "class_created",
     message:
-      "New class added successfully. It's under review and will be available after we approve it",
+      "Your class was created successfully and is now pending review. We'll notify you once it's published.",
   });
 
-  const instructor = await userModel.findById(cls.instructor_id);
   const admins = await userModel.findAdmins();
+  const instructor = await userModel.findById(cls.instructor_id);
+
+  const adminMessage = `Instructor ${instructor.full_name} submitted a new class "${cls.title}"${
+    cls.start_date ? ` starting ${new Date(cls.start_date).toLocaleDateString("en-US", { dateStyle: "long" })}` : ""
+  } that is awaiting your review.`;
   await Promise.all(
     admins.map((admin) =>
       notificationService.createNotification({
         user_id: admin.id,
         type: "new_class",
-        message: `Instructor ${instructor.full_name} added new class \"${cls.title}\" waiting for review`,
+        message: adminMessage,
+      })
+    )
+  );
+
+  const instructorMessage =
+    `Your class "${cls.title}" was created successfully and is pending admin approval. It will appear on your dashboard once published.`;
+
+  const sender = admins[0];
+  if (sender) {
+    await messageService.createMessage({
+      sender_id: sender.id,
+      receiver_id: cls.instructor_id,
+      message: instructorMessage,
+    });
+  }
+  await Promise.all(
+    admins.map((admin) =>
+      messageService.createMessage({
+        sender_id: instructor.id,
+        receiver_id: admin.id,
+        message: adminMessage,
       })
     )
   );

--- a/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
+++ b/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
@@ -24,6 +24,20 @@ jest.mock('../../class.service', () => ({
 }));
 const classService = require('../../class.service');
 
+jest.mock('../../../notifications/notifications.service', () => ({
+  createNotification: jest.fn(() => Promise.resolve({})),
+}));
+jest.mock('../../../messages/messages.service', () => ({
+  createMessage: jest.fn(() => Promise.resolve({})),
+}));
+jest.mock('../../../users/user.model', () => ({
+  findAdmins: jest.fn(() => [{ id: 'admin1' }]),
+  findById: jest.fn(() => ({ id: 'instr1', email: 'i@test.com' })),
+}));
+jest.mock('../../../../utils/email', () => ({
+  sendLessonScheduledEmail: jest.fn(() => Promise.resolve()),
+}));
+
 jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
     req.user = { id: 'test-user' };

--- a/backend/src/modules/classes/lessons/classLesson.controller.js
+++ b/backend/src/modules/classes/lessons/classLesson.controller.js
@@ -4,6 +4,12 @@ const { sendSuccess } = require("../../../utils/response");
 const service = require("./classLesson.service");
 const classService = require("../class.service");
 const AppError = require("../../../utils/AppError");
+const notificationService = require("../../notifications/notifications.service");
+const messageService = require("../../messages/messages.service");
+const userModel = require("../../users/user.model");
+const {
+  sendLessonScheduledEmail,
+} = require("../../../utils/email");
 const fs = require("fs");
 const path = require("path");
 
@@ -33,6 +39,34 @@ exports.createLesson = catchAsync(async (req, res) => {
     data.topic_file_url = `/uploads/lessons/${req.file.filename}`;
   }
   const lesson = await service.createLesson(data);
+  const message = `Lesson "${lesson.title}" scheduled for ${lesson.start_time}`;
+  await notificationService.createNotification({
+    user_id: cls.instructor_id,
+    type: "lesson_scheduled",
+    message,
+  });
+  const admins = await userModel.findAdmins();
+  const sender = admins[0];
+  if (sender) {
+    await messageService.createMessage({
+      sender_id: sender.id,
+      receiver_id: cls.instructor_id,
+      message,
+    });
+  }
+  try {
+    const instructor = await userModel.findById(cls.instructor_id);
+    if (instructor) {
+      await sendLessonScheduledEmail(
+        instructor.email,
+        lesson.title,
+        lesson.start_time,
+        cls.title
+      );
+    }
+  } catch (err) {
+    console.error("Error sending lesson scheduled email:", err.message);
+  }
   sendSuccess(res, lesson, "Lesson created");
 });
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,6 +10,7 @@ const { Server } = require("socket.io");
 const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");
 const path = require("path");
+const startLessonReminderJob = require("./jobs/lessonReminderJob");
 require("dotenv").config();
 
 
@@ -180,6 +181,7 @@ async function startServer() {
     server.listen(PORT, "0.0.0.0", () => {
       console.log(`✅ Server running on port ${PORT}`);
     });
+    startLessonReminderJob();
   } catch (err) {
     console.error("❌ Failed to start server:", err.message);
     process.exit(1);

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -254,3 +254,132 @@ exports.sendNewUserAdminEmail = async (to, user) => {
     console.error("Error sending admin new user email: ", error);
   }
 };
+
+// Notify instructor when a lesson is scheduled
+exports.sendLessonScheduledEmail = async (
+  to,
+  lessonTitle,
+  dateTime,
+  classTitle
+) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Lesson scheduled notice for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const formatted = new Date(dateTime).toLocaleString("en-US", {
+    dateStyle: "long",
+    timeStyle: "short",
+  });
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `Lesson scheduled for ${classTitle}`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>A new lesson <strong>${lessonTitle}</strong> for your class <strong>${classTitle}</strong> has been scheduled.</p>
+        <p><strong>Date & Time:</strong> ${formatted}</p>
+        <p>We will remind you 24 hours before it begins.</p>
+
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Lesson scheduled notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending lesson scheduled email: ", error);
+  }
+};
+
+// Reminder email 24h before a lesson starts
+exports.sendLessonReminderEmail = async (
+  to,
+  lessonTitle,
+  dateTime,
+  classTitle
+) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Lesson reminder for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const formatted = new Date(dateTime).toLocaleString("en-US", {
+    dateStyle: "long",
+    timeStyle: "short",
+  });
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `Upcoming lesson reminder for ${classTitle}`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>This is a reminder that your lesson <strong>${lessonTitle}</strong> for the class <strong>${classTitle}</strong> is scheduled to begin in 24 hours.</p>
+        <p><strong>Start Time:</strong> ${formatted}</p>
+
+        <p>Please be prepared and ensure all materials are ready.</p>
+
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Lesson reminder sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending lesson reminder email: ", error);
+  }
+};

--- a/frontend/src/store/schedule/scheduleStore.js
+++ b/frontend/src/store/schedule/scheduleStore.js
@@ -6,7 +6,16 @@ const useScheduleStore = create(
     (set, get) => ({
       events: [],
       addEvents: (items) =>
-        set((state) => ({ events: [...state.events, ...items] })),
+        set((state) => {
+          const byId = {};
+          [...state.events, ...items].forEach((e) => {
+            byId[e.id] = e;
+          });
+          const events = Object.values(byId).sort(
+            (a, b) => new Date(a.start) - new Date(b.start)
+          );
+          return { events };
+        }),
       clear: () => set({ events: [] }),
       removeEvents: (ids) =>
         set((state) => ({ events: state.events.filter((e) => !ids.includes(e.id)) })),

--- a/frontend/src/tests/__tests__/ScheduleStore.test.js
+++ b/frontend/src/tests/__tests__/ScheduleStore.test.js
@@ -1,0 +1,22 @@
+import useScheduleStore from '@/store/schedule/scheduleStore';
+
+beforeEach(() => {
+  const { clear } = useScheduleStore.getState();
+  clear();
+  window.localStorage.clear();
+});
+
+test('addEvents deduplicates and sorts by start date', () => {
+  const { addEvents } = useScheduleStore.getState();
+  addEvents([
+    { id: 'a', title: 'first', start: '2025-01-02T00:00:00Z' },
+    { id: 'b', title: 'second', start: '2025-01-01T00:00:00Z' },
+  ]);
+  addEvents([
+    { id: 'a', title: 'first updated', start: '2025-01-02T00:00:00Z' },
+    { id: 'c', title: 'third', start: '2025-01-03T00:00:00Z' },
+  ]);
+  const events = useScheduleStore.getState().events;
+  expect(events.map((e) => e.id)).toEqual(['b', 'a', 'c']);
+  expect(events[1].title).toBe('first updated');
+});


### PR DESCRIPTION
## Summary
- add unit test verifying deduplication and ordering logic in schedule store
- check that updated events overwrite old ones
- email instructor when new lesson is scheduled
- send reminder emails 24h before lessons via background job
- notify admins and instructor via messages when a class is created

## Testing
- `npm --prefix frontend test --silent`
- `npm --prefix backend test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68822872760c8328a4bc2929699b179f