### PR TITLE
Add missing tutorial DB tables

### DIFF
--- a/backend/src/migrations/20250725004000_create_tutorial_chapters_table.js
+++ b/backend/src/migrations/20250725004000_create_tutorial_chapters_table.js
@@ -1,0 +1,16 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_chapters', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.string('title').notNullable();
+    table.string('video_url');
+    table.integer('duration');
+    table.integer('order');
+    table.boolean('is_preview').defaultTo(false);
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_chapters');
+};

--- a/backend/src/migrations/20250725004100_create_tutorial_enrollments_table.js
+++ b/backend/src/migrations/20250725004100_create_tutorial_enrollments_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_enrollments', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.string('status').defaultTo('enrolled');
+    table.timestamp('enrolled_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'tutorial_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_enrollments');
+};

--- a/backend/src/migrations/20250725004200_create_tutorial_comments_table.js
+++ b/backend/src/migrations/20250725004200_create_tutorial_comments_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_comments', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.text('message').notNullable();
+    table.uuid('parent_id').references('id').inTable('tutorial_comments').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_comments');
+};

--- a/backend/src/migrations/20250725004300_create_tutorial_views_table.js
+++ b/backend/src/migrations/20250725004300_create_tutorial_views_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_views', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.uuid('viewer_id').references('id').inTable('users').onDelete('SET NULL');
+    table.string('ip_address');
+    table.string('user_agent');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_views');
+};

--- a/backend/src/migrations/20250725004400_create_tutorial_wishlist_table.js
+++ b/backend/src/migrations/20250725004400_create_tutorial_wishlist_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_wishlist', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'tutorial_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_wishlist');
+};


### PR DESCRIPTION
## Summary
- add migrations for tutorial chapters, comments, enrollments, views and wishlist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68889a7d7a7083288e090ce7960107b8