### PR TITLE
Connect ChatGPT API

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ Admins can build a nested list of course categories. CRUD endpoints live under `
 
 ## Third-party integrations
 
-The admin dashboard page under `Settings → Third Party` lets you configure API keys for several external services such as ChatGPT, DeepSeek or Claude. See [docs/admin-third-party-integrations.md](docs/admin-third-party-integrations.md) for details. Once keys are saved, users can choose a provider on the community Ask page and request AI-generated answers.
+The admin dashboard page under `Settings → Third Party` lets you configure API keys for several external services such as ChatGPT, DeepSeek or Claude. For ChatGPT you can register multiple models that users may pick from. See [docs/admin-third-party-integrations.md](docs/admin-third-party-integrations.md) for details. Once keys are saved, users can choose a provider on the community Ask page and request AI-generated answers.

--- a/backend/src/modules/ai/ai.controller.js
+++ b/backend/src/modules/ai/ai.controller.js
@@ -3,8 +3,8 @@ const { sendSuccess } = require('../../utils/response');
 const service = require('./ai.service');
 
 exports.answer = catchAsync(async (req, res) => {
-  const { provider, question } = req.body || {};
-  const result = await service.answerWithAI(provider, question);
+  const { provider, question, model } = req.body || {};
+  const result = await service.answerWithAI(provider, question, model);
   if (result.error) {
     return res.status(400).json({ message: result.error });
   }

--- a/backend/src/modules/ai/ai.service.js
+++ b/backend/src/modules/ai/ai.service.js
@@ -1,12 +1,64 @@
 const thirdPartyConfig = require('../thirdPartyConfig/thirdPartyConfig.service');
 
-exports.answerWithAI = async (provider, question) => {
+/**
+ * Send a question to an AI provider and return the answer.
+ * Currently supports the ChatGPT API when the provider key is "chatgpt".
+ * A specific ChatGPT model can be chosen via the `model` argument when
+ * multiple models are configured in the settings.
+ * Other providers fall back to a simple stubbed response.
+ */
+exports.answerWithAI = async (provider, question, model) => {
   const cfg = (await thirdPartyConfig.getSettings()) || {};
   const settings = cfg[provider] || {};
+
   if (!settings.apiKey) {
     return { answer: null, error: 'No API key configured' };
   }
-  // This is a stub. Replace with real API calls.
+
+  if (provider === 'chatgpt') {
+    try {
+      const models = Array.isArray(settings.models)
+        ? settings.models
+        : settings.model
+          ? [{ name: settings.model, temperature: settings.temperature }]
+          : [];
+
+      const selected = model
+        ? models.find((m) => m.name === model)
+        : models[0];
+
+      if (!selected) {
+        return { answer: null, error: 'Model not configured' };
+      }
+
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${settings.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: selected.name,
+          messages: [{ role: 'user', content: question }],
+          temperature:
+            selected.temperature ?? settings.temperature ?? 0.7,
+        }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        return { answer: null, error: text };
+      }
+
+      const data = await res.json();
+      const answer = data.choices?.[0]?.message?.content?.trim();
+      return { answer, confidence: 0.9 };
+    } catch (err) {
+      return { answer: null, error: err.message };
+    }
+  }
+
+  // Fallback stub for providers not yet implemented
   return {
     answer: `(${provider}) AI answer for: ${question}`,
     confidence: 0.9,

--- a/docs/admin-third-party-integrations.md
+++ b/docs/admin-third-party-integrations.md
@@ -18,3 +18,16 @@ SkillBridge lets administrators manage API keys and settings for various third-p
 - When no provider has an API key configured the page shows "No AI integrations available".
 
 After storing keys on the admin page, users can select a provider from a dropdown on the AI Assistance tab and submit questions powered by the chosen model.
+
+### ChatGPT Configuration
+
+1. Sign in to your OpenAI account and create an API key.
+2. In the admin dashboard navigate to **Settings → Third Party** and open the
+   **ChatGPT** modal.
+3. Paste the key into the **API Key** field. You can configure multiple models
+   by listing their names and default temperatures.
+4. Click **Add model** in the modal to create additional model rows (e.g.
+   `gpt-4`, `gpt-3.5-turbo`). Each question on the Ask page can then choose one
+   of the configured models.
+5. Click **Save** to persist the settings. The backend will use the selected
+   model when calling the OpenAI Chat Completion API.

--- a/frontend/src/components/admin/integrations/ChatGPTModal.js
+++ b/frontend/src/components/admin/integrations/ChatGPTModal.js
@@ -4,15 +4,41 @@ import { FaTimes, FaSave } from "react-icons/fa";
 import { toast } from "react-toastify";
 
 export default function ChatGPTModal({ initialData = {}, onClose, onSave }) {
+  const initModels = initialData.models
+    ? initialData.models
+    : initialData.model
+      ? [{ name: initialData.model, temperature: initialData.temperature ?? 0.7 }]
+      : [{ name: "gpt-4", temperature: 0.7 }];
+
   const [form, setForm] = useState({
-    apiKey: "",
-    model: "gpt-4",
-    temperature: 0.7,
-    ...initialData,
+    apiKey: initialData.apiKey || "",
+    models: initModels,
   });
 
   const handleChange = (key, value) => {
     setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleModelChange = (index, key, value) => {
+    setForm((prev) => {
+      const models = [...prev.models];
+      models[index] = { ...models[index], [key]: value };
+      return { ...prev, models };
+    });
+  };
+
+  const addModel = () => {
+    setForm((prev) => ({
+      ...prev,
+      models: [...prev.models, { name: "", temperature: 0.7 }],
+    }));
+  };
+
+  const removeModel = (index) => {
+    setForm((prev) => ({
+      ...prev,
+      models: prev.models.filter((_, i) => i !== index),
+    }));
   };
 
   const handleSubmit = async () => {
@@ -49,29 +75,46 @@ export default function ChatGPTModal({ initialData = {}, onClose, onSave }) {
             />
           </div>
 
-          <div>
-            <label className="block font-medium">Model</label>
-            <select
-              value={form.model}
-              onChange={(e) => handleChange("model", e.target.value)}
-              className="w-full border border-gray-300 rounded px-3 py-2"
+          <div className="space-y-3">
+            <label className="block font-medium">Models</label>
+            {form.models.map((m, idx) => (
+              <div key={idx} className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={m.name}
+                  onChange={(e) => handleModelChange(idx, "name", e.target.value)}
+                  placeholder="gpt-4"
+                  className="flex-1 border border-gray-300 rounded px-2 py-1"
+                />
+                <input
+                  type="number"
+                  step="0.1"
+                  min="0"
+                  max="1"
+                  value={m.temperature}
+                  onChange={(e) =>
+                    handleModelChange(idx, "temperature", parseFloat(e.target.value))
+                  }
+                  className="w-24 border border-gray-300 rounded px-2 py-1"
+                />
+                {form.models.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => removeModel(idx)}
+                    className="text-red-600"
+                  >
+                    &times;
+                  </button>
+                )}
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addModel}
+              className="text-sm text-blue-600 hover:underline"
             >
-              <option value="gpt-4">GPT-4</option>
-              <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
-            </select>
-          </div>
-
-          <div>
-            <label className="block font-medium">Temperature</label>
-            <input
-              type="number"
-              step="0.1"
-              min="0"
-              max="1"
-              value={form.temperature}
-              onChange={(e) => handleChange("temperature", parseFloat(e.target.value))}
-              className="w-full border border-gray-300 rounded px-3 py-2"
-            />
+              Add model
+            </button>
           </div>
         </div>
 

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -36,6 +36,8 @@ const AskQuestionPage = () => {
   const [showPreview, setShowPreview] = useState(false);
   const [aiOptions, setAiOptions] = useState([]);
   const [selectedAI, setSelectedAI] = useState("");
+  const [chatGPTModels, setChatGPTModels] = useState([]);
+  const [selectedModel, setSelectedModel] = useState("");
 
   // ✅ Fetch Related Questions Based on Title Input
   useEffect(() => {
@@ -59,7 +61,16 @@ const AskQuestionPage = () => {
       try {
         const cfg = await fetchThirdPartyConfig();
         const opts = [];
-        if (cfg.chatgpt?.apiKey) opts.push('chatgpt');
+        if (cfg.chatgpt?.apiKey) {
+          opts.push('chatgpt');
+          if (Array.isArray(cfg.chatgpt.models)) {
+            setChatGPTModels(cfg.chatgpt.models);
+          } else if (cfg.chatgpt.model) {
+            setChatGPTModels([{ name: cfg.chatgpt.model }]);
+          } else {
+            toast.warning('ChatGPT models not configured');
+          }
+        }
         if (cfg.deepseek?.apiKey) opts.push('deepseek');
         if (cfg.claude?.apiKey) opts.push('claude');
         if (cfg.gemini?.apiKey) opts.push('gemini');
@@ -122,6 +133,10 @@ const AskQuestionPage = () => {
       toast.info('Select AI provider');
       return;
     }
+    if (selectedAI === 'chatgpt' && !selectedModel) {
+      toast.info('Select ChatGPT model');
+      return;
+    }
 
     setIsProcessingAI(true);
     setAIResponse("");
@@ -131,7 +146,11 @@ const AskQuestionPage = () => {
       const response = await fetch(AI_API_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ question: title, provider: selectedAI }),
+        body: JSON.stringify({
+          question: title,
+          provider: selectedAI,
+          model: selectedAI === 'chatgpt' ? selectedModel : undefined,
+        }),
       });
 
       const data = await response.json();
@@ -256,7 +275,10 @@ const handleAcceptAIResponse = () => {
             {aiOptions.length > 0 && (
               <select
                 value={selectedAI}
-                onChange={(e) => setSelectedAI(e.target.value)}
+                onChange={(e) => {
+                  setSelectedAI(e.target.value);
+                  setSelectedModel("");
+                }}
                 className="w-full p-3 mt-3 bg-gray-700 rounded-md text-white"
               >
                 <option value="">Select AI Provider</option>
@@ -266,6 +288,23 @@ const handleAcceptAIResponse = () => {
                   </option>
                 ))}
               </select>
+            )}
+            {selectedAI === 'chatgpt' && chatGPTModels.length > 0 && (
+              <select
+                value={selectedModel}
+                onChange={(e) => setSelectedModel(e.target.value)}
+                className="w-full p-3 mt-3 bg-gray-700 rounded-md text-white"
+              >
+                <option value="">Select ChatGPT Model</option>
+                {chatGPTModels.map((m) => (
+                  <option key={m.name} value={m.name}>
+                    {m.name}
+                  </option>
+                ))}
+              </select>
+            )}
+            {selectedAI === 'chatgpt' && chatGPTModels.length === 0 && (
+              <p className="text-red-400 mt-3">ChatGPT models not configured.</p>
             )}
             {aiOptions.length === 0 && (
               <p className="text-red-400 mt-3">No AI integrations available.</p>


### PR DESCRIPTION
## Summary
- hook up ChatGPT integration using the OpenAI Chat Completion API
- document how admins can configure ChatGPT keys in the dashboard
- allow configuring multiple ChatGPT models and selecting them on the Ask page

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a55e28ac88328b6a341e2f2a03683