### PR TITLE
Add coupon management

### DIFF
--- a/backend/src/migrations/20250726001000_create_coupons_table.js
+++ b/backend/src/migrations/20250726001000_create_coupons_table.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+  return knex.schema.createTable('coupons', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('code').notNullable().unique();
+    table.integer('discount_percent').notNullable();
+    table.timestamp('expires_at');
+    table.integer('usage_limit');
+    table.integer('times_used').defaultTo(0);
+    table.uuid('instructor_id').references('id').inTable('users').onDelete('SET NULL');
+    table.timestamps(true, true);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('coupons');
+};

--- a/backend/src/modules/coupons/coupons.controller.js
+++ b/backend/src/modules/coupons/coupons.controller.js
@@ -1,0 +1,50 @@
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./coupons.service");
+const { v4: uuidv4 } = require("uuid");
+
+exports.createCoupon = catchAsync(async (req, res) => {
+  const data = {
+    id: uuidv4(),
+    code: req.body.code,
+    discount_percent: req.body.discount_percent,
+    expires_at: req.body.expires_at || null,
+    usage_limit: req.body.usage_limit || null,
+    instructor_id: req.user?.role === "instructor" ? req.user.id : req.body.instructor_id || null,
+  };
+  const coupon = await service.createCoupon(data);
+  sendSuccess(res, coupon, "Coupon created");
+});
+
+exports.getCoupons = catchAsync(async (_req, res) => {
+  const coupons = await service.getCoupons();
+  sendSuccess(res, coupons);
+});
+
+exports.getCoupon = catchAsync(async (req, res) => {
+  const coupon = await service.getCouponById(req.params.id);
+  if (!coupon) throw new AppError("Coupon not found", 404);
+  sendSuccess(res, coupon);
+});
+
+exports.updateCoupon = catchAsync(async (req, res) => {
+  const coupon = await service.updateCoupon(req.params.id, req.body);
+  if (!coupon) throw new AppError("Coupon not found", 404);
+  sendSuccess(res, coupon, "Coupon updated");
+});
+
+exports.deleteCoupon = catchAsync(async (req, res) => {
+  await service.deleteCoupon(req.params.id);
+  sendSuccess(res, null, "Coupon deleted");
+});
+
+exports.validateCode = catchAsync(async (req, res) => {
+  const { code } = req.params;
+  const coupon = await service.findByCode(code);
+  if (!coupon) throw new AppError("Invalid coupon", 404);
+  if (coupon.expires_at && new Date(coupon.expires_at) < new Date()) {
+    throw new AppError("Coupon expired", 400);
+  }
+  sendSuccess(res, coupon, "Coupon valid");
+});

--- a/backend/src/modules/coupons/coupons.routes.js
+++ b/backend/src/modules/coupons/coupons.routes.js
@@ -1,0 +1,16 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./coupons.controller");
+const validate = require("../../middleware/validate");
+const { verifyToken, isInstructorOrAdmin } = require("../../middleware/auth/authMiddleware");
+const validator = require("./coupons.validator");
+
+router.post("/admin", verifyToken, isInstructorOrAdmin, validate(validator.create), controller.createCoupon);
+router.get("/admin", verifyToken, isInstructorOrAdmin, controller.getCoupons);
+router.get("/admin/:id", verifyToken, isInstructorOrAdmin, controller.getCoupon);
+router.put("/admin/:id", verifyToken, isInstructorOrAdmin, validate(validator.update), controller.updateCoupon);
+router.delete("/admin/:id", verifyToken, isInstructorOrAdmin, controller.deleteCoupon);
+
+router.get("/code/:code", controller.validateCode);
+
+module.exports = router;

--- a/backend/src/modules/coupons/coupons.service.js
+++ b/backend/src/modules/coupons/coupons.service.js
@@ -1,0 +1,27 @@
+const db = require("../../config/database");
+
+exports.createCoupon = async (data) => {
+  const [row] = await db("coupons").insert(data).returning("*");
+  return row;
+};
+
+exports.getCoupons = () => {
+  return db("coupons").orderBy("created_at", "desc");
+};
+
+exports.getCouponById = (id) => {
+  return db("coupons").where({ id }).first();
+};
+
+exports.findByCode = (code) => {
+  return db("coupons").whereRaw("LOWER(code) = LOWER(?)", [code]).first();
+};
+
+exports.updateCoupon = async (id, data) => {
+  const [row] = await db("coupons").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.deleteCoupon = (id) => {
+  return db("coupons").where({ id }).del();
+};

--- a/backend/src/modules/coupons/coupons.validator.js
+++ b/backend/src/modules/coupons/coupons.validator.js
@@ -1,0 +1,19 @@
+const { z } = require("zod");
+
+exports.create = z.object({
+  body: z.object({
+    code: z.string().min(3),
+    discount_percent: z.number().min(1).max(100),
+    expires_at: z.string().optional(),
+    usage_limit: z.number().min(1).optional(),
+    instructor_id: z.string().uuid().optional(),
+  }),
+});
+
+exports.update = z.object({
+  body: z.object({
+    discount_percent: z.number().min(1).max(100).optional(),
+    expires_at: z.string().optional(),
+    usage_limit: z.number().min(1).optional(),
+  }),
+});

--- a/backend/src/seeds/07_coupons_seed.js
+++ b/backend/src/seeds/07_coupons_seed.js
@@ -1,0 +1,14 @@
+exports.seed = async function(knex) {
+  await knex('coupons').del();
+  const instructors = await knex('users').where({ role: 'instructor' }).select('id').limit(1);
+  await knex('coupons').insert([
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      code: 'DISCOUNT10',
+      discount_percent: 10,
+      expires_at: knex.fn.now(),
+      usage_limit: 100,
+      instructor_id: instructors.length ? instructors[0].id : null,
+    },
+  ]);
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -107,6 +107,7 @@ app.use("/api/popup-announcements", require("./modules/popupAnnouncements/popupA
 app.use("/api/policies", require("./modules/policies/policies.routes"));
 app.use("/api/payouts/admin", require("./modules/payouts/payouts.routes"));
 app.use("/api/ads", require("./modules/ads/ads.routes"));
+app.use("/api/coupons", require("./modules/coupons/coupons.routes"));
 app.use("/api/groups", require("./modules/groups/groups.routes"));
 app.use("/api/offers", require("./modules/offers/offers.routes"));
 app.use("/api/offers/:offerId/responses", require("./modules/offers/offerResponses.routes"));

--- a/docs/coupon-management.md
+++ b/docs/coupon-management.md
@@ -1,0 +1,18 @@
+# Coupon Management
+
+This document explains how discount coupons are handled in SkillBridge.
+
+## Backend
+
+- **Routes** live in `backend/src/modules/coupons`.
+- Admins and instructors use `/api/coupons/admin` for CRUD operations.
+- `GET /api/coupons/code/:code` validates a coupon for checkout.
+- Coupons include an optional `instructor_id` so instructors can create their own codes.
+
+## Frontend
+
+- API helpers will be located in `frontend/src/services/admin/couponService.js` and `frontend/src/services/instructor/couponService.js`.
+- Dashboard pages under `frontend/src/pages/dashboard/admin/coupons` and `frontend/src/pages/dashboard/instructor/coupons` will allow managing coupons.
+- The checkout page reads promo codes via `couponService.validateCode` and applies the discount.
+
+A seed file (`07_coupons_seed.js`) creates a demo code `DISCOUNT10` for testing.

--- a/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { fetchCouponById, updateCoupon } from "@/services/admin/couponService";
+
+export default function EditCouponPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [code, setCode] = useState("");
+  const [discount, setDiscount] = useState(10);
+
+  useEffect(() => {
+    if (id) {
+      fetchCouponById(id).then((c) => {
+        if (c) {
+          setCode(c.code);
+          setDiscount(c.discount_percent);
+        }
+      });
+    }
+  }, [id]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await updateCoupon(id, { code, discount_percent: parseInt(discount, 10) }).catch(() => {});
+    router.push("/dashboard/admin/coupons");
+  };
+
+  return (
+    <AdminLayout>
+      <div className="p-6 max-w-lg">
+        <h1 className="text-2xl font-bold mb-4">Edit Coupon</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input value={code} onChange={(e) => setCode(e.target.value)} className="border p-2 w-full" required />
+          <input type="number" value={discount} onChange={(e) => setDiscount(e.target.value)} className="border p-2 w-full" min="1" max="100" />
+          <button className="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+        </form>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/frontend/src/pages/dashboard/admin/coupons/index.js
+++ b/frontend/src/pages/dashboard/admin/coupons/index.js
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { fetchCoupons, deleteCoupon } from "@/services/admin/couponService";
+import Link from "next/link";
+
+export default function AdminCouponsPage() {
+  const [coupons, setCoupons] = useState([]);
+
+  useEffect(() => {
+    fetchCoupons().then(setCoupons).catch(() => setCoupons([]));
+  }, []);
+
+  const handleDelete = async (id) => {
+    if (!confirm("Delete this coupon?")) return;
+    await deleteCoupon(id).catch(() => {});
+    setCoupons((prev) => prev.filter((c) => c.id !== id));
+  };
+
+  return (
+    <AdminLayout>
+      <div className="p-6">
+        <header className="flex justify-between mb-6">
+          <h1 className="text-2xl font-bold">Coupons</h1>
+          <Link href="/dashboard/admin/coupons/new" className="bg-green-600 px-4 py-2 text-white rounded">New Coupon</Link>
+        </header>
+        <table className="min-w-full bg-white text-sm">
+          <thead>
+            <tr>
+              <th className="p-2 border">Code</th>
+              <th className="p-2 border">Discount %</th>
+              <th className="p-2 border">Expires</th>
+              <th className="p-2 border">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {coupons.map((c) => (
+              <tr key={c.id}>
+                <td className="p-2 border">{c.code}</td>
+                <td className="p-2 border">{c.discount_percent}</td>
+                <td className="p-2 border">{c.expires_at ? new Date(c.expires_at).toLocaleDateString() : ""}</td>
+                <td className="p-2 border space-x-2">
+                  <Link href={`/dashboard/admin/coupons/edit/${c.id}`}>Edit</Link>
+                  <button onClick={() => handleDelete(c.id)} className="text-red-600">Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/frontend/src/pages/dashboard/admin/coupons/new.js
+++ b/frontend/src/pages/dashboard/admin/coupons/new.js
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { createCoupon } from "@/services/admin/couponService";
+import { useRouter } from "next/router";
+
+export default function NewCouponPage() {
+  const [code, setCode] = useState("");
+  const [discount, setDiscount] = useState(10);
+  const router = useRouter();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await createCoupon({ code, discount_percent: parseInt(discount, 10) }).catch(() => {});
+    router.push("/dashboard/admin/coupons");
+  };
+
+  return (
+    <AdminLayout>
+      <div className="p-6 max-w-lg">
+        <h1 className="text-2xl font-bold mb-4">New Coupon</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input value={code} onChange={(e) => setCode(e.target.value)} placeholder="CODE" className="border p-2 w-full" required />
+          <input type="number" value={discount} onChange={(e) => setDiscount(e.target.value)} className="border p-2 w-full" min="1" max="100" />
+          <button className="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+        </form>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/frontend/src/pages/dashboard/instructor/coupons/edit/[id].js
+++ b/frontend/src/pages/dashboard/instructor/coupons/edit/[id].js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import { fetchCouponById, updateCoupon } from "@/services/instructor/couponService";
+
+export default function InstructorCouponEdit() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [code, setCode] = useState("");
+  const [discount, setDiscount] = useState(10);
+
+  useEffect(() => {
+    if (id) {
+      fetchCouponById(id).then((c) => {
+        if (c) {
+          setCode(c.code);
+          setDiscount(c.discount_percent);
+        }
+      });
+    }
+  }, [id]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await updateCoupon(id, { code, discount_percent: parseInt(discount, 10) }).catch(() => {});
+    router.push("/dashboard/instructor/coupons");
+  };
+
+  return (
+    <InstructorLayout>
+      <div className="p-6 max-w-lg">
+        <h1 className="text-2xl font-bold mb-4">Edit Coupon</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input value={code} onChange={(e) => setCode(e.target.value)} className="border p-2 w-full" required />
+          <input type="number" value={discount} onChange={(e) => setDiscount(e.target.value)} className="border p-2 w-full" min="1" max="100" />
+          <button className="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+        </form>
+      </div>
+    </InstructorLayout>
+  );
+}

--- a/frontend/src/pages/dashboard/instructor/coupons/index.js
+++ b/frontend/src/pages/dashboard/instructor/coupons/index.js
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import { fetchCoupons, deleteCoupon } from "@/services/instructor/couponService";
+import Link from "next/link";
+
+export default function InstructorCouponsPage() {
+  const [coupons, setCoupons] = useState([]);
+
+  useEffect(() => {
+    fetchCoupons().then(setCoupons).catch(() => setCoupons([]));
+  }, []);
+
+  const handleDelete = async (id) => {
+    if (!confirm("Delete this coupon?")) return;
+    await deleteCoupon(id).catch(() => {});
+    setCoupons((prev) => prev.filter((c) => c.id !== id));
+  };
+
+  return (
+    <InstructorLayout>
+      <div className="p-6">
+        <header className="flex justify-between mb-6">
+          <h1 className="text-2xl font-bold">My Coupons</h1>
+          <Link href="/dashboard/instructor/coupons/new" className="bg-green-600 px-4 py-2 text-white rounded">New Coupon</Link>
+        </header>
+        <table className="min-w-full bg-white text-sm">
+          <thead>
+            <tr>
+              <th className="p-2 border">Code</th>
+              <th className="p-2 border">Discount %</th>
+              <th className="p-2 border">Expires</th>
+              <th className="p-2 border">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {coupons.map((c) => (
+              <tr key={c.id}>
+                <td className="p-2 border">{c.code}</td>
+                <td className="p-2 border">{c.discount_percent}</td>
+                <td className="p-2 border">{c.expires_at ? new Date(c.expires_at).toLocaleDateString() : ""}</td>
+                <td className="p-2 border space-x-2">
+                  <Link href={`/dashboard/instructor/coupons/edit/${c.id}`}>Edit</Link>
+                  <button onClick={() => handleDelete(c.id)} className="text-red-600">Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </InstructorLayout>
+  );
+}

--- a/frontend/src/pages/dashboard/instructor/coupons/new.js
+++ b/frontend/src/pages/dashboard/instructor/coupons/new.js
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import { createCoupon } from "@/services/instructor/couponService";
+import { useRouter } from "next/router";
+
+export default function InstructorCouponNew() {
+  const [code, setCode] = useState("");
+  const [discount, setDiscount] = useState(10);
+  const router = useRouter();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await createCoupon({ code, discount_percent: parseInt(discount, 10) }).catch(() => {});
+    router.push("/dashboard/instructor/coupons");
+  };
+
+  return (
+    <InstructorLayout>
+      <div className="p-6 max-w-lg">
+        <h1 className="text-2xl font-bold mb-4">New Coupon</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input value={code} onChange={(e) => setCode(e.target.value)} placeholder="CODE" className="border p-2 w-full" required />
+          <input type="number" value={discount} onChange={(e) => setDiscount(e.target.value)} className="border p-2 w-full" min="1" max="100" />
+          <button className="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+        </form>
+      </div>
+    </InstructorLayout>
+  );
+}

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { fetchPaymentMethods } from '@/services/paymentMethodService';
 import { fetchClassDetails } from '@/services/classService';
+import { validateCode } from '@/services/couponService';
 import useCartStore from '@/store/cart/cartStore';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
@@ -57,11 +58,12 @@ export default function CheckoutPage() {
     load();
   }, [classId]);
 
-  const handleApplyPromo = () => {
-    if (promoCode.toUpperCase() === 'DISCOUNT10') {
-      setDiscount(10);
+  const handleApplyPromo = async () => {
+    try {
+      const data = await validateCode(promoCode);
+      setDiscount(data.discount_percent);
       setError('');
-    } else {
+    } catch {
       setDiscount(0);
       setError('Invalid promo code');
     }

--- a/frontend/src/services/admin/couponService.js
+++ b/frontend/src/services/admin/couponService.js
@@ -1,0 +1,30 @@
+import api from "@/services/api/api";
+
+export const fetchCoupons = async () => {
+  const { data } = await api.get("/coupons/admin");
+  return data?.data;
+};
+
+export const fetchCouponById = async (id) => {
+  const { data } = await api.get(`/coupons/admin/${id}`);
+  return data?.data;
+};
+
+export const createCoupon = async (payload) => {
+  const { data } = await api.post("/coupons/admin", payload);
+  return data?.data;
+};
+
+export const updateCoupon = async (id, payload) => {
+  const { data } = await api.put(`/coupons/admin/${id}`, payload);
+  return data?.data;
+};
+
+export const deleteCoupon = async (id) => {
+  await api.delete(`/coupons/admin/${id}`);
+};
+
+export const validateCode = async (code) => {
+  const { data } = await api.get(`/coupons/code/${code}`);
+  return data?.data;
+};

--- a/frontend/src/services/couponService.js
+++ b/frontend/src/services/couponService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const validateCode = async (code) => {
+  const { data } = await api.get(`/coupons/code/${code}`);
+  return data?.data;
+};

--- a/frontend/src/services/instructor/couponService.js
+++ b/frontend/src/services/instructor/couponService.js
@@ -1,0 +1,25 @@
+import api from "@/services/api/api";
+
+export const fetchCoupons = async () => {
+  const { data } = await api.get("/coupons/admin");
+  return data?.data || [];
+};
+
+export const createCoupon = async (payload) => {
+  const { data } = await api.post("/coupons/admin", payload);
+  return data?.data;
+};
+
+export const updateCoupon = async (id, payload) => {
+  const { data } = await api.put(`/coupons/admin/${id}`, payload);
+  return data?.data;
+};
+
+export const deleteCoupon = async (id) => {
+  await api.delete(`/coupons/admin/${id}`);
+};
+
+export const validateCode = async (code) => {
+  const { data } = await api.get(`/coupons/code/${code}`);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- add coupon module with migration, seeds and CRUD API
- expose `/api/coupons` in server
- hook coupon validation into checkout page
- add admin and instructor dashboard pages for coupons
- document coupon management workflow

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
- `npm run lint` *(fails: 50 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6889e7f948408328a4e4d83b6c75a910