### PR TITLE
Fix admin payments notice hook

### DIFF
--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -29,6 +29,25 @@ import useAuthStore from '@/store/auth/authStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
 
+// Helper hook for sending admin notifications and chat messages
+const useAdminNotice = () => {
+  const user = useAuthStore((s) => s.user);
+  const refreshNotifications = useNotificationStore((s) => s.fetch);
+  const refreshMessages = useMessageStore((s) => s.fetch);
+  return async (type, message) => {
+    try {
+      await createNotification({ user_id: user.id, type, message });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
+    } catch (err) {
+      console.error(err);
+      const msg = err.response?.data?.message || 'Failed to send notification';
+      toast.error(msg);
+    }
+  };
+};
+
 const tabs = [
   { key: "overview", label: "Overview", icon: <FaChartBar /> },
   { key: "transactions", label: "Transactions", icon: <FaList /> },


### PR DESCRIPTION
## Summary
- add missing `useAdminNotice` helper in the admin payments page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884b8a6227483288ba23f8ae1b4fda0