### PR TITLE
Connect admin assignments page to backend

### DIFF
--- a/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
+++ b/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
@@ -13,6 +13,7 @@ jest.mock('../../../../config/database', () => {
 
 jest.mock('../classAssignment.service', () => ({
   getByClass: jest.fn(),
+  getAllAssignments: jest.fn(),
   createAssignment: jest.fn(),
   updateAssignment: jest.fn(),
   deleteAssignment: jest.fn(),
@@ -51,6 +52,14 @@ describe('Class assignment routes', () => {
     const list = [{ id: '1' }];
     service.getByClass.mockResolvedValue(list);
     const res = await request(app).get('/classes/assignments/class/abc');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual(list);
+  });
+
+  test('get all assignments', async () => {
+    const list = [{ id: '1' }];
+    service.getAllAssignments.mockResolvedValue(list);
+    const res = await request(app).get('/classes/assignments/admin');
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toEqual(list);
   });

--- a/backend/src/modules/classes/assignments/classAssignment.controller.js
+++ b/backend/src/modules/classes/assignments/classAssignment.controller.js
@@ -50,3 +50,8 @@ exports.deleteAssignment = catchAsync(async (req, res) => {
   await service.deleteAssignment(req.params.assignmentId);
   sendSuccess(res, null, "Assignment deleted");
 });
+
+exports.getAllAssignments = catchAsync(async (_req, res) => {
+  const assignments = await service.getAllAssignments();
+  sendSuccess(res, assignments);
+});

--- a/backend/src/modules/classes/assignments/classAssignment.routes.js
+++ b/backend/src/modules/classes/assignments/classAssignment.routes.js
@@ -2,6 +2,7 @@ const router = require("express").Router();
 const ctrl = require("./classAssignment.controller");
 const { verifyToken, isInstructorOrAdmin } = require("../../../middleware/auth/authMiddleware");
 
+router.get("/admin", verifyToken, isInstructorOrAdmin, ctrl.getAllAssignments);
 router.get("/class/:classId", ctrl.getAssignmentsByClass);
 router.post("/class/:classId", verifyToken, isInstructorOrAdmin, ctrl.createAssignment);
 router.put("/:assignmentId", verifyToken, isInstructorOrAdmin, ctrl.updateAssignment);

--- a/backend/src/modules/classes/assignments/classAssignment.service.js
+++ b/backend/src/modules/classes/assignments/classAssignment.service.js
@@ -17,3 +17,19 @@ exports.updateAssignment = async (id, data) => {
 exports.deleteAssignment = async (id) => {
   return db("class_assignments").where({ id }).del();
 };
+
+exports.getAllAssignments = async () => {
+  return db("class_assignments as a")
+    .leftJoin("online_classes as c", "a.class_id", "c.id")
+    .leftJoin("users as u", "c.instructor_id", "u.id")
+    .select(
+      "a.id",
+      "a.title",
+      "a.description",
+      "a.due_date",
+      "a.class_id",
+      "c.title as class_title",
+      "u.full_name as instructor"
+    )
+    .orderBy("a.created_at", "desc");
+};

--- a/frontend/src/pages/dashboard/admin/assignments/index.js
+++ b/frontend/src/pages/dashboard/admin/assignments/index.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaSearch, FaSync, FaEye, FaTrash, FaCheckCircle, FaTimesCircle, FaEdit } from 'react-icons/fa';
+import { fetchAllAssignments } from '@/services/admin/assignmentService';
 
 export default function AdminAssignmentsPage() {
   const [assignments, setAssignments] = useState([]);
@@ -10,27 +11,25 @@ export default function AdminAssignmentsPage() {
   const [filterStatus, setFilterStatus] = useState('all');
 
   useEffect(() => {
-    // Mocked Data
-    setAssignments([
-      {
-        id: 'a1',
-        title: 'React Basics',
-        instructor: 'Ayman Khalid',
-        className: 'React Bootcamp',
-        type: 'MCQ',
-        dueDate: '2025-05-25T23:59:00Z',
-        status: 'Pending'
-      },
-      {
-        id: 'a2',
-        title: 'CSS Challenge',
-        instructor: 'Sara Ali',
-        className: 'Frontend Mastery',
-        type: 'Text',
-        dueDate: '2025-06-01T23:59:00Z',
-        status: 'Approved'
-      },
-    ]);
+    const load = async () => {
+      try {
+        const list = await fetchAllAssignments();
+        setAssignments(
+          list.map((a) => ({
+            id: a.id,
+            title: a.title,
+            instructor: a.instructor,
+            className: a.class_title,
+            type: a.type || 'N/A',
+            dueDate: a.due_date,
+            status: a.status || 'Pending',
+          }))
+        );
+      } catch (err) {
+        console.error('Failed to load assignments', err);
+      }
+    };
+    load();
   }, []);
 
   const filteredAssignments = assignments.filter(a => {

--- a/frontend/src/services/admin/assignmentService.js
+++ b/frontend/src/services/admin/assignmentService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const fetchAllAssignments = async () => {
+  const { data } = await api.get("/users/classes/assignments/admin");
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- enable fetching all assignments from backend
- expose GET `/classes/assignments/admin` API
- integrate new service in admin assignments page
- test coverage for the new API

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883ecacf9448328b9fd23a0aaa8e70e