### PR TITLE
Fix duplicate exports in ticket pages

### DIFF
--- a/frontend/src/pages/dashboard/instructor/support/my-tickets.js
+++ b/frontend/src/pages/dashboard/instructor/support/my-tickets.js
@@ -20,7 +20,6 @@ export default function MyTicketsPage() {
     }
   };
 
-export default function MyTicketsPage() {
   return (
     <InstructorLayout>
       <PageHead title="My Tickets - Dashboard" />

--- a/frontend/src/pages/dashboard/student/support/my-tickets.js
+++ b/frontend/src/pages/dashboard/student/support/my-tickets.js
@@ -20,7 +20,6 @@ export default function MyTicketsPage() {
     }
   };
 
-export default function MyTicketsPage() {
   return (
     <StudentLayout>
       <PageHead title="My Tickets - Dashboard" />


### PR DESCRIPTION
## Summary
- remove duplicated `export default` blocks in `my-tickets` pages

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68854bdd5aa48328a299455ebabcdb1a