### PR TITLE
Fix search service syntax error

### DIFF
--- a/backend/src/modules/search/search.service.js
+++ b/backend/src/modules/search/search.service.js
@@ -32,6 +32,11 @@ exports.searchOffers = async (q) => {
   const term = `%${q}%`;
   return db("offers")
     .whereRaw("title ILIKE ?", [term])
+    .orWhereRaw("description ILIKE ?", [term])
+    .select("id", "title")
+    .limit(5);
+};
+
 exports.searchCommunity = async (q) => {
   const term = `%${q}%`;
   return db("community_discussions")


### PR DESCRIPTION
## Summary
- restore missing lines in `search.service.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cb4bfae5c83289d52d236bd694533