### PR TITLE
Add missing fetchCouponById function

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/instructorLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/instructorLinks.js
@@ -12,6 +12,7 @@ import {
   Brain,
   Megaphone,
   ClipboardList,
+  BadgePercent,
   MailOpen,
   MessageCircle,
   CalendarRange,
@@ -77,6 +78,7 @@ export const instructorNavLinks = [
       { label: 'Earnings', href: '/dashboard/instructor/payments', icon: CreditCard },
       { label: 'Ads Manager', href: '/dashboard/instructor/ads', icon: Megaphone },
       { label: 'Offers', href: '/dashboard/instructor/offers', icon: ClipboardList },
+      { label: 'Coupons', href: '/dashboard/instructor/coupons', icon: BadgePercent },
     ]
   },
   {

--- a/frontend/src/services/instructor/couponService.js
+++ b/frontend/src/services/instructor/couponService.js
@@ -5,6 +5,11 @@ export const fetchCoupons = async () => {
   return data?.data || [];
 };
 
+export const fetchCouponById = async (id) => {
+  const { data } = await api.get(`/coupons/admin/${id}`);
+  return data?.data;
+};
+
 export const createCoupon = async (payload) => {
   const { data } = await api.post("/coupons/admin", payload);
   return data?.data;


### PR DESCRIPTION
## Summary
- add fetchCouponById to instructor coupon service
- add Coupons navigation link for instructors

## Testing
- `npm test --silent` in `frontend`
- `npm run lint --silent` in `frontend` *(fails: 50 errors, 213 warnings)*
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6889ebd617388328a37047d4f99b3239