### PR TITLE
fix: prevent auto video call on messages page

### DIFF
--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -18,6 +18,7 @@ import { FaSearch, FaCommentDots, FaTrash } from "react-icons/fa";
 import ChatImage from "@/components/shared/ChatImage";
 import useMessageStore from "@/store/messages/messageStore";
 import { API_BASE_URL } from "@/config/config";
+import { toast } from "react-toastify";
 
 const MessagesPage = () => {
   const { t } = useTranslation("common");
@@ -141,10 +142,13 @@ const MessagesPage = () => {
   }, [listenCalls]);
 
   useEffect(() => {
-    if (acceptedCall) {
-      router.push(`/video-call?chatId=${acceptedCall.chatId}`);
+    const accepted = acceptedCall();
+    const isDeclined = declined();
+
+    if (accepted?.chatId) {
+      router.push(`/video-call?chatId=${accepted.chatId}`);
       clearCallStatus();
-    } else if (declined) {
+    } else if (isDeclined) {
       toast.info("Call declined");
       clearCallStatus();
     }


### PR DESCRIPTION
## Summary
- prevent automatic video call redirect on /messages by checking call status results
- import toast for decline notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e6aa840a08328be30c0a157094dee