### PR TITLE
feat: add active toggle for third-party integrations

### DIFF
--- a/backend/src/modules/adsense/adsense.controller.js
+++ b/backend/src/modules/adsense/adsense.controller.js
@@ -4,5 +4,6 @@ const service = require("../thirdPartyConfig/thirdPartyConfig.service");
 
 exports.getConfig = catchAsync(async (_req, res) => {
   const settings = await service.getSettings();
-  sendSuccess(res, settings?.googleAdSense || {});
+  const cfg = settings?.googleAdSense;
+  sendSuccess(res, cfg?.active === false ? {} : cfg || {});
 });

--- a/backend/src/modules/ai/ai.service.js
+++ b/backend/src/modules/ai/ai.service.js
@@ -10,6 +10,9 @@ const thirdPartyConfig = require('../thirdPartyConfig/thirdPartyConfig.service')
 exports.answerWithAI = async (provider, question, model) => {
   const cfg = (await thirdPartyConfig.getSettings()) || {};
   const settings = cfg[provider] || {};
+  if (settings.active === false) {
+    return { answer: null, error: 'Provider inactive' };
+  }
 
   // Each provider may store its credential under different keys. Perform a
   // generic check here only when no provider specific credential exists.

--- a/backend/src/modules/googleAnalytics/googleAnalytics.controller.js
+++ b/backend/src/modules/googleAnalytics/googleAnalytics.controller.js
@@ -4,5 +4,6 @@ const service = require("../thirdPartyConfig/thirdPartyConfig.service");
 
 exports.getConfig = catchAsync(async (_req, res) => {
   const settings = await service.getSettings();
-  sendSuccess(res, settings?.googleAnalytics || {});
+  const cfg = settings?.googleAnalytics;
+  sendSuccess(res, cfg?.active === false ? {} : cfg || {});
 });

--- a/backend/src/modules/thirdPartyConfig/thirdPartyConfig.service.js
+++ b/backend/src/modules/thirdPartyConfig/thirdPartyConfig.service.js
@@ -13,7 +13,9 @@ exports.getSettings = async () => {
 };
 
 exports.updateSettings = async (settings) => {
-  const value = JSON.stringify(settings);
+  const prev = (await exports.getSettings()) || {};
+  const merged = { ...prev, ...settings };
+  const value = JSON.stringify(merged);
   const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
   if (existing) {
     await db("settings")
@@ -22,5 +24,5 @@ exports.updateSettings = async (settings) => {
   } else {
     await db("settings").insert({ key: SETTINGS_KEY, value });
   }
-  return settings;
+  return merged;
 };

--- a/backend/tests/adsenseRoutes.test.js
+++ b/backend/tests/adsenseRoutes.test.js
@@ -21,4 +21,13 @@ describe('GET /api/adsense', () => {
     expect(res.body.data).toEqual(cfg);
     expect(service.getSettings).toHaveBeenCalled();
   });
+
+  it('returns empty when inactive', async () => {
+    const cfg = { clientID: 'pub', slotID: '123', enabled: true, active: false };
+    service.getSettings.mockResolvedValue({ googleAdSense: cfg });
+
+    const res = await request(app).get('/api/adsense');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({});
+  });
 });

--- a/backend/tests/googleAnalyticsRoutes.test.js
+++ b/backend/tests/googleAnalyticsRoutes.test.js
@@ -21,4 +21,13 @@ describe('GET /api/google-analytics', () => {
     expect(res.body.data).toEqual(cfg);
     expect(service.getSettings).toHaveBeenCalled();
   });
+
+  it('returns empty when inactive', async () => {
+    const cfg = { measurementId: 'G-TEST', enabled: true, active: false };
+    service.getSettings.mockResolvedValue({ googleAnalytics: cfg });
+
+    const res = await request(app).get('/api/google-analytics');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({});
+  });
 });

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -61,7 +61,7 @@ const AskQuestionPage = () => {
       try {
         const cfg = await fetchThirdPartyConfig();
         const opts = [];
-        if (cfg.chatgpt?.apiKey) {
+        if (cfg.chatgpt?.apiKey && cfg.chatgpt?.active !== false) {
           opts.push('chatgpt');
           if (Array.isArray(cfg.chatgpt.models)) {
             setChatGPTModels(cfg.chatgpt.models);
@@ -71,10 +71,10 @@ const AskQuestionPage = () => {
             toast.warning('ChatGPT models not configured');
           }
         }
-        if (cfg.deepseek?.apiKey) opts.push('deepseek');
-        if (cfg.claude?.apiKey) opts.push('claude');
-        if (cfg.gemini?.apiKey) opts.push('gemini');
-        if (cfg.huggingface?.apiKey) opts.push('huggingface');
+        if (cfg.deepseek?.apiKey && cfg.deepseek?.active !== false) opts.push('deepseek');
+        if (cfg.claude?.apiKey && cfg.claude?.active !== false) opts.push('claude');
+        if (cfg.gemini?.apiKey && cfg.gemini?.active !== false) opts.push('gemini');
+        if (cfg.huggingface?.apiKey && cfg.huggingface?.active !== false) opts.push('huggingface');
         setAiOptions(opts);
         if (opts.length === 0) toast.info('No AI integrations available');
       } catch (err) {

--- a/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
@@ -70,56 +70,71 @@ export default function ThirdPartyIntegrationsPage() {
     }
   };
 
+  const toggleIntegration = (key) => {
+    const current = settings[key] || {};
+    const isActive = current.active !== false;
+    saveSection(key, { ...current, active: !isActive });
+  };
+
   const integrations = [
     {
+      key: 'chatgpt',
       name: "ChatGPT (OpenAI)",
       description: "Manage your OpenAI API keys and usage preferences.",
       icon: <FaRobot className="text-4xl text-blue-600" />,
       onClick: () => setShowChatGPTModal(true),
     },
     {
+      key: 'deepseek',
       name: "DeepSeek AI",
       description: "Configure DeepSeek large language model settings.",
       icon: <FaWrench className="text-4xl text-green-600" />,
       onClick: () => setShowDeepSeekModal(true),
     },
     {
+      key: 'claude',
       name: "Claude (Anthropic)",
       description: "Configure Claude AI model access and behavior.",
       icon: <FaFeather className="text-4xl text-purple-500" />,
       onClick: () => setShowClaudeModal(true),
     },
     {
+      key: 'gemini',
       name: "Gemini (Google AI)",
       description: "Integrate Gemini AI models from Google Cloud.",
       icon: <FaGoogle className="text-4xl text-indigo-600" />,
       onClick: () => setShowGeminiModal(true),
     },
     {
+      key: 'huggingface',
       name: "Hugging Face",
       description: "Connect with Hugging Face-hosted AI models.",
       icon: <SiHuggingface className="text-4xl text-yellow-500" />,
       onClick: () => setShowHuggingFaceModal(true),
     },
     {
+      key: 'googleCalendar',
       name: "Google Calendar",
       description: "Sync platform bookings with Google Calendar.",
       icon: <FaCalendarAlt className="text-4xl text-red-500" />,
       onClick: () => setShowGoogleCalendarModal(true),
     },
     {
+      key: 'googleAnalytics',
       name: "Google Analytics",
       description: "Track user activity using Google Analytics.",
       icon: <FaChartBar className="text-4xl text-green-700" />,
       onClick: () => setShowGoogleAnalyticsModal(true),
     },
     {
+      key: 'googleAdSense',
       name: "Google AdSense",
       description: "Display monetized ads using Google AdSense.",
       icon: <FaAd className="text-4xl text-yellow-600" />,
       onClick: () => setShowGoogleAdSenseModal(true),
     },
     {
+      key: 'recaptcha',
       name: "reCAPTCHA v3",
       description: "Protect your forms with Google reCAPTCHA.",
       icon: <FaShieldAlt className="text-4xl text-blue-800" />,
@@ -132,21 +147,33 @@ export default function ThirdPartyIntegrationsPage() {
       <div className="p-6 max-w-6xl mx-auto">
         <h1 className="text-2xl font-bold mb-6">{t('third_party_integrations')}</h1>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {integrations.map((item, index) => (
-            <div
-              key={index}
-              onClick={item.onClick}
-              className="cursor-pointer border border-gray-200 rounded-xl p-5 shadow hover:shadow-lg bg-white transition"
-            >
-              <div className="flex items-center gap-4">
-                {item.icon}
-                <div>
-                  <h2 className="text-lg font-semibold">{item.name}</h2>
-                  <p className="text-gray-600 text-sm">{item.description}</p>
+          {integrations.map((item, index) => {
+            const isActive = settings[item.key]?.active !== false;
+            return (
+              <div
+                key={index}
+                onClick={item.onClick}
+                className="cursor-pointer border border-gray-200 rounded-xl p-5 shadow hover:shadow-lg bg-white transition"
+              >
+                <div className="flex items-center gap-4">
+                  {item.icon}
+                  <div className="flex-1">
+                    <h2 className="text-lg font-semibold">{item.name}</h2>
+                    <p className="text-gray-600 text-sm">{item.description}</p>
+                  </div>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleIntegration(item.key);
+                    }}
+                    className={`px-2 py-1 rounded text-xs ${isActive ? 'bg-green-500 text-white' : 'bg-gray-300 text-gray-700'}`}
+                  >
+                    {isActive ? 'Active' : 'Inactive'}
+                  </button>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- preserve existing third-party settings when updating configuration
- allow integrations to be activated or deactivated and hide inactive ones on the Ask page
- add backend checks and tests for inactive third-party providers

## Testing
- `cd backend && npm test --silent`
- `cd frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688e37b51f688328aa66c7a3b3deab23