### PR TITLE
Fix language switcher flags

### DIFF
--- a/frontend/src/components/shared/LanguageSwitcher.js
+++ b/frontend/src/components/shared/LanguageSwitcher.js
@@ -35,13 +35,10 @@ export default function LanguageSwitcher({ changeLang }) {
                 src={
                   lang.icon_url
                     ? `${API_BASE_URL}${lang.icon_url}`
-                    : `https://flagcdn.com/24x18/${lang.code
-                        .slice(0, 2)
-                        .toLowerCase()}.png`
+                    : "/flags/default.png"
                 }
                 alt={`${lang.name} flag`}
                 className="w-5 h-5 rounded object-cover"
-                onError={(e) => (e.target.src = "/flags/default.png")}
               />
               <span>{lang.name}</span>
             </button>

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -354,13 +354,10 @@ const Navbar = () => {
             src={
               currentLang?.icon_url
                 ? `${API_BASE_URL}${currentLang.icon_url}`
-                : `https://flagcdn.com/24x18/${currentLang?.code
-                    ?.slice(0, 2)
-                    .toLowerCase()}.png`
+                : "/flags/default.png"
             }
             alt={currentLang ? currentLang.name : 'language'}
             className="w-full h-full object-cover"
-            onError={(e) => (e.target.src = "/flags/default.png")}
           />
         </motion.button>
 


### PR DESCRIPTION
## Summary
- use uploaded language logos in Navbar and LanguageSwitcher

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889db40fd2c83289bbca42509af4875