### PR TITLE
Add coupon validity range and scope

### DIFF
--- a/backend/src/migrations/20250726003000_add_validity_and_scope_to_coupons.js
+++ b/backend/src/migrations/20250726003000_add_validity_and_scope_to_coupons.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('coupons', function(table) {
+    table.timestamp('starts_at');
+    table.enum('applies_to', ['tutorial', 'class', 'plan']);
+    table.uuid('applies_to_id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('coupons', function(table) {
+    table.dropColumn('starts_at');
+    table.dropColumn('applies_to');
+    table.dropColumn('applies_to_id');
+  });
+};

--- a/backend/src/modules/coupons/coupons.controller.js
+++ b/backend/src/modules/coupons/coupons.controller.js
@@ -9,8 +9,11 @@ exports.createCoupon = catchAsync(async (req, res) => {
     id: uuidv4(),
     code: req.body.code,
     discount_percent: req.body.discount_percent,
+    starts_at: req.body.starts_at || null,
     expires_at: req.body.expires_at || null,
     usage_limit: req.body.usage_limit || null,
+    applies_to: req.body.applies_to || null,
+    applies_to_id: req.body.applies_to_id || null,
     instructor_id: req.user?.role === "instructor" ? req.user.id : req.body.instructor_id || null,
   };
   const coupon = await service.createCoupon(data);
@@ -43,6 +46,9 @@ exports.validateCode = catchAsync(async (req, res) => {
   const { code } = req.params;
   const coupon = await service.findByCode(code);
   if (!coupon) throw new AppError("Invalid coupon", 404);
+  if (coupon.starts_at && new Date(coupon.starts_at) > new Date()) {
+    throw new AppError("Coupon not active", 400);
+  }
   if (coupon.expires_at && new Date(coupon.expires_at) < new Date()) {
     throw new AppError("Coupon expired", 400);
   }

--- a/backend/src/modules/coupons/coupons.validator.js
+++ b/backend/src/modules/coupons/coupons.validator.js
@@ -4,8 +4,11 @@ exports.create = z.object({
   body: z.object({
     code: z.string().min(3),
     discount_percent: z.number().min(1).max(100),
+    starts_at: z.string().optional(),
     expires_at: z.string().optional(),
     usage_limit: z.number().min(1).optional(),
+    applies_to: z.enum(["tutorial", "class", "plan"]).optional(),
+    applies_to_id: z.string().uuid().optional(),
     instructor_id: z.string().uuid().optional(),
   }),
 });
@@ -13,7 +16,10 @@ exports.create = z.object({
 exports.update = z.object({
   body: z.object({
     discount_percent: z.number().min(1).max(100).optional(),
+    starts_at: z.string().optional(),
     expires_at: z.string().optional(),
     usage_limit: z.number().min(1).optional(),
+    applies_to: z.enum(["tutorial", "class", "plan"]).optional(),
+    applies_to_id: z.string().uuid().optional(),
   }),
 });

--- a/backend/src/seeds/07_coupons_seed.js
+++ b/backend/src/seeds/07_coupons_seed.js
@@ -6,8 +6,11 @@ exports.seed = async function(knex) {
       id: knex.raw('uuid_generate_v4()'),
       code: 'DISCOUNT10',
       discount_percent: 10,
+      starts_at: knex.fn.now(),
       expires_at: knex.fn.now(),
       usage_limit: 100,
+      applies_to: 'plan',
+      applies_to_id: null,
       instructor_id: instructors.length ? instructors[0].id : null,
     },
   ]);

--- a/docs/coupon-management.md
+++ b/docs/coupon-management.md
@@ -8,6 +8,8 @@ This document explains how discount coupons are handled in SkillBridge.
 - Admins and instructors use `/api/coupons/admin` for CRUD operations.
 - `GET /api/coupons/code/:code` validates a coupon for checkout.
 - Coupons include an optional `instructor_id` so instructors can create their own codes.
+- `starts_at` and `expires_at` define the active window for a coupon.
+- `applies_to` (with optional `applies_to_id`) restricts the coupon to a plan, class or tutorial.
 
 ## Frontend
 

--- a/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
@@ -8,6 +8,11 @@ export default function EditCouponPage() {
   const { id } = router.query;
   const [code, setCode] = useState("");
   const [discount, setDiscount] = useState(10);
+  const [startsAt, setStartsAt] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [usageLimit, setUsageLimit] = useState("");
+  const [appliesTo, setAppliesTo] = useState("plan");
+  const [appliesToId, setAppliesToId] = useState("");
 
   useEffect(() => {
     if (id) {
@@ -15,6 +20,11 @@ export default function EditCouponPage() {
         if (c) {
           setCode(c.code);
           setDiscount(c.discount_percent);
+          setStartsAt(c.starts_at ? c.starts_at.replace('Z', '') : "");
+          setExpiresAt(c.expires_at ? c.expires_at.replace('Z', '') : "");
+          setUsageLimit(c.usage_limit || "");
+          setAppliesTo(c.applies_to || "plan");
+          setAppliesToId(c.applies_to_id || "");
         }
       });
     }
@@ -22,7 +32,15 @@ export default function EditCouponPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await updateCoupon(id, { code, discount_percent: parseInt(discount, 10) }).catch(() => {});
+    await updateCoupon(id, {
+      code,
+      discount_percent: parseInt(discount, 10),
+      starts_at: startsAt || undefined,
+      expires_at: expiresAt || undefined,
+      usage_limit: usageLimit ? parseInt(usageLimit, 10) : undefined,
+      applies_to: appliesTo,
+      applies_to_id: appliesToId || undefined,
+    }).catch(() => {});
     router.push("/dashboard/admin/coupons");
   };
 
@@ -33,6 +51,15 @@ export default function EditCouponPage() {
         <form onSubmit={handleSubmit} className="space-y-4">
           <input value={code} onChange={(e) => setCode(e.target.value)} className="border p-2 w-full" required />
           <input type="number" value={discount} onChange={(e) => setDiscount(e.target.value)} className="border p-2 w-full" min="1" max="100" />
+          <input type="datetime-local" value={startsAt} onChange={(e) => setStartsAt(e.target.value)} className="border p-2 w-full" />
+          <input type="datetime-local" value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} className="border p-2 w-full" />
+          <input type="number" value={usageLimit} onChange={(e) => setUsageLimit(e.target.value)} placeholder="Usage Limit" className="border p-2 w-full" />
+          <select value={appliesTo} onChange={(e) => setAppliesTo(e.target.value)} className="border p-2 w-full">
+            <option value="plan">Plan</option>
+            <option value="class">Class</option>
+            <option value="tutorial">Tutorial</option>
+          </select>
+          <input value={appliesToId} onChange={(e) => setAppliesToId(e.target.value)} placeholder="Target ID" className="border p-2 w-full" />
           <button className="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Save</button>
         </form>
       </div>

--- a/frontend/src/pages/dashboard/admin/coupons/index.js
+++ b/frontend/src/pages/dashboard/admin/coupons/index.js
@@ -28,7 +28,9 @@ export default function AdminCouponsPage() {
             <tr>
               <th className="p-2 border">Code</th>
               <th className="p-2 border">Discount %</th>
+              <th className="p-2 border">Starts</th>
               <th className="p-2 border">Expires</th>
+              <th className="p-2 border">Applies To</th>
               <th className="p-2 border">Actions</th>
             </tr>
           </thead>
@@ -37,7 +39,9 @@ export default function AdminCouponsPage() {
               <tr key={c.id}>
                 <td className="p-2 border">{c.code}</td>
                 <td className="p-2 border">{c.discount_percent}</td>
+                <td className="p-2 border">{c.starts_at ? new Date(c.starts_at).toLocaleDateString() : ""}</td>
                 <td className="p-2 border">{c.expires_at ? new Date(c.expires_at).toLocaleDateString() : ""}</td>
+                <td className="p-2 border">{c.applies_to || ""}</td>
                 <td className="p-2 border space-x-2">
                   <Link href={`/dashboard/admin/coupons/edit/${c.id}`}>Edit</Link>
                   <button onClick={() => handleDelete(c.id)} className="text-red-600">Delete</button>

--- a/frontend/src/pages/dashboard/admin/coupons/new.js
+++ b/frontend/src/pages/dashboard/admin/coupons/new.js
@@ -6,11 +6,24 @@ import { useRouter } from "next/router";
 export default function NewCouponPage() {
   const [code, setCode] = useState("");
   const [discount, setDiscount] = useState(10);
+  const [startsAt, setStartsAt] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [usageLimit, setUsageLimit] = useState("");
+  const [appliesTo, setAppliesTo] = useState("plan");
+  const [appliesToId, setAppliesToId] = useState("");
   const router = useRouter();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await createCoupon({ code, discount_percent: parseInt(discount, 10) }).catch(() => {});
+    await createCoupon({
+      code,
+      discount_percent: parseInt(discount, 10),
+      starts_at: startsAt || undefined,
+      expires_at: expiresAt || undefined,
+      usage_limit: usageLimit ? parseInt(usageLimit, 10) : undefined,
+      applies_to: appliesTo,
+      applies_to_id: appliesToId || undefined,
+    }).catch(() => {});
     router.push("/dashboard/admin/coupons");
   };
 
@@ -21,6 +34,15 @@ export default function NewCouponPage() {
         <form onSubmit={handleSubmit} className="space-y-4">
           <input value={code} onChange={(e) => setCode(e.target.value)} placeholder="CODE" className="border p-2 w-full" required />
           <input type="number" value={discount} onChange={(e) => setDiscount(e.target.value)} className="border p-2 w-full" min="1" max="100" />
+          <input type="datetime-local" value={startsAt} onChange={(e) => setStartsAt(e.target.value)} className="border p-2 w-full" />
+          <input type="datetime-local" value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} className="border p-2 w-full" />
+          <input type="number" value={usageLimit} onChange={(e) => setUsageLimit(e.target.value)} placeholder="Usage Limit" className="border p-2 w-full" />
+          <select value={appliesTo} onChange={(e) => setAppliesTo(e.target.value)} className="border p-2 w-full">
+            <option value="plan">Plan</option>
+            <option value="class">Class</option>
+            <option value="tutorial">Tutorial</option>
+          </select>
+          <input value={appliesToId} onChange={(e) => setAppliesToId(e.target.value)} placeholder="Target ID" className="border p-2 w-full" />
           <button className="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Save</button>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- support `starts_at` and usage scope on coupons
- add migration for new coupon fields
- update admin coupon pages to support time range and scope
- document coupon features

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_688b26f500c48328a70aa95d9f49fca6