### PR TITLE
Fix layout duplication and add translations

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -21,6 +21,7 @@
   "third_party_integrations": "تكاملات الطرف الثالث",
   "settings_saved": "تم حفظ الإعدادات",
   "settings_save_failed": "فشل حفظ الإعدادات",
+  "settings_load_failed": "فشل تحميل الإعدادات",
   "monetization": "تحقيق الدخل",
   "subscription_plans": "خطط الاشتراك",
   "payment_config": "إعدادات الدفع",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -21,6 +21,7 @@
   "third_party_integrations": "Third-Party Integrations",
   "settings_saved": "Settings saved successfully",
   "settings_save_failed": "Failed to save settings",
+  "settings_load_failed": "Failed to load settings",
   "monetization": "Monetization",
   "subscription_plans": "Subscription Plans",
   "payment_config": "Payment Config",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -21,6 +21,7 @@
   "third_party_integrations": "Intégrations tierces",
   "settings_saved": "Paramètres enregistrés",
   "settings_save_failed": "Échec de l'enregistrement des paramètres",
+  "settings_load_failed": "Échec du chargement des paramètres",
   "monetization": "Monétisation",
   "subscription_plans": "Abonnements",
   "payment_config": "Configuration des paiements",

--- a/frontend/src/pages/dashboard/admin/settings/messages-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/messages-config/index.js
@@ -1,4 +1,3 @@
-// pages/dashboard/admin/settings/messages-config.js
 import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaToggleOn, FaToggleOff, FaSave } from "react-icons/fa";
@@ -67,7 +66,7 @@ function MessageServiceConfig() {
           setProviders(data.providers);
         }
       } catch (err) {
-        toast.error("Failed to load settings");
+        toast.error(t('settings_load_failed'));
       } finally {
         setLoading(false);
       }
@@ -107,16 +106,15 @@ function MessageServiceConfig() {
     const save = async () => {
       try {
         await updateMessagesConfig({ providers });
-        toast.success(`${providers[index].name} settings saved!`, { theme: "colored" });
+        toast.success(t('settings_saved'), { theme: "colored" });
       } catch (err) {
-        toast.error("Failed to save settings");
+        toast.error(t('settings_save_failed'));
       }
     };
     save();
   };
 
   return (
-    <AdminLayout>
       <div className="max-w-5xl mx-auto px-4 py-8">
         <h1 className="text-2xl font-bold mb-6">{t('messagesConfigPage.title')}</h1>
 
@@ -232,7 +230,6 @@ function MessageServiceConfig() {
         )}
 
       </div>
-    </AdminLayout>
   );
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate `AdminLayout` wrapper
- internationalize toast messages in messages config page
- provide `settings_load_failed` translations
- clean up stray comment

## Testing
- `npm --prefix frontend test --silent`
- `npm --prefix backend test --silent`
- `npm --prefix frontend run lint` *(fails: 58 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d10f8cd588328bba31fa0862a70ff