### PR TITLE
Enable admin-managed contact info

### DIFF
--- a/frontend/src/pages/contact/index.js
+++ b/frontend/src/pages/contact/index.js
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 
-const mockSettings = {
+import { fetchContactConfig } from "@/services/contactService";
+const defaultSettings = {
   email: "support@skillbridge.com",
   phone: "+1 555-1234",
   addressLine: "123 Remote Learning Ave",
@@ -13,9 +14,21 @@ const mockSettings = {
 };
 
 export default function ContactPage() {
+  const [settings, setSettings] = useState(defaultSettings);
   const [form, setForm] = useState({ name: "", email: "", message: "" });
   const [submitted, setSubmitted] = useState(false);
 
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchContactConfig();
+        if (data) setSettings(prev => ({ ...prev, ...data }));
+      } catch (err) {
+        console.error("Failed to load contact settings", err);
+      }
+    };
+    load();
+  }, []);
   const handleChange = (field, value) => {
     setForm((prev) => ({ ...prev, [field]: value }));
   };
@@ -44,20 +57,20 @@ export default function ContactPage() {
             <div className="space-y-4">
               <div>
                 <p className="text-lg">
-                  <strong>Email:</strong> {mockSettings.email}
+                  <strong>Email:</strong> {settings.email}
                 </p>
                 <p className="text-lg">
-                  <strong>Phone:</strong> {mockSettings.phone}
+                  <strong>Phone:</strong> {settings.phone}
                 </p>
                 <p className="text-lg">
                   <strong>Address:</strong><br />
-                  {mockSettings.addressLine}<br />
-                  {mockSettings.city}, {mockSettings.country}
+                  {settings.addressLine}<br />
+                  {settings.city}, {settings.country}
                 </p>
               </div>
               <div className="rounded overflow-hidden shadow-lg">
                 <iframe
-                  src={mockSettings.mapEmbedUrl}
+                  src={settings.mapEmbedUrl}
                   width="100%"
                   height="250"
                   style={{ border: 0 }}

--- a/frontend/src/services/contactService.js
+++ b/frontend/src/services/contactService.js
@@ -1,0 +1,3 @@
+// Re-export the admin contact settings fetcher so the public
+// site and admin dashboard share a single implementation.
+export { fetchContactConfig } from "@/services/admin/contactConfigService";


### PR DESCRIPTION
## Summary
- fetch contact settings from `/contact-config` via a new shared service
- load those settings on the public contact page so admins can configure the info

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a73d61d6c8328aed30a0e1a477b29