### PR TITLE
Add fallback analytics data

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -19,6 +19,21 @@ import {
 
 const COLORS = ["#60a5fa", "#34d399", "#fbbf24", "#f87171"];
 
+const EMPTY_STATS = {
+  totalStudents: 0,
+  totalRevenue: 0,
+  totalAttendance: 0,
+  completed: 0,
+  revenueBreakdown: {
+    full: 0,
+    installments: 0,
+    free: 0,
+  },
+  locations: [],
+  devices: [],
+  registrationTrend: [],
+};
+
 export default function AnalyticsDashboard() {
   const router = useRouter();
   const { id } = router.query;
@@ -30,7 +45,7 @@ export default function AnalyticsDashboard() {
       .then((data) => setStats(data))
       .catch((err) => {
         console.error("Failed to load analytics", err);
-        setStats(null);
+        setStats(EMPTY_STATS);
       });
   }, [id]);
 


### PR DESCRIPTION
## Summary
- provide zero stats for admin online class analytics
- show zero-filled metrics when analytics fetch fails

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6883f2124c988328af18df63f0e08210