### PR TITLE
Connect student dashboard pages to API

### DIFF
--- a/frontend/src/pages/dashboard/student/index.js
+++ b/frontend/src/pages/dashboard/student/index.js
@@ -1,8 +1,25 @@
 import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
-import { FaBook, FaClipboardList, FaCertificate, FaCalendarAlt, FaBullhorn, FaBell } from "react-icons/fa";
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import {
+  FaBook,
+  FaClipboardList,
+  FaCertificate,
+  FaCalendarAlt,
+  FaBullhorn,
+  FaBell,
+} from "react-icons/fa";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { fetchMyEnrolledClasses } from "@/services/classService";
+import { getStudentProfile } from "@/services/student/studentService";
 
 function StudentDashboardHome() {
   const [hasMounted, setHasMounted] = useState(false);
@@ -33,6 +50,29 @@ function StudentDashboardHome() {
 
   useEffect(() => {
     setHasMounted(true);
+    const load = async () => {
+      try {
+        const profile = await getStudentProfile();
+        setStudentName(profile.full_name);
+      } catch (err) {
+        console.error("Failed to load profile", err);
+      }
+
+      try {
+        const list = await fetchMyEnrolledClasses();
+        const formatted = list.map((cls) => ({
+          id: cls.id,
+          title: cls.title,
+          progress: cls.status === "completed" ? 100 : 0,
+          nextSession: cls.start_date,
+        }));
+        setClasses(formatted);
+      } catch (err) {
+        console.error("Failed to load classes", err);
+      }
+    };
+
+    load();
   }, []);
 
   if (!hasMounted) return null;

--- a/frontend/src/pages/dashboard/student/schedule.js
+++ b/frontend/src/pages/dashboard/student/schedule.js
@@ -1,27 +1,33 @@
 import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import CalendarView from "@/components/shared/CalendarView";
-
-const currentStudentId = 1;
-const mockBookings = [/* same data */];
+import { fetchStudentBookings } from "@/services/student/bookingService";
 
 export default function StudentSchedule() {
   const [events, setEvents] = useState([]);
 
   useEffect(() => {
-    const myLessons = mockBookings
-      .filter((b) => b.status === "approved" && b.student.id === currentStudentId)
-      .map((b) => ({
-        id: b.id,
-        title: `${b.subject} with ${b.instructor.name}`,
-        start: `${b.date}T${b.time}`,
-        extendedProps: {
-          subject: b.subject,
-          instructor: b.instructor.name
-        }
-      }));
+    const load = async () => {
+      try {
+        const bookings = await fetchStudentBookings();
+        const approved = bookings.filter((b) => b.status === "approved");
+        const mapped = approved.map((b) => ({
+          id: b.id,
+          title: `${b.subject || "Lesson"} with ${b.instructor_name}`,
+          start: b.start_time,
+          end: b.end_time,
+          extendedProps: {
+            subject: b.subject || "Lesson",
+            instructor: b.instructor_name,
+          },
+        }));
+        setEvents(mapped);
+      } catch (err) {
+        console.error("Failed to load bookings", err);
+      }
+    };
 
-    setEvents(myLessons);
+    load();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- pull student profile and enrolled classes for dashboard
- load booked lessons from backend

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
- `npm run lint` in `frontend` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688878668f848328be242d30327d67cd