### PR TITLE
Redirect to verification after saving profile

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -240,6 +240,9 @@ export default function StudentProfileEdit() {
       });
 
       toast.success("Profile updated successfully!");
+      setTimeout(() => {
+        router.push("/dashboard/student/profile/steps/Verification");
+      }, 1500);
 
       try {
         const message = "Your student profile was updated.";
@@ -253,7 +256,7 @@ export default function StudentProfileEdit() {
         console.error("[StudentProfileEdit] notification error", err);
       }
 
-      router.push("/dashboard/student/profile/steps/Verification");
+
 
 
     } catch (err) {


### PR DESCRIPTION
## Summary
- ensure student profile page redirects to the verification step

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68887660f7e48328a6a948c56df1f7e2