### PR TITLE
Add duration column to tutorials

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -126,7 +126,7 @@
 - **Purpose**: Tutorial master table
 - **Primary Key**: `id`
 - **Foreign Keys**: `creator_id, category_id → categories(id)`
-- **Columns**: `moderation_status`, `rejection_reason`
+- **Columns**: `duration`, `moderation_status`, `rejection_reason`
 
 ### `tutorial_chapters`
 - **Purpose**: Chapters per tutorial

--- a/backend/src/migrations/20250725003000_add_duration_to_tutorials.js
+++ b/backend/src/migrations/20250725003000_add_duration_to_tutorials.js
@@ -1,0 +1,14 @@
+exports.up = async function(knex) {
+  const hasDuration = await knex.schema.hasColumn('tutorials', 'duration');
+  if (!hasDuration) {
+    await knex.schema.alterTable('tutorials', table => {
+      table.integer('duration');
+    });
+  }
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('tutorials', table => {
+    table.dropColumn('duration');
+  });
+};


### PR DESCRIPTION
## Summary
- add a migration to introduce `duration` column on `tutorials`
- document the new column in `SkillBridge_DB_Schema_Overview.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884f502d5808328868644a4897bf1ca