### PR TITLE
feat: show user online state in message center

### DIFF
--- a/backend/src/modules/chat/chat.service.js
+++ b/backend/src/modules/chat/chat.service.js
@@ -15,7 +15,9 @@ exports.searchUsers = async (currentUserId, term) => {
       "users.email",
       "users.phone",
       db.raw("COALESCE(users.avatar_url, '') as profileImage"),
-      db.raw("COALESCE(unread.count, 0) as unreadMessages")
+      db.raw("COALESCE(unread.count, 0) as unreadMessages"),
+      db.raw("COALESCE(users.is_online, false) as \"isOnline\""),
+      db.raw("EXTRACT(EPOCH FROM users.updated_at) * 1000 as \"lastActive\"")
     )
     .leftJoin(subquery, "users.id", "unread.sender_id")
     .modify((query) => {

--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -1,8 +1,7 @@
 import { useRouter } from "next/router";
-import { FaVideo, FaWhatsapp, FaEnvelope } from "react-icons/fa";
+import { FaVideo, FaWhatsapp, FaEnvelope, FaCircle } from "react-icons/fa";
 import { API_BASE_URL } from "@/config/config";
 import ChatImage from "../shared/ChatImage";
-import useLastSeen from "@/hooks/useLastSeen";
 
 const ChatHeader = ({ selectedChat }) => {
   const router = useRouter();
@@ -21,9 +20,7 @@ const ChatHeader = ({ selectedChat }) => {
     ? selectedChat.cover_image || selectedChat.image
     : selectedChat.profileImage;
 
-  const { lastSeen } = useLastSeen(selectedChat.id);
 
- 
   const handleVideoCall = () => {
     router.push(`/video-call?chatId=${selectedChat.id}`);
   };
@@ -69,7 +66,14 @@ const ChatHeader = ({ selectedChat }) => {
             {selectedChat.groupName || selectedChat.name || "Unknown Chat"}
           </h3>
           {!selectedChat.isGroup && (
-            <p className="text-sm text-gray-400">{lastSeen}</p>
+            <div className="flex items-center text-sm text-gray-400">
+              <FaCircle
+                className={`mr-1 ${
+                  selectedChat.isOnline ? "text-green-500" : "text-gray-500"
+                }`}
+              />
+              {selectedChat.isOnline ? "Online" : "Offline"}
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -98,6 +98,15 @@ const MessagesPage = () => {
     }
   }, [router.query, groups, users]);
 
+  useEffect(() => {
+    if (selectedChat && !selectedChat.isGroup) {
+      const updated = users.find((u) => u.id === selectedChat.id);
+      if (updated && updated !== selectedChat) {
+        setSelectedChat(updated);
+      }
+    }
+  }, [users, selectedChat]);
+
   return (
     <div className="bg-gray-900 min-h-screen text-white">
       <Navbar />


### PR DESCRIPTION
## Summary
- include `isOnline` and `lastActive` fields when fetching chat users
- display live online/offline indicator in chat header
- keep selected chat user in sync with refreshed user list

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e3ef34a0c8328b9fa0944a68a8a6a