### PR TITLE
Enhance ticket deletion security

### DIFF
--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -158,6 +158,20 @@ exports.updateStatus = catchAsync(async (req, res) => {
 });
 
 exports.deleteTicket = catchAsync(async (req, res) => {
+  const ticket = await service.getTicketById(req.params.id);
+  if (!ticket) throw new AppError("Ticket not found", 404);
+  if (
+    ticket.user_id !== req.user.id &&
+    !isAdminRole(req.user.roles || req.user.role)
+  ) {
+    throw new AppError("Access denied", 403);
+  }
+  if (!["resolved", "closed"].includes(ticket.status.toLowerCase())) {
+    throw new AppError(
+      "Only resolved or closed tickets can be deleted",
+      400
+    );
+  }
   await service.removeTicket(req.params.id);
   sendSuccess(res, null, "Ticket deleted");
 });

--- a/frontend/src/components/support/StatusBadge.js
+++ b/frontend/src/components/support/StatusBadge.js
@@ -3,7 +3,7 @@ export default function StatusBadge({ status }) {
     Open: 'bg-blue-100 text-blue-700',
     Pending: 'bg-yellow-100 text-yellow-800',
     Resolved: 'bg-green-100 text-green-700',
-    Closed: 'bg-gray-200 text-gray-700',
+    Closed: 'bg-red-100 text-red-700',
   };
   return (
     <span className={`px-2 py-1 rounded text-xs font-medium capitalize ${colors[status] || ''}`}>{status}</span>

--- a/frontend/src/pages/dashboard/student/support/my-tickets.js
+++ b/frontend/src/pages/dashboard/student/support/my-tickets.js
@@ -3,6 +3,8 @@ import Link from "next/link";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import { useEffect, useState } from "react";
 import { fetchMyTickets, deleteTicket } from "@/services/supportService";
+import StatusBadge from "@/components/support/StatusBadge";
+import { FaEye } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
@@ -11,6 +13,7 @@ import { toast } from "react-toastify";
 export default function MyTicketsPage() {
   const [tickets, setTickets] = useState([]);
   const [statusFilter, setStatusFilter] = useState("All");
+  const [numberFilter, setNumberFilter] = useState("");
   const { t } = useTranslation("dashboard");
 
   useEffect(() => {
@@ -41,7 +44,10 @@ export default function MyTicketsPage() {
   };
 
   const filteredTickets = tickets.filter(
-    (ticket) => statusFilter === "All" || ticket.status === statusFilter
+    (ticket) =>
+      (statusFilter === "All" || ticket.status === statusFilter) &&
+      (numberFilter === "" ||
+        ticket.ticket_number?.toString().includes(numberFilter))
   );
 
   return (
@@ -52,6 +58,13 @@ export default function MyTicketsPage() {
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
           <h1 className="text-3xl font-bold text-gray-900">{t("my_tickets")}</h1>
           <div className="flex items-center gap-3">
+            <input
+              type="text"
+              value={numberFilter}
+              onChange={(e) => setNumberFilter(e.target.value)}
+              placeholder="Ticket #"
+              className="border border-gray-300 rounded px-3 py-2 text-sm"
+            />
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
@@ -92,20 +105,10 @@ export default function MyTicketsPage() {
                     key={ticket.id}
                     className="border-t border-gray-100 hover:bg-gray-50"
                   >
-                    <td className="px-4 py-3 font-mono text-sm text-gray-700">{ticket.id}</td>
+                    <td className="px-4 py-3 font-mono text-sm text-gray-700">{ticket.ticket_number}</td>
                     <td className="px-4 py-3 text-sm text-gray-800">{ticket.subject}</td>
                     <td className="px-4 py-3 text-sm">
-                      <span
-                        className={`inline-block px-2 py-1 rounded text-xs font-medium ${
-                          ticket.status === "Resolved"
-                            ? "bg-green-100 text-green-700"
-                            : ticket.status === "Open"
-                            ? "bg-yellow-100 text-yellow-700"
-                            : "bg-gray-200 text-gray-600"
-                        }`}
-                      >
-                        {ticket.status}
-                      </span>
+                      <StatusBadge status={ticket.status} />
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-500">
                       {new Date(ticket.created_at).toLocaleDateString()}
@@ -113,9 +116,9 @@ export default function MyTicketsPage() {
                     <td className="px-4 py-3 text-sm">
                       <Link
                         href={`/support/tickets/${ticket.id}`}
-                        className="text-blue-600 hover:underline"
+                        className="bg-blue-500 text-white px-3 py-1 rounded inline-flex items-center gap-1 hover:bg-blue-600"
                       >
-                        {t("view_details")}
+                        <FaEye /> {t("view_details")}
                       </Link>
                       {(["Resolved", "Closed"].includes(ticket.status)) && (
                         <button


### PR DESCRIPTION
## Summary
- restrict server-side ticket deletion to owner or admin
- only allow deleting tickets with status resolved or closed

## Testing
- `npm test` in `frontend` *(fails: jest not found)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688671b01ae883289710f519c297e394