### PR TITLE
Fix next-i18next config imports

### DIFF
--- a/frontend/src/pages/admin/payments/index.js
+++ b/frontend/src/pages/admin/payments/index.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { fetchMethods } from '@/services/admin/paymentMethodService';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import nextI18NextConfig from '../../../next-i18next.config.js';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
 
 export default function AdminPaymentsPage() {
   const { t } = useTranslation('dashboard');

--- a/frontend/src/pages/dashboard/admin/payments/methods/create.js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/create.js
@@ -5,7 +5,7 @@ import { FaSave, FaArrowLeft } from "react-icons/fa";
 import { createMethod } from "@/services/admin/paymentMethodService";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 export default function CreatePaymentMethodPage() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- correct relative import paths for `next-i18next.config.js`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883339fbda08328a8643c700c2f8e8e