### PR TITLE
Enable search input in hero

### DIFF
--- a/frontend/src/components/shared/SearchBar.js
+++ b/frontend/src/components/shared/SearchBar.js
@@ -1,13 +1,14 @@
 // src/components/shared/SearchBar.js
 import { Search } from 'lucide-react';
 
-export default function SearchBar({ value, onChange, placeholder = 'Search...' }) {
+export default function SearchBar({ value, onChange, onKeyDown, placeholder = 'Search...' }) {
   return (
     <div className="relative">
       <input
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
         placeholder={placeholder}
         className="w-full border border-gray-300 rounded-lg px-10 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
       />

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { motion, AnimatePresence } from "framer-motion";
 import Image from "next/image";
 import Typewriter from "typewriter-effect";
@@ -17,6 +18,7 @@ import { useTranslation } from "next-i18next";
 
 
 const Hero = () => {
+  const router = useRouter();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isChatOpen, setIsChatOpen] = useState(false);
   const [ads, setAds] = useState([]);
@@ -77,9 +79,14 @@ const Hero = () => {
     trackMouse: true,
   });
 
+  const handleSearch = (query) => {
+    if (!query.trim()) return;
+    router.push(`/search?q=${encodeURIComponent(query.trim())}`);
+  };
+
   const handleSearchSelect = (selectedValue) => {
     setSearchText(selectedValue);
-    alert(`Navigating to results for: ${selectedValue}`); // Replace with real navigation
+    handleSearch(selectedValue);
   };
 
   return (
@@ -127,7 +134,24 @@ const Hero = () => {
 
           {/* 🔍 Modern Search Box */}
           <div className="relative w-full max-w-lg mx-auto mb-6">
-            <SearchBar value={searchText} onChange={setSearchText} onSelect={handleSearchSelect} />
+            <SearchBar
+              value={searchText}
+              onChange={setSearchText}
+              onKeyDown={(e) => e.key === "Enter" && handleSearch(searchText)}
+            />
+            {searchSuggestions.length > 0 && (
+              <ul className="absolute mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg z-20">
+                {searchSuggestions.map((s, idx) => (
+                  <li
+                    key={idx}
+                    onClick={() => handleSearchSelect(s)}
+                    className="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+                  >
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
 
           {/* CTA Buttons */}

--- a/frontend/src/pages/search/index.js
+++ b/frontend/src/pages/search/index.js
@@ -1,13 +1,27 @@
 import { useState, useEffect } from "react";
+import { useRouter } from "next/router";
 import SearchBar from "@/components/shared/SearchBar";
 import SearchFilters from "@/components/shared/SearchFilters";
 import SearchResults from "@/components/shared/SearchResults";
 import mockData from "@/mocks/searchResults.json";
 
 const SearchPage = () => {
+  const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
   const [filteredResults, setFilteredResults] = useState(mockData);
   const [selectedCategory, setSelectedCategory] = useState("all");
+
+  useEffect(() => {
+    if (router.query.q) {
+      setSearchQuery(router.query.q);
+    }
+  }, [router.query.q]);
+
+  useEffect(() => {
+    if (searchQuery) {
+      router.replace({ pathname: '/search', query: { q: searchQuery } }, undefined, { shallow: true });
+    }
+  }, [searchQuery]);
 
   useEffect(() => {
     let results = mockData;
@@ -25,7 +39,11 @@ const SearchPage = () => {
   return (
     <div className="p-6">
       <h1 className="text-3xl font-bold mb-4">Search Results</h1>
-      <SearchBar value={searchQuery} onChange={setSearchQuery} />
+      <SearchBar
+        value={searchQuery}
+        onChange={setSearchQuery}
+        onKeyDown={(e) => e.key === 'Enter' && router.push(`/search?q=${encodeURIComponent(searchQuery)}`)}
+      />
       <SearchFilters selected={selectedCategory} onChange={setSelectedCategory} />
       <SearchResults results={filteredResults} />
     </div>


### PR DESCRIPTION
## Summary
- allow keydown handler in `SearchBar`
- add search suggestions and navigation in homepage hero section
- sync query parameter on search page and support Enter key

## Testing
- `npm --prefix frontend run lint` *(fails: 58 errors)*
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_688a94007e68832884b601e91c081d35