### PR TITLE
Add plan style selection and notifications

### DIFF
--- a/backend/src/modules/plans/plans.controller.js
+++ b/backend/src/modules/plans/plans.controller.js
@@ -3,6 +3,8 @@ const AppError = require("../../utils/AppError");
 const { sendSuccess } = require("../../utils/response");
 const service = require("./plans.service");
 const slugify = require("slugify");
+const notificationService = require("../notifications/notifications.service");
+const userModel = require("../users/user.model");
 
 exports.createPlan = catchAsync(async (req, res) => {
   const {
@@ -38,6 +40,21 @@ exports.createPlan = catchAsync(async (req, res) => {
 
   await service.setFeatures(plan.id, Array.isArray(features) ? features : []);
   const full = await service.getPlanById(plan.id);
+  await notificationService.createNotification({
+    user_id: req.user.id,
+    type: "plan_created",
+    message: `Plan "${full.name}" created successfully`,
+  });
+  const admins = await userModel.findAdmins();
+  await Promise.all(
+    admins.map((admin) =>
+      notificationService.createNotification({
+        user_id: admin.id,
+        type: "plan_created",
+        message: `New plan "${full.name}" created by ${req.user.id}`,
+      })
+    )
+  );
   sendSuccess(res, full, "Plan created");
 });
 

--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -126,12 +126,17 @@ export default function CreatePlanPage() {
           />
         </div>
         <div>
-          <label className="block text-sm font-medium mb-1">Custom CSS Class</label>
-          <input
+          <label className="block text-sm font-medium mb-1">Plan Style</label>
+          <select
             className="w-full border px-4 py-2 rounded"
             value={form.style}
             onChange={(e) => setForm({ ...form, style: e.target.value })}
-          />
+          >
+            <option value="">Default</option>
+            <option value="style-blue">Blue</option>
+            <option value="style-green">Green</option>
+            <option value="style-red">Red</option>
+          </select>
         </div>
         <label className="flex items-center gap-2">
           <input


### PR DESCRIPTION
## Summary
- allow admins to choose a preset style when creating plans
- send notifications to all admins when a new plan is created

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688b3cab4ef083289860cebf47200ff8