### PR TITLE
Increase student avatar upload limit to 10MB

### DIFF
--- a/backend/src/modules/users/student/studentUploadMiddleware.js
+++ b/backend/src/modules/users/student/studentUploadMiddleware.js
@@ -22,7 +22,7 @@ const avatarFileFilter = (req, file, cb) => {
 const avatarUpload = multer({
   storage: avatarStorage,
   fileFilter: avatarFileFilter,
-  limits: { fileSize: 2 * 1024 * 1024 }, // 2MB
+  limits: { fileSize: 10 * 1024 * 1024 }, // 10MB
 });
 
 // ────── Identity Document Upload ──────

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -130,8 +130,8 @@ export default function StudentProfileEdit() {
   const handleAvatarUpload = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
-    if (file.size > 2 * 1024 * 1024) {
-      toast.error("Image size should be less than 2MB");
+    if (file.size > 10 * 1024 * 1024) {
+      toast.error("Image size should be less than 10MB");
       return;
     }
     try {
@@ -361,7 +361,7 @@ export default function StudentProfileEdit() {
                         className="hidden"
                       />
                     </label>
-                    <p className="mt-2 text-xs text-gray-500">JPG, PNG up to 2MB</p>
+                    <p className="mt-2 text-xs text-gray-500">JPG, PNG up to 10MB</p>
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- allow student avatars up to 10 MB on the server
- update student profile editor to handle and describe the 10 MB avatar limit

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e1c60f54483288fddcf82b40e6764