### PR TITLE
Add Google Analytics & AdSense integrations

### DIFF
--- a/backend/src/modules/adsense/adsense.controller.js
+++ b/backend/src/modules/adsense/adsense.controller.js
@@ -1,0 +1,8 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("../thirdPartyConfig/thirdPartyConfig.service");
+
+exports.getConfig = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings?.googleAdSense || {});
+});

--- a/backend/src/modules/adsense/adsense.routes.js
+++ b/backend/src/modules/adsense/adsense.routes.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./adsense.controller");
+
+router.get("/", controller.getConfig);
+
+module.exports = router;

--- a/backend/src/modules/googleAnalytics/googleAnalytics.controller.js
+++ b/backend/src/modules/googleAnalytics/googleAnalytics.controller.js
@@ -1,0 +1,8 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("../thirdPartyConfig/thirdPartyConfig.service");
+
+exports.getConfig = catchAsync(async (_req, res) => {
+  const settings = await service.getSettings();
+  sendSuccess(res, settings?.googleAnalytics || {});
+});

--- a/backend/src/modules/googleAnalytics/googleAnalytics.routes.js
+++ b/backend/src/modules/googleAnalytics/googleAnalytics.routes.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./googleAnalytics.controller");
+
+router.get("/", controller.getConfig);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -100,6 +100,8 @@ app.use("/api/messages/config", require("./modules/messagesConfig/messagesConfig
 app.use("/api/social-login/config", require("./modules/socialLoginConfig/socialLoginConfig.routes"));
 app.use("/api/app-config", require("./modules/appConfig/appConfig.routes"));
 app.use("/api/third-party-config", require("./modules/thirdPartyConfig/thirdPartyConfig.routes"));
+app.use("/api/google-analytics", require("./modules/googleAnalytics/googleAnalytics.routes"));
+app.use("/api/adsense", require("./modules/adsense/adsense.routes"));
 app.use("/api/ai-assistance", require("./modules/ai/ai.routes"));
 app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));
 app.use("/api/contact-config", require("./modules/contactConfig/contactConfig.routes"));

--- a/backend/tests/adsenseRoutes.test.js
+++ b/backend/tests/adsenseRoutes.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/thirdPartyConfig/thirdPartyConfig.service', () => ({
+  getSettings: jest.fn(),
+}));
+
+const service = require('../src/modules/thirdPartyConfig/thirdPartyConfig.service');
+const routes = require('../src/modules/adsense/adsense.routes');
+
+const app = express();
+app.use('/api/adsense', routes);
+
+describe('GET /api/adsense', () => {
+  it('returns adsense config', async () => {
+    const cfg = { clientID: 'pub', slotID: '123', enabled: true };
+    service.getSettings.mockResolvedValue({ googleAdSense: cfg });
+
+    const res = await request(app).get('/api/adsense');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(cfg);
+    expect(service.getSettings).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/googleAnalyticsRoutes.test.js
+++ b/backend/tests/googleAnalyticsRoutes.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/thirdPartyConfig/thirdPartyConfig.service', () => ({
+  getSettings: jest.fn(),
+}));
+
+const service = require('../src/modules/thirdPartyConfig/thirdPartyConfig.service');
+const routes = require('../src/modules/googleAnalytics/googleAnalytics.routes');
+
+const app = express();
+app.use('/api/google-analytics', routes);
+
+describe('GET /api/google-analytics', () => {
+  it('returns analytics config', async () => {
+    const cfg = { measurementId: 'G-TEST', enabled: true };
+    service.getSettings.mockResolvedValue({ googleAnalytics: cfg });
+
+    const res = await request(app).get('/api/google-analytics');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(cfg);
+    expect(service.getSettings).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/shared/GoogleAd.js
+++ b/frontend/src/components/shared/GoogleAd.js
@@ -12,6 +12,19 @@ const GoogleAd = ({ slot }) => {
 
   useEffect(() => {
     if (adConfig && adConfig.enabled) {
+      if (!document.querySelector('script[data-adsbygoogle]')) {
+        const script = document.createElement('script');
+        script.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js';
+        script.async = true;
+        script.dataset.adsbygoogle = 'true';
+        script.crossOrigin = 'anonymous';
+        document.body.appendChild(script);
+      }
+    }
+  }, [adConfig]);
+
+  useEffect(() => {
+    if (adConfig && adConfig.enabled) {
       try {
         (window.adsbygoogle = window.adsbygoogle || []).push({});
       } catch (e) {

--- a/frontend/src/components/website/sections/Footer.js
+++ b/frontend/src/components/website/sections/Footer.js
@@ -181,25 +181,10 @@ const Footer = () => {
           </div>
         </div>
 
-         {/* Google AdSense Ads (If Enabled) */}
-         {/* {showAds && ( */}
-          <div className="mt-6 text-center">
-            {/* <h4 className="text-lg font-bold text-yellow-400 flex items-center gap-2 justify-center">
-              <FaBullhorn /> Sponsored Ads
-            </h4> */}
-            <div className="text-center">
-              {/* Google AdSense Ad Slot */}
-              {/* <ins className="adsbygoogle"
-                style={{ display: "block" }}
-                data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
-                data-ad-slot="1234567890"
-                data-ad-format="auto"
-                data-full-width-responsive="true">
-              </ins> */}
-            </div>
-          </div>
-        {/* )}
-         */}
+        {/* Google AdSense Ads (If Enabled) */}
+        <div className="mt-6 text-center">
+          <GoogleAd />
+        </div>
 
         {/* Divider */}
         <hr className="border-gray-700 my-6" />

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -87,6 +87,28 @@ function MyApp({ Component, pageProps, router, seoSettings }) {
   }, [configLoaded, fetchConfig]);
 
   useEffect(() => {
+    fetch('/api/google-analytics')
+      .then((res) => res.json())
+      .then((cfg) => {
+        if (cfg.enabled && cfg.measurementId) {
+          if (!document.querySelector(`script[data-ga-measurement-id="${cfg.measurementId}"]`)) {
+            const s = document.createElement('script');
+            s.async = true;
+            s.src = `https://www.googletagmanager.com/gtag/js?id=${cfg.measurementId}`;
+            s.dataset.gaMeasurementId = cfg.measurementId;
+            document.head.appendChild(s);
+
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){window.dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', cfg.measurementId);
+          }
+        }
+      })
+      .catch((err) => console.error('Failed to load Google Analytics', err));
+  }, []);
+
+  useEffect(() => {
     if (seoSettings && !seoLoaded) {
       updateSEO(seoSettings);
       useSEOConfigStore.setState({ loaded: true });


### PR DESCRIPTION
## Summary
- expose Google Analytics and AdSense settings via new API routes
- load analytics script in the frontend `_app`
- inject AdSense script and slot component
- show ads in the website footer
- add tests for the new endpoints

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a715d0040832891bb66e398bbf2ed