### PR TITLE
feat: handle video call invitations via sockets

### DIFF
--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -3,6 +3,9 @@ import { FaVideo, FaWhatsapp, FaEnvelope, FaCircle } from "react-icons/fa";
 import { API_BASE_URL } from "@/config/config";
 import formatRelativeTime from "@/utils/relativeTime";
 import ChatImage from "../shared/ChatImage";
+import { startVideoCall } from "@/services/messageService";
+import useCallStore from "@/store/call/callStore";
+import { toast } from "react-toastify";
 
 const ChatHeader = ({ selectedChat }) => {
   const router = useRouter();
@@ -25,8 +28,16 @@ const ChatHeader = ({ selectedChat }) => {
         selectedChat.avatar_url;
 
 
-  const handleVideoCall = () => {
-    router.push(`/video-call?chatId=${selectedChat.id}`);
+  const initiateCall = useCallStore((state) => state.initiateCall);
+
+  const handleVideoCall = async () => {
+    try {
+      await startVideoCall(selectedChat.id);
+      initiateCall({ chatId: selectedChat.id });
+      toast.info("Calling...");
+    } catch (_) {
+      toast.error("Failed to start call");
+    }
   };
 
   const handleWhatsAppChat = () => {

--- a/frontend/src/components/video-call/CallOverlay.js
+++ b/frontend/src/components/video-call/CallOverlay.js
@@ -13,4 +13,4 @@ const CallOverlay = ({ onAccept, onDecline }) => {
       </div>
     );
   };
-  
+  export default CallOverlay;

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -10,6 +10,9 @@ import { getUsers, getGroups } from "@/services/messageService";
 import { FaSearch, FaCommentDots, FaTrash } from "react-icons/fa";
 import ChatImage from "@/components/shared/ChatImage";
 import useMessageStore from "@/store/messages/messageStore";
+import CallOverlay from "@/components/video-call/CallOverlay";
+import useCallStore from "@/store/call/callStore";
+import { toast } from "react-toastify";
 
 const MessagesPage = () => {
   const { t } = useTranslation("common");
@@ -28,6 +31,14 @@ const MessagesPage = () => {
   const startPollingStore = useMessageStore((state) => state.startPolling);
   const markMessageRead = useMessageStore((state) => state.markRead);
   const deleteMessageStore = useMessageStore((state) => state.delete);
+
+  const incomingCall = useCallStore((state) => state.incomingCall);
+  const acceptCall = useCallStore((state) => state.acceptCall);
+  const declineCall = useCallStore((state) => state.declineCall);
+  const listenCalls = useCallStore((state) => state.listen);
+  const acceptedCall = useCallStore((state) => state.acceptedCall);
+  const clearCallStatus = useCallStore((state) => state.clearStatus);
+  const declined = useCallStore((state) => state.declined);
 
   const fetchMessages = useCallback(() => {
     fetchMessagesStore();
@@ -106,6 +117,20 @@ const MessagesPage = () => {
       }
     }
   }, [users, selectedChat]);
+
+  useEffect(() => {
+    listenCalls();
+  }, [listenCalls]);
+
+  useEffect(() => {
+    if (acceptedCall) {
+      router.push(`/video-call?chatId=${acceptedCall.chatId}`);
+      clearCallStatus();
+    } else if (declined) {
+      toast.info("Call declined");
+      clearCallStatus();
+    }
+  }, [acceptedCall, declined, router, clearCallStatus]);
 
   return (
     <div className="bg-gray-900 min-h-screen text-white">
@@ -291,6 +316,9 @@ const MessagesPage = () => {
           </main>
         )}
       </div>
+      {incomingCall && (
+        <CallOverlay onAccept={acceptCall} onDecline={declineCall} />
+      )}
     </div>
   );
 };

--- a/frontend/src/store/call/callStore.js
+++ b/frontend/src/store/call/callStore.js
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+import socket from "@/services/socketService";
+
+const useCallStore = create((set, get) => ({
+  incomingCall: null,
+  outgoingCall: null,
+  acceptedCall: null,
+  declined: false,
+  listening: false,
+  listen: () => {
+    if (get().listening) return;
+    socket.on("incoming-call", (data) => {
+      set({ incomingCall: data });
+    });
+    socket.on("call-accepted", (data) => {
+      set({ acceptedCall: data, outgoingCall: null });
+    });
+    socket.on("call-declined", () => {
+      set({ declined: true, outgoingCall: null });
+    });
+    set({ listening: true });
+  },
+  initiateCall: (info) => set({ outgoingCall: info, declined: false, acceptedCall: null }),
+  acceptCall: () => {
+    const call = get().incomingCall;
+    if (!call) return;
+    socket.emit("call-accepted", call);
+    set({ incomingCall: null, acceptedCall: call });
+  },
+  declineCall: () => {
+    const call = get().incomingCall;
+    if (!call) return;
+    socket.emit("call-declined", call);
+    set({ incomingCall: null, declined: true });
+  },
+  clearStatus: () => set({ acceptedCall: null, declined: false }),
+}));
+
+export default useCallStore;


### PR DESCRIPTION
## Summary
- add Zustand call store listening to incoming/accepted/declined socket events
- show CallOverlay on incoming calls and navigate/notify based on acceptance
- start video calls via API and use socket events to redirect or show toast

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_688e448560f48328bf69846161165693