### PR TITLE
Fix hero background refresh and cleanup admin page

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -48,10 +48,15 @@ const Hero = () => {
   const configLoaded = useAppConfigStore((s) => s.loaded);
   const { t } = useTranslation("website");
 
-  const heroBg =
-    settings.home_bg_url && typeof window !== "undefined"
-      ? `${API_BASE_URL}${settings.home_bg_url}`
-      : heroImage;
+  const [heroBg, setHeroBg] = useState(heroImage);
+
+  useEffect(() => {
+    if (settings.home_bg_url) {
+      setHeroBg(`${API_BASE_URL}${settings.home_bg_url}`);
+    } else {
+      setHeroBg(heroImage);
+    }
+  }, [settings.home_bg_url]);
 
   useEffect(() => {
     if (!configLoaded) fetchAppConfig();

--- a/frontend/src/pages/dashboard/admin/settings/app/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/app/index.js
@@ -219,18 +219,6 @@ export default function AppSettingsPage() {
                 />
               </div>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Meta Description
-                </label>
-                <textarea
-                  rows={3}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 dark:bg-gray-700 dark:text-white"
-                  value={config.metaDescription || ""}
-                  onChange={(e) => handleChange("metaDescription", e.target.value)}
-                  placeholder="Brief description for SEO"
-                />
-              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- remove SEO field from admin app settings
- update hero background logic to react to config changes

## Testing
- `npm test --silent --prefix frontend`
- `npm test --silent --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_688d23d75e6c8328bb2b8dfc5ae55d87