### PR TITLE
Add offer sorting and refine detail view

### DIFF
--- a/frontend/src/pages/offers/[id].js
+++ b/frontend/src/pages/offers/[id].js
@@ -22,8 +22,6 @@ import {
   FaChalkboardTeacher,
   FaComment,
   FaPaperPlane,
-  FaPlayCircle,
-  FaVideo,
 } from "react-icons/fa";
 
 dayjs.extend(relativeTime);
@@ -42,7 +40,25 @@ const OfferDetailsPage = () => {
   useEffect(() => {
     if (!id) return;
     fetchOfferById(id)
-      .then((o) => setOffer(o || null))
+      .then((o) =>
+        setOffer(
+          o
+            ? {
+                id: o.id,
+                title: o.title,
+                description: o.description,
+                type: o.offer_type === "class" ? "instructor" : "student",
+                price: o.budget || "",
+                duration: o.timeframe || "",
+                tags: o.tags?.map((t) => t.name) || [],
+                date: o.created_at || o.updated_at,
+                expires_at: o.expires_at,
+                owner: o.student_name,
+                ownerRole: o.student_role,
+              }
+            : null
+        )
+      )
       .catch(() => setOffer(null));
     fetchResponses(id)
       .then((resps) => {
@@ -102,28 +118,6 @@ const OfferDetailsPage = () => {
     } catch (_) {}
   };
 
-  const renderDealActions = () => {
-    if (offer.type === "student") {
-      return (
-        <button
-          onClick={() => alert("Redirecting to create tutorial form...")}
-          className="mt-6 w-full bg-green-500 hover:bg-green-600 text-white font-bold py-3 px-6 rounded-lg flex items-center justify-center gap-2"
-        >
-          <FaPlayCircle /> Create Tutorial for This Student
-        </button>
-      );
-    } else {
-      return (
-        <button
-          onClick={() => alert("Redirecting to enroll/payment process...")}
-          className="mt-6 w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg flex items-center justify-center gap-2"
-        >
-          <FaVideo /> Join This Live Class / Accept Offer
-        </button>
-      );
-    }
-  };
-
   if (!offer) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-950 text-white">
@@ -165,11 +159,18 @@ const OfferDetailsPage = () => {
           <div className="flex items-center gap-3 text-sm text-gray-300 mb-2">
             <span className="flex items-center gap-1">
               {offer.type === "student" ? <FaUserGraduate /> : <FaChalkboardTeacher />}
-              {offer.type === "student" ? " Student" : " Instructor"}
+              {offer.owner} ({offer.ownerRole})
             </span>
-            <span>• Duration: {offer.duration}</span>
             <span>• Price: {offer.price}</span>
+            <span>• Duration: {offer.duration}</span>
           </div>
+
+          <p className="text-xs text-gray-400 mb-4">
+            Created: {dayjs(offer.date).format("MMM D, YYYY")}
+            {offer.expires_at && (
+              <> • Ends: {dayjs(offer.expires_at).format("MMM D, YYYY")}</>
+            )}
+          </p>
 
           <div className="flex flex-wrap gap-2 mt-4">
             {offer.tags?.map((tag, i) => (
@@ -181,10 +182,6 @@ const OfferDetailsPage = () => {
               </span>
             ))}
           </div>
-
-          <p className="mt-6 text-xs text-gray-500">
-            📅 Posted: {dayjs(offer.date).fromNow()}
-          </p>
 
           {/* Negotiation Chat */}
           <div className="bg-gray-900 p-4 rounded-lg mt-10 shadow-md">
@@ -238,8 +235,6 @@ const OfferDetailsPage = () => {
             </div>
           </div>
 
-          {/* CTA Button based on Role */}
-          {renderDealActions()}
         </div>
       </main>
 

--- a/frontend/src/pages/offers/index.js
+++ b/frontend/src/pages/offers/index.js
@@ -37,6 +37,7 @@ const OffersPage = () => {
   const [offers, setOffers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [sortOption, setSortOption] = useState("date_desc");
 
   useEffect(() => {
     const load = async () => {
@@ -67,7 +68,20 @@ const OffersPage = () => {
         offer.title.toLowerCase().includes(searchQuery.toLowerCase()) &&
         (filterType === "all" || offer.type === filterType)
     )
-    .sort((a, b) => new Date(b.date) - new Date(a.date));
+    .sort((a, b) => {
+      const priceA = parseFloat(String(a.price).replace(/[^0-9.-]+/g, "")) || 0;
+      const priceB = parseFloat(String(b.price).replace(/[^0-9.-]+/g, "")) || 0;
+      switch (sortOption) {
+        case "price_asc":
+          return priceA - priceB;
+        case "price_desc":
+          return priceB - priceA;
+        case "date_asc":
+          return new Date(a.date) - new Date(b.date);
+        default:
+          return new Date(b.date) - new Date(a.date);
+      }
+    });
 
   return (
     <div className="bg-gray-950 text-white min-h-screen">
@@ -111,6 +125,20 @@ const OffersPage = () => {
                 {btn.label}
               </button>
             ))}
+          </div>
+
+          {/* Sort Options */}
+          <div className="flex justify-center mb-6">
+            <select
+              value={sortOption}
+              onChange={(e) => setSortOption(e.target.value)}
+              className="bg-gray-800 border border-gray-600 text-sm rounded px-3 py-2 text-yellow-300"
+            >
+              <option value="date_desc">Newest</option>
+              <option value="date_asc">Oldest</option>
+              <option value="price_asc">Price: Low to High</option>
+              <option value="price_desc">Price: High to Low</option>
+            </select>
           </div>
 
           {/* Search */}


### PR DESCRIPTION
## Summary
- add sort dropdown for offers list with price and date options
- remove unused accept offer CTA and show owner info on offer details

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_688e6c58f2ac8328b52375141bdb7dac