### PR TITLE
feat: add books links to instructor sidebar

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/instructorLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/instructorLinks.js
@@ -19,7 +19,8 @@ import {
   Star,
   LifeBuoy,
   UsersRound,
-  Home
+  Home,
+  Book
 } from 'lucide-react';
 
 export const instructorNavLinks = [
@@ -42,6 +43,13 @@ export const instructorNavLinks = [
     items: [
       { label: 'My Tutorials', href: '/dashboard/instructor/tutorials', icon: Brain },
       { label: 'Create Tutorial', href: '/dashboard/instructor/tutorials/create', icon: PlusCircle },
+    ]
+  },
+  {
+    title: 'Books',
+    items: [
+      { label: 'Create Book', href: '/dashboard/instructor/books/create', icon: PlusCircle },
+      { label: 'My Books', href: '/dashboard/instructor/books', icon: Book },
     ]
   },
   {


### PR DESCRIPTION
## Summary
- add Books section with links to create and manage books in instructor dashboard sidebar

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: Component definition is missing display name in tests)*

------
https://chatgpt.com/codex/tasks/task_e_688e8d3178fc83289378657159e7a1e0