### PR TITLE
feat: add direct messaging options for students and instructors

### DIFF
--- a/backend/src/modules/instructors/instructor.controller.js
+++ b/backend/src/modules/instructors/instructor.controller.js
@@ -1,6 +1,7 @@
 const service = require("./instructor.service");
 const { sendSuccess } = require("../../utils/response");
 const catchAsync = require("../../utils/catchAsync");
+const msgService = require("../messages/messages.service");
 
 exports.list = catchAsync(async (_req, res) => {
   const data = await service.getPublicInstructors();
@@ -28,4 +29,46 @@ exports.getAvailability = catchAsync(async (req, res) => {
 
   const availability = await service.getInstructorAvailability(id);
   sendSuccess(res, availability);
+});
+
+exports.sendEmail = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
+    return res.status(400).json({ message: "Invalid instructor id" });
+  }
+
+  const data = await msgService.sendEmail({
+    sender_id: req.user.id,
+    receiver_id: id,
+    subject: req.body.subject,
+    message: req.body.message,
+  });
+  sendSuccess(res, data, "Email sent");
+});
+
+exports.sendWhatsApp = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
+    return res.status(400).json({ message: "Invalid instructor id" });
+  }
+
+  const data = await msgService.sendWhatsApp({
+    sender_id: req.user.id,
+    receiver_id: id,
+    message: req.body.message,
+  });
+  sendSuccess(res, data, "WhatsApp message sent");
+});
+
+exports.startVideoCall = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
+    return res.status(400).json({ message: "Invalid instructor id" });
+  }
+
+  const data = await msgService.startVideoCall({
+    sender_id: req.user.id,
+    receiver_id: id,
+  });
+  sendSuccess(res, data, "Video call started");
 });

--- a/backend/src/modules/instructors/instructor.routes.js
+++ b/backend/src/modules/instructors/instructor.routes.js
@@ -1,7 +1,11 @@
 const router = require("express").Router();
 const controller = require("./instructor.controller");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
 
 router.get("/", controller.list);
+router.post("/:id/email", verifyToken, controller.sendEmail);
+router.post("/:id/whatsapp", verifyToken, controller.sendWhatsApp);
+router.post("/:id/video-call", verifyToken, controller.startVideoCall);
 // More specific routes should be defined before parameterized ones
 router.get("/:id/availability", controller.getAvailability);
 router.get("/:id", controller.getById);

--- a/backend/src/modules/messages/messages.controller.js
+++ b/backend/src/modules/messages/messages.controller.js
@@ -19,3 +19,30 @@ exports.deleteMessage = catchAsync(async (req, res) => {
   if (!msg) throw new AppError("Message not found", 404);
   sendSuccess(res, msg, "Message deleted");
 });
+
+exports.sendEmail = catchAsync(async (req, res) => {
+  const data = await service.sendEmail({
+    sender_id: req.user.id,
+    receiver_id: req.params.id,
+    subject: req.body.subject,
+    message: req.body.message,
+  });
+  sendSuccess(res, data, "Email sent");
+});
+
+exports.sendWhatsApp = catchAsync(async (req, res) => {
+  const data = await service.sendWhatsApp({
+    sender_id: req.user.id,
+    receiver_id: req.params.id,
+    message: req.body.message,
+  });
+  sendSuccess(res, data, "WhatsApp message sent");
+});
+
+exports.startVideoCall = catchAsync(async (req, res) => {
+  const data = await service.startVideoCall({
+    sender_id: req.user.id,
+    receiver_id: req.params.id,
+  });
+  sendSuccess(res, data, "Video call started");
+});

--- a/backend/src/modules/messages/messages.routes.js
+++ b/backend/src/modules/messages/messages.routes.js
@@ -8,5 +8,8 @@ router.use(verifyToken);
 router.get("/", controller.getMyMessages);
 router.patch("/:id/read", controller.markRead);
 router.delete("/:id", controller.deleteMessage);
+router.post("/:id/email", controller.sendEmail);
+router.post("/:id/whatsapp", controller.sendWhatsApp);
+router.post("/:id/video-call", controller.startVideoCall);
 
 module.exports = router;

--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -1,4 +1,7 @@
 const db = require("../../config/database");
+const { v4: uuidv4 } = require("uuid");
+const mailService = require("../../services/mailService");
+const whatsappService = require("../../services/whatsappService");
 
 exports.createMessage = async ({ sender_id, receiver_id, message, booking_id }) => {
   const [row] = await db("messages")
@@ -38,4 +41,25 @@ exports.deleteMessage = async (userId, id) => {
     .del()
     .returning("*");
   return row;
+};
+
+exports.sendEmail = async ({ sender_id, receiver_id, subject, message }) => {
+  const user = await db("users").select("email").where({ id: receiver_id }).first();
+  if (!user) throw new Error("User not found");
+  await mailService.sendMail({ to: user.email, subject, html: message });
+  return exports.createMessage({ sender_id, receiver_id, message });
+};
+
+exports.sendWhatsApp = async ({ sender_id, receiver_id, message }) => {
+  const user = await db("users").select("phone").where({ id: receiver_id }).first();
+  if (!user || !user.phone) throw new Error("User phone not found");
+  await whatsappService.sendWhatsApp({ to: user.phone, message });
+  return exports.createMessage({ sender_id, receiver_id, message });
+};
+
+exports.startVideoCall = async ({ sender_id, receiver_id }) => {
+  const roomId = uuidv4();
+  const callMsg = `Video call room: ${roomId}`;
+  await exports.createMessage({ sender_id, receiver_id, message: callMsg });
+  return { roomId };
 };

--- a/backend/src/modules/students/student.controller.js
+++ b/backend/src/modules/students/student.controller.js
@@ -1,5 +1,7 @@
 const service = require("./student.service");
 const { sendSuccess } = require("../../utils/response");
+const catchAsync = require("../../utils/catchAsync");
+const msgService = require("../messages/messages.service");
 
 exports.list = async (_req, res) => {
   const data = await service.getPublicStudents();
@@ -18,3 +20,45 @@ exports.getById = async (req, res) => {
   }
   sendSuccess(res, student);
 };
+
+exports.sendEmail = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
+    return res.status(400).json({ message: "Invalid student id" });
+  }
+
+  const data = await msgService.sendEmail({
+    sender_id: req.user.id,
+    receiver_id: id,
+    subject: req.body.subject,
+    message: req.body.message,
+  });
+  sendSuccess(res, data, "Email sent");
+});
+
+exports.sendWhatsApp = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
+    return res.status(400).json({ message: "Invalid student id" });
+  }
+
+  const data = await msgService.sendWhatsApp({
+    sender_id: req.user.id,
+    receiver_id: id,
+    message: req.body.message,
+  });
+  sendSuccess(res, data, "WhatsApp message sent");
+});
+
+exports.startVideoCall = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
+    return res.status(400).json({ message: "Invalid student id" });
+  }
+
+  const data = await msgService.startVideoCall({
+    sender_id: req.user.id,
+    receiver_id: id,
+  });
+  sendSuccess(res, data, "Video call started");
+});

--- a/backend/src/modules/students/student.routes.js
+++ b/backend/src/modules/students/student.routes.js
@@ -1,7 +1,11 @@
 const router = require("express").Router();
 const controller = require("./student.controller");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
 
 router.get("/", controller.list);
+router.post("/:id/email", verifyToken, controller.sendEmail);
+router.post("/:id/whatsapp", verifyToken, controller.sendWhatsApp);
+router.post("/:id/video-call", verifyToken, controller.startVideoCall);
 router.get("/:id", controller.getById);
 
 module.exports = router;

--- a/backend/tests/instructorRoutes.test.js
+++ b/backend/tests/instructorRoutes.test.js
@@ -1,0 +1,64 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  sendEmail: jest.fn(),
+  sendWhatsApp: jest.fn(),
+  startVideoCall: jest.fn(),
+}));
+
+jest.mock('../src/modules/instructors/instructor.service', () => ({}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'user1' }; next(); },
+}));
+
+const msgService = require('../src/modules/messages/messages.service');
+const routes = require('../src/modules/instructors/instructor.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/instructors', routes);
+
+describe('POST /api/instructors/:id/email', () => {
+  it('sends email to instructor', async () => {
+    msgService.sendEmail.mockResolvedValue({});
+    const res = await request(app)
+      .post('/api/instructors/123e4567-e89b-12d3-a456-426614174000/email')
+      .send({ subject: 'Hi', message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(msgService.sendEmail).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '123e4567-e89b-12d3-a456-426614174000',
+      subject: 'Hi',
+      message: 'Hello',
+    });
+  });
+});
+
+describe('POST /api/instructors/:id/whatsapp', () => {
+  it('sends whatsapp to instructor', async () => {
+    msgService.sendWhatsApp.mockResolvedValue({});
+    const res = await request(app)
+      .post('/api/instructors/123e4567-e89b-12d3-a456-426614174000/whatsapp')
+      .send({ message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(msgService.sendWhatsApp).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '123e4567-e89b-12d3-a456-426614174000',
+      message: 'Hello',
+    });
+  });
+});
+
+describe('POST /api/instructors/:id/video-call', () => {
+  it('starts video call with instructor', async () => {
+    msgService.startVideoCall.mockResolvedValue({ roomId: 'abc' });
+    const res = await request(app).post('/api/instructors/123e4567-e89b-12d3-a456-426614174000/video-call');
+    expect(res.status).toBe(200);
+    expect(msgService.startVideoCall).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '123e4567-e89b-12d3-a456-426614174000',
+    });
+  });
+});

--- a/backend/tests/messageRoutes.test.js
+++ b/backend/tests/messageRoutes.test.js
@@ -5,6 +5,9 @@ jest.mock('../src/modules/messages/messages.service', () => ({
   getUserMessages: jest.fn(),
   markAsRead: jest.fn(),
   deleteMessage: jest.fn(),
+  sendEmail: jest.fn(),
+  sendWhatsApp: jest.fn(),
+  startVideoCall: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -47,5 +50,51 @@ describe('DELETE /api/messages/:id', () => {
     const res = await request(app).delete('/api/messages/1');
     expect(res.status).toBe(200);
     expect(service.deleteMessage).toHaveBeenCalledWith('user1', '1');
+  });
+});
+
+describe('POST /api/messages/:id/email', () => {
+  it('sends email', async () => {
+    const data = { id: '1' };
+    service.sendEmail.mockResolvedValue(data);
+    const res = await request(app)
+      .post('/api/messages/2/email')
+      .send({ subject: 'Hi', message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(service.sendEmail).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '2',
+      subject: 'Hi',
+      message: 'Hello',
+    });
+  });
+});
+
+describe('POST /api/messages/:id/whatsapp', () => {
+  it('sends whatsapp message', async () => {
+    const data = { id: '1' };
+    service.sendWhatsApp.mockResolvedValue(data);
+    const res = await request(app)
+      .post('/api/messages/2/whatsapp')
+      .send({ message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(service.sendWhatsApp).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '2',
+      message: 'Hello',
+    });
+  });
+});
+
+describe('POST /api/messages/:id/video-call', () => {
+  it('starts video call', async () => {
+    const data = { roomId: 'abc' };
+    service.startVideoCall.mockResolvedValue(data);
+    const res = await request(app).post('/api/messages/2/video-call');
+    expect(res.status).toBe(200);
+    expect(service.startVideoCall).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '2',
+    });
   });
 });

--- a/backend/tests/studentRoutes.test.js
+++ b/backend/tests/studentRoutes.test.js
@@ -1,0 +1,64 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  sendEmail: jest.fn(),
+  sendWhatsApp: jest.fn(),
+  startVideoCall: jest.fn(),
+}));
+
+jest.mock('../src/modules/students/student.service', () => ({}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'user1' }; next(); },
+}));
+
+const msgService = require('../src/modules/messages/messages.service');
+const routes = require('../src/modules/students/student.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/students', routes);
+
+describe('POST /api/students/:id/email', () => {
+  it('sends email to student', async () => {
+    msgService.sendEmail.mockResolvedValue({});
+    const res = await request(app)
+      .post('/api/students/123e4567-e89b-12d3-a456-426614174000/email')
+      .send({ subject: 'Hi', message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(msgService.sendEmail).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '123e4567-e89b-12d3-a456-426614174000',
+      subject: 'Hi',
+      message: 'Hello',
+    });
+  });
+});
+
+describe('POST /api/students/:id/whatsapp', () => {
+  it('sends whatsapp to student', async () => {
+    msgService.sendWhatsApp.mockResolvedValue({});
+    const res = await request(app)
+      .post('/api/students/123e4567-e89b-12d3-a456-426614174000/whatsapp')
+      .send({ message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(msgService.sendWhatsApp).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '123e4567-e89b-12d3-a456-426614174000',
+      message: 'Hello',
+    });
+  });
+});
+
+describe('POST /api/students/:id/video-call', () => {
+  it('starts video call with student', async () => {
+    msgService.startVideoCall.mockResolvedValue({ roomId: 'abc' });
+    const res = await request(app).post('/api/students/123e4567-e89b-12d3-a456-426614174000/video-call');
+    expect(res.status).toBe(200);
+    expect(msgService.startVideoCall).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: '123e4567-e89b-12d3-a456-426614174000',
+    });
+  });
+});

--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -84,25 +84,21 @@ const ChatHeader = ({ selectedChat }) => {
           <FaVideo /> Video Call
         </button>
 
-        {/* ✅ WhatsApp Button (Only If Phone Exists) */}
-        {selectedChat.phone && (
-          <button
-            className="px-3 py-2 bg-green-500 text-white rounded flex items-center gap-2 hover:bg-green-600 transition"
-            onClick={handleWhatsAppChat}
-          >
-            <FaWhatsapp /> WhatsApp
-          </button>
-        )}
+        {/* ✅ WhatsApp Button */}
+        <button
+          className="px-3 py-2 bg-green-500 text-white rounded flex items-center gap-2 hover:bg-green-600 transition"
+          onClick={handleWhatsAppChat}
+        >
+          <FaWhatsapp /> WhatsApp
+        </button>
 
-        {/* ✅ Email Button (Only If Email Exists) */}
-        {selectedChat.email && (
-          <button
-            className="px-3 py-2 bg-gray-600 text-white rounded flex items-center gap-2 hover:bg-gray-700 transition"
-            onClick={handleSendEmail}
-          >
-            <FaEnvelope /> Email
-          </button>
-        )}
+        {/* ✅ Email Button */}
+        <button
+          className="px-3 py-2 bg-gray-600 text-white rounded flex items-center gap-2 hover:bg-gray-700 transition"
+          onClick={handleSendEmail}
+        >
+          <FaEnvelope /> Email
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/chat/ChatSidebar.js
+++ b/frontend/src/components/chat/ChatSidebar.js
@@ -10,6 +10,7 @@ import {
   FaThumbtack,
   FaStar,
   FaBell,
+  FaWhatsapp,
 } from "react-icons/fa";
 
 const ChatSidebar = ({
@@ -84,6 +85,16 @@ const ChatSidebar = ({
     }
   };
 
+  const handleWhatsAppChat = (phone, e) => {
+    e?.stopPropagation();
+    if (phone) {
+      const phoneNumber = phone.replace(/\D/g, "");
+      window.open(`https://wa.me/${phoneNumber}`, "_blank");
+    } else {
+      alert("Phone number is missing!");
+    }
+  };
+
   return (
     <aside className="bg-gray-800 p-4 rounded-lg shadow-lg col-span-1">
       <h2 className="text-lg font-bold text-yellow-400 mb-4">💬 Chats</h2>
@@ -123,14 +134,18 @@ const ChatSidebar = ({
               onClick={() => setSelectedChat(chat)}
             >
               <p className="text-white font-semibold flex-1">{chat.name}</p>
-              {chat.email && (
-                <button
-                  className="text-gray-400 hover:text-yellow-500"
-                  onClick={(e) => handleSendEmail(chat.email, e)}
-                >
-                  <FaEnvelope />
-                </button>
-              )}
+              <button
+                className="text-gray-400 hover:text-green-500"
+                onClick={(e) => handleWhatsAppChat(chat.phone, e)}
+              >
+                <FaWhatsapp />
+              </button>
+              <button
+                className="text-gray-400 hover:text-yellow-500"
+                onClick={(e) => handleSendEmail(chat.email, e)}
+              >
+                <FaEnvelope />
+              </button>
               <button
                 className="text-gray-400 hover:text-yellow-500"
                 onClick={(e) => {
@@ -189,14 +204,18 @@ const ChatSidebar = ({
               </div>
             )}
 
-            {user.email && (
-              <button
-                className="text-gray-400 hover:text-yellow-500"
-                onClick={(e) => handleSendEmail(user.email, e)}
-              >
-                <FaEnvelope />
-              </button>
-            )}
+            <button
+              className="text-gray-400 hover:text-green-500"
+              onClick={(e) => handleWhatsAppChat(user.phone, e)}
+            >
+              <FaWhatsapp />
+            </button>
+            <button
+              className="text-gray-400 hover:text-yellow-500"
+              onClick={(e) => handleSendEmail(user.email, e)}
+            >
+              <FaEnvelope />
+            </button>
 
             {/* ⭐ Pin Chat */}
             <button
@@ -280,14 +299,18 @@ const ChatSidebar = ({
                 height={40}
               />
               <p className="text-white font-semibold flex-1">{user.name}</p>
-              {user.email && (
-                <button
-                  className="text-gray-400 hover:text-yellow-500"
-                  onClick={(e) => handleSendEmail(user.email, e)}
-                >
-                  <FaEnvelope />
-                </button>
-              )}
+              <button
+                className="text-gray-400 hover:text-green-500"
+                onClick={(e) => handleWhatsAppChat(user.phone, e)}
+              >
+                <FaWhatsapp />
+              </button>
+              <button
+                className="text-gray-400 hover:text-yellow-500"
+                onClick={(e) => handleSendEmail(user.email, e)}
+              >
+                <FaEnvelope />
+              </button>
             </div>
           ))}
       </div>

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -28,6 +28,21 @@ export const deleteMessage = async (id) => {
   return res.data.data || res.data;
 };
 
+export const sendDirectEmail = async (userId, { subject, message }) => {
+  const res = await api.post(`/messages/${userId}/email`, { subject, message });
+  return res.data.data || res.data;
+};
+
+export const sendWhatsAppMessage = async (userId, { message }) => {
+  const res = await api.post(`/messages/${userId}/whatsapp`, { message });
+  return res.data.data || res.data;
+};
+
+export const startVideoCall = async (userId) => {
+  const res = await api.post(`/messages/${userId}/video-call`);
+  return res.data.data || res.data;
+};
+
 export const getConversation = async (userId) => {
   const res = await api.get(`/chat/${userId}`);
   return res.data.data || res.data;

--- a/frontend/src/services/public/instructorService.js
+++ b/frontend/src/services/public/instructorService.js
@@ -14,3 +14,18 @@ export const fetchInstructorAvailability = async (id) => {
   const { data } = await api.get(`/instructors/${id}/availability`);
   return data?.data ?? [];
 };
+
+export const sendEmailToInstructor = async (id, { subject, message }) => {
+  const { data } = await api.post(`/instructors/${id}/email`, { subject, message });
+  return data?.data || data;
+};
+
+export const sendWhatsAppToInstructor = async (id, { message }) => {
+  const { data } = await api.post(`/instructors/${id}/whatsapp`, { message });
+  return data?.data || data;
+};
+
+export const startVideoCallWithInstructor = async (id) => {
+  const { data } = await api.post(`/instructors/${id}/video-call`);
+  return data?.data || data;
+};

--- a/frontend/src/services/public/studentService.js
+++ b/frontend/src/services/public/studentService.js
@@ -9,3 +9,18 @@ export const fetchPublicStudentById = async (id) => {
   const { data } = await api.get(`/students/${id}`);
   return data?.data;
 };
+
+export const sendEmailToStudent = async (id, { subject, message }) => {
+  const { data } = await api.post(`/students/${id}/email`, { subject, message });
+  return data?.data || data;
+};
+
+export const sendWhatsAppToStudent = async (id, { message }) => {
+  const { data } = await api.post(`/students/${id}/whatsapp`, { message });
+  return data?.data || data;
+};
+
+export const startVideoCallWithStudent = async (id) => {
+  const { data } = await api.post(`/students/${id}/video-call`);
+  return data?.data || data;
+};


### PR DESCRIPTION
## Summary
- expose email, WhatsApp, and video call routes on student and instructor profiles
- wire up public services to trigger direct messaging actions
- test student and instructor messaging endpoints
- show WhatsApp and email controls for every user in chat interfaces

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688e397a8d148328ac5fe40322d185b6