### PR TITLE
Fix language dashboard translations

### DIFF
--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -600,7 +600,7 @@
       "Support": "Support",
       "Third Parties Config": "Drittanbieter-Konfiguration",
       "Users": "Benutzer",
-      "Wishlist": "Wunschliste"
+      "Wishlist": "Wunschliste",
       "support_center": "Support-Zentrum",
       "help_center": "Hilfe-Center",
       "submit_ticket": "Ticket einreichen",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -600,7 +600,7 @@
     "Support": "Soporte",
     "Third Parties Config": "Configuración de terceros",
     "Users": "Usuarios",
-    "Wishlist": "Lista de deseos"
+    "Wishlist": "Lista de deseos",
     "support_center": "Centro de soporte",
     "help_center": "Centro de ayuda",
     "submit_ticket": "Enviar ticket",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -656,7 +656,7 @@
     "Support": "Assistance",
     "Third Parties Config": "Configuration des tiers",
     "Users": "Utilisateurs",
-    "Wishlist": "Liste de souhaits"
+    "Wishlist": "Liste de souhaits",
     "support_center": "Centre de support",
     "help_center": "Centre d'aide",
     "submit_ticket": "Soumettre un ticket",

--- a/frontend/src/components/shared/LanguageSwitcher.js
+++ b/frontend/src/components/shared/LanguageSwitcher.js
@@ -31,13 +31,18 @@ export default function LanguageSwitcher({ changeLang }) {
                 i18n.language === lang.code ? "bg-gray-100 font-semibold" : ""
               }`}
             >
-              {lang.icon_url && (
-                <img
-                  src={`${API_BASE_URL}${lang.icon_url}`}
-                  alt={`${lang.name} flag`}
-                  className="w-5 h-5 rounded object-cover"
-                />
-              )}
+              <img
+                src={
+                  lang.icon_url
+                    ? `${API_BASE_URL}${lang.icon_url}`
+                    : `https://flagcdn.com/24x18/${lang.code
+                        .slice(0, 2)
+                        .toLowerCase()}.png`
+                }
+                alt={`${lang.name} flag`}
+                className="w-5 h-5 rounded object-cover"
+                onError={(e) => (e.target.src = "/flags/default.png")}
+              />
               <span>{lang.name}</span>
             </button>
           </li>

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -350,15 +350,18 @@ const Navbar = () => {
           onClick={() => setLanguageOpen(!languageOpen)}
           className="w-8 h-8 rounded-full overflow-hidden border border-gray-300 flex items-center justify-center"
         >
-          {currentLang?.icon_url ? (
-            <img
-              src={`${API_BASE_URL}${currentLang.icon_url}`}
-              alt={currentLang.name}
-              className="w-full h-full object-cover"
-            />
-          ) : (
-            <FaLanguage className="text-xl" />
-          )}
+          <img
+            src={
+              currentLang?.icon_url
+                ? `${API_BASE_URL}${currentLang.icon_url}`
+                : `https://flagcdn.com/24x18/${currentLang?.code
+                    ?.slice(0, 2)
+                    .toLowerCase()}.png`
+            }
+            alt={currentLang ? currentLang.name : 'language'}
+            className="w-full h-full object-cover"
+            onError={(e) => (e.target.src = "/flags/default.png")}
+          />
         </motion.button>
 
         {currentCurrency && (


### PR DESCRIPTION
## Summary
- fix invalid JSON syntax in dashboard translations
- show flag icon even when language icon URL is missing

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68888c88aab88328a4217b31e6a2a84e