### PR TITLE
Integrate video call store for messaging center notifications

### DIFF
--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -6,6 +6,7 @@ import ChatSidebar from "@/components/chat/ChatSidebar";
 import ChatWindow from "@/components/chat/ChatWindow";
 import GroupChat from "@/components/chat/GroupChat";
 import ChatNotifications from "@/components/chat/ChatNotifications";
+import CallOverlay from "@/components/video-call/CallOverlay";
 import {
   getUsers,
   getGroups,
@@ -17,6 +18,7 @@ import {
 import { FaSearch, FaCommentDots, FaTrash } from "react-icons/fa";
 import ChatImage from "@/components/shared/ChatImage";
 import useMessageStore from "@/store/messages/messageStore";
+import useCallStore from "@/store/call/callStore";
 import { API_BASE_URL } from "@/config/config";
 import { toast } from "react-toastify";
 
@@ -26,7 +28,9 @@ const MessagesPage = () => {
   const [users, setUsers] = useState([]);
   const [groups, setGroups] = useState([]);
   const [selectedChat, setSelectedChat] = useState(null);
-  const [incomingCall, setIncomingCall] = useState(null);
+  const incomingCall = useCallStore((state) => state.incomingCall);
+  const acceptCall = useCallStore((state) => state.acceptCall);
+  const declineCall = useCallStore((state) => state.declineCall);
   const [searchTerm, setSearchTerm] = useState("");
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [filteredGroups, setFilteredGroups] = useState([]);
@@ -62,7 +66,6 @@ const MessagesPage = () => {
       // placeholders to avoid ReferenceError during pre-render.
       acceptedCall();
       declined();
-
       clearCallStatus();
     } catch (_) {
       // ignore
@@ -344,8 +347,10 @@ const MessagesPage = () => {
         )}
       </div>
       {incomingCall && (
-        <CallOverlay onAccept={handleAccept} onDecline={handleDecline} />
-
+        <CallOverlay
+          onAccept={() => acceptCall()}
+          onDecline={() => declineCall()}
+        />
       )}
     </div>
   );

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -1,5 +1,6 @@
 
 import api from "@/services/api/api";
+import useCallStore from "@/store/call/callStore";
 
 
 export const getUsers = async () => {
@@ -40,6 +41,8 @@ export const sendWhatsAppMessage = async (userId, { message }) => {
 
 export const startVideoCall = async (userId) => {
   const res = await api.post(`/messages/${userId}/video-call`);
+  // Track outgoing call so the caller can react to accept/decline events
+  useCallStore.getState().initiateCall({ chatId: userId });
   return res.data.data || res.data;
 };
 
@@ -70,18 +73,12 @@ export const togglePinMessage = async (id) => {
   return res.data.data || res.data;
 };
 
-// Placeholder to avoid runtime ReferenceError when build processes
-// expect a call-listener helper. Currently does nothing.
-export const listenCalls = () => {};
+// Attach socket listeners for incoming/accepted/declined calls
+export const listenCalls = () => useCallStore.getState().listen();
 
-// Placeholder to avoid runtime ReferenceError when build processes
-// expect an accepted-call handler. Currently does nothing.
-export const acceptedCall = () => {};
+// Helpers to read call status from the store
+export const acceptedCall = () => useCallStore.getState().acceptedCall;
 
-// Placeholder to avoid runtime ReferenceError when build processes
-// expect a declined-call handler. Currently does nothing.
-export const declined = () => {};
+export const declined = () => useCallStore.getState().declined;
 
-// Placeholder to avoid runtime ReferenceError when build processes
-// expect a helper to clear call status. Currently does nothing.
-export const clearCallStatus = () => {};
+export const clearCallStatus = () => useCallStore.getState().clearStatus();


### PR DESCRIPTION
## Summary
- hook video call APIs into call store to track outgoing and incoming calls
- listen for call events and expose accept/decline status through store
- render call overlay in message center and wire to call store handlers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e707f5cc4832898812e5972ff20ea