### PR TITLE
feat: add incoming call overlay to chat pages

### DIFF
--- a/frontend/src/components/video-call/CallOverlay.js
+++ b/frontend/src/components/video-call/CallOverlay.js
@@ -1,16 +1,17 @@
 const CallOverlay = ({ onAccept, onDecline }) => {
-    return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex flex-col items-center justify-center text-white text-lg font-bold p-6">
-        <p className="mb-4">Incoming Call...</p>
-        <div className="flex gap-4">
-          <button onClick={onAccept} className="px-6 py-3 bg-green-500 rounded-lg hover:bg-green-600">
-            ✅ Accept
-          </button>
-          <button onClick={onDecline} className="px-6 py-3 bg-red-500 rounded-lg hover:bg-red-600">
-            ❌ Decline
-          </button>
-        </div>
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex flex-col items-center justify-center text-white text-lg font-bold p-6">
+      <p className="mb-4">Incoming Call...</p>
+      <div className="flex gap-4">
+        <button onClick={onAccept} className="px-6 py-3 bg-green-500 rounded-lg hover:bg-green-600">
+          ✅ Accept
+        </button>
+        <button onClick={onDecline} className="px-6 py-3 bg-red-500 rounded-lg hover:bg-red-600">
+          ❌ Decline
+        </button>
       </div>
-    );
-  };
-  
+    </div>
+  );
+};
+
+export default CallOverlay;

--- a/frontend/src/pages/messages/chat.js
+++ b/frontend/src/pages/messages/chat.js
@@ -1,18 +1,43 @@
 import { useState, useEffect } from "react";
+import { useRouter } from "next/router";
 import Navbar from "@/components/website/sections/Navbar";
 import ChatSidebar from "@/components/chat/ChatSidebar";
-import ChatWindow from "@/components/chat/ChatWindow"; 
+import ChatWindow from "@/components/chat/ChatWindow";
+import CallOverlay from "@/components/video-call/CallOverlay";
+import socket from "@/services/socketService";
 import { getUsers, getGroups } from "@/services/messageService";
 
 const ChatPage = () => {
   const [users, setUsers] = useState([]);
   const [groups, setGroups] = useState([]);
   const [selectedChat, setSelectedChat] = useState(null);
+  const [incomingCall, setIncomingCall] = useState(null);
+
+  const router = useRouter();
 
   useEffect(() => {
     getUsers().then(setUsers).catch(() => setUsers([]));
     getGroups().then(setGroups).catch(() => setGroups([]));
   }, []);
+
+  useEffect(() => {
+    const handleIncomingCall = ({ chatId }) => setIncomingCall(chatId);
+    socket.on("incoming-call", handleIncomingCall);
+    return () => socket.off("incoming-call", handleIncomingCall);
+  }, []);
+
+  const handleAccept = () => {
+    if (!incomingCall) return;
+    socket.emit("call-accepted", { chatId: incomingCall });
+    router.push(`/video-call?chatId=${incomingCall}`);
+    setIncomingCall(null);
+  };
+
+  const handleDecline = () => {
+    if (!incomingCall) return;
+    socket.emit("call-declined", { chatId: incomingCall });
+    setIncomingCall(null);
+  };
 
   return (
     <div className="bg-gray-900 min-h-screen text-white">
@@ -21,6 +46,9 @@ const ChatPage = () => {
         <ChatSidebar users={users} groups={groups} setSelectedChat={setSelectedChat} selectedChat={selectedChat} />
         {selectedChat ? <ChatWindow selectedChat={selectedChat} /> : <div className="col-span-3 text-center text-gray-400">Select a chat to start messaging</div>}
       </main>
+      {incomingCall && (
+        <CallOverlay onAccept={handleAccept} onDecline={handleDecline} />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -6,6 +6,8 @@ import ChatSidebar from "@/components/chat/ChatSidebar";
 import ChatWindow from "@/components/chat/ChatWindow";
 import GroupChat from "@/components/chat/GroupChat";
 import ChatNotifications from "@/components/chat/ChatNotifications";
+import CallOverlay from "@/components/video-call/CallOverlay";
+import socket from "@/services/socketService";
 import { getUsers, getGroups } from "@/services/messageService";
 import { FaSearch, FaCommentDots, FaTrash } from "react-icons/fa";
 import ChatImage from "@/components/shared/ChatImage";
@@ -17,6 +19,7 @@ const MessagesPage = () => {
   const [users, setUsers] = useState([]);
   const [groups, setGroups] = useState([]);
   const [selectedChat, setSelectedChat] = useState(null);
+  const [incomingCall, setIncomingCall] = useState(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [filteredGroups, setFilteredGroups] = useState([]);
@@ -38,6 +41,25 @@ const MessagesPage = () => {
   }, [startPollingStore]);
 
   const router = useRouter();
+
+  useEffect(() => {
+    const handleIncomingCall = ({ chatId }) => setIncomingCall(chatId);
+    socket.on("incoming-call", handleIncomingCall);
+    return () => socket.off("incoming-call", handleIncomingCall);
+  }, []);
+
+  const handleAccept = () => {
+    if (!incomingCall) return;
+    socket.emit("call-accepted", { chatId: incomingCall });
+    router.push(`/video-call?chatId=${incomingCall}`);
+    setIncomingCall(null);
+  };
+
+  const handleDecline = () => {
+    if (!incomingCall) return;
+    socket.emit("call-declined", { chatId: incomingCall });
+    setIncomingCall(null);
+  };
 
   // Keep unread counts from the backend so new chats show up in the sidebar
   const adjustCounts = useCallback((list) => list, []);
@@ -291,6 +313,9 @@ const MessagesPage = () => {
           </main>
         )}
       </div>
+      {incomingCall && (
+        <CallOverlay onAccept={handleAccept} onDecline={handleDecline} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- export `CallOverlay` as default
- show call overlay on incoming socket events in chat pages
- navigate to `video-call` or decline via socket handlers

## Testing
- `npm test`
- `npm run lint` *(fails: ✖ 284 problems (58 errors, 226 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688e44801ea483289227c56504872da3