### PR TITLE
Add mark as read buttons for message notifications

### DIFF
--- a/frontend/src/components/chat/ChatNotifications.js
+++ b/frontend/src/components/chat/ChatNotifications.js
@@ -1,11 +1,16 @@
 import { useEffect, useState } from "react";
 import { FaEnvelopeOpenText, FaUsers, FaBell } from "react-icons/fa";
-import { getNotifications } from "@/services/notificationService";
+import { getNotifications, markNotificationAsRead } from "@/services/notificationService";
 import formatRelativeTime from "@/utils/relativeTime";
 import LinkText from "@/components/shared/LinkText";
 
 const ChatNotifications = ({ users = [], groups = [], setSelectedChat, userId = 1 }) => {
   const [systemNotifs, setSystemNotifs] = useState([]);
+
+  const handleMarkRead = (id) => {
+    markNotificationAsRead(id).catch(() => {});
+    setSystemNotifs((prev) => prev.filter((n) => n.id !== id));
+  };
 
   useEffect(() => {
     if (!userId) return;
@@ -42,9 +47,17 @@ const ChatNotifications = ({ users = [], groups = [], setSelectedChat, userId = 
           <h4 className="text-yellow-400 font-semibold mt-4">System Alerts</h4>
           <ul className="space-y-2">
             {systemNotifs.map((n) => (
-              <li key={n.id} className="bg-gray-700 p-3 rounded-lg border-l-4 border-yellow-500">
-                <div className="text-sm"><LinkText text={n.message} /></div>
-                <div className="text-xs text-gray-400">{formatRelativeTime(n.timestamp)}</div>
+              <li key={n.id} className="bg-gray-700 p-3 rounded-lg border-l-4 border-yellow-500 flex justify-between items-start">
+                <div>
+                  <div className="text-sm"><LinkText text={n.message} /></div>
+                  <div className="text-xs text-gray-400">{formatRelativeTime(n.timestamp)}</div>
+                </div>
+                <button
+                  onClick={() => handleMarkRead(n.id)}
+                  className="ml-2 text-xs bg-blue-500 text-white px-2 py-1 rounded hover:bg-blue-600"
+                >
+                  Mark as Read
+                </button>
               </li>
             ))}
           </ul>

--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -212,14 +212,23 @@ export default function Header() {
                   {messages.slice(0, 10).map((m) => (
                     <li
                       key={m.id}
-                      onClick={() => markMessageRead(m.id)}
-                      className={`px-4 py-2 cursor-pointer transition ${
+                      className={`flex justify-between items-center px-4 py-2 transition ${
                         m.read
                           ? "text-gray-500 bg-gray-50 dark:bg-gray-700"
                           : "bg-yellow-50 dark:bg-gray-600"
                       }`}
                     >
-                      {m.message}
+                      <span className="mr-2 flex-1">{m.message}</span>
+                      {!m.read ? (
+                        <button
+                          onClick={() => markMessageRead(m.id)}
+                          className="ml-auto text-xs bg-blue-500 text-white px-2 py-1 rounded hover:bg-blue-600"
+                        >
+                          {t('mark_as_read', 'Mark as Read')}
+                        </button>
+                      ) : (
+                        <span className="text-xs text-gray-400">Read</span>
+                      )}
                     </li>
                   ))}
                   {messages.length === 0 && (
@@ -271,14 +280,14 @@ export default function Header() {
                       }`}
                     >
                       <LinkText text={n.message} />
-                      {!n.read && (
-                        <button
-                          onClick={() => markRead(n.id)}
-                          className="text-xs text-blue-600 hover:underline ml-2"
-                        >
-                          Mark as Read
-                        </button>
-                      )}
+                        {!n.read && (
+                          <button
+                            onClick={() => markRead(n.id)}
+                            className="ml-2 text-xs bg-blue-500 text-white px-2 py-1 rounded hover:bg-blue-600"
+                          >
+                            Mark as Read
+                          </button>
+                        )}
                     </li>
                   ))}
                   {notifications.length === 0 && (

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -236,14 +236,20 @@ const Navbar = () => {
                     {messages.slice(0, 10).map((msg) => (
                       <li
                         key={msg.id}
-                        onClick={() => markMessageRead(msg.id)}
-                        className={`flex justify-between items-center p-2 rounded-md cursor-pointer transition ${
+                        className={`flex justify-between items-center p-2 rounded-md transition ${
                           msg.read ? "text-gray-400 bg-gray-50" : "bg-yellow-50"
                         }`}
                       >
-                        <span>{msg.message}</span>
-                        {!msg.read && (
-                          <span className="ml-2 text-xs text-red-500">{t('new')}</span>
+                        <span className="mr-2 flex-1">{msg.message}</span>
+                        {!msg.read ? (
+                          <button
+                            onClick={() => markMessageRead(msg.id)}
+                            className="ml-auto text-xs bg-blue-500 text-white px-2 py-1 rounded hover:bg-blue-600"
+                          >
+                            {t('mark_as_read', 'Mark as Read')}
+                          </button>
+                        ) : (
+                          <span className="text-xs text-gray-400">Read</span>
                         )}
                       </li>
                     ))}
@@ -300,7 +306,7 @@ const Navbar = () => {
                         {!note.read && (
                           <button
                             onClick={() => markRead(note.id)}
-                            className="ml-2 text-xs text-blue-600 hover:underline"
+                            className="ml-2 text-xs bg-blue-500 text-white px-2 py-1 rounded hover:bg-blue-600"
                           >
                             {t('mark_as_read', 'Mark as Read')}
                           </button>


### PR DESCRIPTION
## Summary
- add mark-as-read handler in ChatNotifications
- show Mark as Read buttons for message notifications
- style notification buttons consistently

## Testing
- `npm test` in `backend`
- `npm install` and `npm test` in `frontend`
- `npm run lint` in `frontend` *(fails: 50 errors, 194 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6883184db0f083289c086428019ebb5f