### PR TITLE
Fix footer link slugs

### DIFF
--- a/frontend/src/components/website/sections/Footer.js
+++ b/frontend/src/components/website/sections/Footer.js
@@ -100,13 +100,18 @@ const Footer = () => {
             <div>
               <h3 className="text-lg font-bold mb-4 text-yellow-400">Quick Links</h3>
               <ul className="space-y-2 text-sm">
-                {quickLinks.map((item, index) => (
-                  <li key={index}>
-                    <Link href={`/${item.toLowerCase().replace(/\s/g, "-")}`} className="hover:text-yellow-300 transition">
-                      {item}
-                    </Link>
-                  </li>
-                ))}
+                {quickLinks.map((item, index) => {
+                  const slug = item.toLowerCase().replace(/\s/g, "-");
+                  const pathMap = { 'about-us': 'about', 'contact-us': 'contact' };
+                  const href = `/${pathMap[slug] || slug}`;
+                  return (
+                    <li key={index}>
+                      <Link href={href} className="hover:text-yellow-300 transition">
+                        {item}
+                      </Link>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
 


### PR DESCRIPTION
## Summary
- correct Quick Links slug logic so 'About Us' maps to `/about`

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688a73c7572c832883cce837e5937f9d