### PR TITLE
Add AI-powered chatbot with conversation state

### DIFF
--- a/frontend/src/components/shared/Chatbot.js
+++ b/frontend/src/components/shared/Chatbot.js
@@ -1,18 +1,49 @@
+import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { FaTimes, FaRobot } from "react-icons/fa";
+import { FaTimes } from "react-icons/fa";
+import { askAI } from "@/services/aiService";
 
-const Chatbot = ({ isOpen, onClose }) => {
+const Chatbot = ({ isOpen, onToggle }) => {
+  const [messages, setMessages] = useState([
+    { sender: "ai", text: "👋 Hi! How can I assist you today?" },
+  ]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const question = input.trim();
+    if (!question) return;
+
+    const userMsg = { sender: "user", text: question };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { answer } = await askAI("chatgpt", question);
+      const aiMsg = { sender: "ai", text: answer };
+      setMessages((prev) => [...prev, aiMsg]);
+    } catch (err) {
+      setError("Failed to fetch response");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <AnimatePresence>
       {isOpen && (
         <>
           {/* Overlay Background */}
-          <motion.div 
+          <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 0.5 }}
             exit={{ opacity: 0 }}
             className="fixed inset-0 bg-black backdrop-blur-md z-40"
-            onClick={onClose}
+            onClick={() => onToggle(false)}
           />
 
           {/* Chatbot Panel */}
@@ -26,8 +57,8 @@ const Chatbot = ({ isOpen, onClose }) => {
             {/* Header */}
             <div className="flex items-center justify-between">
               <h3 className="text-xl font-bold text-gray-900">AI Assistant</h3>
-              <button 
-                onClick={onClose} 
+              <button
+                onClick={() => onToggle(false)}
                 className="text-gray-900 hover:text-gray-700 transition"
               >
                 <FaTimes className="text-2xl" />
@@ -35,16 +66,35 @@ const Chatbot = ({ isOpen, onClose }) => {
             </div>
 
             {/* Chat Area */}
-            <div className="flex-1 mt-4 overflow-auto p-2 bg-gray-100 rounded-lg">
-              <p className="text-gray-700">👋 Hi! How can I assist you today?</p>
+            <div className="flex-1 mt-4 overflow-auto p-2 bg-gray-100 rounded-lg space-y-2">
+              {messages.map((msg, idx) => (
+                <div
+                  key={idx}
+                  className={`max-w-[80%] px-3 py-2 rounded-lg text-sm whitespace-pre-wrap ${
+                    msg.sender === "user"
+                      ? "bg-blue-500 text-white ml-auto"
+                      : "bg-gray-300 text-gray-900"
+                  }`}
+                >
+                  {msg.text}
+                </div>
+              ))}
+              {loading && (
+                <div className="text-gray-500 text-sm">Thinking...</div>
+              )}
+              {error && <div className="text-red-500 text-sm">{error}</div>}
             </div>
 
             {/* Input Field */}
-            <input
-              type="text"
-              placeholder="Type a message..."
-              className="w-full p-3 mt-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none"
-            />
+            <form onSubmit={handleSubmit} className="mt-2">
+              <input
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="Type a message..."
+                className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none"
+              />
+            </form>
           </motion.div>
         </>
       )}

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -194,7 +194,7 @@ const Hero = () => {
 
         {/* Sidebar & Chatbot */}
         <SidebarMenu isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
-        <Chatbot isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />
+        <Chatbot isOpen={isChatOpen} onToggle={setIsChatOpen} />
 
         {/* Floating Sidebar Button */}
         <motion.button


### PR DESCRIPTION
## Summary
- Add stateful `Chatbot` component that tracks conversation history and user input
- Use `askAI` service to fetch responses from `/ai-assistance` endpoint with loading and error handling
- Update `Hero` to toggle the chat window via the new `onToggle` handler

## Testing
- `npm test`
- `npm run lint` *(fails: 58 errors, 227 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688e0ef29d588328a415f7ee74a01bf5