### PR TITLE
Fix admin profile edit initialization

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -41,7 +41,7 @@ const profileSchema = z.object({
 
 function ProfileEditTemplate() {
   const router = useRouter();
-  const { user, hasHydrated } = useAuthStore();
+  const { user, hasHydrated, setUser } = useAuthStore();
   const [loadingProfile, setLoadingProfile] = useState(true);
   const [formData, setFormData] = useState({
     full_name: "",
@@ -65,6 +65,14 @@ function ProfileEditTemplate() {
   const [tempAvatar, setTempAvatar] = useState(null);
   const [tempFileName, setTempFileName] = useState("");
   const fetchNotifications = useNotificationStore((state) => state.fetch);
+
+  useEffect(() => {
+    const local = localStorage.getItem("auth");
+    const parsed = JSON.parse(local)?.state;
+    if (hasHydrated && !user && parsed?.user) {
+      setUser(parsed.user);
+    }
+  }, [hasHydrated]);
 
   useEffect(() => {
 
@@ -221,7 +229,6 @@ function ProfileEditTemplate() {
       });
 
       const fresh = await getAdminProfile();
-      const setUser = useAuthStore.getState().setUser;
       setUser({
         ...user,
         full_name: fresh.full_name,


### PR DESCRIPTION
## Summary
- hydrate user from local storage on admin profile edit
- update profile store after saving changes

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883efdf8c108328bc82cc931b7e37ba