### PR TITLE
Notify admins on support ticket submission

### DIFF
--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -51,6 +51,25 @@ exports.createTicket = catchAsync(async (req, res) => {
       ticket.subject,
       ticket.ticket_number
     );
+    // Create notifications/messages for admins
+    await Promise.all(
+      admins.map((admin) =>
+        notificationService.createNotification({
+          user_id: admin.id,
+          type: "new_support_ticket",
+          message: `New support ticket from ${req.user.full_name}: '${ticket.subject}'`,
+        })
+      )
+    );
+    await Promise.all(
+      admins.map((admin) =>
+        messageService.createMessage({
+          sender_id: req.user.id,
+          receiver_id: admin.id,
+          message: `New support ticket '${ticket.subject}' submitted`,
+        })
+      )
+    );
   } catch (err) {
     console.error("Error sending support ticket emails:", err.message);
   }


### PR DESCRIPTION
## Summary
- trigger admin notifications and messages when new support tickets are created

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68867127db188328a48c654ac020bc9e