### PR TITLE
Add full stack search

### DIFF
--- a/backend/src/modules/search/search.controller.js
+++ b/backend/src/modules/search/search.controller.js
@@ -1,0 +1,19 @@
+const service = require('./search.service');
+const catchAsync = require('../../utils/catchAsync');
+const { sendSuccess } = require('../../utils/response');
+
+exports.search = catchAsync(async (req, res) => {
+  const q = req.query.q ? req.query.q.trim() : '';
+  if (!q) return res.status(400).json({ error: 'Missing query string' });
+
+  const [classes, tutorials, instructors, offers, community, blog] = await Promise.all([
+    service.searchClasses(q),
+    service.searchTutorials(q),
+    service.searchInstructors(q),
+    service.searchOffers(q),
+    service.searchCommunity(q),
+    service.searchBlog(q),
+  ]);
+
+  sendSuccess(res, { classes, tutorials, instructors, offers, community, blog });
+});

--- a/backend/src/modules/search/search.routes.js
+++ b/backend/src/modules/search/search.routes.js
@@ -1,0 +1,6 @@
+const router = require('express').Router();
+const controller = require('./search.controller');
+
+router.get('/', controller.search);
+
+module.exports = router;

--- a/backend/src/modules/search/search.service.js
+++ b/backend/src/modules/search/search.service.js
@@ -1,0 +1,49 @@
+const db = require("../../config/database");
+
+exports.searchClasses = async (q) => {
+  return db("online_classes")
+    .whereILike("title", `%${q}%`)
+    .orWhereILike("description", `%${q}%`)
+    .select("id", "title", "cover_image as cover", "slug")
+    .limit(5);
+};
+
+exports.searchTutorials = async (q) => {
+  return db("tutorials")
+    .whereILike("title", `%${q}%`)
+    .orWhereILike("description", `%${q}%`)
+    .select("id", "title", "cover_image as cover", "slug")
+    .limit(5);
+};
+
+exports.searchInstructors = async (q) => {
+  return db("users")
+    .whereILike("full_name", `%${q}%`)
+    .andWhereRaw("LOWER(role) = ?", ["instructor"])
+    .select("id", "full_name", "avatar_url")
+    .limit(5);
+};
+
+exports.searchOffers = async (q) => {
+  return db("offers")
+    .whereILike("title", `%${q}%`)
+    .orWhereILike("description", `%${q}%`)
+    .select("id", "title")
+    .limit(5);
+};
+
+exports.searchCommunity = async (q) => {
+  return db("community_discussions")
+    .whereILike("title", `%${q}%`)
+    .orWhereILike("content", `%${q}%`)
+    .select("id", "title")
+    .limit(5);
+};
+
+exports.searchBlog = async (q) => {
+  return db("blog_posts")
+    .whereILike("title", `%${q}%`)
+    .orWhereILike("excerpt", `%${q}%`)
+    .select("id", "title", "slug", "image_url as image")
+    .limit(5);
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -128,6 +128,7 @@ app.use("/api/blog", require("./modules/blog/blog.routes"));
 app.use("/api/support", require("./modules/support/support.routes"));
 app.use("/api/tickets", require("./modules/tickets/tickets.routes"));
 app.use("/api/media", require("./modules/media/media.routes"));
+app.use("/api/search", require("./modules/search/search.routes"));
 
 app.get("/", (req, res) => res.send("🚀 SkillBridge API is live."));
 

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { motion, AnimatePresence } from "framer-motion";
 import Image from "next/image";
 import Typewriter from "typewriter-effect";
@@ -24,18 +23,18 @@ import SidebarMenu from "@/components/shared/SidebarMenu";
 import Chatbot from "@/components/shared/Chatbot";
 import heroImage from "@/shared/assets/images/home/hero.png";
 import { getAds } from "@/services/adsService";
+import { searchAll } from "@/services/searchService";
 import { useTranslation } from "next-i18next";
 
 
 const Hero = () => {
-  const router = useRouter();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isChatOpen, setIsChatOpen] = useState(false);
   const [ads, setAds] = useState([]);
   const [currentAd, setCurrentAd] = useState(0);
   const [showMedia, setShowMedia] = useState(false);
   const [searchText, setSearchText] = useState("");
-  const [searchSuggestions, setSearchSuggestions] = useState([]);
+  const [results, setResults] = useState(null);
   const [country, setCountry] = useState("");
   const { t } = useTranslation("website");
 
@@ -66,28 +65,9 @@ const Hero = () => {
     return () => clearInterval(interval);
   }, [ads]);
 
-  // Search Suggestions (async with debounce)
+  // Clear results when input cleared
   useEffect(() => {
-    if (searchText.trim().length < 2) {
-      setSearchSuggestions([]);
-      return;
-    }
-    const timeout = setTimeout(async () => {
-      try {
-        const res = await fetch(
-          `/api/search/suggestions?q=${encodeURIComponent(searchText.trim())}`
-        );
-        if (res.ok) {
-          const data = await res.json();
-          setSearchSuggestions(data);
-        } else {
-          setSearchSuggestions([]);
-        }
-      } catch {
-        setSearchSuggestions([]);
-      }
-    }, 300);
-    return () => clearTimeout(timeout);
+    if (!searchText.trim()) setResults(null);
   }, [searchText]);
 
   // Detect user country using IP lookup with locale fallback
@@ -151,9 +131,16 @@ const Hero = () => {
     trackMouse: true,
   });
 
-  const handleSearch = (query) => {
-    if (!query.trim()) return;
-    router.push(`/search?q=${encodeURIComponent(query.trim())}`);
+  const handleSearch = async (query) => {
+    const term = query.trim();
+    if (!term) return;
+    try {
+      const data = await searchAll(term);
+      setResults(data);
+    } catch (err) {
+      console.error('Search failed', err);
+      setResults(null);
+    }
   };
 
   const handleSearchSelect = (selectedValue) => {
@@ -223,18 +210,69 @@ const Hero = () => {
                 <FaSearch />
               </button>
             </div>
-            {searchSuggestions.length > 0 && (
-              <ul className="absolute mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg z-20">
-                {searchSuggestions.map((s, idx) => (
-                  <li
-                    key={idx}
-                    onClick={() => handleSearchSelect(s)}
-                    className="px-4 py-2 hover:bg-gray-100 cursor-pointer"
-                  >
-                    {s}
-                  </li>
-                ))}
-              </ul>
+            {results && (
+              <div className="absolute mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg z-20 max-h-80 overflow-y-auto text-left">
+                {results.classes?.length > 0 && (
+                  <div className="py-1">
+                    <h3 className="px-4 py-1 text-sm font-semibold text-gray-500">📚 Online Classes</h3>
+                    {results.classes.map((c) => (
+                      <Link href={`/online-classes/${c.id}`} key={`c-${c.id}`}>
+                        <span className="block px-4 py-2 hover:bg-gray-100 cursor-pointer">{c.title}</span>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+                {results.tutorials?.length > 0 && (
+                  <div className="py-1">
+                    <h3 className="px-4 py-1 text-sm font-semibold text-gray-500">📘 Tutorials</h3>
+                    {results.tutorials.map((t) => (
+                      <Link href={`/tutorials/${t.id}`} key={`t-${t.id}`}>
+                        <span className="block px-4 py-2 hover:bg-gray-100 cursor-pointer">{t.title}</span>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+                {results.instructors?.length > 0 && (
+                  <div className="py-1">
+                    <h3 className="px-4 py-1 text-sm font-semibold text-gray-500">👩‍🏫 Instructors</h3>
+                    {results.instructors.map((i) => (
+                      <Link href={`/instructors/${i.id}`} key={`i-${i.id}`}>
+                        <span className="block px-4 py-2 hover:bg-gray-100 cursor-pointer">{i.full_name}</span>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+                {results.offers?.length > 0 && (
+                  <div className="py-1">
+                    <h3 className="px-4 py-1 text-sm font-semibold text-gray-500">💼 Offers</h3>
+                    {results.offers.map((o) => (
+                      <Link href={`/offers/${o.id}`} key={`o-${o.id}`}>
+                        <span className="block px-4 py-2 hover:bg-gray-100 cursor-pointer">{o.title}</span>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+                {results.community?.length > 0 && (
+                  <div className="py-1">
+                    <h3 className="px-4 py-1 text-sm font-semibold text-gray-500">💬 Community</h3>
+                    {results.community.map((d) => (
+                      <Link href={`/community/${d.id}`} key={`d-${d.id}`}>
+                        <span className="block px-4 py-2 hover:bg-gray-100 cursor-pointer">{d.title}</span>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+                {results.blog?.length > 0 && (
+                  <div className="py-1">
+                    <h3 className="px-4 py-1 text-sm font-semibold text-gray-500">📝 Blog</h3>
+                    {results.blog.map((b) => (
+                      <Link href={`/blog/${b.slug}`} key={`b-${b.id}`}>
+                        <span className="block px-4 py-2 hover:bg-gray-100 cursor-pointer">{b.title}</span>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
           </div>
 

--- a/frontend/src/pages/api/search/index.js
+++ b/frontend/src/pages/api/search/index.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+export default async function handler(req, res) {
+  const { q = '' } = req.query;
+  const query = q.trim();
+  if (!query) return res.status(400).json({ error: 'Missing query string' });
+  try {
+    const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_BASE_URL}/search`, {
+      params: { q: query },
+      headers: req.headers.cookie ? { Cookie: req.headers.cookie } : {},
+      withCredentials: true,
+    });
+    return res.status(200).json(data.data || data);
+  } catch (err) {
+    const status = err.response?.status || 500;
+    const message = err.response?.data?.message || 'Search failed';
+    res.status(status).json({ error: message });
+  }
+}

--- a/frontend/src/services/searchService.js
+++ b/frontend/src/services/searchService.js
@@ -1,0 +1,6 @@
+import api from '@/services/api/api';
+
+export const searchAll = async (query) => {
+  const { data } = await api.get('/search', { params: { q: query } });
+  return data;
+};


### PR DESCRIPTION
## Summary
- add backend search service and route for unified content search
- create proxy API route in Next.js
- expose searchAll service for client use
- display grouped results in Hero search UI

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688c834dcec083289ead321b1f81091f