### PR TITLE
Enable admin class student pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
@@ -3,8 +3,9 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchClassStudent } from "@/services/admin/classService";
+import withAuthProtection from "@/hooks/withAuthProtection";
 
-export default function ManageStudentInClassPage() {
+function ManageStudentInClassPage() {
   const { id, studentId } = useRouter().query;
 
   const [student, setStudent] = useState(null);
@@ -104,3 +105,12 @@ export default function ManageStudentInClassPage() {
 ManageStudentInClassPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+const ProtectedManageStudentInClassPage = withAuthProtection(
+  ManageStudentInClassPage,
+  ["admin", "superadmin", "instructor"]
+);
+
+ProtectedManageStudentInClassPage.getLayout = ManageStudentInClassPage.getLayout;
+
+export default ProtectedManageStudentInClassPage;

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
@@ -1,9 +1,11 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchClassStudents } from "@/services/admin/classService";
+import withAuthProtection from "@/hooks/withAuthProtection";
 
-export default function ClassStudentsPage() {
+function ClassStudentsPage() {
   const { id } = useRouter().query;
   const [students, setStudents] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -51,13 +53,18 @@ export default function ClassStudentsPage() {
             <tbody>
               {students.map((stu) => (
                 <tr key={stu.id} className="odd:bg-white even:bg-gray-50">
-
-                  <td className="border p-2">{stu.full_name}</td>
+                  <td className="border p-2">
+                    <Link
+                      href={`/dashboard/admin/online-classes/${id}/students/${stu.id}`}
+                      className="text-blue-600 hover:underline"
+                    >
+                      {stu.full_name}
+                    </Link>
+                  </td>
                   <td className="border p-2">{stu.email}</td>
                   <td className="border p-2 text-center">{stu.status}</td>
                   <td className="border p-2 text-center">
                     {new Date(stu.enrolled_at).toLocaleDateString()}
-
                   </td>
                 </tr>
               ))}
@@ -72,3 +79,13 @@ export default function ClassStudentsPage() {
 ClassStudentsPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+const ProtectedClassStudentsPage = withAuthProtection(ClassStudentsPage, [
+  "admin",
+  "superadmin",
+  "instructor",
+]);
+
+ProtectedClassStudentsPage.getLayout = ClassStudentsPage.getLayout;
+
+export default ProtectedClassStudentsPage;


### PR DESCRIPTION
## Summary
- secure admin class student pages with auth wrapper
- link each student to detail page

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883ceef8ca88328bc72f35b1d5ccf38