### PR TITLE
Fix dynamic group page build error

### DIFF
--- a/frontend/src/pages/dashboard/student/groups/[id].js
+++ b/frontend/src/pages/dashboard/student/groups/[id].js
@@ -340,7 +340,7 @@ export default function GroupDetailsPage() {
   );
 }
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),


### PR DESCRIPTION
## Summary
- convert group details dynamic page to use `getServerSideProps`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(no output, likely due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6885e550e30883288fb265e44917501b