### PR TITLE
Fix admin class detail i18n path

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -8,7 +8,7 @@ import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
 import { safeEncodeURI } from "@/utils/url";
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import nextI18NextConfig from '../../../../../next-i18next.config.js';
+import nextI18NextConfig from '../../../../../../next-i18next.config.js';
 
 export default function AdminClassDetailPage() {
   const { id } = useRouter().query;
@@ -245,7 +245,7 @@ AdminClassDetailPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),


### PR DESCRIPTION
## Summary
- fix dynamic admin class detail page to use `getServerSideProps`
- ensure correct i18n config path

## Testing
- `npm run lint` *(fails: 50 errors)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888bb91e1d48328b58ad5e0d855ae68