### PR TITLE
Fix incorrect i18next config paths

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
@@ -3,7 +3,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState, useEffect } from "react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { fetchThirdPartyConfig, updateThirdPartyConfig } from "@/services/admin/thirdPartyService";
 import { toast } from "react-toastify";
 import {

--- a/frontend/src/pages/dashboard/admin/users/index.js
+++ b/frontend/src/pages/dashboard/admin/users/index.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import UserList from "@/components/admin/users/UserList";
 import { fetchAllUsers } from "@/services/admin/userService";


### PR DESCRIPTION
## Summary
- fix broken relative import path in admin third-party settings page
- fix broken relative import path in admin users page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885373696208328b1c389e0145b5111