### PR TITLE
Fix language dashboard translations

### DIFF
--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -600,7 +600,7 @@
       "Support": "Support",
       "Third Parties Config": "Drittanbieter-Konfiguration",
       "Users": "Benutzer",
-      "Wishlist": "Wunschliste"
+      "Wishlist": "Wunschliste",
       "support_center": "Support-Zentrum",
       "help_center": "Hilfe-Center",
       "submit_ticket": "Ticket einreichen",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -600,7 +600,7 @@
     "Support": "Soporte",
     "Third Parties Config": "Configuración de terceros",
     "Users": "Usuarios",
-    "Wishlist": "Lista de deseos"
+    "Wishlist": "Lista de deseos",
     "support_center": "Centro de soporte",
     "help_center": "Centro de ayuda",
     "submit_ticket": "Enviar ticket",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -656,7 +656,7 @@
     "Support": "Assistance",
     "Third Parties Config": "Configuration des tiers",
     "Users": "Utilisateurs",
-    "Wishlist": "Liste de souhaits"
+    "Wishlist": "Liste de souhaits",
     "support_center": "Centre de support",
     "help_center": "Centre d'aide",
     "submit_ticket": "Soumettre un ticket",


### PR DESCRIPTION
## Summary
- fix invalid JSON syntax in dashboard translations

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68888c88aab88328a4217b31e6a2a84e