### PR TITLE
Improve subscription plan management

### DIFF
--- a/backend/src/modules/plans/plans.controller.js
+++ b/backend/src/modules/plans/plans.controller.js
@@ -33,6 +33,10 @@ exports.createPlan = catchAsync(async (req, res) => {
         throw new Error("Invalid gradient start color");
       if (conf.gradientEnd && !isHex(conf.gradientEnd))
         throw new Error("Invalid gradient end color");
+      if (conf.buttonColor && !isHex(conf.buttonColor))
+        throw new Error("Invalid button color");
+      if (conf.buttonTextColor && !isHex(conf.buttonTextColor))
+        throw new Error("Invalid button text color");
     } catch (err) {
       throw new AppError("Invalid style format", 400);
     }
@@ -112,6 +116,10 @@ exports.updatePlan = catchAsync(async (req, res) => {
         throw new Error("Invalid gradient start color");
       if (conf.gradientEnd && !isHex(conf.gradientEnd))
         throw new Error("Invalid gradient end color");
+      if (conf.buttonColor && !isHex(conf.buttonColor))
+        throw new Error("Invalid button color");
+      if (conf.buttonTextColor && !isHex(conf.buttonTextColor))
+        throw new Error("Invalid button text color");
     } catch (err) {
       throw new AppError("Invalid style format", 400);
     }

--- a/docs/subscription-plan-style.md
+++ b/docs/subscription-plan-style.md
@@ -1,9 +1,13 @@
 # Subscription Plan Style Configuration
 
-Subscription plans have two optional fields that control how they appear on the website pricing page:
+Subscription plans have optional fields that control how they appear on the website pricing page:
 
 - **color** – background color of the plan card.
-- **style** – additional CSS/Tailwind classes applied to the card.
+- **style** – JSON string with additional visual settings:
+  - `textColor` – text color for the card contents.
+  - `gradientStart`/`gradientEnd` – optional gradient background.
+  - `buttonColor` – subscription button background color.
+  - `buttonTextColor` – subscription button text color.
 
 Administrators can set these values when creating or editing a plan from
 `/dashboard/admin/plans`. The `SubscriptionPlans` component automatically

--- a/frontend/src/components/website/sections/SubscriptionPlans.js
+++ b/frontend/src/components/website/sections/SubscriptionPlans.js
@@ -61,6 +61,11 @@ const SubscriptionPlans = () => {
               if (styleConf.textColor) styleObj.color = styleConf.textColor;
               if (styleConf.textSize) styleObj.fontSize = `${styleConf.textSize}px`;
             }
+            const buttonStyles = {};
+            if (styleConf) {
+              if (styleConf.buttonColor) buttonStyles.backgroundColor = styleConf.buttonColor;
+              if (styleConf.buttonTextColor) buttonStyles.color = styleConf.buttonTextColor;
+            }
 
             const cardClasses = `p-6 rounded-lg shadow-2xl transition-all duration-300 ${isMiddle ? "md:scale-105" : ""} relative`;
 
@@ -91,7 +96,8 @@ const SubscriptionPlans = () => {
                 </ul>
 
                 <button
-                  className="mt-6 px-6 py-3 rounded-lg font-semibold bg-gray-900 text-white hover:bg-gray-800"
+                  className="mt-6 px-6 py-3 rounded-lg font-semibold hover:opacity-90"
+                  style={buttonStyles}
                   onClick={() => setSelectedPlan(plan)}
                 >
                   {t("subscription_select_plan")}

--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -18,6 +18,8 @@ export default function CreatePlanPage() {
     currency: "USD",
     color: "#1F2937",
     textColor: "#ffffff",
+    buttonColor: "#111827",
+    buttonTextColor: "#ffffff",
     textSize: 16,
     gradientStart: "",
     gradientEnd: "",
@@ -46,7 +48,8 @@ export default function CreatePlanPage() {
       toast.error("Name is required");
       return;
     }
-    if (!isHex(form.color) || !isHex(form.textColor)) {
+    if (!isHex(form.color) || !isHex(form.textColor) ||
+        !isHex(form.buttonColor) || !isHex(form.buttonTextColor)) {
       toast.error("Invalid color value");
       return;
     }
@@ -61,6 +64,8 @@ export default function CreatePlanPage() {
 
     const style = {
       textColor: form.textColor,
+      buttonColor: form.buttonColor,
+      buttonTextColor: form.buttonTextColor,
       textSize: Number(form.textSize) || 16,
       gradientStart: form.gradientStart || null,
       gradientEnd: form.gradientEnd || null,
@@ -110,7 +115,7 @@ export default function CreatePlanPage() {
         </button>
       </div>
 
-      <form className="bg-white rounded shadow p-6 space-y-4" onSubmit={handleSubmit}>
+      <form className="bg-white rounded shadow p-6 grid grid-cols-1 md:grid-cols-2 gap-4" onSubmit={handleSubmit}>
         <div>
           <label className="block text-sm font-medium mb-1">Plan Name</label>
           <input
@@ -162,6 +167,24 @@ export default function CreatePlanPage() {
             className="w-full border px-4 py-2 rounded"
             value={form.textColor}
             onChange={(e) => setForm({ ...form, textColor: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Button Color</label>
+          <input
+            type="color"
+            className="w-full border px-4 py-2 rounded"
+            value={form.buttonColor}
+            onChange={(e) => setForm({ ...form, buttonColor: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Button Text Color</label>
+          <input
+            type="color"
+            className="w-full border px-4 py-2 rounded"
+            value={form.buttonTextColor}
+            onChange={(e) => setForm({ ...form, buttonTextColor: e.target.value })}
           />
         </div>
         <div>

--- a/frontend/src/pages/dashboard/admin/plans/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/plans/edit/[id].js
@@ -37,6 +37,8 @@ export default function EditPlanPage() {
         if (data) {
           let styleConf = {
             textColor: "#ffffff",
+            buttonColor: "#111827",
+            buttonTextColor: "#ffffff",
             textSize: 16,
             gradientStart: "",
             gradientEnd: "",
@@ -55,6 +57,8 @@ export default function EditPlanPage() {
             currency: data.currency,
             color: data.color || "#1F2937",
             textColor: styleConf.textColor,
+            buttonColor: styleConf.buttonColor,
+            buttonTextColor: styleConf.buttonTextColor,
             textSize: styleConf.textSize,
             gradientStart: styleConf.gradientStart,
             gradientEnd: styleConf.gradientEnd,
@@ -81,7 +85,8 @@ export default function EditPlanPage() {
       toast.error("Name is required");
       return;
     }
-    if (!isHex(form.color) || !isHex(form.textColor)) {
+    if (!isHex(form.color) || !isHex(form.textColor) ||
+        !isHex(form.buttonColor) || !isHex(form.buttonTextColor)) {
       toast.error("Invalid color value");
       return;
     }
@@ -96,6 +101,8 @@ export default function EditPlanPage() {
 
     const style = {
       textColor: form.textColor,
+      buttonColor: form.buttonColor,
+      buttonTextColor: form.buttonTextColor,
       textSize: Number(form.textSize) || 16,
       gradientStart: form.gradientStart || null,
       gradientEnd: form.gradientEnd || null,
@@ -152,7 +159,7 @@ export default function EditPlanPage() {
         </button>
       </div>
 
-      <form className="bg-white rounded shadow p-6 space-y-4" onSubmit={handleSubmit}>
+      <form className="bg-white rounded shadow p-6 grid grid-cols-1 md:grid-cols-2 gap-4" onSubmit={handleSubmit}>
         <div>
           <label className="block text-sm font-medium mb-1">Plan Name</label>
           <input
@@ -204,6 +211,24 @@ export default function EditPlanPage() {
             className="w-full border px-4 py-2 rounded"
             value={form.textColor}
             onChange={(e) => setForm({ ...form, textColor: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Button Color</label>
+          <input
+            type="color"
+            className="w-full border px-4 py-2 rounded"
+            value={form.buttonColor}
+            onChange={(e) => setForm({ ...form, buttonColor: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Button Text Color</label>
+          <input
+            type="color"
+            className="w-full border px-4 py-2 rounded"
+            value={form.buttonTextColor}
+            onChange={(e) => setForm({ ...form, buttonTextColor: e.target.value })}
           />
         </div>
         <div>

--- a/frontend/src/pages/dashboard/admin/plans/index.js
+++ b/frontend/src/pages/dashboard/admin/plans/index.js
@@ -10,6 +10,7 @@ import { toast } from "react-toastify";
 export default function PlansIndex() {
   const [plans, setPlans] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [selectedIds, setSelectedIds] = useState([]);
 
   const router = useRouter();
   const { accessToken, user, hasHydrated } = useAuthStore();
@@ -70,6 +71,29 @@ export default function PlansIndex() {
     }
   };
 
+  const toggleSelect = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((pid) => pid !== id) : [...prev, id]
+    );
+  };
+
+  const selectAll = () => setSelectedIds(plans.map((p) => p.id));
+  const clearAll = () => setSelectedIds([]);
+
+  const bulkDelete = async () => {
+    if (!selectedIds.length) return;
+    if (!confirm("Delete selected plans?")) return;
+    try {
+      await Promise.all(selectedIds.map((id) => deletePlan(id)));
+      setPlans((prev) => prev.filter((p) => !selectedIds.includes(p.id)));
+      setSelectedIds([]);
+      toast.success("Plans deleted");
+    } catch (err) {
+      console.error("Bulk delete failed", err);
+      toast.error("Failed to delete plans");
+    }
+  };
+
   if (!hasHydrated) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-white">
@@ -82,13 +106,29 @@ export default function PlansIndex() {
     <AdminLayout title="Manage Subscription Plans">
       <div className="bg-white rounded-xl p-6 shadow mb-10">
         <div className="flex flex-wrap justify-between items-center gap-4 mb-6">
-          <h1 className="text-3xl font-bold text-gray-800">📦 Subscription Plans</h1>
+          <h1 className="text-3xl font-bold text-gray-800 flex items-center gap-2">
+            <input
+              type="checkbox"
+              onChange={(e) => (e.target.checked ? selectAll() : clearAll())}
+              checked={selectedIds.length === plans.length && plans.length > 0}
+            />
+            <span>📦 Subscription Plans</span>
+          </h1>
           <Link href="/dashboard/admin/plans/create">
             <button className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded-lg flex items-center gap-2 shadow">
               <FaPlus /> Add Plan
             </button>
           </Link>
         </div>
+        {selectedIds.length > 0 && (
+          <div className="flex justify-between items-center bg-yellow-50 border border-yellow-200 p-4 rounded mb-4">
+            <span>{selectedIds.length} selected</span>
+            <div className="flex gap-2">
+              <button onClick={bulkDelete} className="bg-red-600 text-white px-3 py-1 rounded text-sm">Delete Selected</button>
+              <button onClick={clearAll} className="text-sm text-gray-500 hover:text-black">Clear</button>
+            </div>
+          </div>
+        )}
         {loading ? (
           <p>Loading...</p>
         ) : (
@@ -115,10 +155,16 @@ export default function PlansIndex() {
               return (
                 <div
                   key={plan.id}
-                  className="border rounded p-4 flex justify-between items-center"
+                  className={`border rounded p-4 flex justify-between items-center ${selectedIds.includes(plan.id) ? 'ring-2 ring-blue-500' : ''}`}
                   style={styleObj}
                 >
                 <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    className="mr-2"
+                    checked={selectedIds.includes(plan.id)}
+                    onChange={() => toggleSelect(plan.id)}
+                  />
                   <span
                     className="w-4 h-4 rounded"
                     style={{ backgroundColor: plan.color || "#1f2937" }}


### PR DESCRIPTION
## Summary
- let admins configure button colors for subscription plans
- support responsive form layout for plans
- allow bulk deletion of plans from the dashboard
- document new style settings

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688b59e8210c8328a34844b05032dc58