### PR TITLE
Implement admin certificates API and frontend integration

### DIFF
--- a/backend/src/modules/certificates/certificates.controller.js
+++ b/backend/src/modules/certificates/certificates.controller.js
@@ -1,0 +1,11 @@
+const service = require("./certificates.service");
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+
+/**
+ * List all certificates
+ */
+exports.list = catchAsync(async (_req, res) => {
+  const certificates = await service.getAll();
+  sendSuccess(res, certificates);
+});

--- a/backend/src/modules/certificates/certificates.routes.js
+++ b/backend/src/modules/certificates/certificates.routes.js
@@ -1,0 +1,9 @@
+const router = require("express").Router();
+const ctrl = require("./certificates.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.get("/", ctrl.list);
+
+module.exports = router;

--- a/backend/src/modules/certificates/certificates.service.js
+++ b/backend/src/modules/certificates/certificates.service.js
@@ -1,0 +1,16 @@
+const db = require("../../config/database");
+
+/**
+ * Fetch all certificates with related student and class info
+ */
+exports.getAll = async () => {
+  return db("certificates")
+    .leftJoin("users", "certificates.user_id", "users.id")
+    .leftJoin("online_classes", "certificates.class_id", "online_classes.id")
+    .select(
+      "certificates.*",
+      "users.full_name as student_name",
+      "online_classes.title as class_name"
+    )
+    .orderBy("certificates.created_at", "desc");
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -83,6 +83,7 @@ app.use("/api/auth", require("./modules/auth/routes/auth.routes"));
 app.use("/api/users", require("./modules/users/user.routes"));
 app.use("/api/verify", require("./modules/verify/verify.routes"));
 app.use("/api/certificates", require("./modules/users/tutorials/certificate/certificatePublic.routes"));
+app.use("/api/certificates/admin", require("./modules/certificates/certificates.routes"));
 app.use("/api/bookings/admin", require("./modules/bookings/bookings.routes"));
 app.use("/api/bookings/student", require("./modules/bookings/student.routes"));
 app.use("/api/bookings/instructor", require("./modules/bookings/instructor.routes"));

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -327,6 +327,16 @@
     "invalid_date": "\u062a\u0646\u0633\u064a\u0642 \u0627\u0644\u062a\u0627\u0631\u064a\u062e \u063a\u064a\u0631 \u0635\u0627\u0644\u062d",
     "url_invalid": "\u064a\u062c\u0628 \u0623\u0646 \u064a\u0643\u0648\u0646 \u0631\u0627\u0628\u0637\u0627\u064b \u0635\u0627\u0644\u062d\u0627ً"
   },
+  "adminCertificatesPage": {
+    "title": "Certificates",
+    "search_placeholder": "Search students or classes",
+    "all_status": "All Status",
+    "issued": "Issued",
+    "pending": "Pending",
+    "revoked": "Revoked",
+    "refresh": "Refresh",
+    "no_certificates": "No certificates found."
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -309,6 +309,16 @@
     "invalid_date": "Ung\u00fcltiges Datumsformat",
     "url_invalid": "Muss eine g\u00fcltige URL sein"
   },
+  "adminCertificatesPage": {
+    "title": "Certificates",
+    "search_placeholder": "Search students or classes",
+    "all_status": "All Status",
+    "issued": "Issued",
+    "pending": "Pending",
+    "revoked": "Revoked",
+    "refresh": "Refresh",
+    "no_certificates": "No certificates found."
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -327,6 +327,16 @@
     "invalid_date": "Invalid date format",
     "url_invalid": "Must be a valid URL"
   },
+  "adminCertificatesPage": {
+    "title": "Certificates",
+    "search_placeholder": "Search students or classes",
+    "all_status": "All Status",
+    "issued": "Issued",
+    "pending": "Pending",
+    "revoked": "Revoked",
+    "refresh": "Refresh",
+    "no_certificates": "No certificates found."
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -309,6 +309,16 @@
     "invalid_date": "Formato de fecha inválido",
     "url_invalid": "Debe ser una URL válida"
   },
+  "adminCertificatesPage": {
+    "title": "Certificates",
+    "search_placeholder": "Search students or classes",
+    "all_status": "All Status",
+    "issued": "Issued",
+    "pending": "Pending",
+    "revoked": "Revoked",
+    "refresh": "Refresh",
+    "no_certificates": "No certificates found."
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -316,6 +316,16 @@
     "invalid_date": "Format de date invalide",
     "url_invalid": "Doit être une URL valide"
   },
+  "adminCertificatesPage": {
+    "title": "Certificates",
+    "search_placeholder": "Search students or classes",
+    "all_status": "All Status",
+    "issued": "Issued",
+    "pending": "Pending",
+    "revoked": "Revoked",
+    "refresh": "Refresh",
+    "no_certificates": "No certificates found."
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/src/pages/dashboard/admin/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/certificates/index.js
@@ -1,32 +1,32 @@
-// pages/dashboard/admin/certificates/index.js
+// ─────────────────────────────────────
+// 📁 dashboard/admin/certificates/index.js
+// ─────────────────────────────────────
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSearch, FaSync, FaEye, FaDownload, FaCheckCircle, FaTimesCircle } from "react-icons/fa";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import { fetchAllCertificates } from "@/services/admin/certificateService";
 
 export default function AdminCertificatesPage() {
+  const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'adminCertificatesPage' });
+
   const [certificates, setCertificates] = useState([]);
   const [search, setSearch] = useState('');
   const [filterStatus, setFilterStatus] = useState('all');
 
   useEffect(() => {
-    // Mock data (later replace with fetch from backend)
-    setCertificates([
-      {
-        id: 'c1',
-        studentName: 'Sara Ali',
-        className: 'React & Next.js Bootcamp',
-        issueDate: '2025-05-30T10:00:00Z',
-        status: 'Issued'
-      },
-      {
-        id: 'c2',
-        studentName: 'Mohammed Saleh',
-        className: 'UI/UX Design Basics',
-        issueDate: '2025-06-05T14:00:00Z',
-        status: 'Pending'
+    const load = async () => {
+      try {
+        const data = await fetchAllCertificates();
+        setCertificates(data);
+      } catch (err) {
+        console.error('Failed to load certificates', err);
       }
-    ]);
+    };
+    load();
   }, []);
 
   const filteredCertificates = certificates.filter(c => {
@@ -38,14 +38,14 @@ export default function AdminCertificatesPage() {
 
   return (
     <AdminLayout>
-      <div className="min-h-screen px-6 py-10 bg-white text-gray-900">
-        <h1 className="text-2xl font-bold text-yellow-500 mb-6">🎓 Manage Certificates</h1>
+      <div className="min-h-screen px-6 py-10 bg-white text-gray-900" dir={i18n.dir()}> 
+        <h1 className="text-2xl font-bold text-yellow-500 mb-6">🎓 {t('title')}</h1>
 
         {/* Filters */}
         <div className="flex flex-wrap gap-4 mb-6">
           <input
             type="text"
-            placeholder="Search student or class..."
+            placeholder={t('search_placeholder')}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="flex-1 p-2 border rounded bg-gray-100"
@@ -56,17 +56,17 @@ export default function AdminCertificatesPage() {
             onChange={(e) => setFilterStatus(e.target.value)}
             className="p-2 border rounded bg-gray-100"
           >
-            <option value="all">All Status</option>
-            <option value="issued">Issued</option>
-            <option value="pending">Pending</option>
-            <option value="revoked">Revoked</option>
+            <option value="all">{t('all_status')}</option>
+            <option value="issued">{t('issued')}</option>
+            <option value="pending">{t('pending')}</option>
+            <option value="revoked">{t('revoked')}</option>
           </select>
 
           <button
             onClick={() => window.location.reload()}
             className="bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-600 flex items-center gap-2"
           >
-            <FaSync /> Refresh
+            <FaSync /> {t('refresh')}
           </button>
         </div>
 
@@ -131,7 +131,7 @@ export default function AdminCertificatesPage() {
               {filteredCertificates.length === 0 && (
                 <tr>
                   <td colSpan="5" className="text-center p-6 text-gray-400">
-                    No certificates found.
+                    {t('no_certificates')}
                   </td>
                 </tr>
               )}
@@ -141,4 +141,12 @@ export default function AdminCertificatesPage() {
       </div>
     </AdminLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }

--- a/frontend/src/services/admin/certificateService.js
+++ b/frontend/src/services/admin/certificateService.js
@@ -1,0 +1,9 @@
+import api from "@/services/api/api";
+
+/**
+ * Fetch all certificates for admin
+ */
+export const fetchAllCertificates = async () => {
+  const { data } = await api.get("/certificates/admin");
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- add certificates admin API with service, controller and routes
- expose route in server.js
- update admin certificates page to fetch from backend and support translations
- document code sections
- add adminCertificatesPage translations for all locales
- create certificateService for admin actions

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883f5f0fbdc83289a8fd2b0208f72c8