### PR TITLE
Localize admin payment method config

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -24,6 +24,8 @@
   "manage_payment_gateways": "إدارة بوابات الدفع",
   "payment_methods": "طرق الدفع",
   "add_payment_method": "إضافة طريقة دفع جديدة",
+  "configure_payment_method": "تكوين طريقة الدفع",
+  "configure_payment_method_title": "تكوين {{id}}",
   "payment_enabled": "مفعل",
   "payment_disabled": "معطل",
   "save_method": "حفظ الطريقة",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -24,6 +24,8 @@
   "manage_payment_gateways": "Manage Payment Gateways",
   "payment_methods": "Payment Methods",
   "add_payment_method": "Add New Payment Method",
+  "configure_payment_method": "Configure Payment Method",
+  "configure_payment_method_title": "Configure {{id}}",
   "payment_enabled": "Enabled",
   "payment_disabled": "Disabled",
   "save_method": "Save Method",

--- a/frontend/src/components/payments/PaymentProviderConfig.js
+++ b/frontend/src/components/payments/PaymentProviderConfig.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "next-i18next";
 import {
   fetchMethodById,
   updateMethod,
@@ -32,6 +33,7 @@ export default function PaymentProviderConfig({ providerId }) {
   const [settings, setSettings] = useState("{}");
   const [loading, setLoading] = useState(true);
   const notify = useAdminNotice();
+  const { t } = useTranslation('dashboard');
 
   useEffect(() => {
     if (!providerId) return;
@@ -53,22 +55,22 @@ export default function PaymentProviderConfig({ providerId }) {
     try {
       const parsed = settings ? JSON.parse(settings) : {};
       await updateMethod(providerId, { settings: parsed });
-      toast.success("Configuration saved");
+      toast.success(t('paymentsPage.config_saved'));
       notify("payment_method_updated", `Payment method \"${providerId}\" configuration updated`);
     } catch (err) {
       console.error("Failed to save settings", err);
-      toast.error("Failed to save configuration");
+      toast.error(t('paymentsPage.config_save_failed'));
     }
   };
 
-  if (loading) return <p>Loading...</p>;
+  if (loading) return <p>{t('common:loading')}</p>;
 
   return (
     <form
       onSubmit={handleSave}
       className="space-y-4 bg-white p-6 rounded-xl shadow"
     >
-      <label className="block text-sm font-medium">Settings (JSON)</label>
+      <label className="block text-sm font-medium">{t('settings')}</label>
       <textarea
         className="w-full border rounded p-2 font-mono text-sm"
         rows={10}
@@ -79,7 +81,7 @@ export default function PaymentProviderConfig({ providerId }) {
         type="submit"
         className="bg-yellow-400 px-6 py-2 rounded-full text-white"
       >
-        Save Configuration
+        {t('paymentsPage.save_configuration')}
       </button>
     </form>
   );

--- a/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
@@ -1,17 +1,31 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
 import PaymentProviderConfig from "@/components/payments/PaymentProviderConfig";
 
 export default function ConfigurePaymentMethodPage() {
   const router = useRouter();
   const { id } = router.query;
+  const { t } = useTranslation('dashboard');
 
   return (
-    <AdminLayout title="Configure Payment Method">
+    <AdminLayout title={t('configure_payment_method')}>
       <div className="max-w-2xl mx-auto">
-        <h1 className="text-2xl font-bold mb-4">Configure {id}</h1>
+        <h1 className="text-2xl font-bold mb-4">
+          {t('configure_payment_method_title', { id })}
+        </h1>
         <PaymentProviderConfig providerId={id} />
       </div>
     </AdminLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- add locale entries for Configure Payment Method in English and Arabic
- show translated strings on payment provider configuration page
- localize PaymentProviderConfig component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884dd11859c83289a87e5eeb8d3349b