### PR TITLE
Fix i18next config path in currency pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/currency/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/create.js
@@ -14,7 +14,7 @@ import { createCurrency } from "@/services/admin/currencyService";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 const useAdminNotice = () => {
   const user = useAuthStore((state) => state.user);

--- a/frontend/src/pages/dashboard/admin/settings/currency/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/index.js
@@ -11,7 +11,7 @@ import Link from "next/link";
 import useSWR from "swr";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 import withAuthProtection from "@/hooks/withAuthProtection";
 import {


### PR DESCRIPTION
## Summary
- fix relative import path to `next-i18next.config.js` in admin currency pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688305d540388328a51187af3e3416c7