### PR TITLE
Add frontend community page tests

### DIFF
--- a/frontend/src/tests/__tests__/CommunityPages.test.js
+++ b/frontend/src/tests/__tests__/CommunityPages.test.js
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CommunityPage from '../../pages/community';
+import AskQuestionPage from '../../pages/community/ask';
+import QuestionDetails from '../../pages/community/question/details';
+import * as communityService from '../../services/communityService';
+
+jest.mock('../../components/website/sections/Navbar', () => () => <div>Navbar</div>);
+jest.mock('../../components/website/sections/Footer', () => () => <div>Footer</div>);
+jest.mock('../../components/community/QuestionCard', () => ({ question }) => <div>{question.title}</div>);
+jest.mock('../../components/community/Filters', () => () => <div />);
+jest.mock('../../components/community/Pagination', () => () => <div />);
+jest.mock('../../components/FileUploader', () => () => <div />);
+// simple textarea mock for rich text editor
+jest.mock('../../components/RichTextEditor', () => ({ onChange }) => (
+  <textarea data-testid="editor" onChange={(e) => onChange && onChange(e.target.value)} />
+));
+jest.mock('react-markdown', () => (props) => <div>{props.children}</div>);
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }) => <a href={href}>{children}</a>,
+}));
+
+const mockUseRouter = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => mockUseRouter(),
+}));
+
+jest.mock('../../services/communityService');
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+beforeAll(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ questions: [] }) })
+  );
+});
+
+const { fetchDiscussions, createDiscussion, fetchDiscussionById, fetchReplies, createReply } = communityService;
+
+
+describe('Community pages', () => {
+  test('discussions load on community page', async () => {
+    fetchDiscussions.mockResolvedValue([{ id: 1, title: 'First question' }]);
+    mockUseRouter.mockReturnValue({});
+    render(<CommunityPage />);
+    expect(fetchDiscussions).toHaveBeenCalled();
+    expect(await screen.findByText('First question')).toBeInTheDocument();
+  });
+
+  test('submitting a question triggers API call', async () => {
+    createDiscussion.mockResolvedValue({});
+    mockUseRouter.mockReturnValue({});
+    render(<AskQuestionPage />);
+    fireEvent.change(screen.getByPlaceholderText('Enter question title'), {
+      target: { value: 'My Question' },
+    });
+    fireEvent.click(screen.getByText(/Submit Question/i));
+    await waitFor(() => {
+      expect(createDiscussion).toHaveBeenCalledWith({
+        title: 'My Question',
+        content: '',
+        tags: [],
+      });
+    });
+  });
+
+  test('posting a reply displays it', async () => {
+    fetchDiscussionById.mockResolvedValue({ id: 1, title: 'Q', content: '' });
+    fetchReplies.mockResolvedValue([]);
+    createReply.mockResolvedValue({
+      id: 2,
+      content: 'My reply',
+      user_name: 'User',
+      created_at: new Date().toISOString(),
+    });
+    mockUseRouter.mockReturnValue({ query: { id: '1' }, push: jest.fn() });
+    render(<QuestionDetails />);
+    expect(await screen.findByText('Q')).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('editor'), {
+      target: { value: 'My reply' },
+    });
+    fireEvent.click(screen.getByText('Post Reply'));
+    await waitFor(() => {
+      expect(createReply).toHaveBeenCalled();
+    });
+    expect(await screen.findByText('My reply')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add new Jest tests for community pages to ensure discussions load, questions submit, and replies post

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a5c1758cc832882a452089e1ec72c