### PR TITLE
Improve SEO settings page

### DIFF
--- a/backend/src/modules/seoConfig/seoConfig.controller.js
+++ b/backend/src/modules/seoConfig/seoConfig.controller.js
@@ -33,3 +33,13 @@ exports.updateSettings = catchAsync(async (req, res) => {
     )
   );
 });
+
+exports.regenerateSitemap = catchAsync(async (_req, res) => {
+  const result = await service.generateSitemap();
+  sendSuccess(res, result, "Sitemap regenerated");
+});
+
+exports.scanMetaIssues = catchAsync(async (_req, res) => {
+  const result = await service.scanMetaIssues();
+  sendSuccess(res, result, "Scan complete");
+});

--- a/backend/src/modules/seoConfig/seoConfig.routes.js
+++ b/backend/src/modules/seoConfig/seoConfig.routes.js
@@ -6,5 +6,7 @@ const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware")
 router.get("/", controller.getSettings);
 router.use(verifyToken, isAdmin);
 router.put("/", controller.updateSettings);
+router.post("/sitemap/regenerate", controller.regenerateSitemap);
+router.get("/meta-scan", controller.scanMetaIssues);
 
 module.exports = router;

--- a/backend/src/modules/seoConfig/seoConfig.service.js
+++ b/backend/src/modules/seoConfig/seoConfig.service.js
@@ -24,3 +24,64 @@ exports.updateSettings = async (settings) => {
   }
   return settings;
 };
+
+// Generate sitemap.xml file based on saved sitemap config
+exports.generateSitemap = async () => {
+  const fs = require("fs");
+  const path = require("path");
+
+  const settings = (await exports.getSettings()) || {};
+  const pages = settings.sitemap || [];
+  const baseUrl = settings.baseUrl || process.env.FRONTEND_URL || "https://example.com";
+
+  const urlset = pages
+    .filter((p) => p.include)
+    .map(
+      (p) =>
+        `  <url><loc>${baseUrl.replace(/\/$/, "")}${p.path}</loc><changefreq>${p.freq || "weekly"}</changefreq><priority>${p.priority || 0.5}</priority></url>`
+    )
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlset}\n</urlset>`;
+
+  const dir = path.join(__dirname, "../../../uploads/seo");
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, "sitemap.xml");
+  fs.writeFileSync(filePath, xml);
+
+  const updated = new Date().toISOString();
+  settings.sitemapUpdated = updated;
+  await exports.updateSettings(settings);
+
+  return { url: "/uploads/seo/sitemap.xml", updated };
+};
+
+// Scan saved meta tags for missing title or description
+exports.scanMetaIssues = async () => {
+  const settings = (await exports.getSettings()) || {};
+  const meta = settings.metaTags || {};
+  const issues = [];
+  Object.entries(meta).forEach(([path, data]) => {
+    const missing = [];
+    if (!data.title) missing.push("title");
+    if (!data.description) missing.push("description");
+    if (missing.length) issues.push({ path, missing });
+  });
+
+  const stats = {
+    indexedPages: (settings.sitemap || []).filter((p) => p.include).length,
+    pagesMissingMeta: issues.length,
+    sitemapUpdated: settings.sitemapUpdated || null,
+    robotsStatus: settings.robots ? "Active" : "Empty",
+    openGraphReady: settings.openGraph ? Object.keys(settings.openGraph).length : 0,
+  };
+
+  const scannedAt = new Date().toISOString();
+  stats.lastChecked = scannedAt;
+
+  settings.stats = stats;
+  settings.lastChecked = scannedAt;
+  await exports.updateSettings(settings);
+
+  return { stats, issues, scannedAt };
+};

--- a/backend/tests/seoConfigRoutes.test.js
+++ b/backend/tests/seoConfigRoutes.test.js
@@ -4,6 +4,8 @@ const express = require('express');
 jest.mock('../src/modules/seoConfig/seoConfig.service', () => ({
   getSettings: jest.fn(),
   updateSettings: jest.fn(),
+  generateSitemap: jest.fn(),
+  scanMetaIssues: jest.fn(),
 }));
 
 jest.mock('../src/modules/users/user.model', () => ({
@@ -51,5 +53,29 @@ describe('PUT /api/seo-config', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(payload);
     expect(service.updateSettings).toHaveBeenCalledWith(payload);
+  });
+});
+
+describe('POST /api/seo-config/sitemap/regenerate', () => {
+  it('regenerates sitemap', async () => {
+    const result = { url: '/uploads/seo/sitemap.xml', updated: 'now' };
+    service.generateSitemap.mockResolvedValue(result);
+
+    const res = await request(app).post('/api/seo-config/sitemap/regenerate');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(result);
+    expect(service.generateSitemap).toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/seo-config/meta-scan', () => {
+  it('scans meta tags', async () => {
+    const scan = { stats: { indexedPages: 1 }, issues: [], scannedAt: '2025-07-28T11:00:00Z' };
+    service.scanMetaIssues.mockResolvedValue(scan);
+
+    const res = await request(app).get('/api/seo-config/meta-scan');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(scan);
+    expect(service.scanMetaIssues).toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/dashboard/admin/settings/seo/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/seo/index.js
@@ -1,10 +1,48 @@
 // pages/dashboard/admin/settings/seo/index.js
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, Fragment } from "react";
 import { toast } from "react-toastify";
-import { fetchSEOConfig, updateSEOConfig } from "@/services/admin/seoConfigService";
-import { Tab } from "@headlessui/react";
-import { FaTags, FaSitemap, FaRobot, FaCog, FaTwitter, FaGlobe, FaEdit } from "react-icons/fa";
+import { updateSEOConfig } from "@/services/admin/seoConfigService";
+import { Tab, Dialog, Transition } from "@headlessui/react";
+import {
+  FaTags,
+  FaSitemap,
+  FaRobot,
+  FaCog,
+  FaTwitter,
+  FaGlobe,
+  FaEdit,
+  FaSpinner,
+  FaQuestionCircle,
+} from "react-icons/fa";
+import useSEOConfigStore from "@/store/seoConfigStore";
+
+const defaultConfig = {
+  metaTags: {},
+  sitemap: [],
+  robots: "",
+  openGraph: {},
+  twitter: {},
+  globalSEO: {
+    forceCanonical: true,
+    noindexSitewide: false,
+    autoPingSitemap: true,
+  },
+  redirects: [],
+  jsonSchema: "",
+};
+
+// Collect unique page paths from existing config sections
+function collectPages(cfg) {
+  const pages = new Set(["/"]);
+  if (Array.isArray(cfg?.sitemap)) {
+    cfg.sitemap.forEach((p) => p.path && pages.add(p.path));
+  }
+  [cfg?.metaTags, cfg?.openGraph, cfg?.twitter].forEach((section) => {
+    if (section) Object.keys(section).forEach((p) => pages.add(p));
+  });
+  return Array.from(pages).sort();
+}
 
 const tabs = [
   { key: "overview", label: "Overview", icon: <FaGlobe /> },
@@ -18,6 +56,15 @@ const tabs = [
 
 export default function SEOSettingsPage() {
   const [activeTab, setActiveTab] = useState("overview");
+  const fetchConfig = useSEOConfigStore((state) => state.fetch);
+  const seoConfig = useSEOConfigStore((state) => state.settings);
+  const updateStore = useSEOConfigStore((state) => state.update);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  const config = { ...defaultConfig, ...seoConfig };
 
   return (
     <AdminLayout title="SEO Settings">
@@ -40,25 +87,25 @@ export default function SEOSettingsPage() {
 
         <Tab.Panels className="bg-white p-6 rounded-md shadow">
           <Tab.Panel>
-            <SEOOverview />
+          <SEOOverview config={config} onChangeTab={setActiveTab} />
           </Tab.Panel>
           <Tab.Panel>
-            <MetaTagsManager />
+            <MetaTagsManager config={config} update={updateStore} />
           </Tab.Panel>
           <Tab.Panel>
-            <SitemapManager />
+            <SitemapManager config={config} update={updateStore} />
           </Tab.Panel>
           <Tab.Panel>
-            <RobotsEditor />
+            <RobotsEditor config={config} update={updateStore} />
           </Tab.Panel>
           <Tab.Panel>
-            <OpenGraphSettings />
+            <OpenGraphSettings config={config} update={updateStore} />
           </Tab.Panel>
           <Tab.Panel>
-            <TwitterCardSettings />
+            <TwitterCardSettings config={config} update={updateStore} />
           </Tab.Panel>
           <Tab.Panel>
-            <AdvancedSEOSettings />
+            <AdvancedSEOSettings config={config} update={updateStore} />
           </Tab.Panel>
         </Tab.Panels>
       </Tab.Group>
@@ -66,60 +113,260 @@ export default function SEOSettingsPage() {
   );
 }
 
-// Placeholder components to be built next
-// Inside the SEOSettingsPage file, update this component
-function SEOOverview() {
-  const stats = [
-    { label: "Indexed Pages", value: 124, icon: "🧭" },
-    { label: "Pages Missing Meta Tags", value: 16, icon: "⚠️" },
-    { label: "Sitemap Last Updated", value: "2025-05-14", icon: "📆" },
-    { label: "Robots.txt Status", value: "Active", icon: "🤖" },
-    { label: "Open Graph Ready Pages", value: 89, icon: "📸" },
-  ];
+function SEOOverview({ config, onChangeTab }) {
+  const regenerate = useSEOConfigStore((s) => s.regenerate);
+  const scan = useSEOConfigStore((s) => s.scan);
+
+  const [sitemapLoading, setSitemapLoading] = useState(false);
+  const [scanLoading, setScanLoading] = useState(false);
+  const [sitemapAlert, setSitemapAlert] = useState(null);
+  const [scanAlert, setScanAlert] = useState(null);
+  const [issues, setIssues] = useState([]);
+  const [showModal, setShowModal] = useState(false);
+  const [scanTime, setScanTime] = useState(config.lastChecked);
+
+  useEffect(() => {
+    setScanTime(config.lastChecked);
+  }, [config.lastChecked]);
+
+  const stats = config.stats
+    ? [
+        {
+          label: "Indexed Pages",
+          value: config.stats.indexedPages,
+          icon: "🧭",
+          status: Array.isArray(config.stats.indexedPages)
+            ? config.stats.indexedPages.length > 0
+              ? "ok"
+              : "warning"
+            : config.stats.indexedPages > 0
+            ? "ok"
+            : "warning",
+        },
+        {
+          label: "Pages Missing Meta Tags",
+          value: config.stats.pagesMissingMeta,
+          icon: "⚠️",
+          status: config.stats.pagesMissingMeta > 0 ? "warning" : "ok",
+        },
+        {
+          label: "Sitemap Last Updated",
+          value: config.stats.sitemapUpdated || "-",
+          icon: "📆",
+          status: config.stats.sitemapUpdated ? "ok" : "warning",
+        },
+        {
+          label: "Robots.txt Status",
+          value: config.stats.robotsStatus,
+          icon: "🤖",
+          status: config.stats.robotsStatus === "Active" ? "ok" : "error",
+        },
+        {
+          label: "Open Graph Ready Pages",
+          value: config.stats.openGraphReady,
+          icon: "📸",
+          status: config.stats.openGraphReady > 0 ? "ok" : "warning",
+        },
+      ]
+    : [];
 
   const actions = [
-    { label: "Regenerate Sitemap", icon: "🔁", onClick: () => alert("Sitemap regenerated!") },
-    { label: "Edit Robots.txt", icon: "✏️", onClick: () => alert("Redirecting to robots.txt...") },
-    { label: "Scan for Meta Issues", icon: "🕵️", onClick: () => alert("Scanning...") },
+    {
+      label: "Regenerate Sitemap",
+      icon: "🔁",
+      tip: "Generate a fresh sitemap.xml file",
+      onClick: async () => {
+        setSitemapLoading(true);
+        setSitemapAlert(null);
+        try {
+          await regenerate();
+          setSitemapAlert({ type: "success", text: "Sitemap regenerated" });
+        } catch {
+          setSitemapAlert({ type: "error", text: "Failed to regenerate" });
+        } finally {
+          setSitemapLoading(false);
+        }
+      },
+    },
+    {
+      label: "Edit Robots.txt",
+      icon: "✏️",
+      tip: "Manage crawler instructions",
+      onClick: () => onChangeTab("robots"),
+    },
+    {
+      label: "Scan for Meta Issues",
+      icon: "🕵️",
+      tip: "Check pages for missing titles and descriptions",
+      onClick: async () => {
+        setScanLoading(true);
+        setScanAlert(null);
+        try {
+          const res = await scan();
+          setIssues(res.issues || []);
+          setShowModal(true);
+          setScanTime(res.scannedAt);
+          setScanAlert({ type: "success", text: `${res.issues.length} issues found` });
+        } catch {
+          setScanAlert({ type: "error", text: "Failed to scan" });
+        } finally {
+          setScanLoading(false);
+        }
+      },
+    },
   ];
 
   return (
     <div className="space-y-8">
       <div>
         <h2 className="text-lg font-semibold mb-4 text-gray-800">📊 SEO Stats</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
           {stats.map((s, i) => (
             <div key={i} className="bg-gray-50 border rounded-lg p-4 shadow-sm">
-              <div className="text-2xl mb-1">{s.icon}</div>
-              <div className="text-sm text-gray-600">{s.label}</div>
-              <div className="text-xl font-bold text-yellow-600">{s.value}</div>
+              <div className="flex justify-between items-start">
+                <div className="text-2xl">{s.icon}</div>
+                {s.status && (
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded-full ${
+                      s.status === "ok"
+                        ? "bg-green-100 text-green-800"
+                        : s.status === "warning"
+                        ? "bg-yellow-100 text-yellow-800"
+                        : "bg-red-100 text-red-800"
+                    }`}
+                  >
+                    {s.status === "ok" ? "OK" : s.status === "warning" ? "Warning" : "Error"}
+                  </span>
+                )}
+              </div>
+              <div className="text-sm text-gray-600 mt-1">{s.label}</div>
+              <div className="text-xl font-bold text-yellow-600">
+                {Array.isArray(s.value) ? s.value.length : s.value}
+              </div>
+              {Array.isArray(s.value) && s.value.length > 0 && (
+                <details className="mt-1 text-sm">
+                  <summary className="cursor-pointer text-blue-600">View pages</summary>
+                  <ul className="list-disc list-inside mt-1">
+                    {s.value.map((p) => (
+                      <li key={p}>
+                        <a href={p} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                          {p}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              )}
             </div>
           ))}
         </div>
+        {scanTime && (
+          <div className="text-xs text-gray-500 mt-2 text-right">Last checked: {new Date(scanTime).toLocaleString()}</div>
+        )}
       </div>
 
       <div>
         <h2 className="text-lg font-semibold mb-4 text-gray-800">⚡ Quick Actions</h2>
         <div className="flex flex-wrap gap-4">
           {actions.map((a, i) => (
-            <button
-              key={i}
-              onClick={a.onClick}
-              className="flex items-center gap-2 bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded-md shadow"
-            >
-              <span>{a.icon}</span>
-              <span>{a.label}</span>
-            </button>
+            <div key={i} className="flex flex-col items-start">
+              <button
+                onClick={a.onClick}
+                disabled={a.label.includes('Sitemap') ? sitemapLoading : scanLoading}
+                title={a.tip}
+                className="flex items-center gap-2 bg-yellow-500 disabled:opacity-50 hover:bg-yellow-600 text-white px-4 py-2 rounded-md shadow"
+              >
+                {a.label.includes('Sitemap') && sitemapLoading && <FaSpinner className="animate-spin" />}
+                {a.label.includes('Meta') && scanLoading && <FaSpinner className="animate-spin" />}
+                <span>{a.icon}</span>
+                <span>{a.label}</span>
+                <FaQuestionCircle className="ml-1 text-xs" />
+              </button>
+              {a.label.includes('Sitemap') && sitemapAlert && (
+                <span className={`mt-1 text-sm ${sitemapAlert.type === 'success' ? 'text-green-600' : 'text-red-600'}`}>{sitemapAlert.text}</span>
+              )}
+              {a.label.includes('Meta') && scanAlert && (
+                <span className={`mt-1 text-sm ${scanAlert.type === 'success' ? 'text-green-600' : 'text-red-600'}`}>{scanAlert.text}</span>
+              )}
+            </div>
           ))}
         </div>
       </div>
+
+      <Transition appear show={showModal} as={Fragment}>
+        <Dialog as="div" className="relative z-10" onClose={() => setShowModal(false)}>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-black/30" />
+          </Transition.Child>
+
+          <div className="fixed inset-0 overflow-y-auto">
+            <div className="flex min-h-full items-center justify-center p-4 text-center">
+              <Transition.Child
+                as={Fragment}
+                enter="ease-out duration-300"
+                enterFrom="opacity-0 scale-95"
+                enterTo="opacity-100 scale-100"
+                leave="ease-in duration-200"
+                leaveFrom="opacity-100 scale-100"
+                leaveTo="opacity-0 scale-95"
+              >
+                <Dialog.Panel className="w-full max-w-lg transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl">
+                  <Dialog.Title className="text-lg font-medium text-gray-900">Meta Issues ({issues.length})</Dialog.Title>
+                  <div className="mt-2">
+                    {issues.length === 0 ? (
+                      <p className="text-sm text-gray-500">No issues found 🎉</p>
+                    ) : (
+                      <ul className="space-y-2 text-sm">
+                        {issues.map((iss, idx) => (
+                          <li key={idx} className="border-b pb-1">
+                            <div className="font-medium">{iss.path}</div>
+                            <div className="text-red-600">Missing: {iss.missing.join(', ')}</div>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                    {scanTime && (
+                      <p className="mt-2 text-xs text-gray-500">Last checked: {new Date(scanTime).toLocaleString()}</p>
+                    )}
+                  </div>
+                  <div className="mt-4 flex justify-end gap-2">
+                    {issues.length > 0 && (
+                      <button
+                        className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded"
+                        onClick={() => {
+                          setShowModal(false);
+                          onChangeTab('meta');
+                        }}
+                      >
+                        Edit Meta
+                      </button>
+                    )}
+                    <button className="bg-gray-100 px-4 py-2 rounded" onClick={() => setShowModal(false)}>
+                      Close
+                    </button>
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition>
     </div>
   );
 }
 
 
-function MetaTagsManager() {
-  const [selectedPage, setSelectedPage] = useState("/");
+function MetaTagsManager({ config, update: updateConfig }) {
+  const pages = useMemo(() => collectPages(config), [config]);
+  const [selectedPage, setSelectedPage] = useState(pages[0] || "/");
   const [form, setForm] = useState({
     title: "",
     description: "",
@@ -129,17 +376,32 @@ function MetaTagsManager() {
     nofollow: false,
   });
 
-  const pages = [
-    "/", "/about", "/courses", "/courses/[id]", "/community", "/contact",
-  ];
+  useEffect(() => {
+    if (!pages.includes(selectedPage)) setSelectedPage(pages[0] || "/");
+  }, [pages, selectedPage]);
+
+  useEffect(() => {
+    const meta = config.metaTags?.[selectedPage] || {};
+    setForm((prev) => ({ ...prev, ...meta }));
+  }, [selectedPage, config.metaTags]);
+
 
   const handleChange = (field, value) => {
     setForm(prev => ({ ...prev, [field]: value }));
   };
 
-  const handleSave = () => {
-    // TODO: Send to backend
-    alert(`Saved meta for ${selectedPage}`);
+  const handleSave = async () => {
+    const updated = {
+      ...config,
+      metaTags: { ...config.metaTags, [selectedPage]: form },
+    };
+    updateConfig(updated);
+    try {
+      await updateSEOConfig(updated);
+      toast.success("Meta tags saved");
+    } catch (_err) {
+      toast.error("Failed to save");
+    }
   };
 
   return (
@@ -236,13 +498,9 @@ function MetaTagsManager() {
   );
 }
 
-function SitemapManager() {
-  const [pages, setPages] = useState([
+function SitemapManager({ config, update }) {
+  const [pages, setPages] = useState(config.sitemap.length ? config.sitemap : [
     { path: "/", include: true, priority: 1.0, freq: "daily" },
-    { path: "/about", include: true, priority: 0.8, freq: "monthly" },
-    { path: "/courses", include: true, priority: 0.9, freq: "weekly" },
-    { path: "/community", include: false, priority: 0.7, freq: "monthly" },
-    { path: "/contact", include: true, priority: 0.6, freq: "yearly" },
   ]);
 
   const changeFreqOptions = ["always", "hourly", "daily", "weekly", "monthly", "yearly", "never"];
@@ -253,9 +511,15 @@ function SitemapManager() {
     setPages(updated);
   };
 
-  const regenerateSitemap = () => {
-    // TODO: call backend or API
-    alert("🗺️ Sitemap regenerated!");
+  const regenerateSitemap = async () => {
+    const updated = { ...config, sitemap: pages };
+    update(updated);
+    try {
+      await updateSEOConfig(updated);
+      toast.success("Sitemap saved");
+    } catch (_err) {
+      toast.error("Failed to save");
+    }
   };
 
   return (
@@ -317,15 +581,17 @@ function SitemapManager() {
         </tbody>
       </table>
 
-      <div className="text-sm text-gray-500 italic">
-        Last updated: 2025-05-14 15:12 GMT+3 (mocked)
-      </div>
+      {config.sitemapUpdated && (
+        <div className="text-sm text-gray-500 italic">
+          Last updated: {config.sitemapUpdated}
+        </div>
+      )}
     </div>
   );
 }
 
 
-function RobotsEditor() {
+function RobotsEditor({ config, update }) {
   const defaultContent = `
 User-agent: *
 Disallow: /dashboard/
@@ -335,13 +601,19 @@ Allow: /
 Sitemap: https://yourdomain.com/sitemap.xml
   `.trim();
 
-  const [content, setContent] = useState(defaultContent);
+  const [content, setContent] = useState(config.robots || defaultContent);
   const [saved, setSaved] = useState(false);
 
-  const handleSave = () => {
-    // TODO: Connect to backend API
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+  const handleSave = async () => {
+    const updated = { ...config, robots: content };
+    update(updated);
+    try {
+      await updateSEOConfig(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (_err) {
+      toast.error("Failed to save");
+    }
   };
 
   const restoreDefault = () => {
@@ -386,16 +658,15 @@ Sitemap: https://yourdomain.com/sitemap.xml
 }
 
 
-function OpenGraphSettings() {
-  const [selectedPage, setSelectedPage] = useState("/");
+function OpenGraphSettings({ config, update }) {
+  const pages = useMemo(() => collectPages(config), [config]);
+  const [selectedPage, setSelectedPage] = useState(pages[0] || "/");
   const [form, setForm] = useState({
     title: "",
     description: "",
     type: "website",
     image: "",
   });
-
-  const pages = ["/", "/about", "/courses", "/courses/[id]", "/community"];
 
   const handleChange = (key, value) => {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -408,9 +679,27 @@ function OpenGraphSettings() {
     handleChange("image", url);
   };
 
-  const handleSave = () => {
-    // TODO: POST to backend
-    alert(`✅ Open Graph settings saved for ${selectedPage}`);
+  useEffect(() => {
+    if (!pages.includes(selectedPage)) setSelectedPage(pages[0] || "/");
+  }, [pages, selectedPage]);
+
+  useEffect(() => {
+    const data = config.openGraph?.[selectedPage] || {};
+    setForm((prev) => ({ ...prev, ...data }));
+  }, [selectedPage, config.openGraph]);
+
+  const handleSave = async () => {
+    const updated = {
+      ...config,
+      openGraph: { ...config.openGraph, [selectedPage]: form },
+    };
+    update(updated);
+    try {
+      await updateSEOConfig(updated);
+      toast.success("Open Graph saved");
+    } catch (_err) {
+      toast.error("Failed to save");
+    }
   };
 
   return (
@@ -490,8 +779,9 @@ function OpenGraphSettings() {
   );
 }
 
-function TwitterCardSettings() {
-  const [selectedPage, setSelectedPage] = useState("/");
+function TwitterCardSettings({ config, update }) {
+  const pages = useMemo(() => collectPages(config), [config]);
+  const [selectedPage, setSelectedPage] = useState(pages[0] || "/");
   const [form, setForm] = useState({
     title: "",
     description: "",
@@ -499,8 +789,6 @@ function TwitterCardSettings() {
     image: "",
     handle: "@yourhandle"
   });
-
-  const pages = ["/", "/about", "/courses", "/community"];
 
   const handleChange = (key, value) => {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -513,9 +801,27 @@ function TwitterCardSettings() {
     handleChange("image", url);
   };
 
-  const handleSave = () => {
-    // TODO: Send to backend
-    alert(`✅ Twitter Card settings saved for ${selectedPage}`);
+  useEffect(() => {
+    if (!pages.includes(selectedPage)) setSelectedPage(pages[0] || "/");
+  }, [pages, selectedPage]);
+
+  useEffect(() => {
+    const data = config.twitter?.[selectedPage] || {};
+    setForm((prev) => ({ ...prev, ...data }));
+  }, [selectedPage, config.twitter]);
+
+  const handleSave = async () => {
+    const updated = {
+      ...config,
+      twitter: { ...config.twitter, [selectedPage]: form },
+    };
+    update(updated);
+    try {
+      await updateSEOConfig(updated);
+      toast.success("Twitter card saved");
+    } catch (_err) {
+      toast.error("Failed to save");
+    }
   };
 
   return (
@@ -606,7 +912,7 @@ function TwitterCardSettings() {
 }
 
 
-function AdvancedSEOSettings() {
+function AdvancedSEOSettings({ config, update }) {
   const [globalSEO, setGlobalSEO] = useState({
     forceCanonical: true,
     noindexSitewide: false,
@@ -644,25 +950,17 @@ function AdvancedSEOSettings() {
   };
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const data = await fetchSEOConfig();
-        if (data) {
-          if (data.globalSEO) setGlobalSEO((prev) => ({ ...prev, ...data.globalSEO }));
-          if (data.redirects) setRedirects(data.redirects);
-          if (data.jsonSchema) setJsonSchema(data.jsonSchema);
-        }
-      } catch (err) {
-        toast.error("Failed to load settings");
-      }
-    };
-    load();
+    if (config.globalSEO) setGlobalSEO({ ...globalSEO, ...config.globalSEO });
+    if (config.redirects) setRedirects(config.redirects);
+    if (config.jsonSchema) setJsonSchema(config.jsonSchema);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [config]);
 
   const handleSave = async () => {
+    const updated = { ...config, globalSEO, redirects, jsonSchema };
+    update(updated);
     try {
-      await updateSEOConfig({ globalSEO, redirects, jsonSchema });
+      await updateSEOConfig(updated);
       toast.success("SEO settings saved!");
     } catch (err) {
       toast.error("Failed to save settings");

--- a/frontend/src/services/admin/seoConfigService.js
+++ b/frontend/src/services/admin/seoConfigService.js
@@ -9,3 +9,13 @@ export const updateSEOConfig = async (payload) => {
   const { data } = await api.put("/seo-config", payload);
   return data?.data;
 };
+
+export const regenerateSitemap = async () => {
+  const { data } = await api.post("/seo-config/sitemap/regenerate");
+  return data?.data;
+};
+
+export const scanMetaIssues = async () => {
+  const { data } = await api.get("/seo-config/meta-scan");
+  return data?.data;
+};

--- a/frontend/src/store/seoConfigStore.js
+++ b/frontend/src/store/seoConfigStore.js
@@ -1,0 +1,55 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import {
+  fetchSEOConfig,
+  regenerateSitemap,
+  scanMetaIssues,
+} from "@/services/admin/seoConfigService";
+
+const useSEOConfigStore = create(
+  persist(
+    (set, get) => ({
+      settings: {},
+      loading: false,
+      loaded: false,
+      fetch: async () => {
+        if (get().loading) return;
+        set({ loading: true });
+        try {
+          const data = await fetchSEOConfig();
+          set({ settings: data || {}, loaded: true, loading: false });
+        } catch (_err) {
+          set({ loaded: true, loading: false });
+        }
+      },
+      update: (newSettings) =>
+        set((state) => ({ settings: { ...state.settings, ...newSettings } })),
+      regenerate: async () => {
+        const result = await regenerateSitemap();
+        if (result?.updated) {
+          set((state) => ({
+            settings: { ...state.settings, sitemapUpdated: result.updated },
+          }));
+        }
+        return result;
+      },
+      scan: async () => {
+        const result = await scanMetaIssues();
+        if (result?.stats) {
+          set((state) => ({
+            settings: {
+              ...state.settings,
+              stats: result.stats,
+              lastChecked: result.scannedAt,
+            },
+          }));
+        }
+        return result;
+      },
+      clear: () => set({ settings: {}, loaded: false })
+    }),
+    { name: "seo-config" }
+  )
+);
+
+export default useSEOConfigStore;


### PR DESCRIPTION
## Summary
- collect page paths from SEO config
- use dynamic pages for Meta Tags, Open Graph, and Twitter settings
- remove leftover placeholder comments
- sort pages alphabetically for predictable options
- show live meta scan issues and status badges in SEO Overview
- store last scan timestamp

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68873f69e25483288d672ddec6eac9b4