### PR TITLE
Add support dashboard content

### DIFF
--- a/frontend/src/pages/dashboard/admin/support/analytics/index.js
+++ b/frontend/src/pages/dashboard/admin/support/analytics/index.js
@@ -1,17 +1,65 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
 import PageHead from "@/components/common/PageHead";
+import { useEffect, useState } from "react";
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from "recharts";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 export default function AdminSupportAnalytics() {
   const { t } = useTranslation('dashboard');
+  const [stats, setStats] = useState({ open: 0, pending: 0, resolved: 0, avg: '0h' });
+  const [chart, setChart] = useState([]);
+
+  useEffect(() => {
+    const generate = () => {
+      setStats({
+        open: Math.floor(Math.random() * 20) + 5,
+        pending: Math.floor(Math.random() * 10) + 2,
+        resolved: Math.floor(Math.random() * 30) + 10,
+        avg: `${Math.floor(Math.random() * 4) + 1}h`,
+      });
+      setChart(
+        Array.from({ length: 7 }).map((_, i) => ({
+          day: `Day ${i + 1}`,
+          tickets: Math.floor(Math.random() * 20) + 5,
+        }))
+      );
+    };
+    generate();
+  }, []);
+
   return (
     <AdminLayout>
       <PageHead title={t('support_analytics')} />
-      <div className="p-6">
-        <h1 className="text-2xl font-bold mb-2">{t('support_analytics')}</h1>
-        <p className="text-gray-600">{t('under_construction')}</p>
+      <div className="p-6 space-y-8">
+        <h1 className="text-2xl font-bold">{t('support_analytics')}</h1>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {[
+            { label: 'Open', value: stats.open },
+            { label: 'Pending', value: stats.pending },
+            { label: 'Resolved', value: stats.resolved },
+            { label: 'Avg. Response', value: stats.avg },
+          ].map((m) => (
+            <div key={m.label} className="bg-white rounded shadow p-4 text-center">
+              <div className="text-2xl font-bold">{m.value}</div>
+              <div className="text-sm text-gray-500">{m.label}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="bg-white rounded shadow p-4">
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={chart}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="day" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="tickets" stroke="#2563eb" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
       </div>
     </AdminLayout>
   );

--- a/frontend/src/pages/dashboard/admin/support/customers/index.js
+++ b/frontend/src/pages/dashboard/admin/support/customers/index.js
@@ -1,17 +1,61 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
 import PageHead from "@/components/common/PageHead";
+import { useEffect, useState } from "react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import { fetchAllUsers } from "@/services/admin/userService";
 
 export default function AdminSupportCustomers() {
   const { t } = useTranslation('dashboard');
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchAllUsers();
+        setUsers(data);
+      } catch (err) {
+        console.error('Failed to load users', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
   return (
     <AdminLayout>
       <PageHead title={t('customer_management')} />
       <div className="p-6">
-        <h1 className="text-2xl font-bold mb-2">{t('customer_management')}</h1>
-        <p className="text-gray-600">{t('under_construction')}</p>
+        <h1 className="text-2xl font-bold mb-4">{t('customer_management')}</h1>
+        {loading ? (
+          <p className="text-gray-600">{t('loading')}</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full bg-white border rounded-md">
+              <thead className="bg-gray-100">
+                <tr>
+                  <th className="px-4 py-2 text-left">{t('name')}</th>
+                  <th className="px-4 py-2 text-left">{t('email')}</th>
+                  <th className="px-4 py-2 text-left">{t('status')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <tr key={user.id} className="border-t">
+                    <td className="px-4 py-2">{user.name}</td>
+                    <td className="px-4 py-2">{user.email}</td>
+                    <td className="px-4 py-2 capitalize">
+                      {user.status || 'active'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </AdminLayout>
   );

--- a/frontend/src/pages/dashboard/admin/support/knowledge/index.js
+++ b/frontend/src/pages/dashboard/admin/support/knowledge/index.js
@@ -1,17 +1,32 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
 import PageHead from "@/components/common/PageHead";
+import { useState } from "react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 export default function AdminSupportKnowledge() {
   const { t } = useTranslation('dashboard');
+  const [articles] = useState([
+    { id: 1, title: 'Creating a support ticket', excerpt: 'Learn how to submit a ticket and track its status.' },
+    { id: 2, title: 'Updating your profile', excerpt: 'Steps to keep your account information up to date.' },
+    { id: 3, title: 'Resetting your password', excerpt: 'How to securely reset a forgotten password.' },
+  ]);
+
   return (
     <AdminLayout>
       <PageHead title={t('knowledge_base')} />
-      <div className="p-6">
-        <h1 className="text-2xl font-bold mb-2">{t('knowledge_base')}</h1>
-        <p className="text-gray-600">{t('under_construction')}</p>
+      <div className="p-6 space-y-6">
+        <h1 className="text-2xl font-bold">{t('knowledge_base')}</h1>
+
+        <ul className="space-y-4">
+          {articles.map((article) => (
+            <li key={article.id} className="bg-white border rounded p-4">
+              <h2 className="font-semibold text-lg mb-1">{article.title}</h2>
+              <p className="text-sm text-gray-600">{article.excerpt}</p>
+            </li>
+          ))}
+        </ul>
       </div>
     </AdminLayout>
   );


### PR DESCRIPTION
## Summary
- flesh out Admin Support pages
- implement mock analytics data and charts
- show user list for customer management
- add knowledge base article placeholders

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: React hook rule violations and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68864350430c8328a59572cb35b03843