### PR TITLE
feat: improve offer handling

### DIFF
--- a/backend/src/modules/offers/offers.controller.js
+++ b/backend/src/modules/offers/offers.controller.js
@@ -36,7 +36,17 @@ exports.createOffer = catchAsync(async (req, res) => {
     }
     data.expires_at = expires_at;
   }
-  const tags = rawTags ? JSON.parse(rawTags) : [];
+  let tags = [];
+  if (rawTags) {
+    try {
+      tags = typeof rawTags === "string" ? JSON.parse(rawTags) : rawTags;
+      if (!Array.isArray(tags)) {
+        return res.status(400).json({ message: "Tags must be an array" });
+      }
+    } catch (e) {
+      return res.status(400).json({ message: "Invalid tags format" });
+    }
+  }
   const offer = await service.createOffer(data);
   if (tags.length) {
     const tagIds = [];
@@ -124,11 +134,17 @@ exports.updateOffer = catchAsync(async (req, res) => {
   }
   const offer = await service.updateOffer(req.params.id, data);
 
-  const tags = rawTags
-    ? typeof rawTags === "string"
-      ? JSON.parse(rawTags)
-      : rawTags
-    : null;
+  let tags = null;
+  if (rawTags) {
+    try {
+      tags = typeof rawTags === "string" ? JSON.parse(rawTags) : rawTags;
+      if (!Array.isArray(tags)) {
+        return res.status(400).json({ message: "Tags must be an array" });
+      }
+    } catch (e) {
+      return res.status(400).json({ message: "Invalid tags format" });
+    }
+  }
   if (tags) {
     await db("offer_tag_map").where({ offer_id: offer.id }).del();
     if (tags.length) {

--- a/backend/src/modules/offers/offers.routes.js
+++ b/backend/src/modules/offers/offers.routes.js
@@ -15,8 +15,14 @@ router.post(
 );
 router.get("/", controller.getOffers);
 router.get("/:id", controller.getOfferById);
-router.put("/:id", verifyToken, validate(validator.update), controller.updateOffer);
-router.delete("/:id", verifyToken, controller.deleteOffer);
+router.put(
+  "/:id",
+  verifyToken,
+  ensureVerified,
+  validate(validator.update),
+  controller.updateOffer
+);
+router.delete("/:id", verifyToken, ensureVerified, controller.deleteOffer);
 
 // Tags
 router.get("/tags", tagController.listTags);

--- a/frontend/src/pages/dashboard/admin/offers/new.js
+++ b/frontend/src/pages/dashboard/admin/offers/new.js
@@ -9,6 +9,8 @@ const NewOfferPage = () => {
   const [form, setForm] = useState({
     title: "",
     price: "",
+    timeframe: "",
+    offerType: "class",
     expiresAt: "",
     tags: "",
     description: "",
@@ -31,6 +33,8 @@ const NewOfferPage = () => {
         title: form.title,
         description: form.description,
         budget: form.price,
+        timeframe: form.timeframe,
+        offer_type: form.offerType,
         expires_at: form.expiresAt || undefined,
         tags: JSON.stringify(tags),
       });
@@ -71,13 +75,37 @@ const NewOfferPage = () => {
         </div>
 
         <div>
+          <label className="block font-medium mb-1">Timeframe</label>
+          <input
+            name="timeframe"
+            value={form.timeframe}
+            onChange={handleChange}
+            required
+            placeholder="e.g. 3 months"
+            className="w-full border border-gray-300 rounded px-4 py-2"
+          />
+        </div>
+
+        <div>
+          <label className="block font-medium mb-1">Offer Type</label>
+          <select
+            name="offerType"
+            value={form.offerType}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-4 py-2"
+          >
+            <option value="class">Class</option>
+            <option value="tutorial">Tutorial</option>
+          </select>
+        </div>
+
+        <div>
           <label className="block font-medium mb-1">Expires At</label>
           <input
             type="date"
             name="expiresAt"
             value={form.expiresAt}
             onChange={handleChange}
-            required
             className="w-full border border-gray-300 rounded px-4 py-2"
           />
         </div>

--- a/frontend/src/pages/offers/index.js
+++ b/frontend/src/pages/offers/index.js
@@ -1,7 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { motion } from "framer-motion";
-import Link from "next/link";
 import {
   FaSearch,
   FaTag,
@@ -11,36 +10,7 @@ import {
 } from "react-icons/fa";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
-
-const sampleOffers = [
-  {
-    id: 1,
-    title: "Need Physics Tutor",
-    type: "student",
-    price: "$200",
-    duration: "3 months",
-    tags: ["OneOnOne", "Urgent"],
-    date: "2024-04-03T12:00:00Z",
-  },
-  {
-    id: 2,
-    title: "Math Tutoring Available",
-    type: "instructor",
-    price: "$100/month",
-    duration: "8 months",
-    tags: ["Discount", "LiveClass"],
-    date: "2024-04-05T08:00:00Z",
-  },
-  {
-    id: 3,
-    title: "Seeking Spanish Lessons",
-    type: "student",
-    price: "$150",
-    duration: "5 months",
-    tags: ["Flexible"],
-    date: "2024-04-04T10:30:00Z",
-  },
-];
+import { fetchOffers } from "@/services/offerService";
 
 const tagColors = {
   Urgent: "bg-red-500 text-white",
@@ -64,8 +34,34 @@ const OffersPage = () => {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
   const [filterType, setFilterType] = useState("all");
+  const [offers, setOffers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
 
-  const filtered = sampleOffers
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchOffers();
+        const normalized = data.map((o) => ({
+          id: o.id,
+          title: o.title,
+          type: o.offer_type === "class" ? "instructor" : "student",
+          price: o.budget || "",
+          duration: o.timeframe || "",
+          tags: o.tags?.map((t) => t.name) || [],
+          date: o.created_at || o.updated_at || new Date().toISOString(),
+        }));
+        setOffers(normalized);
+      } catch (err) {
+        setError("Failed to load offers");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const filtered = offers
     .filter(
       (offer) =>
         offer.title.toLowerCase().includes(searchQuery.toLowerCase()) &&
@@ -131,7 +127,15 @@ const OffersPage = () => {
 
           {/* Offers Grid */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filtered.length > 0 ? (
+            {loading ? (
+              <div className="col-span-full text-center text-gray-500 text-lg py-20">
+                Loading offers...
+              </div>
+            ) : error ? (
+              <div className="col-span-full text-center text-red-500 text-lg py-20">
+                {error}
+              </div>
+            ) : filtered.length > 0 ? (
               filtered.map((offer, index) => (
                 <motion.div
                   key={offer.id}

--- a/frontend/src/pages/offers/new.js
+++ b/frontend/src/pages/offers/new.js
@@ -12,6 +12,7 @@ const availableTags = ["Urgent", "LiveClass", "Discount", "Flexible", "OneOnOne"
 const CreateOffer = () => {
   const router = useRouter();
   const [offerType, setOfferType] = useState("student");
+  const [offerCategory, setOfferCategory] = useState("class");
   const [title, setTitle] = useState("");
   const [duration, setDuration] = useState("");
   const [price, setPrice] = useState("");
@@ -26,6 +27,8 @@ const CreateOffer = () => {
         description,
         budget: price,
         timeframe: duration,
+        offer_type: offerCategory,
+        tags: JSON.stringify(tags),
       });
       toast.success("🎉 Offer posted successfully!", { theme: "dark" });
       setTimeout(() => router.push("/offers"), 1800);
@@ -54,7 +57,7 @@ const CreateOffer = () => {
             onSubmit={handleSubmit}
             className="bg-gray-800 p-6 rounded-lg shadow-lg"
           >
-            {/* Offer Type */}
+            {/* User Type */}
             <div className="mb-4">
               <label className="block text-white font-bold">I am a:</label>
               <select
@@ -64,6 +67,19 @@ const CreateOffer = () => {
               >
                 <option value="student">Student (Looking for a tutor)</option>
                 <option value="instructor">Instructor (Offering lessons)</option>
+              </select>
+            </div>
+
+            {/* Offer Type */}
+            <div className="mb-4">
+              <label className="block text-white font-bold">Offer Type:</label>
+              <select
+                className="w-full p-3 bg-gray-700 text-white rounded-lg mt-2"
+                value={offerCategory}
+                onChange={(e) => setOfferCategory(e.target.value)}
+              >
+                <option value="class">Class</option>
+                <option value="tutorial">Tutorial</option>
               </select>
             </div>
 
@@ -152,7 +168,6 @@ const CreateOffer = () => {
 };
 
 export default CreateOffer;
-1
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 


### PR DESCRIPTION
## Summary
- enforce verified accounts for offer updates and deletes
- validate offer tags and fetch offers on public page
- include offer type/timeframe in creation forms

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e54b2bdf883289e1c832780dffb5e