### PR TITLE
Add admin payments transactions page

### DIFF
--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -56,7 +56,7 @@ const defaultConfig = {
 };
 
 
-export default function AdminPaymentsPage() {
+export default function AdminPaymentsPage({ initialTab = "overview" } = {}) {
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
   const refreshNotifications = useNotificationStore((s) => s.fetch);
@@ -74,7 +74,7 @@ export default function AdminPaymentsPage() {
       toast.error(msg);
     }
   };
-  const [activeTab, setActiveTab] = useState("overview");
+  const [activeTab, setActiveTab] = useState(initialTab);
 
   const [transactions, setTransactions] = useState([]);
   const [methods, setMethods] = useState([]);

--- a/frontend/src/pages/dashboard/admin/payments/transactions/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/transactions/index.js
@@ -1,0 +1,5 @@
+import AdminPaymentsPage from '../index'
+
+export default function AdminPaymentsTransactions() {
+  return <AdminPaymentsPage initialTab="transactions" />
+}


### PR DESCRIPTION
## Summary
- allow selecting initial tab for admin payments dashboard
- create standalone transactions page that uses the new prop

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6884b7fb7eec83289c2c62e4f04a58bd