### PR TITLE
Add notifications when editing student profile

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -10,6 +10,10 @@ import {
   uploadStudentIdentity
 } from "@/services/student/studentService";
 import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
 import {
   FaUpload, FaTrash, FaFilePdf, FaSpinner,
   FaUserCircle, FaIdCard, FaLinkedin, FaGithub,
@@ -32,6 +36,8 @@ const studentProfileSchema = z.object({
 export default function StudentProfileEdit() {
   const router = useRouter();
   const { user, logout, hasHydrated, setUser } = useAuthStore();
+  const refreshNotifications = useNotificationStore((s) => s.fetch);
+  const refreshMessages = useMessageStore((s) => s.fetch);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [expanded, setExpanded] = useState({
@@ -218,6 +224,20 @@ export default function StudentProfileEdit() {
       });
 
       toast.success("Profile updated successfully!");
+
+      try {
+        const message = "Your student profile was updated.";
+        await createNotification({
+          user_id: user.id,
+          type: "profile_update",
+          message,
+        });
+        await sendChatMessage(user.id, { text: message });
+        refreshNotifications?.();
+        refreshMessages?.();
+      } catch (err) {
+        console.error(err);
+      }
 
       // 🚀 Direct new users to email/phone verification
       router.push("/dashboard/student/profile/steps/Verification");

--- a/frontend/src/pages/dashboard/student/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/Verification.js
@@ -5,6 +5,8 @@ import { motion } from "framer-motion";
 import { useRouter } from "next/router";
 import { FaArrowLeft, FaCheckCircle, FaEnvelope, FaPhone } from "react-icons/fa";
 import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
 import {
   sendEmailOtp,
   sendPhoneOtp,
@@ -18,6 +20,8 @@ const Verification = ({ prevStep = () => {} }) => {
   const router = useRouter();
 
   const { user, refreshUser } = useAuthStore();
+  const refreshNotifications = useNotificationStore((s) => s.fetch);
+  const refreshMessages = useMessageStore((s) => s.fetch);
   const [emailVerified, setEmailVerified] = useState(user?.is_email_verified || false);
   const [phoneVerified, setPhoneVerified] = useState(user?.is_phone_verified || false);
   const [emailOTP, setEmailOTP] = useState("");
@@ -63,6 +67,8 @@ const Verification = ({ prevStep = () => {} }) => {
       type === "email" ? setEmailVerified(true) : setPhoneVerified(true);
 
       await refreshUser();
+      refreshNotifications?.();
+      refreshMessages?.();
 
       const emailNow = type === "email" ? true : emailVerified;
       const phoneNow = type === "phone" ? true : phoneVerified;


### PR DESCRIPTION
## Summary
- notify student via notification and message after updating profile
- refresh notifications and messages after verifying email or phone

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688513dded28832898f9ff5f4229b90d