### PR TITLE
feat: add student payment history

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -31,6 +31,11 @@ exports.getPayments = catchAsync(async (_req, res) => {
   sendSuccess(res, data);
 });
 
+exports.getMyPayments = catchAsync(async (req, res) => {
+  const data = await service.getByUser(req.user.id);
+  sendSuccess(res, data);
+});
+
 exports.getPayment = catchAsync(async (req, res) => {
   const payment = await service.getById(req.params.id);
   if (!payment) throw new AppError("Payment not found", 404);

--- a/backend/src/modules/payments/payments.service.js
+++ b/backend/src/modules/payments/payments.service.js
@@ -18,6 +18,21 @@ exports.getAll = async () => {
     .orderBy('p.created_at', 'desc');
 };
 
+exports.getByUser = async (userId) => {
+  return db({ p: 'payments' })
+    .leftJoin('payment_methods_config as m', 'p.method_id', 'm.id')
+    .leftJoin('online_classes as c', function () {
+      this.on('p.item_id', '=', 'c.id').andOn('p.item_type', '=', db.raw('?', ['class']));
+    })
+    .select(
+      'p.*',
+      'm.name as method_name',
+      'c.title as class_title'
+    )
+    .where('p.user_id', userId)
+    .orderBy('p.created_at', 'desc');
+};
+
 exports.getById = async (id) => {
   return db("payments").where({ id }).first();
 };

--- a/backend/src/modules/payments/student.routes.js
+++ b/backend/src/modules/payments/student.routes.js
@@ -1,0 +1,9 @@
+const router = require("express").Router();
+const controller = require("./payments.controller");
+const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isStudent);
+
+router.get("/", controller.getMyPayments);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -94,6 +94,7 @@ app.use("/api/community", require("./modules/community/public/public.routes"));
 app.use("/api/roles", require("./modules/roles/roles.routes"));
 app.use("/api/plans", require("./modules/plans/plans.routes"));
 app.use("/api/payment-methods", require("./modules/paymentMethods/paymentMethods.public.routes"));
+app.use("/api/payments/student", require("./modules/payments/student.routes"));
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
 app.use("/api/payment-methods/admin", require("./modules/paymentMethods/paymentMethods.routes"));
 app.use("/api/payments/config", require("./modules/paymentConfig/paymentConfig.routes"));

--- a/backend/tests/studentPaymentRoutes.test.js
+++ b/backend/tests/studentPaymentRoutes.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/payments/payments.service', () => ({
+  getByUser: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'user1' }; next(); },
+  isStudent: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/payments/payments.service');
+const routes = require('../src/modules/payments/student.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payments/student', routes);
+
+describe('GET /api/payments/student', () => {
+  it('returns student payments', async () => {
+    const mock = [{ id: 'p1' }];
+    service.getByUser.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/payments/student');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getByUser).toHaveBeenCalledWith('user1');
+  });
+});

--- a/frontend/src/pages/dashboard/student/payments/index.js
+++ b/frontend/src/pages/dashboard/student/payments/index.js
@@ -2,23 +2,28 @@ import StudentLayout from "@/components/layouts/StudentLayout";
 import { useState, useEffect } from "react";
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
-import { FaCreditCard, FaClock, FaCheckCircle, FaDownload, FaFileInvoice } from "react-icons/fa";
-
-const mockPayments = [
-  { id: 1, title: "React Bootcamp", amount: 49, method: "Stripe", date: "2025-04-01", status: "Paid" },
-  { id: 2, title: "Python Basics", amount: 39, method: "PayPal", date: "2025-04-15", status: "Paid" },
-  { id: 3, title: "Node.js Fundamentals", amount: 59, method: "Bank Transfer", date: "2025-05-05", status: "Pending" },
-];
+import { FaCreditCard, FaClock, FaCheckCircle, FaFileInvoice } from "react-icons/fa";
+import { fetchMyPayments } from "@/services/student/paymentService";
 
 export default function StudentPaymentsPage() {
   const [payments, setPayments] = useState([]);
 
   useEffect(() => {
-    setPayments(mockPayments);
+    const load = async () => {
+      try {
+        const data = await fetchMyPayments();
+        setPayments(data);
+      } catch (err) {
+        console.error("Failed to load payments", err);
+      }
+    };
+    load();
   }, []);
 
-  const totalPaid = payments.filter(p => p.status === "Paid").reduce((sum, p) => sum + p.amount, 0);
-  const pending = payments.filter(p => p.status === "Pending").length;
+  const totalPaid = payments
+    .filter(p => p.status === "paid")
+    .reduce((sum, p) => sum + Number(p.amount), 0);
+  const pending = payments.filter(p => p.status === "pending").length;
 
   const downloadInvoicePDF = async (id) => {
     const element = document.getElementById(`invoice-${id}`);
@@ -90,11 +95,13 @@ export default function StudentPaymentsPage() {
             <tbody>
               {payments.map((p) => (
                 <tr key={p.id} className="border-b hover:bg-gray-50">
-                  <td className="p-3 font-medium">{p.title}</td>
+                  <td className="p-3 font-medium">{p.class_title || p.item_id}</td>
                   <td className="p-3">${p.amount}</td>
-                  <td className="p-3">{p.method}</td>
-                  <td className="p-3">{p.date}</td>
-                  <td className={`p-3 font-medium ${p.status === "Paid" ? "text-green-600" : "text-yellow-600"}`}>{p.status}</td>
+                  <td className="p-3">{p.method_name || "-"}</td>
+                  <td className="p-3">{p.paid_at ? new Date(p.paid_at).toLocaleDateString() : "-"}</td>
+                  <td className={`p-3 font-medium ${p.status === "paid" ? "text-green-600" : "text-yellow-600"}`}>
+                    {p.status ? p.status.charAt(0).toUpperCase() + p.status.slice(1) : ""}
+                  </td>
                   <td className="p-3">
                     <button
                       onClick={() => downloadInvoicePDF(p.id)}
@@ -105,10 +112,10 @@ export default function StudentPaymentsPage() {
                     <div id={`invoice-${p.id}`} className="hidden">
                       <div className="p-4 w-[600px] bg-white text-black">
                         <h2 className="text-xl font-bold mb-2">Invoice #{p.id}</h2>
-                        <p><strong>Course:</strong> {p.title}</p>
+                        <p><strong>Course:</strong> {p.class_title || p.item_id}</p>
                         <p><strong>Amount:</strong> ${p.amount}</p>
                         <p><strong>Status:</strong> {p.status}</p>
-                        <p><strong>Date:</strong> {p.date}</p>
+                        <p><strong>Date:</strong> {p.paid_at ? new Date(p.paid_at).toLocaleDateString() : "-"}</p>
                         <p><strong>Student:</strong> Sara Ali</p>
                         <p><strong>Email:</strong> sara@example.com</p>
                       </div>

--- a/frontend/src/services/student/paymentService.js
+++ b/frontend/src/services/student/paymentService.js
@@ -1,0 +1,6 @@
+import api from "@/services/api/api";
+
+export const fetchMyPayments = async () => {
+  const { data } = await api.get("/payments/student");
+  return data?.data ?? [];
+};


### PR DESCRIPTION
## Summary
- expose student payment API and wire into dashboard
- fetch student payments with new service
- show live payment data and invoices

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e8d3f18688328bb5b55cea6dc06be