### PR TITLE
Add wishlist translations and restrict nav

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -871,4 +871,19 @@
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
   }
+  ,"wishlistPage": {
+    "title": "قائمة الرغبات",
+    "search_placeholder": "ابحث في القائمة...",
+    "sort": "فرز",
+    "share": "مشاركة",
+    "classes": "الدورات",
+    "no_classes": "لا توجد دورات في القائمة.",
+    "enroll": "تسجيل",
+    "add_to_cart": "أضف إلى السلة",
+    "set_reminder": "تعيين تذكير",
+    "remove": "إزالة",
+    "add_tag": "أضف وسم",
+    "tutorials": "الدروس",
+    "no_tutorials": "لا توجد دروس في القائمة."
+  }
 }

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -872,5 +872,20 @@
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
   }
+  ,"wishlistPage": {
+    "title": "My Wishlist",
+    "search_placeholder": "Search wishlist...",
+    "sort": "Sort",
+    "share": "Share",
+    "classes": "Classes",
+    "no_classes": "No classes in wishlist.",
+    "enroll": "Enroll",
+    "add_to_cart": "Add to Cart",
+    "set_reminder": "Set Reminder",
+    "remove": "Remove",
+    "add_tag": "Add tag",
+    "tutorials": "Tutorials",
+    "no_tutorials": "No tutorials in wishlist."
+  }
 
 }

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -860,4 +860,19 @@
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
   }
+  ,"wishlistPage": {
+    "title": "Ma liste de souhaits",
+    "search_placeholder": "Rechercher dans la liste...",
+    "sort": "Trier",
+    "share": "Partager",
+    "classes": "Cours",
+    "no_classes": "Aucun cours dans la liste.",
+    "enroll": "S'inscrire",
+    "add_to_cart": "Ajouter au panier",
+    "set_reminder": "Rappel",
+    "remove": "Supprimer",
+    "add_tag": "Ajouter un tag",
+    "tutorials": "Tutoriels",
+    "no_tutorials": "Aucun tutoriel dans la liste."
+  }
 }

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -446,15 +446,17 @@ const Navbar = () => {
                       <span>{t('change_password')}</span>
                     </Link>
                   </li>
-                  <li>
-                    <Link
-                      href="/dashboard/student/wishlist"
-                      className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 transition rounded-md"
-                    >
-                      <FaHeart className="text-gray-500" />
-                      <span>{t('wishlist')}</span>
-                    </Link>
-                  </li>
+                  {userRole === 'student' && (
+                    <li>
+                      <Link
+                        href="/dashboard/student/wishlist"
+                        className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 transition rounded-md"
+                      >
+                        <FaHeart className="text-gray-500" />
+                        <span>{t('wishlist')}</span>
+                      </Link>
+                    </li>
+                  )}
                   {userRole === "superadmin" && profile?.job_title && (
                     <li className="px-3 pt-1 text-xs text-gray-400 font-medium italic">
                       {profile.job_title}

--- a/frontend/src/pages/dashboard/student/wishlist/index.js
+++ b/frontend/src/pages/dashboard/student/wishlist/index.js
@@ -5,6 +5,9 @@ import { getMyTutorialWishlist, removeTutorialFromWishlist } from '@/services/tu
 import useCartStore from '@/store/cart/cartStore';
 import { FaSearch, FaSortAmountDown, FaShareAlt, FaBell } from 'react-icons/fa';
 import { toast } from 'react-toastify';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../../../next-i18next.config.js';
 
 export default function WishlistPage() {
   const [classes, setClasses] = useState([]);
@@ -13,6 +16,7 @@ export default function WishlistPage() {
   const [sortOrder, setSortOrder] = useState('asc');
   const [tags, setTags] = useState({});
   const addItem = useCartStore((state) => state.addItem);
+  const { t } = useTranslation('dashboard', { keyPrefix: 'wishlistPage' });
 
   useEffect(() => {
     const load = async () => {
@@ -59,7 +63,7 @@ export default function WishlistPage() {
 
   const shareWishlist = async () => {
     const titles = [...classes, ...tutorials].map(i => i.title).join(', ');
-    const text = `My SkillBridge Wishlist: ${titles}`;
+    const text = `${t('title')}: ${titles}`;
     if (navigator.share) {
       try { await navigator.share({ text }); } catch (err) { console.error(err); }
     } else {
@@ -85,13 +89,13 @@ export default function WishlistPage() {
 
   return (
     <StudentLayout>
-      <h1 className="text-2xl font-bold mb-6 text-yellow-600">My Wishlist</h1>
+      <h1 className="text-2xl font-bold mb-6 text-yellow-600">{t('title')}</h1>
       <div className="flex flex-col sm:flex-row gap-3 mb-6 items-center">
         <div className="flex items-center gap-2 border rounded px-3 py-2 w-full sm:w-1/2">
           <FaSearch className="text-gray-500" />
           <input
             type="text"
-            placeholder="Search wishlist..."
+            placeholder={t('search_placeholder')}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full outline-none"
@@ -101,54 +105,54 @@ export default function WishlistPage() {
           onClick={() => setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc')}
           className="flex items-center gap-2 bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded text-sm"
         >
-          <FaSortAmountDown /> Sort ({sortOrder})
+          <FaSortAmountDown /> {t('sort')} ({sortOrder})
         </button>
         <button
           onClick={shareWishlist}
           className="flex items-center gap-2 bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded text-sm"
         >
-          <FaShareAlt /> Share
+          <FaShareAlt /> {t('share')}
         </button>
       </div>
-      <h2 className="text-xl font-semibold mb-2">Classes</h2>
-      {filteredClasses.length===0? <p className="text-gray-500">No classes in wishlist.</p>:
+      <h2 className="text-xl font-semibold mb-2">{t('classes')}</h2>
+      {filteredClasses.length===0? <p className="text-gray-500">{t('no_classes')}</p>:
         <ul className="space-y-2">{filteredClasses.map(c=>(
           <li key={c.id} className="bg-white p-3 rounded-md shadow">
             <div className="flex justify-between items-center">
               <span className="font-medium">{c.title}</span>
               <div className="flex gap-2">
-                <button onClick={()=>handleEnroll(c)} className="text-green-600 text-sm">Enroll</button>
-                <button onClick={()=>handleAddToCart(c)} className="text-blue-600 text-sm">Add to Cart</button>
-                <button onClick={()=>setReminder(c)} className="text-yellow-600 text-sm" title="Set Reminder"><FaBell/></button>
-                <button onClick={()=>removeClass(c.id)} className="text-red-500 text-sm">Remove</button>
+                <button onClick={()=>handleEnroll(c)} className="text-green-600 text-sm">{t('enroll')}</button>
+                <button onClick={()=>handleAddToCart(c)} className="text-blue-600 text-sm">{t('add_to_cart')}</button>
+                <button onClick={()=>setReminder(c)} className="text-yellow-600 text-sm" title={t('set_reminder')}><FaBell/></button>
+                <button onClick={()=>removeClass(c.id)} className="text-red-500 text-sm">{t('remove')}</button>
               </div>
             </div>
             <p className="text-xs text-gray-600 mt-1">{c.start_date ? new Date(c.start_date).toLocaleDateString() : ''} {c.status && `- ${c.status}`}</p>
             <input
               type="text"
-              placeholder="Add tag"
+              placeholder={t('add_tag')}
               value={tags[c.id] || ''}
               onChange={(e)=>updateTag(c.id, e.target.value)}
               className="mt-2 w-full border rounded p-1 text-sm"
             />
           </li>))}
         </ul>}
-      <h2 className="text-xl font-semibold mt-6 mb-2">Tutorials</h2>
-      {filteredTutorials.length===0? <p className="text-gray-500">No tutorials in wishlist.</p>:
+      <h2 className="text-xl font-semibold mt-6 mb-2">{t('tutorials')}</h2>
+      {filteredTutorials.length===0? <p className="text-gray-500">{t('no_tutorials')}</p>:
         <ul className="space-y-2">{filteredTutorials.map(t=>(
           <li key={t.id} className="bg-white p-3 rounded-md shadow">
             <div className="flex justify-between items-center">
               <span className="font-medium">{t.title}</span>
               <div className="flex gap-2">
-                <button onClick={()=>handleAddToCart(t)} className="text-blue-600 text-sm">Add to Cart</button>
-                <button onClick={()=>setReminder(t)} className="text-yellow-600 text-sm" title="Set Reminder"><FaBell/></button>
-                <button onClick={()=>removeTutorial(t.id)} className="text-red-500 text-sm">Remove</button>
+                <button onClick={()=>handleAddToCart(t)} className="text-blue-600 text-sm">{t('add_to_cart')}</button>
+                <button onClick={()=>setReminder(t)} className="text-yellow-600 text-sm" title={t('set_reminder')}><FaBell/></button>
+                <button onClick={()=>removeTutorial(t.id)} className="text-red-500 text-sm">{t('remove')}</button>
               </div>
             </div>
             <p className="text-xs text-gray-600 mt-1">{t.status && t.status}</p>
             <input
               type="text"
-              placeholder="Add tag"
+              placeholder={t('add_tag')}
               value={tags[t.id] || ''}
               onChange={(e)=>updateTag(t.id, e.target.value)}
               className="mt-2 w-full border rounded p-1 text-sm"
@@ -157,4 +161,12 @@ export default function WishlistPage() {
         </ul>}
     </StudentLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- localize student wishlist page
- hide wishlist option from navbar for non-students
- add translations for wishlist page in EN/FR/AR

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688d2dfbbda88328af27343768cfc4f2