### PR TITLE
Enable community voting and avatars

### DIFF
--- a/backend/src/migrations/20250726000050_create_community_likes_table.js
+++ b/backend/src/migrations/20250726000050_create_community_likes_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('community_likes', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('discussion_id').notNullable().references('id').inTable('community_discussions').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'discussion_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('community_likes');
+};

--- a/backend/src/migrations/20250726000060_create_community_votes_table.js
+++ b/backend/src/migrations/20250726000060_create_community_votes_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('community_votes', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('discussion_id').notNullable().references('id').inTable('community_discussions').onDelete('CASCADE');
+    table.integer('vote').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'discussion_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('community_votes');
+};

--- a/backend/src/migrations/20250726000070_create_community_views_table.js
+++ b/backend/src/migrations/20250726000070_create_community_views_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('community_views', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('discussion_id').notNullable().references('id').inTable('community_discussions').onDelete('CASCADE');
+    table.uuid('viewer_id').references('id').inTable('users').onDelete('SET NULL');
+    table.string('ip_address');
+    table.string('user_agent');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('community_views');
+};

--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -9,7 +9,12 @@ exports.listDiscussions = catchAsync(async (_req, res) => {
 });
 
 exports.getDiscussion = catchAsync(async (req, res) => {
-  const disc = await service.getDiscussion(req.params.id);
+  const disc = await service.getDiscussion(
+    req.params.id,
+    req.user?.id,
+    req.ip,
+    req.headers['user-agent']
+  );
   if (!disc) throw new AppError("Discussion not found", 404);
   sendSuccess(res, disc);
 });
@@ -64,4 +69,27 @@ exports.createReply = catchAsync(async (req, res) => {
     file_url: req.file ? `/uploads/community/${req.file.filename}` : null,
   });
   sendSuccess(res, reply, 'Reply posted');
+});
+
+exports.likeDiscussion = catchAsync(async (req, res) => {
+  await service.likeDiscussion(req.user.id, req.params.id);
+  const likes = await service.getLikeCount(req.params.id);
+  sendSuccess(res, { likes }, 'Liked');
+});
+
+exports.unlikeDiscussion = catchAsync(async (req, res) => {
+  await service.unlikeDiscussion(req.user.id, req.params.id);
+  const likes = await service.getLikeCount(req.params.id);
+  sendSuccess(res, { likes }, 'Unliked');
+});
+
+exports.voteDiscussion = catchAsync(async (req, res) => {
+  const { type } = req.body || {};
+  if (!['up', 'down'].includes(type)) throw new AppError('Invalid vote', 400);
+  const votes = await service.voteDiscussion(
+    req.user.id,
+    req.params.id,
+    type === 'up' ? 1 : -1
+  );
+  sendSuccess(res, { votes }, 'Voted');
 });

--- a/backend/src/modules/community/public/public.routes.js
+++ b/backend/src/modules/community/public/public.routes.js
@@ -9,6 +9,9 @@ router.get("/discussions/:id", ctrl.getDiscussion);
 router.post("/discussions", verifyToken, upload, ctrl.createDiscussion);
 router.get("/discussions/:id/replies", ctrl.listReplies);
 router.post("/discussions/:id/replies", verifyToken, replyUpload, ctrl.createReply);
+router.post("/discussions/:id/like", verifyToken, ctrl.likeDiscussion);
+router.delete("/discussions/:id/like", verifyToken, ctrl.unlikeDiscussion);
+router.post("/discussions/:id/vote", verifyToken, ctrl.voteDiscussion);
 router.get("/contributors", ctrl.listContributors);
 router.get("/tags", ctrl.listTags);
 

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -16,6 +16,33 @@ exports.getDiscussionTags = async (ids) => {
 exports.listDiscussions = async () => {
   const rows = await db("community_discussions as d")
     .leftJoin("users as u", "d.user_id", "u.id")
+    .leftJoin(
+      db("community_views")
+        .select("discussion_id")
+        .count({ views: "id" })
+        .groupBy("discussion_id")
+        .as("v"),
+      "v.discussion_id",
+      "d.id"
+    )
+    .leftJoin(
+      db("community_likes")
+        .select("discussion_id")
+        .count({ likes: "id" })
+        .groupBy("discussion_id")
+        .as("l"),
+      "l.discussion_id",
+      "d.id"
+    )
+    .leftJoin(
+      db("community_votes")
+        .select("discussion_id")
+        .sum({ votes: "vote" })
+        .groupBy("discussion_id")
+        .as("t"),
+      "t.discussion_id",
+      "d.id"
+    )
     .select(
       "d.id",
       "d.title",
@@ -25,16 +52,47 @@ exports.listDiscussions = async () => {
       "d.resolved",
       "d.locked",
       "u.full_name as user_name",
-      "u.avatar_url as user_avatar"
+      "u.avatar_url as user_avatar",
+      db.raw("COALESCE(v.views,0) as views"),
+      db.raw("COALESCE(l.likes,0) as likes"),
+      db.raw("COALESCE(t.votes,0) as votes")
     )
     .orderBy("d.created_at", "desc");
   const tagsMap = await exports.getDiscussionTags(rows.map((r) => r.id));
   return rows.map((r) => ({ ...r, tags: tagsMap[r.id] || [] }));
 };
 
-exports.getDiscussion = async (id) => {
+exports.getDiscussion = async (id, viewerId, ip, userAgent) => {
+  await exports.recordView(id, viewerId, ip, userAgent);
   const row = await db("community_discussions as d")
     .leftJoin("users as u", "d.user_id", "u.id")
+    .leftJoin(
+      db("community_views")
+        .select("discussion_id")
+        .count({ views: "id" })
+        .groupBy("discussion_id")
+        .as("v"),
+      "v.discussion_id",
+      "d.id"
+    )
+    .leftJoin(
+      db("community_likes")
+        .select("discussion_id")
+        .count({ likes: "id" })
+        .groupBy("discussion_id")
+        .as("l"),
+      "l.discussion_id",
+      "d.id"
+    )
+    .leftJoin(
+      db("community_votes")
+        .select("discussion_id")
+        .sum({ votes: "vote" })
+        .groupBy("discussion_id")
+        .as("t"),
+      "t.discussion_id",
+      "d.id"
+    )
     .select(
       "d.id",
       "d.title",
@@ -44,7 +102,10 @@ exports.getDiscussion = async (id) => {
       "d.resolved",
       "d.locked",
       "u.full_name as user_name",
-      "u.avatar_url as user_avatar"
+      "u.avatar_url as user_avatar",
+      db.raw("COALESCE(v.views,0) as views"),
+      db.raw("COALESCE(l.likes,0) as likes"),
+      db.raw("COALESCE(t.votes,0) as votes")
     )
     .where("d.id", id)
     .first();
@@ -192,4 +253,52 @@ exports.createReply = async (data) => {
     user_name: user?.full_name,
     user_avatar: user?.avatar_url,
   };
+};
+
+// View tracking
+exports.recordView = async (discussionId, viewerId, ip, userAgent) => {
+  return db('community_views').insert({
+    id: uuidv4(),
+    discussion_id: discussionId,
+    viewer_id: viewerId || null,
+    ip_address: ip,
+    user_agent: userAgent,
+  });
+};
+
+exports.getViewCount = async (discussionId) => {
+  const [row] = await db('community_views').where({ discussion_id: discussionId }).count();
+  return parseInt(row.count, 10) || 0;
+};
+
+// Likes
+exports.likeDiscussion = async (userId, discussionId) => {
+  const [row] = await db('community_likes')
+    .insert({ id: uuidv4(), user_id: userId, discussion_id: discussionId })
+    .onConflict(['user_id', 'discussion_id']).ignore()
+    .returning('*');
+  return row;
+};
+
+exports.unlikeDiscussion = async (userId, discussionId) => {
+  return db('community_likes').where({ user_id: userId, discussion_id: discussionId }).del();
+};
+
+exports.getLikeCount = async (discussionId) => {
+  const [row] = await db('community_likes').where({ discussion_id: discussionId }).count();
+  return parseInt(row.count, 10) || 0;
+};
+
+// Votes
+exports.voteDiscussion = async (userId, discussionId, vote) => {
+  await db('community_votes')
+    .insert({ id: uuidv4(), user_id: userId, discussion_id: discussionId, vote })
+    .onConflict(['user_id', 'discussion_id']).merge({ vote });
+  const [row] = await db('community_votes').where({ discussion_id: discussionId }).sum({ score: 'vote' });
+  return parseInt(row.score, 10) || 0;
+};
+
+exports.getVoteScore = async (discussionId) => {
+  const [row] = await db('community_votes').where({ discussion_id: discussionId }).sum({ score: 'vote' });
+  return parseInt(row.score, 10) || 0;
 };

--- a/backend/tests/communityRoutes.test.js
+++ b/backend/tests/communityRoutes.test.js
@@ -33,6 +33,12 @@ describe('GET /api/community/discussions/:id', () => {
     service.getDiscussion.mockResolvedValue(mock);
     const res = await request(app).get('/api/community/discussions/1');
     expect(res.status).toBe(200);
+    expect(service.getDiscussion).toHaveBeenCalledWith(
+      '1',
+      undefined,
+      expect.anything(),
+      undefined
+    );
     expect(res.body.data).toEqual(mock);
   });
 });

--- a/frontend/src/components/community/QuestionCard.js
+++ b/frontend/src/components/community/QuestionCard.js
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { FaArrowUp, FaArrowDown, FaEye, FaComment } from "react-icons/fa";
+import { FaArrowUp, FaArrowDown, FaEye, FaComment, FaHeart, FaUser } from "react-icons/fa";
 
 const QuestionCard = ({ question }) => {
   const router = useRouter();
@@ -20,13 +20,10 @@ const QuestionCard = ({ question }) => {
     >
       {/* Votes */}
       <div className="flex items-center space-x-2">
-        <button className="text-gray-400 hover:text-yellow-500">
-          <FaArrowUp />
-        </button>
+        <FaArrowUp />
         <span className="text-yellow-400 font-bold">{question.votes ?? 0}</span>
-        <button className="text-gray-400 hover:text-yellow-500">
-          <FaArrowDown />
-        </button>
+        <FaArrowDown />
+        <span className="flex items-center gap-1 text-red-400 ml-4"><FaHeart /> {question.likes ?? 0}</span>
       </div>
 
       {/* Question Content */}
@@ -50,7 +47,14 @@ const QuestionCard = ({ question }) => {
       <div className="flex justify-between mt-3 text-gray-400 text-sm">
         <span className="flex items-center gap-1"><FaEye /> {question.views ?? 0} views</span>
         <span className="flex items-center gap-1"><FaComment /> {answersCount} answers</span>
-        <span className="text-yellow-500">{question.user?.name || question.user_name || 'Anonymous'}</span>
+        <span className="flex items-center gap-1">
+          {question.user_avatar ? (
+            <img src={question.user_avatar} alt="avatar" className="w-5 h-5 rounded-full" />
+          ) : (
+            <FaUser />
+          )}
+          <span className="text-yellow-500">{question.user?.name || question.user_name || 'Anonymous'}</span>
+        </span>
       </div>
     </div>
   );

--- a/frontend/src/pages/community/question/details.js
+++ b/frontend/src/pages/community/question/details.js
@@ -5,13 +5,21 @@ import Footer from "@/components/website/sections/Footer";
 import { useRouter } from "next/router";
 import RichTextEditor from "@/components/RichTextEditor";
 import ReactMarkdown from "react-markdown";
-import { fetchDiscussionById, fetchReplies, createReply } from "@/services/communityService";
+import {
+  fetchDiscussionById,
+  fetchReplies,
+  createReply,
+  likeDiscussion,
+  unlikeDiscussion,
+  voteDiscussion,
+} from "@/services/communityService";
 
 const QuestionDetails = () => {
   const router = useRouter();
   const [question, setQuestion] = useState(null);
   const [likes, setLikes] = useState(0);
   const [votes, setVotes] = useState(0);
+  const [liked, setLiked] = useState(false);
   const [replyText, setReplyText] = useState("");
   const [replies, setReplies] = useState([]);
   const [audioFile, setAudioFile] = useState(null);
@@ -37,12 +45,30 @@ const QuestionDetails = () => {
   }, [router.query.id]);
 
   // ✅ Handle Like Button
-  const handleLike = () => setLikes(likes + 1);
+  const handleLike = async () => {
+    try {
+      if (!liked) {
+        const res = await likeDiscussion(router.query.id);
+        setLikes(res.likes);
+        setLiked(true);
+      } else {
+        const res = await unlikeDiscussion(router.query.id);
+        setLikes(res.likes);
+        setLiked(false);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   // ✅ Handle Vote System
-  const handleVote = (type) => {
-    if (type === "up") setVotes(votes + 1);
-    if (type === "down") setVotes(votes - 1);
+  const handleVote = async (type) => {
+    try {
+      const res = await voteDiscussion(router.query.id, type);
+      setVotes(res.votes);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   // ✅ Handle Audio Upload

--- a/frontend/src/services/communityService.js
+++ b/frontend/src/services/communityService.js
@@ -34,3 +34,18 @@ export const createReply = async (discussionId, payload) => {
   const { data } = await api.post(`/community/discussions/${discussionId}/replies`, payload);
   return data?.data;
 };
+
+export const likeDiscussion = async (id) => {
+  const { data } = await api.post(`/community/discussions/${id}/like`);
+  return data?.data;
+};
+
+export const unlikeDiscussion = async (id) => {
+  const { data } = await api.delete(`/community/discussions/${id}/like`);
+  return data?.data;
+};
+
+export const voteDiscussion = async (id, type) => {
+  const { data } = await api.post(`/community/discussions/${id}/vote`, { type });
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- store likes, votes, and view data for community discussions
- expose endpoints for voting and liking discussions
- show avatars and interaction counts on community pages
- persist vote and like actions from the UI
- add migrations and adjust tests

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a7acc84b483288d2a07a1ddf83be9