### PR TITLE
Fix admin alert page syntax

### DIFF
--- a/frontend/src/pages/admin/alerts.js
+++ b/frontend/src/pages/admin/alerts.js
@@ -6,7 +6,7 @@ import useErrorLogStore from "@/store/errorLogs/errorLogStore";
 import formatRelativeTime from "@/utils/relativeTime";
 
 function AdminAlertsPage() {
-  const logs = useErrorLogStore((state) => s
+  const logs = useErrorLogStore((state) => state.logs);
   const fetchLogs = useErrorLogStore((state) => state.fetch);
   const startPolling = useErrorLogStore((state) => state.startPolling);
   const stopPolling = useErrorLogStore((state) => state.stopPolling);


### PR DESCRIPTION
## Summary
- resolve syntax error in `AdminAlertsPage`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883408c63448328b9be359be7d6820a