### PR TITLE
Enable admin-managed contact info

### DIFF
--- a/backend/src/modules/contactForm/contactForm.controller.js
+++ b/backend/src/modules/contactForm/contactForm.controller.js
@@ -1,0 +1,12 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const contactConfigService = require("../contactConfig/contactConfig.service");
+const { sendContactFormEmail } = require("../../utils/email");
+
+exports.submitForm = catchAsync(async (req, res) => {
+  const { name, email, message } = req.body;
+  const cfg = (await contactConfigService.getSettings()) || {};
+  const to = cfg.formRecipient || cfg.email || "support@eduskillbridge.net";
+  await sendContactFormEmail(to, name, email, message);
+  sendSuccess(res, null, "Message sent");
+});

--- a/backend/src/modules/contactForm/contactForm.routes.js
+++ b/backend/src/modules/contactForm/contactForm.routes.js
@@ -1,0 +1,8 @@
+const router = require("express").Router();
+const controller = require("./contactForm.controller");
+const validate = require("../../middleware/validate");
+const validator = require("./contactForm.validator");
+
+router.post("/", validate(validator.submit), controller.submitForm);
+
+module.exports = router;

--- a/backend/src/modules/contactForm/contactForm.validator.js
+++ b/backend/src/modules/contactForm/contactForm.validator.js
@@ -1,0 +1,9 @@
+const { z } = require("zod");
+
+exports.submit = {
+  body: z.object({
+    name: z.string().min(1),
+    email: z.string().email(),
+    message: z.string().min(1),
+  }),
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -105,6 +105,7 @@ app.use("/api/adsense", require("./modules/adsense/adsense.routes"));
 app.use("/api/ai-assistance", require("./modules/ai/ai.routes"));
 app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));
 app.use("/api/contact-config", require("./modules/contactConfig/contactConfig.routes"));
+app.use("/api/contact", require("./modules/contactForm/contactForm.routes"));
 app.use("/api/seo-config", require("./modules/seoConfig/seoConfig.routes"));
 app.use("/api/popup-announcements", require("./modules/popupAnnouncements/popupAnnouncements.routes"));
 app.use("/api/policies", require("./modules/policies/policies.routes"));

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -942,3 +942,57 @@ exports.sendCartAddedEmail = async (to, itemName) => {
     console.error("Error sending cart added email: ", error);
   }
 };
+
+// Handle contact form submissions from the public site
+exports.sendContactFormEmail = async (to, name, senderEmail, content) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Contact message from ${senderEmail}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: senderEmail,
+    to,
+    subject: `New contact message from ${name}`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>You have received a new contact form submission.</p>
+        <p><strong>Name:</strong> ${name}<br/>
+           <strong>Email:</strong> ${senderEmail}</p>
+        <p style="white-space:pre-line">${content}</p>
+        <p>Thank you,<br/>The ${fromName} Site</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Contact form email sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending contact form email: ", error);
+  }
+};

--- a/frontend/src/pages/contact/index.js
+++ b/frontend/src/pages/contact/index.js
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 
-const mockSettings = {
+import { fetchContactConfig, sendContactMessage } from "@/services/contactService";
+const defaultSettings = {
   email: "support@skillbridge.com",
   phone: "+1 555-1234",
   addressLine: "123 Remote Learning Ave",
@@ -13,18 +14,33 @@ const mockSettings = {
 };
 
 export default function ContactPage() {
+  const [settings, setSettings] = useState(defaultSettings);
   const [form, setForm] = useState({ name: "", email: "", message: "" });
   const [submitted, setSubmitted] = useState(false);
 
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchContactConfig();
+        if (data) setSettings(prev => ({ ...prev, ...data }));
+      } catch (err) {
+        console.error("Failed to load contact settings", err);
+      }
+    };
+    load();
+  }, []);
   const handleChange = (field, value) => {
     setForm((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Form submitted:", form);
-    setSubmitted(true);
-    // TODO: Send to backend
+    try {
+      await sendContactMessage(form);
+      setSubmitted(true);
+    } catch (err) {
+      console.error("Failed to send message", err);
+    }
   };
 
   return (
@@ -44,20 +60,20 @@ export default function ContactPage() {
             <div className="space-y-4">
               <div>
                 <p className="text-lg">
-                  <strong>Email:</strong> {mockSettings.email}
+                  <strong>Email:</strong> {settings.email}
                 </p>
                 <p className="text-lg">
-                  <strong>Phone:</strong> {mockSettings.phone}
+                  <strong>Phone:</strong> {settings.phone}
                 </p>
                 <p className="text-lg">
                   <strong>Address:</strong><br />
-                  {mockSettings.addressLine}<br />
-                  {mockSettings.city}, {mockSettings.country}
+                  {settings.addressLine}<br />
+                  {settings.city}, {settings.country}
                 </p>
               </div>
               <div className="rounded overflow-hidden shadow-lg">
                 <iframe
-                  src={mockSettings.mapEmbedUrl}
+                  src={settings.mapEmbedUrl}
                   width="100%"
                   height="250"
                   style={{ border: 0 }}
@@ -106,7 +122,7 @@ export default function ContactPage() {
                 Send Message
               </button>
               {submitted && (
-                <p className="text-green-400 mt-2">✅ Your message was sent (mock).</p>
+                <p className="text-green-400 mt-2">✅ Your message was sent.</p>
               )}
             </form>
           </div>

--- a/frontend/src/services/contactService.js
+++ b/frontend/src/services/contactService.js
@@ -1,0 +1,9 @@
+// Re-export the admin contact settings fetcher so the public
+// site and admin dashboard share a single implementation.
+export { fetchContactConfig } from "@/services/admin/contactConfigService";
+import api from "@/services/api/api";
+
+export const sendContactMessage = async (payload) => {
+  const { data } = await api.post("/contact", payload);
+  return data?.message || data?.data;
+};


### PR DESCRIPTION
## Summary
- fetch contact settings from `/contact-config` via a new shared service
- load those settings on the public contact page so admins can configure the info
- send contact form submissions to the configured email address

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a73d61d6c8328aed30a0e1a477b29