### PR TITLE
Implement basic support ticket system

### DIFF
--- a/backend/src/migrations/20250725003700_create_support_tables.js
+++ b/backend/src/migrations/20250725003700_create_support_tables.js
@@ -1,0 +1,23 @@
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('support_tickets', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+      table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      table.string('subject').notNullable();
+      table.string('status').notNullable().defaultTo('open');
+      table.timestamps(true, true);
+    })
+    .createTable('support_messages', function(table) {
+      table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+      table.uuid('ticket_id').notNullable().references('id').inTable('support_tickets').onDelete('CASCADE');
+      table.uuid('sender_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      table.text('message').notNullable();
+      table.timestamp('created_at').defaultTo(knex.fn.now());
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .dropTable('support_messages')
+    .dropTable('support_tickets');
+};

--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -1,0 +1,49 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
+const service = require("./support.service");
+
+exports.createTicket = catchAsync(async (req, res) => {
+  const ticket = await service.createTicket({
+    user_id: req.user.id,
+    subject: req.body.subject,
+    message: req.body.message,
+  });
+  sendSuccess(res, ticket, "Ticket created");
+});
+
+exports.listMyTickets = catchAsync(async (req, res) => {
+  const tickets = await service.listUserTickets(req.user.id);
+  sendSuccess(res, tickets);
+});
+
+exports.listAllTickets = catchAsync(async (_req, res) => {
+  const tickets = await service.listAllTickets();
+  sendSuccess(res, tickets);
+});
+
+exports.getTicket = catchAsync(async (req, res) => {
+  const data = await service.getTicketById(req.params.id);
+  if (!data) throw new AppError("Ticket not found", 404);
+  sendSuccess(res, data);
+});
+
+exports.addMessage = catchAsync(async (req, res) => {
+  const ticket = await service.getTicketById(req.params.id);
+  if (!ticket) throw new AppError("Ticket not found", 404);
+  if (ticket.user_id !== req.user.id && !req.user.roles.includes("admin")) {
+    throw new AppError("Access denied", 403);
+  }
+  const msg = await service.addMessage({
+    ticket_id: req.params.id,
+    sender_id: req.user.id,
+    message: req.body.message,
+  });
+  sendSuccess(res, msg, "Message added");
+});
+
+exports.updateStatus = catchAsync(async (req, res) => {
+  const ticket = await service.updateStatus(req.params.id, req.body.status);
+  if (!ticket) throw new AppError("Ticket not found", 404);
+  sendSuccess(res, ticket, "Status updated");
+});

--- a/backend/src/modules/support/support.routes.js
+++ b/backend/src/modules/support/support.routes.js
@@ -1,0 +1,15 @@
+const router = require("express").Router();
+const controller = require("./support.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken);
+
+router.post("/tickets", controller.createTicket);
+router.get("/my-tickets", controller.listMyTickets);
+router.get("/tickets/:id", controller.getTicket);
+router.post("/tickets/:id/messages", controller.addMessage);
+
+router.get("/admin/tickets", isAdmin, controller.listAllTickets);
+router.patch("/admin/tickets/:id/status", isAdmin, controller.updateStatus);
+
+module.exports = router;

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -1,0 +1,54 @@
+const db = require("../../config/database");
+
+exports.createTicket = async ({ user_id, subject, message }) => {
+  const [ticket] = await db("support_tickets")
+    .insert({ user_id, subject })
+    .returning("*");
+  await db("support_messages").insert({
+    ticket_id: ticket.id,
+    sender_id: user_id,
+    message,
+  });
+  return ticket;
+};
+
+exports.listUserTickets = (user_id) => {
+  return db("support_tickets")
+    .where({ user_id })
+    .orderBy("created_at", "desc");
+};
+
+exports.listAllTickets = () => {
+  return db("support_tickets")
+    .leftJoin("users", "support_tickets.user_id", "users.id")
+    .select("support_tickets.*", "users.email as user")
+    .orderBy("support_tickets.created_at", "desc");
+};
+
+exports.getTicketById = async (id) => {
+  const ticket = await db("support_tickets")
+    .leftJoin("users", "support_tickets.user_id", "users.id")
+    .select("support_tickets.*", "users.email as user")
+    .where({ "support_tickets.id": id })
+    .first();
+  if (!ticket) return null;
+  const messages = await db("support_messages")
+    .where({ ticket_id: id })
+    .orderBy("created_at", "asc");
+  return { ...ticket, messages };
+};
+
+exports.addMessage = async ({ ticket_id, sender_id, message }) => {
+  const [row] = await db("support_messages")
+    .insert({ ticket_id, sender_id, message })
+    .returning("*");
+  return row;
+};
+
+exports.updateStatus = async (id, status) => {
+  const [row] = await db("support_tickets")
+    .where({ id })
+    .update({ status, updated_at: db.fn.now() })
+    .returning("*");
+  return row;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -118,6 +118,7 @@ app.use("/api/chat", require("./modules/chat/chat.routes"));
 app.use("/api/languages", require("./modules/languages/languages.routes"));
 app.use("/api/currencies", require("./modules/currencies/currencies.routes"));
 app.use("/api/blog", require("./modules/blog/blog.routes"));
+app.use("/api/support", require("./modules/support/support.routes"));
 app.use("/api/media", require("./modules/media/media.routes"));
 
 app.get("/", (req, res) => res.send("🚀 SkillBridge API is live."));

--- a/frontend/src/pages/dashboard/admin/support/tickets/[id].js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/[id].js
@@ -1,57 +1,63 @@
 import { useRouter } from "next/router";
 import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { fetchTicketById, addMessage, updateStatus } from "@/services/supportService";
 
-const mockThread = {
-  id: "TCK-1001",
-  subject: "Refund not processed",
-  user: "ayman@example.com",
-  status: "Open",
-  messages: [
-    {
-      sender: "user",
-      name: "Ayman Osman",
-      timestamp: "2025-05-01 10:15",
-      content: "I requested a refund 3 days ago but haven't received it yet."
-    },
-    {
-      sender: "support",
-      name: "Support Agent",
-      timestamp: "2025-05-02 09:00",
-      content: "Thank you for your message. We are reviewing your refund request."
-    }
-  ]
-};
 
 export default function AdminTicketDetail() {
   const router = useRouter();
   const { id } = router.query;
+  const [ticket, setTicket] = useState(null);
   const [reply, setReply] = useState("");
-  const [status, setStatus] = useState(mockThread.status);
+  const [status, setStatus] = useState("open");
 
-  const handleReply = (e) => {
-    e.preventDefault();
-    alert("Reply sent: " + reply);
-    setReply("");
-    // TODO: Integrate reply with backend
-  };
+  useEffect(() => {
+    if (id) load();
+  }, [id]);
 
-  const handleClose = () => {
-    const confirmed = confirm("Are you sure you want to close this ticket?");
-    if (confirmed) {
-      setStatus("Resolved");
-      alert("Ticket marked as resolved.");
-      // TODO: Update backend
+  const load = async () => {
+    try {
+      const data = await fetchTicketById(id);
+      setTicket(data);
+      setStatus(data.status);
+    } catch (err) {
+      console.error("Failed to fetch ticket", err);
     }
   };
 
-  const handleReopen = () => {
+  const handleReply = async (e) => {
+    e.preventDefault();
+    try {
+      await addMessage(id, reply);
+      setReply("");
+      load();
+    } catch (err) {
+      console.error("Failed to send reply", err);
+    }
+  };
+
+  const handleClose = async () => {
+    const confirmed = confirm("Are you sure you want to close this ticket?");
+    if (confirmed) {
+      try {
+        await updateStatus(id, "resolved");
+        setStatus("resolved");
+      } catch (err) {
+        console.error("Failed to close ticket", err);
+      }
+    }
+  };
+
+  const handleReopen = async () => {
     const confirmed = confirm("Reopen this ticket?");
     if (confirmed) {
-      setStatus("Open");
-      alert("Ticket reopened.");
-      // TODO: Update backend
+      try {
+        await updateStatus(id, "open");
+        setStatus("open");
+      } catch (err) {
+        console.error("Failed to reopen ticket", err);
+      }
     }
   };
 
@@ -60,7 +66,7 @@ export default function AdminTicketDetail() {
       <PageHead title={`Ticket ${id} - Admin`} />
       <div className="px-6 py-10">
         <div className="flex items-center justify-between mb-2">
-          <h1 className="text-2xl font-bold text-gray-900">{mockThread.subject}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{ticket?.subject}</h1>
           {status === "Resolved" ? (
             <button
               onClick={handleReopen}
@@ -77,10 +83,10 @@ export default function AdminTicketDetail() {
             </button>
           )}
         </div>
-        <p className="text-sm text-gray-500 mb-8">From: <strong>{mockThread.user}</strong> | Status: <span className="font-semibold text-yellow-600">{status}</span></p>
+        <p className="text-sm text-gray-500 mb-8">From: <strong>{ticket?.user}</strong> | Status: <span className="font-semibold text-yellow-600">{status}</span></p>
 
         <div className="space-y-6 mb-12">
-          {mockThread.messages.map((msg, index) => (
+          {ticket?.messages?.map((msg, index) => (
             <div
               key={index}
               className={`p-4 rounded-lg border ${msg.sender === "user" ? "bg-white border-gray-200" : "bg-yellow-50 border-yellow-200"}`}

--- a/frontend/src/pages/dashboard/admin/support/tickets/index.js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/index.js
@@ -1,83 +1,68 @@
 import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import Link from "next/link";
-
-const mockTickets = [
-    {
-        id: "TCK-1001",
-        subject: "Refund not processed",
-        user: "ayman@example.com",
-        category: "Billing",
-        status: "Open",
-        createdAt: "2025-05-01",
-        priority: "High",
-    },
-    {
-        id: "TCK-1002",
-        subject: "Unable to join live class",
-        user: "student@domain.com",
-        category: "Technical",
-        status: "Resolved",
-        createdAt: "2025-04-28",
-        priority: "Medium",
-    },
-];
+import { useEffect, useState } from "react";
+import { fetchAllTickets } from "@/services/supportService";
 
 export default function AdminSupportTicketsPage() {
-    return (
-        <AdminLayout>
-            <PageHead title="Support Tickets - Admin" />
-            <div className="px-6 py-10">
-                <h1 className="text-2xl font-bold text-gray-900 mb-6">All Support Tickets</h1>
+  const [tickets, setTickets] = useState([]);
 
-                <div className="overflow-x-auto border border-gray-200 rounded shadow-sm">
-                    <table className="min-w-full table-auto bg-white">
-                        <thead className="bg-gray-100 text-sm text-gray-600 uppercase">
-                            <tr>
-                                <th className="text-left px-4 py-3">Ticket ID</th>
-                                <th className="text-left px-4 py-3">User</th>
-                                <th className="text-left px-4 py-3">Subject</th>
-                                <th className="text-left px-4 py-3">Category</th>
-                                <th className="text-left px-4 py-3">Priority</th>
-                                <th className="text-left px-4 py-3">Status</th>
-                                <th className="text-left px-4 py-3">Created</th>
-                                <th className="text-left px-4 py-3">Action</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {mockTickets.map((ticket) => (
-                                <tr key={ticket.id} className="border-t border-gray-100 hover:bg-gray-50">
-                                    <td className="px-4 py-3 font-mono text-sm">{ticket.id}</td>
-                                    <td className="px-4 py-3 text-sm">{ticket.user}</td>
-                                    <td className="px-4 py-3 text-sm">{ticket.subject}</td>
-                                    <td className="px-4 py-3 text-sm">{ticket.category}</td>
-                                    <td className="px-4 py-3 text-sm">{ticket.priority}</td>
-                                    <td className="px-4 py-3 text-sm">
-                                        <span className={`px-2 py-1 rounded text-xs font-medium ${ticket.status === "Resolved"
-                                                ? "bg-green-100 text-green-700"
-                                                : ticket.status === "Open"
-                                                    ? "bg-yellow-100 text-yellow-800"
-                                                    : "bg-gray-100 text-gray-600"
-                                            }`}>
-                                            {ticket.status}
-                                        </span>
+  useEffect(() => {
+    load();
+  }, []);
 
-                                    </td>
-                                    <td className="px-4 py-3 text-sm text-gray-500">{ticket.createdAt}</td>
-                                    <td className="px-4 py-3 text-sm">
-                                        <Link
-                                            href={`/support/tickets/${ticket.id}`}
-                                            className="text-blue-600 hover:underline"
-                                        >
-                                            View
-                                        </Link>
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </AdminLayout>
-    );
+  const load = async () => {
+    try {
+      const data = await fetchAllTickets();
+      setTickets(data);
+    } catch (err) {
+      console.error("Failed to fetch tickets", err);
+    }
+  };
+
+  return (
+    <AdminLayout>
+      <PageHead title="Support Tickets - Admin" />
+      <div className="px-6 py-10">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">All Support Tickets</h1>
+
+        <div className="overflow-x-auto border border-gray-200 rounded shadow-sm">
+          <table className="min-w-full table-auto bg-white">
+            <thead className="bg-gray-100 text-sm text-gray-600 uppercase">
+              <tr>
+                <th className="text-left px-4 py-3">Ticket ID</th>
+                <th className="text-left px-4 py-3">Subject</th>
+                <th className="text-left px-4 py-3">Status</th>
+                <th className="text-left px-4 py-3">Created</th>
+                <th className="text-left px-4 py-3">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tickets.map((ticket) => (
+                <tr key={ticket.id} className="border-t border-gray-100 hover:bg-gray-50">
+                  <td className="px-4 py-3 font-mono text-sm">{ticket.id}</td>
+                  <td className="px-4 py-3 text-sm">{ticket.subject}</td>
+                  <td className="px-4 py-3 text-sm">
+                    <span
+                      className={`px-2 py-1 rounded text-xs font-medium ${ticket.status === "resolved" ? "bg-green-100 text-green-700" : "bg-yellow-100 text-yellow-800"}`}
+                    >
+                      {ticket.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">
+                    {new Date(ticket.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <Link href={`/dashboard/admin/support/tickets/${ticket.id}`} className="text-blue-600 hover:underline">
+                      View
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </AdminLayout>
+  );
 }

--- a/frontend/src/pages/dashboard/instructor/support/my-tickets.js
+++ b/frontend/src/pages/dashboard/instructor/support/my-tickets.js
@@ -1,27 +1,28 @@
 import PageHead from "@/components/common/PageHead";
 import Link from "next/link";
-import StudentLayout from "@/components/layouts/StudentLayout";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import { useEffect, useState } from "react";
+import { fetchMyTickets } from "@/services/supportService";
 
-const mockTickets = [
-  {
-    id: "TCK-1001",
-    subject: "Refund not processed",
-    status: "Open",
-    createdAt: "2025-05-01",
-    lastUpdated: "2025-05-03",
-  },
-  {
-    id: "TCK-1002",
-    subject: "Unable to join live class",
-    status: "Resolved",
-    createdAt: "2025-04-28",
-    lastUpdated: "2025-04-30",
-  },
-];
+export default function MyTicketsPage() {
+  const [tickets, setTickets] = useState([]);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const load = async () => {
+    try {
+      const data = await fetchMyTickets();
+      setTickets(data);
+    } catch (err) {
+      console.error("Failed to load tickets", err);
+    }
+  };
 
 export default function MyTicketsPage() {
   return (
-    <StudentLayout>
+    <InstructorLayout>
       <PageHead title="My Tickets - Dashboard" />
       <div className="px-6 py-10">
         <div className="flex items-center justify-between mb-6">
@@ -34,7 +35,7 @@ export default function MyTicketsPage() {
           </Link>
         </div>
 
-        {mockTickets.length === 0 ? (
+        {tickets.length === 0 ? (
           <p className="text-gray-500 text-center">You haven’t submitted any tickets yet.</p>
         ) : (
           <div className="overflow-x-auto border border-gray-200 rounded shadow-sm">
@@ -45,12 +46,11 @@ export default function MyTicketsPage() {
                   <th className="text-left px-4 py-3">Subject</th>
                   <th className="text-left px-4 py-3">Status</th>
                   <th className="text-left px-4 py-3">Created</th>
-                  <th className="text-left px-4 py-3">Last Updated</th>
                   <th className="text-left px-4 py-3">Action</th>
                 </tr>
               </thead>
               <tbody>
-                {mockTickets.map((ticket) => (
+                {tickets.map((ticket) => (
                   <tr key={ticket.id} className="border-t border-gray-100 hover:bg-gray-50">
                     <td className="px-4 py-3 font-mono text-sm">{ticket.id}</td>
                     <td className="px-4 py-3 text-sm">{ticket.subject}</td>
@@ -65,8 +65,7 @@ export default function MyTicketsPage() {
                         {ticket.status}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{ticket.createdAt}</td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{ticket.lastUpdated}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{new Date(ticket.created_at).toLocaleDateString()}</td>
                     <td className="px-4 py-3 text-sm">
                       <Link
                         href={`/support/tickets/${ticket.id}`}
@@ -82,6 +81,6 @@ export default function MyTicketsPage() {
           </div>
         )}
       </div>
-    </StudentLayout>
+    </InstructorLayout>
   );
 }

--- a/frontend/src/pages/dashboard/student/support/my-tickets.js
+++ b/frontend/src/pages/dashboard/student/support/my-tickets.js
@@ -1,23 +1,24 @@
 import PageHead from "@/components/common/PageHead";
 import Link from "next/link";
 import StudentLayout from "@/components/layouts/StudentLayout";
+import { useEffect, useState } from "react";
+import { fetchMyTickets } from "@/services/supportService";
 
-const mockTickets = [
-  {
-    id: "TCK-1001",
-    subject: "Refund not processed",
-    status: "Open",
-    createdAt: "2025-05-01",
-    lastUpdated: "2025-05-03",
-  },
-  {
-    id: "TCK-1002",
-    subject: "Unable to join live class",
-    status: "Resolved",
-    createdAt: "2025-04-28",
-    lastUpdated: "2025-04-30",
-  },
-];
+export default function MyTicketsPage() {
+  const [tickets, setTickets] = useState([]);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const load = async () => {
+    try {
+      const data = await fetchMyTickets();
+      setTickets(data);
+    } catch (err) {
+      console.error("Failed to load tickets", err);
+    }
+  };
 
 export default function MyTicketsPage() {
   return (
@@ -34,7 +35,7 @@ export default function MyTicketsPage() {
           </Link>
         </div>
 
-        {mockTickets.length === 0 ? (
+        {tickets.length === 0 ? (
           <p className="text-gray-500 text-center">You haven’t submitted any tickets yet.</p>
         ) : (
           <div className="overflow-x-auto border border-gray-200 rounded shadow-sm">
@@ -45,12 +46,11 @@ export default function MyTicketsPage() {
                   <th className="text-left px-4 py-3">Subject</th>
                   <th className="text-left px-4 py-3">Status</th>
                   <th className="text-left px-4 py-3">Created</th>
-                  <th className="text-left px-4 py-3">Last Updated</th>
                   <th className="text-left px-4 py-3">Action</th>
                 </tr>
               </thead>
               <tbody>
-                {mockTickets.map((ticket) => (
+                {tickets.map((ticket) => (
                   <tr key={ticket.id} className="border-t border-gray-100 hover:bg-gray-50">
                     <td className="px-4 py-3 font-mono text-sm">{ticket.id}</td>
                     <td className="px-4 py-3 text-sm">{ticket.subject}</td>
@@ -65,8 +65,7 @@ export default function MyTicketsPage() {
                         {ticket.status}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{ticket.createdAt}</td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{ticket.lastUpdated}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{new Date(ticket.created_at).toLocaleDateString()}</td>
                     <td className="px-4 py-3 text-sm">
                       <Link
                         href={`/support/tickets/${ticket.id}`}

--- a/frontend/src/pages/support/submit.js
+++ b/frontend/src/pages/support/submit.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createTicket } from "@/services/supportService";
 import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
@@ -16,11 +17,15 @@ export default function SubmitTicketPage() {
     setForm((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Submitted ticket:", form);
-    // TODO: Integrate with backend API
-    alert("Support ticket submitted!");
+    try {
+      await createTicket({ subject: form.subject, message: form.message });
+      alert("Support ticket submitted!");
+      setForm({ subject: "", category: "", priority: "Medium", message: "", attachment: null });
+    } catch (err) {
+      console.error("Failed to submit ticket", err);
+    }
   };
 
   return (

--- a/frontend/src/pages/support/tickets/[id].js
+++ b/frontend/src/pages/support/tickets/[id].js
@@ -2,39 +2,37 @@ import { useRouter } from "next/router";
 import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
-import { useState } from "react";
-
-// Mocked ticket and message thread
-const mockThread = {
-  id: "TCK-1001",
-  subject: "Refund not processed",
-  status: "Open",
-  messages: [
-    {
-      sender: "user",
-      name: "Ayman Osman",
-      timestamp: "2025-05-01 10:15",
-      content: "I requested a refund 3 days ago but haven't received it yet."
-    },
-    {
-      sender: "support",
-      name: "Support Agent",
-      timestamp: "2025-05-02 09:00",
-      content: "Thank you for your message. We are reviewing your refund request."
-    }
-  ]
-};
+import { useEffect, useState } from "react";
+import { fetchTicketById, addMessage } from "@/services/supportService";
 
 export default function TicketDetailPage() {
   const router = useRouter();
   const { id } = router.query;
+  const [ticket, setTicket] = useState(null);
   const [reply, setReply] = useState("");
 
-  const handleReply = (e) => {
+  useEffect(() => {
+    if (id) load();
+  }, [id]);
+
+  const load = async () => {
+    try {
+      const data = await fetchTicketById(id);
+      setTicket(data);
+    } catch (err) {
+      console.error("Failed to fetch ticket", err);
+    }
+  };
+
+  const handleReply = async (e) => {
     e.preventDefault();
-    alert("Reply sent: " + reply);
-    setReply("");
-    // TODO: Integrate reply with backend
+    try {
+      await addMessage(id, reply);
+      setReply("");
+      load();
+    } catch (err) {
+      console.error("Failed to send reply", err);
+    }
   };
 
   return (
@@ -42,11 +40,11 @@ export default function TicketDetailPage() {
       <PageHead title={`Ticket ${id} - Support`} />
       <Navbar />
       <main className="max-w-4xl mx-auto px-4 py-20">
-        <h1 className="text-2xl font-bold text-yellow-500 mb-4">{mockThread.subject}</h1>
-        <p className="text-sm text-gray-400 mb-8">Status: <span className="font-semibold text-yellow-300">{mockThread.status}</span></p>
+        <h1 className="text-2xl font-bold text-yellow-500 mb-4">{ticket?.subject}</h1>
+        <p className="text-sm text-gray-400 mb-8">Status: <span className="font-semibold text-yellow-300">{ticket?.status}</span></p>
 
         <div className="space-y-6 mb-12">
-          {mockThread.messages.map((msg, index) => (
+          {ticket?.messages?.map((msg, index) => (
             <div
               key={index}
               className={`p-4 rounded-lg ${msg.sender === "user" ? "bg-gray-800" : "bg-gray-700"}`}
@@ -55,7 +53,7 @@ export default function TicketDetailPage() {
                 <span className="font-semibold text-yellow-400">{msg.name}</span>
                 <span className="text-gray-400">{msg.timestamp}</span>
               </div>
-              <p className="text-gray-200 whitespace-pre-line">{msg.content}</p>
+              <p className="text-gray-200 whitespace-pre-line">{msg.message}</p>
             </div>
           ))}
         </div>

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -1,0 +1,31 @@
+import api from "@/services/api/api";
+
+export const createTicket = async ({ subject, message }) => {
+  const { data } = await api.post("/support/tickets", { subject, message });
+  return data?.data;
+};
+
+export const fetchMyTickets = async () => {
+  const { data } = await api.get("/support/my-tickets");
+  return data?.data ?? [];
+};
+
+export const fetchAllTickets = async () => {
+  const { data } = await api.get("/support/admin/tickets");
+  return data?.data ?? [];
+};
+
+export const fetchTicketById = async (id) => {
+  const { data } = await api.get(`/support/tickets/${id}`);
+  return data?.data;
+};
+
+export const addMessage = async (id, message) => {
+  const { data } = await api.post(`/support/tickets/${id}/messages`, { message });
+  return data?.data;
+};
+
+export const updateStatus = async (id, status) => {
+  const { data } = await api.patch(`/support/admin/tickets/${id}/status`, { status });
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- add backend support ticket tables, service, controller and routes
- expose support routes in server
- create support service in frontend
- hook up admin/student/instructor support pages to the API
- allow users to submit and reply to tickets

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_688544bfaa388328b98872ca25f8fdc4