### PR TITLE
feat: add direct email, whatsapp, and video call

### DIFF
--- a/backend/src/modules/messages/messages.controller.js
+++ b/backend/src/modules/messages/messages.controller.js
@@ -19,3 +19,30 @@ exports.deleteMessage = catchAsync(async (req, res) => {
   if (!msg) throw new AppError("Message not found", 404);
   sendSuccess(res, msg, "Message deleted");
 });
+
+exports.sendEmail = catchAsync(async (req, res) => {
+  const data = await service.sendEmail({
+    sender_id: req.user.id,
+    receiver_id: req.params.id,
+    subject: req.body.subject,
+    message: req.body.message,
+  });
+  sendSuccess(res, data, "Email sent");
+});
+
+exports.sendWhatsApp = catchAsync(async (req, res) => {
+  const data = await service.sendWhatsApp({
+    sender_id: req.user.id,
+    receiver_id: req.params.id,
+    message: req.body.message,
+  });
+  sendSuccess(res, data, "WhatsApp message sent");
+});
+
+exports.startVideoCall = catchAsync(async (req, res) => {
+  const data = await service.startVideoCall({
+    sender_id: req.user.id,
+    receiver_id: req.params.id,
+  });
+  sendSuccess(res, data, "Video call started");
+});

--- a/backend/src/modules/messages/messages.routes.js
+++ b/backend/src/modules/messages/messages.routes.js
@@ -8,5 +8,8 @@ router.use(verifyToken);
 router.get("/", controller.getMyMessages);
 router.patch("/:id/read", controller.markRead);
 router.delete("/:id", controller.deleteMessage);
+router.post("/:id/email", controller.sendEmail);
+router.post("/:id/whatsapp", controller.sendWhatsApp);
+router.post("/:id/video-call", controller.startVideoCall);
 
 module.exports = router;

--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -1,4 +1,7 @@
 const db = require("../../config/database");
+const { v4: uuidv4 } = require("uuid");
+const mailService = require("../../services/mailService");
+const whatsappService = require("../../services/whatsappService");
 
 exports.createMessage = async ({ sender_id, receiver_id, message, booking_id }) => {
   const [row] = await db("messages")
@@ -38,4 +41,25 @@ exports.deleteMessage = async (userId, id) => {
     .del()
     .returning("*");
   return row;
+};
+
+exports.sendEmail = async ({ sender_id, receiver_id, subject, message }) => {
+  const user = await db("users").select("email").where({ id: receiver_id }).first();
+  if (!user) throw new Error("User not found");
+  await mailService.sendMail({ to: user.email, subject, html: message });
+  return exports.createMessage({ sender_id, receiver_id, message });
+};
+
+exports.sendWhatsApp = async ({ sender_id, receiver_id, message }) => {
+  const user = await db("users").select("phone").where({ id: receiver_id }).first();
+  if (!user || !user.phone) throw new Error("User phone not found");
+  await whatsappService.sendWhatsApp({ to: user.phone, message });
+  return exports.createMessage({ sender_id, receiver_id, message });
+};
+
+exports.startVideoCall = async ({ sender_id, receiver_id }) => {
+  const roomId = uuidv4();
+  const callMsg = `Video call room: ${roomId}`;
+  await exports.createMessage({ sender_id, receiver_id, message: callMsg });
+  return { roomId };
 };

--- a/backend/tests/messageRoutes.test.js
+++ b/backend/tests/messageRoutes.test.js
@@ -5,6 +5,9 @@ jest.mock('../src/modules/messages/messages.service', () => ({
   getUserMessages: jest.fn(),
   markAsRead: jest.fn(),
   deleteMessage: jest.fn(),
+  sendEmail: jest.fn(),
+  sendWhatsApp: jest.fn(),
+  startVideoCall: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -47,5 +50,51 @@ describe('DELETE /api/messages/:id', () => {
     const res = await request(app).delete('/api/messages/1');
     expect(res.status).toBe(200);
     expect(service.deleteMessage).toHaveBeenCalledWith('user1', '1');
+  });
+});
+
+describe('POST /api/messages/:id/email', () => {
+  it('sends email', async () => {
+    const data = { id: '1' };
+    service.sendEmail.mockResolvedValue(data);
+    const res = await request(app)
+      .post('/api/messages/2/email')
+      .send({ subject: 'Hi', message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(service.sendEmail).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '2',
+      subject: 'Hi',
+      message: 'Hello',
+    });
+  });
+});
+
+describe('POST /api/messages/:id/whatsapp', () => {
+  it('sends whatsapp message', async () => {
+    const data = { id: '1' };
+    service.sendWhatsApp.mockResolvedValue(data);
+    const res = await request(app)
+      .post('/api/messages/2/whatsapp')
+      .send({ message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(service.sendWhatsApp).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '2',
+      message: 'Hello',
+    });
+  });
+});
+
+describe('POST /api/messages/:id/video-call', () => {
+  it('starts video call', async () => {
+    const data = { roomId: 'abc' };
+    service.startVideoCall.mockResolvedValue(data);
+    const res = await request(app).post('/api/messages/2/video-call');
+    expect(res.status).toBe(200);
+    expect(service.startVideoCall).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '2',
+    });
   });
 });

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -28,6 +28,21 @@ export const deleteMessage = async (id) => {
   return res.data.data || res.data;
 };
 
+export const sendDirectEmail = async (userId, { subject, message }) => {
+  const res = await api.post(`/messages/${userId}/email`, { subject, message });
+  return res.data.data || res.data;
+};
+
+export const sendWhatsAppMessage = async (userId, { message }) => {
+  const res = await api.post(`/messages/${userId}/whatsapp`, { message });
+  return res.data.data || res.data;
+};
+
+export const startVideoCall = async (userId) => {
+  const res = await api.post(`/messages/${userId}/video-call`);
+  return res.data.data || res.data;
+};
+
 export const getConversation = async (userId) => {
   const res = await api.get(`/chat/${userId}`);
   return res.data.data || res.data;


### PR DESCRIPTION
## Summary
- allow sending emails, WhatsApp messages, and initiating video calls from the messaging system
- expose new message endpoints and frontend helpers
- cover new messaging endpoints with tests

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688e397a8d148328ac5fe40322d185b6