### PR TITLE
Add groups list to ChatSidebar

### DIFF
--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -6,8 +6,8 @@ import ChatImage from "../shared/ChatImage";
 const ChatHeader = ({ selectedChat }) => {
   const router = useRouter();
 
-  const getAvatarUrl = (url) => {
-    if (!url) return "/images/default-avatar.png";
+  const getAvatarUrl = (url, fallback = "/images/default-avatar.png") => {
+    if (!url) return fallback;
     if (url.startsWith("http") || url.startsWith("blob:")) return url;
     return `${API_BASE_URL}${url}`;
   };
@@ -15,6 +15,10 @@ const ChatHeader = ({ selectedChat }) => {
   if (!selectedChat) {
     return <div className="text-gray-400 text-center p-4">No chat selected</div>;
   }
+
+  const avatar = selectedChat.isGroup
+    ? selectedChat.cover_image || selectedChat.image
+    : selectedChat.profileImage;
 
  
   const handleVideoCall = () => {
@@ -48,7 +52,10 @@ const ChatHeader = ({ selectedChat }) => {
       {/* Chat Name */}
       <h3 className="text-lg font-bold text-yellow-500 flex items-center gap-2">
         <ChatImage
-          src={getAvatarUrl(selectedChat.profileImage)}
+          src={getAvatarUrl(
+            avatar,
+            selectedChat.isGroup ? "/images/group-placeholder.jpg" : undefined
+          )}
           alt="avatar"
           className="w-8 h-8 rounded-full border border-gray-500"
           width={32}

--- a/frontend/src/components/chat/ChatSidebar.js
+++ b/frontend/src/components/chat/ChatSidebar.js
@@ -57,6 +57,10 @@ const ChatSidebar = ({
     return fields.some((f) => f && f.toLowerCase().includes(term));
   });
 
+  const filteredGroups = sortedGroups.filter((group) =>
+    group.name?.toLowerCase().includes(searchTerm.toLowerCase().trim())
+  );
+
   // ✅ Function to Pin/Unpin Chats
   const togglePinChat = (chat) => {
     setPinnedChats((prev) =>
@@ -201,6 +205,47 @@ const ChatSidebar = ({
         ))}
         {filteredUsers.length === 0 && (
           <p className="text-gray-400 text-center">No chats found.</p>
+        )}
+      </div>
+
+      {/* 👥 Groups */}
+      <h3 className="text-md font-bold text-yellow-400 mt-6">👥 Groups</h3>
+      <div className="space-y-3">
+        {filteredGroups.map((group) => (
+          <div
+            key={group.id}
+            className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer hover:bg-gray-700 transition ${
+              selectedChat?.id === group.id ? "bg-gray-700" : ""
+            }`}
+            onClick={() => setSelectedChat({ ...group, isGroup: true })}
+          >
+            <div className="w-10 h-10 bg-gray-600 rounded-full flex items-center justify-center text-white font-bold">
+              {group.name ? group.name.charAt(0).toUpperCase() : "?"}
+            </div>
+            <div className="flex-1">
+              <p className="text-white font-semibold">{group.name}</p>
+              <p className="text-gray-400 text-sm truncate w-40">
+                {group.lastMessage ? group.lastMessage : "No messages yet"}
+              </p>
+            </div>
+            {group.unreadMessages > 0 && (
+              <div className="bg-red-500 text-white text-xs px-2 py-1 rounded-full flex items-center gap-1">
+                <FaEnvelope /> {group.unreadMessages}
+              </div>
+            )}
+            <button
+              className="text-gray-400 hover:text-yellow-500"
+              onClick={(e) => {
+                e.stopPropagation();
+                togglePinChat({ ...group, isGroup: true });
+              }}
+            >
+              <FaStar />
+            </button>
+          </div>
+        ))}
+        {filteredGroups.length === 0 && (
+          <p className="text-gray-400 text-center">No groups found.</p>
         )}
       </div>
 

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import Navbar from "@/components/website/sections/Navbar";
 import ChatSidebar from "@/components/chat/ChatSidebar";
 import ChatWindow from "@/components/chat/ChatWindow";
+import GroupChat from "@/components/chat/GroupChat";
 import ChatNotifications from "@/components/chat/ChatNotifications";
 import { getUsers, getGroups } from "@/services/messageService";
 import { FaSearch, FaCommentDots } from "react-icons/fa";
@@ -85,7 +86,7 @@ const MessagesPage = () => {
     const { groupId, userId } = router.query;
     if (groupId) {
       const group = groups.find((g) => g.id === Number(groupId));
-      if (group) setSelectedChat(group);
+      if (group) setSelectedChat({ ...group, isGroup: true });
     } else if (userId) {
       const user = users.find((u) => u.id === Number(userId));
       if (user) setSelectedChat(user);
@@ -212,7 +213,7 @@ const MessagesPage = () => {
                           </div>
                           <button
                             className="flex items-center gap-2 bg-yellow-500 text-gray-900 px-3 py-1 rounded-md hover:bg-yellow-600 transition"
-                            onClick={() => setSelectedChat(group)}
+                            onClick={() => setSelectedChat({ ...group, isGroup: true })}
                           >
                             <FaCommentDots /> Join Group
                           </button>
@@ -242,7 +243,14 @@ const MessagesPage = () => {
               setSelectedChat={setSelectedChat}
               selectedChat={selectedChat}
             />
-            <ChatWindow selectedChat={selectedChat} refreshUsers={fetchUsersList} />
+            {selectedChat.isGroup ? (
+              <GroupChat
+                groupId={selectedChat.id}
+                groupName={selectedChat.name}
+              />
+            ) : (
+              <ChatWindow selectedChat={selectedChat} refreshUsers={fetchUsersList} />
+            )}
           </main>
         )}
       </div>

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -8,7 +8,7 @@ export const getUsers = async () => {
 };
 
 export const getGroups = async () => {
-  const res = await api.get("/chat/groups");
+  const res = await api.get("/groups/my");
   return res.data.data || res.data;
 };
 


### PR DESCRIPTION
## Summary
- show any groups the user belongs to in the chat sidebar
- treat groups differently when opened to show group chat messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68854462eb4c832887733b703e45d086