### PR TITLE
Enable admin payments dashboard

### DIFF
--- a/backend/src/migrations/20250725001000_create_payments_table.js
+++ b/backend/src/migrations/20250725001000_create_payments_table.js
@@ -1,0 +1,19 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('payments', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users');
+    table.uuid('method_id').notNullable().references('id').inTable('payment_methods_config');
+    table.string('item_type').notNullable();
+    table.uuid('item_id').notNullable();
+    table.decimal('amount', 10, 2).notNullable();
+    table.string('currency').notNullable().defaultTo('USD');
+    table.string('status').notNullable().defaultTo('pending');
+    table.string('reference_id');
+    table.timestamp('paid_at');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('payments');
+};

--- a/backend/src/migrations/20250725002000_create_payouts_table.js
+++ b/backend/src/migrations/20250725002000_create_payouts_table.js
@@ -1,0 +1,17 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('payouts', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('instructor_id').notNullable().references('id').inTable('users');
+    table.decimal('amount', 10, 2).notNullable();
+    table.string('currency').notNullable().defaultTo('USD');
+    table.string('status').notNullable().defaultTo('pending');
+    table.text('notes');
+    table.timestamp('requested_at').defaultTo(knex.fn.now());
+    table.timestamp('processed_at');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('payouts');
+};

--- a/backend/src/modules/payments/payments.service.js
+++ b/backend/src/modules/payments/payments.service.js
@@ -6,7 +6,16 @@ exports.create = async (data) => {
 };
 
 exports.getAll = async () => {
-  return db("payments").select("*").orderBy("created_at", "desc");
+  return db({ p: 'payments' })
+    .leftJoin('users as u', 'p.user_id', 'u.id')
+    .leftJoin('payment_methods_config as m', 'p.method_id', 'm.id')
+    .select(
+      'p.*',
+      'u.full_name as user_name',
+      'u.role as user_role',
+      'm.name as method_name'
+    )
+    .orderBy('p.created_at', 'desc');
 };
 
 exports.getById = async (id) => {

--- a/backend/src/seeds/05_payments_seed.js
+++ b/backend/src/seeds/05_payments_seed.js
@@ -1,0 +1,22 @@
+exports.seed = async function(knex) {
+  await knex('payments').del();
+
+  const users = await knex('users').select('id').limit(1);
+  const methods = await knex('payment_methods_config').select('id').limit(1);
+
+  if (users.length && methods.length) {
+    await knex('payments').insert([
+      {
+        id: knex.raw('uuid_generate_v4()'),
+        user_id: users[0].id,
+        method_id: methods[0].id,
+        item_type: 'class',
+        item_id: knex.raw('uuid_generate_v4()'),
+        amount: 99.99,
+        currency: 'USD',
+        status: 'paid',
+        paid_at: knex.fn.now(),
+      },
+    ]);
+  }
+};

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -67,7 +67,16 @@ export default function AdminPaymentsPage() {
           fetchPaymentConfig(),
           fetchPayouts(),
         ]);
-        setTransactions(txns);
+        setTransactions(
+          txns.map((t) => ({
+            ...t,
+            date: t.paid_at || t.created_at,
+            user: t.user_name,
+            role: t.user_role,
+            method: t.method_name,
+            type: t.item_type,
+          }))
+        );
         setMethods(
           mths.map((m) => ({
             ...m,


### PR DESCRIPTION
## Summary
- create payments and payouts tables
- seed example payment
- join user and method info when listing payments
- normalize payment data in admin page for display

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884b3fcbb288328831e63d5d23a7af9