### PR TITLE
Fix admin community navigation

### DIFF
--- a/frontend/src/pages/dashboard/admin/community/discussions/index.js
+++ b/frontend/src/pages/dashboard/admin/community/discussions/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import {
   FaSearch,
@@ -19,6 +20,7 @@ export default function AdminCommunityDiscussionsPage() {
   const [discussions, setDiscussions] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
+  const router = useRouter();
 
   useEffect(() => {
     const load = async () => {
@@ -40,7 +42,7 @@ export default function AdminCommunityDiscussionsPage() {
   }, []);
 
   const handleView = (discussion) => {
-    window.location.href = `/dashboard/admin/community/discussions/${discussion.id}`;
+    router.push(`/dashboard/admin/community/discussions/${discussion.id}`);
   };
 
   const handleLock = async (discussion) => {


### PR DESCRIPTION
## Summary
- fix navigation in admin community discussions to use Next.js router

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688a50b4a8148328a8c2191acbabd7e7