### PR TITLE
Enhance group security and translations

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -607,6 +607,24 @@
     "user_added": "تم إضافة المستخدم بنجاح.",
     "user_add_failed": "فشل إضافة المستخدم."
   },
+  "groupsPage": {
+    "explore_title": "استكشاف المجموعات العامة",
+    "join_group": "انضم إلى المجموعة",
+    "request_sent": "تم إرسال الطلب",
+    "your_group": "مجموعتك",
+    "member": "عضو",
+    "no_groups": "لا توجد مجموعات.",
+    "create_one": "أنشئ واحدة؟",
+    "search_placeholder": "ابحث بالاسم أو الوسم...",
+    "sort_newest": "الأحدث",
+    "sort_members": "أكثر الأعضاء",
+    "sort_az": "أ-ي",
+    "view_group": "عرض المجموعة",
+    "back_to_my_groups": "العودة إلى مجموعاتي",
+    "pending_requests": "طلب انضمام معلق",
+    "join_pending": "⏳ جاري موافقة طلب الانضمام",
+    "joined": "✅ أنت عضو في هذه المجموعة"
+  },
   "sidebar": {
     "Account": "\u0627\u0644\u062d\u0633\u0627\u0628",
     "Bookings": "\u0627\u0644\u062d\u062c\u0648\u0632\u0627\u062a",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -515,6 +515,24 @@
     "delete_failed": "Failed to delete method",
     "configure": "Configure"
   },
+  "groupsPage": {
+    "explore_title": "Öffentliche Gruppen erkunden",
+    "join_group": "Gruppe beitreten",
+    "request_sent": "Anfrage gesendet",
+    "your_group": "Deine Gruppe",
+    "member": "Mitglied",
+    "no_groups": "Keine Gruppen gefunden.",
+    "create_one": "Eine erstellen?",
+    "search_placeholder": "Suche nach Name oder Tag...",
+    "sort_newest": "Neueste",
+    "sort_members": "Meiste Mitglieder",
+    "sort_az": "A-Z",
+    "view_group": "Gruppe anzeigen",
+    "back_to_my_groups": "Zurück zu meinen Gruppen",
+    "pending_requests": "ausstehende Beitrittsanfrage",
+    "join_pending": "⏳ Beitrittsanfrage ausstehend",
+    "joined": "✅ Du bist Mitglied dieser Gruppe"
+  },
   "sidebar": {
       "Account": "Konto",
       "Bookings": "Buchungen",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -607,6 +607,24 @@
     "user_added": "User added successfully.",
     "user_add_failed": "Failed to add user."
   },
+  "groupsPage": {
+    "explore_title": "Explore Public Groups",
+    "join_group": "Join Group",
+    "request_sent": "Request Sent",
+    "your_group": "Your Group",
+    "member": "Member",
+    "no_groups": "No groups found.",
+    "create_one": "Create one?",
+    "search_placeholder": "Search by name or tag...",
+    "sort_newest": "Newest",
+    "sort_members": "Most Members",
+    "sort_az": "A-Z",
+    "view_group": "View Group",
+    "back_to_my_groups": "Back to My Groups",
+    "pending_requests": "pending join request{{count}}",
+    "join_pending": "\u23F3 Join request pending approval",
+    "joined": "\u2705 You are a member of this group"
+  },
   "sidebar": {
     "Account": "Account",
     "Bookings": "Bookings",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -513,7 +513,25 @@
     "default_updated": "Default status updated",
     "method_deleted": "Payment method deleted",
     "delete_failed": "Failed to delete method",
-    "configure": "Configure"
+  "configure": "Configure"
+  },
+  "groupsPage": {
+    "explore_title": "Explorar grupos públicos",
+    "join_group": "Unirse al grupo",
+    "request_sent": "Solicitud enviada",
+    "your_group": "Tu grupo",
+    "member": "Miembro",
+    "no_groups": "No se encontraron grupos.",
+    "create_one": "¿Crear uno?",
+    "search_placeholder": "Buscar por nombre o etiqueta...",
+    "sort_newest": "Más recientes",
+    "sort_members": "Más miembros",
+    "sort_az": "A-Z",
+    "view_group": "Ver grupo",
+    "back_to_my_groups": "Volver a mis grupos",
+    "pending_requests": "solicitud de unión pendiente",
+    "join_pending": "⏳ Solicitud de unión pendiente",
+    "joined": "✅ Eres miembro de este grupo"
   },
   "sidebar": {
     "Account": "Cuenta",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -525,6 +525,24 @@
     "delete_failed": "Failed to delete method",
   "configure": "Configure"
   },
+  "groupsPage": {
+    "explore_title": "Explorer les groupes publics",
+    "join_group": "Rejoindre le groupe",
+    "request_sent": "Demande envoyée",
+    "your_group": "Votre groupe",
+    "member": "Membre",
+    "no_groups": "Aucun groupe trouvé.",
+    "create_one": "Créer un ?",
+    "search_placeholder": "Rechercher par nom ou étiquette...",
+    "sort_newest": "Les plus récents",
+    "sort_members": "Plus de membres",
+    "sort_az": "A-Z",
+    "view_group": "Voir le groupe",
+    "back_to_my_groups": "Retour à mes groupes",
+    "pending_requests": "demande en attente",
+    "join_pending": "⏳ Demande d'adhésion en attente",
+    "joined": "✅ Vous êtes membre de ce groupe"
+  },
   "tutorialsPage": {
     "title": "Gérer les tutoriels",
     "description": "Créer, éditer et gérer tous les tutoriels du système",

--- a/frontend/src/pages/dashboard/instructor/index.js
+++ b/frontend/src/pages/dashboard/instructor/index.js
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../next-i18next.config.js";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import {
   FaChalkboardTeacher,
   FaCalendarAlt,
@@ -71,7 +72,7 @@ const mockDashboardCounts = {
 
 const getInitials = (name) => name.split(' ').map(n => n[0]).join('').toUpperCase();
 
-export default function InstructorDashboard() {
+function InstructorDashboard() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'instructorDashboardPage' });
   const [activeTab, setActiveTab] = useState("tutorials");
   const [chartData, setChartData] = useState([]);
@@ -331,6 +332,10 @@ export default function InstructorDashboard() {
     </InstructorLayout>
   );
 }
+
+const ProtectedInstructorDashboard = withAuthProtection(InstructorDashboard, ['instructor']);
+
+export default ProtectedInstructorDashboard;
 
 export async function getStaticProps({ locale }) {
   return {

--- a/frontend/src/pages/dashboard/student/groups/[id].js
+++ b/frontend/src/pages/dashboard/student/groups/[id].js
@@ -8,11 +8,15 @@ import GroupMembersList from '@/components/groups/GroupMembersList';
 import groupService from '@/services/groupService';
 import JoinRequestCard from '@/components/groups/JoinRequestCard';
 import useAuthStore from '@/store/auth/authStore';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../next-i18next.config.js';
 
 
 export default function GroupDetailsPage() {
   const router = useRouter();
   const { id: groupId } = router.query;
+  const { t } = useTranslation('dashboard', { keyPrefix: 'groupsPage' });
 
   const [group, setGroup] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -26,6 +30,12 @@ export default function GroupDetailsPage() {
   const [newName, setNewName] = useState("");
 
   const { user, hasHydrated } = useAuthStore();
+
+  useEffect(() => {
+    if (hasHydrated && !user) {
+      router.replace('/auth/login');
+    }
+  }, [hasHydrated, user, router]);
 
   useEffect(() => {
     // Avoid running when navigating away from this page. When the route
@@ -136,7 +146,7 @@ export default function GroupDetailsPage() {
     <StudentLayout>
       <div className="max-w-4xl mx-auto p-6 space-y-6">
         <Link href="/dashboard/student/groups/my-groups">
-          <button className="text-sm text-blue-600 hover:underline">&larr; Back to My Groups</button>
+          <button className="text-sm text-blue-600 hover:underline">&larr; {t('back_to_my_groups')}</button>
         </Link>
 
         <div className="flex items-center justify-between">
@@ -144,7 +154,7 @@ export default function GroupDetailsPage() {
             <h1 className="text-2xl font-bold">{group.name}</h1>
             {pendingCount > 0 && (
               <div className="bg-red-100 text-red-800 px-3 py-1 rounded mt-2">
-                {pendingCount} pending join request{pendingCount > 1 ? 's' : ''}
+                {pendingCount} {t('pending_requests')}
               </div>
             )}
             {["admin", "moderator"].includes(currentUserRole) && !editingName && (
@@ -251,14 +261,14 @@ export default function GroupDetailsPage() {
                 onClick={handleJoin}
                 className="bg-yellow-600 hover:bg-yellow-700 text-white px-6 py-2 rounded-lg"
               >
-                Join Group
+                {t('join_group')}
               </button>
             )}
             {joinStatus === 'pending' && (
-              <div className="text-yellow-700 font-semibold">⏳ Join request pending approval</div>
+              <div className="text-yellow-700 font-semibold">{t('join_pending')}</div>
             )}
             {joinStatus === 'joined' && (
-              <div className="text-green-600 font-semibold">✅ You are a member of this group</div>
+              <div className="text-green-600 font-semibold">{t('joined')}</div>
             )}
 
 
@@ -328,4 +338,12 @@ export default function GroupDetailsPage() {
       </div>
     </StudentLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+    },
+  };
 }

--- a/frontend/src/pages/dashboard/student/groups/explore.js
+++ b/frontend/src/pages/dashboard/student/groups/explore.js
@@ -4,9 +4,13 @@ import { Search } from 'lucide-react';
 import StudentLayout from '@/components/layouts/StudentLayout';
 import toast from 'react-hot-toast';
 import groupService from '@/services/groupService';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../next-i18next.config.js';
 
 
 export default function ExploreGroupsPage() {
+  const { t } = useTranslation('dashboard', { keyPrefix: 'groupsPage' });
   const [groups, setGroups] = useState([]);
   const [filteredGroups, setFilteredGroups] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
@@ -104,7 +108,7 @@ export default function ExploreGroupsPage() {
       <div className="max-w-6xl mx-auto p-4 space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold">🌐 Explore Public Groups</h1>
+          <h1 className="text-2xl font-bold">🌐 {t('explore_title')}</h1>
           <Link href="/dashboard/student/groups/create">
             <button className="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded shadow">
               + Create Group
@@ -120,7 +124,7 @@ export default function ExploreGroupsPage() {
               type="text"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              placeholder="Search by name or tag..."
+              placeholder={t('search_placeholder')}
               className="w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-500"
               aria-label="Search groups"
             />
@@ -134,9 +138,9 @@ export default function ExploreGroupsPage() {
             className="border px-3 py-2 rounded-lg"
             aria-label="Sort groups"
           >
-            <option value="newest">🆕 Newest</option>
-            <option value="members">👥 Most Members</option>
-            <option value="az">🔤 A-Z</option>
+            <option value="newest">🆕 {t('sort_newest')}</option>
+            <option value="members">👥 {t('sort_members')}</option>
+            <option value="az">🔤 {t('sort_az')}</option>
           </select>
         </div>
 
@@ -163,9 +167,9 @@ export default function ExploreGroupsPage() {
         {/* Group Cards */}
         {filteredGroups.length === 0 ? (
           <p className="text-gray-500">
-            No groups found.{' '}
+            {t('no_groups')}{" "}
             <Link href="/dashboard/student/groups/create" className="text-blue-600 underline">
-              Create one?
+              {t('create_one')}
             </Link>
           </p>
         ) : (
@@ -232,12 +236,12 @@ export default function ExploreGroupsPage() {
                     role === 'admin' || role === 'member' || requestSent;
                   const label =
                     role === 'admin'
-                      ? 'Your Group'
+                      ? t('your_group')
                       : role === 'member'
-                      ? 'Member'
+                      ? t('member')
                       : requestSent
-                      ? 'Request Sent'
-                      : 'Join Group';
+                      ? t('request_sent')
+                      : t('join_group');
                   return (
                     <button
                       onClick={() => handleJoin(group.id)}
@@ -254,7 +258,9 @@ export default function ExploreGroupsPage() {
                 })()}
 
                 <Link href={`/dashboard/student/groups/${group.id}`}>
-                  <button className="text-sm text-blue-600 underline w-full mt-1">View Group</button>
+                  <button className="text-sm text-blue-600 underline w-full mt-1">
+                    {t('view_group')}
+                  </button>
                 </Link>
               </div>
             ))}
@@ -263,4 +269,12 @@ export default function ExploreGroupsPage() {
       </div>
     </StudentLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+    },
+  };
 }

--- a/frontend/src/pages/dashboard/student/index.js
+++ b/frontend/src/pages/dashboard/student/index.js
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import { FaBook, FaClipboardList, FaCertificate, FaCalendarAlt, FaBullhorn, FaBell } from "react-icons/fa";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 
-export default function StudentDashboardHome() {
+function StudentDashboardHome() {
   const [hasMounted, setHasMounted] = useState(false);
   const [studentName, setStudentName] = useState("Sara Ali");
   const [showNotifications, setShowNotifications] = useState(false);
@@ -166,3 +167,7 @@ export default function StudentDashboardHome() {
     </StudentLayout>
   );
 }
+
+const ProtectedStudentDashboardHome = withAuthProtection(StudentDashboardHome, ['student']);
+
+export default ProtectedStudentDashboardHome;


### PR DESCRIPTION
## Summary
- wrap student/instructor dashboards with role-based guard
- redirect unauthenticated users from group pages
- add translations and use i18n for group listing and details
- provide new group-related strings in all locales

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885da3c73f0832894f2b1c568154a55