### PR TITLE
Enable real emails for contact page

### DIFF
--- a/backend/src/modules/contact/contact.controller.js
+++ b/backend/src/modules/contact/contact.controller.js
@@ -1,0 +1,39 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const mailService = require("../../services/mailService");
+const appConfigService = require("../appConfig/appConfig.service");
+const AppError = require("../../utils/AppError");
+const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+
+exports.submitForm = catchAsync(async (req, res) => {
+  const { name, email, message } = req.body || {};
+  if (!name || !email || !message) {
+    throw new AppError("Name, email and message are required", 400);
+  }
+  const app = (await appConfigService.getSettings()) || {};
+  const to = app.contactEmail || process.env.CONTACT_EMAIL || "support@eduskillbridge.net";
+  const html = `
+    <p><strong>Name:</strong> ${name}</p>
+    <p><strong>Email:</strong> ${email}</p>
+    <p>${message}</p>
+  `;
+  await mailService.sendMail({
+    to,
+    from: `${name} <${email}>`,
+    subject: `New contact form submission`,
+    html,
+  });
+  const admins = await userModel.findAdmins();
+  const note = `New contact message from ${name} (${email})`;
+  await Promise.all(
+    admins.map((admin) =>
+      notificationService.createNotification({
+        user_id: admin.id,
+        type: "contact_message",
+        message: note,
+      })
+    )
+  );
+  sendSuccess(res, null, "Message sent");
+});

--- a/backend/src/modules/contact/contact.routes.js
+++ b/backend/src/modules/contact/contact.routes.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./contact.controller");
+
+router.post("/", controller.submitForm);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -105,6 +105,7 @@ app.use("/api/adsense", require("./modules/adsense/adsense.routes"));
 app.use("/api/ai-assistance", require("./modules/ai/ai.routes"));
 app.use("/api/email-config", require("./modules/emailConfig/emailConfig.routes"));
 app.use("/api/contact-config", require("./modules/contactConfig/contactConfig.routes"));
+app.use("/api/contact", require("./modules/contact/contact.routes"));
 app.use("/api/seo-config", require("./modules/seoConfig/seoConfig.routes"));
 app.use("/api/popup-announcements", require("./modules/popupAnnouncements/popupAnnouncements.routes"));
 app.use("/api/policies", require("./modules/policies/policies.routes"));

--- a/frontend/src/pages/contact/index.js
+++ b/frontend/src/pages/contact/index.js
@@ -3,7 +3,7 @@ import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 
-import { fetchContactConfig } from "@/services/contactService";
+import { fetchContactConfig, sendContactMessage } from "@/services/contactService";
 const defaultSettings = {
   email: "support@skillbridge.com",
   phone: "+1 555-1234",
@@ -33,11 +33,14 @@ export default function ContactPage() {
     setForm((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Form submitted:", form);
-    setSubmitted(true);
-    // TODO: Send to backend
+    try {
+      await sendContactMessage(form);
+      setSubmitted(true);
+    } catch (err) {
+      console.error("Failed to send message", err);
+    }
   };
 
   return (
@@ -119,7 +122,7 @@ export default function ContactPage() {
                 Send Message
               </button>
               {submitted && (
-                <p className="text-green-400 mt-2">✅ Your message was sent (mock).</p>
+                <p className="text-green-400 mt-2">✅ Your message was sent successfully.</p>
               )}
             </form>
           </div>

--- a/frontend/src/services/contactService.js
+++ b/frontend/src/services/contactService.js
@@ -1,3 +1,9 @@
 // Re-export the admin contact settings fetcher so the public
 // site and admin dashboard share a single implementation.
 export { fetchContactConfig } from "@/services/admin/contactConfigService";
+import api from "@/services/api/api";
+
+export const sendContactMessage = async ({ name, email, message }) => {
+  const { data } = await api.post("/contact", { name, email, message });
+  return data;
+};


### PR DESCRIPTION
## Summary
- implement backend contact form endpoint that sends an email
- expose new service on frontend to send messages
- call the API from the contact page and show success notice
- notify admins about new contact messages

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688a88df17e48328a4d9435f0d281f98