### PR TITLE
Fix student_id FK type in book_purchases migration

### DIFF
--- a/backend/src/migrations/20250729010000_create_book_purchases_table.js
+++ b/backend/src/migrations/20250729010000_create_book_purchases_table.js
@@ -4,14 +4,15 @@ exports.up = function (knex) {
   return knex.schema.createTable(TABLE_NAME, (table) => {
     table.increments('id').primary();
     table
-      .integer('student_id')
-      .unsigned()
+      .uuid('student_id')
+      .notNullable()
       .references('id')
       .inTable('users')
       .onDelete('CASCADE');
     table
       .integer('book_id')
       .unsigned()
+      .notNullable()
       .references('id')
       .inTable('books')
       .onDelete('CASCADE');


### PR DESCRIPTION
## Summary
- use `uuid` for `student_id` in book_purchases migration to match users table
- ensure both foreign keys are non-null to maintain referential integrity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e8ac4e30c8328a1f05743aa16cb5c