### PR TITLE
Add global SEO meta tags

### DIFF
--- a/frontend/src/components/common/SeoTags.js
+++ b/frontend/src/components/common/SeoTags.js
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import useSEOConfigStore from '@/store/seoConfigStore';
+
+export default function SeoTags() {
+  const router = useRouter();
+  const path = router.asPath.split('?')[0] || '/';
+  const fetchConfig = useSEOConfigStore((s) => s.fetch);
+  const loaded = useSEOConfigStore((s) => s.loaded);
+  const settings = useSEOConfigStore((s) => s.settings);
+
+  useEffect(() => {
+    if (!loaded) fetchConfig();
+  }, [loaded, fetchConfig]);
+
+  const meta = settings.metaTags?.[path] || {};
+  const og = settings.openGraph?.[path] || {};
+  const twitter = settings.twitter?.[path] || {};
+
+  const baseUrl = settings.baseUrl || (typeof window !== 'undefined' ? window.location.origin : '');
+  const canonical = meta.canonical || (settings.globalSEO?.forceCanonical ? `${baseUrl}${path}` : '');
+
+  const robots = settings.globalSEO?.noindexSitewide || meta.noindex || meta.nofollow
+    ? `${settings.globalSEO?.noindexSitewide || meta.noindex ? 'noindex' : 'index'},${meta.nofollow ? 'nofollow' : 'follow'}`
+    : null;
+
+  return (
+    <Head>
+      {meta.title && <title>{meta.title}</title>}
+      {meta.description && <meta name="description" content={meta.description} />}
+      {meta.keywords && <meta name="keywords" content={meta.keywords} />}
+      {canonical && <link rel="canonical" href={canonical} />}
+      {robots && <meta name="robots" content={robots} />}
+      {Object.entries(og).map(([k, v]) => v ? <meta key={`og-${k}`} property={`og:${k}`} content={v} /> : null)}
+      {twitter.cardType && <meta name="twitter:card" content={twitter.cardType} />}
+      {twitter.title && <meta name="twitter:title" content={twitter.title} />}
+      {twitter.description && <meta name="twitter:description" content={twitter.description} />}
+      {twitter.image && <meta name="twitter:image" content={twitter.image} />}
+      {twitter.handle && <meta name="twitter:site" content={twitter.handle} />}
+      {settings.jsonSchema && (
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: settings.jsonSchema }} />
+      )}
+    </Head>
+  );
+}

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import App from "next/app";
 import { appWithTranslation, useTranslation } from "next-i18next";
 import useSWR from "swr";
 import nextI18NextConfig from "../../next-i18next.config.js";
@@ -13,10 +14,13 @@ import useAuthStore from "@/store/auth/authStore";
 import useAppConfigStore from "@/store/appConfigStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import { fetchSEOConfig } from "@/services/admin/seoConfigService";
+import useSEOConfigStore from "@/store/seoConfigStore";
 import * as authService from "@/services/auth/authService";
 import { getFullProfile } from "@/services/profile/profileService";
 import Head from "next/head";
 import { getLanguages } from "@/services/languageService";
+import SeoTags from "@/components/common/SeoTags";
 
 const langFetcher = () => getLanguages();
 
@@ -29,7 +33,7 @@ const langFetcher = () => getLanguages();
  * - Injects per-page layout support
  * - Includes global toast notifications
  */
-function MyApp({ Component, pageProps, router }) {
+function MyApp({ Component, pageProps, router, seoSettings }) {
   // Support for per-page layout pattern
   const getLayout = Component.getLayout || ((page) => page);
 
@@ -40,6 +44,9 @@ function MyApp({ Component, pageProps, router }) {
   const fetchNotifs = useNotificationStore((s) => s.fetch);
   const startMsgPolling = useMessageStore((s) => s.startPolling);
   const fetchMsgs = useMessageStore((s) => s.fetch);
+  const seoLoaded = useSEOConfigStore((s) => s.loaded);
+  const fetchSEO = useSEOConfigStore((s) => s.fetch);
+  const updateSEO = useSEOConfigStore((s) => s.update);
   const { i18n } = useTranslation();
   const { data: langs } = useSWR("/languages", langFetcher);
   const currentLang = langs?.find((l) => l.code === i18n.language);
@@ -78,6 +85,15 @@ function MyApp({ Component, pageProps, router }) {
   useEffect(() => {
     if (!configLoaded) fetchConfig();
   }, [configLoaded, fetchConfig]);
+
+  useEffect(() => {
+    if (seoSettings && !seoLoaded) {
+      updateSEO(seoSettings);
+      useSEOConfigStore.setState({ loaded: true });
+    } else if (!seoLoaded) {
+      fetchSEO();
+    }
+  }, [seoSettings, seoLoaded, fetchSEO, updateSEO]);
 
   useEffect(() => {
     if (user) {
@@ -141,6 +157,7 @@ function MyApp({ Component, pageProps, router }) {
             />
           )}
         </Head>
+        <SeoTags />
         {/* Render page with layout */}
         {getLayout(<Component {...pageProps} />)}
 
@@ -160,5 +177,15 @@ function MyApp({ Component, pageProps, router }) {
     </AnimatePresence>
   );
 }
+
+MyApp.getInitialProps = async (appContext) => {
+  const appProps = await App.getInitialProps(appContext);
+  try {
+    const data = await fetchSEOConfig();
+    return { ...appProps, seoSettings: data };
+  } catch {
+    return { ...appProps, seoSettings: null };
+  }
+};
 
 export default appWithTranslation(MyApp, nextI18NextConfig);


### PR DESCRIPTION
## Summary
- include SEO tags through a new `<SeoTags>` component
- load SEO tags globally from `_app`
- preload SEO settings server-side to render tags in HTML

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_6889fb72efb08328aee38c6cd70c7382