### PR TITLE
Fix message center user status and contact actions

### DIFF
--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -24,6 +24,9 @@ const ChatHeader = ({ selectedChat }) => {
         selectedChat.profile_image ||
         selectedChat.avatar_url;
 
+  const isOnline =
+    selectedChat.isOnline ?? selectedChat.is_online ?? selectedChat.status === "online";
+  const lastActive = selectedChat.lastActive || selectedChat.last_active;
 
   const handleVideoCall = () => {
     router.push(`/video-call?chatId=${selectedChat.id}`);
@@ -69,7 +72,7 @@ const ChatHeader = ({ selectedChat }) => {
           {!selectedChat.isGroup && (
             <span
               className={`absolute bottom-0 right-0 w-3 h-3 rounded-full border border-gray-700 ${
-                selectedChat.isOnline ? "bg-green-500" : "bg-gray-500"
+                isOnline ? "bg-green-500" : "bg-gray-500"
               }`}
             />
           )}
@@ -79,11 +82,8 @@ const ChatHeader = ({ selectedChat }) => {
             {selectedChat.groupName || selectedChat.name || "Unknown Chat"}
           </h3>
           {!selectedChat.isGroup && (
-
             <div className="text-sm text-gray-400">
-              {selectedChat.isOnline
-                ? "Online"
-                : `Last active ${formatRelativeTime(selectedChat.lastActive)}`}
+              {isOnline ? "Online" : `Last active ${formatRelativeTime(lastActive)}`}
             </div>
           )}
         </div>

--- a/frontend/src/components/chat/ChatSidebar.js
+++ b/frontend/src/components/chat/ChatSidebar.js
@@ -32,6 +32,9 @@ const ChatSidebar = ({
     return `${API_BASE_URL}${url}`;
   };
 
+  const isUserOnline = (user) =>
+    user?.isOnline ?? user?.is_online ?? user?.status === "online";
+
   const getGroupAvatar = (g) => {
     const src = g.cover_image || g.image;
     return getAvatarUrl(src);
@@ -40,11 +43,16 @@ const ChatSidebar = ({
   // ✅ Sort users by online status & last active
   useEffect(() => {
     const sortedUsers = [...users].sort((a, b) => {
-      if (a.isOnline === b.isOnline) return b.lastActive - a.lastActive;
-      return a.isOnline ? -1 : 1;
+      const aOnline = isUserOnline(a);
+      const bOnline = isUserOnline(b);
+      if (aOnline === bOnline)
+        return (b.lastActive || b.last_active || 0) - (a.lastActive || a.last_active || 0);
+      return aOnline ? -1 : 1;
     });
 
-    const sortedGroups = [...groups].sort((a, b) => b.lastActive - a.lastActive);
+    const sortedGroups = [...groups].sort(
+      (a, b) => (b.lastActive || b.last_active || 0) - (a.lastActive || a.last_active || 0)
+    );
 
     setSortedUsers(sortedUsers);
     setSortedGroups(sortedGroups);
@@ -182,9 +190,7 @@ const ChatSidebar = ({
               />
               <span
                 className={`absolute bottom-0 right-0 w-3 h-3 rounded-full border border-gray-800 ${
-                  (user.isOnline ?? user.status === "online")
-                    ? "bg-green-500"
-                    : "bg-red-500"
+                  isUserOnline(user) ? "bg-green-500" : "bg-red-500"
                 }`}
               />
             </div>

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -10,6 +10,7 @@ import { getUsers, getGroups } from "@/services/messageService";
 import { FaSearch, FaCommentDots, FaTrash } from "react-icons/fa";
 import ChatImage from "@/components/shared/ChatImage";
 import useMessageStore from "@/store/messages/messageStore";
+import { API_BASE_URL } from "@/config/config";
 
 const MessagesPage = () => {
   const { t } = useTranslation("common");
@@ -28,6 +29,12 @@ const MessagesPage = () => {
   const startPollingStore = useMessageStore((state) => state.startPolling);
   const markMessageRead = useMessageStore((state) => state.markRead);
   const deleteMessageStore = useMessageStore((state) => state.delete);
+
+  const getAvatarUrl = (url, fallback = "/images/default-avatar.png") => {
+    if (!url) return fallback;
+    if (url.startsWith("http") || url.startsWith("blob:")) return url;
+    return `${API_BASE_URL}${url}`;
+  };
 
   const fetchMessages = useCallback(() => {
     fetchMessagesStore();
@@ -206,7 +213,7 @@ const MessagesPage = () => {
                         >
                           <div className="flex items-center gap-3">
                             <ChatImage
-                              src={user.profileImage || "/images/default-avatar.png"}
+                              src={getAvatarUrl(user.profileImage)}
                               alt={user.name || "User"}
                               className="w-10 h-10 rounded-full border border-yellow-500"
                               width={40}
@@ -243,7 +250,12 @@ const MessagesPage = () => {
                         >
                           <div className="flex items-center gap-3">
                             <ChatImage
-                              src={group.cover_image || group.image || "/images/group-placeholder.jpg"}
+                              src={
+                                getAvatarUrl(
+                                  group.cover_image || group.image,
+                                  "/images/group-placeholder.jpg"
+                                )
+                              }
                               alt={group.name}
                               className="w-10 h-10 rounded-full border border-gray-500"
                               width={40}


### PR DESCRIPTION
## Summary
- handle multiple online status fields when rendering chats
- show accurate last-active info and online indicator in chat headers
- ensure avatars use API base URL so they display correctly

## Testing
- `cd frontend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_688e446410b883289b670fc25d8914ff