### PR TITLE
Fix next-i18next config path

### DIFF
--- a/frontend/src/pages/admin/payments/index.js
+++ b/frontend/src/pages/admin/payments/index.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { fetchMethods } from '@/services/admin/paymentMethodService';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import nextI18NextConfig from '../../../next-i18next.config.js';
+import nextI18NextConfig from '../../../../next-i18next.config.js';
 
 export default function AdminPaymentsPage() {
   const { t } = useTranslation('dashboard');

--- a/frontend/src/pages/dashboard/admin/payments/methods/create.js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/create.js
@@ -11,7 +11,7 @@ import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 const useAdminNotice = () => {
   const user = useAuthStore((state) => state.user);


### PR DESCRIPTION
## Summary
- correct next-i18next config import paths for admin payment pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68833bd9bd1c8328b0bdb1f614a9d369