### PR TITLE
Add ticketing module

### DIFF
--- a/backend/src/migrations/20250725003800_create_tickets_table.js
+++ b/backend/src/migrations/20250725003800_create_tickets_table.js
@@ -1,0 +1,17 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tickets', function(table) {
+    table.increments('id');
+    table.string('subject');
+    table.text('description');
+    table.enu('status', ['Open', 'Pending', 'Resolved', 'Closed']).defaultTo('Open');
+    table.enu('priority', ['Low', 'Medium', 'High', 'Urgent']).defaultTo('Medium');
+    table.integer('user_id').unsigned().references('id').inTable('users');
+    table.integer('assigned_admin_id').unsigned().references('id').inTable('users');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('tickets');
+};

--- a/backend/src/migrations/20250725003810_create_ticket_messages_table.js
+++ b/backend/src/migrations/20250725003810_create_ticket_messages_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ticket_messages', function(table) {
+    table.increments('id');
+    table.integer('ticket_id').references('id').inTable('tickets').onDelete('CASCADE');
+    table.integer('sender_id').references('id').inTable('users');
+    table.text('message');
+    table.boolean('is_internal_note').defaultTo(false);
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('ticket_messages');
+};

--- a/backend/src/migrations/20250725003820_create_ticket_attachments_table.js
+++ b/backend/src/migrations/20250725003820_create_ticket_attachments_table.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ticket_attachments', function(table) {
+    table.increments('id');
+    table.integer('message_id').references('id').inTable('ticket_messages');
+    table.string('file_url');
+    table.string('file_name');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('ticket_attachments');
+};

--- a/backend/src/migrations/20250725003830_create_ticket_tags_table.js
+++ b/backend/src/migrations/20250725003830_create_ticket_tags_table.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('ticket_tags', function(table) {
+    table.increments('id');
+    table.integer('ticket_id').references('id').inTable('tickets');
+    table.string('tag');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('ticket_tags');
+};

--- a/backend/src/modules/tickets/tickets.constants.js
+++ b/backend/src/modules/tickets/tickets.constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+  STATUS: ['Open', 'Pending', 'Resolved', 'Closed'],
+  PRIORITY: ['Low', 'Medium', 'High', 'Urgent'],
+};

--- a/backend/src/modules/tickets/tickets.controller.js
+++ b/backend/src/modules/tickets/tickets.controller.js
@@ -1,0 +1,65 @@
+const service = require('./tickets.service');
+const catchAsync = require('../../utils/catchAsync');
+const AppError = require('../../utils/AppError');
+const { sendSuccess } = require('../../utils/response');
+
+exports.createTicket = catchAsync(async (req, res) => {
+  const ticket = await service.createTicket({
+    subject: req.body.subject,
+    description: req.body.description,
+    user_id: req.user.id,
+  });
+  sendSuccess(res, ticket, 'Ticket created');
+});
+
+exports.getAllTickets = catchAsync(async (req, res) => {
+  const tickets = await service.getAllTickets(req.query);
+  sendSuccess(res, tickets);
+});
+
+exports.getTicketById = catchAsync(async (req, res) => {
+  const data = await service.getTicketById(req.params.id);
+  if (!data) throw new AppError('Ticket not found', 404);
+  sendSuccess(res, data);
+});
+
+exports.addMessage = catchAsync(async (req, res) => {
+  const msg = await service.addMessage(req.params.id, {
+    sender_id: req.user.id,
+    message: req.body.message,
+  });
+  sendSuccess(res, msg, 'Message added');
+});
+
+exports.addNote = catchAsync(async (req, res) => {
+  const msg = await service.addNote(req.params.id, {
+    sender_id: req.user.id,
+    message: req.body.message,
+  });
+  sendSuccess(res, msg, 'Note added');
+});
+
+exports.updateStatus = catchAsync(async (req, res) => {
+  const [ticket] = await service.updateStatus(req.params.id, req.body.status);
+  if (!ticket) throw new AppError('Ticket not found', 404);
+  sendSuccess(res, ticket, 'Status updated');
+});
+
+exports.updatePriority = catchAsync(async (req, res) => {
+  const [ticket] = await service.updatePriority(req.params.id, req.body.priority);
+  if (!ticket) throw new AppError('Ticket not found', 404);
+  sendSuccess(res, ticket, 'Priority updated');
+});
+
+exports.assignTicket = catchAsync(async (req, res) => {
+  const [ticket] = await service.assignTicket(req.params.id, req.body.adminId);
+  if (!ticket) throw new AppError('Ticket not found', 404);
+  sendSuccess(res, ticket, 'Ticket assigned');
+});
+
+exports.uploadAttachment = catchAsync(async (req, res) => {
+  const file = req.file;
+  if (!file) throw new AppError('No file uploaded', 400);
+  const attachment = await service.uploadAttachment(req.params.messageId, file);
+  sendSuccess(res, attachment, 'Attachment uploaded');
+});

--- a/backend/src/modules/tickets/tickets.model.js
+++ b/backend/src/modules/tickets/tickets.model.js
@@ -1,0 +1,18 @@
+const db = require('../../config/database');
+
+exports.create = (data) => db('tickets').insert(data).returning('*');
+exports.findAll = (filters = {}) => {
+  let query = db('tickets');
+  if (filters.status) query.where('status', filters.status);
+  if (filters.priority) query.where('priority', filters.priority);
+  return query.orderBy('created_at', 'desc');
+};
+exports.findById = (id) => db('tickets').where({ id }).first();
+exports.update = (id, data) => db('tickets').where({ id }).update(data).returning('*');
+
+exports.addMessage = (message) => db('ticket_messages').insert(message).returning('*');
+exports.getMessages = (ticket_id) => db('ticket_messages').where({ ticket_id }).orderBy('created_at');
+exports.addAttachment = (attachment) => db('ticket_attachments').insert(attachment).returning('*');
+exports.getAttachmentsByMessage = (message_id) => db('ticket_attachments').where({ message_id });
+exports.addTag = (tag) => db('ticket_tags').insert(tag).returning('*');
+exports.getTags = (ticket_id) => db('ticket_tags').where({ ticket_id });

--- a/backend/src/modules/tickets/tickets.routes.js
+++ b/backend/src/modules/tickets/tickets.routes.js
@@ -1,0 +1,21 @@
+const router = require('express').Router();
+const controller = require('./tickets.controller');
+const validate = require('../../middleware/validate');
+const { verifyToken, isAdmin } = require('../../middleware/auth/authMiddleware');
+const validation = require('./tickets.validation');
+const multer = require('multer');
+const upload = multer({ dest: 'uploads/ticket_attachments' });
+
+router.use(verifyToken);
+
+router.get('/', isAdmin, controller.getAllTickets);
+router.get('/:id', controller.getTicketById);
+router.post('/', validate(validation.createTicketSchema), controller.createTicket);
+router.post('/:id/reply', validate(validation.replySchema), controller.addMessage);
+router.post('/:id/note', isAdmin, validate(validation.replySchema), controller.addNote);
+router.put('/:id/status', isAdmin, validate(validation.statusSchema), controller.updateStatus);
+router.put('/:id/priority', isAdmin, validate(validation.prioritySchema), controller.updatePriority);
+router.put('/:id/assign', isAdmin, validate(validation.assignSchema), controller.assignTicket);
+router.post('/:messageId/upload', upload.single('file'), controller.uploadAttachment);
+
+module.exports = router;

--- a/backend/src/modules/tickets/tickets.service.js
+++ b/backend/src/modules/tickets/tickets.service.js
@@ -1,0 +1,33 @@
+const ticketsModel = require('./tickets.model');
+
+exports.createTicket = async (data) => {
+  const [ticket] = await ticketsModel.create(data);
+  return ticket;
+};
+
+exports.getAllTickets = (filters) => ticketsModel.findAll(filters);
+
+exports.getTicketById = async (id) => {
+  const ticket = await ticketsModel.findById(id);
+  if (!ticket) return null;
+  const messages = await ticketsModel.getMessages(id);
+  return { ...ticket, messages };
+};
+
+exports.addMessage = async (ticketId, data) => {
+  const [msg] = await ticketsModel.addMessage({ ticket_id: ticketId, ...data });
+  return msg;
+};
+
+exports.addNote = async (ticketId, data) => {
+  const [msg] = await ticketsModel.addMessage({ ticket_id: ticketId, is_internal_note: true, ...data });
+  return msg;
+};
+
+exports.assignTicket = (ticketId, adminId) => ticketsModel.update(ticketId, { assigned_admin_id: adminId });
+
+exports.updateStatus = (ticketId, status) => ticketsModel.update(ticketId, { status, updated_at: new Date() });
+
+exports.updatePriority = (ticketId, priority) => ticketsModel.update(ticketId, { priority, updated_at: new Date() });
+
+exports.uploadAttachment = (messageId, file) => ticketsModel.addAttachment({ message_id: messageId, file_url: file.path, file_name: file.originalname });

--- a/backend/src/modules/tickets/tickets.validation.js
+++ b/backend/src/modules/tickets/tickets.validation.js
@@ -1,0 +1,23 @@
+const { z } = require('zod');
+const { STATUS, PRIORITY } = require('./tickets.constants');
+
+exports.createTicketSchema = z.object({
+  subject: z.string().min(1),
+  description: z.string().min(1),
+});
+
+exports.replySchema = z.object({
+  message: z.string().min(1),
+});
+
+exports.statusSchema = z.object({
+  status: z.enum(STATUS),
+});
+
+exports.prioritySchema = z.object({
+  priority: z.enum(PRIORITY),
+});
+
+exports.assignSchema = z.object({
+  adminId: z.number().int(),
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -119,6 +119,7 @@ app.use("/api/languages", require("./modules/languages/languages.routes"));
 app.use("/api/currencies", require("./modules/currencies/currencies.routes"));
 app.use("/api/blog", require("./modules/blog/blog.routes"));
 app.use("/api/support", require("./modules/support/support.routes"));
+app.use("/api/tickets", require("./modules/tickets/tickets.routes"));
 app.use("/api/media", require("./modules/media/media.routes"));
 
 app.get("/", (req, res) => res.send("🚀 SkillBridge API is live."));

--- a/frontend/src/components/support/AssignmentModal.js
+++ b/frontend/src/components/support/AssignmentModal.js
@@ -1,0 +1,18 @@
+export default function AssignmentModal({ open, onAssign, onClose }) {
+  const handleAssign = () => {
+    const id = prompt('Enter admin ID to assign');
+    if (id) onAssign(Number(id));
+  };
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center">
+      <div className="bg-white p-4 rounded shadow">
+        <h3 className="font-semibold mb-2">Assign Ticket</h3>
+        <div className="flex gap-2">
+          <button onClick={handleAssign} className="bg-blue-600 text-white px-3 py-1 rounded">Assign</button>
+          <button onClick={onClose} className="border px-3 py-1 rounded">Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/support/PrioritySelector.js
+++ b/frontend/src/components/support/PrioritySelector.js
@@ -1,0 +1,17 @@
+const options = ['Low', 'Medium', 'High', 'Urgent'];
+
+export default function PrioritySelector({ value, onChange }) {
+  return (
+    <select
+      className="border rounded px-2 py-1"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {options.map((o) => (
+        <option key={o} value={o}>
+          {o}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/components/support/StatusBadge.js
+++ b/frontend/src/components/support/StatusBadge.js
@@ -1,0 +1,11 @@
+export default function StatusBadge({ status }) {
+  const colors = {
+    Open: 'bg-blue-100 text-blue-700',
+    Pending: 'bg-yellow-100 text-yellow-800',
+    Resolved: 'bg-green-100 text-green-700',
+    Closed: 'bg-gray-200 text-gray-700',
+  };
+  return (
+    <span className={`px-2 py-1 rounded text-xs font-medium ${colors[status] || ''}`}>{status}</span>
+  );
+}

--- a/frontend/src/components/support/TagEditor.js
+++ b/frontend/src/components/support/TagEditor.js
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+export default function TagEditor({ tags = [], onAdd }) {
+  const [value, setValue] = useState('');
+  const handleAdd = () => {
+    if (value.trim()) {
+      onAdd(value.trim());
+      setValue('');
+    }
+  };
+  return (
+    <div className="mt-2">
+      <div className="flex gap-2 mb-2">
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="border rounded px-2 py-1 flex-1"
+          placeholder="Add tag"
+        />
+        <button onClick={handleAdd} className="bg-gray-200 px-2 rounded">
+          Add
+        </button>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {tags.map((t) => (
+          <span key={t} className="text-xs bg-gray-100 px-2 py-1 rounded">
+            {t}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/support/TicketCard.js
+++ b/frontend/src/components/support/TicketCard.js
@@ -1,0 +1,16 @@
+import StatusBadge from './StatusBadge';
+
+export default function TicketCard({ ticket, onClick }) {
+  return (
+    <div
+      onClick={onClick}
+      className="border p-4 rounded shadow hover:bg-gray-50 cursor-pointer"
+    >
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="font-semibold">{ticket.subject}</h3>
+        <StatusBadge status={ticket.status} />
+      </div>
+      <p className="text-sm text-gray-500">Priority: {ticket.priority}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/support/TicketDetailPanel.js
+++ b/frontend/src/components/support/TicketDetailPanel.js
@@ -1,0 +1,19 @@
+import StatusBadge from './StatusBadge';
+
+export default function TicketDetailPanel({ ticket }) {
+  if (!ticket) return <div className="p-4">Select a ticket</div>;
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-1">{ticket.subject}</h2>
+      <StatusBadge status={ticket.status} />
+      <p className="mt-2 whitespace-pre-line">{ticket.description}</p>
+      <div className="mt-4 space-y-2">
+        {ticket.messages?.map((m) => (
+          <div key={m.id} className="border p-2 rounded">
+            <p className="text-sm text-gray-600">{m.message}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/support/TicketMetaSidebar.js
+++ b/frontend/src/components/support/TicketMetaSidebar.js
@@ -1,0 +1,18 @@
+import PrioritySelector from './PrioritySelector';
+import StatusBadge from './StatusBadge';
+
+export default function TicketMetaSidebar({ ticket, onStatusChange, onPriorityChange }) {
+  if (!ticket) return null;
+  return (
+    <div className="border-l p-4 w-60">
+      <div className="mb-4">
+        <div className="text-sm font-medium text-gray-500">Status</div>
+        <StatusBadge status={ticket.status} />
+      </div>
+      <div className="mb-4">
+        <div className="text-sm font-medium text-gray-500 mb-1">Priority</div>
+        <PrioritySelector value={ticket.priority} onChange={onPriorityChange} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/support/TicketReplyBox.js
+++ b/frontend/src/components/support/TicketReplyBox.js
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+export default function TicketReplyBox({ onSend }) {
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSend(message);
+    setMessage('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 flex gap-2">
+      <input
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        className="flex-1 border rounded px-2 py-1"
+        placeholder="Type a reply"
+      />
+      <button className="bg-yellow-500 text-black px-3 rounded" type="submit">
+        Send
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/dashboard/admin/support/tickets/[id].js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/[id].js
@@ -3,6 +3,9 @@ import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useEffect, useState } from "react";
 import { fetchTicketById, addMessage, updateStatus } from "@/services/supportService";
+import TicketDetailPanel from "@/components/support/TicketDetailPanel";
+import TicketReplyBox from "@/components/support/TicketReplyBox";
+import TicketMetaSidebar from "@/components/support/TicketMetaSidebar";
 
 
 export default function AdminTicketDetail() {
@@ -64,61 +67,12 @@ export default function AdminTicketDetail() {
   return (
     <AdminLayout>
       <PageHead title={`Ticket ${id} - Admin`} />
-      <div className="px-6 py-10">
-        <div className="flex items-center justify-between mb-2">
-          <h1 className="text-2xl font-bold text-gray-900">{ticket?.subject}</h1>
-          {status === "Resolved" ? (
-            <button
-              onClick={handleReopen}
-              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition"
-            >
-              Reopen Ticket
-            </button>
-          ) : (
-            <button
-              onClick={handleClose}
-              className="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600 transition"
-            >
-              Close Ticket
-            </button>
-          )}
+      <div className="flex">
+        <div className="flex-1 px-6 py-10">
+          <TicketDetailPanel ticket={ticket} />
+          <TicketReplyBox onSend={handleReply} />
         </div>
-        <p className="text-sm text-gray-500 mb-8">From: <strong>{ticket?.user}</strong> | Status: <span className="font-semibold text-yellow-600">{status}</span></p>
-
-        <div className="space-y-6 mb-12">
-          {ticket?.messages?.map((msg, index) => (
-            <div
-              key={index}
-              className={`p-4 rounded-lg border ${msg.sender === "user" ? "bg-white border-gray-200" : "bg-yellow-50 border-yellow-200"}`}
-            >
-              <div className="flex justify-between text-sm mb-1">
-                <span className="font-semibold text-gray-800">{msg.name}</span>
-                <span className="text-gray-500">{msg.timestamp}</span>
-              </div>
-              <p className="text-gray-700 whitespace-pre-line">{msg.content}</p>
-            </div>
-          ))}
-        </div>
-
-        {status !== "Resolved" && (
-          <form onSubmit={handleReply} className="space-y-4">
-            <label className="block text-sm font-medium text-gray-700">Your Reply</label>
-            <textarea
-              rows={5}
-              className="w-full border border-gray-300 rounded px-4 py-2"
-              placeholder="Type your reply..."
-              value={reply}
-              onChange={(e) => setReply(e.target.value)}
-              required
-            ></textarea>
-            <button
-              type="submit"
-              className="bg-yellow-500 text-black px-6 py-2 rounded hover:bg-yellow-600 transition"
-            >
-              Send Reply
-            </button>
-          </form>
-        )}
+        <TicketMetaSidebar ticket={ticket} onStatusChange={handleClose} onPriorityChange={() => {}} />
       </div>
     </AdminLayout>
   );

--- a/frontend/src/pages/dashboard/admin/support/tickets/index.js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/index.js
@@ -1,8 +1,8 @@
 import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { fetchAllTickets } from "@/services/supportService";
+import TicketCard from "@/components/support/TicketCard";
 
 export default function AdminSupportTicketsPage() {
   const [tickets, setTickets] = useState([]);
@@ -25,42 +25,14 @@ export default function AdminSupportTicketsPage() {
       <PageHead title="Support Tickets - Admin" />
       <div className="px-6 py-10">
         <h1 className="text-2xl font-bold text-gray-900 mb-6">All Support Tickets</h1>
-
-        <div className="overflow-x-auto border border-gray-200 rounded shadow-sm">
-          <table className="min-w-full table-auto bg-white">
-            <thead className="bg-gray-100 text-sm text-gray-600 uppercase">
-              <tr>
-                <th className="text-left px-4 py-3">Ticket ID</th>
-                <th className="text-left px-4 py-3">Subject</th>
-                <th className="text-left px-4 py-3">Status</th>
-                <th className="text-left px-4 py-3">Created</th>
-                <th className="text-left px-4 py-3">Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {tickets.map((ticket) => (
-                <tr key={ticket.id} className="border-t border-gray-100 hover:bg-gray-50">
-                  <td className="px-4 py-3 font-mono text-sm">{ticket.id}</td>
-                  <td className="px-4 py-3 text-sm">{ticket.subject}</td>
-                  <td className="px-4 py-3 text-sm">
-                    <span
-                      className={`px-2 py-1 rounded text-xs font-medium ${ticket.status === "resolved" ? "bg-green-100 text-green-700" : "bg-yellow-100 text-yellow-800"}`}
-                    >
-                      {ticket.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-500">
-                    {new Date(ticket.created_at).toLocaleDateString()}
-                  </td>
-                  <td className="px-4 py-3 text-sm">
-                    <Link href={`/dashboard/admin/support/tickets/${ticket.id}`} className="text-blue-600 hover:underline">
-                      View
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="grid gap-4">
+          {tickets.map((ticket) => (
+            <TicketCard
+              key={ticket.id}
+              ticket={ticket}
+              onClick={() => (window.location.href = `/dashboard/admin/support/tickets/${ticket.id}`)}
+            />
+          ))}
         </div>
       </div>
     </AdminLayout>


### PR DESCRIPTION
## Summary
- implement new `/api/tickets` endpoints
- add Knex migrations for tickets and related tables
- add ticket service/model/controller
- add admin ticket inbox UI components

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6885e46e1c388328b065f7a0305c9cf9