### PR TITLE
Add delete support ticket endpoint

### DIFF
--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -131,6 +131,11 @@ exports.updateStatus = catchAsync(async (req, res) => {
   sendSuccess(res, ticket, "Status updated");
 });
 
+exports.deleteTicket = catchAsync(async (req, res) => {
+  await service.removeTicket(req.params.id);
+  sendSuccess(res, null, "Ticket deleted");
+});
+
 exports.listRecentActivity = catchAsync(async (_req, res) => {
   const data = await service.getRecentActivity();
   sendSuccess(res, data);

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -83,6 +83,9 @@ exports.updateStatus = async (id, status) => {
   return row;
 };
 
+exports.removeTicket = (id) =>
+  db("support_tickets").where({ id }).del();
+
 // Fetch recent support ticket activity for admin dashboard
 exports.getRecentActivity = async (limit = 10) => {
   return db("support_tickets")

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -48,6 +48,11 @@ export const addMessage = async (id, message) => {
   return data?.data;
 };
 
+export const deleteTicket = async (id) => {
+  const { data } = await api.delete(`/support/tickets/${id}`);
+  return data?.data;
+};
+
 export const updateStatus = async (id, status) => {
   const { data } = await api.patch(`/support/admin/tickets/${id}/status`, { status });
   return data?.data;


### PR DESCRIPTION
## Summary
- implement `removeTicket` service method
- add controller action for deleting tickets
- expose ticket deletion via API and frontend service
- ensure routes reference new controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68865ec829388328a2a59a15c3fc91f7