### PR TITLE
Fix missing tutorial tag tables

### DIFF
--- a/backend/src/migrations/20250725003500_create_tags_table.js
+++ b/backend/src/migrations/20250725003500_create_tags_table.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tags', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable().unique();
+    table.string('slug').notNullable().unique();
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tags');
+};

--- a/backend/src/migrations/20250725003600_create_tutorial_tag_map_table.js
+++ b/backend/src/migrations/20250725003600_create_tutorial_tag_map_table.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_tag_map', function(table) {
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.uuid('tag_id').notNullable().references('id').inTable('tags').onDelete('CASCADE');
+    table.primary(['tutorial_id', 'tag_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_tag_map');
+};


### PR DESCRIPTION
## Summary
- add migrations for `tags` and tutorial tag mapping

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68851d30f0c48328a6f895dfcc0660a0