### PR TITLE
Enable instructor tutorial view analytics

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -338,3 +338,16 @@ exports.getDashboardStats = async (req, res) => {
     const data = await require('./instructor.service').getDashboardStats(userId);
     res.json({ data });
 };
+
+/**
+ * @desc Get tutorial views grouped by week for instructor
+ * @route GET /api/users/instructor/tutorial-views
+ * @access Instructor
+ */
+exports.getTutorialViews = async (req, res) => {
+    const userId = req.user.id;
+    const weeks = parseInt(req.query.weeks, 10) || 4;
+    const service = require('./instructor.service');
+    const data = await service.getTutorialViewsByWeek(userId, weeks);
+    res.json({ data });
+};

--- a/backend/src/modules/users/instructor/instructor.routes.js
+++ b/backend/src/modules/users/instructor/instructor.routes.js
@@ -158,4 +158,11 @@ router.get(
   controller.getDashboardStats
 );
 
+router.get(
+  "/tutorial-views",
+  verifyToken,
+  isInstructor,
+  controller.getTutorialViews
+);
+
 module.exports = router;

--- a/backend/src/modules/users/instructor/instructor.service.js
+++ b/backend/src/modules/users/instructor/instructor.service.js
@@ -132,8 +132,29 @@ const getDashboardStats = async (userId) => {
   };
 };
 
+// 📊 Tutorial views grouped by week for the instructor
+const getTutorialViewsByWeek = async (userId, weeks = 4) => {
+  const rows = await db('tutorial_views as v')
+    .join('tutorials as t', 'v.tutorial_id', 't.id')
+    .where('t.instructor_id', userId)
+    .where('v.created_at', '>=', db.raw(`CURRENT_DATE - INTERVAL '${weeks} weeks'`))
+    .select(
+      db.raw("DATE_TRUNC('week', v.created_at) as week"),
+      db.raw('COUNT(*) as views')
+    )
+    .groupBy('week')
+    .orderBy('week');
+
+  return rows.map((r) => ({
+    week:
+      r.week instanceof Date ? r.week.toISOString().split('T')[0] : r.week,
+    views: parseInt(r.views, 10) || 0,
+  }));
+};
+
 module.exports = {
   getInstructorProfile,
   updateInstructorProfile,
   getDashboardStats,
+  getTutorialViewsByWeek,
 };

--- a/backend/tests/instructorDashboardRoutes.test.js
+++ b/backend/tests/instructorDashboardRoutes.test.js
@@ -6,6 +6,7 @@ jest.mock('../src/config/database', () => ({
 }));
 jest.mock('../src/modules/users/instructor/instructor.service', () => ({
   getDashboardStats: jest.fn(),
+  getTutorialViewsByWeek: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -28,6 +29,18 @@ describe('GET /api/users/instructor/dashboard-stats', () => {
     const res = await request(app).get('/api/users/instructor/dashboard-stats');
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mockStats);
-    expect(service.getDashboardStats).toHaveBeenCalled();
+  expect(service.getDashboardStats).toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/users/instructor/tutorial-views', () => {
+  it('returns tutorial view history', async () => {
+    const mockData = [{ week: '2024-01-01', views: 5 }];
+    service.getTutorialViewsByWeek.mockResolvedValue(mockData);
+
+    const res = await request(app).get('/api/users/instructor/tutorial-views');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mockData);
+    expect(service.getTutorialViewsByWeek).toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/dashboard/instructor/index.js
+++ b/frontend/src/pages/dashboard/instructor/index.js
@@ -23,17 +23,14 @@ import { Calendar, momentLocalizer } from "react-big-calendar";
 import moment from "moment";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import "tailwindcss/tailwind.css";
-import { fetchInstructorDashboardStats } from "@/services/instructor/instructorService";
+import {
+  fetchInstructorDashboardStats,
+  fetchInstructorTutorialViews,
+} from "@/services/instructor/instructorService";
 import { fetchInstructorScheduleEvents } from "@/services/instructor/classService";
 
 const localizer = momentLocalizer(moment);
 
-const mockChartData = [
-  { name: 'Week 1', views: 420 },
-  { name: 'Week 2', views: 620 },
-  { name: 'Week 3', views: 580 },
-  { name: 'Week 4', views: 760 },
-];
 
 const mockTutorials = [
   { id: 1, title: "React Basics", status: "Draft" },
@@ -85,7 +82,16 @@ export default function InstructorDashboard() {
       } catch (err) {
         console.error('Failed to load dashboard stats', err);
       }
-      setChartData(mockChartData);
+      try {
+        const views = await fetchInstructorTutorialViews();
+        const formatted = views.map((v, idx) => ({
+          name: `Week ${idx + 1}`,
+          views: v.views,
+        }));
+        setChartData(formatted);
+      } catch (err) {
+        console.error('Failed to load tutorial views', err);
+      }
     }
     loadStats();
     async function loadEvents() {

--- a/frontend/src/services/instructor/instructorService.js
+++ b/frontend/src/services/instructor/instructorService.js
@@ -92,3 +92,10 @@ export const fetchInstructorDashboardStats = async () => {
   const res = await api.get("/users/instructor/dashboard-stats");
   return res.data?.data;
 };
+
+export const fetchInstructorTutorialViews = async (weeks = 4) => {
+  const res = await api.get("/users/instructor/tutorial-views", {
+    params: { weeks },
+  });
+  return res.data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- add weekly tutorial view analytics backend API
- expose tutorial views route
- load tutorial view data on instructor dashboard
- support fetching tutorial views from frontend service
- test new route

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688305aed2d883288fcd87d0de51c963