### PR TITLE
Add editable plan feature list

### DIFF
--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -27,6 +27,20 @@ export default function CreatePlanPage() {
     active: true,
   });
 
+  const [features, setFeatures] = useState([]);
+
+  const addFeature = () =>
+    setFeatures([...features, { feature_key: "", value: "", description: "" }]);
+
+  const updateFeature = (index, field, value) => {
+    const updated = [...features];
+    updated[index][field] = value;
+    setFeatures(updated);
+  };
+
+  const removeFeature = (index) =>
+    setFeatures(features.filter((_, i) => i !== index));
+
   useEffect(() => {
     if (!hasHydrated) return;
     if (!accessToken || !user) {
@@ -81,7 +95,9 @@ export default function CreatePlanPage() {
         style: JSON.stringify(style),
         recommended: form.recommended,
         active: form.active,
-        features: [],
+        features: features.filter(
+          (f) => f.feature_key || f.value || f.description
+        ),
       });
       toast.success("Plan created");
       router.push("/dashboard/admin/plans");
@@ -215,6 +231,52 @@ export default function CreatePlanPage() {
             value={form.gradientEnd}
             onChange={(e) => setForm({ ...form, gradientEnd: e.target.value })}
           />
+        </div>
+
+        <div className="md:col-span-2">
+          <h4 className="font-semibold mb-2">Plan Features</h4>
+          {features.map((feat, idx) => (
+            <div key={idx} className="grid grid-cols-3 gap-2 mb-2 items-center">
+              <input
+                className="border px-2 py-1 rounded"
+                placeholder="Key"
+                value={feat.feature_key}
+                onChange={(e) =>
+                  updateFeature(idx, "feature_key", e.target.value)
+                }
+              />
+              <input
+                className="border px-2 py-1 rounded"
+                placeholder="Value"
+                value={feat.value}
+                onChange={(e) => updateFeature(idx, "value", e.target.value)}
+              />
+              <div className="flex gap-2">
+                <input
+                  className="border px-2 py-1 rounded flex-1"
+                  placeholder="Description"
+                  value={feat.description}
+                  onChange={(e) =>
+                    updateFeature(idx, "description", e.target.value)
+                  }
+                />
+                <button
+                  type="button"
+                  onClick={() => removeFeature(idx)}
+                  className="text-red-500 text-sm"
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={addFeature}
+            className="mt-2 bg-gray-200 px-3 py-1 rounded text-sm"
+          >
+            + Add Feature
+          </button>
         </div>
         <label className="flex items-center gap-2">
           <input

--- a/frontend/src/pages/dashboard/admin/plans/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/plans/edit/[id].js
@@ -17,6 +17,19 @@ export default function EditPlanPage() {
 
   const [form, setForm] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [features, setFeatures] = useState([]);
+
+  const addFeature = () =>
+    setFeatures([...features, { feature_key: "", value: "", description: "" }]);
+
+  const updateFeature = (index, field, value) => {
+    const updated = [...features];
+    updated[index][field] = value;
+    setFeatures(updated);
+  };
+
+  const removeFeature = (index) =>
+    setFeatures(features.filter((_, i) => i !== index));
 
   useEffect(() => {
     if (!router.isReady || !hasHydrated) return;
@@ -65,6 +78,7 @@ export default function EditPlanPage() {
             recommended: data.recommended,
             active: data.active,
           });
+          setFeatures(data.features || []);
         }
       } catch (err) {
         toast.error("Failed to load plan");
@@ -118,6 +132,9 @@ export default function EditPlanPage() {
         style: JSON.stringify(style),
         recommended: form.recommended,
         active: form.active,
+        features: features.filter(
+          (f) => f.feature_key || f.value || f.description
+        ),
       });
       toast.success("Plan updated");
       router.push("/dashboard/admin/plans");
@@ -259,6 +276,52 @@ export default function EditPlanPage() {
             value={form.gradientEnd}
             onChange={(e) => setForm({ ...form, gradientEnd: e.target.value })}
           />
+        </div>
+
+        <div className="md:col-span-2">
+          <h4 className="font-semibold mb-2">Plan Features</h4>
+          {features.map((feat, idx) => (
+            <div key={idx} className="grid grid-cols-3 gap-2 mb-2 items-center">
+              <input
+                className="border px-2 py-1 rounded"
+                placeholder="Key"
+                value={feat.feature_key}
+                onChange={(e) =>
+                  updateFeature(idx, "feature_key", e.target.value)
+                }
+              />
+              <input
+                className="border px-2 py-1 rounded"
+                placeholder="Value"
+                value={feat.value}
+                onChange={(e) => updateFeature(idx, "value", e.target.value)}
+              />
+              <div className="flex gap-2">
+                <input
+                  className="border px-2 py-1 rounded flex-1"
+                  placeholder="Description"
+                  value={feat.description}
+                  onChange={(e) =>
+                    updateFeature(idx, "description", e.target.value)
+                  }
+                />
+                <button
+                  type="button"
+                  onClick={() => removeFeature(idx)}
+                  className="text-red-500 text-sm"
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={addFeature}
+            className="mt-2 bg-gray-200 px-3 py-1 rounded text-sm"
+          >
+            + Add Feature
+          </button>
         </div>
         <label className="flex items-center gap-2">
           <input


### PR DESCRIPTION
## Summary
- allow feature editing when creating plans
- load and edit features on the admin plan edit page

## Testing
- `npm test --prefix frontend`
- `npm install --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_688b6121e8548328ba6d7343c3d5c77e