### PR TITLE
Fix tutorial thumbnail DB column mismatch

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -92,7 +92,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     instructor_id,
     status,
     moderation_status: status === "published" ? "Pending" : null,
-    thumbnail_url: thumbnailFile
+    cover_image: thumbnailFile
       ? `/uploads/tutorials/${roleDir}/${thumbnailFile.filename}`
       : null,
     preview_video: previewFile
@@ -204,7 +204,7 @@ exports.updateTutorial = catchAsync(async (req, res) => {
   }
   const roleDir = getRoleDir(req);
   if (req.files?.thumbnail) {
-    data.thumbnail_url = `/uploads/tutorials/${roleDir}/${req.files.thumbnail[0].filename}`;
+    data.cover_image = `/uploads/tutorials/${roleDir}/${req.files.thumbnail[0].filename}`;
   }
   if (req.files?.preview) {
     data.preview_video = `/uploads/tutorials/${roleDir}/${req.files.preview[0].filename}`;

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -31,6 +31,8 @@ export const fetchAllTutorials = async () => {
     instructorId: t.instructor_id,
     thumbnail: t.thumbnail_url
       ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${t.thumbnail_url}`
+      : t.cover_image
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${t.cover_image}`
       : null,
     createdAt: t.created_at,
     updatedAt: t.updated_at,
@@ -87,6 +89,8 @@ export const fetchTutorialById = async (id) => {
     tags: t.tags || [],
     thumbnail: t.thumbnail_url
       ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${t.thumbnail_url}`
+      : t.cover_image
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${t.cover_image}`
       : null,
     preview: t.preview_video
       ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${t.preview_video}`

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -5,6 +5,8 @@ const formatBase = (tut) => ({
   ...tut,
   thumbnail: tut.thumbnail_url
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.thumbnail_url}`
+    : tut.cover_image
+    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.cover_image}`
     : null,
   preview: tut.preview_video
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.preview_video}`


### PR DESCRIPTION
## Summary
- use `cover_image` instead of missing `thumbnail_url` when creating and updating tutorials
- support `cover_image` fallback when formatting tutorials on the frontend

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68851211fcbc83289252c5bb9aa556a1