### PR TITLE
Improve community engagement section

### DIFF
--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -26,3 +26,9 @@ exports.createDiscussion = catchAsync(async (req, res) => {
   });
   sendSuccess(res, disc, "Discussion created");
 });
+
+exports.listContributors = catchAsync(async (req, res) => {
+  const limit = parseInt(req.query.limit, 10) || 5;
+  const contributors = await service.getTopContributors(limit);
+  sendSuccess(res, contributors);
+});

--- a/backend/src/modules/community/public/public.routes.js
+++ b/backend/src/modules/community/public/public.routes.js
@@ -5,5 +5,6 @@ const { verifyToken } = require("../../../middleware/auth/authMiddleware");
 router.get("/discussions", ctrl.listDiscussions);
 router.get("/discussions/:id", ctrl.getDiscussion);
 router.post("/discussions", verifyToken, ctrl.createDiscussion);
+router.get("/contributors", ctrl.listContributors);
 
 module.exports = router;

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -1,27 +1,34 @@
-let discussions = [
-  {
-    id: '1',
-    title: 'How to use useEffect in React?',
-    content: "I'm struggling to understand the use cases for useEffect.",
-    tags: ['React', 'Hooks'],
-    created_at: new Date().toISOString(),
-  },
-  {
-    id: '2',
-    title: 'Best practices for database indexing?',
-    content: 'What are the best indexing strategies for MySQL?',
-    tags: ['Database', 'MySQL'],
-    created_at: new Date().toISOString(),
-  },
-];
+const db = require("../../../config/database");
 
-exports.listDiscussions = async () => discussions;
+exports.listDiscussions = async () => {
+  return db("community_discussions as d")
+    .leftJoin("users as u", "d.user_id", "u.id")
+    .select(
+      "d.id",
+      "d.title",
+      "d.content",
+      "d.created_at",
+      "d.resolved",
+      "d.locked",
+      "u.full_name as user_name"
+    )
+    .orderBy("d.created_at", "desc");
+};
 
-exports.getDiscussion = async (id) => discussions.find((d) => d.id === id);
-
-// Utility for tests to reset data
-exports.__setDiscussions = (data) => {
-  discussions = data;
+exports.getDiscussion = async (id) => {
+  return db("community_discussions as d")
+    .leftJoin("users as u", "d.user_id", "u.id")
+    .select(
+      "d.id",
+      "d.title",
+      "d.content",
+      "d.created_at",
+      "d.resolved",
+      "d.locked",
+      "u.full_name as user_name"
+    )
+    .where("d.id", id)
+    .first();
 };
 
 const { v4: uuidv4 } = require('uuid');
@@ -68,16 +75,32 @@ async function notifyAllUsers(discussion) {
 }
 
 exports.createDiscussion = async (data) => {
-  const disc = {
-    id: uuidv4(),
-    user_id: data.user_id,
-    user_name: data.user_name,
-    title: data.title,
-    content: data.content,
-    tags: data.tags || [],
-    created_at: new Date().toISOString(),
-  };
-  discussions.push(disc);
+  const [row] = await db("community_discussions")
+    .insert({
+      id: uuidv4(),
+      user_id: data.user_id,
+      title: data.title,
+      content: data.content,
+      tags: JSON.stringify(data.tags || []),
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    })
+    .returning("*");
+
+  const disc = { ...row, user_name: data.user_name };
   await notifyAllUsers(disc);
   return disc;
+};
+
+exports.getTopContributors = async (limit = 5) => {
+  return db("community_contributors as c")
+    .join("users as u", "c.user_id", "u.id")
+    .select(
+      "u.full_name as name",
+      "u.avatar_url as avatar",
+      "c.discussions_count as contributions",
+      "c.score as reputation"
+    )
+    .orderBy("c.score", "desc")
+    .limit(limit);
 };

--- a/frontend/src/components/website/sections/CommunityEngagement.js
+++ b/frontend/src/components/website/sections/CommunityEngagement.js
@@ -1,41 +1,62 @@
 // ✅ Enhanced Community Landing Page with Full Features
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { FaUserCircle, FaCommentDots, FaUsers, FaPlus, FaSearch } from "react-icons/fa";
+import {
+  FaUserCircle,
+  FaCommentDots,
+  FaUsers,
+  FaPlus,
+  FaSearch,
+} from "react-icons/fa";
 import Link from "next/link";
-import Navbar from "@/components/website/sections/Navbar";
+import { fetchDiscussions, fetchTopContributors } from "@/services/communityService";
+import { getBadge } from "@/utils/community/reputation";
 
 const CommunityLandingPage = () => {
   const [discussions, setDiscussions] = useState([]);
   const [contributors, setContributors] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [tags] = useState(["React", "AI", "Odoo", "Next.js", "Docker"]);
+  const [tags, setTags] = useState([]);
 
   useEffect(() => {
-    // Simulate fetch
-    setDiscussions([
-      { id: 1, title: "How to build a full-stack application?", user: "John Doe", replies: 15 },
-      { id: 2, title: "Best resources for learning AI?", user: "Jane Smith", replies: 20 },
-      { id: 3, title: "How to improve UI/UX design skills?", user: "Emily Johnson", replies: 12 },
-    ]);
+    const load = async () => {
+      try {
+        const list = await fetchDiscussions();
+        setDiscussions(
+          list.slice(0, 5).map((d) => ({
+            id: d.id,
+            title: d.title,
+            user: d.user_name || "Anonymous",
+            replies: d.replies || 0,
+          }))
+        );
 
-    setContributors([
-      { name: "John Doe", contributions: 50, reputation: 800, avatar: "/avatars/john.png" },
-      { name: "Jane Smith", contributions: 45, reputation: 720, avatar: "/avatars/jane.png" },
-      { name: "Emily Johnson", contributions: 38, reputation: 650, avatar: "" },
-    ]);
+        const tagSet = new Set();
+        list.forEach((d) => {
+          if (Array.isArray(d.tags)) {
+            d.tags.forEach((t) => tagSet.add(t));
+          }
+        });
+        if (tagSet.size) {
+          setTags(Array.from(tagSet).slice(0, 5));
+        }
+      } catch (err) {
+        console.error("Failed to load discussions", err);
+      }
+
+      try {
+        const contribs = await fetchTopContributors();
+        setContributors(contribs);
+      } catch (err) {
+        console.error("Failed to load contributors", err);
+      }
+    };
+    load();
   }, []);
 
-  const getBadge = (count) => {
-    if (count >= 50) return "🥇";
-    if (count >= 30) return "🥈";
-    if (count >= 10) return "🥉";
-    return "";
-  };
 
   return (
     <div className="bg-gray-900 min-h-screen text-white">
-      <Navbar />
       <motion.section
         initial={{ opacity: 0, y: 50 }}
         whileInView={{ opacity: 1, y: 0 }}
@@ -89,7 +110,9 @@ const CommunityLandingPage = () => {
                   key={discussion.id}
                   className="p-4 bg-gray-700 rounded-lg flex justify-between items-center hover:bg-gray-600 cursor-pointer transition"
                   whileHover={{ scale: 1.03 }}
-                  onClick={() => window.location.href = `/community/questions/${discussion.id}`}
+                  onClick={() => {
+                    window.location.href = `/community/question/details?id=${discussion.id}`;
+                  }}
                 >
                   <div>
                     <h4 className="text-lg font-semibold">{discussion.title}</h4>

--- a/frontend/src/services/communityService.js
+++ b/frontend/src/services/communityService.js
@@ -14,3 +14,8 @@ export const createDiscussion = async (payload) => {
   const { data } = await api.post('/community/discussions', payload);
   return data?.data;
 };
+
+export const fetchTopContributors = async (limit = 5) => {
+  const { data } = await api.get(`/community/contributors?limit=${limit}`);
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- refactor CommunityEngagement component to load tags and top contributors from backend
- add new `fetchTopContributors` API helper
- replace mock data in community public service with database queries
- expose `/community/contributors` route and controller handler

## Testing
- `npm test --silent --prefix frontend`
- `npm test --silent --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6888cd5783ac8328ab8bae1e2aba6211