### PR TITLE
Enforce verification on offer creation

### DIFF
--- a/backend/src/modules/offers/offers.routes.js
+++ b/backend/src/modules/offers/offers.routes.js
@@ -3,9 +3,16 @@ const controller = require("./offers.controller");
 const tagController = require("./offerTag.controller");
 const validate = require("../../middleware/validate");
 const { verifyToken } = require("../../middleware/auth/authMiddleware");
+const ensureVerified = require("../../middleware/ensureVerified");
 const validator = require("./offers.validator");
 
-router.post("/", verifyToken, validate(validator.create), controller.createOffer);
+router.post(
+  "/",
+  verifyToken,
+  ensureVerified,
+  validate(validator.create),
+  controller.createOffer
+);
 router.get("/", controller.getOffers);
 router.get("/:id", controller.getOfferById);
 router.put("/:id", verifyToken, validate(validator.update), controller.updateOffer);


### PR DESCRIPTION
## Summary
- require login and verified email & phone before creating offers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e224d8a608328bc2bfa4f1039c1af