### PR TITLE
Add tag input with suggestions for community questions

### DIFF
--- a/backend/src/migrations/20250726000000_create_community_discussions_table.js
+++ b/backend/src/migrations/20250726000000_create_community_discussions_table.js
@@ -1,0 +1,17 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('community_discussions', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.string('title').notNullable();
+    table.text('content').notNullable();
+    table.jsonb('tags').defaultTo('[]');
+    table.string('image_url');
+    table.boolean('resolved').defaultTo(false);
+    table.boolean('locked').defaultTo(false);
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('community_discussions');
+};

--- a/backend/src/migrations/20250726000010_create_community_replies_table.js
+++ b/backend/src/migrations/20250726000010_create_community_replies_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('community_replies', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('discussion_id').notNullable().references('id').inTable('community_discussions').onDelete('CASCADE');
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.text('content').notNullable();
+    table.boolean('is_answer').defaultTo(false);
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('community_replies');
+};

--- a/backend/src/migrations/20250726000020_create_community_tags_table.js
+++ b/backend/src/migrations/20250726000020_create_community_tags_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('community_tags', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable().unique();
+    table.string('slug').notNullable().unique();
+    table.boolean('active').defaultTo(true);
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('community_tags');
+};

--- a/backend/src/migrations/20250726000030_create_community_discussion_tags_table.js
+++ b/backend/src/migrations/20250726000030_create_community_discussion_tags_table.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('community_discussion_tags', function(table) {
+    table.uuid('discussion_id').notNullable().references('id').inTable('community_discussions').onDelete('CASCADE');
+    table.uuid('tag_id').notNullable().references('id').inTable('community_tags').onDelete('CASCADE');
+    table.primary(['discussion_id', 'tag_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('community_discussion_tags');
+};

--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -42,3 +42,9 @@ exports.listContributors = catchAsync(async (req, res) => {
   const contributors = await service.getTopContributors(limit);
   sendSuccess(res, contributors);
 });
+
+exports.listTags = catchAsync(async (req, res) => {
+  const q = req.query.q || '';
+  const tags = await service.searchTags(q);
+  sendSuccess(res, tags);
+});

--- a/backend/src/modules/community/public/public.routes.js
+++ b/backend/src/modules/community/public/public.routes.js
@@ -7,5 +7,6 @@ router.get("/discussions", ctrl.listDiscussions);
 router.get("/discussions/:id", ctrl.getDiscussion);
 router.post("/discussions", verifyToken, upload, ctrl.createDiscussion);
 router.get("/contributors", ctrl.listContributors);
+router.get("/tags", ctrl.listTags);
 
 module.exports = router;

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -147,3 +147,10 @@ exports.getTopContributors = async (limit = 5) => {
     .orderBy("c.score", "desc")
     .limit(limit);
 };
+exports.searchTags = async (q) => {
+  return db('community_tags')
+    .whereILike('name', `%${q}%`)
+    .select('id', 'name', 'slug')
+    .orderBy('name')
+    .limit(10);
+};

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -6,7 +6,7 @@ import RichTextEditor from "@/components/RichTextEditor";
 import { FaPaperPlane, FaEdit, FaCheckCircle } from "react-icons/fa";
 import ReactMarkdown from "react-markdown";
 import { toast } from "react-toastify";
-import { createDiscussion } from "@/services/communityService";
+import { createDiscussion, searchTags } from "@/services/communityService";
 import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
 
 // ✅ AI API URL - Update with your actual backend API endpoint
@@ -25,6 +25,8 @@ const AskQuestionPage = () => {
   const [tags, setTags] = useState([]);
   const [uploadedFiles, setUploadedFiles] = useState([]);
 
+  const [tagInput, setTagInput] = useState("");
+  const [tagSuggestions, setTagSuggestions] = useState([]);
   // ✅ AI Assistance States
   const [aiResponse, setAIResponse] = useState("");
   const [isProcessingAI, setIsProcessingAI] = useState(false);
@@ -82,11 +84,38 @@ const AskQuestionPage = () => {
   }, [title, description, tags]);
 
   // ✅ Handle File Upload
+  useEffect(() => {
+    if (tagInput.trim()) {
+      searchTags(tagInput.trim()).then(setTagSuggestions).catch(() => {});
+    } else {
+      setTagSuggestions([]);
+    }
+  }, [tagInput]);
+
   const handleFileUpload = (files) => {
     setUploadedFiles([...uploadedFiles, ...files]);
   };
 
   // ✅ Fetch AI Response for Given Question
+  const handleAddTag = (t) => {
+    const tag = t.trim();
+    if (tag && !tags.includes(tag)) {
+      setTags([...tags, tag]);
+    }
+    setTagInput("");
+    setTagSuggestions([]);
+  };
+
+  const handleRemoveTag = (t) => {
+    setTags(tags.filter((tag) => tag !== t));
+  };
+
+  const handleTagKeyDown = (e) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      handleAddTag(tagInput);
+    }
+  };
   const fetchAIResponse = async () => {
     if (!title.trim()) return;
     if (!selectedAI) {
@@ -160,6 +189,35 @@ const handleAcceptAIResponse = () => {
           <form onSubmit={handleSubmit} className="bg-gray-800 p-6 rounded-md mt-6">
             <label className="block font-bold">Title</label>
             <input className="w-full p-3 mt-2 bg-gray-700 rounded-md text-white" placeholder="Enter question title" value={title} onChange={(e) => setTitle(e.target.value)} />
+            <label className="block font-bold mt-4">Tags</label>
+            <div className="relative">
+              <input
+                className="w-full p-3 mt-2 bg-gray-700 rounded-md text-white"
+                placeholder="Add tags"
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={handleTagKeyDown}
+              />
+              {tagSuggestions.length > 0 && (
+                <ul className="absolute z-10 bg-gray-700 border border-gray-600 mt-1 rounded-md w-full max-h-40 overflow-y-auto">
+                  {tagSuggestions.map((s) => (
+                    <li key={s.id} className="px-2 py-1 cursor-pointer hover:bg-gray-600" onClick={() => handleAddTag(s.name)}>
+                      {s.name}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2 mt-2">
+              {tags.map((t) => (
+                <span key={t} className="bg-yellow-500 text-gray-900 px-2 py-1 rounded flex items-center">
+                  {t}
+                  <button type="button" className="ml-1 text-gray-900 hover:text-gray-700" onClick={() => handleRemoveTag(t)}>
+                    &times;
+                  </button>
+                </span>
+              ))}
+            </div>
 
             {/* ✅ Show Related Questions */}
             {relatedQuestions.length > 0 && (

--- a/frontend/src/services/communityService.js
+++ b/frontend/src/services/communityService.js
@@ -19,3 +19,8 @@ export const fetchTopContributors = async (limit = 5) => {
   const { data } = await api.get(`/community/contributors?limit=${limit}`);
   return data?.data ?? [];
 };
+
+export const searchTags = async (q) => {
+  const { data } = await api.get(`/community/tags?q=${encodeURIComponent(q)}`);
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- add migrations for community discussion/tag tables
- expose new `/community/tags` endpoint
- implement tag searching in community service
- add tag input field with suggestions on ask page

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6889e28d6f78832895ee6fdf8f929513