### PR TITLE
Redirect to verification after saving profile

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -253,7 +253,10 @@ export default function StudentProfileEdit() {
         console.error("[StudentProfileEdit] notification error", err);
       }
 
+      await new Promise((resolve) => setTimeout(resolve, 1500));
       router.push("/dashboard/student/profile/steps/Verification");
+
+
 
 
     } catch (err) {


### PR DESCRIPTION
## Summary
- ensure student profile page waits for notifications then redirects to verification

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68887660f7e48328a6a948c56df1f7e2