### PR TITLE
Integrate instructor community pages with API

### DIFF
--- a/frontend/src/pages/dashboard/instructor/community/ask.js
+++ b/frontend/src/pages/dashboard/instructor/community/ask.js
@@ -1,16 +1,21 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { FaPaperPlane } from "react-icons/fa";
 import { useRouter } from "next/router";
-
-const availableTags = ["React", "Odoo", "Next.js", "APIs", "UI/UX", "Authentication"];
+import { createDiscussion, searchTags } from "@/services/communityService";
+import toast from "react-hot-toast";
 
 export default function AskQuestionPage() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [selectedTags, setSelectedTags] = useState([]);
   const [submitted, setSubmitted] = useState(false);
+  const [availableTags, setAvailableTags] = useState([]);
   const router = useRouter();
+
+  useEffect(() => {
+    searchTags("").then(setAvailableTags).catch(() => {});
+  }, []);
 
   const toggleTag = (tag) => {
     setSelectedTags((prev) =>
@@ -18,13 +23,27 @@ export default function AskQuestionPage() {
     );
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!title.trim()) return alert("Please enter a question title.");
-    // Here you'd call an API to save the question
-    console.log({ title, description, selectedTags });
-    setSubmitted(true);
-    setTimeout(() => router.push("/dashboard/student/community"), 1000);
+    if (!title.trim()) {
+      toast.error("Please enter a question title.");
+      return;
+    }
+    try {
+      await createDiscussion({
+        title,
+        content: description,
+        tags: selectedTags,
+      });
+      setSubmitted(true);
+      setTitle("");
+      setDescription("");
+      setSelectedTags([]);
+      setTimeout(() => router.push("/dashboard/instructor/community"), 1000);
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to submit question");
+    }
   };
 
   return (
@@ -69,15 +88,15 @@ export default function AskQuestionPage() {
                 {availableTags.map((tag) => (
                   <button
                     type="button"
-                    key={tag}
-                    onClick={() => toggleTag(tag)}
+                    key={tag.id || tag.name || tag}
+                    onClick={() => toggleTag(tag.name || tag)}
                     className={`px-3 py-1 rounded-full text-sm border ${
-                      selectedTags.includes(tag)
+                      selectedTags.includes(tag.name || tag)
                         ? "bg-yellow-500 text-white border-yellow-500"
                         : "bg-gray-100 text-gray-600 border-gray-300 hover:bg-gray-200"
                     }`}
                   >
-                    #{tag}
+                    #{tag.name || tag}
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/dashboard/instructor/community/index.js
+++ b/frontend/src/pages/dashboard/instructor/community/index.js
@@ -1,38 +1,55 @@
-// pages/dashboard/student/community/index.js
+// Instructor community dashboard page
 import { useEffect, useState } from "react";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import Link from "next/link";
 import { FaSearch, FaPlus, FaTags } from "react-icons/fa";
 import toast, { Toaster } from "react-hot-toast";
+import { fetchDiscussions, searchTags } from "@/services/communityService";
+import useAuthStore from "@/store/auth/authStore";
 
-const allDiscussions = [
-  { id: 1, title: "How do I integrate Tailwind with Next.js?", replies: 5, user: "Ali" },
-  { id: 2, title: "Best Odoo learning path for beginners?", replies: 3, user: "Fatima" },
-  { id: 3, title: "React vs Vue: Which is better for SaaS?", replies: 7, user: "Hassan" },
-  { id: 4, title: "How to secure an API with JWT?", replies: 2, user: "Lina" },
-  { id: 5, title: "Best practices for UI design systems?", replies: 6, user: "Yusuf" },
-  { id: 6, title: "How to test React components with Jest?", replies: 1, user: "Aisha" },
-];
-
-const myQuestions = [
-  { id: 101, title: "How to connect Odoo with Google Sheets?", replies: 2, tags: ["Odoo", "API"] },
-  { id: 102, title: "What’s the best Next.js folder structure?", replies: 0, tags: ["Next.js"] },
-];
-
-const mockTags = ["React", "Odoo", "Next.js", "UI/UX", "APIs"];
-
-export default function StudentCommunityPage() {
+export default function InstructorCommunityPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [activeTab, setActiveTab] = useState("all");
   const [activeTag, setActiveTag] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
+  const [allDiscussions, setAllDiscussions] = useState([]);
+  const [tags, setTags] = useState([]);
   const itemsPerPage = 5;
+  const { user } = useAuthStore();
 
-  const discussions = activeTab === "mine" ? myQuestions : allDiscussions;
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const list = await fetchDiscussions();
+        setAllDiscussions(list);
+      } catch (err) {
+        console.error(err);
+        toast.error("Failed to load discussions");
+      }
+    };
+    load();
+    searchTags("").then(setTags).catch(() => {});
+  }, []);
+
+  const normalized = allDiscussions.map((d) => ({
+    ...d,
+    tags: Array.isArray(d.tags)
+      ? d.tags
+      : typeof d.tags === "string" && d.tags
+      ? JSON.parse(d.tags)
+      : [],
+  }));
+
+  const discussions =
+    activeTab === "mine"
+      ? normalized.filter((d) => user && d.user_name === user.full_name)
+      : normalized;
+
   const filtered = discussions.filter(
     (d) =>
       d.title.toLowerCase().includes(searchQuery.toLowerCase()) &&
-      (activeTag === "" || d.title.toLowerCase().includes(activeTag.toLowerCase()))
+      (activeTag === "" ||
+        d.tags.some((t) => t.toLowerCase().includes(activeTag.toLowerCase())))
   );
 
   const paginated = filtered.slice(
@@ -52,7 +69,7 @@ export default function StudentCommunityPage() {
               Share your questions and get help from peers.
             </p>
           </div>
-          <Link href="/dashboard/student/community/ask">
+          <Link href="/dashboard/instructor/community/ask">
             <button className="bg-yellow-500 hover:bg-yellow-600 text-white px-5 py-2 rounded-lg font-semibold flex items-center gap-2">
               <FaPlus /> Ask a Question
             </button>
@@ -104,17 +121,17 @@ export default function StudentCommunityPage() {
         {/* Tags */}
         <div className="flex flex-wrap gap-2 mb-8 items-center">
           <FaTags className="text-yellow-500" />
-          {mockTags.map((tag) => (
+          {tags.map((tag) => (
             <button
-              key={tag}
-              onClick={() => setActiveTag(tag === activeTag ? "" : tag)}
+              key={tag.id || tag.name || tag}
+              onClick={() => setActiveTag((tag.name || tag) === activeTag ? "" : (tag.name || tag))}
               className={`px-3 py-1 rounded-full text-sm border ${
-                tag === activeTag
+                (tag.name || tag) === activeTag
                   ? "bg-yellow-500 text-white border-yellow-500"
                   : "bg-gray-100 text-gray-600 border-gray-300 hover:bg-gray-200"
               }`}
             >
-              #{tag}
+              #{tag.name || tag}
             </button>
           ))}
         </div>
@@ -125,14 +142,14 @@ export default function StudentCommunityPage() {
             paginated.map((d) => (
               <Link
                 key={d.id}
-                href={`/dashboard/student/community/questions/${d.id}`}
+                href={`/dashboard/instructor/community/questions/${d.id}`}
               >
                 <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm hover:shadow-md transition cursor-pointer">
                   <h3 className="text-lg font-semibold text-gray-800 mb-1">
                     {d.title}
                   </h3>
                   <p className="text-sm text-gray-500">
-                    {activeTab === "mine" ? "You" : d.user} • {d.replies} replies
+                    {activeTab === "mine" ? "You" : d.user_name} • {d.replies || 0} replies
                   </p>
                 </div>
               </Link>

--- a/frontend/src/pages/dashboard/instructor/community/my-questions.js
+++ b/frontend/src/pages/dashboard/instructor/community/my-questions.js
@@ -1,29 +1,37 @@
 import { useEffect, useState } from "react";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import Link from "next/link";
-import { FaCommentDots, FaEye } from "react-icons/fa";
-
-const mockMyQuestions = [
-  {
-    id: 1,
-    title: "How to connect Odoo with Google Sheets?",
-    replies: 4,
-    tags: ["Odoo", "API"],
-  },
-  {
-    id: 2,
-    title: "Best way to structure a Next.js education platform?",
-    replies: 2,
-    tags: ["Next.js", "Design"],
-  },
-];
+import { FaEye } from "react-icons/fa";
+import { fetchDiscussions } from "@/services/communityService";
+import useAuthStore from "@/store/auth/authStore";
 
 export default function MyQuestionsPage() {
   const [questions, setQuestions] = useState([]);
+  const { user } = useAuthStore();
 
   useEffect(() => {
-    setQuestions(mockMyQuestions); // Replace with real API later
-  }, []);
+    const load = async () => {
+      try {
+        const list = await fetchDiscussions();
+        const normalized = (list || []).map((q) => ({
+          ...q,
+          tags: Array.isArray(q.tags)
+            ? q.tags
+            : typeof q.tags === "string" && q.tags
+            ? JSON.parse(q.tags)
+            : [],
+        }));
+        if (user) {
+          setQuestions(
+            normalized.filter((q) => q.user_name === user.full_name)
+          );
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [user]);
 
   return (
     <InstructorLayout title="My Questions">
@@ -51,7 +59,7 @@ export default function MyQuestionsPage() {
                     </span>
                   ))}
                 </div>
-                <Link href={`/dashboard/student/community/questions/${q.id}`}>
+                <Link href={`/dashboard/instructor/community/questions/${q.id}`}>
                   <button className="bg-blue-100 text-blue-700 px-4 py-2 rounded text-sm font-semibold flex items-center gap-2 hover:bg-blue-200">
                     <FaEye /> View Discussion
                   </button>

--- a/frontend/src/pages/dashboard/instructor/community/questions/[id].js
+++ b/frontend/src/pages/dashboard/instructor/community/questions/[id].js
@@ -2,20 +2,13 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { FaReply, FaUserCircle } from "react-icons/fa";
+import {
+  fetchDiscussionById,
+  fetchReplies,
+  createReply,
+} from "@/services/communityService";
+import ReactMarkdown from "react-markdown";
 
-const mockQuestions = {
-  1: {
-    id: 1,
-    title: "How do I integrate Tailwind with Next.js?",
-    description: "I'm building a frontend using Next.js. How do I properly use Tailwind CSS with it?",
-    user: "Ali",
-    tags: ["Next.js", "Tailwind"],
-    replies: [
-      { id: 1, author: "Fatima", content: "Install Tailwind via npm and add to your config files.", timestamp: "1 hour ago" },
-      { id: 2, author: "Omar", content: "Check the Tailwind docs — they have a great Next.js guide.", timestamp: "30 mins ago" },
-    ],
-  },
-};
 
 export default function QuestionDetailPage() {
   const router = useRouter();
@@ -25,18 +18,43 @@ export default function QuestionDetailPage() {
   const [replyText, setReplyText] = useState("");
   const [submitted, setSubmitted] = useState(false);
 
+  const [replies, setReplies] = useState([]);
+
   useEffect(() => {
-    if (id && mockQuestions[id]) {
-      setQuestion(mockQuestions[id]);
-    }
+    if (!id) return;
+    const load = async () => {
+      try {
+        const q = await fetchDiscussionById(id);
+        if (q) {
+          setQuestion({
+            ...q,
+            tags: Array.isArray(q.tags)
+              ? q.tags
+              : typeof q.tags === "string" && q.tags
+              ? JSON.parse(q.tags)
+              : [],
+          });
+          const r = await fetchReplies(id);
+          setReplies(r);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
   }, [id]);
 
-  const handleReply = () => {
+  const handleReply = async () => {
     if (!replyText.trim()) return;
-    alert("Reply submitted (mock)");
-    setSubmitted(true);
-    setReplyText("");
-    setTimeout(() => setSubmitted(false), 1500);
+    try {
+      const newReply = await createReply(id, { content: replyText });
+      setReplies([...replies, newReply]);
+      setSubmitted(true);
+      setReplyText("");
+      setTimeout(() => setSubmitted(false), 1500);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   if (!question) return <InstructorLayout title="Loading..."><div className="p-6">Loading...</div></InstructorLayout>;
@@ -47,8 +65,8 @@ export default function QuestionDetailPage() {
         {/* Question */}
         <div className="bg-white border border-gray-200 p-6 rounded-lg shadow">
           <h1 className="text-2xl font-bold mb-2 text-gray-800">{question.title}</h1>
-          <p className="text-sm text-gray-500 mb-2">Asked by <strong>{question.user}</strong></p>
-          <p className="text-gray-700 mb-4">{question.description}</p>
+          <p className="text-sm text-gray-500 mb-2">Asked by <strong>{question.user_name}</strong></p>
+          <p className="text-gray-700 mb-4">{question.content}</p>
           <div className="flex gap-2 flex-wrap">
             {question.tags.map((tag) => (
               <span key={tag} className="text-xs px-3 py-1 bg-yellow-100 text-yellow-800 rounded-full font-medium">
@@ -61,13 +79,13 @@ export default function QuestionDetailPage() {
         {/* Replies */}
         <div className="space-y-4">
           <h2 className="text-lg font-semibold text-gray-800">Replies</h2>
-          {question.replies.map((reply) => (
+          {replies.map((reply) => (
             <div key={reply.id} className="bg-gray-50 border border-gray-200 p-4 rounded-lg flex gap-3">
               <FaUserCircle className="text-3xl text-gray-400" />
               <div>
-                <p className="text-sm font-semibold text-gray-800">{reply.author}</p>
-                <p className="text-gray-600 text-sm">{reply.content}</p>
-                <span className="text-xs text-gray-400">{reply.timestamp}</span>
+                <p className="text-sm font-semibold text-gray-800">{reply.user_name}</p>
+                <p className="text-gray-600 text-sm"><ReactMarkdown>{reply.content}</ReactMarkdown></p>
+                <span className="text-xs text-gray-400">{new Date(reply.created_at).toLocaleDateString()}</span>
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- connect instructor community index with real backend data
- wire up ask page to create discussions via API
- list instructor's questions from backend
- load discussions and replies for detail page

## Testing
- `cd backend && npm test --silent`
- `cd frontend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a4f621b78832890874c4b8a4ffd48