### PR TITLE
feat: allow admin to create offers

### DIFF
--- a/frontend/src/components/website/sections/LearningMarketplace.js
+++ b/frontend/src/components/website/sections/LearningMarketplace.js
@@ -63,16 +63,17 @@ const OffersIndex = () => {
       student: "/dashboard/student/offers",
       instructor: "/dashboard/instructor/offers",
       admin: "/dashboard/admin/offers",
+      superadmin: "/dashboard/admin/offers",
     };
 
     if (action === "post") {
-      if (!role) {
+      if (!role || !routes[role]) {
         toast.error(t('login_to_post_offer'));
         return;
       }
       router.push(`${routes[role]}/new`);
     } else if (action === "detail" && id) {
-      if (!role) {
+      if (!role || !routes[role]) {
         toast.error(t('login_to_post_offer'));
         return;
       }

--- a/frontend/src/pages/dashboard/admin/offers/new.js
+++ b/frontend/src/pages/dashboard/admin/offers/new.js
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
-import StudentLayout from "@/components/layouts/StudentLayout";
+import { toast } from "react-toastify";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { createOffer } from "@/services/admin/offerService";
 
 const NewOfferPage = () => {
   const router = useRouter();
@@ -17,13 +19,26 @@ const NewOfferPage = () => {
     setForm((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
+    const tags = form.tags
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
 
-    // Simulate API call
-    console.log("Submitting new offer:", form);
-    alert("Your request has been posted!");
-    router.push("/dashboard/student/offers");
+    try {
+      await createOffer({
+        title: form.title,
+        description: form.description,
+        budget: form.price,
+        timeframe: form.duration,
+        tags: JSON.stringify(tags),
+      });
+      toast.success("Offer created successfully");
+      router.push("/dashboard/admin/offers");
+    } catch (error) {
+      toast.error("Failed to create offer");
+    }
   };
 
   return (
@@ -110,6 +125,6 @@ const NewOfferPage = () => {
   );
 };
 
-NewOfferPage.getLayout = (page) => <StudentLayout>{page}</StudentLayout>;
+NewOfferPage.getLayout = (page) => <AdminLayout>{page}</AdminLayout>;
 
 export default NewOfferPage;

--- a/frontend/src/services/admin/offerService.js
+++ b/frontend/src/services/admin/offerService.js
@@ -5,6 +5,11 @@ export const fetchOffers = async () => {
   return data?.data ?? [];
 };
 
+export const createOffer = async (payload) => {
+  const { data } = await api.post("/offers", payload);
+  return data;
+};
+
 export const fetchOfferById = async (id) => {
   const { data } = await api.get(`/offers/${id}`);
   return data?.data ?? null;


### PR DESCRIPTION
## Summary
- add createOffer API helper for admin
- connect admin offer creation page to backend and admin layout
- route website Add Offer button to admin dashboard for admin and super admin roles

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e09a024288328917b3892e42e81c0