### PR TITLE
Fix save_changes translation

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -479,7 +479,7 @@ function ProfileEditTemplate() {
                   <FaSpinner className="animate-spin mr-2" /> {t('processing')}
                 </span>
               ) : (
-                {t('save_changes')}
+                t('save_changes')
               )}
             </button>
           </div>


### PR DESCRIPTION
## Summary
- correct JSX syntax for save_changes translation in Admin profile edit page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883fb0ab4d48328b3d8a15cdb3f6e8b