### PR TITLE
Fix admin alerts page

### DIFF
--- a/frontend/src/pages/admin/alerts.js
+++ b/frontend/src/pages/admin/alerts.js
@@ -1,31 +1,20 @@
 // pages/admin/alerts.js
+import { useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
-
-const alerts = [
-  {
-    id: 1,
-    type: "License Violation",
-    message: "Unauthorized domain attempted to use the platform.",
-    time: "2025-04-14 08:15",
-    level: "Critical"
-  },
-  {
-    id: 2,
-    type: "Chat Flag",
-    message: "User 'guest123' used inappropriate language in class.",
-    time: "2025-04-14 10:42",
-    level: "Warning"
-  },
-  {
-    id: 3,
-    type: "System Notice",
-    message: "API key for payment gateway expiring soon.",
-    time: "2025-04-14 09:00",
-    level: "Info"
-  }
-];
+import withAuthProtection from "@/hooks/withAuthProtection";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import formatRelativeTime from "@/utils/relativeTime";
 
 function AdminAlertsPage() {
+  const alerts = useNotificationStore((state) => state.items);
+  const fetchAlerts = useNotificationStore((state) => state.fetch);
+  const startPolling = useNotificationStore((state) => state.startPolling);
+
+  useEffect(() => {
+    fetchAlerts();
+    startPolling();
+  }, [fetchAlerts, startPolling]);
+
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-6">🚨 Real-Time Alerts</h1>
@@ -45,14 +34,20 @@ function AdminAlertsPage() {
               <tr key={alert.id} className="border-b">
                 <td className="px-4 py-2 font-medium">{alert.type}</td>
                 <td className="px-4 py-2 text-gray-700">{alert.message}</td>
-                <td className="px-4 py-2">{alert.time}</td>
                 <td className="px-4 py-2">
-                  <span className={`px-2 py-1 rounded text-xs font-semibold ${
-                    alert.level === 'Critical' ? 'bg-red-100 text-red-600' :
-                    alert.level === 'Warning' ? 'bg-yellow-100 text-yellow-600' :
-                    'bg-blue-100 text-blue-600'
-                  }`}>
-                    {alert.level}
+                  {formatRelativeTime(alert.created_at || alert.time)}
+                </td>
+                <td className="px-4 py-2">
+                  <span
+                    className={`px-2 py-1 rounded text-xs font-semibold ${
+                      alert.level === 'Critical'
+                        ? 'bg-red-100 text-red-600'
+                        : alert.level === 'Warning'
+                        ? 'bg-yellow-100 text-yellow-600'
+                        : 'bg-blue-100 text-blue-600'
+                    }`}
+                  >
+                    {alert.level || 'Info'}
                   </span>
                 </td>
               </tr>
@@ -68,4 +63,4 @@ AdminAlertsPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
 
-export default AdminAlertsPage;
+export default withAuthProtection(AdminAlertsPage, ["admin", "superadmin"]);


### PR DESCRIPTION
## Summary
- load alerts from the notification API
- protect admin alerts page

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_688310b046fc832885f752eb10d214a9