### PR TITLE
Fix currency creation validations

### DIFF
--- a/backend/src/modules/currencies/currencies.controller.js
+++ b/backend/src/modules/currencies/currencies.controller.js
@@ -6,12 +6,33 @@ const path = require('path');
 const fs = require('fs');
 
 exports.createCurrency = catchAsync(async (req, res) => {
+  const { label, code, symbol, exchange_rate } = req.body;
+  if (!label || !code || !symbol)
+    throw new AppError('Label, code and symbol are required', 400);
+  if (exchange_rate && isNaN(Number(exchange_rate))) {
+    throw new AppError('Invalid exchange rate', 400);
+  }
+
   const data = { ...req.body };
   if (req.file) {
     data.logo_url = `/uploads/currencies/${req.file.filename}`;
   }
-  const currency = await service.create(data);
-  sendSuccess(res, currency, 'Currency created');
+  // Coerce numeric and boolean values from multipart/form-data
+  if (data.exchange_rate) data.exchange_rate = Number(data.exchange_rate);
+  ['is_active', 'is_default', 'auto_update'].forEach((k) => {
+    if (data[k] !== undefined) data[k] = data[k] === 'true' || data[k] === true;
+  });
+
+  try {
+    const currency = await service.create(data);
+    sendSuccess(res, currency, 'Currency created');
+  } catch (err) {
+    if (err.code === '23505') {
+      // duplicate currency code
+      return res.status(400).json({ message: 'Currency code already exists' });
+    }
+    throw err;
+  }
 });
 
 exports.listCurrencies = catchAsync(async (_req, res) => {
@@ -22,6 +43,21 @@ exports.listCurrencies = catchAsync(async (_req, res) => {
 exports.updateCurrency = catchAsync(async (req, res) => {
   const existing = await service.getById(req.params.id);
   if (!existing) throw new AppError('Currency not found', 404);
+
+  const { label, code, symbol, exchange_rate } = req.body;
+  if (label !== undefined && !label) {
+    throw new AppError('Label is required', 400);
+  }
+  if (code !== undefined && !code) {
+    throw new AppError('Code is required', 400);
+  }
+  if (symbol !== undefined && !symbol) {
+    throw new AppError('Symbol is required', 400);
+  }
+  if (exchange_rate && isNaN(Number(exchange_rate))) {
+    throw new AppError('Invalid exchange rate', 400);
+  }
+
   const data = { ...req.body };
   if (req.file) {
     if (existing.logo_url) {
@@ -30,8 +66,21 @@ exports.updateCurrency = catchAsync(async (req, res) => {
     }
     data.logo_url = `/uploads/currencies/${req.file.filename}`;
   }
-  const updated = await service.update(req.params.id, data);
-  sendSuccess(res, updated, 'Currency updated');
+
+  if (data.exchange_rate) data.exchange_rate = Number(data.exchange_rate);
+  ['is_active', 'is_default', 'auto_update'].forEach((k) => {
+    if (data[k] !== undefined) data[k] = data[k] === 'true' || data[k] === true;
+  });
+
+  try {
+    const updated = await service.update(req.params.id, data);
+    sendSuccess(res, updated, 'Currency updated');
+  } catch (err) {
+    if (err.code === '23505') {
+      return res.status(400).json({ message: 'Currency code already exists' });
+    }
+    throw err;
+  }
 });
 
 exports.deleteCurrency = catchAsync(async (req, res) => {


### PR DESCRIPTION
## Summary
- add robust validation and duplicate code handling when creating or updating currencies

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6882f56b4d288328a46afaf8bc5b71a7