### PR TITLE
Add robots.txt file and SEO docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For detailed instructions see [docs/installation.md](docs/installation.md).
 See [docs/deployment.md](docs/deployment.md) for tips on configuring environment variables when hosting the app.
 New users can follow the [Student Registration Guide](docs/student-registration-guide.md) to learn how to sign up and enroll in classes.
 If Google sign-in fails with `redirect_uri_mismatch`, see [docs/social-login-setup.md](docs/social-login-setup.md) for the required OAuth callback URL.
+For details on generating a sitemap and exposing `robots.txt`, see [docs/seo-guide.md](docs/seo-guide.md).
 
 ## Booking API
 

--- a/docs/seo-guide.md
+++ b/docs/seo-guide.md
@@ -1,0 +1,29 @@
+# SEO Configuration
+
+SkillBridge includes a basic SEO settings page inside the admin dashboard under
+`/dashboard/admin/settings/seo`. From there you can update meta tags, manage the
+sitemap and edit the content of `robots.txt`.
+
+## Serving robots.txt
+
+Next.js automatically serves any files placed in `frontend/public` at the site
+root. To expose a `robots.txt` file, create or upload it to
+`frontend/public/robots.txt`. After rebuilding the frontend the file will be
+available at `https://yourdomain.com/robots.txt`.
+
+A recommended starting point is:
+
+```txt
+User-agent: *
+Disallow: /dashboard/
+Disallow: /admin/
+Disallow: /api/
+Disallow: /auth/
+Disallow: /delete-account
+Disallow: /error/
+Allow: /
+
+Sitemap: https://yourdomain.com/sitemap.xml
+```
+
+Replace `yourdomain.com` with your real domain name.

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,10 @@
+User-agent: *
+Disallow: /dashboard/
+Disallow: /admin/
+Disallow: /api/
+Disallow: /auth/
+Disallow: /delete-account
+Disallow: /error/
+Allow: /
+
+Sitemap: https://yourdomain.com/sitemap.xml


### PR DESCRIPTION
## Summary
- provide `robots.txt` in `frontend/public`
- document how to serve and customize robots.txt in new SEO guide
- reference the guide from README

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6887a8bfe0708328bc4f2bf776f9beef