### PR TITLE
Add Hugging Face provider

### DIFF
--- a/backend/src/modules/ai/ai.service.js
+++ b/backend/src/modules/ai/ai.service.js
@@ -71,6 +71,35 @@ exports.answerWithAI = async (provider, question, model) => {
     }
   }
 
+  if (provider === 'huggingface') {
+    try {
+      const url = `https://api-inference.huggingface.co/models/${settings.model}`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${settings.token || settings.apiKey}`,
+        },
+        body: JSON.stringify({ inputs: question }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        return { answer: null, error: text };
+      }
+
+      const data = await res.json();
+      let answer = '';
+      if (Array.isArray(data) && data[0]?.generated_text) answer = data[0].generated_text;
+      else if (data?.generated_text) answer = data.generated_text;
+      else if (data?.answer) answer = data.answer;
+      else answer = JSON.stringify(data);
+      return { answer, confidence: 0.9 };
+    } catch (err) {
+      return { answer: null, error: err.message };
+    }
+  }
+
   // Fallback stub for providers not yet implemented
   return {
     answer: `(${provider}) AI answer for: ${question}`,

--- a/docs/admin-third-party-integrations.md
+++ b/docs/admin-third-party-integrations.md
@@ -31,3 +31,13 @@ After storing keys on the admin page, users can select a provider from a dropdow
    of the configured models.
 5. Click **Save** to persist the settings. The backend will use the selected
    model when calling the OpenAI Chat Completion API.
+
+### Hugging Face Configuration
+
+1. Generate an access token in your Hugging Face account: <https://huggingface.co/settings/tokens>.
+   A fine‑grained token with the `inference:serverless` permission is sufficient.
+2. In the admin dashboard open **Settings → Third Party** and launch the **Hugging Face** modal.
+3. Paste the token into the **Access Token** field and specify the desired model
+   endpoint (e.g. `gpt2` or `google/flan-t5-base`).
+4. Click **Save** to store the settings.
+5. Users can now choose `huggingface` as the provider when asking AI questions.


### PR DESCRIPTION
## Summary
- support Hugging Face tokens in AI service
- document how to configure a Hugging Face access token for admins

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a684d48108328917e0c60101ba882