### PR TITLE
Add AI service and hook up tutoring pages

### DIFF
--- a/frontend/src/pages/ai-tutoring/chat.js
+++ b/frontend/src/pages/ai-tutoring/chat.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { askAI } from "@/services/aiService";
 
 const models = [
   { key: "chatgpt", label: "ChatGPT 4" },
@@ -10,20 +11,22 @@ export default function AIChatTutorPage() {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
 
-  const sendMessage = () => {
+  const sendMessage = async () => {
     if (!input.trim()) return;
     const userMessage = { sender: "user", text: input };
     setMessages((prev) => [...prev, userMessage]);
     setInput("");
 
-    // Simulate AI response
-    setTimeout(() => {
-      const aiReply = {
-        sender: "ai",
-        text: `🤖 [${selectedModel.toUpperCase()}] Here’s a helpful explanation for: "${userMessage.text}"`
-      };
+    try {
+      const { answer } = await askAI(selectedModel, userMessage.text);
+      const aiReply = { sender: "ai", text: answer };
       setMessages((prev) => [...prev, aiReply]);
-    }, 1000);
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        { sender: "ai", text: "Error fetching response" },
+      ]);
+    }
   };
 
   return (

--- a/frontend/src/pages/ai-tutoring/feedback.js
+++ b/frontend/src/pages/ai-tutoring/feedback.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { askAI } from "@/services/aiService";
 
 const models = [
   { key: "chatgpt", label: "ChatGPT 4" },
@@ -11,20 +12,19 @@ export default function InstantFeedbackPage() {
   const [feedback, setFeedback] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!text.trim()) return;
     setLoading(true);
     setFeedback(null);
 
-    setTimeout(() => {
-      setFeedback(
-        `🤖 [${selectedModel.toUpperCase()}] Feedback:
-
-Great structure! Make sure to elaborate more on paragraph 2.
-Keep your tone consistent and cite sources properly.`
-      );
+    try {
+      const { answer } = await askAI(selectedModel, text);
+      setFeedback(answer);
+    } catch (err) {
+      setFeedback("Error fetching feedback");
+    } finally {
       setLoading(false);
-    }, 1500);
+    }
   };
 
   return (

--- a/frontend/src/pages/ai-tutoring/lesson-planner.js
+++ b/frontend/src/pages/ai-tutoring/lesson-planner.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { FaArrowRight } from "react-icons/fa";
+import { askAI } from "@/services/aiService";
 
 const goals = [
   "Improve coding skills",
@@ -26,20 +27,25 @@ export default function LessonPlannerPage() {
     setLoading(true);
     setGeneratedPlan(null);
 
-    // Simulate API call (replace with real backend integration)
-    setTimeout(() => {
+    try {
+      const { answer } = await askAI(
+        selectedModel,
+        `Create a lesson plan for: ${selectedGoal}`
+      );
       setGeneratedPlan({
         goal: selectedGoal,
         model: selectedModel,
-        plan: [
-          "🧠 Week 1: Assessment & foundational concepts",
-          "📘 Week 2–3: Targeted lessons with interactive content",
-          "📝 Week 4: Practice quizzes + feedback",
-          "🚀 Week 5+: Final project and certification prep"
-        ]
+        plan: answer.split("\n").filter(Boolean),
       });
+    } catch (err) {
+      setGeneratedPlan({
+        goal: selectedGoal,
+        model: selectedModel,
+        plan: ["Error generating plan"],
+      });
+    } finally {
       setLoading(false);
-    }, 1000);
+    }
   };
 
   return (

--- a/frontend/src/pages/ai-tutoring/research.js
+++ b/frontend/src/pages/ai-tutoring/research.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { askAI } from "@/services/aiService";
 
 const models = [
   { key: "chatgpt", label: "ChatGPT 4" },
@@ -19,24 +20,32 @@ export default function ResearchAssistantPage() {
   const [followUp, setFollowUp] = useState("");
   const [followUpResponse, setFollowUpResponse] = useState(null);
 
-  const handleAnalyze = () => {
+  const handleAnalyze = async () => {
     if (!inputText.trim()) return;
     setLoading(true);
     setOutput(null);
 
-    setTimeout(() => {
-      setOutput(
-        selectedMode === "summary"
-          ? `📚 [${selectedModel.toUpperCase()}] Summary:\n\nThis paper presents an overview of key findings, emphasizes important correlations, and outlines suggestions for future research.`
-          : `🧠 [${selectedModel.toUpperCase()}] Explanation:\n\nThis section discusses complex methodologies. The use of regression analysis implies a predictive modeling approach, focusing on variable X's impact on Y.`
+    try {
+      const { answer } = await askAI(
+        selectedModel,
+        `${selectedMode}: ${inputText}`
       );
+      setOutput(answer);
+    } catch (err) {
+      setOutput("Error generating response");
+    } finally {
       setLoading(false);
-    }, 1500);
+    }
   };
 
-  const handleFollowUp = () => {
+  const handleFollowUp = async () => {
     if (!followUp.trim()) return;
-    setFollowUpResponse(`💬 [${selectedModel.toUpperCase()}] Follow-up response:\n\nHere's what you need to know about: "${followUp}". It's a crucial element in context of the provided content.`);
+    try {
+      const { answer } = await askAI(selectedModel, followUp);
+      setFollowUpResponse(answer);
+    } catch (err) {
+      setFollowUpResponse("Error fetching response");
+    }
   };
 
   const handleFileUpload = (e) => {

--- a/frontend/src/pages/ai-tutoring/transcript.js
+++ b/frontend/src/pages/ai-tutoring/transcript.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { FaDownload, FaHistory } from "react-icons/fa";
+import { askAI } from "@/services/aiService";
 
 const mockTranscript = {
   model: "ChatGPT 4",
@@ -17,8 +18,19 @@ export default function AITranscriptPage() {
   const [data, setData] = useState(null);
 
   useEffect(() => {
-    // Simulate fetching user transcript
-    setTimeout(() => setData(mockTranscript), 800);
+    const load = async () => {
+      try {
+        const { answer } = await askAI(
+          "chatgpt",
+          "Provide a sample learning transcript as JSON"
+        );
+        const parsed = JSON.parse(answer);
+        setData(parsed);
+      } catch (err) {
+        setData(mockTranscript);
+      }
+    };
+    load();
   }, []);
 
   const downloadTranscript = () => {

--- a/frontend/src/services/aiService.js
+++ b/frontend/src/services/aiService.js
@@ -1,0 +1,15 @@
+import api from "@/services/api/api";
+
+/**
+ * Send a question to the AI backend and return the answer.
+ * @param {string} provider - AI provider key
+ * @param {string} question - Question text
+ * @param {string} [model] - Optional model name
+ * @returns {Promise<object>} { answer: string, ... }
+ */
+export const askAI = async (provider, question, model) => {
+  const { data } = await api.post("/ai", { provider, question, model });
+  return data?.data ?? data;
+};
+
+export default { askAI };


### PR DESCRIPTION
## Summary
- add `aiService` for querying `/api/ai`
- connect Chat Tutor, Lesson Planner, Instant Feedback, Research Assistant, and Transcript pages to the new service

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a5c14ae788328a0c1bc1716ce407e