### PR TITLE
Add third party AI integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ Administrators can monitor runtime warnings and errors from the dashboard. The a
 ## Admin category management
 
 Admins can build a nested list of course categories. CRUD endpoints live under `/api/users/admin/categories`. See [docs/admin-category-management.md](docs/admin-category-management.md) for an overview of the routes and frontend pages.
+
+## Third-party integrations
+
+The admin dashboard page under `Settings → Third Party` lets you configure API keys for several external services such as ChatGPT, DeepSeek or Claude. See [docs/admin-third-party-integrations.md](docs/admin-third-party-integrations.md) for details. Once keys are saved, users can choose a provider on the community Ask page and request AI-generated answers.

--- a/docs/admin-third-party-integrations.md
+++ b/docs/admin-third-party-integrations.md
@@ -1,0 +1,20 @@
+# Admin Third Party Integrations
+
+SkillBridge lets administrators manage API keys and settings for various third-party services. These include multiple AI chat providers used on the community "Ask" page.
+
+## Backend
+
+- **Settings storage:** `backend/src/modules/thirdPartyConfig`
+- **API endpoints:** `/api/third-party-config` for get and update
+- **AI endpoint:** `/api/ai-assistance` implemented in `backend/src/modules/ai`
+- AI service reads provider config from the settings record before sending requests.
+
+## Frontend
+
+- Admin page: `frontend/src/pages/dashboard/admin/settings/thirdParty`
+- Integration modals under `frontend/src/components/admin/integrations` allow entering API keys for ChatGPT, DeepSeek, Claude, Gemini and Hugging Face.
+- Saved settings are fetched through `frontend/src/services/admin/thirdPartyService.js`.
+- Community question page `frontend/src/pages/community/ask.js` calls `fetchThirdPartyConfig` to list available AI providers for users.
+- When no provider has an API key configured the page shows "No AI integrations available".
+
+After storing keys on the admin page, users can select a provider from a dropdown on the AI Assistance tab and submit questions powered by the chosen model.


### PR DESCRIPTION
## Summary
- explain how admins can configure ChatGPT, DeepSeek and other AI services
- link to the new doc from the README

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_688a52b0f1b883288fb57c7cc2d691cb