### PR TITLE
Add group request alerts and toasts

### DIFF
--- a/frontend/src/components/groups/GroupMembersList.js
+++ b/frontend/src/components/groups/GroupMembersList.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import groupService from "@/services/groupService";
+import { toast } from "react-toastify";
 import { FaUserSlash, FaVolumeMute, FaUserShield, FaBan } from "react-icons/fa";
 
 export default function GroupMembersList({
@@ -14,15 +15,42 @@ export default function GroupMembersList({
   }, [groupId]);
 
   const handleAction = async (memberId, action) => {
-    const success = await groupService.manageMember(groupId, memberId, action);
-    if (success) {
-      setMembers((prev) =>
-        prev.map((m) =>
-          m.id === memberId
-            ? { ...m, ...getUpdatedRoleOrStatus(m, action) }
-            : m,
-        ),
-      );
+    try {
+      const success = await groupService.manageMember(groupId, memberId, action);
+      if (success) {
+        setMembers((prev) =>
+          prev.map((m) =>
+            m.id === memberId
+              ? { ...m, ...getUpdatedRoleOrStatus(m, action) }
+              : m,
+          ),
+        );
+
+        toast.success(actionMessage(action));
+      }
+    } catch (_) {
+      toast.error("Failed to update member");
+    }
+  };
+
+  const actionMessage = (action) => {
+    switch (action) {
+      case "kick":
+        return "Member removed";
+      case "mute":
+        return "Member muted";
+      case "unmute":
+        return "Member unmuted";
+      case "promote":
+        return "Member promoted";
+      case "demote":
+        return "Member demoted";
+      case "disable":
+        return "Member disabled";
+      case "enable":
+        return "Member enabled";
+      default:
+        return "Action completed";
     }
   };
 

--- a/frontend/src/components/groups/JoinRequestCard.js
+++ b/frontend/src/components/groups/JoinRequestCard.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import groupService from '@/services/groupService';
+import { toast } from 'react-toastify';
 
 export default function JoinRequestCard({ groupId, onCountChange }) {
   const [requests, setRequests] = useState([]);
@@ -16,14 +17,23 @@ export default function JoinRequestCard({ groupId, onCountChange }) {
   }, [groupId]);
 
   const handleAction = async (id, action) => {
-    if (action === 'approve') await groupService.approveRequest(id);
-    else await groupService.rejectRequest(id);
+    try {
+      if (action === 'approve') {
+        await groupService.approveRequest(id);
+        toast.success('Request approved');
+      } else {
+        await groupService.rejectRequest(id);
+        toast.info('Request rejected');
+      }
 
-    setRequests(prev => {
-      const next = prev.filter(r => r.id !== id);
-      if (onCountChange) onCountChange(next.length);
-      return next;
-    });
+      setRequests(prev => {
+        const next = prev.filter(r => r.id !== id);
+        if (onCountChange) onCountChange(next.length);
+        return next;
+      });
+    } catch (_) {
+      toast.error('Failed to process request');
+    }
   };
 
   if (loading) return <p>Loading join requests...</p>;

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -150,6 +150,11 @@ export default function AdminGroupDetailsPage() {
         </button>
 
         <h1 className="text-3xl font-bold text-gray-800">🔍 Group Overview: {group.name}</h1>
+        {pendingCount > 0 && (
+          <div className="bg-red-100 text-red-800 px-4 py-2 rounded mb-2">
+            {pendingCount} pending join request{pendingCount > 1 ? 's' : ''}
+          </div>
+        )}
 
         <div className="flex gap-2 border-b pb-3">
           {['overview', 'members', 'requests'].map((tab) => (

--- a/frontend/src/pages/dashboard/instructor/groups/[id].js
+++ b/frontend/src/pages/dashboard/instructor/groups/[id].js
@@ -147,6 +147,11 @@ export default function GroupDetailsPage() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold">{group.name}</h1>
+            {pendingCount > 0 && (
+              <div className="bg-red-100 text-red-800 px-3 py-1 rounded mt-2">
+                {pendingCount} pending join request{pendingCount > 1 ? 's' : ''}
+              </div>
+            )}
             {["admin", "moderator"].includes(currentUserRole) &&
               !editingName && (
                 <button

--- a/frontend/src/pages/dashboard/student/groups/[id].js
+++ b/frontend/src/pages/dashboard/student/groups/[id].js
@@ -143,6 +143,11 @@ export default function GroupDetailsPage() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold">{group.name}</h1>
+            {pendingCount > 0 && (
+              <div className="bg-red-100 text-red-800 px-3 py-1 rounded mt-2">
+                {pendingCount} pending join request{pendingCount > 1 ? 's' : ''}
+              </div>
+            )}
             {["admin", "moderator"].includes(currentUserRole) && !editingName && (
               <button
                 onClick={() => {


### PR DESCRIPTION
## Summary
- show toast messages when managing group members or join requests
- highlight pending join requests in group detail pages

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885bca342ac8328b5598baf887b8410