### PR TITLE
Connect community pages to backend API

### DIFF
--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -1,0 +1,15 @@
+const catchAsync = require("../../../utils/catchAsync");
+const AppError = require("../../../utils/AppError");
+const { sendSuccess } = require("../../../utils/response");
+const service = require("./public.service");
+
+exports.listDiscussions = catchAsync(async (_req, res) => {
+  const list = await service.listDiscussions();
+  sendSuccess(res, list);
+});
+
+exports.getDiscussion = catchAsync(async (req, res) => {
+  const disc = await service.getDiscussion(req.params.id);
+  if (!disc) throw new AppError("Discussion not found", 404);
+  sendSuccess(res, disc);
+});

--- a/backend/src/modules/community/public/public.routes.js
+++ b/backend/src/modules/community/public/public.routes.js
@@ -1,0 +1,7 @@
+const router = require("express").Router();
+const ctrl = require("./public.controller");
+
+router.get("/discussions", ctrl.listDiscussions);
+router.get("/discussions/:id", ctrl.getDiscussion);
+
+module.exports = router;

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -1,0 +1,25 @@
+let discussions = [
+  {
+    id: '1',
+    title: 'How to use useEffect in React?',
+    content: "I'm struggling to understand the use cases for useEffect.",
+    tags: ['React', 'Hooks'],
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: '2',
+    title: 'Best practices for database indexing?',
+    content: 'What are the best indexing strategies for MySQL?',
+    tags: ['Database', 'MySQL'],
+    created_at: new Date().toISOString(),
+  },
+];
+
+exports.listDiscussions = async () => discussions;
+
+exports.getDiscussion = async (id) => discussions.find((d) => d.id === id);
+
+// Utility for tests to reset data
+exports.__setDiscussions = (data) => {
+  discussions = data;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -88,6 +88,7 @@ app.use("/api/bookings/admin", require("./modules/bookings/bookings.routes"));
 app.use("/api/bookings/student", require("./modules/bookings/student.routes"));
 app.use("/api/bookings/instructor", require("./modules/bookings/instructor.routes"));
 app.use("/api/community/admin", require("./modules/community/admin/admin.routes"));
+app.use("/api/community", require("./modules/community/public/public.routes"));
 app.use("/api/roles", require("./modules/roles/roles.routes"));
 app.use("/api/plans", require("./modules/plans/plans.routes"));
 app.use("/api/payment-methods", require("./modules/paymentMethods/paymentMethods.public.routes"));

--- a/backend/tests/communityRoutes.test.js
+++ b/backend/tests/communityRoutes.test.js
@@ -1,0 +1,34 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/community/public/public.service', () => ({
+  listDiscussions: jest.fn(),
+  getDiscussion: jest.fn(),
+}));
+
+const service = require('../src/modules/community/public/public.service');
+const routes = require('../src/modules/community/public/public.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/community', routes);
+
+describe('GET /api/community/discussions', () => {
+  it('returns discussions', async () => {
+    const mock = [{ id: '1' }];
+    service.listDiscussions.mockResolvedValue(mock);
+    const res = await request(app).get('/api/community/discussions');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+  });
+});
+
+describe('GET /api/community/discussions/:id', () => {
+  it('returns discussion by id', async () => {
+    const mock = { id: '1' };
+    service.getDiscussion.mockResolvedValue(mock);
+    const res = await request(app).get('/api/community/discussions/1');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+  });
+});

--- a/frontend/src/pages/community/index.js
+++ b/frontend/src/pages/community/index.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import QuestionCard from "@/components/community/QuestionCard";
@@ -6,42 +6,28 @@ import Filters from "@/components/community/Filters";
 import Pagination from "@/components/community/Pagination";
 import { FaPlus } from "react-icons/fa";
 import Link from "next/link";
+import { fetchDiscussions } from "@/services/communityService";
 
-// Sample Questions Data
-const sampleQuestions = [
-  {
-    id: 1,
-    title: "How to use useEffect in React?",
-    description: "I'm struggling to understand the use cases for useEffect.",
-    tags: ["React", "Hooks"],
-    votes: 12,
-    answers: [{ text: "Use useEffect for API calls!" }],
-    views: 150,
-    user: { name: "John Doe", reputation: 320 },
-    date: "2 days ago",
-  },
-  {
-    id: 2,
-    title: "Best practices for database indexing?",
-    description: "What are the best indexing strategies for MySQL?",
-    tags: ["Database", "MySQL"],
-    votes: 8,
-    answers: [],
-    views: 90,
-    user: { name: "Emma Wilson", reputation: 210 },
-    date: "5 days ago",
-  },
-];
 
 const CommunityPage = () => {
-  const [filteredQuestions, setFilteredQuestions] = useState(sampleQuestions);
+  const [allQuestions, setAllQuestions] = useState([]);
+  const [filteredQuestions, setFilteredQuestions] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const questionsPerPage = 3;
   const totalPages = Math.ceil(filteredQuestions.length / questionsPerPage);
 
+  useEffect(() => {
+    const load = async () => {
+      const list = await fetchDiscussions();
+      setAllQuestions(list);
+      setFilteredQuestions(list);
+    };
+    load();
+  }, []);
+
   // Handle Filter Change
   const handleFilterChange = (filter) => {
-    let updatedQuestions = [...sampleQuestions];
+    let updatedQuestions = [...allQuestions];
 
     if (filter.noAnswers) {
       updatedQuestions = updatedQuestions.filter((q) => q.answers.length === 0);

--- a/frontend/src/pages/community/question/details.js
+++ b/frontend/src/pages/community/question/details.js
@@ -5,40 +5,30 @@ import Footer from "@/components/website/sections/Footer";
 import { useRouter } from "next/router";
 import RichTextEditor from "@/components/RichTextEditor";
 import ReactMarkdown from "react-markdown";
-
-const sampleQuestion = {
-  id: 1,
-  title: "How to use useEffect in React?",
-  description: "I'm struggling to understand the use cases for useEffect. When should I use it?",
-  tags: ["React", "Hooks", "JavaScript"],
-  votes: 12,
-  likes: 5,
-  answers: [
-    {
-      id: 1,
-      text: "You should use useEffect for side effects like API calls, event listeners, or updating the DOM.",
-      user: { name: "Alice", reputation: 400 },
-      date: "1 day ago",
-      votes: 5,
-      replies: [
-        { id: 11, text: "I use it for API calls!", user: { name: "Bob", reputation: 350 }, date: "10 hours ago" },
-        { id: 12, text: "Don't forget cleanup functions!", user: { name: "Charlie", reputation: 420 }, date: "5 hours ago" }
-      ],
-    },
-  ],
-  views: 150,
-  user: { name: "John Doe", reputation: 320 },
-  date: "2 days ago",
-};
+import { fetchDiscussionById } from "@/services/communityService";
 
 const QuestionDetails = () => {
-  const [likes, setLikes] = useState(sampleQuestion.likes);
-  const [votes, setVotes] = useState(sampleQuestion.votes);
+  const router = useRouter();
+  const [question, setQuestion] = useState(null);
+  const [likes, setLikes] = useState(0);
+  const [votes, setVotes] = useState(0);
   const [replyText, setReplyText] = useState("");
   const [replies, setReplies] = useState([]);
   const [audioFile, setAudioFile] = useState(null);
   const [file, setFile] = useState(null);
-  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.query.id) return;
+    const load = async () => {
+      const data = await fetchDiscussionById(router.query.id);
+      if (data) {
+        setQuestion(data);
+        setLikes(data.likes || 0);
+        setVotes(data.votes || 0);
+      }
+    };
+    load();
+  }, [router.query.id]);
 
   // ✅ Handle Like Button
   const handleLike = () => setLikes(likes + 1);
@@ -73,11 +63,11 @@ const QuestionDetails = () => {
     <div className="bg-gray-900 min-h-screen text-white">
       <Navbar />
       <div className="container mx-auto px-6 py-8 mt-16">
-        <h1 className="text-3xl font-bold text-yellow-500">{sampleQuestion.title}</h1>
+        <h1 className="text-3xl font-bold text-yellow-500">{question?.title}</h1>
         <div className="flex items-center text-gray-400 text-sm mt-2">
           <FaUser className="mr-2 text-yellow-500" />
-          <span className="font-bold text-white">{sampleQuestion.user.name}</span>
-          <span className="ml-4">{sampleQuestion.date}</span>
+          <span className="font-bold text-white">{question?.user?.name}</span>
+          <span className="ml-4">{question?.date}</span>
         </div>
 
         {/* ✅ Voting, Likes, Views */}
@@ -92,16 +82,16 @@ const QuestionDetails = () => {
             <FaArrowDown /> Downvote
           </button>
           <span className="flex items-center gap-1">
-            <FaEye /> {sampleQuestion.views} views
-          </span>
-        </div>
+            <FaEye /> {question?.views} views
+        </span>
+      </div>
 
-        {/* ✅ Question Content */}
-        <p className="text-gray-300 mt-4">{sampleQuestion.description}</p>
+      {/* ✅ Question Content */}
+        <p className="text-gray-300 mt-4">{question?.description}</p>
 
         {/* ✅ Tags */}
         <div className="flex space-x-2 mt-3">
-          {sampleQuestion.tags.map((tag, index) => (
+          {question?.tags?.map((tag, index) => (
             <span key={index} className="bg-yellow-600 px-2 py-1 rounded text-sm text-white">
               {tag}
             </span>
@@ -111,7 +101,7 @@ const QuestionDetails = () => {
         {/* ✅ Answers Section */}
         <h2 className="text-2xl font-bold text-yellow-500 mt-8">Answers</h2>
         <div className="mt-4 space-y-6">
-          {sampleQuestion.answers.map((answer) => (
+          {question?.answers?.map((answer) => (
             <div key={answer.id} className="bg-gray-800 p-4 rounded-lg shadow-md">
               <p className="text-gray-300 mt-2"><ReactMarkdown>{answer.text}</ReactMarkdown></p>
 

--- a/frontend/src/services/communityService.js
+++ b/frontend/src/services/communityService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const fetchDiscussions = async () => {
+  const { data } = await api.get("/community/discussions");
+  return data?.data ?? [];
+};
+
+export const fetchDiscussionById = async (id) => {
+  const { data } = await api.get(`/community/discussions/${id}`);
+  return data?.data ?? null;
+};


### PR DESCRIPTION
## Summary
- add public community routes to return discussion data
- expose new routes in server
- create new service functions for community
- hook website community pages to API
- test public community endpoints

## Testing
- `npm test --silent --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6888b6c04a148328aecd60a268aae7fe