### PR TITLE
Add message deletion endpoint

### DIFF
--- a/backend/src/modules/messages/messages.controller.js
+++ b/backend/src/modules/messages/messages.controller.js
@@ -13,3 +13,9 @@ exports.markRead = catchAsync(async (req, res) => {
   if (!msg) throw new AppError("Message not found", 404);
   sendSuccess(res, msg, "Message marked as read");
 });
+
+exports.deleteMessage = catchAsync(async (req, res) => {
+  const msg = await service.deleteMessage(req.user.id, req.params.id);
+  if (!msg) throw new AppError("Message not found", 404);
+  sendSuccess(res, msg, "Message deleted");
+});

--- a/backend/src/modules/messages/messages.routes.js
+++ b/backend/src/modules/messages/messages.routes.js
@@ -7,5 +7,6 @@ router.use(verifyToken);
 
 router.get("/", controller.getMyMessages);
 router.patch("/:id/read", controller.markRead);
+router.delete("/:id", controller.deleteMessage);
 
 module.exports = router;

--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -28,3 +28,14 @@ exports.markAsRead = async (id, userId) => {
     .returning("*");
   return row;
 };
+
+exports.deleteMessage = async (userId, id) => {
+  const [row] = await db("messages")
+    .where({ id })
+    .andWhere(function () {
+      this.where({ sender_id: userId }).orWhere({ receiver_id: userId });
+    })
+    .del()
+    .returning("*");
+  return row;
+};

--- a/backend/tests/messageRoutes.test.js
+++ b/backend/tests/messageRoutes.test.js
@@ -4,6 +4,7 @@ const express = require('express');
 jest.mock('../src/modules/messages/messages.service', () => ({
   getUserMessages: jest.fn(),
   markAsRead: jest.fn(),
+  deleteMessage: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -36,5 +37,15 @@ describe('PATCH /api/messages/:id/read', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(msg);
     expect(service.markAsRead).toHaveBeenCalledWith('1', 'user1');
+  });
+});
+
+describe('DELETE /api/messages/:id', () => {
+  it('deletes message', async () => {
+    const msg = { id: '1' };
+    service.deleteMessage.mockResolvedValue(msg);
+    const res = await request(app).delete('/api/messages/1');
+    expect(res.status).toBe(200);
+    expect(service.deleteMessage).toHaveBeenCalledWith('user1', '1');
   });
 });

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -23,6 +23,11 @@ export const markMessageAsRead = async (id) => {
 
 };
 
+export const deleteMessage = async (id) => {
+  const res = await api.delete(`/messages/${id}`);
+  return res.data.data || res.data;
+};
+
 export const getConversation = async (userId) => {
   const res = await api.get(`/chat/${userId}`);
   return res.data.data || res.data;

--- a/frontend/src/store/messages/messageStore.js
+++ b/frontend/src/store/messages/messageStore.js
@@ -1,6 +1,10 @@
 import { create } from "zustand";
 import { toast } from "react-toastify";
-import { getMessages, markMessageAsRead } from "@/services/messageService";
+import {
+  getMessages,
+  markMessageAsRead,
+  deleteMessage as apiDeleteMessage,
+} from "@/services/messageService";
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -56,6 +60,15 @@ const useMessageStore = create((set, get) => ({
         ),
       }));
     }, HOUR_MS);
+  },
+
+  delete: async (id) => {
+    try {
+      await apiDeleteMessage(id);
+      set((state) => ({
+        items: state.items.filter((m) => m.id !== id),
+      }));
+    } catch (_) {}
   },
 
   startPolling: () => {


### PR DESCRIPTION
## Summary
- add service, controller, and route for deleting system messages
- expose API function on the frontend
- update message store to remove deleted messages
- cover new route with tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884e04b3bf083289db3f8c9d775997c