### PR TITLE
Fix books table foreign key types

### DIFF
--- a/backend/src/migrations/20250729000000_create_books_table.js
+++ b/backend/src/migrations/20250729000000_create_books_table.js
@@ -9,14 +9,12 @@ exports.up = function (knex) {
     table.string('pdf_url');
     table.string('cover_image_url');
     table
-      .integer('category_id')
-      .unsigned()
+      .uuid('category_id')
       .references('id')
       .inTable('book_categories')
       .onDelete('SET NULL');
     table
-      .integer('instructor_id')
-      .unsigned()
+      .uuid('instructor_id')
       .references('id')
       .inTable('users')
       .onDelete('CASCADE');


### PR DESCRIPTION
## Summary
- use UUIDs for book `category_id` and `instructor_id` foreign keys

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e8681bae88328bc253df1abe6b170