### PR TITLE
Implement backend recent activity API

### DIFF
--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -84,3 +84,8 @@ exports.updateStatus = catchAsync(async (req, res) => {
   }
   sendSuccess(res, ticket, "Status updated");
 });
+
+exports.listRecentActivity = catchAsync(async (_req, res) => {
+  const data = await service.getRecentActivity();
+  sendSuccess(res, data);
+});

--- a/backend/src/modules/support/support.routes.js
+++ b/backend/src/modules/support/support.routes.js
@@ -11,5 +11,6 @@ router.post("/tickets/:id/messages", controller.addMessage);
 
 router.get("/admin/tickets", isAdmin, controller.listAllTickets);
 router.patch("/admin/tickets/:id/status", isAdmin, controller.updateStatus);
+router.get("/admin/recent-activity", isAdmin, controller.listRecentActivity);
 
 module.exports = router;

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -82,3 +82,18 @@ exports.updateStatus = async (id, status) => {
     .returning("*");
   return row;
 };
+
+// Fetch recent support ticket activity for admin dashboard
+exports.getRecentActivity = async (limit = 10) => {
+  return db("support_tickets")
+    .leftJoin("users", "support_tickets.user_id", "users.id")
+    .select(
+      "support_tickets.id",
+      "support_tickets.subject",
+      "support_tickets.status",
+      "support_tickets.created_at",
+      "users.full_name as user_name"
+    )
+    .orderBy("support_tickets.created_at", "desc")
+    .limit(limit);
+};

--- a/frontend/src/pages/dashboard/admin/support/index.js
+++ b/frontend/src/pages/dashboard/admin/support/index.js
@@ -1,13 +1,30 @@
 import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import Link from "next/link";
-import { FiFilter, FiInbox, FiUsers, FiBarChart2, FiHelpCircle, FiSettings } from "react-icons/fi";
+import { FiInbox, FiUsers, FiBarChart2, FiHelpCircle } from "react-icons/fi";
 import { useTranslation } from "next-i18next";
+import { useEffect, useState } from "react";
+import { fetchRecentActivity } from "@/services/supportService";
+import formatRelativeTime from "@/utils/relativeTime";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 
 export default function AdminSupportHome() {
   const { t } = useTranslation('dashboard');
+  const [activity, setActivity] = useState([]);
+
+  useEffect(() => {
+    loadActivity();
+  }, []);
+
+  const loadActivity = async () => {
+    try {
+      const data = await fetchRecentActivity();
+      setActivity(data);
+    } catch (err) {
+      console.error('Failed to load activity', err);
+    }
+  };
   return (
     <AdminLayout>
       <PageHead title={t('support_dashboard')} />
@@ -18,26 +35,7 @@ export default function AdminSupportHome() {
             <p className="text-gray-600 mt-2">{t('manage_support')}</p>
           </div>
           
-          <div className="mt-4 md:mt-0 flex space-x-3">
-            <div className="relative">
-              <select className="appearance-none bg-white border border-gray-300 rounded-lg px-4 py-2 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                <option>Last 7 days</option>
-                <option>Last 30 days</option>
-                <option>Last 90 days</option>
-              </select>
-              <FiFilter className="absolute right-3 top-2.5 text-gray-400" />
-            </div>
-            
-            <div className="relative">
-              <select className="appearance-none bg-white border border-gray-300 rounded-lg px-4 py-2 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                <option>All Status</option>
-                <option>Open</option>
-                <option>Pending</option>
-                <option>Resolved</option>
-              </select>
-              <FiFilter className="absolute right-3 top-2.5 text-gray-400" />
-            </div>
-          </div>
+          <div></div>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
@@ -124,15 +122,15 @@ export default function AdminSupportHome() {
             <h3 className="text-lg font-semibold text-gray-900">{t('recent_activity')}</h3>
           </div>
           <div className="divide-y divide-gray-200">
-            {[1, 2, 3, 4].map((item) => (
-              <div key={item} className="px-6 py-4 flex items-start hover:bg-gray-50 transition">
+            {activity.map((item) => (
+              <div key={item.id} className="px-6 py-4 flex items-start hover:bg-gray-50 transition">
                 <div className="flex-shrink-0 mt-1">
                   <div className="h-2 w-2 rounded-full bg-blue-500"></div>
                 </div>
                 <div className="ml-4">
-                  <p className="text-sm font-medium text-gray-900">New ticket #123{item} created</p>
-                  <p className="text-sm text-gray-500">Customer reported issue with login</p>
-                  <p className="text-xs text-gray-400 mt-1">2{item} minutes ago</p>
+                  <p className="text-sm font-medium text-gray-900">New ticket #{item.id} created</p>
+                  <p className="text-sm text-gray-500">{item.subject}</p>
+                  <p className="text-xs text-gray-400 mt-1">{formatRelativeTime(item.created_at)}</p>
                 </div>
               </div>
             ))}

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -57,3 +57,8 @@ export const updatePriority = async (id, priority) => {
   const { data } = await api.put(`/tickets/${id}/priority`, { priority });
   return data?.data;
 };
+
+export const fetchRecentActivity = async () => {
+  const { data } = await api.get("/support/admin/recent-activity");
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- remove unused dashboard filters
- provide recent support activity from backend API
- integrate recent activity fetch in admin support page

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688643d1bad483289251aa92dd7a2dc1