### PR TITLE
Improve auth page responsiveness

### DIFF
--- a/frontend/src/pages/auth/forgot-password.js
+++ b/frontend/src/pages/auth/forgot-password.js
@@ -54,7 +54,7 @@ export default function ForgotPassword() {
       <motion.div
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-96 border border-gray-700 text-white flex flex-col items-center"
+        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-full max-w-md border border-gray-700 text-white flex flex-col items-center"
       >
         <h2 className="text-2xl font-bold text-yellow-400 mb-6">{t('forgot_password_title')}</h2>
         <p className="text-gray-400 text-sm text-center mb-4">

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -161,7 +161,7 @@ export default function Login() {
         animate={{ opacity: 1, y: 0 }}
         whileHover={{ scale: 1.03 }}
         transition={{ duration: 0.3 }}
-        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-96 border border-gray-700 text-white flex flex-col items-center"
+        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-full max-w-md border border-gray-700 text-white flex flex-col items-center"
       >
         <div className="w-24 h-24 rounded-full border-4 border-yellow-500 bg-gray-900 flex items-center justify-center mb-4 shadow-lg overflow-hidden">
 

--- a/frontend/src/pages/auth/reset-password.js
+++ b/frontend/src/pages/auth/reset-password.js
@@ -80,7 +80,7 @@ export default function ResetPassword() {
       <motion.div
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-96 border border-gray-700 text-white flex flex-col items-center"
+        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-full max-w-md border border-gray-700 text-white flex flex-col items-center"
       >
         <h2 className="text-2xl font-bold text-yellow-400 mb-6">{t('reset_password')}</h2>
         <p className="text-gray-400 text-sm text-center mb-4">

--- a/frontend/src/pages/auth/success-reset.js
+++ b/frontend/src/pages/auth/success-reset.js
@@ -32,7 +32,7 @@ export default function SuccessReset() {
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
-        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-96 border border-gray-700 text-white flex flex-col items-center"
+        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-full max-w-md border border-gray-700 text-white flex flex-col items-center"
       >
         {/* Success Icon */}
         <motion.div

--- a/frontend/src/pages/auth/verify-otp.js
+++ b/frontend/src/pages/auth/verify-otp.js
@@ -101,7 +101,7 @@ export default function VerifyOTP() {
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4 }}
-        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-96 border border-gray-700 text-white flex flex-col items-center"
+        className="relative bg-gray-800 rounded-lg shadow-lg p-8 w-full max-w-md border border-gray-700 text-white flex flex-col items-center"
       >
         {!isVerified ? (
           <>


### PR DESCRIPTION
## Summary
- make auth pages responsive on mobile devices by using `w-full max-w-md`
- keep background animation

## Testing
- `npm test`
- `npm run lint` *(fails: 50 errors, 197 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688401eafca88328acae10be1351132b