### PR TITLE
Enable admin class student pages

### DIFF
--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -60,12 +60,14 @@ router.get(
   isInstructorOrAdmin,
   controller.getClassAnalytics
 );
+// List students enrolled in a specific class
 router.get(
   "/admin/:id/students",
   verifyToken,
   isInstructorOrAdmin,
   enrollmentCtrl.getStudentsByClass
 );
+// Fetch details for a single student's enrollment
 router.get(
   "/admin/:classId/students/:studentId",
   verifyToken,

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -1,3 +1,4 @@
+// Controller for class enrollment operations
 const { v4: uuidv4 } = require("uuid");
 const catchAsync = require("../../../utils/catchAsync");
 const { sendSuccess } = require("../../../utils/response");

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -331,6 +331,21 @@
     "preview": "Preview",
     "download": "Download"
   },
+  "classStudentsPage": {
+    "title": "Enrolled Students",
+    "no_students": "No students enrolled.",
+    "status": "Status",
+    "date_joined": "Date Joined",
+    "back_to_class": "Back to Class"
+  },
+  "studentDetailPage": {
+    "title": "Student Overview",
+    "issue_certificate": "Issue Certificate",
+    "add_note": "Add Note",
+    "edit_attendance": "Edit Attendance",
+    "back_to_list": "Back to Student List",
+    "student_not_found": "Student not found"
+  },
   "sidebar": {
     "Account": "\u0627\u0644\u062d\u0633\u0627\u0628",
     "Bookings": "\u0627\u0644\u062d\u062c\u0648\u0632\u0627\u062a",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -313,6 +313,21 @@
     "preview": "Preview",
     "download": "Download"
   },
+  "classStudentsPage": {
+    "title": "Enrolled Students",
+    "no_students": "No students enrolled.",
+    "status": "Status",
+    "date_joined": "Date Joined",
+    "back_to_class": "Back to Class"
+  },
+  "studentDetailPage": {
+    "title": "Student Overview",
+    "issue_certificate": "Issue Certificate",
+    "add_note": "Add Note",
+    "edit_attendance": "Edit Attendance",
+    "back_to_list": "Back to Student List",
+    "student_not_found": "Student not found"
+  },
   "sidebar": {
       "Account": "Konto",
       "Bookings": "Buchungen",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -331,6 +331,21 @@
     "preview": "Preview",
     "download": "Download"
   },
+  "classStudentsPage": {
+    "title": "Enrolled Students",
+    "no_students": "No students enrolled.",
+    "status": "Status",
+    "date_joined": "Date Joined",
+    "back_to_class": "Back to Class"
+  },
+  "studentDetailPage": {
+    "title": "Student Overview",
+    "issue_certificate": "Issue Certificate",
+    "add_note": "Add Note",
+    "edit_attendance": "Edit Attendance",
+    "back_to_list": "Back to Student List",
+    "student_not_found": "Student not found"
+  },
   "sidebar": {
     "Account": "Account",
     "Bookings": "Bookings",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -313,6 +313,21 @@
     "preview": "Preview",
     "download": "Download"
   },
+  "classStudentsPage": {
+    "title": "Enrolled Students",
+    "no_students": "No students enrolled.",
+    "status": "Status",
+    "date_joined": "Date Joined",
+    "back_to_class": "Back to Class"
+  },
+  "studentDetailPage": {
+    "title": "Student Overview",
+    "issue_certificate": "Issue Certificate",
+    "add_note": "Add Note",
+    "edit_attendance": "Edit Attendance",
+    "back_to_list": "Back to Student List",
+    "student_not_found": "Student not found"
+  },
   "sidebar": {
     "Account": "Cuenta",
     "Bookings": "Reservas",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -320,6 +320,21 @@
     "preview": "Preview",
     "download": "Download"
   },
+  "classStudentsPage": {
+    "title": "Enrolled Students",
+    "no_students": "No students enrolled.",
+    "status": "Status",
+    "date_joined": "Date Joined",
+    "back_to_class": "Back to Class"
+  },
+  "studentDetailPage": {
+    "title": "Student Overview",
+    "issue_certificate": "Issue Certificate",
+    "add_note": "Add Note",
+    "edit_attendance": "Edit Attendance",
+    "back_to_list": "Back to Student List",
+    "student_not_found": "Student not found"
+  },
   "sidebar": {
     "Account": "Compte",
     "Bookings": "Réservations",

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
@@ -1,11 +1,18 @@
 // pages/dashboard/admin/online-classes/[id]/students/[studentId].js
+// Admin page showing details for a single student's enrollment
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
+import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchClassStudent } from "@/services/admin/classService";
+import withAuthProtection from "@/hooks/withAuthProtection";
 
-export default function ManageStudentInClassPage() {
+function ManageStudentInClassPage() {
   const { id, studentId } = useRouter().query;
+  const { t, i18n } = useTranslation('dashboard');
 
   const [student, setStudent] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -26,18 +33,29 @@ export default function ManageStudentInClassPage() {
   }, [id, studentId]);
 
   if (loading) {
-    return <div className="p-6">Loading...</div>;
+    return <div className="p-6">{t('loading')}</div>;
   }
 
   if (!student) {
-    return <div className="p-6">Student not found.</div>;
+    return <div className="p-6">{t('studentDetailPage.student_not_found')}</div>;
   }
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold text-gray-800">
-        🧑‍🎓 Student Overview: {student.name}
-      </h1>
+    <div className="p-6 space-y-6" dir={i18n.dir()}>
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold text-gray-800">
+          🧑‍🎓 {t('studentDetailPage.title')}: {student.name}
+        </h1>
+        <Link
+          href={`/dashboard/admin/online-classes/${id}/students`}
+          className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clipRule="evenodd" />
+          </svg>
+          {t('studentDetailPage.back_to_list')}
+        </Link>
+      </div>
       <div className="bg-white shadow rounded-xl p-6 border space-y-6">
         <div className="grid md:grid-cols-2 gap-6">
           <div>
@@ -87,13 +105,13 @@ export default function ManageStudentInClassPage() {
 
         <div className="pt-4 flex gap-3">
           <button className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 text-sm">
-            🎓 Issue Certificate
+            🎓 {t('studentDetailPage.issue_certificate')}
           </button>
           <button className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm">
-            ➕ Add Note
+            ➕ {t('studentDetailPage.add_note')}
           </button>
           <button className="bg-yellow-500 text-white px-4 py-2 rounded hover:bg-yellow-600 text-sm">
-            ✏️ Edit Attendance
+            ✏️ {t('studentDetailPage.edit_attendance')}
           </button>
         </div>
       </div>
@@ -104,3 +122,20 @@ export default function ManageStudentInClassPage() {
 ManageStudentInClassPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+const ProtectedManageStudentInClassPage = withAuthProtection(
+  ManageStudentInClassPage,
+  ["admin", "superadmin", "instructor"]
+);
+
+ProtectedManageStudentInClassPage.getLayout = ManageStudentInClassPage.getLayout;
+
+export default ProtectedManageStudentInClassPage;
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common', 'dashboard'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
@@ -1,10 +1,17 @@
+// Admin page listing students enrolled in a specific class
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchClassStudents } from "@/services/admin/classService";
+import withAuthProtection from "@/hooks/withAuthProtection";
 
-export default function ClassStudentsPage() {
+function ClassStudentsPage() {
   const { id } = useRouter().query;
+  const { t, i18n } = useTranslation('dashboard');
   const [students, setStudents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -27,14 +34,27 @@ export default function ClassStudentsPage() {
   }, [id]);
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold text-gray-800">Enrolled Students</h1>
+    <div className="p-6 space-y-6" dir={i18n.dir()}>
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold text-gray-800">
+          {t('classStudentsPage.title')}
+        </h1>
+        <Link
+          href={`/dashboard/admin/online-classes/${id}`}
+          className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clipRule="evenodd" />
+          </svg>
+          {t('classStudentsPage.back_to_class')}
+        </Link>
+      </div>
       {loading ? (
-        <p>Loading...</p>
+        <p>{t('loading')}</p>
       ) : error ? (
         <p className="text-red-600">{error}</p>
       ) : students.length === 0 ? (
-        <p>No students enrolled.</p>
+        <p>{t('classStudentsPage.no_students')}</p>
       ) : (
         <div className="overflow-x-auto">
 
@@ -42,22 +62,27 @@ export default function ClassStudentsPage() {
             <thead className="bg-gray-50">
 
               <tr>
-                <th className="border p-2 text-left">Name</th>
-                <th className="border p-2 text-left">Email</th>
-                <th className="border p-2">Status</th>
-                <th className="border p-2">Date Joined</th>
+                <th className="border p-2 text-left">{t('instructorDashboardPage.name')}</th>
+                <th className="border p-2 text-left">{t('instructorDashboardPage.email')}</th>
+                <th className="border p-2">{t('classStudentsPage.status')}</th>
+                <th className="border p-2">{t('classStudentsPage.date_joined')}</th>
               </tr>
             </thead>
             <tbody>
               {students.map((stu) => (
                 <tr key={stu.id} className="odd:bg-white even:bg-gray-50">
-
-                  <td className="border p-2">{stu.full_name}</td>
+                  <td className="border p-2">
+                    <Link
+                      href={`/dashboard/admin/online-classes/${id}/students/${stu.id}`}
+                      className="text-blue-600 hover:underline"
+                    >
+                      {stu.full_name}
+                    </Link>
+                  </td>
                   <td className="border p-2">{stu.email}</td>
                   <td className="border p-2 text-center">{stu.status}</td>
                   <td className="border p-2 text-center">
                     {new Date(stu.enrolled_at).toLocaleDateString()}
-
                   </td>
                 </tr>
               ))}
@@ -72,3 +97,21 @@ export default function ClassStudentsPage() {
 ClassStudentsPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+const ProtectedClassStudentsPage = withAuthProtection(ClassStudentsPage, [
+  "admin",
+  "superadmin",
+  "instructor",
+]);
+
+ProtectedClassStudentsPage.getLayout = ClassStudentsPage.getLayout;
+
+export default ProtectedClassStudentsPage;
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common', 'dashboard'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -97,11 +97,13 @@ export const rejectAdminClass = async (id, reason) => {
   return data?.data;
 };
 
+// Retrieve all students registered for a class
 export const fetchClassStudents = async (id) => {
   const { data } = await api.get(`/users/classes/admin/${id}/students`);
   return data?.data ?? [];
 };
 
+// Get enrollment details for a specific student
 export const fetchClassStudent = async (classId, studentId) => {
   const { data } = await api.get(
     `/users/classes/admin/${classId}/students/${studentId}`


### PR DESCRIPTION
## Summary
- secure admin class student pages with auth wrapper
- link each student to detail page
- add back buttons and i18n translations
- document backend routes and API helpers

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883ceef8ca88328bc72f35b1d5ccf38