### PR TITLE
Implement admin support analytics

### DIFF
--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -89,3 +89,8 @@ exports.listRecentActivity = catchAsync(async (_req, res) => {
   const data = await service.getRecentActivity();
   sendSuccess(res, data);
 });
+
+exports.getAnalytics = catchAsync(async (_req, res) => {
+  const data = await service.getAnalytics();
+  sendSuccess(res, data);
+});

--- a/backend/src/modules/support/support.routes.js
+++ b/backend/src/modules/support/support.routes.js
@@ -12,5 +12,6 @@ router.post("/tickets/:id/messages", controller.addMessage);
 router.get("/admin/tickets", isAdmin, controller.listAllTickets);
 router.patch("/admin/tickets/:id/status", isAdmin, controller.updateStatus);
 router.get("/admin/recent-activity", isAdmin, controller.listRecentActivity);
+router.get("/admin/analytics", isAdmin, controller.getAnalytics);
 
 module.exports = router;

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -97,3 +97,44 @@ exports.getRecentActivity = async (limit = 10) => {
     .orderBy("support_tickets.created_at", "desc")
     .limit(limit);
 };
+
+// ---------------------------------------------------------------------------
+// 📊 Analytics for admin support dashboard
+// ---------------------------------------------------------------------------
+
+exports.getAnalytics = async () => {
+  const [openRow] = await db("support_tickets").where({ status: "Open" }).count();
+  const [pendingRow] = await db("support_tickets")
+    .where({ status: "Pending" })
+    .count();
+  const [resolvedRow] = await db("support_tickets")
+    .where({ status: "Resolved" })
+    .count();
+
+  const [avgRow] = await db("support_tickets")
+    .whereNotNull("updated_at")
+    .select(
+      db.raw(
+        "AVG(EXTRACT(EPOCH FROM (updated_at - created_at))/3600) as avg_hours"
+      )
+    );
+
+  const chartRows = await db("support_tickets")
+    .where("created_at", ">=", db.raw("CURRENT_DATE - INTERVAL '6 days'"))
+    .select(db.raw("DATE(created_at) as day"))
+    .count("* as tickets")
+    .groupByRaw("DATE(created_at)")
+    .orderBy("day");
+
+  return {
+    open: parseInt(openRow.count, 10) || 0,
+    pending: parseInt(pendingRow.count, 10) || 0,
+    resolved: parseInt(resolvedRow.count, 10) || 0,
+    avgHours: parseFloat(avgRow.avg_hours) || 0,
+    chart: chartRows.map((r) => ({
+      day:
+        r.day instanceof Date ? r.day.toISOString().split("T")[0] : r.day,
+      tickets: parseInt(r.tickets, 10),
+    })),
+  };
+};

--- a/backend/tests/supportRoutes.test.js
+++ b/backend/tests/supportRoutes.test.js
@@ -1,0 +1,31 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database', () => ({ raw: jest.fn(() => Promise.resolve()) }));
+
+jest.mock('../src/modules/support/support.service', () => ({
+  getAnalytics: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/support/support.service');
+const routes = require('../src/modules/support/support.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/support', routes);
+
+describe('GET /api/support/admin/analytics', () => {
+  it('returns analytics', async () => {
+    const mock = { open: 1 };
+    service.getAnalytics.mockResolvedValue(mock);
+    const res = await request(app).get('/api/support/admin/analytics');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getAnalytics).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/dashboard/admin/support/analytics/index.js
+++ b/frontend/src/pages/dashboard/admin/support/analytics/index.js
@@ -5,6 +5,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContai
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import { fetchSupportAnalytics } from "@/services/supportService";
 
 export default function AdminSupportAnalytics() {
   const { t } = useTranslation('dashboard');
@@ -12,21 +13,19 @@ export default function AdminSupportAnalytics() {
   const [chart, setChart] = useState([]);
 
   useEffect(() => {
-    const generate = () => {
-      setStats({
-        open: Math.floor(Math.random() * 20) + 5,
-        pending: Math.floor(Math.random() * 10) + 2,
-        resolved: Math.floor(Math.random() * 30) + 10,
-        avg: `${Math.floor(Math.random() * 4) + 1}h`,
+    fetchSupportAnalytics()
+      .then((data) => {
+        setStats({
+          open: data.open,
+          pending: data.pending,
+          resolved: data.resolved,
+          avg: `${data.avgHours?.toFixed ? data.avgHours.toFixed(1) : data.avgHours}h`,
+        });
+        setChart(data.chart);
+      })
+      .catch((err) => {
+        console.error("Failed to load analytics", err);
       });
-      setChart(
-        Array.from({ length: 7 }).map((_, i) => ({
-          day: `Day ${i + 1}`,
-          tickets: Math.floor(Math.random() * 20) + 5,
-        }))
-      );
-    };
-    generate();
   }, []);
 
   return (

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -62,3 +62,14 @@ export const fetchRecentActivity = async () => {
   const { data } = await api.get("/support/admin/recent-activity");
   return data?.data ?? [];
 };
+
+export const fetchSupportAnalytics = async () => {
+  const { data } = await api.get("/support/admin/analytics");
+  return data?.data ?? {
+    open: 0,
+    pending: 0,
+    resolved: 0,
+    avgHours: 0,
+    chart: [],
+  };
+};


### PR DESCRIPTION
## Summary
- add backend endpoint `/api/support/admin/analytics`
- compute analytics statistics and chart from database
- expose analytics retrieval in supportService on frontend
- load analytics on admin dashboard support analytics page
- test new analytics route

## Testing
- `npm install` in `backend`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68864a9826288328a52e30a107454131