### PR TITLE
Fix search API result handling

### DIFF
--- a/frontend/src/services/searchService.js
+++ b/frontend/src/services/searchService.js
@@ -2,5 +2,7 @@ import api from '@/services/api/api';
 
 export const searchAll = async (query) => {
   const { data } = await api.get('/search', { params: { q: query } });
-  return data;
+  // API may return `{status, message, data}` or the raw results object
+  // Normalize by always returning the payload containing the lists
+  return data.data || data;
 };


### PR DESCRIPTION
## Summary
- normalize search service to return flattened results

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688ce9340064832897a8c02df58fe80a