### PR TITLE
Connect ChatGPT API

### DIFF
--- a/backend/src/modules/ai/ai.service.js
+++ b/backend/src/modules/ai/ai.service.js
@@ -1,12 +1,47 @@
 const thirdPartyConfig = require('../thirdPartyConfig/thirdPartyConfig.service');
 
+/**
+ * Send a question to an AI provider and return the answer.
+ * Currently supports the ChatGPT API when the provider key is "chatgpt".
+ * Other providers fall back to a simple stubbed response.
+ */
 exports.answerWithAI = async (provider, question) => {
   const cfg = (await thirdPartyConfig.getSettings()) || {};
   const settings = cfg[provider] || {};
+
   if (!settings.apiKey) {
     return { answer: null, error: 'No API key configured' };
   }
-  // This is a stub. Replace with real API calls.
+
+  if (provider === 'chatgpt') {
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${settings.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: settings.model || 'gpt-3.5-turbo',
+          messages: [{ role: 'user', content: question }],
+          temperature: settings.temperature ?? 0.7,
+        }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        return { answer: null, error: text };
+      }
+
+      const data = await res.json();
+      const answer = data.choices?.[0]?.message?.content?.trim();
+      return { answer, confidence: 0.9 };
+    } catch (err) {
+      return { answer: null, error: err.message };
+    }
+  }
+
+  // Fallback stub for providers not yet implemented
   return {
     answer: `(${provider}) AI answer for: ${question}`,
     confidence: 0.9,

--- a/docs/admin-third-party-integrations.md
+++ b/docs/admin-third-party-integrations.md
@@ -18,3 +18,13 @@ SkillBridge lets administrators manage API keys and settings for various third-p
 - When no provider has an API key configured the page shows "No AI integrations available".
 
 After storing keys on the admin page, users can select a provider from a dropdown on the AI Assistance tab and submit questions powered by the chosen model.
+
+### ChatGPT Configuration
+
+1. Sign in to your OpenAI account and create an API key.
+2. In the admin dashboard navigate to **Settings → Third Party** and open the
+   **ChatGPT** modal.
+3. Paste the key into the **API Key** field and optionally adjust the model name
+   (e.g. `gpt-4`) and temperature.
+4. Click **Save** to persist the settings. The backend will use these values
+   when calling the OpenAI Chat Completion API.


### PR DESCRIPTION
## Summary
- hook up ChatGPT integration using the OpenAI Chat Completion API
- document how admins can configure ChatGPT keys in the dashboard

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a55e28ac88328b6a341e2f2a03683