### PR TITLE
fix: update user online status

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -100,10 +100,10 @@ exports.logout = catchAsync(async (req, res) => {
   if (token) {
     try {
       const decoded = authService.verifyRefreshToken(token);
-      const user = await userModel.findById(decoded.id);
-      if (user && user.role && user.role.toLowerCase() === "instructor") {
-        await userModel.updateUser(user.id, { is_online: false });
-      }
+      await userModel.updateUser(decoded.id, {
+        is_online: false,
+        updated_at: new Date(),
+      });
     } catch (err) {
       console.error("Failed to update online status on logout:", err.message);
     }

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -130,10 +130,12 @@ exports.loginUser = async ({ email, password }) => {
   const match = await bcrypt.compare(password, user.password_hash);
   if (!match) throw new AppError("Invalid credentials", 401);
 
-  if (user.role && user.role.toLowerCase() === "instructor") {
-    await userModel.updateUser(user.id, { is_online: true });
-    user.is_online = true;
-  }
+  // Mark user as online on successful login
+  await userModel.updateUser(user.id, {
+    is_online: true,
+    updated_at: new Date(),
+  });
+  user.is_online = true;
 
   const roles = await userModel.getUserRoles(user.id);
   const tokenRoles = roles.length ? roles : [user.role];


### PR DESCRIPTION
## Summary
- set users online at login and update last active timestamp
- clear online status at logout

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e712db1a8832893eb1645a89a12f6