### PR TITLE
Fix missing gender column

### DIFF
--- a/backend/src/migrations/20250727000000_add_gender_column_to_users.js
+++ b/backend/src/migrations/20250727000000_add_gender_column_to_users.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  const hasGender = await knex.schema.hasColumn('users', 'gender');
+  if (!hasGender) {
+    await knex.schema.alterTable('users', function(table) {
+      table.string('gender');
+    });
+  }
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  const hasGender = await knex.schema.hasColumn('users', 'gender');
+  if (hasGender) {
+    await knex.schema.alterTable('users', function(table) {
+      table.dropColumn('gender');
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- add new migration to ensure the `gender` column exists on the `users` table

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688d37e9a44c8328a64402d2f94046c4