### PR TITLE
Enable replies and media for community discussions

### DIFF
--- a/backend/src/migrations/20250726000040_add_file_url_to_community_replies.js
+++ b/backend/src/migrations/20250726000040_add_file_url_to_community_replies.js
@@ -1,0 +1,14 @@
+exports.up = async function(knex) {
+  const hasColumn = await knex.schema.hasColumn('community_replies', 'file_url');
+  if (!hasColumn) {
+    return knex.schema.alterTable('community_replies', table => {
+      table.string('file_url');
+    });
+  }
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('community_replies', table => {
+    table.dropColumn('file_url');
+  });
+};

--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -48,3 +48,20 @@ exports.listTags = catchAsync(async (req, res) => {
   const tags = await service.searchTags(q);
   sendSuccess(res, tags);
 });
+
+exports.listReplies = catchAsync(async (req, res) => {
+  const replies = await service.listReplies(req.params.id);
+  sendSuccess(res, replies);
+});
+
+exports.createReply = catchAsync(async (req, res) => {
+  const { content } = req.body || {};
+  if (!content) throw new AppError('Missing fields', 400);
+  const reply = await service.createReply({
+    discussion_id: req.params.id,
+    user_id: req.user.id,
+    content,
+    file_url: req.file ? `/uploads/community/${req.file.filename}` : null,
+  });
+  sendSuccess(res, reply, 'Reply posted');
+});

--- a/backend/src/modules/community/public/public.routes.js
+++ b/backend/src/modules/community/public/public.routes.js
@@ -2,10 +2,13 @@ const router = require("express").Router();
 const ctrl = require("./public.controller");
 const { verifyToken } = require("../../../middleware/auth/authMiddleware");
 const upload = require("./discussionUpload.middleware");
+const replyUpload = require("./replyUpload.middleware");
 
 router.get("/discussions", ctrl.listDiscussions);
 router.get("/discussions/:id", ctrl.getDiscussion);
 router.post("/discussions", verifyToken, upload, ctrl.createDiscussion);
+router.get("/discussions/:id/replies", ctrl.listReplies);
+router.post("/discussions/:id/replies", verifyToken, replyUpload, ctrl.createReply);
 router.get("/contributors", ctrl.listContributors);
 router.get("/tags", ctrl.listTags);
 

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -24,7 +24,8 @@ exports.listDiscussions = async () => {
       "d.created_at",
       "d.resolved",
       "d.locked",
-      "u.full_name as user_name"
+      "u.full_name as user_name",
+      "u.avatar_url as user_avatar"
     )
     .orderBy("d.created_at", "desc");
   const tagsMap = await exports.getDiscussionTags(rows.map((r) => r.id));
@@ -42,7 +43,8 @@ exports.getDiscussion = async (id) => {
       "d.created_at",
       "d.resolved",
       "d.locked",
-      "u.full_name as user_name"
+      "u.full_name as user_name",
+      "u.avatar_url as user_avatar"
     )
     .where("d.id", id)
     .first();
@@ -153,4 +155,41 @@ exports.searchTags = async (q) => {
     .select('id', 'name', 'slug')
     .orderBy('name')
     .limit(10);
+};
+
+exports.listReplies = async (discussionId) => {
+  return db('community_replies as r')
+    .leftJoin('users as u', 'r.user_id', 'u.id')
+    .where('r.discussion_id', discussionId)
+    .select(
+      'r.id',
+      'r.content',
+      'r.file_url',
+      'r.is_answer',
+      'r.created_at',
+      'u.full_name as user_name',
+      'u.avatar_url as user_avatar'
+    )
+    .orderBy('r.created_at', 'asc');
+};
+
+exports.createReply = async (data) => {
+  const [row] = await db('community_replies')
+    .insert({
+      discussion_id: data.discussion_id,
+      user_id: data.user_id,
+      content: data.content,
+      file_url: data.file_url || null,
+    })
+    .returning('*');
+
+  const user = await db('users')
+    .where({ id: data.user_id })
+    .first('full_name', 'avatar_url');
+
+  return {
+    ...row,
+    user_name: user?.full_name,
+    user_avatar: user?.avatar_url,
+  };
 };

--- a/backend/src/modules/community/public/replyUpload.middleware.js
+++ b/backend/src/modules/community/public/replyUpload.middleware.js
@@ -1,0 +1,22 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
+const uploadDir = path.join(__dirname, '../../../../uploads/community');
+if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    const base = path.basename(file.originalname, ext).replace(/\s+/g, '-');
+    cb(null, `${Date.now()}-${base}${ext}`);
+  },
+});
+
+const fileFilter = (_req, file, cb) => {
+  cb(null, allowed.includes(file.mimetype));
+};
+
+module.exports = multer({ storage, fileFilter, limits: { fileSize: 5 * 1024 * 1024 } }).single('file');

--- a/frontend/src/pages/community/question/details.js
+++ b/frontend/src/pages/community/question/details.js
@@ -5,7 +5,7 @@ import Footer from "@/components/website/sections/Footer";
 import { useRouter } from "next/router";
 import RichTextEditor from "@/components/RichTextEditor";
 import ReactMarkdown from "react-markdown";
-import { fetchDiscussionById } from "@/services/communityService";
+import { fetchDiscussionById, fetchReplies, createReply } from "@/services/communityService";
 
 const QuestionDetails = () => {
   const router = useRouter();
@@ -25,6 +25,12 @@ const QuestionDetails = () => {
         setQuestion(data);
         setLikes(data.likes || 0);
         setVotes(data.votes || 0);
+        try {
+          const r = await fetchReplies(router.query.id);
+          setReplies(r);
+        } catch (err) {
+          console.error(err);
+        }
       }
     };
     load();
@@ -52,10 +58,18 @@ const QuestionDetails = () => {
   };
 
   // ✅ Handle Reply Submission
-  const handleReply = () => {
-    if (replyText) {
-      setReplies([...replies, { text: replyText, user: { name: "You" }, date: "Just now" }]);
-      setReplyText("");
+  const handleReply = async () => {
+    if (!replyText) return;
+    const fd = new FormData();
+    fd.append('content', replyText);
+    if (file) fd.append('file', file);
+    try {
+      const newReply = await createReply(router.query.id, fd);
+      setReplies([...replies, newReply]);
+      setReplyText('');
+      setFile(null);
+    } catch (err) {
+      console.error(err);
     }
   };
 
@@ -65,9 +79,13 @@ const QuestionDetails = () => {
       <div className="container mx-auto px-6 py-8 mt-16">
         <h1 className="text-3xl font-bold text-yellow-500">{question?.title}</h1>
         <div className="flex items-center text-gray-400 text-sm mt-2">
-          <FaUser className="mr-2 text-yellow-500" />
-          <span className="font-bold text-white">{question?.user?.name}</span>
-          <span className="ml-4">{question?.date}</span>
+          {question?.user_avatar ? (
+            <img src={question.user_avatar} alt="avatar" className="w-6 h-6 rounded-full mr-2" />
+          ) : (
+            <FaUser className="mr-2 text-yellow-500" />
+          )}
+          <span className="font-bold text-white">{question?.user_name}</span>
+          <span className="ml-4">{new Date(question?.created_at || '').toLocaleDateString()}</span>
         </div>
 
         {/* ✅ Voting, Likes, Views */}
@@ -87,7 +105,10 @@ const QuestionDetails = () => {
       </div>
 
       {/* ✅ Question Content */}
-        <p className="text-gray-300 mt-4">{question?.description}</p>
+        {question?.image_url && (
+          <img src={question.image_url} alt="attachment" className="mt-4 max-w-full rounded" />
+        )}
+        <p className="text-gray-300 mt-4">{question?.content}</p>
 
         {/* ✅ Tags */}
         <div className="flex space-x-2 mt-3">
@@ -98,24 +119,27 @@ const QuestionDetails = () => {
           ))}
         </div>
 
-        {/* ✅ Answers Section */}
-        <h2 className="text-2xl font-bold text-yellow-500 mt-8">Answers</h2>
+        {/* ✅ Replies Section */}
+        <h2 className="text-2xl font-bold text-yellow-500 mt-8">Replies</h2>
         <div className="mt-4 space-y-6">
-          {question?.answers?.map((answer) => (
-            <div key={answer.id} className="bg-gray-800 p-4 rounded-lg shadow-md">
-              <p className="text-gray-300 mt-2"><ReactMarkdown>{answer.text}</ReactMarkdown></p>
-
-              {/* ✅ Reply to Answer */}
-              <textarea
-                className="w-full mt-3 p-2 bg-gray-700 text-white rounded-lg"
-                rows="2"
-                placeholder="Reply to this answer..."
-              ></textarea>
-              <button className="mt-2 px-4 py-2 bg-yellow-500 text-gray-900 font-bold rounded-lg hover:bg-yellow-600">
-                Post Reply
-              </button>
+          {replies.map((reply) => (
+            <div key={reply.id} className="bg-gray-800 p-4 rounded-lg shadow-md">
+              <div className="flex items-center text-sm text-gray-400 mb-2">
+                {reply.user_avatar ? (
+                  <img src={reply.user_avatar} alt="avatar" className="w-5 h-5 rounded-full mr-2" />
+                ) : (
+                  <FaUser className="mr-2" />
+                )}
+                <span className="font-bold text-white">{reply.user_name}</span>
+                <span className="ml-2">{new Date(reply.created_at).toLocaleDateString()}</span>
+              </div>
+              <p className="text-gray-300 mt-2"><ReactMarkdown>{reply.content}</ReactMarkdown></p>
+              {reply.file_url && (
+                <img src={reply.file_url} alt="attachment" className="mt-2 max-w-full rounded" />
+              )}
             </div>
           ))}
+          {replies.length === 0 && <p className="text-gray-400">No replies yet.</p>}
         </div>
 
         {/* ✅ User Reply Section */}

--- a/frontend/src/services/communityService.js
+++ b/frontend/src/services/communityService.js
@@ -24,3 +24,13 @@ export const searchTags = async (q) => {
   const { data } = await api.get(`/community/tags?q=${encodeURIComponent(q)}`);
   return data?.data ?? [];
 };
+
+export const fetchReplies = async (discussionId) => {
+  const { data } = await api.get(`/community/discussions/${discussionId}/replies`);
+  return data?.data ?? [];
+};
+
+export const createReply = async (discussionId, payload) => {
+  const { data } = await api.post(`/community/discussions/${discussionId}/replies`, payload);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- allow users to upload media with replies
- expose API endpoints for listing and creating replies
- persist file URL for replies
- fetch and display discussion author avatar and replies
- show uploaded media for discussions

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889e7456aa88328aadc1fdecbfe3028