### PR TITLE
Allow non-validated social links

### DIFF
--- a/frontend/src/components/profile/steps/SocialLinks.js
+++ b/frontend/src/components/profile/steps/SocialLinks.js
@@ -14,13 +14,8 @@ const SocialLinks = ({ formData, setFormData, onNext, onBack }) => {
     setErrors({ ...errors, [e.target.name]: "" });
   };
 
-  // ✅ Validate URLs
-  const validateURL = (name, value) => {
-    const urlRegex = /^(https?:\/\/)?([\w\d]+\.)?[\w\d]+\.\w+\/?.*$/;
-    if (value && !urlRegex.test(value)) {
-      setErrors((prev) => ({ ...prev, [name]: "Enter a valid URL" }));
-    }
-  };
+  // Validation removed to allow any text values
+  const validateURL = () => {};
 
   return (
     <motion.div
@@ -45,11 +40,10 @@ const SocialLinks = ({ formData, setFormData, onNext, onBack }) => {
           <div className="flex items-center bg-gray-700 rounded-lg p-2">
             {icon}
             <input
-              type="url"
+              type="text"
               name={name}
               value={formData.socialLinks[name] || ""}
               onChange={handleChange}
-              onBlur={(e) => validateURL(name, e.target.value)}
               className="w-full p-2 bg-gray-700 text-white border-none focus:outline-none ml-3"
               placeholder={`https://your-${name}.com`}
             />

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -40,7 +40,8 @@ const profileSchema = z.object({
   department: z.string().min(2),
   gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
   date_of_birth: z.string().refine((val) => !isNaN(Date.parse(val)), { message: "Invalid date format" }),
-  socialLinks: z.record(z.string().url("Must be a valid URL")).optional(),
+  // Social links are optional strings without URL validation
+  socialLinks: z.record(z.string()).optional(),
 });
 
 function ProfileEditTemplate() {
@@ -451,7 +452,7 @@ function ProfileEditTemplate() {
                 <div>
                   <label className="block text-sm font-medium mb-1">LinkedIn</label>
                   <input
-                    type="url"
+                    type="text"
                     name="linkedin"
                     value={formData.socialLinks.linkedin || ""}
                     onChange={(e) =>

--- a/frontend/src/pages/dashboard/instructor/profile/steps/SocialLinks.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/SocialLinks.js
@@ -21,14 +21,8 @@ const SocialLinks = ({
     setErrors((prev) => ({ ...prev, [name]: "" }));
   };
 
-  // ✅ Validate URLs
-  const validateURL = (name, value) => {
-    const urlRegex =
-      /^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/\S*)?$/;
-    if (value && !urlRegex.test(value.trim())) {
-      setErrors((prev) => ({ ...prev, [name]: "Enter a valid URL" }));
-    }
-  };
+  // Validation removed to allow any text values
+  const validateURL = () => {};
 
   return (
     <motion.div
@@ -53,11 +47,10 @@ const SocialLinks = ({
           <div className="flex items-center bg-gray-700 rounded-lg p-2">
             {icon}
             <input
-              type="url"
+              type="text"
               name={name}
               value={socialLinks[name] || ""}
               onChange={handleChange}
-              onBlur={(e) => validateURL(name, e.target.value)}
               className="w-full p-2 bg-gray-700 text-white border-none focus:outline-none ml-3"
               placeholder={`https://your-${name}.com`}
             />

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -30,7 +30,8 @@ const studentProfileSchema = z.object({
   education_level: z.string().min(2, "Education level is required"),
   topics: z.array(z.string()).optional(),
   learning_goals: z.string().optional(),
-  socialLinks: z.record(z.string().url("Must be a valid URL")).optional(),
+  // Social links are optional strings without strict URL validation
+  socialLinks: z.record(z.string()).optional(),
 });
 
 export default function StudentProfileEdit() {
@@ -581,7 +582,7 @@ export default function StudentProfileEdit() {
                       LinkedIn Profile URL
                     </label>
                     <input
-                      type="url"
+                      type="text"
                       name="linkedin"
                       value={formData.socialLinks.linkedin || ""}
                       onChange={handleSocialChange}
@@ -596,7 +597,7 @@ export default function StudentProfileEdit() {
                       GitHub Profile URL
                     </label>
                     <input
-                      type="url"
+                      type="text"
                       name="github"
                       value={formData.socialLinks.github || ""}
                       onChange={handleSocialChange}

--- a/frontend/src/pages/dashboard/student/profile/steps/SocialLinks.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/SocialLinks.js
@@ -28,15 +28,9 @@ const SocialLinks = ({
     setErrors((prev) => ({ ...prev, [name]: "" }));
   };
 
-  const validateURL = (name, value) => {
-    const urlRegex =
-      /^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/\S*)?$/;
-    if (value && !urlRegex.test(value.trim())) {
-      setErrors((prev) => ({ ...prev, [name]: "Enter a valid URL" }));
-    }
-  };
-
-  const isFormValid = Object.values(errors).every((e) => !e);
+  // Validation removed to allow any text values
+  const validateURL = () => {};
+  const isFormValid = true;
 
   return (
     <motion.div
@@ -64,16 +58,15 @@ const SocialLinks = ({
           </label>
           <div className="flex items-center border border-gray-300 rounded-lg px-3 py-2 bg-white">
             {icon}
-            <input
-              id={name}
-              type="url"
-              name={name}
-              value={socialLinks[name] || ""}
-              onChange={handleChange}
-              onBlur={(e) => validateURL(name, e.target.value)}
-              placeholder={`https://your-${name}.com`}
-              className="ml-3 w-full bg-transparent text-sm text-gray-800 focus:outline-none focus:ring-1 focus:ring-yellow-500"
-            />
+              <input
+                id={name}
+                type="text"
+                name={name}
+                value={socialLinks[name] || ""}
+                onChange={handleChange}
+                placeholder={`https://your-${name}.com`}
+                className="ml-3 w-full bg-transparent text-sm text-gray-800 focus:outline-none focus:ring-1 focus:ring-yellow-500"
+              />
           </div>
           {errors[name] && (
             <p className="text-red-500 text-xs mt-1">{errors[name]}</p>


### PR DESCRIPTION
## Summary
- remove strict URL validation from student and admin profile schemas
- change social link inputs to plain text and drop validation

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_688a166d99f88328b68654ac456292a9