### PR TITLE
Fix ticket table FK types

### DIFF
--- a/backend/src/migrations/20250725003800_create_tickets_table.js
+++ b/backend/src/migrations/20250725003800_create_tickets_table.js
@@ -5,8 +5,17 @@ exports.up = function(knex) {
     table.text('description');
     table.enu('status', ['Open', 'Pending', 'Resolved', 'Closed']).defaultTo('Open');
     table.enu('priority', ['Low', 'Medium', 'High', 'Urgent']).defaultTo('Medium');
-    table.integer('user_id').unsigned().references('id').inTable('users');
-    table.integer('assigned_admin_id').unsigned().references('id').inTable('users');
+    // Users table uses UUID primary keys, so we store references as UUID as well
+    table
+      .uuid('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('SET NULL');
+    table
+      .uuid('assigned_admin_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('SET NULL');
     table.timestamp('created_at').defaultTo(knex.fn.now());
     table.timestamp('updated_at').defaultTo(knex.fn.now());
   });

--- a/backend/src/migrations/20250725003810_create_ticket_messages_table.js
+++ b/backend/src/migrations/20250725003810_create_ticket_messages_table.js
@@ -2,7 +2,12 @@ exports.up = function(knex) {
   return knex.schema.createTable('ticket_messages', function(table) {
     table.increments('id');
     table.integer('ticket_id').references('id').inTable('tickets').onDelete('CASCADE');
-    table.integer('sender_id').references('id').inTable('users');
+    // Users table uses UUID primary keys, so match the column type here as well
+    table
+      .uuid('sender_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('SET NULL');
     table.text('message');
     table.boolean('is_internal_note').defaultTo(false);
     table.timestamp('created_at').defaultTo(knex.fn.now());


### PR DESCRIPTION
## Summary
- update tickets migration to use UUID user references
- fix ticket messages sender_id type

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688600ab88ac832899d778a8b1e54004