### PR TITLE
Update admin profile upload limits

### DIFF
--- a/backend/src/modules/users/admin/adminUploadMiddleware.js
+++ b/backend/src/modules/users/admin/adminUploadMiddleware.js
@@ -68,5 +68,5 @@ const fileFilter = (req, file, cb) => {
 module.exports = multer({
   storage,
   fileFilter,
-  limits: { fileSize: 5 * 1024 * 1024 }, // Max 5MB
+  limits: { fileSize: 10 * 1024 * 1024 }, // Max 10MB
 });

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -444,7 +444,7 @@
     "cancel": "إلغاء",
     "upload": "رفع",
     "load_profile_failed": "فشل في تحميل الملف الشخصي",
-    "avatar_max_size": "الحد الأقصى 2 ميغابايت",
+    "avatar_max_size": "الحد الأقصى 10 ميغابايت",
     "avatar_upload_failed": "فشل في رفع الصورة",
     "profile_update_success": "تم تحديث الملف الشخصي بنجاح!",
     "profile_update_failed": "فشل في تحديث الملف الشخصي",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -421,7 +421,7 @@
     "cancel": "Abbrechen",
     "upload": "Hochladen",
     "load_profile_failed": "Profil konnte nicht geladen werden",
-    "avatar_max_size": "Maximalgr\u00f6\u00dfe 2MB",
+    "avatar_max_size": "Maximalgr\u00f6\u00dfe 10MB",
     "avatar_upload_failed": "Fehler beim Hochladen des Bildes",
     "profile_update_success": "Profil erfolgreich aktualisiert!",
     "profile_update_failed": "Fehler beim Aktualisieren des Profils",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -445,7 +445,7 @@
     "cancel": "Cancel",
     "upload": "Upload",
     "load_profile_failed": "Failed to load profile",
-    "avatar_max_size": "Max size 2MB",
+    "avatar_max_size": "Max size 10MB",
     "avatar_upload_failed": "Failed to upload avatar",
     "profile_update_success": "Profile updated successfully!",
     "profile_update_failed": "Failed to update profile",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -421,7 +421,7 @@
     "cancel": "Cancelar",
     "upload": "Subir",
     "load_profile_failed": "Error al cargar el perfil",
-    "avatar_max_size": "Tamaño máximo 2MB",
+    "avatar_max_size": "Tamaño máximo 10MB",
     "avatar_upload_failed": "Error al subir el avatar",
     "profile_update_success": "¡Perfil actualizado con éxito!",
     "profile_update_failed": "Error al actualizar el perfil",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -432,7 +432,7 @@
     "cancel": "Annuler",
     "upload": "Télécharger",
     "load_profile_failed": "Échec du chargement du profil",
-    "avatar_max_size": "Taille maximale 2 Mo",
+    "avatar_max_size": "Taille maximale 10 Mo",
     "avatar_upload_failed": "Échec du téléchargement de l'avatar",
     "profile_update_success": "Profil mis à jour avec succès !",
     "profile_update_failed": "Échec de la mise à jour du profil",

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -172,7 +172,7 @@ useEffect(() => {
   const handleAvatarSelect = (e) => {
     const file = e.target.files[0];
     if (!file) return;
-    if (file.size > 2 * 1024 * 1024) {
+    if (file.size > 10 * 1024 * 1024) {
       toast.error(t('avatar_max_size'));
       return;
     }


### PR DESCRIPTION
## Summary
- increase avatar upload size limit to 10MB for admin profile
- update admin profile translation strings to mention 10MB

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688d1d2af5cc83288352b05abb00398c