### PR TITLE
Add verbose logging for Infobip SMS requests

### DIFF
--- a/backend/src/services/smsService.js
+++ b/backend/src/services/smsService.js
@@ -43,6 +43,11 @@ exports.sendSMS = async ({ to, text }) => {
       const auth = provider.apiKey.trim().startsWith('App ')
         ? provider.apiKey.trim()
         : `App ${provider.apiKey.trim()}`;
+      console.log('Sending SMS via Infobip', {
+        url,
+        provider: { region: provider.region, senderId: provider.senderId },
+        payload,
+      });
       const res = await fetchFn(url, {
         method: 'POST',
         headers: {
@@ -52,6 +57,7 @@ exports.sendSMS = async ({ to, text }) => {
         },
         body: JSON.stringify(payload),
       });
+      console.log('Infobip response status:', res.status);
       if (!res.ok) {
         const msg = await res.text();
         console.error('Infobip SMS error:', msg);


### PR DESCRIPTION
## Summary
- add console logs before and after Infobip SMS API call

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688ce8e205248328be792be6dbbd1893