### PR TITLE
Fix Next.js build error for admin tutorial edit page

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -200,7 +200,7 @@ function EditTutorialPage() {
 
 export default withAuthProtection(EditTutorialPage, ["admin", "superadmin"]);
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),


### PR DESCRIPTION
## Summary
- use `getServerSideProps` instead of `getStaticProps` on `dashboard/admin/tutorials/[id]/edit`

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`
- `npm run lint` in `frontend` *(fails: 50 errors, 199 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6884ee4a888c8328840c4822bd08fe1a