### PR TITLE
Add streaming endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Endpoints for creating and managing live classes are served under `/api/users/cl
 
 For an overview of the student purchase and enrollment process see [docs/student-enrollment-workflow.md](docs/student-enrollment-workflow.md).
 
+## Media streaming
+
+Large videos under `/uploads` can be streamed efficiently using `GET /api/media/:filename`.
+This endpoint supports HTTP range requests so media plays smoothly even for big files.
+
 ## Student helper class
 
 The backend contains a small utility class `Student` located at

--- a/backend/src/modules/media/media.controller.js
+++ b/backend/src/modules/media/media.controller.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const mime = require('mime-types');
+
+exports.stream = (req, res) => {
+  const filePath = path.join(__dirname, '../../../uploads', req.params.filename);
+  fs.stat(filePath, (err, stats) => {
+    if (err || !stats.isFile()) {
+      return res.status(404).json({ message: 'File not found' });
+    }
+
+    const range = req.headers.range;
+    const contentType = mime.lookup(filePath) || 'application/octet-stream';
+
+    if (!range) {
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Length', stats.size);
+      res.setHeader('Cache-Control', 'public, max-age=3600');
+      return fs.createReadStream(filePath).pipe(res);
+    }
+
+    const positions = range.replace(/bytes=/, '').split('-');
+    const start = parseInt(positions[0], 10);
+    const end = positions[1] ? parseInt(positions[1], 10) : stats.size - 1;
+
+    if (start >= stats.size || end >= stats.size) {
+      res.status(416).setHeader('Content-Range', `bytes */${stats.size}`);
+      return res.end();
+    }
+
+    const chunkSize = end - start + 1;
+    res.writeHead(206, {
+      'Content-Range': `bytes ${start}-${end}/${stats.size}`,
+      'Accept-Ranges': 'bytes',
+      'Content-Length': chunkSize,
+      'Content-Type': contentType,
+      'Cache-Control': 'public, max-age=3600',
+    });
+
+    fs.createReadStream(filePath, { start, end }).pipe(res);
+  });
+};

--- a/backend/src/modules/media/media.routes.js
+++ b/backend/src/modules/media/media.routes.js
@@ -1,0 +1,6 @@
+const router = require('express').Router();
+const controller = require('./media.controller');
+
+router.get('/:filename', controller.stream);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -116,6 +116,7 @@ app.use("/api/chat", require("./modules/chat/chat.routes"));
 app.use("/api/languages", require("./modules/languages/languages.routes"));
 app.use("/api/currencies", require("./modules/currencies/currencies.routes"));
 app.use("/api/blog", require("./modules/blog/blog.routes"));
+app.use("/api/media", require("./modules/media/media.routes"));
 
 app.get("/", (req, res) => res.send("🚀 SkillBridge API is live."));
 


### PR DESCRIPTION
## Summary
- create media module with controller and routes
- support HTTP range streaming for uploaded videos
- document `/api/media/:filename` endpoint
- wire module into server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883cf962e588328b022df38f15eb725