### PR TITLE
Use plan styling fields

### DIFF
--- a/docs/subscription-plan-style.md
+++ b/docs/subscription-plan-style.md
@@ -1,0 +1,11 @@
+# Subscription Plan Style Configuration
+
+Subscription plans have two optional fields that control how they appear on the website pricing page:
+
+- **color** – background color of the plan card.
+- **style** – additional CSS/Tailwind classes applied to the card.
+
+Administrators can set these values when creating or editing a plan from
+`/dashboard/admin/plans`. The `SubscriptionPlans` component automatically
+uses these fields, so adjusting them in the dashboard updates the site
+without code changes.

--- a/frontend/src/pages/dashboard/admin/plans/index.js
+++ b/frontend/src/pages/dashboard/admin/plans/index.js
@@ -96,13 +96,20 @@ export default function PlansIndex() {
             {plans.map((plan) => (
               <div
                 key={plan.id}
-                className="border rounded p-4 flex justify-between items-center"
+                className={`border rounded p-4 flex justify-between items-center ${plan.style || ""}`}
+                style={{ backgroundColor: plan.color || "transparent" }}
               >
-                <div>
-                  <h2 className="font-bold text-lg">{plan.name}</h2>
-                  <p className="text-sm text-gray-600">
-                    Monthly: {plan.price_monthly} {plan.currency} | Yearly: {plan.price_yearly} {plan.currency}
-                  </p>
+                <div className="flex items-center gap-2">
+                  <span
+                    className="w-4 h-4 rounded"
+                    style={{ backgroundColor: plan.color || "#1f2937" }}
+                  ></span>
+                  <div>
+                    <h2 className="font-bold text-lg">{plan.name}</h2>
+                    <p className="text-sm text-gray-600">
+                      Monthly: {plan.price_monthly} {plan.currency} | Yearly: {plan.price_yearly} {plan.currency}
+                    </p>
+                  </div>
                 </div>
                 <div className="flex gap-2">
                   <button


### PR DESCRIPTION
## Summary
- apply plan colors/styles on the admin plan list
- document how color and style fields work for subscription plans

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`
- `npm run lint --silent` in `frontend` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b3781ff8483289afd8ea1dd0d01ea