### PR TITLE
feat: trigger video call invitation

### DIFF
--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -4,7 +4,7 @@ import { API_BASE_URL } from "@/config/config";
 import formatRelativeTime from "@/utils/relativeTime";
 import ChatImage from "../shared/ChatImage";
 
-const ChatHeader = ({ selectedChat }) => {
+const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
   const router = useRouter();
 
   const getAvatarUrl = (url, fallback = "/images/default-avatar.png") => {
@@ -25,7 +25,10 @@ const ChatHeader = ({ selectedChat }) => {
         selectedChat.avatar_url;
 
 
-  const handleVideoCall = () => {
+  const handleVideoCall = async () => {
+    if (onStartVideoCall) {
+      await onStartVideoCall(selectedChat.id);
+    }
     router.push(`/video-call?chatId=${selectedChat.id}`);
   };
 

--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -12,9 +12,10 @@ import {
   sendChatMessage,
   deleteChatMessage as apiDeleteChatMessage,
   togglePinMessage as apiTogglePinMessage,
+  startVideoCall,
 } from "@/services/messageService";
 
-const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
+const ChatWindow = ({ selectedChat, refreshUsers }) => {
   const currentUser = useAuthStore((state) => state.user);
   const [messages, setMessages] = useState([]);
   const [typing, setTyping] = useState(false);
@@ -69,6 +70,15 @@ const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
     }
   }, [typing]);
 
+  const handleStartVideoCall = async (chatId) => {
+    try {
+      await startVideoCall(chatId);
+      toast.info("Video call invitation sent");
+    } catch (_) {
+      toast.error("Failed to start video call");
+    }
+  };
+
   const sendMessage = async (newMessage) => {
     if (!newMessage.text && !newMessage.file && !newMessage.audio) {
       toast.error("Message is empty!");
@@ -122,7 +132,7 @@ const ChatWindow = ({ selectedChat, onStartVideoCall, refreshUsers }) => {
     <div className="flex flex-col h-[calc(100vh-7rem)] bg-gray-800 rounded-lg shadow-md overflow-hidden w-full md:col-span-3">
       {/* Header */}
       <div className="border-b border-gray-700">
-        <ChatHeader selectedChat={selectedChat} onStartVideoCall={onStartVideoCall} />
+        <ChatHeader selectedChat={selectedChat} onStartVideoCall={handleStartVideoCall} />
       </div>
 
       {/* Pinned */}

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -69,3 +69,7 @@ export const togglePinMessage = async (id) => {
   const res = await api.patch(`/chat/messages/${id}/pin`);
   return res.data.data || res.data;
 };
+
+// Placeholder to avoid runtime ReferenceError when build processes
+// expect a call-listener helper. Currently does nothing.
+export const listenCalls = () => {};


### PR DESCRIPTION
## Summary
- trigger video call invitation before redirect
- call video-call service when button clicked
- add stub call listener to avoid runtime errors

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: process interrupted while optimizing build)*

------
https://chatgpt.com/codex/tasks/task_e_688e4481a9d08328bef4b24165f114cf