### PR TITLE
Fix OTP verification schema

### DIFF
--- a/frontend/src/utils/auth/validationSchemas.js
+++ b/frontend/src/utils/auth/validationSchemas.js
@@ -39,7 +39,6 @@ export const registerSchema = (t) =>
 // 🔢 OTP Verification Schema
 export const otpSchema = (t) =>
   z.object({
-    email: z.string().email(t("invalid_email")),
     code: z
       .string()
       .length(6, t("otp_exactly_6_digits"))


### PR DESCRIPTION
## Summary
- remove email requirement from `otpSchema`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688d3481fb308328900b866681fdc597