### PR TITLE
Fix notification dates and enable deletion

### DIFF
--- a/backend/src/modules/notifications/notifications.controller.js
+++ b/backend/src/modules/notifications/notifications.controller.js
@@ -22,3 +22,9 @@ exports.create = catchAsync(async (req, res) => {
   const note = await service.createNotification({ user_id, type, message });
   sendSuccess(res, note, "Notification created");
 });
+
+exports.remove = catchAsync(async (req, res) => {
+  const note = await service.deleteNotification(req.params.id, req.user.id);
+  if (!note) throw new AppError("Notification not found", 404);
+  sendSuccess(res, note, "Notification deleted");
+});

--- a/backend/src/modules/notifications/notifications.routes.js
+++ b/backend/src/modules/notifications/notifications.routes.js
@@ -8,5 +8,6 @@ router.use(verifyToken);
 router.get("/", controller.getMyNotifications);
 router.post("/", controller.create);
 router.patch("/:id/read", controller.markRead);
+router.delete("/:id", controller.remove);
 
 module.exports = router;

--- a/backend/src/modules/notifications/notifications.service.js
+++ b/backend/src/modules/notifications/notifications.service.js
@@ -25,3 +25,11 @@ exports.markAsRead = async (id, userId) => {
     .returning("*");
   return row;
 };
+
+exports.deleteNotification = async (id, userId) => {
+  const [row] = await db("notifications")
+    .where({ id, user_id: userId })
+    .del()
+    .returning("*");
+  return row;
+};

--- a/backend/tests/notificationRoutes.test.js
+++ b/backend/tests/notificationRoutes.test.js
@@ -5,6 +5,7 @@ jest.mock('../src/modules/notifications/notifications.service', () => ({
   getUserNotifications: jest.fn(),
   markAsRead: jest.fn(),
   createNotification: jest.fn(),
+  deleteNotification: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -49,5 +50,16 @@ describe('POST /api/notifications', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mockNote);
     expect(service.createNotification).toHaveBeenCalledWith(payload);
+  });
+});
+
+describe('DELETE /api/notifications/:id', () => {
+  it('deletes notification', async () => {
+    const mockNote = { id: '1' };
+    service.deleteNotification.mockResolvedValue(mockNote);
+    const res = await request(app).delete('/api/notifications/1');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mockNote);
+    expect(service.deleteNotification).toHaveBeenCalledWith('1', 'user1');
   });
 });

--- a/frontend/src/pages/dashboard/admin/notifications/index.js
+++ b/frontend/src/pages/dashboard/admin/notifications/index.js
@@ -11,6 +11,7 @@ export default function AdminNotificationsPage() {
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const startPolling = useNotificationStore((state) => state.startPolling);
   const markRead = useNotificationStore((state) => state.markRead);
+  const remove = useNotificationStore((state) => state.remove);
 
   useEffect(() => {
     fetchNotifications();
@@ -28,9 +29,7 @@ export default function AdminNotificationsPage() {
   };
 
   const handleDelete = (id) => {
-    // No backend endpoint for deletion; remove locally
-    // Deleted notifications will automatically be cleaned up after an hour
-    markRead(id);
+    remove(id);
   };
 
   const filtered = notifications.filter((n) =>
@@ -84,7 +83,7 @@ export default function AdminNotificationsPage() {
                   <div>
                     <p className="text-sm mb-1 leading-relaxed font-medium"><LinkText text={note.message} /></p>
                     <p className="text-xs text-gray-500 flex items-center gap-1">
-                      <FaCalendarAlt /> {formatRelativeTime(note.date)}
+                      <FaCalendarAlt /> {formatRelativeTime(note.created_at)}
                     </p>
                   </div>
                 </div>

--- a/frontend/src/pages/dashboard/instructor/notifications/index.js
+++ b/frontend/src/pages/dashboard/instructor/notifications/index.js
@@ -11,6 +11,7 @@ export default function InstructorNotificationsPage() {
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const startPolling = useNotificationStore((state) => state.startPolling);
   const markRead = useNotificationStore((state) => state.markRead);
+  const remove = useNotificationStore((state) => state.remove);
 
   useEffect(() => {
     fetchNotifications();
@@ -28,9 +29,7 @@ export default function InstructorNotificationsPage() {
   };
 
   const handleDelete = (id) => {
-    // No backend endpoint for deletion; remove locally
-    // Deleted notifications will automatically be cleaned up after an hour
-    markRead(id);
+    remove(id);
   };
 
   const filtered = notifications.filter((n) =>
@@ -84,7 +83,7 @@ export default function InstructorNotificationsPage() {
                   <div>
                     <p className="text-sm mb-1 leading-relaxed font-medium"><LinkText text={note.message} /></p>
                     <p className="text-xs text-gray-500 flex items-center gap-1">
-                      <FaCalendarAlt /> {formatRelativeTime(note.date)}
+                      <FaCalendarAlt /> {formatRelativeTime(note.created_at)}
                     </p>
                   </div>
                 </div>

--- a/frontend/src/pages/dashboard/student/notifications/index.js
+++ b/frontend/src/pages/dashboard/student/notifications/index.js
@@ -11,6 +11,7 @@ export default function StudentNotificationsPage() {
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const startPolling = useNotificationStore((state) => state.startPolling);
   const markRead = useNotificationStore((state) => state.markRead);
+  const remove = useNotificationStore((state) => state.remove);
 
   useEffect(() => {
     fetchNotifications();
@@ -28,9 +29,7 @@ export default function StudentNotificationsPage() {
   };
 
   const handleDelete = (id) => {
-    // No backend endpoint for deletion; remove locally
-    // Deleted notifications will automatically be cleaned up after an hour
-    markRead(id);
+    remove(id);
   };
 
   const filtered = notifications.filter((n) =>
@@ -84,7 +83,7 @@ export default function StudentNotificationsPage() {
                   <div>
                     <p className="text-sm mb-1 leading-relaxed font-medium"><LinkText text={note.message} /></p>
                     <p className="text-xs text-gray-500 flex items-center gap-1">
-                      <FaCalendarAlt /> {formatRelativeTime(note.date)}
+                      <FaCalendarAlt /> {formatRelativeTime(note.created_at)}
                     </p>
                   </div>
                 </div>

--- a/frontend/src/services/notificationService.js
+++ b/frontend/src/services/notificationService.js
@@ -10,6 +10,11 @@ export const markNotificationAsRead = async (id) => {
   return res.data.data || res.data;
 };
 
+export const deleteNotification = async (id) => {
+  const res = await api.delete(`/notifications/${id}`);
+  return res.data.data || res.data;
+};
+
 export const createNotification = async (payload) => {
   const res = await api.post('/notifications', payload);
   return res.data.data || res.data;

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { toast } from "react-toastify";
 import React from "react";
 import LinkText from "@/components/shared/LinkText";
-import { getNotifications, markNotificationAsRead } from "@/services/notificationService";
+import { getNotifications, markNotificationAsRead, deleteNotification } from "@/services/notificationService";
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -37,6 +37,13 @@ const useNotificationStore = create((set, get) => ({
 
   markRead: async (id) => {
     await markNotificationAsRead(id);
+    set((state) => ({
+      items: state.items.filter((n) => n.id !== id),
+    }));
+  },
+
+  remove: async (id) => {
+    await deleteNotification(id);
     set((state) => ({
       items: state.items.filter((n) => n.id !== id),
     }));


### PR DESCRIPTION
## Summary
- display notification created_at timestamps
- allow deleting notifications via API
- extend backend notifications service and controller
- add delete route and tests

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6882e2539e788328a92d9668a3d6be04