### PR TITLE
Fix locale issues on dashboard

### DIFF
--- a/frontend/src/pages/dashboard/admin/index.js
+++ b/frontend/src/pages/dashboard/admin/index.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import useAuthStore from "@/store/auth/authStore";
 import withAuthProtection from "@/hooks/withAuthProtection";
@@ -159,3 +161,12 @@ ProtectedAdminDashboard.getLayout = function getLayout(page) {
 };
 
 export default ProtectedAdminDashboard;
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common', 'dashboard'], nextI18NextConfig)),
+    },
+  };
+}
+

--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -34,16 +34,19 @@ const enrolledCourses = allCourses.slice(0, 3); // Mocked enrolled courses
 const recommendedCourses = getRecommendedCourses(enrolledCourses, allCourses);
 
 const DashboardPage = () => {
-  const { t } = useTranslation('dashboard');
+  const { t, i18n } = useTranslation('dashboard');
   const { user } = useAuthStore();
   const router = useRouter();
 
   useEffect(() => {
     const role = user?.role?.toLowerCase();
     if (!role) return;
-    if (role === "admin" || role === "superadmin") router.replace("/dashboard/admin");
-    else router.replace(`/dashboard/${role}`);
-  }, [user, router]);
+    const target =
+      role === "admin" || role === "superadmin"
+        ? "/dashboard/admin"
+        : `/dashboard/${role}`;
+    router.replace(target, undefined, { locale: i18n.language });
+  }, [user, router, i18n.language]);
   return (
     <div className="flex flex-col min-h-screen bg-gray-900 text-white">
       <Navbar />


### PR DESCRIPTION
## Summary
- preserve locale when redirecting from dashboard root
- load translations for admin dashboard home page

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688899a1b6388328ba31debcfc9aa153