### PR TITLE
Add configurable hero background

### DIFF
--- a/backend/src/modules/appConfig/appConfig.controller.js
+++ b/backend/src/modules/appConfig/appConfig.controller.js
@@ -60,3 +60,14 @@ exports.uploadFavicon = catchAsync(async (req, res) => {
   sendSuccess(res, updated, "Favicon updated");
 });
 
+exports.uploadHomeBackground = catchAsync(async (req, res) => {
+  if (!req.file) throw new AppError("No file uploaded", 400);
+  const existing = await service.getSettings();
+  if (existing.home_bg_url) {
+    const oldPath = path.join(__dirname, "../../../", existing.home_bg_url);
+    if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
+  }
+  const bgUrl = `/uploads/app/${req.file.filename}`;
+  const updated = await service.updateSettings({ ...existing, home_bg_url: bgUrl });
+  sendSuccess(res, updated, "Background updated");
+});

--- a/backend/src/modules/appConfig/appConfig.routes.js
+++ b/backend/src/modules/appConfig/appConfig.routes.js
@@ -4,6 +4,7 @@ const controller = require("./appConfig.controller");
 const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
 const logoUpload = require("./appLogoUploadMiddleware");
 const faviconUpload = require("./appFaviconUploadMiddleware");
+const homeBgUpload = require("./appHomeBgUploadMiddleware");
 
 // Log incoming GET requests to debug potential auth or DB issues
 router.get("/", (req, res, next) => {
@@ -17,4 +18,9 @@ router.use(verifyToken, isAdmin);
 router.put("/", controller.updateSettings);
 router.patch("/logo", logoUpload.single("logo"), controller.uploadLogo);
 router.patch("/favicon", faviconUpload.single("favicon"), controller.uploadFavicon);
+router.patch(
+  "/home-bg",
+  homeBgUpload.single("home_bg"),
+  controller.uploadHomeBackground
+);
 module.exports = router;

--- a/backend/src/modules/appConfig/appHomeBgUploadMiddleware.js
+++ b/backend/src/modules/appConfig/appHomeBgUploadMiddleware.js
@@ -1,0 +1,23 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const uploadDir = path.join(__dirname, '../../../uploads/app');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    cb(null, `home-bg-${Date.now()}${ext}`);
+  },
+});
+
+const fileFilter = (_req, file, cb) => {
+  if (file.mimetype.startsWith('image/')) cb(null, true);
+  else cb(new Error('Only image files are allowed'), false);
+};
+
+module.exports = multer({ storage, fileFilter, limits: { fileSize: 5 * 1024 * 1024 } });

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -22,6 +22,8 @@ import AdMediaModal from "@/components/website/AdMediaModal";
 import SidebarMenu from "@/components/shared/SidebarMenu";
 import Chatbot from "@/components/shared/Chatbot";
 import heroImage from "@/shared/assets/images/home/hero.png";
+import useAppConfigStore from "@/store/appConfigStore";
+import { API_BASE_URL } from "@/config/config";
 import { getAds } from "@/services/adsService";
 import { searchAll } from "@/services/searchService";
 import { useTranslation } from "next-i18next";
@@ -41,7 +43,13 @@ const Hero = () => {
       (arr) => Array.isArray(arr) && arr.length > 0
     );
   const [country, setCountry] = useState("");
+  const settings = useAppConfigStore((s) => s.settings);
   const { t } = useTranslation("website");
+
+  const heroBg =
+    settings.home_bg_url && typeof window !== "undefined"
+      ? `${API_BASE_URL}${settings.home_bg_url}`
+      : heroImage;
 
   const typewriterText = [
     t("hero_slogan_1"),
@@ -195,7 +203,7 @@ const Hero = () => {
 
         {/* Background Image with Overlay */}
         <div className="absolute inset-0 w-full h-full">
-          <Image src={heroImage} alt="Learning Illustration" layout="fill" objectFit="cover" priority />
+          <Image src={heroBg} alt="Learning Illustration" layout="fill" objectFit="cover" priority />
           <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-transparent"></div>
         </div>
 

--- a/frontend/src/pages/dashboard/admin/settings/app/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/app/index.js
@@ -1,6 +1,12 @@
 import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { fetchAppConfig, updateAppConfig, uploadAppLogo, uploadAppFavicon } from "@/services/admin/appConfigService";
+import {
+  fetchAppConfig,
+  updateAppConfig,
+  uploadAppLogo,
+  uploadAppFavicon,
+  uploadHomeBackground,
+} from "@/services/admin/appConfigService";
 import useAppConfigStore from "@/store/appConfigStore";
 import { FaSave, FaUpload, FaImage, FaGlobe } from "react-icons/fa";
 import { toast } from "react-toastify";
@@ -9,8 +15,9 @@ import { API_BASE_URL } from "@/config/config";
 const defaultConfig = { 
   appName: "", 
   siteTitle: "", 
-  logo_url: "", 
+  logo_url: "",
   favicon_url: "",
+  home_bg_url: "",
   metaDescription: "",
   contactEmail: ""
 };
@@ -19,9 +26,11 @@ export default function AppSettingsPage() {
   const [config, setConfig] = useState(defaultConfig);
   const [logoFile, setLogoFile] = useState(null);
   const [faviconFile, setFaviconFile] = useState(null);
+  const [homeBgFile, setHomeBgFile] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [logoPreview, setLogoPreview] = useState("");
   const [faviconPreview, setFaviconPreview] = useState("");
+  const [homeBgPreview, setHomeBgPreview] = useState("");
   const updateConfigStore = useAppConfigStore((state) => state.update);
 
   useEffect(() => {
@@ -62,6 +71,16 @@ export default function AppSettingsPage() {
     setFaviconPreview(objectUrl);
     return () => URL.revokeObjectURL(objectUrl);
   }, [faviconFile]);
+
+  useEffect(() => {
+    if (!homeBgFile) {
+      setHomeBgPreview("");
+      return;
+    }
+    const objectUrl = URL.createObjectURL(homeBgFile);
+    setHomeBgPreview(objectUrl);
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [homeBgFile]);
 
   const handleChange = (field, value) => {
     setConfig((prev) => ({ ...prev, [field]: value }));
@@ -113,6 +132,22 @@ export default function AppSettingsPage() {
       toast.success("Favicon uploaded successfully");
     } catch (err) {
       toast.error("Favicon upload failed");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleHomeBgUpload = async () => {
+    if (!homeBgFile) return;
+    setIsLoading(true);
+    try {
+      const data = await uploadHomeBackground(homeBgFile);
+      setConfig((prev) => ({ ...prev, ...data }));
+      updateConfigStore(data);
+      setHomeBgFile(null);
+      toast.success("Background uploaded successfully");
+    } catch (err) {
+      toast.error("Background upload failed");
     } finally {
       setIsLoading(false);
     }
@@ -293,18 +328,67 @@ export default function AppSettingsPage() {
                     />
                   </label>
                   
-                  {faviconFile && (
-                    <button
-                      type="button"
-                      onClick={handleFaviconUpload}
-                      disabled={isLoading}
-                      className="px-4 py-2 bg-yellow-600 hover:bg-yellow-700 text-white rounded-md transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
-                    >
-                      Upload
-                    </button>
-                  )}
-                </div>
+              {faviconFile && (
+                <button
+                  type="button"
+                  onClick={handleFaviconUpload}
+                  disabled={isLoading}
+                  className="px-4 py-2 bg-yellow-600 hover:bg-yellow-700 text-white rounded-md transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
+                >
+                  Upload
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Home Background Upload */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Home Background
+            </label>
+
+            {(config.home_bg_url || homeBgPreview) && (
+              <div className="mb-3 flex items-center gap-4">
+                <img
+                  src={
+                    homeBgPreview ||
+                    (config.home_bg_url ? `${API_BASE_URL}${config.home_bg_url}` : "")
+                  }
+                  alt="Background preview"
+                  className="h-24 w-full object-cover border border-gray-200 dark:border-gray-600 rounded"
+                />
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  Recommended: 1600x900px
+                </span>
               </div>
+            )}
+
+            <div className="flex items-center gap-2">
+              <label className="flex-1">
+                <div className="flex items-center justify-center w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-md border border-gray-300 dark:border-gray-600 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                  <FaUpload className="mr-2" />
+                  {homeBgFile ? homeBgFile.name : "Choose File"}
+                </div>
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={(e) => setHomeBgFile(e.target.files[0])}
+                />
+              </label>
+
+              {homeBgFile && (
+                <button
+                  type="button"
+                  onClick={handleHomeBgUpload}
+                  disabled={isLoading}
+                  className="px-4 py-2 bg-yellow-600 hover:bg-yellow-700 text-white rounded-md transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
+                >
+                  Upload
+                </button>
+              )}
+            </div>
+          </div>
             </div>
           </div>
         </div>

--- a/frontend/src/services/admin/appConfigService.js
+++ b/frontend/src/services/admin/appConfigService.js
@@ -29,3 +29,12 @@ export const uploadAppFavicon = async (file) => {
   return data?.data;
 };
 
+export const uploadHomeBackground = async (file) => {
+  const formData = new FormData();
+  formData.append("home_bg", file);
+  const { data } = await api.patch("/app-config/home-bg", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return data?.data;
+};
+


### PR DESCRIPTION
## Summary
- allow uploading a home background image in admin app settings
- expose backend API for home background upload
- pull `home_bg_url` from settings in the Hero component
- render hero background dynamically

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`
- `npm run lint --prefix frontend` *(fails: 58 errors, 224 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688d05ba0cac832886a64b62445dc7f5