### PR TITLE
feat: allow offer creator and admins to close offers

### DIFF
--- a/backend/src/modules/offers/offers.controller.js
+++ b/backend/src/modules/offers/offers.controller.js
@@ -98,6 +98,17 @@ exports.getOfferById = catchAsync(async (req, res) => {
 
 exports.updateOffer = catchAsync(async (req, res) => {
   const existing = await service.getOfferById(req.params.id);
+  if (!existing) {
+    return res.status(404).json({ message: "Offer not found" });
+  }
+
+  if (
+    req.user.role?.toLowerCase() !== "admin" &&
+    req.user.id !== existing.student_id
+  ) {
+    return res.status(403).json({ message: "Not authorized" });
+  }
+
   const { tags: rawTags, ...data } = req.body;
   if (data.expires_at && new Date(data.expires_at) <= new Date()) {
     return res.status(400).json({ message: "Expiration must be in the future" });

--- a/frontend/src/pages/dashboard/admin/offers/[id].js
+++ b/frontend/src/pages/dashboard/admin/offers/[id].js
@@ -12,7 +12,7 @@ import {
 } from "react-icons/fa";
 import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { fetchOfferById } from "@/services/admin/offerService";
+import { fetchOfferById, updateOffer } from "@/services/admin/offerService";
 import {
   fetchResponses,
   fetchMessages as fetchResponseMessages,
@@ -32,6 +32,18 @@ const AdminOfferDetails = () => {
 
   const [offer, setOffer] = useState(null);
   const [messages, setMessages] = useState([]);
+
+  const handleCloseOffer = async () => {
+    if (!offer || offer.status === "closed") return;
+    if (!confirm("Close this offer?")) return;
+    try {
+      await updateOffer(offer.id, { status: "closed" });
+      setOffer((prev) => ({ ...prev, status: "closed" }));
+      alert("Offer closed.");
+    } catch (_) {
+      alert("Failed to close offer.");
+    }
+  };
 
   useEffect(() => {
     if (!id) return;
@@ -168,12 +180,14 @@ const AdminOfferDetails = () => {
           >
             <FaUserShield /> Flag User
           </button>
-          <button
-            onClick={() => confirm("Deactivate this offer?") && alert("Offer deactivated.")}
-            className="flex items-center gap-2 bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg font-semibold text-sm"
-          >
-            <FaBan /> Deactivate Offer
-          </button>
+          {offer.status !== "closed" && (
+            <button
+              onClick={handleCloseOffer}
+              className="flex items-center gap-2 bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg font-semibold text-sm"
+            >
+              <FaBan /> Close Offer
+            </button>
+          )}
         </div>
 
         <div className="mt-6">

--- a/frontend/src/pages/dashboard/student/offers/[id].js
+++ b/frontend/src/pages/dashboard/student/offers/[id].js
@@ -21,6 +21,7 @@ import {
   createResponse,
   deleteMessage as deleteResponseMessage,
 } from "@/services/offerResponseService";
+import { updateOffer } from "@/services/admin/offerService";
 import MessageInput from "@/components/chat/MessageInput";
 import formatRelativeTime from "@/utils/relativeTime";
 import { API_BASE_URL } from "@/config/config";
@@ -58,6 +59,18 @@ const OfferDetailsPage = () => {
   const [response, setResponse] = useState(null);
   const [messages, setMessages] = useState([]);
   const [replyTo, setReplyTo] = useState(null);
+
+  const handleCloseOffer = async () => {
+    if (!offer || offer.status === "closed") return;
+    if (!confirm("Close this offer?")) return;
+    try {
+      await updateOffer(offer.id, { status: "closed" });
+      setOffer((prev) => ({ ...prev, status: "closed" }));
+      toast.success("Offer closed.");
+    } catch (_) {
+      toast.error("Failed to close offer");
+    }
+  };
 
   useEffect(() => {
     if (!id) return;
@@ -342,6 +355,17 @@ const OfferDetailsPage = () => {
           </div>
         </>
       </div>
+
+      {isMyRequest && offer.status !== "closed" && (
+        <div className="border-t pt-6 mb-10">
+          <button
+            onClick={handleCloseOffer}
+            className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg font-semibold"
+          >
+            Close Offer
+          </button>
+        </div>
+      )}
 
       {/* Contact / Copy Link */}
       <div className="border-t pt-6">


### PR DESCRIPTION
## Summary
- restrict offer updates to creators or admins
- let admins close offers from dashboard
- allow offer creators to close their own offers

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e2620d240832889d5a30cc7a63c09