### PR TITLE
Check for empty tags before posting discussion

### DIFF
--- a/frontend/src/pages/dashboard/student/community/ask.js
+++ b/frontend/src/pages/dashboard/student/community/ask.js
@@ -45,6 +45,10 @@ export default function AskQuestionPage() {
       toast.error("Title required");
       return;
     }
+    if (selectedTags.length === 0) {
+      toast.error("At least one tag required");
+      return;
+    }
     try {
       await createDiscussion({ title, content: description, tags: selectedTags });
       setSubmitted(true);


### PR DESCRIPTION
## Summary
- prevent submitting a new discussion without any tags

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a5c1599308328bf0a79bb539b6f13