### PR TITLE
Fix loading state on student profile edit page when user missing

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -74,7 +74,17 @@ export default function StudentProfileEdit() {
   }, [hasHydrated]);
 
   useEffect(() => {
-    if (!user || user.role?.toLowerCase() !== "student") return;
+    if (!user) {
+      // No logged in user – stop loading to avoid endless spinner
+      setIsLoading(false);
+      return;
+    }
+
+    if (user.role?.toLowerCase() !== "student") {
+      // Logged in but not a student; redirect to a safe dashboard
+      router.push("/dashboard");
+      return;
+    }
 
     const loadProfile = async () => {
       try {
@@ -109,7 +119,7 @@ export default function StudentProfileEdit() {
     };
 
     loadProfile();
-  }, [user]);
+  }, [user, router]);
 
   const toggleSection = (section) => setExpanded(prev => ({ ...prev, [section]: !prev[section] }));
 


### PR DESCRIPTION
## Summary
- prevent infinite spinner on student profile edit when user data isn't available
- redirect non-student roles away from student profile edit page

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*


------
https://chatgpt.com/codex/tasks/task_e_688e37ebc2788328abd357567d382d0f