### PR TITLE
Add migration for payment methods table

### DIFF
--- a/backend/src/migrations/20250725000000_create_payment_methods_config_table.js
+++ b/backend/src/migrations/20250725000000_create_payment_methods_config_table.js
@@ -1,0 +1,16 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('payment_methods_config', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable();
+    table.string('type').notNullable();
+    table.string('icon');
+    table.boolean('active').notNullable().defaultTo(true);
+    table.jsonb('settings').defaultTo('{}');
+    table.boolean('is_default').notNullable().defaultTo(false);
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('payment_methods_config');
+};

--- a/backend/src/modules/paymentMethods/paymentMethods.controller.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.controller.js
@@ -4,6 +4,9 @@ const { sendSuccess } = require("../../utils/response");
 const service = require("./paymentMethods.service");
 const path = require("path");
 const fs = require("fs");
+const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
 
 exports.createMethod = catchAsync(async (req, res) => {
   const { name, type } = req.body;
@@ -14,6 +17,26 @@ exports.createMethod = catchAsync(async (req, res) => {
   }
   const method = await service.create(data);
   sendSuccess(res, method, "Method created");
+
+  const admins = await userModel.findAdmins();
+  const senderId = req.user?.id;
+  const message = `Payment method "${method.name}" created`;
+  await Promise.all(
+    admins.map((admin) =>
+      Promise.all([
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "payment_method_created",
+          message,
+        }),
+        messageService.createMessage({
+          sender_id: senderId || admin.id,
+          receiver_id: admin.id,
+          message,
+        }),
+      ])
+    )
+  );
 });
 
 exports.getMethods = catchAsync(async (_req, res) => {
@@ -47,9 +70,50 @@ exports.updateMethod = catchAsync(async (req, res) => {
 
   const method = await service.update(req.params.id, data);
   sendSuccess(res, method, "Method updated");
+
+  const admins = await userModel.findAdmins();
+  const senderId = req.user?.id;
+  const message = `Payment method "${method.name}" updated`;
+  await Promise.all(
+    admins.map((admin) =>
+      Promise.all([
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "payment_method_updated",
+          message,
+        }),
+        messageService.createMessage({
+          sender_id: senderId || admin.id,
+          receiver_id: admin.id,
+          message,
+        }),
+      ])
+    )
+  );
 });
 
 exports.deleteMethod = catchAsync(async (req, res) => {
+  const existing = await service.getById(req.params.id);
   await service.delete(req.params.id);
   sendSuccess(res, null, "Method deleted");
+
+  const admins = await userModel.findAdmins();
+  const senderId = req.user?.id;
+  const message = `Payment method "${existing?.name || req.params.id}" deleted`;
+  await Promise.all(
+    admins.map((admin) =>
+      Promise.all([
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "payment_method_deleted",
+          message,
+        }),
+        messageService.createMessage({
+          sender_id: senderId || admin.id,
+          receiver_id: admin.id,
+          message,
+        }),
+      ])
+    )
+  );
 });

--- a/frontend/src/components/payments/PaymentProviderConfig.js
+++ b/frontend/src/components/payments/PaymentProviderConfig.js
@@ -3,10 +3,35 @@ import {
   fetchMethodById,
   updateMethod,
 } from "@/services/admin/paymentMethodService";
+import { toast } from "react-toastify";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
+import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
+
+const useAdminNotice = () => {
+  const user = useAuthStore((s) => s.user);
+  const refreshNotifications = useNotificationStore((s) => s.fetch);
+  const refreshMessages = useMessageStore((s) => s.fetch);
+  return async (type, message) => {
+    try {
+      await createNotification({ user_id: user.id, type, message });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
+    } catch (err) {
+      console.error(err);
+      const msg = err.response?.data?.message || "Failed to send notification";
+      toast.error(msg);
+    }
+  };
+};
 
 export default function PaymentProviderConfig({ providerId }) {
   const [settings, setSettings] = useState("{}");
   const [loading, setLoading] = useState(true);
+  const notify = useAdminNotice();
 
   useEffect(() => {
     if (!providerId) return;
@@ -28,10 +53,11 @@ export default function PaymentProviderConfig({ providerId }) {
     try {
       const parsed = settings ? JSON.parse(settings) : {};
       await updateMethod(providerId, { settings: parsed });
-      alert("Configuration saved");
+      toast.success("Configuration saved");
+      notify("payment_method_updated", `Payment method \"${providerId}\" configuration updated`);
     } catch (err) {
       console.error("Failed to save settings", err);
-      alert("Failed to save configuration");
+      toast.error("Failed to save configuration");
     }
   };
 


### PR DESCRIPTION
## Summary
- add missing `payment_methods_config` migration
- notify admins when payment methods are created, updated or deleted
- show toasts when saving payment provider configuration

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ac5d22648328bfd4007f7388e196