### PR TITLE
Add pagination and improved actions in languages admin

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/languages/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/index.js
@@ -3,12 +3,16 @@ import Link from "next/link";
 import useSWR from "swr";
 import api from "@/services/api/api";
 import { useRouter } from "next/router";
+import { useState } from "react";
+import { FaEdit, FaTrashAlt } from "react-icons/fa";
 
 const fetcher = url => api.get(url).then(res => res.data.data);
 
 export default function LanguagesPage() {
   const router = useRouter();
   const { data: languages, mutate } = useSWR("/languages", fetcher);
+  const [currentPage, setCurrentPage] = useState(1);
+  const ITEMS_PER_PAGE = 5;
 
   const toggleActive = async (lang) => {
     await api.put(`/languages/${lang.id}`, { ...lang, is_active: !lang.is_active });
@@ -26,6 +30,12 @@ export default function LanguagesPage() {
       mutate();
     }
   };
+
+  const totalPages = Math.ceil((languages?.length || 0) / ITEMS_PER_PAGE);
+  const paginated = languages?.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  );
 
   return (
     <AdminLayout>
@@ -47,7 +57,7 @@ export default function LanguagesPage() {
             </tr>
           </thead>
           <tbody>
-            {languages?.map((lang) => (
+            {paginated?.map((lang) => (
               <tr key={lang.id} className="border-t">
                 <td className="p-3">
                   {lang.icon_url && (
@@ -67,13 +77,46 @@ export default function LanguagesPage() {
                   <input type="checkbox" checked={lang.is_active} onChange={() => toggleActive(lang)} />
                 </td>
                 <td className="p-3 space-x-2">
-                  <button onClick={() => router.push(`/dashboard/admin/settings/languages/edit/${lang.code}`)} className="text-blue-600">Edit</button>
-                  <button onClick={() => remove(lang.id)} className="text-red-600">Delete</button>
+                  <button
+                    onClick={() => router.push(`/dashboard/admin/settings/languages/edit/${lang.code}`)}
+                    className="inline-flex items-center gap-1 px-2 py-1 border border-blue-500 text-blue-600 hover:bg-blue-50 rounded-md transition text-sm"
+                  >
+                    <FaEdit className="text-xs" /> Edit
+                  </button>
+                  <button
+                    onClick={() => remove(lang.id)}
+                    className="inline-flex items-center gap-1 px-2 py-1 border border-red-500 text-red-600 hover:bg-red-50 rounded-md transition text-sm"
+                  >
+                    <FaTrashAlt className="text-xs" /> Delete
+                  </button>
                 </td>
               </tr>
             ))}
           </tbody>
         </table>
+        {totalPages > 1 && (
+          <div className="flex justify-center mt-4 gap-3">
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))}
+              disabled={currentPage === 1}
+              className="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded disabled:opacity-50"
+            >
+              Previous
+            </button>
+            <span className="px-4 py-2 text-sm text-gray-600">
+              Page {currentPage} of {totalPages}
+            </span>
+            <button
+              onClick={() =>
+                setCurrentPage((p) => (p < totalPages ? p + 1 : p))
+              }
+              disabled={currentPage >= totalPages}
+              className="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        )}
       </div>
     </AdminLayout>
   );


### PR DESCRIPTION
## Summary
- paginate the languages list on the admin settings page
- style edit and delete actions as buttons

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_6883c84cc0a48328b06b7354a2a78cb3