### PR TITLE
Integrate video call store for messaging center notifications

### DIFF
--- a/frontend/src/components/video-call/CallOverlay.js
+++ b/frontend/src/components/video-call/CallOverlay.js
@@ -1,14 +1,26 @@
-const CallOverlay = ({ onAccept, onDecline }) => {
+const CallOverlay = ({ incoming, name, onAccept, onDecline }) => {
+  const label = incoming
+    ? `${name ? name + " is" : ""} calling...`
+    : `Calling${name ? ` ${name}` : ""}...`;
+
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex flex-col items-center justify-center text-white text-lg font-bold p-6">
-      <p className="mb-4">Incoming Call...</p>
+      <p className="mb-4">{label}</p>
       <div className="flex gap-4">
-        <button onClick={onAccept} className="px-6 py-3 bg-green-500 rounded-lg hover:bg-green-600">
-          ✅ Accept
-        </button>
-        <button onClick={onDecline} className="px-6 py-3 bg-red-500 rounded-lg hover:bg-red-600">
-          ❌ Decline
-        </button>
+        {incoming ? (
+          <>
+            <button onClick={onAccept} className="px-6 py-3 bg-green-500 rounded-lg hover:bg-green-600">
+              ✅ Accept
+            </button>
+            <button onClick={onDecline} className="px-6 py-3 bg-red-500 rounded-lg hover:bg-red-600">
+              ❌ Decline
+            </button>
+          </>
+        ) : (
+          <button onClick={onDecline} className="px-6 py-3 bg-red-500 rounded-lg hover:bg-red-600">
+            ❌ Cancel
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -6,6 +6,7 @@ import ChatSidebar from "@/components/chat/ChatSidebar";
 import ChatWindow from "@/components/chat/ChatWindow";
 import GroupChat from "@/components/chat/GroupChat";
 import ChatNotifications from "@/components/chat/ChatNotifications";
+import CallOverlay from "@/components/video-call/CallOverlay";
 import {
   getUsers,
   getGroups,
@@ -17,6 +18,7 @@ import {
 import { FaSearch, FaCommentDots, FaTrash } from "react-icons/fa";
 import ChatImage from "@/components/shared/ChatImage";
 import useMessageStore from "@/store/messages/messageStore";
+import useCallStore from "@/store/call/callStore";
 import { API_BASE_URL } from "@/config/config";
 import { toast } from "react-toastify";
 
@@ -26,7 +28,11 @@ const MessagesPage = () => {
   const [users, setUsers] = useState([]);
   const [groups, setGroups] = useState([]);
   const [selectedChat, setSelectedChat] = useState(null);
-  const [incomingCall, setIncomingCall] = useState(null);
+  const incomingCall = useCallStore((state) => state.incomingCall);
+  const outgoingCall = useCallStore((state) => state.outgoingCall);
+  const acceptCall = useCallStore((state) => state.acceptCall);
+  const declineCall = useCallStore((state) => state.declineCall);
+  const cancelCall = useCallStore((state) => state.cancelCall);
   const [searchTerm, setSearchTerm] = useState("");
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [filteredGroups, setFilteredGroups] = useState([]);
@@ -62,7 +68,6 @@ const MessagesPage = () => {
       // placeholders to avoid ReferenceError during pre-render.
       acceptedCall();
       declined();
-
       clearCallStatus();
     } catch (_) {
       // ignore
@@ -136,10 +141,6 @@ const MessagesPage = () => {
       }
     }
   }, [users, selectedChat]);
-
-  useEffect(() => {
-    listenCalls();
-  }, [listenCalls]);
 
   useEffect(() => {
     const accepted = acceptedCall();
@@ -343,9 +344,13 @@ const MessagesPage = () => {
           </main>
         )}
       </div>
-      {incomingCall && (
-        <CallOverlay onAccept={handleAccept} onDecline={handleDecline} />
-
+      {(incomingCall || outgoingCall) && (
+        <CallOverlay
+          incoming={!!incomingCall}
+          name={incomingCall?.name || selectedChat?.name}
+          onAccept={incomingCall ? () => acceptCall() : undefined}
+          onDecline={incomingCall ? () => declineCall() : cancelCall}
+        />
       )}
     </div>
   );

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -1,5 +1,6 @@
 
 import api from "@/services/api/api";
+import useCallStore from "@/store/call/callStore";
 
 
 export const getUsers = async () => {
@@ -40,6 +41,8 @@ export const sendWhatsAppMessage = async (userId, { message }) => {
 
 export const startVideoCall = async (userId) => {
   const res = await api.post(`/messages/${userId}/video-call`);
+  // Track outgoing call so the caller can react to accept/decline events
+  useCallStore.getState().initiateCall({ chatId: userId });
   return res.data.data || res.data;
 };
 
@@ -70,18 +73,12 @@ export const togglePinMessage = async (id) => {
   return res.data.data || res.data;
 };
 
-// Placeholder to avoid runtime ReferenceError when build processes
-// expect a call-listener helper. Currently does nothing.
-export const listenCalls = () => {};
+// Attach socket listeners for incoming/accepted/declined calls
+export const listenCalls = () => useCallStore.getState().listen();
 
-// Placeholder to avoid runtime ReferenceError when build processes
-// expect an accepted-call handler. Currently does nothing.
-export const acceptedCall = () => {};
+// Helpers to read call status from the store
+export const acceptedCall = () => useCallStore.getState().acceptedCall;
 
-// Placeholder to avoid runtime ReferenceError when build processes
-// expect a declined-call handler. Currently does nothing.
-export const declined = () => {};
+export const declined = () => useCallStore.getState().declined;
 
-// Placeholder to avoid runtime ReferenceError when build processes
-// expect a helper to clear call status. Currently does nothing.
-export const clearCallStatus = () => {};
+export const clearCallStatus = () => useCallStore.getState().clearStatus();

--- a/frontend/src/store/call/callStore.js
+++ b/frontend/src/store/call/callStore.js
@@ -18,6 +18,9 @@ const useCallStore = create((set, get) => ({
     socket.on("call-declined", () => {
       set({ declined: true, outgoingCall: null });
     });
+    socket.on("call-cancelled", () => {
+      set({ incomingCall: null });
+    });
     set({ listening: true });
   },
   initiateCall: (info) => set({ outgoingCall: info, declined: false, acceptedCall: null }),
@@ -32,6 +35,12 @@ const useCallStore = create((set, get) => ({
     if (!call) return;
     socket.emit("call-declined", call);
     set({ incomingCall: null, declined: true });
+  },
+  cancelCall: () => {
+    const call = get().outgoingCall;
+    if (!call) return;
+    socket.emit("call-cancelled", call);
+    set({ outgoingCall: null });
   },
   clearStatus: () => set({ acceptedCall: null, declined: false }),
 }));


### PR DESCRIPTION
## Summary
- add cancelable call handling and listener for call cancellations
- improve call overlay to display incoming/outgoing states with cancel option
- wire messaging page to show overlay for outgoing calls and remove duplicate listener

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e707f5cc4832898812e5972ff20ea