### PR TITLE
Add admin category docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ For a walkthrough of creating a class, managing assignments, calculating final s
 ## Admin alerts
 
 Administrators can monitor runtime warnings and errors from the dashboard. The alerts page fetches the last entries in `logs/error.log` via `/api/system-errors` and displays them with pagination. See [docs/admin-alerts.md](docs/admin-alerts.md) for details.
+
+## Admin category management
+
+Admins can build a nested list of course categories. CRUD endpoints live under `/api/users/admin/categories`. See [docs/admin-category-management.md](docs/admin-category-management.md) for an overview of the routes and frontend pages.

--- a/backend/src/modules/users/categories/category.controller.js
+++ b/backend/src/modules/users/categories/category.controller.js
@@ -1,3 +1,7 @@
+/**
+ * Admin Category Management controller
+ * See docs/admin-category-management.md
+ */
 const catchAsync = require("../../../utils/catchAsync");
 const AppError = require("../../../utils/AppError");
 const service = require("./category.service");

--- a/backend/src/modules/users/categories/category.routes.js
+++ b/backend/src/modules/users/categories/category.routes.js
@@ -1,6 +1,7 @@
 /**
  * Category Routes
  * @file category.routes.js
+ * @see docs/admin-category-management.md
  */
 const express = require("express");
 const router = express.Router();

--- a/backend/src/modules/users/categories/category.service.js
+++ b/backend/src/modules/users/categories/category.service.js
@@ -1,3 +1,7 @@
+/**
+ * Admin Category Management service
+ * See docs/admin-category-management.md
+ */
 const db = require("../../../config/database");
 
 exports.create = async (data) => db("categories").insert(data).returning("*").then(rows => rows[0]);

--- a/backend/src/modules/users/categories/category.validator.js
+++ b/backend/src/modules/users/categories/category.validator.js
@@ -1,3 +1,7 @@
+/**
+ * Validation schemas for admin categories
+ * See docs/admin-category-management.md
+ */
 const { z } = require("zod");
 
 exports.createCategorySchema = z.object({

--- a/backend/src/modules/users/categories/categoryUploadMiddleware.js
+++ b/backend/src/modules/users/categories/categoryUploadMiddleware.js
@@ -1,3 +1,7 @@
+/**
+ * Admin Category image upload middleware
+ * See docs/admin-category-management.md
+ */
 const multer = require("multer");
 const path = require("path");
 const fs = require("fs");

--- a/docs/admin-category-management.md
+++ b/docs/admin-category-management.md
@@ -1,0 +1,25 @@
+# Admin Category Management
+
+Administrators can organize classes and tutorials into a hierarchical list of categories. Each category may have an optional parent so nested structures like `Programming > Web Development > JavaScript` are supported.
+
+## Backend
+
+- **Routes:** exposed under `/api/users/admin/categories` and implemented in `backend/src/modules/users/categories`.
+- `POST /create` – create a new category. Supports uploading an image file via the `image` form field.
+- `PUT /:id` – update name, parent, status or image.
+- `PATCH /:id/status` – toggle between `active` and `inactive`.
+- `DELETE /:id` – remove a category that has no sub‑categories.
+- `GET /` – list categories with optional `search` and `status` filters.
+- `GET /tree` – return categories in a nested structure for dropdowns.
+- `GET /:id` – fetch a single category by id.
+
+## Frontend
+
+- Pages live in `frontend/src/pages/dashboard/admin/categories`.
+  - `index.js` lists categories and allows status toggling or deletion.
+  - `create.js` provides a form to add a new category.
+  - `edit/[id].js` edits an existing category.
+- Requests are handled through `frontend/src/services/admin/categoryService.js`.
+- Images are previewed client‑side before upload and stored in `/uploads/categories` on the server.
+
+See also the seed files under `backend/src/seeds` for example parent and child categories.

--- a/frontend/src/pages/dashboard/admin/categories/create.js
+++ b/frontend/src/pages/dashboard/admin/categories/create.js
@@ -1,3 +1,7 @@
+// ─────────────────────────────────────────────────────────
+// Admin Category Management
+// See docs/admin-category-management.md
+// ─────────────────────────────────────────────────────────
 import React, { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";

--- a/frontend/src/pages/dashboard/admin/categories/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/categories/edit/[id].js
@@ -1,3 +1,7 @@
+// ─────────────────────────────────────────────────────────
+// Admin Category Management
+// See docs/admin-category-management.md
+// ─────────────────────────────────────────────────────────
 import React, { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";

--- a/frontend/src/pages/dashboard/admin/categories/index.js
+++ b/frontend/src/pages/dashboard/admin/categories/index.js
@@ -1,3 +1,7 @@
+// ─────────────────────────────────────────────────────────
+// Admin Category Management
+// See docs/admin-category-management.md
+// ─────────────────────────────────────────────────────────
 import React, { useEffect, useState } from "react";
 import { Plus, Search, FolderKanban, Pencil, Trash2 } from "lucide-react";
 import Link from "next/link";

--- a/frontend/src/services/admin/categoryService.js
+++ b/frontend/src/services/admin/categoryService.js
@@ -1,3 +1,7 @@
+// ─────────────────────────────────────────────────────────
+// Admin Category Management API helpers
+// See docs/admin-category-management.md
+// ─────────────────────────────────────────────────────────
 import api from "@/services/api/api";
 
 export const fetchAllCategories = async (params = {}) => {


### PR DESCRIPTION
## Summary
- document admin category CRUD for backend and frontend
- link the new doc from the main README
- reference the doc from admin category source files

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883ecef80f483289691986d0eb41c0c