### PR TITLE
Add migration for payment methods table

### DIFF
--- a/backend/src/migrations/20250725000000_create_payment_methods_config_table.js
+++ b/backend/src/migrations/20250725000000_create_payment_methods_config_table.js
@@ -1,0 +1,16 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('payment_methods_config', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable();
+    table.string('type').notNullable();
+    table.string('icon');
+    table.boolean('active').notNullable().defaultTo(true);
+    table.jsonb('settings').defaultTo('{}');
+    table.boolean('is_default').notNullable().defaultTo(false);
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('payment_methods_config');
+};


### PR DESCRIPTION
## Summary
- add missing `payment_methods_config` migration

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6884ac5d22648328bfd4007f7388e196