### PR TITLE
Fix AddUserModal fields and add translations

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -530,6 +530,12 @@
     "update_success": "تم تحديث الدرس بنجاح!",
     "update_failed": "فشل تحديث الدرس"
   },
+  "usersPage": {
+    "title": "إدارة المستخدمين",
+    "add_user": "إضافة مستخدم",
+    "user_added": "تم إضافة المستخدم بنجاح.",
+    "user_add_failed": "فشل إضافة المستخدم."
+  },
   "sidebar": {
     "Account": "\u0627\u0644\u062d\u0633\u0627\u0628",
     "Bookings": "\u0627\u0644\u062d\u062c\u0648\u0632\u0627\u062a",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -530,6 +530,12 @@
     "update_success": "Tutorial updated successfully!",
     "update_failed": "Failed to update tutorial"
   },
+  "usersPage": {
+    "title": "User Management",
+    "add_user": "Add User",
+    "user_added": "User added successfully.",
+    "user_add_failed": "Failed to add user."
+  },
   "sidebar": {
     "Account": "Account",
     "Bookings": "Bookings",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -494,6 +494,12 @@
     "update_success": "Tutoriel mis à jour avec succès !",
     "update_failed": "Échec de la mise à jour du tutoriel"
   },
+  "usersPage": {
+    "title": "Gestion des utilisateurs",
+    "add_user": "Ajouter un utilisateur",
+    "user_added": "Utilisateur ajouté avec succès.",
+    "user_add_failed": "Échec de l'ajout de l'utilisateur."
+  },
   "sidebar": {
     "Account": "Compte",
     "Bookings": "Réservations",

--- a/frontend/src/components/admin/users/AddUserModal.js
+++ b/frontend/src/components/admin/users/AddUserModal.js
@@ -1,11 +1,15 @@
 import { useState, useEffect } from "react";
 import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
 import "react-toastify/dist/ReactToastify.css";
 
 export default function AddUserModal({ isOpen, onClose, onSubmit }) {
+  const { t } = useTranslation("dashboard");
   const [formData, setFormData] = useState({
     full_name: "",
     email: "",
+    phone: "",
+    password: "",
     role: "student",
     status: "active",
     avatar: null,
@@ -20,6 +24,8 @@ export default function AddUserModal({ isOpen, onClose, onSubmit }) {
       setFormData({
         full_name: "",
         email: "",
+        phone: "",
+        password: "",
         role: "student",
         status: "active",
         avatar: null,
@@ -48,24 +54,29 @@ export default function AddUserModal({ isOpen, onClose, onSubmit }) {
   };
 
   const handleSubmit = async () => {
-    if (!formData.full_name.trim() || !formData.email.trim() || !formData.password.trim() || !formData.phone.trim()) {
-      toast.error("Please fill in all required fields.");
+    if (
+      !formData.full_name.trim() ||
+      !formData.email.trim() ||
+      !formData.password.trim() ||
+      !formData.phone.trim()
+    ) {
+      toast.error(t("fill_required_fields"));
       return;
     }
 
     const emailRegex = /\S+@\S+\.\S+/;
     if (!emailRegex.test(formData.email)) {
-      toast.error("Please enter a valid email address.");
+      toast.error(t("please_enter_valid_email", { ns: "auth" }));
       return;
     }
 
     setLoading(true);
     try {
       await onSubmit(formData);
-      toast.success("User added successfully.");
+      toast.success(t("usersPage.user_added"));
       onClose();
     } catch (err) {
-      toast.error(err.response?.data?.message || "Something went wrong.");
+      toast.error(err.response?.data?.message || t("usersPage.user_add_failed"));
     } finally {
       setLoading(false);
     }
@@ -81,7 +92,9 @@ export default function AddUserModal({ isOpen, onClose, onSubmit }) {
       className="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center"
     >
       <div className="bg-white p-6 rounded-lg w-full max-w-md shadow-lg">
-        <h2 id="modal-title" className="text-xl font-bold mb-4">Add New User</h2>
+        <h2 id="modal-title" className="text-xl font-bold mb-4">
+          {t("usersPage.add_user")}
+        </h2>
 
         <input
           type="text"

--- a/frontend/src/pages/dashboard/admin/users/index.js
+++ b/frontend/src/pages/dashboard/admin/users/index.js
@@ -1,12 +1,17 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import UserList from "@/components/admin/users/UserList";
 import { fetchAllUsers } from "@/services/admin/userService";
 import useAuthStore from "@/store/auth/authStore";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import { toast } from "react-toastify";
 
-export default function UsersPage() {
+function UsersPage() {
+  const { t } = useTranslation("dashboard");
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [editUser, setEditUser] = useState(null);
@@ -68,12 +73,12 @@ export default function UsersPage() {
     <AdminLayout>
       <div className="p-8">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="text-3xl font-bold text-gray-800">User Management</h1>
+          <h1 className="text-3xl font-bold text-gray-800">{t("usersPage.title")}</h1>
           <button
             onClick={() => router.push("/dashboard/admin/users/create")}
             className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg transition"
           >
-            + Add User
+            + {t("usersPage.add_user")}
           </button>
         </div>
 
@@ -105,4 +110,16 @@ export default function UsersPage() {
       </div>
     </AdminLayout>
   );
+}
+
+const ProtectedUsersPage = withAuthProtection(UsersPage, ["admin", "superadmin"]);
+
+export default ProtectedUsersPage;
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard", "auth"], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- add phone and password fields to AddUserModal state
- internationalize AddUserModal strings and user list page
- add `usersPage` translation keys in en, ar and fr locales
- wrap admin users page with auth protection
- add i18n support on admin users page

## Testing
- `node scripts/checkTranslations.js` *(shows missing keys for es/fr due to incomplete translations)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68852e28ca448328bfe58c66e2dbb6e1