### PR TITLE
Add sharing and expiration info to admin offer detail page

### DIFF
--- a/backend/src/modules/offers/offers.service.js
+++ b/backend/src/modules/offers/offers.service.js
@@ -12,7 +12,9 @@ exports.getOffers = () => {
       "o.*",
       "u.full_name as student_name",
       "u.role as student_role",
-      "u.avatar_url as student_avatar"
+      "u.avatar_url as student_avatar",
+      "u.email as student_email",
+      "u.phone as student_phone"
     )
     .where("o.status", "open")
     .andWhere(function () {
@@ -28,7 +30,9 @@ exports.getOfferById = (id) => {
       "o.*",
       "u.full_name as student_name",
       "u.role as student_role",
-      "u.avatar_url as student_avatar"
+      "u.avatar_url as student_avatar",
+      "u.email as student_email",
+      "u.phone as student_phone"
     )
     .where("o.id", id)
     .andWhere(function () {

--- a/frontend/src/pages/dashboard/admin/offers/[id].js
+++ b/frontend/src/pages/dashboard/admin/offers/[id].js
@@ -32,6 +32,7 @@ const AdminOfferDetails = () => {
 
   const [offer, setOffer] = useState(null);
   const [messages, setMessages] = useState([]);
+  const [offerUrl, setOfferUrl] = useState("");
 
   const handleCloseOffer = async () => {
     if (!offer || offer.status === "closed") return;
@@ -46,6 +47,10 @@ const AdminOfferDetails = () => {
   };
 
   useEffect(() => {
+    setOfferUrl(window.location.href);
+  }, []);
+
+  useEffect(() => {
     if (!id) return;
 
     fetchOfferById(id)
@@ -54,16 +59,24 @@ const AdminOfferDetails = () => {
         setOffer({
           id: o.id,
           userId: o.student_id,
-          type: o.student_role?.toLowerCase() === "instructor" ? "instructor" : "student",
+          type:
+            o.student_role?.toLowerCase() === "instructor"
+              ? "instructor"
+              : "student",
           title: o.title,
           price: o.budget || "",
           duration: o.timeframe || "",
           tags: [],
-          date: o.created_at ? new Date(o.created_at).toLocaleDateString() : "",
+          date: o.created_at
+            ? new Date(o.created_at).toLocaleDateString()
+            : "",
+          expiresAt: o.expires_at
+            ? new Date(o.expires_at).toLocaleDateString()
+            : null,
           description: o.description || "",
           status: o.status,
-          email: o.email || "",
-          phone: o.phone || "",
+          email: o.student_email || "",
+          phone: o.student_phone || "",
         });
 
         return fetchResponses(o.id);
@@ -110,8 +123,9 @@ const AdminOfferDetails = () => {
         </span>
       </div>
 
-      <div className="flex justify-between text-sm text-gray-500 mb-6">
+      <div className="flex flex-col sm:flex-row justify-between gap-2 text-sm text-gray-500 mb-6">
         <p>Posted: {offer.date}</p>
+        {offer.expiresAt && <p>Available until: {offer.expiresAt}</p>}
         <span className="bg-gray-100 px-2 py-1 rounded-full text-xs text-gray-700">
           Status: {offer.status}
         </span>
@@ -135,7 +149,14 @@ const AdminOfferDetails = () => {
 
       <div className="mb-10">
         <h3 className="text-md font-semibold text-gray-700 mb-2">Description</h3>
-        <p className="text-gray-700 leading-relaxed whitespace-pre-line">{offer.description}</p>
+        <p className="text-gray-700 leading-relaxed whitespace-pre-line">
+          {offer.description}
+        </p>
+        {offer.expiresAt && (
+          <p className="text-sm text-gray-500 mt-4">
+            This offer is available until {offer.expiresAt}.
+          </p>
+        )}
       </div>
 
       <div className="border-t pt-6 mb-10">
@@ -157,20 +178,28 @@ const AdminOfferDetails = () => {
       <div className="border-t border-gray-200 pt-6">
         <h4 className="text-sm font-semibold text-gray-600 mb-3">Contact Info</h4>
         <div className="flex flex-wrap gap-4 items-center">
-          <a
-            href={`https://wa.me/${offer.phone.replace(/\D/g, "")}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 bg-green-500 hover:bg-green-600 text-white px-5 py-2 rounded-lg font-semibold transition"
-          >
-            <FaWhatsapp /> WhatsApp
-          </a>
-          <a
-            href={`mailto:${offer.email}`}
-            className="flex items-center gap-2 bg-gray-600 hover:bg-gray-700 text-white px-5 py-2 rounded-lg font-semibold transition"
-          >
-            <FaEnvelope /> Email
-          </a>
+          {offer.phone && (
+            <a
+              href={`https://wa.me/${offer.phone.replace(/\D/g, "")}?text=${encodeURIComponent(
+                `Check out this offer: ${offerUrl}`
+              )}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 bg-green-500 hover:bg-green-600 text-white px-5 py-2 rounded-lg font-semibold transition"
+            >
+              <FaWhatsapp /> WhatsApp
+            </a>
+          )}
+          {offer.email && (
+            <a
+              href={`mailto:${offer.email}?subject=${encodeURIComponent(
+                `Offer: ${offer.title}`
+              )}&body=${encodeURIComponent(`Check out this offer: ${offerUrl}`)}`}
+              className="flex items-center gap-2 bg-gray-600 hover:bg-gray-700 text-white px-5 py-2 rounded-lg font-semibold transition"
+            >
+              <FaEnvelope /> Email
+            </a>
+          )}
         </div>
 
         <div className="mt-6 flex flex-wrap gap-3">


### PR DESCRIPTION
## Summary
- allow admins to share offers via WhatsApp or email directly with the offer creator
- surface offer expiration date and availability notice

## Testing
- `npm test` (backend)
- `npm test` (frontend)
- `npm run lint` (frontend) *(fails: import/no-anonymous-default-export, react/display-name, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688e2901f5ac83289517ac61193aed19