### PR TITLE
Enforce numeric tutorial fields

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -9,6 +9,12 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const userModel = require("../user.model");
 const analyticsService = require("../../../services/analyticsService");
+const {
+  sendTutorialCreatedAdminEmail,
+  sendTutorialCreatedInstructorEmail,
+  sendTutorialApprovedEmail,
+  sendTutorialRejectedEmail,
+} = require("../../../utils/email");
 
 const catchAsync = require("../../../utils/catchAsync");
 const { v4: uuidv4 } = require("uuid");
@@ -87,7 +93,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     description,
     category_id,
     level,
-    duration: duration ? parseInt(duration) : null,
+    duration: duration ?? null,
     price,
     instructor_id,
     status,
@@ -154,6 +160,12 @@ exports.createTutorial = catchAsync(async (req, res) => {
       })
     )
   );
+  // Email admins about the new tutorial
+  await Promise.all(
+    admins.map((admin) =>
+      sendTutorialCreatedAdminEmail(admin.email, instructor.full_name, title)
+    )
+  );
 
   // Send direct messages to admins about the new tutorial
   if (admins.length) {
@@ -174,6 +186,11 @@ exports.createTutorial = catchAsync(async (req, res) => {
     receiver_id: instructor_id,
     message: "Your tutorial was submitted and is pending review",
   });
+  try {
+    await sendTutorialCreatedInstructorEmail(instructor.email, title);
+  } catch (err) {
+    console.error("Error sending tutorial created email:", err.message);
+  }
 
   sendSuccess(res, tutorial, "Tutorial with chapters created");
 });
@@ -199,9 +216,6 @@ exports.getTutorialById = catchAsync(async (req, res) => {
 
 exports.updateTutorial = catchAsync(async (req, res) => {
   const { tags: rawTags, ...data } = req.body;
-  if (data.duration) {
-    data.duration = parseInt(data.duration);
-  }
   const roleDir = getRoleDir(req);
   if (req.files?.thumbnail) {
     data.cover_image = `/uploads/tutorials/${roleDir}/${req.files.thumbnail[0].filename}`;
@@ -302,6 +316,12 @@ exports.approveTutorial = catchAsync(async (req, res) => {
         message,
       }),
     ]);
+    try {
+      const instr = await userModel.findById(tut.instructor_id);
+      if (instr) await sendTutorialApprovedEmail(instr.email, tut.title);
+    } catch (err) {
+      console.error("Error sending tutorial approved email:", err.message);
+    }
   }
 
   sendSuccess(res, { message: "Tutorial approved" });
@@ -329,6 +349,13 @@ exports.rejectTutorial = catchAsync(async (req, res) => {
         message,
       }),
     ]);
+    try {
+      const instr = await userModel.findById(tut.instructor_id);
+      if (instr)
+        await sendTutorialRejectedEmail(instr.email, tut.title, reason);
+    } catch (err) {
+      console.error("Error sending tutorial rejected email:", err.message);
+    }
   }
 
   sendSuccess(res, { message: "Tutorial rejected" });
@@ -359,6 +386,18 @@ exports.bulkApproveTutorials = catchAsync(async (req, res) => {
             receiver_id: tut.instructor_id,
             message,
           }),
+          (async () => {
+            try {
+              const instr = await userModel.findById(tut.instructor_id);
+              if (instr)
+                await sendTutorialApprovedEmail(instr.email, tut.title);
+            } catch (err) {
+              console.error(
+                "Error sending tutorial approved email:",
+                err.message
+              );
+            }
+          })(),
         ]);
       }
       return Promise.resolve();

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -25,7 +25,14 @@ exports.create = z.object({
     category_id: z.string(), // assuming UUID
     level: z.string(),
     status: z.enum(["draft", "published", "archived"]).optional(),
-    price: z.string().optional(),
+    price: z.preprocess(
+      (val) => (val === '' || val === undefined ? undefined : Number(val)),
+      z.number().nonnegative()
+    ).optional(),
+    duration: z.preprocess(
+      (val) => (val === '' || val === undefined ? undefined : parseInt(val, 10)),
+      z.number().int().nonnegative()
+    ).optional(),
     is_paid: z.preprocess(toBoolean, z.boolean().optional()),
     tags: z.preprocess(parseJson, z.array(z.string()).optional()),
     chapters: z
@@ -37,6 +44,10 @@ exports.create = z.object({
               title: z.string(),
               content: z.string().optional(),
               video_url: z.string().url().optional(),
+              duration: z.preprocess(
+                (val) => (val === '' || val === undefined ? undefined : parseInt(val, 10)),
+                z.number().int().nonnegative()
+              ).optional(),
               order: z.number(),
               is_preview: z.boolean().optional(),
             })

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -570,3 +570,219 @@ exports.sendSupportTicketUpdateEmail = async (
   }
 };
 
+// Notify admins when a new tutorial is created
+exports.sendTutorialCreatedAdminEmail = async (
+  to,
+  instructorName,
+  tutorialTitle
+) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Tutorial created notice to ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `New tutorial awaiting review`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>Instructor <strong>${instructorName}</strong> has submitted a new tutorial titled "${tutorialTitle}".</p>
+        <p>Please review it at your earliest convenience.</p>
+
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Tutorial created admin notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending tutorial created admin email: ", error);
+  }
+};
+
+// Confirm tutorial creation to the instructor
+exports.sendTutorialCreatedInstructorEmail = async (to, tutorialTitle) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Tutorial creation notice for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `Your tutorial was submitted`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>Your tutorial "${tutorialTitle}" was created successfully and is awaiting admin review.</p>
+
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Tutorial created instructor notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending tutorial created instructor email: ", error);
+  }
+};
+
+// Notify instructor when a tutorial is approved
+exports.sendTutorialApprovedEmail = async (to, tutorialTitle) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Tutorial approved notice for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `Your tutorial was approved`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>Your tutorial "${tutorialTitle}" has been approved and is now published on the platform.</p>
+
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Tutorial approved notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending tutorial approved email: ", error);
+  }
+};
+
+// Notify instructor when a tutorial is rejected
+exports.sendTutorialRejectedEmail = async (to, tutorialTitle, reason) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Tutorial rejection notice for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const reasonLine = reason ? `<p>Reason: ${reason}</p>` : "";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `Your tutorial was rejected`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>Your tutorial "${tutorialTitle}" was rejected.${reasonLine}</p>
+        <p>You may edit it and resubmit for review.</p>
+
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Tutorial rejection notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending tutorial rejected email: ", error);
+  }
+};
+

--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -50,6 +50,9 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
         }
         return { ...prev, lessonCount: value, chapters };
       });
+    } else if (field === "price") {
+      const clean = value.replace(/[^0-9.]/g, "");
+      setTutorialData((prev) => ({ ...prev, price: clean }));
     } else {
       setTutorialData((prev) => ({ ...prev, [field]: value }));
     }

--- a/frontend/src/components/tutorials/create/CurriculumStep.js
+++ b/frontend/src/components/tutorials/create/CurriculumStep.js
@@ -28,7 +28,11 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
 
   const handleChange = (index, field, value) => {
     const updated = [...tutorialData.chapters];
-    updated[index][field] = value;
+    if (field === "duration") {
+      updated[index][field] = value.replace(/[^0-9]/g, "");
+    } else {
+      updated[index][field] = value;
+    }
     setTutorialData((prev) => ({
       ...prev,
       chapters: updated,
@@ -91,11 +95,11 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
           <div>
             <label className="block mb-1 font-semibold text-gray-700">Duration (e.g. 5 min)</label>
             <input
-              type="text"
+              type="number"
               value={chapter.duration}
               onChange={(e) => handleChange(index, "duration", e.target.value)}
               className="p-2 border rounded w-full"
-              placeholder="e.g. 10 min"
+              placeholder="e.g. 10"
             />
           </div>
 


### PR DESCRIPTION
## Summary
- require numeric values for tutorial `price` and `duration`
- sanitize numeric inputs on tutorial forms
- allow chapter duration to be number-only
- send email notifications when tutorials are created, approved or rejected

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6888b4d06ce0832886ecd60a339624a2