### PR TITLE
Generate robots.txt in frontend public dir

### DIFF
--- a/backend/src/modules/seoConfig/seoConfig.service.js
+++ b/backend/src/modules/seoConfig/seoConfig.service.js
@@ -22,6 +22,21 @@ exports.updateSettings = async (settings) => {
   } else {
     await db("settings").insert({ key: SETTINGS_KEY, value });
   }
+
+  // Also write robots.txt if robots content is provided
+  try {
+    const fs = require("fs");
+    const path = require("path");
+    const robotsPath = path.join(__dirname, "../../../../frontend/public/robots.txt");
+    if (settings.robots) {
+      fs.writeFileSync(robotsPath, settings.robots);
+    } else if (fs.existsSync(robotsPath)) {
+      fs.unlinkSync(robotsPath);
+    }
+  } catch (err) {
+    console.error("Failed to write robots.txt", err);
+  }
+
   return settings;
 };
 


### PR DESCRIPTION
## Summary
- write robots.txt to `frontend/public` when SEO settings are updated

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888632889c88328b0e51af896b514ff