### PR TITLE
Integrate student community pages with backend

### DIFF
--- a/frontend/src/pages/dashboard/student/community/ask.js
+++ b/frontend/src/pages/dashboard/student/community/ask.js
@@ -1,30 +1,58 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import { FaPaperPlane } from "react-icons/fa";
 import { useRouter } from "next/router";
-
-const availableTags = ["React", "Odoo", "Next.js", "APIs", "UI/UX", "Authentication"];
+import { createDiscussion, searchTags } from "@/services/communityService";
+import toast from "react-hot-toast";
 
 export default function AskQuestionPage() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [selectedTags, setSelectedTags] = useState([]);
+  const [tagInput, setTagInput] = useState("");
+  const [tagSuggestions, setTagSuggestions] = useState([]);
   const [submitted, setSubmitted] = useState(false);
   const router = useRouter();
 
-  const toggleTag = (tag) => {
-    setSelectedTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-    );
+  useEffect(() => {
+    if (tagInput.trim()) {
+      searchTags(tagInput.trim()).then(setTagSuggestions).catch(() => {});
+    } else {
+      setTagSuggestions([]);
+    }
+  }, [tagInput]);
+
+  const addTag = (tag) => {
+    if (!tag || selectedTags.includes(tag)) return;
+    setSelectedTags((prev) => [...prev, tag]);
   };
 
-  const handleSubmit = (e) => {
+  const removeTag = (tag) => {
+    setSelectedTags((prev) => prev.filter((t) => t !== tag));
+  };
+
+  const handleTagKeyDown = (e) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      if (tagInput.trim()) addTag(tagInput.trim());
+      setTagInput("");
+    }
+  };
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!title.trim()) return alert("Please enter a question title.");
-    // Here you'd call an API to save the question
-    console.log({ title, description, selectedTags });
-    setSubmitted(true);
-    setTimeout(() => router.push("/dashboard/student/community"), 1000);
+    if (!title.trim()) {
+      toast.error("Title required");
+      return;
+    }
+    try {
+      await createDiscussion({ title, content: description, tags: selectedTags });
+      setSubmitted(true);
+      setTimeout(() => router.push("/dashboard/student/community"), 1000);
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to submit");
+    }
   };
 
   return (
@@ -65,20 +93,41 @@ export default function AskQuestionPage() {
             {/* Tags */}
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">Tags</label>
-              <div className="flex flex-wrap gap-2">
-                {availableTags.map((tag) => (
-                  <button
-                    type="button"
-                    key={tag}
-                    onClick={() => toggleTag(tag)}
-                    className={`px-3 py-1 rounded-full text-sm border ${
-                      selectedTags.includes(tag)
-                        ? "bg-yellow-500 text-white border-yellow-500"
-                        : "bg-gray-100 text-gray-600 border-gray-300 hover:bg-gray-200"
-                    }`}
-                  >
-                    #{tag}
-                  </button>
+              <div className="relative">
+                <input
+                  type="text"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none"
+                  placeholder="Add tags"
+                  value={tagInput}
+                  onChange={(e) => setTagInput(e.target.value)}
+                  onKeyDown={handleTagKeyDown}
+                />
+                {tagSuggestions.length > 0 && (
+                  <ul className="absolute z-10 bg-white border border-gray-300 w-full mt-1 rounded shadow max-h-40 overflow-y-auto">
+                    {tagSuggestions.map((s) => (
+                      <li
+                        key={s.id}
+                        className="px-3 py-1 cursor-pointer hover:bg-gray-100"
+                        onClick={() => {
+                          addTag(s.name);
+                          setTagInput("");
+                          setTagSuggestions([]);
+                        }}
+                      >
+                        {s.name}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <div className="flex flex-wrap gap-2 mt-2">
+                {selectedTags.map((t) => (
+                  <span key={t} className="bg-yellow-500 text-white px-2 py-1 rounded flex items-center">
+                    {t}
+                    <button type="button" className="ml-1" onClick={() => removeTag(t)}>
+                      &times;
+                    </button>
+                  </span>
                 ))}
               </div>
             </div>

--- a/frontend/src/pages/dashboard/student/community/index.js
+++ b/frontend/src/pages/dashboard/student/community/index.js
@@ -4,35 +4,54 @@ import StudentLayout from "@/components/layouts/StudentLayout";
 import Link from "next/link";
 import { FaSearch, FaPlus, FaTags } from "react-icons/fa";
 import toast, { Toaster } from "react-hot-toast";
-
-const allDiscussions = [
-  { id: 1, title: "How do I integrate Tailwind with Next.js?", replies: 5, user: "Ali" },
-  { id: 2, title: "Best Odoo learning path for beginners?", replies: 3, user: "Fatima" },
-  { id: 3, title: "React vs Vue: Which is better for SaaS?", replies: 7, user: "Hassan" },
-  { id: 4, title: "How to secure an API with JWT?", replies: 2, user: "Lina" },
-  { id: 5, title: "Best practices for UI design systems?", replies: 6, user: "Yusuf" },
-  { id: 6, title: "How to test React components with Jest?", replies: 1, user: "Aisha" },
-];
-
-const myQuestions = [
-  { id: 101, title: "How to connect Odoo with Google Sheets?", replies: 2, tags: ["Odoo", "API"] },
-  { id: 102, title: "What’s the best Next.js folder structure?", replies: 0, tags: ["Next.js"] },
-];
-
-const mockTags = ["React", "Odoo", "Next.js", "UI/UX", "APIs"];
+import { fetchDiscussions } from "@/services/communityService";
+import useAuthStore from "@/store/auth/authStore";
 
 export default function StudentCommunityPage() {
+  const { user } = useAuthStore();
   const [searchQuery, setSearchQuery] = useState("");
   const [activeTab, setActiveTab] = useState("all");
   const [activeTag, setActiveTag] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
+  const [allDiscussions, setAllDiscussions] = useState([]);
+  const [tags, setTags] = useState([]);
   const itemsPerPage = 5;
 
-  const discussions = activeTab === "mine" ? myQuestions : allDiscussions;
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const list = await fetchDiscussions();
+        const formatted = (list || []).map((d) => ({
+          id: d.id,
+          title: d.title,
+          user: d.user_name || "Anonymous",
+          tags: Array.isArray(d.tags)
+            ? d.tags
+            : typeof d.tags === "string" && d.tags
+            ? JSON.parse(d.tags)
+            : [],
+        }));
+        setAllDiscussions(formatted);
+        const tagSet = new Set();
+        formatted.forEach((q) => q.tags?.forEach((t) => tagSet.add(t)));
+        setTags(Array.from(tagSet));
+      } catch (err) {
+        console.error(err);
+        toast.error("Failed to load discussions");
+      }
+    };
+    load();
+  }, []);
+
+  const discussions =
+    activeTab === "mine"
+      ? allDiscussions.filter((d) => d.user === user?.full_name)
+      : allDiscussions;
+
   const filtered = discussions.filter(
     (d) =>
       d.title.toLowerCase().includes(searchQuery.toLowerCase()) &&
-      (activeTag === "" || d.title.toLowerCase().includes(activeTag.toLowerCase()))
+      (activeTag === "" || d.tags?.some((t) => t.toLowerCase() === activeTag.toLowerCase()))
   );
 
   const paginated = filtered.slice(
@@ -104,7 +123,7 @@ export default function StudentCommunityPage() {
         {/* Tags */}
         <div className="flex flex-wrap gap-2 mb-8 items-center">
           <FaTags className="text-yellow-500" />
-          {mockTags.map((tag) => (
+          {tags.map((tag) => (
             <button
               key={tag}
               onClick={() => setActiveTag(tag === activeTag ? "" : tag)}
@@ -132,7 +151,7 @@ export default function StudentCommunityPage() {
                     {d.title}
                   </h3>
                   <p className="text-sm text-gray-500">
-                    {activeTab === "mine" ? "You" : d.user} • {d.replies} replies
+                    {activeTab === "mine" ? "You" : d.user}
                   </p>
                 </div>
               </Link>

--- a/frontend/src/pages/dashboard/student/community/my-questions.js
+++ b/frontend/src/pages/dashboard/student/community/my-questions.js
@@ -1,29 +1,37 @@
 import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import Link from "next/link";
-import { FaCommentDots, FaEye } from "react-icons/fa";
-
-const mockMyQuestions = [
-  {
-    id: 1,
-    title: "How to connect Odoo with Google Sheets?",
-    replies: 4,
-    tags: ["Odoo", "API"],
-  },
-  {
-    id: 2,
-    title: "Best way to structure a Next.js education platform?",
-    replies: 2,
-    tags: ["Next.js", "Design"],
-  },
-];
+import { FaEye } from "react-icons/fa";
+import { fetchDiscussions } from "@/services/communityService";
+import useAuthStore from "@/store/auth/authStore";
+import toast from "react-hot-toast";
 
 export default function MyQuestionsPage() {
+  const { user } = useAuthStore();
   const [questions, setQuestions] = useState([]);
 
   useEffect(() => {
-    setQuestions(mockMyQuestions); // Replace with real API later
-  }, []);
+    const load = async () => {
+      try {
+        const list = await fetchDiscussions();
+        const formatted = (list || []).map((d) => ({
+          id: d.id,
+          title: d.title,
+          tags: Array.isArray(d.tags)
+            ? d.tags
+            : typeof d.tags === "string" && d.tags
+            ? JSON.parse(d.tags)
+            : [],
+          user: d.user_name,
+        }));
+        setQuestions(formatted.filter((q) => q.user === user?.full_name));
+      } catch (err) {
+        console.error(err);
+        toast.error("Failed to load questions");
+      }
+    };
+    load();
+  }, [user]);
 
   return (
     <StudentLayout title="My Questions">
@@ -40,7 +48,6 @@ export default function MyQuestionsPage() {
                 className="bg-white border border-gray-200 p-4 rounded-lg shadow-sm hover:shadow-md transition"
               >
                 <h2 className="text-lg font-semibold text-gray-800 mb-1">{q.title}</h2>
-                <p className="text-sm text-gray-500 mb-2">{q.replies} replies</p>
                 <div className="flex flex-wrap gap-2 mb-3">
                   {q.tags.map((tag) => (
                     <span

--- a/frontend/src/pages/dashboard/student/community/questions/[id].js
+++ b/frontend/src/pages/dashboard/student/community/questions/[id].js
@@ -2,41 +2,56 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import { FaReply, FaUserCircle } from "react-icons/fa";
-
-const mockQuestions = {
-  1: {
-    id: 1,
-    title: "How do I integrate Tailwind with Next.js?",
-    description: "I'm building a frontend using Next.js. How do I properly use Tailwind CSS with it?",
-    user: "Ali",
-    tags: ["Next.js", "Tailwind"],
-    replies: [
-      { id: 1, author: "Fatima", content: "Install Tailwind via npm and add to your config files.", timestamp: "1 hour ago" },
-      { id: 2, author: "Omar", content: "Check the Tailwind docs — they have a great Next.js guide.", timestamp: "30 mins ago" },
-    ],
-  },
-};
+import { fetchDiscussionById, fetchReplies, createReply } from "@/services/communityService";
+import toast from "react-hot-toast";
 
 export default function QuestionDetailPage() {
   const router = useRouter();
   const { id } = router.query;
 
   const [question, setQuestion] = useState(null);
+  const [replies, setReplies] = useState([]);
   const [replyText, setReplyText] = useState("");
-  const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
-    if (id && mockQuestions[id]) {
-      setQuestion(mockQuestions[id]);
-    }
+    if (!id) return;
+    const load = async () => {
+      try {
+        const q = await fetchDiscussionById(id);
+        if (q) {
+          q.tags = Array.isArray(q.tags)
+            ? q.tags
+            : typeof q.tags === "string" && q.tags
+            ? JSON.parse(q.tags)
+            : [];
+          setQuestion(q);
+        }
+        const r = await fetchReplies(id);
+        setReplies(r);
+      } catch (err) {
+        console.error(err);
+        toast.error("Failed to load discussion");
+      }
+    };
+    load();
   }, [id]);
 
-  const handleReply = () => {
+  const handleReply = async () => {
     if (!replyText.trim()) return;
-    alert("Reply submitted (mock)");
-    setSubmitted(true);
-    setReplyText("");
-    setTimeout(() => setSubmitted(false), 1500);
+    setSubmitting(true);
+    const fd = new FormData();
+    fd.append("content", replyText);
+    try {
+      const newReply = await createReply(id, fd);
+      setReplies((prev) => [...prev, newReply]);
+      setReplyText("");
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to post reply");
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   if (!question) return <StudentLayout title="Loading..."><div className="p-6">Loading...</div></StudentLayout>;
@@ -47,8 +62,8 @@ export default function QuestionDetailPage() {
         {/* Question */}
         <div className="bg-white border border-gray-200 p-6 rounded-lg shadow">
           <h1 className="text-2xl font-bold mb-2 text-gray-800">{question.title}</h1>
-          <p className="text-sm text-gray-500 mb-2">Asked by <strong>{question.user}</strong></p>
-          <p className="text-gray-700 mb-4">{question.description}</p>
+          <p className="text-sm text-gray-500 mb-2">Asked by <strong>{question.user_name}</strong></p>
+          <p className="text-gray-700 mb-4">{question.content}</p>
           <div className="flex gap-2 flex-wrap">
             {question.tags.map((tag) => (
               <span key={tag} className="text-xs px-3 py-1 bg-yellow-100 text-yellow-800 rounded-full font-medium">
@@ -61,13 +76,13 @@ export default function QuestionDetailPage() {
         {/* Replies */}
         <div className="space-y-4">
           <h2 className="text-lg font-semibold text-gray-800">Replies</h2>
-          {question.replies.map((reply) => (
+          {replies.map((reply) => (
             <div key={reply.id} className="bg-gray-50 border border-gray-200 p-4 rounded-lg flex gap-3">
               <FaUserCircle className="text-3xl text-gray-400" />
               <div>
-                <p className="text-sm font-semibold text-gray-800">{reply.author}</p>
+                <p className="text-sm font-semibold text-gray-800">{reply.user_name}</p>
                 <p className="text-gray-600 text-sm">{reply.content}</p>
-                <span className="text-xs text-gray-400">{reply.timestamp}</span>
+                <span className="text-xs text-gray-400">{new Date(reply.created_at).toLocaleDateString()}</span>
               </div>
             </div>
           ))}
@@ -85,14 +100,11 @@ export default function QuestionDetailPage() {
           />
           <button
             onClick={handleReply}
-            className="mt-2 bg-yellow-500 hover:bg-yellow-600 text-white px-5 py-2 rounded-lg font-semibold flex items-center gap-2"
+            disabled={submitting}
+            className="mt-2 bg-yellow-500 hover:bg-yellow-600 text-white px-5 py-2 rounded-lg font-semibold flex items-center gap-2 disabled:opacity-50"
           >
-            <FaReply /> Reply
+            <FaReply /> {submitting ? 'Posting...' : 'Reply'}
           </button>
-
-          {submitted && (
-            <p className="text-green-600 text-sm mt-2">✅ Reply submitted!</p>
-          )}
         </div>
       </div>
     </StudentLayout>


### PR DESCRIPTION
## Summary
- connect student community list page to backend API
- add backend discussion creation and tag search in student ask page
- fetch only the current user's questions on student "My Questions" page
- load discussion details and replies from backend and allow posting replies

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688a4f35974c83289a4ce4e243030c76