### PR TITLE
Add community question posting and AI integration stub

### DIFF
--- a/backend/src/modules/ai/ai.controller.js
+++ b/backend/src/modules/ai/ai.controller.js
@@ -1,0 +1,12 @@
+const catchAsync = require('../../utils/catchAsync');
+const { sendSuccess } = require('../../utils/response');
+const service = require('./ai.service');
+
+exports.answer = catchAsync(async (req, res) => {
+  const { provider, question } = req.body || {};
+  const result = await service.answerWithAI(provider, question);
+  if (result.error) {
+    return res.status(400).json({ message: result.error });
+  }
+  sendSuccess(res, result);
+});

--- a/backend/src/modules/ai/ai.routes.js
+++ b/backend/src/modules/ai/ai.routes.js
@@ -1,0 +1,6 @@
+const router = require('express').Router();
+const ctrl = require('./ai.controller');
+
+router.post('/', ctrl.answer);
+
+module.exports = router;

--- a/backend/src/modules/ai/ai.service.js
+++ b/backend/src/modules/ai/ai.service.js
@@ -1,0 +1,14 @@
+const thirdPartyConfig = require('../thirdPartyConfig/thirdPartyConfig.service');
+
+exports.answerWithAI = async (provider, question) => {
+  const cfg = (await thirdPartyConfig.getSettings()) || {};
+  const settings = cfg[provider] || {};
+  if (!settings.apiKey) {
+    return { answer: null, error: 'No API key configured' };
+  }
+  // This is a stub. Replace with real API calls.
+  return {
+    answer: `(${provider}) AI answer for: ${question}`,
+    confidence: 0.9,
+  };
+};

--- a/backend/src/modules/community/public/__tests__/public.routes.test.js
+++ b/backend/src/modules/community/public/__tests__/public.routes.test.js
@@ -1,0 +1,53 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../public.service', () => ({
+  listDiscussions: jest.fn(),
+  getDiscussion: jest.fn(),
+  createDiscussion: jest.fn(),
+}));
+const service = require('../public.service');
+
+jest.mock('../../../notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+jest.mock('../../../messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+jest.mock('../../../users/user.model', () => ({
+  findAdmins: jest.fn(() => [{ id: 'a1', full_name: 'Admin' }]),
+  findInstructors: jest.fn(() => []),
+  findStudents: jest.fn(() => []),
+  findContactInfo: jest.fn(() => ({ email: 'u@test.com', full_name: 'User' })),
+}));
+jest.mock('../../../../utils/email', () => ({
+  sendNewDiscussionEmail: jest.fn(),
+}));
+
+jest.mock('../../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'u1', full_name: 'Test User' }; next(); },
+}));
+
+const routes = require('../public.routes');
+const app = express();
+app.use(express.json());
+app.use('/community', routes);
+
+describe('community public routes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('create discussion', async () => {
+    const disc = { id: 'd1', title: 't', content: 'c' };
+    service.createDiscussion.mockResolvedValue(disc);
+    const res = await request(app).post('/community/discussions').send({ title: 't', content: 'c' });
+    expect(res.statusCode).toBe(200);
+    expect(service.createDiscussion).toHaveBeenCalledWith({
+      user_id: 'u1',
+      user_name: 'Test User',
+      title: 't',
+      content: 'c',
+      tags: undefined,
+    });
+    expect(res.body.data).toEqual(disc);
+  });
+});

--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -13,3 +13,16 @@ exports.getDiscussion = catchAsync(async (req, res) => {
   if (!disc) throw new AppError("Discussion not found", 404);
   sendSuccess(res, disc);
 });
+
+exports.createDiscussion = catchAsync(async (req, res) => {
+  const { title, content, tags } = req.body || {};
+  if (!title || !content) throw new AppError("Missing fields", 400);
+  const disc = await service.createDiscussion({
+    user_id: req.user.id,
+    user_name: req.user.full_name,
+    title,
+    content,
+    tags,
+  });
+  sendSuccess(res, disc, "Discussion created");
+});

--- a/backend/src/modules/community/public/public.routes.js
+++ b/backend/src/modules/community/public/public.routes.js
@@ -1,7 +1,9 @@
 const router = require("express").Router();
 const ctrl = require("./public.controller");
+const { verifyToken } = require("../../../middleware/auth/authMiddleware");
 
 router.get("/discussions", ctrl.listDiscussions);
 router.get("/discussions/:id", ctrl.getDiscussion);
+router.post("/discussions", verifyToken, ctrl.createDiscussion);
 
 module.exports = router;

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -23,3 +23,61 @@ exports.getDiscussion = async (id) => discussions.find((d) => d.id === id);
 exports.__setDiscussions = (data) => {
   discussions = data;
 };
+
+const { v4: uuidv4 } = require('uuid');
+const notificationService = require('../../notifications/notifications.service');
+const messageService = require('../../messages/messages.service');
+const userModel = require('../../users/user.model');
+const emailUtil = require('../../../utils/email');
+
+async function notifyAllUsers(discussion) {
+  const admins = await userModel.findAdmins();
+  const instructors = await userModel.findInstructors();
+  const students = await userModel.findStudents();
+  const sender = admins[0];
+  const ids = [
+    ...admins.map((a) => a.id),
+    ...instructors.map((i) => i.id),
+    ...students.map((s) => s.id),
+  ].filter((id) => id !== discussion.user_id);
+
+  const message = `New question posted: ${discussion.title}`;
+
+  for (const id of ids) {
+    await notificationService.createNotification({
+      user_id: id,
+      type: 'community',
+      message,
+    });
+    if (sender) {
+      await messageService.createMessage({
+        sender_id: sender.id,
+        receiver_id: id,
+        message,
+      });
+    }
+    const info = await userModel.findContactInfo(id);
+    if (info?.email) {
+      await emailUtil.sendNewDiscussionEmail(
+        info.email,
+        discussion.user_name,
+        discussion.title
+      );
+    }
+  }
+}
+
+exports.createDiscussion = async (data) => {
+  const disc = {
+    id: uuidv4(),
+    user_id: data.user_id,
+    user_name: data.user_name,
+    title: data.title,
+    content: data.content,
+    tags: data.tags || [],
+    created_at: new Date().toISOString(),
+  };
+  discussions.push(disc);
+  await notifyAllUsers(disc);
+  return disc;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -99,6 +99,7 @@ app.use("/api/messages/config", require("./modules/messagesConfig/messagesConfig
 app.use("/api/social-login/config", require("./modules/socialLoginConfig/socialLoginConfig.routes"));
 app.use("/api/app-config", require("./modules/appConfig/appConfig.routes"));
 app.use("/api/third-party-config", require("./modules/thirdPartyConfig/thirdPartyConfig.routes"));
+app.use("/api/ai-assistance", require("./modules/ai/ai.routes"));
 app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));
 app.use("/api/contact-config", require("./modules/contactConfig/contactConfig.routes"));
 app.use("/api/seo-config", require("./modules/seoConfig/seoConfig.routes"));

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -786,3 +786,56 @@ exports.sendTutorialRejectedEmail = async (to, tutorialTitle, reason) => {
   }
 };
 
+// Notify users when a new community question is posted
+exports.sendNewDiscussionEmail = async (to, askerName, questionTitle) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] New discussion notice for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `New question posted on ${fromName}`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>${askerName} just asked a new question:</p>
+        <p><strong>${questionTitle}</strong></p>
+        <p>Visit the community forum to view and reply.</p>
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`New discussion notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending new discussion email: ", error);
+  }
+};
+

--- a/backend/tests/communityRoutes.test.js
+++ b/backend/tests/communityRoutes.test.js
@@ -6,6 +6,10 @@ jest.mock('../src/modules/community/public/public.service', () => ({
   getDiscussion: jest.fn(),
 }));
 
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+}));
+
 const service = require('../src/modules/community/public/public.service');
 const routes = require('../src/modules/community/public/public.routes');
 

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -5,6 +5,9 @@ import FileUploader from "@/components/FileUploader";
 import RichTextEditor from "@/components/RichTextEditor";
 import { FaPaperPlane, FaEdit, FaCheckCircle } from "react-icons/fa";
 import ReactMarkdown from "react-markdown";
+import { toast } from "react-toastify";
+import { createDiscussion } from "@/services/communityService";
+import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
 
 // ✅ AI API URL - Update with your actual backend API endpoint
 const AI_API_URL = "/api/ai-assistance";
@@ -29,6 +32,8 @@ const AskQuestionPage = () => {
   const [relatedQuestions, setRelatedQuestions] = useState([]);
   const [editableResponse, setEditableResponse] = useState("");
   const [showPreview, setShowPreview] = useState(false);
+  const [aiOptions, setAiOptions] = useState([]);
+  const [selectedAI, setSelectedAI] = useState("");
 
   // ✅ Fetch Related Questions Based on Title Input
   useEffect(() => {
@@ -45,6 +50,25 @@ const AskQuestionPage = () => {
     setTitle(localStorage.getItem("draftTitle") || "");
     setDescription(localStorage.getItem("draftDescription") || "");
     setTags(JSON.parse(localStorage.getItem("draftTags")) || []);
+  }, []);
+
+  useEffect(() => {
+    const loadAI = async () => {
+      try {
+        const cfg = await fetchThirdPartyConfig();
+        const opts = [];
+        if (cfg.chatgpt?.apiKey) opts.push('chatgpt');
+        if (cfg.deepseek?.apiKey) opts.push('deepseek');
+        if (cfg.claude?.apiKey) opts.push('claude');
+        if (cfg.gemini?.apiKey) opts.push('gemini');
+        if (cfg.huggingface?.apiKey) opts.push('huggingface');
+        setAiOptions(opts);
+        if (opts.length === 0) toast.info('No AI integrations available');
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    loadAI();
   }, []);
 
   // ✅ Auto-Save Draft Every 2 Seconds
@@ -65,6 +89,10 @@ const AskQuestionPage = () => {
   // ✅ Fetch AI Response for Given Question
   const fetchAIResponse = async () => {
     if (!title.trim()) return;
+    if (!selectedAI) {
+      toast.info('Select AI provider');
+      return;
+    }
 
     setIsProcessingAI(true);
     setAIResponse("");
@@ -74,7 +102,7 @@ const AskQuestionPage = () => {
       const response = await fetch(AI_API_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ question: title }),
+        body: JSON.stringify({ question: title, provider: selectedAI }),
       });
 
       const data = await response.json();
@@ -91,9 +119,23 @@ const AskQuestionPage = () => {
   };
 
   // ✅ Accept AI Answer & Convert to Community Question
-  const handleAcceptAIResponse = () => {
-    setDescription(editableResponse);
-    setActiveTab("community");
+const handleAcceptAIResponse = () => {
+  setDescription(editableResponse);
+  setActiveTab("community");
+};
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await createDiscussion({ title, content: description, tags });
+      toast.success("Question posted");
+      setTitle("");
+      setDescription("");
+      setTags([]);
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to post question");
+    }
   };
 
   return (
@@ -115,7 +157,7 @@ const AskQuestionPage = () => {
 
         {/* ✅ Community Tab */}
         {activeTab === "community" && (
-          <form className="bg-gray-800 p-6 rounded-md mt-6">
+          <form onSubmit={handleSubmit} className="bg-gray-800 p-6 rounded-md mt-6">
             <label className="block font-bold">Title</label>
             <input className="w-full p-3 mt-2 bg-gray-700 rounded-md text-white" placeholder="Enter question title" value={title} onChange={(e) => setTitle(e.target.value)} />
 
@@ -152,6 +194,24 @@ const AskQuestionPage = () => {
         {activeTab === "ai" && (
           <div className="bg-gray-800 p-6 rounded-md mt-6">
             <h2 className="text-2xl font-bold text-yellow-500">💡 AI Assistance</h2>
+
+            {aiOptions.length > 0 && (
+              <select
+                value={selectedAI}
+                onChange={(e) => setSelectedAI(e.target.value)}
+                className="w-full p-3 mt-3 bg-gray-700 rounded-md text-white"
+              >
+                <option value="">Select AI Provider</option>
+                {aiOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            )}
+            {aiOptions.length === 0 && (
+              <p className="text-red-400 mt-3">No AI integrations available.</p>
+            )}
 
             {/* ✅ AI Question Input */}
             <input className="w-full p-3 mt-3 bg-gray-700 rounded-md text-white" placeholder="Ask AI a question..." value={title} onChange={(e) => setTitle(e.target.value)} />

--- a/frontend/src/services/communityService.js
+++ b/frontend/src/services/communityService.js
@@ -9,3 +9,8 @@ export const fetchDiscussionById = async (id) => {
   const { data } = await api.get(`/community/discussions/${id}`);
   return data?.data ?? null;
 };
+
+export const createDiscussion = async (payload) => {
+  const { data } = await api.post('/community/discussions', payload);
+  return data?.data;
+};

--- a/frontend/src/services/thirdPartyService.js
+++ b/frontend/src/services/thirdPartyService.js
@@ -1,0 +1,6 @@
+import api from '@/services/api/api';
+
+export const fetchThirdPartyConfig = async () => {
+  const { data } = await api.get('/third-party-config');
+  return data?.data ?? {};
+};


### PR DESCRIPTION
## Summary
- allow posting community discussions
- notify all users about new posts and email them
- expose `/api/ai-assistance` with provider stub
- show available AI providers on ask page and allow selecting one
- add toast on submit and fetch AI
- cover new routes with tests

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6888c797b3d48328ad215668f61b7e62