### PR TITLE
Include phone field in user lookup

### DIFF
--- a/backend/src/modules/users/user.model.js
+++ b/backend/src/modules/users/user.model.js
@@ -66,6 +66,7 @@ exports.findById = (id) => {
       "full_name",
       "role",
       "avatar_url",
+      "phone",
       "is_online",
       "status",
       "profile_complete",

--- a/frontend/src/services/searchService.js
+++ b/frontend/src/services/searchService.js
@@ -2,5 +2,7 @@ import api from '@/services/api/api';
 
 export const searchAll = async (query) => {
   const { data } = await api.get('/search', { params: { q: query } });
-  return data;
+  // API may return `{status, message, data}` or the raw results object
+  // Normalize by always returning the payload containing the lists
+  return data.data || data;
 };


### PR DESCRIPTION
## Summary
- return `phone` in `findById` so OTP SMS has the destination number

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688ce9340064832897a8c02df58fe80a