### PR TITLE
Add plan style customization

### DIFF
--- a/backend/src/migrations/20250726001500_add_color_and_style_to_plans.js
+++ b/backend/src/migrations/20250726001500_add_color_and_style_to_plans.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('plans', function(table) {
+    table.string('color').defaultTo('#1F2937');
+    table.string('style');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('plans', function(table) {
+    table.dropColumn('color');
+    table.dropColumn('style');
+  });
+};

--- a/backend/src/modules/plans/plans.controller.js
+++ b/backend/src/modules/plans/plans.controller.js
@@ -13,6 +13,8 @@ exports.createPlan = catchAsync(async (req, res) => {
     currency = "USD",
     recommended = false,
     active = true,
+    color = '#1F2937',
+    style = null,
     features = [],
   } = req.body;
 
@@ -30,6 +32,8 @@ exports.createPlan = catchAsync(async (req, res) => {
     currency,
     recommended,
     active,
+    color,
+    style,
   });
 
   await service.setFeatures(plan.id, Array.isArray(features) ? features : []);
@@ -58,6 +62,8 @@ exports.updatePlan = catchAsync(async (req, res) => {
     currency,
     recommended,
     active,
+    color,
+    style,
     features,
   } = req.body;
 
@@ -68,6 +74,8 @@ exports.updatePlan = catchAsync(async (req, res) => {
   if (currency) updates.currency = currency;
   if (recommended !== undefined) updates.recommended = recommended;
   if (active !== undefined) updates.active = active;
+  if (color !== undefined) updates.color = color;
+  if (style !== undefined) updates.style = style;
 
   if (slug || name) {
     const planSlug = slug || slugify(name, { lower: true, strict: true });

--- a/frontend/src/components/website/sections/SubscriptionPlans.js
+++ b/frontend/src/components/website/sections/SubscriptionPlans.js
@@ -1,55 +1,27 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaCheck, FaCreditCard, FaMoneyBillWave, FaWallet, FaEthereum } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
-
-const plans = [
-  {
-    id: 1,
-    name: "plan_basic",
-    price: "$10/month",
-    features: [
-      "Access to selected free tutorials",
-      "Browse community questions",
-      "View public offers",
-      "Community forum read-only access"
-    ]
-  },
-  {
-    id: 2,
-    name: "plan_regular",
-    price: "$20/month",
-    features: [
-      "Full course access",
-      "Post & reply in community",
-      "Message instructors",
-      "Completion certificates",
-      "Preview live classes",
-      "Apply for student offers"
-    ]
-  },
-  {
-    id: 3,
-    name: "plan_premium",
-    price: "$30/month",
-    features: [
-      "Everything in Regular Plan",
-      "Join live class sessions",
-      "Book 1-on-1 sessions",
-      "Full AI Tutor access",
-      "Priority support & feedback",
-      "Earn NFT certification",
-      "Post & respond to premium offers"
-    ],
-    popular: true
-  }
-];
+import { fetchPublicPlans } from "@/services/public/planService";
 
 
 
 const SubscriptionPlans = () => {
   const { t } = useTranslation("website");
+  const [plans, setPlans] = useState([]);
   const [selectedPlan, setSelectedPlan] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchPublicPlans();
+        setPlans(data.filter((p) => p.active));
+      } catch (err) {
+        console.error("Failed to load plans", err);
+      }
+    };
+    load();
+  }, []);
 
   return (
 
@@ -69,37 +41,37 @@ const SubscriptionPlans = () => {
         {/* Subscription Plans */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto relative z-10">
           {plans.map((plan, index) => {
-            const isPremium = plan.name === "plan_premium";
             const isMiddle = index === 1;
+            const cardClasses = `p-6 rounded-lg shadow-2xl transition-all duration-300 ${plan.style || ""} ${isMiddle ? "md:scale-105" : ""} relative`;
 
             return (
               <motion.div
                 key={plan.id}
-                className={`p-6 rounded-lg shadow-2xl transition-all duration-300 ${isPremium ? "bg-yellow-500 text-gray-900 border-4 border-yellow-300" : "bg-gray-800 text-white"} ${isMiddle ? "md:scale-105 md:shadow-yellow-400" : ""} relative`}
+                className={cardClasses}
+                style={{ backgroundColor: plan.color || "#1f2937", color: "#fff" }}
                 whileHover={{ scale: 1.08 }}
               >
-                {/* Glow Effect for Premium */}
-                {isPremium && (
+                {plan.recommended && (
                   <div className="absolute -top-4 right-4 bg-white text-yellow-500 font-bold px-3 py-1 rounded-full text-xs shadow-md animate-pulse z-20">
                     {t("subscription_most_popular")}
                   </div>
                 )}
 
-                <h3 className="text-2xl font-extrabold mb-2">{t(plan.name)}</h3>
-                <p className="text-3xl font-bold mb-4">{plan.price}</p>
+                <h3 className="text-2xl font-extrabold mb-2">{plan.name}</h3>
+                <p className="text-3xl font-bold mb-4">
+                  {plan.price_monthly} {plan.currency}/mo
+                </p>
 
-                <ul className={`space-y-2 ${isPremium ? "text-gray-800" : "text-gray-300"}`}>
-                  {plan.features.map((feature, idx) => (
+                <ul className="space-y-2 text-gray-300">
+                  {plan.features?.map((feature, idx) => (
                     <li key={idx} className="flex items-center justify-center gap-2">
-                      <FaCheck className="text-green-400" /> {feature}
+                      <FaCheck className="text-green-400" /> {feature.description || feature.value}
                     </li>
                   ))}
                 </ul>
 
                 <button
-                  className={`mt-6 px-6 py-3 rounded-lg font-semibold transition
-            ${isPremium ? "bg-gray-900 text-white hover:bg-gray-800" : "bg-yellow-500 text-gray-900 hover:bg-yellow-600"}
-          `}
+                  className="mt-6 px-6 py-3 rounded-lg font-semibold bg-gray-900 text-white hover:bg-gray-800"
                   onClick={() => setSelectedPlan(plan)}
                 >
                   {t("subscription_select_plan")}
@@ -119,9 +91,11 @@ const SubscriptionPlans = () => {
               className="bg-gray-900 p-6 rounded-lg text-white shadow-xl max-w-lg text-center"
             >
               <h3 className="text-xl font-bold mb-4">
-                {t("payment_complete_for", { plan: t(selectedPlan.name) })}
+                {t("payment_complete_for", { plan: selectedPlan.name })}
               </h3>
-              <p className="text-gray-300">{selectedPlan.price}</p>
+              <p className="text-gray-300">
+                {selectedPlan.price_monthly} {selectedPlan.currency}/mo
+              </p>
 
               {/* Payment Methods */}
               <div className="mt-4 flex flex-col gap-4">

--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -16,6 +16,8 @@ export default function CreatePlanPage() {
     priceMonthly: 0,
     priceYearly: 0,
     currency: "USD",
+    color: "#1F2937",
+    style: "",
     recommended: false,
     active: true,
   });
@@ -40,6 +42,8 @@ export default function CreatePlanPage() {
         price_monthly: Number(form.priceMonthly),
         price_yearly: Number(form.priceYearly),
         currency: form.currency,
+        color: form.color,
+        style: form.style,
         recommended: form.recommended,
         active: form.active,
         features: [],
@@ -110,6 +114,23 @@ export default function CreatePlanPage() {
             className="w-full border px-4 py-2 rounded"
             value={form.currency}
             onChange={(e) => setForm({ ...form, currency: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Plan Color</label>
+          <input
+            type="color"
+            className="w-full border px-4 py-2 rounded"
+            value={form.color}
+            onChange={(e) => setForm({ ...form, color: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Custom CSS Class</label>
+          <input
+            className="w-full border px-4 py-2 rounded"
+            value={form.style}
+            onChange={(e) => setForm({ ...form, style: e.target.value })}
           />
         </div>
         <label className="flex items-center gap-2">

--- a/frontend/src/pages/dashboard/admin/plans/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/plans/edit/[id].js
@@ -40,6 +40,8 @@ export default function EditPlanPage() {
             priceMonthly: data.price_monthly,
             priceYearly: data.price_yearly,
             currency: data.currency,
+            color: data.color || "#1F2937",
+            style: data.style || "",
             recommended: data.recommended,
             active: data.active,
           });
@@ -63,6 +65,8 @@ export default function EditPlanPage() {
         price_monthly: Number(form.priceMonthly),
         price_yearly: Number(form.priceYearly),
         currency: form.currency,
+        color: form.color,
+        style: form.style,
         recommended: form.recommended,
         active: form.active,
       });
@@ -140,6 +144,23 @@ export default function EditPlanPage() {
             className="w-full border px-4 py-2 rounded"
             value={form.currency}
             onChange={(e) => setForm({ ...form, currency: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Plan Color</label>
+          <input
+            type="color"
+            className="w-full border px-4 py-2 rounded"
+            value={form.color}
+            onChange={(e) => setForm({ ...form, color: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Custom CSS Class</label>
+          <input
+            className="w-full border px-4 py-2 rounded"
+            value={form.style}
+            onChange={(e) => setForm({ ...form, style: e.target.value })}
           />
         </div>
         <label className="flex items-center gap-2">

--- a/frontend/src/services/public/planService.js
+++ b/frontend/src/services/public/planService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const fetchPublicPlans = async () => {
+  const { data } = await api.get("/plans");
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- allow storing color & style for plans
- expose public plan service
- load subscription plans from backend
- extend admin plan forms with styling options
- migration to add color/style columns

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688b011f09b883288e973d8c0bfaa0a7