### PR TITLE
Enforce numeric tutorial fields

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -87,7 +87,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     description,
     category_id,
     level,
-    duration: duration ? parseInt(duration) : null,
+    duration: duration ?? null,
     price,
     instructor_id,
     status,
@@ -199,9 +199,6 @@ exports.getTutorialById = catchAsync(async (req, res) => {
 
 exports.updateTutorial = catchAsync(async (req, res) => {
   const { tags: rawTags, ...data } = req.body;
-  if (data.duration) {
-    data.duration = parseInt(data.duration);
-  }
   const roleDir = getRoleDir(req);
   if (req.files?.thumbnail) {
     data.cover_image = `/uploads/tutorials/${roleDir}/${req.files.thumbnail[0].filename}`;

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -25,7 +25,14 @@ exports.create = z.object({
     category_id: z.string(), // assuming UUID
     level: z.string(),
     status: z.enum(["draft", "published", "archived"]).optional(),
-    price: z.string().optional(),
+    price: z.preprocess(
+      (val) => (val === '' || val === undefined ? undefined : Number(val)),
+      z.number().nonnegative()
+    ).optional(),
+    duration: z.preprocess(
+      (val) => (val === '' || val === undefined ? undefined : parseInt(val, 10)),
+      z.number().int().nonnegative()
+    ).optional(),
     is_paid: z.preprocess(toBoolean, z.boolean().optional()),
     tags: z.preprocess(parseJson, z.array(z.string()).optional()),
     chapters: z
@@ -37,6 +44,10 @@ exports.create = z.object({
               title: z.string(),
               content: z.string().optional(),
               video_url: z.string().url().optional(),
+              duration: z.preprocess(
+                (val) => (val === '' || val === undefined ? undefined : parseInt(val, 10)),
+                z.number().int().nonnegative()
+              ).optional(),
               order: z.number(),
               is_preview: z.boolean().optional(),
             })

--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -50,6 +50,9 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
         }
         return { ...prev, lessonCount: value, chapters };
       });
+    } else if (field === "price") {
+      const clean = value.replace(/[^0-9.]/g, "");
+      setTutorialData((prev) => ({ ...prev, price: clean }));
     } else {
       setTutorialData((prev) => ({ ...prev, [field]: value }));
     }

--- a/frontend/src/components/tutorials/create/CurriculumStep.js
+++ b/frontend/src/components/tutorials/create/CurriculumStep.js
@@ -28,7 +28,11 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
 
   const handleChange = (index, field, value) => {
     const updated = [...tutorialData.chapters];
-    updated[index][field] = value;
+    if (field === "duration") {
+      updated[index][field] = value.replace(/[^0-9]/g, "");
+    } else {
+      updated[index][field] = value;
+    }
     setTutorialData((prev) => ({
       ...prev,
       chapters: updated,
@@ -91,11 +95,11 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
           <div>
             <label className="block mb-1 font-semibold text-gray-700">Duration (e.g. 5 min)</label>
             <input
-              type="text"
+              type="number"
               value={chapter.duration}
               onChange={(e) => handleChange(index, "duration", e.target.value)}
               className="p-2 border rounded w-full"
-              placeholder="e.g. 10 min"
+              placeholder="e.g. 10"
             />
           </div>
 


### PR DESCRIPTION
## Summary
- require numeric values for tutorial `price` and `duration`
- sanitize numeric inputs on tutorial forms
- allow chapter duration to be number-only

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6888b4d06ce0832886ecd60a339624a2