### PR TITLE
Add join request notifications for group admins

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -216,7 +216,33 @@ exports.getMyGroups = catchAsync(async (req, res) => {
 });
 
 exports.joinGroup = catchAsync(async (req, res) => {
-  const reqRow = await service.requestJoin(req.params.id, req.user.id);
+  const groupId = req.params.id;
+  const reqRow = await service.requestJoin(groupId, req.user.id);
+
+  const group = await service.getGroupById(groupId);
+  const adminIds = await service.listAdminIds(groupId);
+  const note = `${req.user.full_name} requested to join the group "${group.name}"`;
+
+  const recipients = adminIds.filter((uid) => uid !== req.user.id);
+  await Promise.all(
+    recipients.map((uid) =>
+      notificationService.createNotification({
+        user_id: uid,
+        type: "join_request",
+        message: note,
+      })
+    )
+  );
+  await Promise.all(
+    recipients.map((uid) =>
+      messageService.createMessage({
+        sender_id: req.user.id,
+        receiver_id: uid,
+        message: note,
+      })
+    )
+  );
+
   sendSuccess(res, reqRow, "Request sent");
 });
 
@@ -262,6 +288,23 @@ exports.manageJoinRequest = catchAsync(async (req, res) => {
     throw new AppError("Invalid action", 400);
   }
   const result = await service.manageJoinRequest(requestId, action);
+  if (result) {
+    const group = await service.getGroupById(result.group_id);
+    const note =
+      action === "approve"
+        ? `Your request to join "${group.name}" was approved`
+        : `Your request to join "${group.name}" was rejected`;
+    await notificationService.createNotification({
+      user_id: result.user_id,
+      type: "join_request_" + action,
+      message: note,
+    });
+    await messageService.createMessage({
+      sender_id: req.user.id,
+      receiver_id: result.user_id,
+      message: note,
+    });
+  }
   sendSuccess(res, result);
 });
 

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -209,6 +209,15 @@ exports.listMembers = (groupId) => {
     .where("gm.group_id", groupId);
 };
 
+// List user IDs of admins and moderators for a group
+exports.listAdminIds = async (groupId) => {
+  const rows = await db("group_members")
+    .where({ group_id: groupId })
+    .whereIn("role", ["admin", "moderator"])
+    .select("user_id");
+  return rows.map((r) => r.user_id);
+};
+
 // Update member role or remove
 exports.manageMember = async (groupId, userId, action) => {
   if (action === "kick") {

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -29,6 +29,7 @@ export default function AdminGroupDetailsPage() {
   const [activeTab, setActiveTab] = useState('overview');
   const [members, setMembers] = useState([]);
   const [requests, setRequests] = useState([]);
+  const [pendingCount, setPendingCount] = useState(0);
   const [searchTerm, setSearchTerm] = useState('');
   const [sortKey, setSortKey] = useState('name');
   const [selectedMembers, setSelectedMembers] = useState([]);
@@ -53,8 +54,10 @@ export default function AdminGroupDetailsPage() {
       try {
         const reqs = await groupService.getJoinRequestsForGroup(id);
         setRequests(reqs);
+        setPendingCount(Array.isArray(reqs) ? reqs.length : 0);
       } catch {
         setRequests([]);
+        setPendingCount(0);
       }
     };
     load();
@@ -158,7 +161,18 @@ export default function AdminGroupDetailsPage() {
                   : 'text-gray-600 hover:text-yellow-600'
                 }`}
             >
-              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+              {tab === 'requests' ? (
+                <>
+                  Requests
+                  {pendingCount > 0 && (
+                    <span className="ml-1 px-2 py-0.5 text-xs rounded-full bg-red-600 text-white">
+                      {pendingCount}
+                    </span>
+                  )}
+                </>
+              ) : (
+                tab.charAt(0).toUpperCase() + tab.slice(1)
+              )}
             </button>
           ))}
         </div>
@@ -375,7 +389,9 @@ export default function AdminGroupDetailsPage() {
                                   ...members,
                                   { id: req.userId, name: req.name, role: 'member' },
                                 ]);
-                                setRequests(requests.filter((r) => r.id !== req.id));
+                                const next = requests.filter((r) => r.id !== req.id);
+                                setRequests(next);
+                                setPendingCount(next.length);
                               } catch {
                                 // ignore
                               }
@@ -390,7 +406,9 @@ export default function AdminGroupDetailsPage() {
                             if (confirm(`Reject ${req.name}?`)) {
                               try {
                                 await groupService.rejectRequest(req.id);
-                                setRequests(requests.filter((r) => r.id !== req.id));
+                                const next = requests.filter((r) => r.id !== req.id);
+                                setRequests(next);
+                                setPendingCount(next.length);
                               } catch {
                                 // ignore
                               }


### PR DESCRIPTION
## Summary
- notify admins and moderators when users request to join a group
- inform requesters when their request is approved or rejected
- show pending join request count on admin group page

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_688547db59b88328b4f13e0044ad7d42