### PR TITLE
feat: add real-time video call signaling

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -142,7 +142,50 @@ const io = new Server(server, {
 });
 const rooms = {}, participants = {}, callMessages = {};
 
+const userSockets = {};
+
 io.on("connection", (socket) => {
+  socket.on("register", ({ userId }) => {
+    if (!userId) return;
+    userSockets[userId] = socket.id;
+    socket.userId = userId;
+  });
+
+  socket.on("call-user", ({ to, roomId }) => {
+    const from = socket.userId;
+    const target = userSockets[to];
+    if (from && target) {
+      io.to(target).emit("incoming-call", { chatId: from, roomId });
+    }
+  });
+
+  socket.on("call-accepted", ({ chatId, roomId }) => {
+    const target = userSockets[chatId];
+    if (socket.userId && target) {
+      io.to(target).emit("call-accepted", { chatId: socket.userId, roomId });
+    }
+  });
+
+  socket.on("call-declined", ({ chatId }) => {
+    const target = userSockets[chatId];
+    if (socket.userId && target) {
+      io.to(target).emit("call-declined", { chatId: socket.userId });
+    }
+  });
+
+  socket.on("call-cancelled", ({ chatId }) => {
+    const target = userSockets[chatId];
+    if (socket.userId && target) {
+      io.to(target).emit("call-cancelled", { chatId: socket.userId });
+    }
+  });
+
+  socket.on("disconnect", () => {
+    if (socket.userId && userSockets[socket.userId] === socket.id) {
+      delete userSockets[socket.userId];
+    }
+  });
+
   socket.on("join-room", ({ roomId, name, role }) => {
     rooms[roomId] = rooms[roomId] || [];
     participants[roomId] = participants[roomId] || [];

--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -33,9 +33,11 @@ const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
 
   const handleVideoCall = async () => {
     if (onStartVideoCall) {
-      await onStartVideoCall(selectedChat.id);
+      const res = await onStartVideoCall(selectedChat.id);
+      if (res?.roomId) {
+        router.push(`/video-call?roomId=${res.roomId}`);
+      }
     }
-    router.push(`/video-call?chatId=${selectedChat.id}`);
   };
 
   const handleWhatsAppChat = () => {

--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -72,10 +72,12 @@ const ChatWindow = ({ selectedChat, refreshUsers }) => {
 
   const handleStartVideoCall = async (chatId) => {
     try {
-      await startVideoCall(chatId);
+      const { roomId } = await startVideoCall(chatId);
       toast.info("Video call invitation sent");
+      return { roomId };
     } catch (_) {
       toast.error("Failed to start video call");
+      return null;
     }
   };
 

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -148,8 +148,8 @@ const MessagesPage = () => {
   }, [users, selectedChat]);
 
   useEffect(() => {
-    if (callAccepted?.chatId) {
-      router.push(`/video-call?chatId=${callAccepted.chatId}`);
+    if (callAccepted?.roomId) {
+      router.push(`/video-call?roomId=${callAccepted.roomId}`);
       clearCallStatus();
     } else if (callDeclined) {
       toast.info("Call declined");
@@ -349,7 +349,11 @@ const MessagesPage = () => {
       {(incomingCall || outgoingCall) && (
         <CallOverlay
           incoming={!!incomingCall}
-          name={incomingCall?.name || selectedChat?.name}
+          name={
+            incomingCall
+              ? users.find((u) => u.id === incomingCall.chatId)?.name
+              : selectedChat?.name
+          }
           onAccept={incomingCall ? () => acceptCall() : undefined}
           onDecline={incomingCall ? () => declineCall() : cancelCall}
         />

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -1,6 +1,8 @@
 
 import api from "@/services/api/api";
 import useCallStore from "@/store/call/callStore";
+import useAuthStore from "@/store/auth/authStore";
+import socket from "@/services/socketService";
 
 
 export const getUsers = async () => {
@@ -41,9 +43,13 @@ export const sendWhatsAppMessage = async (userId, { message }) => {
 
 export const startVideoCall = async (userId) => {
   const res = await api.post(`/messages/${userId}/video-call`);
-  // Track outgoing call so the caller can react to accept/decline events
-  useCallStore.getState().initiateCall({ chatId: userId });
-  return res.data.data || res.data;
+  const { roomId } = res.data.data || res.data;
+  useCallStore.getState().initiateCall({ chatId: userId, roomId });
+  const caller = useAuthStore.getState().user;
+  if (caller?.id) {
+    socket.emit("call-user", { to: userId, roomId });
+  }
+  return { roomId };
 };
 
 export const getConversation = async (userId) => {

--- a/frontend/src/store/call/callStore.js
+++ b/frontend/src/store/call/callStore.js
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import socket from "@/services/socketService";
+import useAuthStore from "@/store/auth/authStore";
 
 const useCallStore = create((set, get) => ({
   incomingCall: null,
@@ -9,6 +10,10 @@ const useCallStore = create((set, get) => ({
   listening: false,
   listen: () => {
     if (get().listening) return;
+    const user = useAuthStore.getState().user;
+    if (user?.id) {
+      socket.emit("register", { userId: user.id });
+    }
     socket.on("incoming-call", (data) => {
       set({ incomingCall: data });
     });


### PR DESCRIPTION
## Summary
- send call signalling events via socket.io to deliver incoming call invites
- start calls from chats and join rooms by `roomId`
- register user sockets and handle accept/decline/cancel flows

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ef3e6bcdc83288b441d1bf137865c