### PR TITLE
Fix blank layout on instructor tutorials load error

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -83,17 +83,21 @@ export default function InstructorTutorialsPage() {
 
   if (loading) {
     return (
-      <div className="p-6 flex justify-center items-center h-screen">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-yellow-500"></div>
-      </div>
+      <InstructorLayout>
+        <div className="p-6 flex justify-center items-center h-screen">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-yellow-500"></div>
+        </div>
+      </InstructorLayout>
     );
   }
 
   if (error) {
     return (
-      <div className="p-6 text-red-500 bg-red-50 rounded-lg max-w-md mx-auto mt-10 text-center">
-        {error}
-      </div>
+      <InstructorLayout>
+        <div className="p-6 text-red-500 bg-red-50 rounded-lg max-w-md mx-auto mt-10 text-center">
+          {error}
+        </div>
+      </InstructorLayout>
     );
   }
 


### PR DESCRIPTION
## Summary
- keep InstructorLayout visible when loading or erroring on tutorials page

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688893658a6883288c768c1b34b38a49