### PR TITLE
Fix hero media by deriving image domains

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -93,28 +93,11 @@ This ensures custom branding files persist across deployments.
 
 ## Next.js image domains
 
-If your uploads are served from the backend domain you should update the
-`remotePatterns` in `frontend/next.config.mjs` to include your production domain
-so Next.js can display those images. For example add an entry for
-`https://yourdomain.com`:
-
-```js
-// frontend/next.config.mjs
-export default {
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'yourdomain.com',
-        pathname: '/uploads/**',
-      },
-    ],
-  },
-};
-```
-
-Rebuild the frontend container after editing this file so Next.js picks up the
-new domain.
+Uploads served from the backend domain are now automatically whitelisted for
+Next.js Image. The hostname and port are derived from
+`NEXT_PUBLIC_API_BASE_URL` at build time.  If you need to allow additional
+domains you can still extend `remotePatterns` in
+`frontend/next.config.mjs`.
 
 ## Troubleshooting
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,40 +1,38 @@
 import nextI18NextConfig from './next-i18next.config.js';
 
 /** @type {import('next').NextConfig} */
+const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5002/api';
+const { protocol, hostname, port } = new URL(apiBase);
 const nextConfig = {
   images: {
     remotePatterns: [
-
       {
-        protocol: 'http',
-        hostname: '147.93.121.45',
-        port: '5002', // Add port explicitly
+        protocol: protocol.replace(':', ''),
+        hostname,
+        port,
         pathname: '/**',
       },
       {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '5002',
-        pathname: '/**',
+        protocol: protocol.replace(':', ''),
+        hostname,
+        port,
+        pathname: '/api/uploads/**',
       },
       {
-        protocol: 'https',
-        hostname: 'eduskillbridge.net',
-        pathname: '/api/uploads/**', // Production domain
-      },
-      {
-        protocol: 'https',
-        hostname: 'eduskillbridge.net',
+        protocol: protocol.replace(':', ''),
+        hostname,
+        port,
         pathname: '/uploads/**',
       },
+      // Legacy patterns kept for backward compatibility
       {
-        protocol: 'http',
-        hostname: '147.93.121.45',
-        pathname: '/api/uploads/**', // Production IP
+        protocol: 'https',
+        hostname: 'eduskillbridge.net',
+        pathname: '/api/uploads/**',
       },
       {
-        protocol: 'http',
-        hostname: '147.93.121.45',
+        protocol: 'https',
+        hostname: 'eduskillbridge.net',
         pathname: '/uploads/**',
       },
     ],


### PR DESCRIPTION
## Summary
- derive Next.js remote image domains from `NEXT_PUBLIC_API_BASE_URL`
- update deployment docs

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688b2f149eb08328b68cb0a776934c42