### PR TITLE
feat: add book categories manager

### DIFF
--- a/backend/src/migrations/20250728000000_create_book_categories_table.js
+++ b/backend/src/migrations/20250728000000_create_book_categories_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('book_categories', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable();
+    table.string('slug').notNullable().unique();
+    table.string('status').notNullable().defaultTo('active');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('book_categories');
+};

--- a/backend/src/modules/bookCategories/bookCategories.controller.js
+++ b/backend/src/modules/bookCategories/bookCategories.controller.js
@@ -1,0 +1,37 @@
+const service = require("./bookCategories.service");
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
+const slugify = require("slugify");
+
+exports.createCategory = catchAsync(async (req, res) => {
+  const data = {
+    name: req.body.name,
+    slug: slugify(req.body.name, { lower: true }),
+    status: req.body.status || "active",
+  };
+  const category = await service.create(data);
+  sendSuccess(res, category, "Category created");
+});
+
+exports.listCategories = catchAsync(async (_req, res) => {
+  const categories = await service.list();
+  sendSuccess(res, categories);
+});
+
+exports.updateCategory = catchAsync(async (req, res) => {
+  const existing = await service.getById(req.params.id);
+  if (!existing) throw new AppError("Category not found", 404);
+
+  const data = { ...req.body };
+  if (data.name) {
+    data.slug = slugify(data.name, { lower: true });
+  }
+  const category = await service.update(req.params.id, data);
+  sendSuccess(res, category, "Category updated");
+});
+
+exports.deleteCategory = catchAsync(async (req, res) => {
+  await service.remove(req.params.id);
+  sendSuccess(res, null, "Category deleted");
+});

--- a/backend/src/modules/bookCategories/bookCategories.routes.js
+++ b/backend/src/modules/bookCategories/bookCategories.routes.js
@@ -1,0 +1,10 @@
+const router = require("express").Router();
+const controller = require("./bookCategories.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", controller.listCategories);
+router.post("/", verifyToken, isAdmin, controller.createCategory);
+router.put("/:id", verifyToken, isAdmin, controller.updateCategory);
+router.delete("/:id", verifyToken, isAdmin, controller.deleteCategory);
+
+module.exports = router;

--- a/backend/src/modules/bookCategories/bookCategories.service.js
+++ b/backend/src/modules/bookCategories/bookCategories.service.js
@@ -1,0 +1,21 @@
+const db = require("../../config/database");
+
+exports.create = async (data) => {
+  const [row] = await db("book_categories").insert(data).returning("*");
+  return row;
+};
+
+exports.list = () => {
+  return db("book_categories").select("*").orderBy("created_at", "desc");
+};
+
+exports.getById = (id) => {
+  return db("book_categories").where({ id }).first();
+};
+
+exports.update = async (id, data) => {
+  const [row] = await db("book_categories").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.remove = (id) => db("book_categories").where({ id }).del();

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -129,6 +129,7 @@ app.use("/api/blog", require("./modules/blog/blog.routes"));
 app.use("/api/support", require("./modules/support/support.routes"));
 app.use("/api/tickets", require("./modules/tickets/tickets.routes"));
 app.use("/api/media", require("./modules/media/media.routes"));
+app.use("/api/book-categories", require("./modules/bookCategories/bookCategories.routes"));
 app.use("/api/search", require("./modules/search/search.routes"));
 
 app.get("/", (req, res) => res.send("🚀 SkillBridge API is live."));

--- a/backend/tests/bookCategoriesRoutes.test.js
+++ b/backend/tests/bookCategoriesRoutes.test.js
@@ -1,0 +1,62 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/bookCategories/bookCategories.service', () => ({
+  list: jest.fn(),
+  create: jest.fn(),
+  getById: jest.fn(),
+  update: jest.fn(),
+  remove: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/bookCategories/bookCategories.service');
+const routes = require('../src/modules/bookCategories/bookCategories.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/book-categories', routes);
+
+describe('GET /api/book-categories', () => {
+  it('returns categories list', async () => {
+    const list = [{ id: '1', name: 'Test' }];
+    service.list.mockResolvedValue(list);
+    const res = await request(app).get('/api/book-categories');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(list);
+    expect(service.list).toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/book-categories', () => {
+  it('creates a category', async () => {
+    const payload = { name: 'New' };
+    service.create.mockResolvedValue({ id: '1', ...payload });
+    const res = await request(app).post('/api/book-categories').send(payload);
+    expect(res.status).toBe(200);
+    expect(service.create).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/book-categories/:id', () => {
+  it('updates a category', async () => {
+    service.getById.mockResolvedValue({ id: '1', name: 'Old' });
+    service.update.mockResolvedValue({ id: '1', name: 'Updated' });
+    const res = await request(app).put('/api/book-categories/1').send({ name: 'Updated' });
+    expect(res.status).toBe(200);
+    expect(service.update).toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/book-categories/:id', () => {
+  it('deletes a category', async () => {
+    service.remove.mockResolvedValue(1);
+    const res = await request(app).delete('/api/book-categories/1');
+    expect(res.status).toBe(200);
+    expect(service.remove).toHaveBeenCalledWith('1');
+  });
+});

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { fetchBookCategories } from "@/services/bookCategoryService";
+
+export default function BookForm({ onSubmit }) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm();
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchBookCategories();
+        setCategories(data);
+      } catch (e) {
+        console.error("Failed to load categories", e);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium mb-1">Title</label>
+        <input
+          type="text"
+          {...register("title", { required: "Title is required" })}
+          className="w-full border rounded p-2"
+        />
+        {errors.title && (
+          <p className="text-red-500 text-sm mt-1">{errors.title.message}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Category</label>
+        <select
+          {...register("category_id", { required: "Category is required" })}
+          className="w-full border rounded p-2"
+        >
+          <option value="">Select category</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        {errors.category_id && (
+          <p className="text-red-500 text-sm mt-1">
+            {errors.category_id.message}
+          </p>
+        )}
+      </div>
+
+      <button
+        type="submit"
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+      >
+        Save
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -1,0 +1,26 @@
+import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+import api from "@/services/api/api";
+import BookForm from "@/components/books/BookForm";
+
+export default function CreateBook() {
+  const router = useRouter();
+
+  const handleSubmit = async (values) => {
+    try {
+      await api.post("/books", values);
+      toast.success("Book created");
+      router.push("/dashboard/instructor/books");
+    } catch (e) {
+      console.error("Failed to create book", e);
+      toast.error("Failed to create book");
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold mb-4">Add New Book</h1>
+      <BookForm onSubmit={handleSubmit} />
+    </div>
+  );
+}

--- a/frontend/src/services/bookCategoryService.js
+++ b/frontend/src/services/bookCategoryService.js
@@ -1,0 +1,8 @@
+import api from "@/services/api/api";
+
+export const fetchBookCategories = async () => {
+  const { data } = await api.get("/book-categories");
+  return data?.data ?? [];
+};
+
+export default { fetchBookCategories };

--- a/frontend/src/tests/__tests__/bookCategoryService.test.js
+++ b/frontend/src/tests/__tests__/bookCategoryService.test.js
@@ -1,0 +1,16 @@
+import api from "../../services/api/api";
+import { fetchBookCategories } from "../../services/bookCategoryService";
+
+jest.mock("../../services/api/api", () => ({ get: jest.fn() }));
+
+describe("bookCategoryService", () => {
+  it("fetches book categories", async () => {
+    const mock = [{ id: 1, name: "Fiction" }];
+    api.get.mockResolvedValue({ data: { data: mock } });
+
+    const categories = await fetchBookCategories();
+
+    expect(api.get).toHaveBeenCalledWith("/book-categories");
+    expect(categories).toEqual(mock);
+  });
+});


### PR DESCRIPTION
## Summary
- add service to fetch book categories
- create BookForm component with category select
- implement instructor book creation page using BookForm
- add tests for book category service

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e768a3ad08328b09f7c8ef061cbd2