### PR TITLE
Add missing fetchCouponById function

### DIFF
--- a/frontend/src/services/instructor/couponService.js
+++ b/frontend/src/services/instructor/couponService.js
@@ -5,6 +5,11 @@ export const fetchCoupons = async () => {
   return data?.data || [];
 };
 
+export const fetchCouponById = async (id) => {
+  const { data } = await api.get(`/coupons/admin/${id}`);
+  return data?.data;
+};
+
 export const createCoupon = async (payload) => {
   const { data } = await api.post("/coupons/admin", payload);
   return data?.data;


### PR DESCRIPTION
## Summary
- fix missing export error by adding `fetchCouponById` to the instructor coupon service

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`
- `npm run lint --silent` in `frontend` *(fails: 50 errors, 213 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6889ebd617388328a37047d4f99b3239