### PR TITLE
Fix admin class detail i18n path

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -8,7 +8,7 @@ import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
 import { safeEncodeURI } from "@/utils/url";
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import nextI18NextConfig from '../../../../../next-i18next.config.js';
+import nextI18NextConfig from '../../../../../../../next-i18next.config.js';
 
 export default function AdminClassDetailPage() {
   const { id } = useRouter().query;


### PR DESCRIPTION
## Summary
- fix incorrect relative path to next-i18next config in admin online class detail page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888bb91e1d48328b58ad5e0d855ae68