### PR TITLE
Integrate SMS service and enforce single active gateway

### DIFF
--- a/backend/src/modules/messagesConfig/messagesConfig.service.js
+++ b/backend/src/modules/messagesConfig/messagesConfig.service.js
@@ -13,6 +13,25 @@ exports.getSettings = async () => {
 };
 
 exports.updateSettings = async (settings) => {
+  // Ensure only one Gateway provider is active and default
+  if (Array.isArray(settings?.providers)) {
+    let activeSet = false;
+    let defaultSet = false;
+    settings.providers = settings.providers.map((p) => {
+      if (p.type === "Gateway") {
+        if (p.active) {
+          if (!activeSet) activeSet = true;
+          else p.active = false;
+        }
+        if (p.isDefault) {
+          if (!defaultSet) defaultSet = true;
+          else p.isDefault = false;
+        }
+      }
+      return p;
+    });
+  }
+
   const value = JSON.stringify(settings);
   const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
   if (existing) {

--- a/backend/src/modules/verify/verify.service.js
+++ b/backend/src/modules/verify/verify.service.js
@@ -4,6 +4,7 @@ const notificationService = require("../notifications/notifications.service");
 const messageService = require("../messages/messages.service");
 const userModel = require("../users/user.model");
 const { sendOtpEmail } = require("../../utils/email");
+const smsService = require("../../services/smsService");
 
 const generateCode = () =>
   Math.floor(100000 + Math.random() * 900000).toString();
@@ -34,7 +35,14 @@ exports.sendOtp = async (userId, type) => {
       console.error("Error sending OTP email:", err.message);
     }
   } else {
-    console.log(`[SMS] Phone OTP for ${user.phone}: ${code}`); // Replace with SMS provider
+    try {
+      await smsService.sendSMS({
+        to: user.phone,
+        text: `Your SkillBridge OTP is: ${code}`,
+      });
+    } catch (err) {
+      console.error("Error sending OTP SMS:", err.message);
+    }
   }
 
   console.log(`[OTP] Sent ${type} code:`, code);

--- a/backend/src/services/smsService.js
+++ b/backend/src/services/smsService.js
@@ -1,0 +1,67 @@
+const messagesConfigService = require("../modules/messagesConfig/messagesConfig.service");
+
+const fetchFn =
+  typeof fetch === 'function'
+    ? fetch
+    : (...args) => import('node-fetch').then(({ default: f }) => f(...args));
+
+const SMS_DISABLED = process.env.DISABLE_SMS === "true";
+
+async function getActiveProvider() {
+  const cfg = await messagesConfigService.getSettings();
+  if (!cfg || !Array.isArray(cfg.providers)) return null;
+  return cfg.providers.find(p => p.type === 'Gateway' && p.active);
+}
+
+exports.sendSMS = async ({ to, text }) => {
+  if (SMS_DISABLED) {
+    console.log(`[SMS DISABLED] to ${to}: ${text}`);
+    return;
+  }
+
+  const provider = await getActiveProvider();
+  if (!provider) {
+    console.log(`[SMS] No active provider. Message to ${to}: ${text}`);
+    return;
+  }
+
+  if (provider.name === 'Infobip') {
+    const base = provider.region.startsWith('http')
+      ? provider.region
+      : `https://${provider.region}`;
+    const url = `${base.replace(/\/$/, '')}/sms/2/text/advanced`;
+    const payload = {
+      messages: [
+        {
+          from: provider.senderId,
+          destinations: [{ to }],
+          text,
+        },
+      ],
+    };
+    try {
+      const auth = provider.apiKey.trim().startsWith('App ')
+        ? provider.apiKey.trim()
+        : `App ${provider.apiKey.trim()}`;
+      const res = await fetchFn(url, {
+        method: 'POST',
+        headers: {
+          Authorization: auth,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const msg = await res.text();
+        console.error('Infobip SMS error:', msg);
+      } else {
+        console.log(`SMS sent via Infobip to ${to}`);
+      }
+    } catch (err) {
+      console.error('Failed to send SMS via Infobip:', err.message);
+    }
+  } else {
+    console.log(`[SMS MOCK ${provider.name}] to ${to}: ${text}`);
+  }
+};

--- a/frontend/src/components/profile/steps/Verification.js
+++ b/frontend/src/components/profile/steps/Verification.js
@@ -148,9 +148,10 @@ const Verification = ({ onNext, onBack }) => {
                   ? setEmailOTP(e.target.value)
                   : setPhoneOTP(e.target.value)
               }
-              className="w-full px-3 py-2 border rounded mb-4"
+              className="w-full px-3 py-2 border rounded mb-2"
               placeholder="Enter OTP"
             />
+            <p className="text-xs text-gray-500 mb-2">Default OTP: <code>123456</code></p>
             <div className="flex justify-end gap-2">
               <button
                 onClick={() => setShowOtpModal(null)}

--- a/frontend/src/pages/dashboard/admin/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/admin/profile/steps/Verification.js
@@ -161,10 +161,11 @@ const Verification = ({ onBack = () => {} }) => {
                 onChange={(e) =>
                   showOtpModal === "email" ? setEmailOTP(e.target.value) : setPhoneOTP(e.target.value)
                 }
-                className="w-full px-3 py-2 border rounded mb-4"
-                placeholder="Enter OTP"
-              />
-              <div className="flex justify-end gap-2">
+              className="w-full px-3 py-2 border rounded mb-2"
+              placeholder="Enter OTP"
+            />
+            <p className="text-xs text-gray-500 mb-2">Default OTP: <code>123456</code></p>
+            <div className="flex justify-end gap-2">
                 <button
                   onClick={() => setShowOtpModal(null)}
                   className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"

--- a/frontend/src/pages/dashboard/admin/settings/messages-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/messages-config/index.js
@@ -80,6 +80,16 @@ export default function MessageServiceConfig() {
     setProviders(updated);
   };
 
+  const toggleActive = (index) => {
+    setProviders((prev) =>
+      prev.map((p, i) =>
+        p.type === "Gateway"
+          ? { ...p, active: i === index ? !p.active : false }
+          : p
+      )
+    );
+  };
+
   const setDefault = (index) => {
     setProviders((prev) =>
       prev.map((p, i) =>
@@ -121,7 +131,7 @@ export default function MessageServiceConfig() {
                   Default
                 </label>
                 <button
-                  onClick={() => handleChange(providers.findIndex(p => p.id === provider.id), "active", !provider.active)}
+                  onClick={() => toggleActive(providers.findIndex(p => p.id === provider.id))}
                   className={`text-xl ${provider.active ? "text-green-500" : "text-gray-400"}`}
                 >
                   {provider.active ? <FaToggleOn /> : <FaToggleOff />}
@@ -139,6 +149,7 @@ export default function MessageServiceConfig() {
                     handleChange(providers.findIndex(p => p.id === provider.id), "apiKey", e.target.value)
                   }
                 />
+                <p className="text-xs text-gray-500 mt-1">Do not include the <code>App</code> prefix.</p>
               </div>
               <div>
                 <label className="block font-medium mb-1">Sender ID</label>
@@ -152,7 +163,7 @@ export default function MessageServiceConfig() {
                 />
               </div>
               <div>
-                <label className="block font-medium mb-1">Region</label>
+                <label className="block font-medium mb-1">Base URL / Region</label>
                 <input
                   type="text"
                   className="w-full border rounded p-2"
@@ -191,7 +202,7 @@ export default function MessageServiceConfig() {
                   />
                 </div>
                 <div>
-                  <label className="block font-medium mb-1">Region</label>
+                  <label className="block font-medium mb-1">Base URL / Region</label>
                   <input
                     type="text"
                     className="w-full border rounded p-2"

--- a/frontend/src/pages/dashboard/instructor/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/Verification.js
@@ -161,9 +161,10 @@ const Verification = ({ onBack = () => {} }) => {
                   ? setEmailOTP(e.target.value)
                   : setPhoneOTP(e.target.value)
               }
-              className="w-full px-3 py-2 border rounded mb-4"
+              className="w-full px-3 py-2 border rounded mb-2"
               placeholder="Enter OTP"
             />
+            <p className="text-xs text-gray-500 mb-2">Default OTP: <code>123456</code></p>
             <div className="flex justify-end gap-2">
               <button
                 onClick={() => setShowOtpModal(null)}

--- a/frontend/src/pages/dashboard/student/profile/steps/Verification.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/Verification.js
@@ -183,8 +183,9 @@ const Verification = ({ prevStep = () => {} }) => {
                 placeholder="Enter Phone OTP"
                 value={phoneOTP}
                 onChange={(e) => setPhoneOTP(e.target.value)}
-                className="w-full px-3 py-2 border rounded"
+                className="w-full px-3 py-2 border rounded mb-2"
               />
+              <p className="text-xs text-gray-500">Default OTP: <code>123456</code></p>
               <button
                 onClick={() => verifyOtp("phone")}
                 className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"


### PR DESCRIPTION
## Summary
- create `smsService` for sending SMS via Infobip
- use `smsService` when sending phone OTP codes
- restrict message provider settings to one active/default gateway
- ensure UI toggles active provider exclusively
- display default `123456` OTP hint in verification pop‑ups
- fix Infobip base URL handling and update label
- handle API key with or without `App` prefix for Infobip requests

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688c919bb8d08328bbe3599831f07377