### PR TITLE
Fix profile wizard navigation bug

### DIFF
--- a/frontend/src/pages/profile/edit.js
+++ b/frontend/src/pages/profile/edit.js
@@ -78,8 +78,21 @@ const ProfileEdit = () => {
           exit={{ opacity: 0, x: -30 }}
           transition={{ duration: 0.4 }}
         >
-          {step === 1 && <PersonalDetails formData={formData} setFormData={setFormData} />}
-          {step === 2 && <Verification formData={formData} setFormData={setFormData} />}
+          {step === 1 && (
+            <PersonalDetails
+              formData={formData}
+              setFormData={setFormData}
+              nextStep={nextStep}
+            />
+          )}
+          {step === 2 && (
+            <Verification
+              formData={formData}
+              setFormData={setFormData}
+              onNext={nextStep}
+              onBack={prevStep}
+            />
+          )}
           {step === 3 && <RoleSelection formData={formData} setFormData={setFormData} onNext={nextStep} />}
           {step === 4 && formData.role === "student" && <StudentDetails formData={formData} setFormData={setFormData} nextStep={nextStep} prevStep={prevStep} />}
           {step === 5 && formData.role === "instructor" && <InstructorDetails formData={formData} setFormData={setFormData} nextStep={nextStep} prevStep={prevStep} />}


### PR DESCRIPTION
## Summary
- pass nextStep and prevStep handlers to first two profile setup steps

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`
- `npm run lint` in `frontend` *(fails: 50 errors, 207 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68873cb320d08328972c7b99ead2f8c4