### PR TITLE
Fix community page rendering when API returns minimal fields

### DIFF
--- a/frontend/src/components/community/QuestionCard.js
+++ b/frontend/src/components/community/QuestionCard.js
@@ -4,10 +4,19 @@ import { FaArrowUp, FaArrowDown, FaEye, FaComment } from "react-icons/fa";
 const QuestionCard = ({ question }) => {
   const router = useRouter();
 
+  const tags = Array.isArray(question.tags)
+    ? question.tags
+    : [];
+  const answersCount = Array.isArray(question.answers)
+    ? question.answers.length
+    : 0;
+
+  const description = question.description || question.content || "";
+
   return (
-    <div 
+    <div
       className="bg-gray-800 p-4 rounded-lg shadow-md hover:shadow-lg transition cursor-pointer"
-      onClick={() => router.push("/community/question/details")} // ✅ Navigate to Static Page
+      onClick={() => router.push(`/community/question/${question.id}`)}
     >
       {/* Votes */}
       <div className="flex items-center space-x-2">
@@ -22,12 +31,12 @@ const QuestionCard = ({ question }) => {
 
       {/* Question Content */}
       <h2 className="text-lg font-bold text-white">{question.title}</h2>
-      <p className="text-gray-400">{question.description}</p>
+      <p className="text-gray-400">{description}</p>
 
       {/* Tags */}
       <div className="flex space-x-2 mt-2">
-        {question.tags.length > 0 ? (
-          question.tags.map((tag, index) => (
+        {tags.length > 0 ? (
+          tags.map((tag, index) => (
             <span key={index} className="bg-yellow-600 px-2 py-1 rounded text-sm text-white">
               {tag}
             </span>
@@ -39,9 +48,9 @@ const QuestionCard = ({ question }) => {
 
       {/* Footer: Views, Answers Count, User Info */}
       <div className="flex justify-between mt-3 text-gray-400 text-sm">
-        <span className="flex items-center gap-1"><FaEye /> {question.views} views</span>
-        <span className="flex items-center gap-1"><FaComment /> {question.answers.length} answers</span>
-        <span className="text-yellow-500">{question.user?.name ?? "Anonymous"}</span>
+        <span className="flex items-center gap-1"><FaEye /> {question.views ?? 0} views</span>
+        <span className="flex items-center gap-1"><FaComment /> {answersCount} answers</span>
+        <span className="text-yellow-500">{question.user?.name || question.user_name || 'Anonymous'}</span>
       </div>
     </div>
   );

--- a/frontend/src/pages/community/index.js
+++ b/frontend/src/pages/community/index.js
@@ -19,8 +19,20 @@ const CommunityPage = () => {
   useEffect(() => {
     const load = async () => {
       const list = await fetchDiscussions();
-      setAllQuestions(list);
-      setFilteredQuestions(list);
+      const normalized = list.map((q) => ({
+        ...q,
+        description: q.description || q.content || "",
+        tags: Array.isArray(q.tags)
+          ? q.tags
+          : typeof q.tags === "string" && q.tags
+          ? JSON.parse(q.tags)
+          : [],
+        answers: Array.isArray(q.answers) ? q.answers : [],
+        date: q.date || q.created_at,
+        user: q.user ? q.user : { name: q.user_name },
+      }));
+      setAllQuestions(normalized);
+      setFilteredQuestions(normalized);
     };
     load();
   }, []);
@@ -30,13 +42,17 @@ const CommunityPage = () => {
     let updatedQuestions = [...allQuestions];
 
     if (filter.noAnswers) {
-      updatedQuestions = updatedQuestions.filter((q) => q.answers.length === 0);
+      updatedQuestions = updatedQuestions.filter(
+        (q) => (q.answers?.length ?? 0) === 0
+      );
     }
 
     if (filter.sortBy === "Newest") {
-      updatedQuestions.sort((a, b) => new Date(b.date) - new Date(a.date));
+      updatedQuestions.sort(
+        (a, b) => new Date(b.date || 0) - new Date(a.date || 0)
+      );
     } else if (filter.sortBy === "Highest Score") {
-      updatedQuestions.sort((a, b) => b.votes - a.votes);
+      updatedQuestions.sort((a, b) => (b.votes || 0) - (a.votes || 0));
     }
 
     setFilteredQuestions(updatedQuestions);


### PR DESCRIPTION
## Summary
- handle optional tags and answers in `QuestionCard`
- normalize discussion data after fetch in community index page
- sort and filter robustly for missing data

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6889aa3412d48328b8e73bd593e3230b