### PR TITLE
Fix ticket table FK types

### DIFF
--- a/backend/src/migrations/20250725003800_create_tickets_table.js
+++ b/backend/src/migrations/20250725003800_create_tickets_table.js
@@ -5,8 +5,17 @@ exports.up = function(knex) {
     table.text('description');
     table.enu('status', ['Open', 'Pending', 'Resolved', 'Closed']).defaultTo('Open');
     table.enu('priority', ['Low', 'Medium', 'High', 'Urgent']).defaultTo('Medium');
-    table.integer('user_id').unsigned().references('id').inTable('users');
-    table.integer('assigned_admin_id').unsigned().references('id').inTable('users');
+    // Users table uses UUID primary keys, so we store references as UUID as well
+    table
+      .uuid('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('SET NULL');
+    table
+      .uuid('assigned_admin_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('SET NULL');
     table.timestamp('created_at').defaultTo(knex.fn.now());
     table.timestamp('updated_at').defaultTo(knex.fn.now());
   });


### PR DESCRIPTION
## Summary
- update tickets migration to use UUID user references

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688600ab88ac832899d778a8b1e54004