### PR TITLE
Add AI provider activation toggle

### DIFF
--- a/backend/src/modules/ai/ai.service.js
+++ b/backend/src/modules/ai/ai.service.js
@@ -3,8 +3,8 @@ const thirdPartyConfig = require('../thirdPartyConfig/thirdPartyConfig.service')
 exports.answerWithAI = async (provider, question) => {
   const cfg = (await thirdPartyConfig.getSettings()) || {};
   const settings = cfg[provider] || {};
-  if (!settings.apiKey) {
-    return { answer: null, error: 'No API key configured' };
+  if (!settings.apiKey || settings.active === false) {
+    return { answer: null, error: 'Provider not configured' };
   }
   // This is a stub. Replace with real API calls.
   return {

--- a/frontend/src/components/admin/integrations/ChatGPTModal.js
+++ b/frontend/src/components/admin/integrations/ChatGPTModal.js
@@ -8,6 +8,7 @@ export default function ChatGPTModal({ initialData = {}, onClose, onSave }) {
     apiKey: "",
     model: "gpt-4",
     temperature: 0.7,
+    active: true,
     ...initialData,
   });
 
@@ -73,6 +74,15 @@ export default function ChatGPTModal({ initialData = {}, onClose, onSave }) {
               className="w-full border border-gray-300 rounded px-3 py-2"
             />
           </div>
+
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(e) => handleChange('active', e.target.checked)}
+            />
+            Active
+          </label>
         </div>
 
         <div className="flex justify-end gap-3 mt-6">

--- a/frontend/src/components/admin/integrations/ClaudeModal.js
+++ b/frontend/src/components/admin/integrations/ClaudeModal.js
@@ -3,7 +3,12 @@ import { FaSave } from "react-icons/fa";
 import { toast } from "react-toastify";
 
 export default function ClaudeModal({ initialData = {}, onClose, onSave }) {
-  const [form, setForm] = useState({ apiKey: "", model: "claude-3-opus", ...initialData });
+  const [form, setForm] = useState({
+    apiKey: "",
+    model: "claude-3-opus",
+    active: true,
+    ...initialData,
+  });
 
   const handleSubmit = async () => {
     if (!onSave) return onClose();
@@ -46,6 +51,15 @@ export default function ClaudeModal({ initialData = {}, onClose, onSave }) {
               className="w-full border border-gray-300 rounded px-3 py-2"
             />
           </div>
+
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(e) => setForm({ ...form, active: e.target.checked })}
+            />
+            Active
+          </label>
         </div>
 
         <div className="flex justify-end gap-3 mt-6">

--- a/frontend/src/components/admin/integrations/DeepSeekModal.js
+++ b/frontend/src/components/admin/integrations/DeepSeekModal.js
@@ -8,6 +8,7 @@ export default function DeepSeekModal({ initialData = {}, onClose, onSave }) {
     apiKey: "",
     model: "deepseek-chat",
     maxTokens: 1024,
+    active: true,
     ...initialData,
   });
 
@@ -69,6 +70,15 @@ export default function DeepSeekModal({ initialData = {}, onClose, onSave }) {
               className="w-full border border-gray-300 rounded px-3 py-2"
             />
           </div>
+
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(e) => handleChange('active', e.target.checked)}
+            />
+            Active
+          </label>
         </div>
 
         <div className="flex justify-end gap-3 mt-6">

--- a/frontend/src/components/admin/integrations/GeminiModal.js
+++ b/frontend/src/components/admin/integrations/GeminiModal.js
@@ -3,7 +3,12 @@ import { FaSave } from "react-icons/fa";
 import { toast } from "react-toastify";
 
 export default function GeminiModal({ initialData = {}, onClose, onSave }) {
-  const [form, setForm] = useState({ apiKey: "", model: "gemini-pro", ...initialData });
+  const [form, setForm] = useState({
+    apiKey: "",
+    model: "gemini-pro",
+    active: true,
+    ...initialData,
+  });
 
   const handleSubmit = async () => {
     if (!onSave) return onClose();
@@ -54,6 +59,15 @@ export default function GeminiModal({ initialData = {}, onClose, onSave }) {
               <option value="gemini-ultra">Gemini Ultra</option>
             </select>
           </div>
+
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(e) => setForm({ ...form, active: e.target.checked })}
+            />
+            Active
+          </label>
         </div>
 
         <div className="flex justify-end gap-3 mt-6">

--- a/frontend/src/components/admin/integrations/HuggingFaceModal.js
+++ b/frontend/src/components/admin/integrations/HuggingFaceModal.js
@@ -3,7 +3,12 @@ import { FaSave } from "react-icons/fa";
 import { toast } from "react-toastify";
 
 export default function HuggingFaceModal({ initialData = {}, onClose, onSave }) {
-  const [form, setForm] = useState({ token: "", model: "", ...initialData });
+  const [form, setForm] = useState({
+    token: "",
+    model: "",
+    active: true,
+    ...initialData,
+  });
 
   const handleSubmit = async () => {
     if (!onSave) return onClose();
@@ -52,6 +57,15 @@ export default function HuggingFaceModal({ initialData = {}, onClose, onSave }) 
               className="w-full border border-gray-300 rounded px-3 py-2"
             />
           </div>
+
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(e) => setForm({ ...form, active: e.target.checked })}
+            />
+            Active
+          </label>
         </div>
 
         <div className="flex justify-end gap-3 mt-6">

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -59,11 +59,11 @@ const AskQuestionPage = () => {
       try {
         const cfg = await fetchThirdPartyConfig();
         const opts = [];
-        if (cfg.chatgpt?.apiKey) opts.push('chatgpt');
-        if (cfg.deepseek?.apiKey) opts.push('deepseek');
-        if (cfg.claude?.apiKey) opts.push('claude');
-        if (cfg.gemini?.apiKey) opts.push('gemini');
-        if (cfg.huggingface?.apiKey) opts.push('huggingface');
+        if (cfg.chatgpt?.apiKey && cfg.chatgpt.active !== false) opts.push('chatgpt');
+        if (cfg.deepseek?.apiKey && cfg.deepseek.active !== false) opts.push('deepseek');
+        if (cfg.claude?.apiKey && cfg.claude.active !== false) opts.push('claude');
+        if (cfg.gemini?.apiKey && cfg.gemini.active !== false) opts.push('gemini');
+        if (cfg.huggingface?.apiKey && cfg.huggingface.active !== false) opts.push('huggingface');
         setAiOptions(opts);
         if (opts.length === 0) toast.info('No AI integrations available');
       } catch (err) {


### PR DESCRIPTION
## Summary
- add `active` field to AI integration modals
- filter inactive integrations on community ask page
- check `active` flag when answering with AI backend

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6889e5d7f9a883289c703610eeddd697