### PR TITLE
Add translations and notifications to tutorial pages

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -486,7 +486,47 @@
     "default_updated": "Default status updated",
     "method_deleted": "Payment method deleted",
     "delete_failed": "Failed to delete method",
-    "configure": "Configure"
+  "configure": "Configure"
+  },
+  "tutorialsPage": {
+    "title": "إدارة الدروس",
+    "description": "إنشاء وتحرير وإدارة جميع الدروس في النظام",
+    "create_tutorial": "إنشاء درس جديد",
+    "status_updated": "تم تحديث حالة الدرس!",
+    "update_failed": "فشل تحديث الحالة",
+    "deleted": "تم حذف الدرس!",
+    "delete_failed": "فشل حذف الدرس",
+    "rejected": "تم رفض الدرس مع ذكر السبب!",
+    "reject_failed": "فشل رفض الدرس",
+    "approved": "تمت الموافقة على الدرس بنجاح!",
+    "approval_failed": "فشل تحديث الدرس",
+    "bulk_deleted": "تم حذف الدروس المحددة!",
+    "bulk_delete_failed": "فشل حذف الدروس",
+    "bulk_approved": "تمت الموافقة على الدروس المحددة!",
+    "bulk_approve_failed": "فشل الموافقة على الدروس",
+    "load_error": "فشل تحميل الدروس",
+    "confirm_title": "تأكيد الحذف",
+    "confirm_delete": "هل أنت متأكد من حذف هذا الدرس نهائياً؟ هذا الإجراء لا يمكن التراجع عنه.",
+    "reject_title": "رفض الدرس"
+  },
+  "tutorialCreatePage": {
+    "title": "إنشاء درس جديد",
+    "basic_info": "معلومات أساسية",
+    "curriculum": "المنهج",
+    "media": "الوسائط",
+    "pricing_publish": "التسعير والنشر",
+    "save_draft": "حفظ المسودة",
+    "next": "التالي",
+    "back": "عودة",
+    "draft_success": "تم حفظ الدرس كمسودة!",
+    "submit_success": "تم إرسال الدرس بنجاح! بانتظار موافقة المسؤول.",
+    "video_required": "يرجى تحميل فيديو لكل درس قبل الإرسال.",
+    "creation_failed": "فشل إنشاء الدرس",
+    "load_categories_failed": "فشل تحميل التصنيفات"
+  },
+  "tutorialEditPage": {
+    "update_success": "تم تحديث الدرس بنجاح!",
+    "update_failed": "فشل تحديث الدرس"
   },
   "sidebar": {
     "Account": "\u0627\u0644\u062d\u0633\u0627\u0628",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -486,7 +486,47 @@
     "default_updated": "Default status updated",
     "method_deleted": "Payment method deleted",
     "delete_failed": "Failed to delete method",
-    "configure": "Configure"
+  "configure": "Configure"
+  },
+  "tutorialsPage": {
+    "title": "Manage Tutorials",
+    "description": "Create, edit, and manage all tutorials in the system",
+    "create_tutorial": "Create New Tutorial",
+    "status_updated": "Tutorial status updated!",
+    "update_failed": "Failed to update status",
+    "deleted": "Tutorial deleted!",
+    "delete_failed": "Failed to delete tutorial",
+    "rejected": "Tutorial rejected with reason!",
+    "reject_failed": "Failed to reject tutorial",
+    "approved": "Tutorial approved successfully!",
+    "approval_failed": "Failed to update tutorial",
+    "bulk_deleted": "Selected tutorials deleted!",
+    "bulk_delete_failed": "Failed to delete tutorials",
+    "bulk_approved": "Selected tutorials approved!",
+    "bulk_approve_failed": "Failed to approve tutorials",
+    "load_error": "Failed to load tutorials",
+    "confirm_title": "Confirm Deletion",
+    "confirm_delete": "Are you sure you want to permanently delete this tutorial? This action cannot be undone.",
+    "reject_title": "Reject Tutorial"
+  },
+  "tutorialCreatePage": {
+    "title": "Create New Tutorial",
+    "basic_info": "Basic Info",
+    "curriculum": "Curriculum",
+    "media": "Media",
+    "pricing_publish": "Pricing & Publish",
+    "save_draft": "Save Draft",
+    "next": "Next",
+    "back": "Back",
+    "draft_success": "Tutorial saved as draft!",
+    "submit_success": "Tutorial submitted successfully! Waiting for admin approval.",
+    "video_required": "Please upload a video for each lesson before submitting.",
+    "creation_failed": "Failed to create tutorial",
+    "load_categories_failed": "Failed to load categories"
+  },
+  "tutorialEditPage": {
+    "update_success": "Tutorial updated successfully!",
+    "update_failed": "Failed to update tutorial"
   },
   "sidebar": {
     "Account": "Account",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -452,7 +452,47 @@
     "default_updated": "Default status updated",
     "method_deleted": "Payment method deleted",
     "delete_failed": "Failed to delete method",
-    "configure": "Configure"
+  "configure": "Configure"
+  },
+  "tutorialsPage": {
+    "title": "Gérer les tutoriels",
+    "description": "Créer, éditer et gérer tous les tutoriels du système",
+    "create_tutorial": "Créer un nouveau tutoriel",
+    "status_updated": "Statut du tutoriel mis à jour !",
+    "update_failed": "Échec de la mise à jour du statut",
+    "deleted": "Tutoriel supprimé !",
+    "delete_failed": "Échec de la suppression du tutoriel",
+    "rejected": "Tutoriel rejeté avec raison !",
+    "reject_failed": "Échec du rejet du tutoriel",
+    "approved": "Tutoriel approuvé avec succès !",
+    "approval_failed": "Échec de la mise à jour du tutoriel",
+    "bulk_deleted": "Tutoriels sélectionnés supprimés !",
+    "bulk_delete_failed": "Échec de la suppression des tutoriels",
+    "bulk_approved": "Tutoriels sélectionnés approuvés !",
+    "bulk_approve_failed": "Échec de l'approbation des tutoriels",
+    "load_error": "Échec du chargement des tutoriels",
+    "confirm_title": "Confirmer la suppression",
+    "confirm_delete": "Supprimer définitivement ce tutoriel ? Cette action est irréversible.",
+    "reject_title": "Rejeter le tutoriel"
+  },
+  "tutorialCreatePage": {
+    "title": "Créer un nouveau tutoriel",
+    "basic_info": "Informations de base",
+    "curriculum": "Programme",
+    "media": "Média",
+    "pricing_publish": "Tarification et publication",
+    "save_draft": "Enregistrer le brouillon",
+    "next": "Suivant",
+    "back": "Retour",
+    "draft_success": "Tutoriel enregistré en brouillon !",
+    "submit_success": "Tutoriel soumis avec succès ! En attente de l'approbation de l'admin.",
+    "video_required": "Veuillez télécharger une vidéo pour chaque leçon avant de soumettre.",
+    "creation_failed": "Échec de la création du tutoriel",
+    "load_categories_failed": "Échec du chargement des catégories"
+  },
+  "tutorialEditPage": {
+    "update_success": "Tutoriel mis à jour avec succès !",
+    "update_failed": "Échec de la mise à jour du tutoriel"
   },
   "sidebar": {
     "Account": "Compte",

--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -2,6 +2,9 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
@@ -21,6 +24,7 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 
 function EditTutorialPage() {
+  const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialEditPage' });
   const router = useRouter();
   const { id } = router.query;
 
@@ -159,7 +163,7 @@ function EditTutorialPage() {
 
               try {
                 await updateTutorial(id, formData);
-                toast.success("Tutorial updated successfully!");
+                toast.success(t('update_success'));
                 await createNotification({
                   user_id: user.id,
                   type: "tutorial_updated",
@@ -184,7 +188,7 @@ function EditTutorialPage() {
                 router.push("/dashboard/admin/tutorials");
               } catch (err) {
                 console.error(err);
-                toast.error("Failed to update tutorial");
+                toast.error(t('update_failed'));
               }
             }}
           />
@@ -195,3 +199,11 @@ function EditTutorialPage() {
 }
 
 export default withAuthProtection(EditTutorialPage, ["admin", "superadmin"]);
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -1,6 +1,9 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
@@ -10,8 +13,29 @@ import ReviewStep from "@/components/tutorials/create/ReviewStep";
 import { createTutorial } from "@/services/admin/tutorialService";
 import { fetchAllCategories } from "@/services/admin/categoryService";
 import StepProgressBar from "@/components/tutorials/create/StepProgressBar";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
+import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
 
 function CreateTutorialPage() {
+  const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialCreatePage' });
+  const user = useAuthStore((s) => s.user);
+  const refreshNotifications = useNotificationStore((s) => s.fetch);
+  const refreshMessages = useMessageStore((s) => s.fetch);
+  const notify = async (type, message) => {
+    try {
+      await createNotification({ user_id: user.id, type, message });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
+    } catch (err) {
+      console.error(err);
+      const msg = err.response?.data?.message || t('creation_failed');
+      toast.error(msg);
+    }
+  };
   const [step, setStep] = useState(1);
   const router = useRouter();
   const [tutorialData, setTutorialData] = useState({
@@ -40,6 +64,7 @@ function CreateTutorialPage() {
         ...draft,
         thumbnail: null,
         preview: null,
+        language: draft.language || "",
         lessonCount: draft.lessonCount || draft.chapters?.length || 1,
       });
     }
@@ -53,6 +78,7 @@ function CreateTutorialPage() {
       
       } catch (err) {
         console.error("Failed to load categories", err);
+        toast.error(t('load_categories_failed'));
       }
     };
 
@@ -64,11 +90,17 @@ function CreateTutorialPage() {
 
 
   const submitTutorial = async (status) => {
+    if (tutorialData.chapters.some((ch) => !ch.videoUrl)) {
+      toast.error(t('video_required'));
+      return;
+    }
+
     const formData = new FormData();
     formData.append("title", tutorialData.title);
     formData.append("description", tutorialData.shortDescription);
     formData.append("category_id", tutorialData.category);
     formData.append("level", tutorialData.level);
+    formData.append("language", tutorialData.language);
     formData.append("status", status);
     formData.append("is_paid", (!tutorialData.isFree).toString());
     if (!tutorialData.isFree) {
@@ -93,10 +125,13 @@ function CreateTutorialPage() {
     try {
       await createTutorial(formData);
       toast.success(
-        status === "draft"
-          ? "Tutorial saved as draft!"
-          : "Tutorial submitted for approval!"
+        status === "draft" ? t('draft_success') : t('submit_success')
       );
+      const msg =
+        status === "draft"
+          ? `Tutorial "${tutorialData.title}" saved as draft.`
+          : `Tutorial "${tutorialData.title}" submitted for approval.`;
+      notify('tutorial_created', msg);
       localStorage.removeItem("tutorialDraft");
       router.push("/dashboard/admin/tutorials");
     } catch (err) {
@@ -104,7 +139,7 @@ function CreateTutorialPage() {
       if (err.response?.data?.message) {
         toast.error(err.response.data.message);
       } else {
-        toast.error("Failed to create tutorial");
+        toast.error(t('creation_failed'));
       }
     }
   };
@@ -115,11 +150,16 @@ function CreateTutorialPage() {
   return (
     <AdminLayout>
       <div className="p-8 bg-gray-100 min-h-screen max-w-4xl mx-auto">
-        <h1 className="text-3xl font-bold text-gray-800 mb-8">🎬 Create New Tutorial</h1>
+        <h1 className="text-3xl font-bold text-gray-800 mb-8">🎬 {t('title')}</h1>
 
         {/* Step Progress */}
         <StepProgressBar
-          steps={["Basic Info", "Curriculum", "Media", "Pricing & Publish"]}
+          steps={[
+            t('basic_info'),
+            t('curriculum'),
+            t('media'),
+            t('pricing_publish'),
+          ]}
           currentStep={step}
           onStepClick={(s) => {
             if (s < step) setStep(s);
@@ -169,14 +209,14 @@ function CreateTutorialPage() {
                 onClick={prevStep}
                 className="bg-gray-400 hover:bg-gray-500 text-white px-6 py-2 rounded-full font-bold"
               >
-                ⬅️ Back
+                ⬅️ {t('back')}
               </button>
             )}
             <button
               onClick={saveDraft}
               className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-full font-bold"
             >
-              💾 Save Draft
+              💾 {t('save_draft')}
             </button>
           </div>
           {step < 4 && (
@@ -184,7 +224,7 @@ function CreateTutorialPage() {
               onClick={nextStep}
               className="bg-yellow-500 hover:bg-yellow-600 text-white px-6 py-2 rounded-full font-bold"
             >
-              Next ➡️
+              {t('next')} ➡️
             </button>
           )}
         </div>
@@ -194,3 +234,11 @@ function CreateTutorialPage() {
 }
 
 export default withAuthProtection(CreateTutorialPage, ["admin", "superadmin"]);
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -4,6 +4,9 @@ import withAuthProtection from "@/hooks/withAuthProtection";
 import { Button } from "@/components/ui/button";
 import { FaEdit, FaTrash, FaPlus, FaSearch, FaCheck, FaTimes, FaSpinner } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import RejectionReasonModal from "@/components/common/RejectionReasonModal";
@@ -24,6 +27,7 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 
 function AdminTutorialsPage() {
+  const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialsPage' });
   const router = useRouter();
   const [tutorials, setTutorials] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -59,7 +63,7 @@ function AdminTutorialsPage() {
         setCategories(cats?.data || cats || []);
       } catch (err) {
         console.error(err);
-        toast.error("Failed to load tutorials");
+        toast.error(t('load_error'));
       } finally {
         setLoading(false);
       }
@@ -128,7 +132,7 @@ function AdminTutorialsPage() {
         })
       );
       const message = `Tutorial "${target.title}" status changed to ${target.status}.`;
-      toast.success("Tutorial status updated!");
+      toast.success(t('status_updated'));
       await createNotification({
         user_id: user.id,
         type: "tutorial_status_changed",
@@ -149,7 +153,7 @@ function AdminTutorialsPage() {
       refreshMessages?.();
     } catch (err) {
       console.error(err);
-      toast.error("Failed to update status");
+      toast.error(t('update_failed'));
     }
   };
 
@@ -168,10 +172,10 @@ function AdminTutorialsPage() {
     try {
       await permanentlyDeleteTutorial(tutorialToDelete);
       setTutorials((prev) => prev.filter((tut) => tut.id !== tutorialToDelete));
-      toast.success("Tutorial deleted!");
+      toast.success(t('deleted'));
     } catch (err) {
       console.error(err);
-      toast.error("Failed to delete tutorial");
+      toast.error(t('delete_failed'));
     } finally {
       setSelectedTutorials((prev) => prev.filter((id) => id !== tutorialToDelete));
       setTutorialToDelete(null);
@@ -192,7 +196,7 @@ function AdminTutorialsPage() {
           return tut;
         })
       );
-      toast.success("Tutorial rejected with reason!");
+      toast.success(t('rejected'));
       const message = `Tutorial "${target.title}" was rejected.`;
       await createNotification({
         user_id: user.id,
@@ -214,7 +218,7 @@ function AdminTutorialsPage() {
       refreshMessages?.();
     } catch (err) {
       console.error(err);
-      toast.error("Failed to reject tutorial");
+      toast.error(t('reject_failed'));
     } finally {
       setIsRejectionModalOpen(false);
       setTutorialToReject(null);
@@ -234,7 +238,7 @@ function AdminTutorialsPage() {
           return tut;
         })
       );
-      toast.success("Tutorial approved successfully!");
+      toast.success(t('approved'));
       const message = `Tutorial "${target.title}" approved.`;
       await createNotification({
         user_id: user.id,
@@ -256,7 +260,7 @@ function AdminTutorialsPage() {
       refreshMessages?.();
     } catch (err) {
       console.error(err);
-      toast.error("Failed to update tutorial");
+      toast.error(t('approval_failed'));
     }
   };
 
@@ -265,10 +269,10 @@ function AdminTutorialsPage() {
     try {
       await bulkDeleteTutorials(selectedTutorials);
       setTutorials((prev) => prev.filter((tut) => !selectedTutorials.includes(tut.id)));
-      toast.success("Selected tutorials deleted!");
+      toast.success(t('bulk_deleted'));
     } catch (err) {
       console.error(err);
-      toast.error("Failed to delete tutorials");
+      toast.error(t('bulk_delete_failed'));
     } finally {
       setSelectedTutorials([]);
     }
@@ -285,10 +289,10 @@ function AdminTutorialsPage() {
             : tut
         )
       );
-      toast.success("Selected tutorials approved!");
+      toast.success(t('bulk_approved'));
     } catch (err) {
       console.error(err);
-      toast.error("Failed to approve tutorials");
+      toast.error(t('bulk_approve_failed'));
     }
     setSelectedTutorials([]);
   };
@@ -351,16 +355,14 @@ function AdminTutorialsPage() {
         {/* Header */}
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
-            <h1 className="text-3xl font-bold text-gray-800">📚 Manage Tutorials</h1>
-            <p className="text-gray-600 mt-1">
-              Create, edit, and manage all tutorials in the system
-            </p>
+            <h1 className="text-3xl font-bold text-gray-800">📚 {t('title')}</h1>
+            <p className="text-gray-600 mt-1">{t('description')}</p>
           </div>
           <Button
             onClick={() => router.push("/dashboard/admin/tutorials/create")}
             className="bg-gradient-to-r from-yellow-500 to-yellow-600 hover:from-yellow-600 hover:to-yellow-700 text-white font-bold py-2.5 px-6 rounded-lg flex items-center shadow-md hover:shadow-lg transition-all"
           >
-            <FaPlus className="mr-2" /> Create New Tutorial
+            <FaPlus className="mr-2" /> {t('create_tutorial')}
           </Button>
         </div>
 
@@ -703,15 +705,15 @@ function AdminTutorialsPage() {
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
           onConfirm={handleConfirmDelete}
-          title="Confirm Deletion"
-          message="Are you sure you want to permanently delete this tutorial? This action cannot be undone."
+          title={t('confirm_title')}
+          message={t('confirm_delete')}
         />
         
         <RejectionReasonModal
           isOpen={isRejectionModalOpen}
           onClose={() => setIsRejectionModalOpen(false)}
           onConfirm={handleConfirmReject}
-          title="Reject Tutorial"
+          title={t('reject_title')}
         />
       </div>
     </AdminLayout>
@@ -719,3 +721,11 @@ function AdminTutorialsPage() {
 }
 
 export default withAuthProtection(AdminTutorialsPage, ["admin", "superadmin"]);
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- integrate i18n and admin notifications on tutorial creation page
- localize toasts and labels on admin tutorials list and edit pages
- add new tutorial strings in English, French and Arabic translations

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`
- `npm run lint --silent --prefix frontend` *(fails: 50 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884ddd84bf883288b38e4038301656a