### PR TITLE
fix: guard offer tags

### DIFF
--- a/frontend/src/pages/offers/[id].js
+++ b/frontend/src/pages/offers/[id].js
@@ -172,7 +172,7 @@ const OfferDetailsPage = () => {
           </div>
 
           <div className="flex flex-wrap gap-2 mt-4">
-            {offer.tags.map((tag, i) => (
+            {offer.tags?.map((tag, i) => (
               <span
                 key={i}
                 className="bg-yellow-500 text-black px-3 py-1 rounded-full text-xs flex items-center gap-1"


### PR DESCRIPTION
## Summary
- handle missing offer tags when rendering offer details

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_688e1c4d93f48328ac28b9028e15206e