### PR TITLE
Add system error log page

### DIFF
--- a/backend/logs/error.log
+++ b/backend/logs/error.log
@@ -1,0 +1,5 @@
+2023-01-01T00:00:00Z [ERROR] Example system failure
+2023-01-02T00:00:00Z [WARN] Example warning
+2025-07-25T07:37:28.580Z [ERROR] ❌ 400 - Invalid or expired OTP
+2025-07-25T07:37:28.580Z [ERROR] ❌ 404 - Email not found
+2025-07-25T07:37:28.600Z [ERROR] ❌ 400 - Invalid or expired OTP

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -21,6 +21,7 @@ module.exports = (err, req, res, next) => {
     if (err.code === 'LIMIT_FILE_SIZE') message = 'File too large';
   }
 
-  console.error(`❌ ${status} - ${message}`);
+  const logger = require("../utils/logger");
+  logger.error(`❌ ${status} - ${message}`);
   res.status(status).json({ message });
 };

--- a/backend/src/modules/errorLogs/errorLogs.controller.js
+++ b/backend/src/modules/errorLogs/errorLogs.controller.js
@@ -1,0 +1,8 @@
+const catchAsync = require('../../utils/catchAsync');
+const { sendSuccess } = require('../../utils/response');
+const service = require('./errorLogs.service');
+
+exports.list = catchAsync(async (_req, res) => {
+  const logs = await service.getRecentErrors();
+  sendSuccess(res, logs);
+});

--- a/backend/src/modules/errorLogs/errorLogs.routes.js
+++ b/backend/src/modules/errorLogs/errorLogs.routes.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const controller = require('./errorLogs.controller');
+const { verifyToken, isAdmin } = require('../../middleware/auth/authMiddleware');
+
+router.use(verifyToken, isAdmin);
+router.get('/', controller.list);
+
+module.exports = router;

--- a/backend/src/modules/errorLogs/errorLogs.service.js
+++ b/backend/src/modules/errorLogs/errorLogs.service.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_FILE = path.join(__dirname, '../../../logs/error.log');
+
+exports.getRecentErrors = async (limit = 50) => {
+  try {
+    const data = fs.readFileSync(LOG_FILE, 'utf8');
+    const lines = data.trim().split('\n');
+    const recent = lines.slice(-limit).map((line, idx) => {
+      const [timePart, levelPart, ...rest] = line.split(' ');
+      const level = levelPart ? levelPart.replace(/\[|\]/g, '') : 'INFO';
+      const message = rest.join(' ');
+      return {
+        id: idx,
+        time: new Date(timePart).toISOString(),
+        level,
+        message,
+        type: 'system',
+      };
+    });
+    return recent.reverse();
+  } catch (err) {
+    return [];
+  }
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -110,6 +110,7 @@ app.use("/api/instructors", require("./modules/instructors/instructor.routes"));
 app.use("/api/students", require("./modules/students/student.routes"));
 app.use("/api/cart", require("./modules/cart/cart.routes"));
 app.use("/api/notifications", require("./modules/notifications/notifications.routes"));
+app.use("/api/system-errors", require("./modules/errorLogs/errorLogs.routes"));
 app.use("/api/messages", require("./modules/messages/messages.routes"));
 app.use("/api/chat", require("./modules/chat/chat.routes"));
 app.use("/api/languages", require("./modules/languages/languages.routes"));

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -1,6 +1,34 @@
 // 📁 src/utils/logger.js
+const fs = require("fs");
+const path = require("path");
+
+const LOG_DIR = path.join(__dirname, "../../logs");
+const LOG_FILE = path.join(LOG_DIR, "error.log");
+
+if (!fs.existsSync(LOG_DIR)) {
+  fs.mkdirSync(LOG_DIR);
+}
+
+function append(type, args) {
+  const line = `${new Date().toISOString()} [${type}] ${args.join(" ")}\n`;
+  try {
+    fs.appendFileSync(LOG_FILE, line);
+  } catch (_) {
+    // fail silently
+  }
+}
+
 module.exports = {
-  log: (...args) => console.log("[LOG]", ...args),
-  warn: (...args) => console.warn("[WARN]", ...args),
-  error: (...args) => console.error("[ERROR]", ...args),
+  log: (...args) => {
+    append("INFO", args);
+    console.log("[LOG]", ...args);
+  },
+  warn: (...args) => {
+    append("WARN", args);
+    console.warn("[WARN]", ...args);
+  },
+  error: (...args) => {
+    append("ERROR", args);
+    console.error("[ERROR]", ...args);
+  },
 };

--- a/frontend/src/pages/admin/alerts.js
+++ b/frontend/src/pages/admin/alerts.js
@@ -2,18 +2,16 @@
 import { useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
-import useNotificationStore from "@/store/notifications/notificationStore";
+import useErrorLogStore from "@/store/errorLogs/errorLogStore";
 import formatRelativeTime from "@/utils/relativeTime";
 
 function AdminAlertsPage() {
-  const alerts = useNotificationStore((state) => state.items);
-  const fetchAlerts = useNotificationStore((state) => state.fetch);
-  const startPolling = useNotificationStore((state) => state.startPolling);
+  const logs = useErrorLogStore((state) => state.logs);
+  const fetchLogs = useErrorLogStore((state) => state.fetch);
 
   useEffect(() => {
-    fetchAlerts();
-    startPolling();
-  }, [fetchAlerts, startPolling]);
+    fetchLogs();
+  }, [fetchLogs]);
 
   return (
     <div className="p-6">
@@ -30,24 +28,24 @@ function AdminAlertsPage() {
             </tr>
           </thead>
           <tbody>
-            {alerts.map((alert) => (
-              <tr key={alert.id} className="border-b">
-                <td className="px-4 py-2 font-medium">{alert.type}</td>
-                <td className="px-4 py-2 text-gray-700">{alert.message}</td>
+            {logs.map((log) => (
+              <tr key={log.id} className="border-b">
+                <td className="px-4 py-2 font-medium">{log.type}</td>
+                <td className="px-4 py-2 text-gray-700">{log.message}</td>
                 <td className="px-4 py-2">
-                  {formatRelativeTime(alert.created_at || alert.time)}
+                  {formatRelativeTime(log.time)}
                 </td>
                 <td className="px-4 py-2">
                   <span
                     className={`px-2 py-1 rounded text-xs font-semibold ${
-                      alert.level === 'Critical'
+                      log.level === 'ERROR'
                         ? 'bg-red-100 text-red-600'
-                        : alert.level === 'Warning'
+                        : log.level === 'WARN'
                         ? 'bg-yellow-100 text-yellow-600'
                         : 'bg-blue-100 text-blue-600'
                     }`}
                   >
-                    {alert.level || 'Info'}
+                    {log.level}
                   </span>
                 </td>
               </tr>

--- a/frontend/src/services/errorLogService.js
+++ b/frontend/src/services/errorLogService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const getSystemErrors = async () => {
+  const res = await api.get("/system-errors");
+  return res.data.data || res.data;
+};

--- a/frontend/src/store/errorLogs/errorLogStore.js
+++ b/frontend/src/store/errorLogs/errorLogStore.js
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+import { getSystemErrors } from "@/services/errorLogService";
+
+const useErrorLogStore = create((set) => ({
+  logs: [],
+  loading: false,
+  fetch: async () => {
+    set({ loading: true });
+    try {
+      const data = await getSystemErrors();
+      set({ logs: data, loading: false });
+    } catch (err) {
+      set({ loading: false });
+    }
+  },
+}));
+
+export default useErrorLogStore;


### PR DESCRIPTION
## Summary
- log server errors to `logs/error.log`
- expose a `/api/system-errors` endpoint for admins
- show error logs on `/admin/alerts`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883331c2bc88328a3a405a55e65f4aa