### PR TITLE
fix: load hero background for guests

### DIFF
--- a/frontend/src/services/appConfigService.js
+++ b/frontend/src/services/appConfigService.js
@@ -1,9 +1,18 @@
 import axios from "axios";
 import { API_BASE_URL } from "@/config/config";
 
+/**
+ * Fetch global application configuration.
+ *
+ * This endpoint is public and should work for guests as well as
+ * authenticated users.  We intentionally omit credentials so that
+ * browsers don't enforce stricter CORS rules, which previously caused
+ * the request to fail for unauthenticated visitors and hid the hero
+ * background image.
+ */
 export const getAppConfig = async () => {
   const { data } = await axios.get(`${API_BASE_URL}/app-config`, {
-    withCredentials: true,
+    withCredentials: false,
   });
-  return data?.data ?? {};
+  return data?.data ?? data ?? {};
 };


### PR DESCRIPTION
## Summary
- ensure app config request works without credentials so hero background appears for all users
- gracefully handle different app config response shapes

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e26a088d88328a13e69d339b5e5f2