### PR TITLE
Implement payment config notifications

### DIFF
--- a/backend/src/modules/paymentConfig/paymentConfig.controller.js
+++ b/backend/src/modules/paymentConfig/paymentConfig.controller.js
@@ -1,6 +1,9 @@
 const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const service = require("./paymentConfig.service");
+const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
 
 exports.getSettings = catchAsync(async (_req, res) => {
   const settings = await service.getSettings();
@@ -10,4 +13,23 @@ exports.getSettings = catchAsync(async (_req, res) => {
 exports.updateSettings = catchAsync(async (req, res) => {
   const settings = await service.updateSettings(req.body);
   sendSuccess(res, settings, "Settings updated");
+
+  const admins = await userModel.findAdmins();
+  const senderId = req.user?.id;
+  await Promise.all(
+    admins.map((admin) =>
+      Promise.all([
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "payment_config_updated",
+          message: "Payment configuration updated",
+        }),
+        messageService.createMessage({
+          sender_id: senderId || admin.id,
+          receiver_id: admin.id,
+          message: "Payment configuration updated",
+        }),
+      ])
+    )
+  );
 });

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -23,6 +23,29 @@ import {
 import { fetchPaymentConfig, updatePaymentConfig } from '@/services/admin/paymentConfigService';
 import { fetchPayouts, updatePayout } from '@/services/admin/payoutService';
 import { toast } from 'react-toastify';
+import { createNotification } from '@/services/notificationService';
+import { sendChatMessage } from '@/services/messageService';
+import useAuthStore from '@/store/auth/authStore';
+import useNotificationStore from '@/store/notifications/notificationStore';
+import useMessageStore from '@/store/messages/messageStore';
+
+const useAdminNotice = () => {
+  const user = useAuthStore((state) => state.user);
+  const refreshNotifications = useNotificationStore((state) => state.fetch);
+  const refreshMessages = useMessageStore((state) => state.fetch);
+  return async (type, message) => {
+    try {
+      await createNotification({ user_id: user.id, type, message });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
+    } catch (err) {
+      console.error(err);
+      const msg = err.response?.data?.message || 'Failed to send notification';
+      toast.error(msg);
+    }
+  };
+};
 
 const tabs = [
   { key: "overview", label: "Overview", icon: <FaChartBar /> },
@@ -57,6 +80,7 @@ export default function AdminPaymentsPage() {
 
   const [transactions, setTransactions] = useState([]);
   const [methods, setMethods] = useState([]);
+  const notify = useAdminNotice();
 
   useEffect(() => {
     const loadData = async () => {
@@ -171,6 +195,7 @@ export default function AdminPaymentsPage() {
     try {
       await updatePaymentConfig(form);
       toast.success("Configuration saved successfully!");
+      notify("payment_config_updated", "Payment configuration updated");
     } catch (err) {
       toast.error(err?.response?.data?.message || "Failed to save configuration");
     }


### PR DESCRIPTION
## Summary
- notify admins when updating payment configuration
- display toast + update notifications/messages when saving config in admin UI

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884b57608888328b8f4b8deda62c19a