### PR TITLE
Fix hero media by deriving image domains

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -93,28 +93,11 @@ This ensures custom branding files persist across deployments.
 
 ## Next.js image domains
 
-If your uploads are served from the backend domain you should update the
-`remotePatterns` in `frontend/next.config.mjs` to include your production domain
-so Next.js can display those images. For example add an entry for
-`https://yourdomain.com`:
-
-```js
-// frontend/next.config.mjs
-export default {
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'yourdomain.com',
-        pathname: '/uploads/**',
-      },
-    ],
-  },
-};
-```
-
-Rebuild the frontend container after editing this file so Next.js picks up the
-new domain.
+Uploads served from the backend domain are now automatically whitelisted for
+Next.js Image. The hostname and port are derived from
+`NEXT_PUBLIC_API_BASE_URL` at build time.  If you need to allow additional
+domains you can still extend `remotePatterns` in
+`frontend/next.config.mjs`.
 
 ## Troubleshooting
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,40 +1,38 @@
 import nextI18NextConfig from './next-i18next.config.js';
 
 /** @type {import('next').NextConfig} */
+const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5002/api';
+const { protocol, hostname, port } = new URL(apiBase);
 const nextConfig = {
   images: {
     remotePatterns: [
-
       {
-        protocol: 'http',
-        hostname: '147.93.121.45',
-        port: '5002', // Add port explicitly
+        protocol: protocol.replace(':', ''),
+        hostname,
+        port,
         pathname: '/**',
       },
       {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '5002',
-        pathname: '/**',
+        protocol: protocol.replace(':', ''),
+        hostname,
+        port,
+        pathname: '/api/uploads/**',
       },
       {
-        protocol: 'https',
-        hostname: 'eduskillbridge.net',
-        pathname: '/api/uploads/**', // Production domain
-      },
-      {
-        protocol: 'https',
-        hostname: 'eduskillbridge.net',
+        protocol: protocol.replace(':', ''),
+        hostname,
+        port,
         pathname: '/uploads/**',
       },
+      // Legacy patterns kept for backward compatibility
       {
-        protocol: 'http',
-        hostname: '147.93.121.45',
-        pathname: '/api/uploads/**', // Production IP
+        protocol: 'https',
+        hostname: 'eduskillbridge.net',
+        pathname: '/api/uploads/**',
       },
       {
-        protocol: 'http',
-        hostname: '147.93.121.45',
+        protocol: 'https',
+        hostname: 'eduskillbridge.net',
         pathname: '/uploads/**',
       },
     ],

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -1,4 +1,5 @@
 import api from "@/services/api/api";
+import { API_BASE_URL } from "@/config/config";
 
 export const createAd = async (payload) => {
   const { data } = await api.post("/ads/admin", payload, {
@@ -11,14 +12,11 @@ export const fetchAds = async () => {
   const { data } = await api.get("/ads");
 
   const ads = data?.data ?? [];
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
   return ads.map((ad) => ({
     ...ad,
-    image: ad.image_url
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.image_url}`
-      : null,
-    video: ad.video_url
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.video_url}`
-      : null,
+    image: ad.image_url ? `${base}${ad.image_url}` : null,
+    video: ad.video_url ? `${base}${ad.video_url}` : null,
     link: ad.link_url,
     targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
   }));
@@ -28,14 +26,11 @@ export const fetchAdById = async (id) => {
   const { data } = await api.get(`/ads/${id}`);
   const ad = data?.data;
   if (!ad) return null;
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
   return {
     ...ad,
-    image: ad.image_url
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.image_url}`
-      : null,
-    video: ad.video_url
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.video_url}`
-      : null,
+    image: ad.image_url ? `${base}${ad.image_url}` : null,
+    video: ad.video_url ? `${base}${ad.video_url}` : null,
     link: ad.link_url,
     targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
   };

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -1,17 +1,15 @@
 import api from "@/services/api/api";
+import { API_BASE_URL } from "@/config/config";
 
 export const getAds = async () => {
   const { data } = await api.get("/ads");
 
   const ads = data?.data ?? [];
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
   return ads.map((ad) => ({
     ...ad,
-    image: ad.image_url
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.image_url}`
-      : null,
-    video: ad.video_url
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${ad.video_url}`
-      : null,
+    image: ad.image_url ? `${base}${ad.image_url}` : null,
+    video: ad.video_url ? `${base}${ad.video_url}` : null,
     link: ad.link_url,
   }));
 };


### PR DESCRIPTION
## Summary
- derive Next.js remote image domains from `NEXT_PUBLIC_API_BASE_URL`
- update deployment docs
- fix ads service URL handling when API base is unset

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688b2f149eb08328b68cb0a776934c42