### PR TITLE
Enhance admin ticket management

### DIFF
--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -97,6 +97,7 @@ exports.listAllTickets = catchAsync(async (req, res) => {
   const filters = {
     status: req.query.status,
     search: req.query.search,
+    ticketNumber: req.query.ticketNumber,
   };
   const tickets = await service.listAllTickets(filters);
   sendSuccess(res, tickets);

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -42,7 +42,7 @@ exports.listUserTickets = (user_id) => {
     .orderBy("created_at", "desc");
 };
 
-exports.listAllTickets = ({ status, search } = {}) => {
+exports.listAllTickets = ({ status, search, ticketNumber } = {}) => {
   const query = db("support_tickets")
     .leftJoin("users", "support_tickets.user_id", "users.id")
     .select(
@@ -63,6 +63,10 @@ exports.listAllTickets = ({ status, search } = {}) => {
         .orWhereILike("users.full_name", `%${search}%`)
         .orWhereILike("users.email", `%${search}%`);
     });
+  }
+
+  if (ticketNumber) {
+    query.whereILike("support_tickets.ticket_number", `%${ticketNumber}%`);
   }
 
   return query;

--- a/frontend/src/components/support/TicketCard.js
+++ b/frontend/src/components/support/TicketCard.js
@@ -2,16 +2,25 @@ import StatusBadge from './StatusBadge';
 import { FiClock, FiTag } from 'react-icons/fi';
 
 export default function TicketCard({ ticket, onClick }) {
+  const bgColors = {
+    open: 'bg-blue-50',
+    pending: 'bg-yellow-50',
+    resolved: 'bg-green-50',
+    closed: 'bg-gray-50',
+  };
+
   return (
     <div
       onClick={onClick}
-      className="border p-4 rounded-xl bg-white shadow-sm transition hover:shadow-md hover:border-yellow-400 cursor-pointer"
+      className={`border p-4 rounded-xl shadow-sm transition hover:shadow-md hover:border-yellow-400 cursor-pointer ${bgColors[ticket.status] || 'bg-white'}`}
     >
       {/* Header: Subject & Status */}
       <div className="flex justify-between items-center mb-2">
         <h3 className="font-semibold text-lg text-gray-800 truncate">{ticket.subject}</h3>
         <StatusBadge status={ticket.status} />
       </div>
+
+      <div className="text-xs text-gray-500 mb-2 font-mono">#{ticket.ticket_number}</div>
 
       {/* Metadata: Priority, User, Date */}
       <div className="flex items-center text-sm text-gray-500 gap-4 flex-wrap">

--- a/frontend/src/pages/dashboard/admin/support/tickets/index.js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/index.js
@@ -14,6 +14,7 @@ export default function AdminSupportTicketsPage() {
   const [status, setStatus] = useState("");
   const [priority, setPriority] = useState("");
   const [search, setSearch] = useState("");
+  const [ticketNumber, setTicketNumber] = useState("");
   const [dateRange, setDateRange] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const { t } = useTranslation("dashboard");
@@ -29,6 +30,7 @@ export default function AdminSupportTicketsPage() {
         status: status || undefined,
         priority: priority || undefined,
         search: search || undefined,
+        ticketNumber: ticketNumber || undefined,
         dateRange: dateRange || undefined,
       });
       setTickets(data);
@@ -43,6 +45,7 @@ export default function AdminSupportTicketsPage() {
     setStatus("");
     setPriority("");
     setSearch("");
+    setTicketNumber("");
     setDateRange("");
     load();
   };
@@ -69,7 +72,7 @@ export default function AdminSupportTicketsPage() {
 
         {/* Filters */}
         <div className="bg-white rounded-lg shadow-xs p-4 mb-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4 items-end">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4 items-end">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 {t("status")}
@@ -128,6 +131,20 @@ export default function AdminSupportTicketsPage() {
                 </select>
                 <FiCalendar className="absolute right-3 top-2.5 text-gray-400" />
               </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {t("ticket_id")}
+              </label>
+              <input
+                type="text"
+                value={ticketNumber}
+                onChange={(e) => setTicketNumber(e.target.value)}
+                onKeyPress={(e) => e.key === 'Enter' && load()}
+                className="block w-full border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                placeholder="#"
+              />
             </div>
 
             <div className="lg:col-span-2">


### PR DESCRIPTION
## Summary
- allow filtering tickets by number on backend and frontend
- show ticket ID in ticket card and color cards by status
- add ticket number search field on admin tickets page

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688687bd1de0832883201eadf7c5eb59