### PR TITLE
Add cart notifications and reminder email

### DIFF
--- a/backend/src/jobs/cartReminderJob.js
+++ b/backend/src/jobs/cartReminderJob.js
@@ -1,0 +1,42 @@
+const cartService = require("../modules/cart/cart.service");
+const notificationService = require("../modules/notifications/notifications.service");
+const messageService = require("../modules/messages/messages.service");
+const userModel = require("../modules/users/user.model");
+const { sendCartReminderEmail } = require("../utils/email");
+
+function startCartReminderJob() {
+  setInterval(async () => {
+    const items = cartService.getAll();
+    const now = Date.now();
+    const admins = await userModel.findAdmins();
+    const sender = admins[0];
+    for (const item of items) {
+      if (item.reminder_sent) continue;
+      const added = new Date(item.added_at).getTime();
+      if (now - added >= 4 * 60 * 60 * 1000) {
+        const message = `Don't forget about ${item.name || "item"} in your cart!`;
+        await notificationService.createNotification({
+          user_id: item.user_id,
+          type: "cart_reminder",
+          message,
+        });
+        if (sender) {
+          await messageService.createMessage({
+            sender_id: sender.id,
+            receiver_id: item.user_id,
+            message,
+          });
+        }
+        try {
+          const user = await userModel.findById(item.user_id);
+          if (user?.email) await sendCartReminderEmail(user.email, item.name);
+        } catch (err) {
+          console.error("Error sending cart reminder email:", err.message);
+        }
+        item.reminder_sent = true;
+      }
+    }
+  }, 60 * 60 * 1000); // hourly
+}
+
+module.exports = startCartReminderJob;

--- a/backend/src/modules/cart/cart.controller.js
+++ b/backend/src/modules/cart/cart.controller.js
@@ -1,26 +1,45 @@
-const service = require('./cart.service');
-const { sendSuccess } = require('../../utils/response');
+const service = require("./cart.service");
+const { sendSuccess } = require("../../utils/response");
+const catchAsync = require("../../utils/catchAsync");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
+const userModel = require("../users/user.model");
 
-exports.addItem = (req, res) => {
-  const item = service.add(req.body);
-  sendSuccess(res, item, 'Item added to cart');
-};
+exports.addItem = catchAsync(async (req, res) => {
+  const item = service.add(req.user.id, req.body);
 
-exports.getItems = (_req, res) => {
-  const items = service.list();
+  const message = `Added ${item.name || "item"} to your cart`;
+  await notificationService.createNotification({
+    user_id: req.user.id,
+    type: "cart_added",
+    message,
+  });
+  const admins = await userModel.findAdmins();
+  const sender = admins[0];
+  if (sender) {
+    await messageService.createMessage({
+      sender_id: sender.id,
+      receiver_id: req.user.id,
+      message,
+    });
+  }
+
+  sendSuccess(res, item, "Item added to cart");
+});
+
+exports.getItems = catchAsync(async (req, res) => {
+  const items = service.list(req.user.id);
   sendSuccess(res, items);
-};
+});
 
-exports.updateItem = (req, res) => {
-  // Accept string IDs without parsing to integer
-  const item = service.update(req.params.id, req.body.quantity);
-  if (!item) return res.status(404).json({ message: 'Item not found' });
-  sendSuccess(res, item, 'Cart updated');
-};
+exports.updateItem = catchAsync(async (req, res) => {
+  const item = service.update(req.user.id, req.params.id, req.body.quantity);
+  if (!item) return res.status(404).json({ message: "Item not found" });
+  sendSuccess(res, item, "Cart updated");
+});
 
-exports.removeItem = (req, res) => {
-  // Accept string IDs without parsing to integer
-  const item = service.remove(req.params.id);
-  if (!item) return res.status(404).json({ message: 'Item not found' });
-  sendSuccess(res, null, 'Item removed');
-};
+exports.removeItem = catchAsync(async (req, res) => {
+  const item = service.remove(req.user.id, req.params.id);
+  if (!item) return res.status(404).json({ message: "Item not found" });
+  sendSuccess(res, null, "Item removed");
+});

--- a/backend/src/modules/cart/cart.routes.js
+++ b/backend/src/modules/cart/cart.routes.js
@@ -1,9 +1,10 @@
-const router = require('express').Router();
-const controller = require('./cart.controller');
+const router = require("express").Router();
+const controller = require("./cart.controller");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
 
-router.post('/add', controller.addItem);
-router.get('/', controller.getItems);
-router.put('/update/:id', controller.updateItem);
-router.delete('/remove/:id', controller.removeItem);
+router.post("/add", verifyToken, controller.addItem);
+router.get("/", verifyToken, controller.getItems);
+router.put("/update/:id", verifyToken, controller.updateItem);
+router.delete("/remove/:id", verifyToken, controller.removeItem);
 
 module.exports = router;

--- a/backend/src/modules/cart/cart.service.js
+++ b/backend/src/modules/cart/cart.service.js
@@ -1,27 +1,35 @@
 const cart = [];
 
-exports.list = () => cart;
+exports.list = (userId) => cart.filter((c) => c.user_id === userId);
 
-exports.add = (item) => {
-  const existing = cart.find((c) => c.id === item.id);
+exports.getAll = () => cart;
+
+exports.add = (userId, item) => {
+  const existing = cart.find((c) => c.id === item.id && c.user_id === userId);
   if (existing) {
     existing.quantity += item.quantity || 1;
     return existing;
   }
-  const newItem = { ...item, quantity: item.quantity || 1 };
+  const newItem = {
+    ...item,
+    user_id: userId,
+    quantity: item.quantity || 1,
+    added_at: new Date(),
+    reminder_sent: false,
+  };
   cart.push(newItem);
   return newItem;
 };
 
-exports.update = (id, quantity) => {
-  const item = cart.find((c) => c.id === id);
+exports.update = (userId, id, quantity) => {
+  const item = cart.find((c) => c.id === id && c.user_id === userId);
   if (!item) return null;
   item.quantity = quantity;
   return item;
 };
 
-exports.remove = (id) => {
-  const index = cart.findIndex((c) => c.id === id);
+exports.remove = (userId, id) => {
+  const index = cart.findIndex((c) => c.id === id && c.user_id === userId);
   if (index === -1) return null;
   return cart.splice(index, 1)[0];
 };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -11,6 +11,7 @@ const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");
 const path = require("path");
 const startLessonReminderJob = require("./jobs/lessonReminderJob");
+const startCartReminderJob = require("./jobs/cartReminderJob");
 require("dotenv").config();
 
 
@@ -191,6 +192,7 @@ async function startServer() {
       console.log(`✅ Server running on port ${PORT}`);
     });
     startLessonReminderJob();
+    startCartReminderJob();
   } catch (err) {
     console.error("❌ Failed to start server:", err.message);
     process.exit(1);

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -839,3 +839,55 @@ exports.sendNewDiscussionEmail = async (to, askerName, questionTitle) => {
   }
 };
 
+// Reminder email for abandoned cart items
+exports.sendCartReminderEmail = async (to, itemName) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Cart reminder for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `Don't forget your cart item`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>You left <strong>${itemName}</strong> in your cart.</p>
+        <p>Don't let the chance slip away! Complete your purchase now.</p>
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Cart reminder email sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending cart reminder email: ", error);
+  }
+};
+


### PR DESCRIPTION
## Summary
- notify user when adding items to cart
- require authentication for cart routes
- track cart items per-user and schedule reminder
- email reminder if item stays in cart over 4 hours
- start new cart reminder job on server startup

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a1cee1d688328b62575bed585193f