### PR TITLE
Fix chat user status indicators

### DIFF
--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 import { FaVideo, FaWhatsapp, FaEnvelope } from "react-icons/fa";
 import { API_BASE_URL } from "@/config/config";
 import ChatImage from "../shared/ChatImage";
+import useLastSeen from "@/hooks/useLastSeen";
 
 const ChatHeader = ({ selectedChat }) => {
   const router = useRouter();
@@ -19,6 +20,8 @@ const ChatHeader = ({ selectedChat }) => {
   const avatar = selectedChat.isGroup
     ? selectedChat.cover_image || selectedChat.image
     : selectedChat.profileImage;
+
+  const { lastSeen } = useLastSeen(selectedChat.id);
 
  
   const handleVideoCall = () => {
@@ -50,7 +53,7 @@ const ChatHeader = ({ selectedChat }) => {
   return (
     <div className="flex justify-between items-center mb-4 border-b pb-2 border-gray-700">
       {/* Chat Name */}
-      <h3 className="text-lg font-bold text-yellow-500 flex items-center gap-2">
+      <div className="flex items-center gap-2">
         <ChatImage
           src={getAvatarUrl(
             avatar,
@@ -61,8 +64,15 @@ const ChatHeader = ({ selectedChat }) => {
           width={32}
           height={32}
         />
-        {selectedChat.groupName || selectedChat.name || "Unknown Chat"}
-      </h3>
+        <div>
+          <h3 className="text-lg font-bold text-yellow-500">
+            {selectedChat.groupName || selectedChat.name || "Unknown Chat"}
+          </h3>
+          {!selectedChat.isGroup && (
+            <p className="text-sm text-gray-400">{lastSeen}</p>
+          )}
+        </div>
+      </div>
 
       {/* Action Buttons */}
       <div className="flex gap-2">

--- a/frontend/src/components/chat/ChatSidebar.js
+++ b/frontend/src/components/chat/ChatSidebar.js
@@ -167,7 +167,9 @@ const ChatSidebar = ({
               />
               <span
                 className={`absolute bottom-0 right-0 w-3 h-3 rounded-full border border-gray-800 ${
-                  user.isOnline ? "bg-green-500" : "bg-gray-400"
+                  (user.isOnline ?? user.status === "online")
+                    ? "bg-green-500"
+                    : "bg-red-500"
                 }`}
               />
             </div>
@@ -176,7 +178,7 @@ const ChatSidebar = ({
             <div className="flex-1">
               <p className="text-white font-semibold">{user.name}</p>
               <p className="text-gray-400 text-sm truncate w-40">
-                {user.lastMessage ? user.lastMessage : "No messages yet"}
+                {user.lastMessage || user.last_message || "No messages yet"}
               </p>
             </div>
 
@@ -234,7 +236,7 @@ const ChatSidebar = ({
             <div className="flex-1">
               <p className="text-white font-semibold">{group.name}</p>
               <p className="text-gray-400 text-sm truncate w-40">
-                {group.lastMessage ? group.lastMessage : "No messages yet"}
+                {group.lastMessage || group.last_message || "No messages yet"}
               </p>
             </div>
             {group.unreadMessages > 0 && (

--- a/frontend/src/hooks/useLastSeen.js
+++ b/frontend/src/hooks/useLastSeen.js
@@ -9,8 +9,16 @@ const useLastSeen = (userId) => {
     // Simulate fetching user data (Replace with API Call)
     const user = mockUsers.find((user) => user.id === userId);
     if (user) {
-      setIsOnline(user.isOnline);
-      setLastSeen(user.isOnline ? "Online" : `Last seen ${user.lastSeen}`);
+      const online =
+        user.isOnline !== undefined ? user.isOnline : user.status === "online";
+      setIsOnline(online);
+      if (online) {
+        setLastSeen("Online");
+      } else if (user.lastSeen) {
+        setLastSeen(`Last seen ${user.lastSeen}`);
+      } else {
+        setLastSeen("Offline");
+      }
     }
   }, [userId]);
 


### PR DESCRIPTION
## Summary
- show online/offline status dot correctly
- display last message snippet in sidebar
- add last seen text in chat header
- improve `useLastSeen` hook for mock data

## Testing
- `npm test --silent --prefix frontend`
- `npm test --silent --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6885e3410d1c8328808941526b28df1f