### PR TITLE
feat: enhance instructor book management

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -1,21 +1,81 @@
 const service = require("./book.service");
+const tagService = require("./bookTag.service");
 const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
+const slugify = require("slugify");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
+const mailService = require("../../services/mailService");
 
 exports.createBook = catchAsync(async (req, res) => {
+  const { tags: rawTags, ...body } = req.body || {};
   const data = {
-    title: req.body.title,
-    description: req.body.description,
-    price: req.body.price,
-    pdf_url: req.body.pdf_url,
-    cover_image_url: req.body.cover_image_url,
-    category_id: req.body.category_id,
+    title: body.title,
+    short_description: body.short_description,
+    detailed_description: body.detailed_description,
+    price: body.price,
+    language: body.language,
+    license_type: body.license_type,
+    category_id: body.category_id,
     instructor_id: req.user.id,
-    status: req.body.status || "pending",
+    status: "pending",
   };
+  if (req.files?.cover_image?.[0]) data.cover_image_url = req.files.cover_image[0].path;
+  if (req.files?.book_file?.[0]) data.pdf_url = req.files.book_file[0].path;
+
   const book = await service.createBook(data);
-  sendSuccess(res, book, "Book created");
+
+  let tags = [];
+  if (rawTags) {
+    try {
+      tags = typeof rawTags === "string" ? JSON.parse(rawTags) : rawTags;
+      if (!Array.isArray(tags)) tags = [];
+    } catch {
+      tags = [];
+    }
+  }
+  if (tags.length) {
+    const tagIds = [];
+    for (const name of tags) {
+      const existing = await tagService.findByName(name);
+      const tag =
+        existing ||
+        (await tagService.createTag({
+          name,
+          slug: slugify(name, { lower: true, strict: true }),
+        }));
+      tagIds.push(tag.id);
+    }
+    await service.addBookTags(book.id, tagIds);
+    book.tags = await service.getBookTags(book.id);
+  } else {
+    book.tags = [];
+  }
+
+  const message =
+    "Your book was submitted successfully and is under review.";
+  await Promise.all([
+    notificationService.createNotification({
+      user_id: req.user.id,
+      type: "book_submitted",
+      message,
+    }),
+    messageService.createMessage({
+      sender_id: req.user.id,
+      receiver_id: req.user.id,
+      message,
+    }),
+    req.user.email
+      ? mailService.sendMail({
+          to: req.user.email,
+          subject: "Book submitted for review",
+          html: `<p>${message} We will notify you when it is published.</p>`,
+        })
+      : Promise.resolve(),
+  ]);
+
+  sendSuccess(res, book, "Book submitted for review");
 });
 
 exports.listBooks = catchAsync(async (_req, res) => {

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -1,7 +1,10 @@
 const router = require("express").Router();
 const controller = require("./book.controller");
+const tagController = require("./bookTag.controller");
 const { verifyToken, isInstructor } = require("../../middleware/auth/authMiddleware");
 
+router.get("/tags", verifyToken, isInstructor, tagController.listTags);
+router.post("/tags", verifyToken, isInstructor, tagController.createTag);
 router.get("/", controller.listBooks);
 router.get("/:id", controller.getBook);
 router.post("/", verifyToken, isInstructor, controller.createBook);

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -11,3 +11,15 @@ exports.listBooks = () =>
     .orderBy("created_at", "desc");
 
 exports.getBookById = (id) => db("books").where({ id }).first();
+
+exports.addBookTags = async (bookId, tagIds) => {
+  if (!tagIds.length) return;
+  const rows = tagIds.map((tag_id) => ({ book_id: bookId, tag_id }));
+  await db("book_tag_map").insert(rows);
+};
+
+exports.getBookTags = (bookId) =>
+  db("book_tag_map as m")
+    .join("tags as t", "m.tag_id", "t.id")
+    .where("m.book_id", bookId)
+    .select("t.id", "t.name", "t.slug");

--- a/backend/src/modules/books/bookTag.controller.js
+++ b/backend/src/modules/books/bookTag.controller.js
@@ -1,0 +1,23 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./bookTag.service");
+const slugify = require("slugify");
+
+exports.listTags = catchAsync(async (req, res) => {
+  const { search = "" } = req.query;
+  const tags = search ? await service.searchTags(search) : await service.getAllTags();
+  sendSuccess(res, tags);
+});
+
+exports.createTag = catchAsync(async (req, res) => {
+  const { name } = req.body;
+  if (!name) return sendSuccess(res, null, "Name required");
+  let tag = await service.findByName(name);
+  if (!tag) {
+    tag = await service.createTag({
+      name,
+      slug: slugify(name, { lower: true, strict: true }),
+    });
+  }
+  sendSuccess(res, tag, "Tag created");
+});

--- a/backend/src/modules/books/bookTag.service.js
+++ b/backend/src/modules/books/bookTag.service.js
@@ -1,0 +1,19 @@
+const db = require("../../config/database");
+
+exports.getAllTags = () => db("tags").select("*").orderBy("created_at", "desc");
+
+exports.findByName = (name) =>
+  db("tags").whereRaw("LOWER(name) = ?", [name.toLowerCase()]).first();
+
+exports.createTag = async (data) => {
+  const [row] = await db("tags").insert(data).returning("*");
+  return row;
+};
+
+exports.searchTags = (search, limit = 10) =>
+  db("tags")
+    .modify((q) => {
+      if (search) q.whereILike("name", `%${search}%`);
+    })
+    .orderBy("name")
+    .limit(limit);

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -1,14 +1,24 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { fetchBookCategories } from "@/services/bookCategoryService";
+import { fetchBookTags, createBookTag } from "@/services/bookTagService";
+import { getLanguages } from "@/services/languageService";
 
 export default function BookForm({ onSubmit }) {
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm();
+    setValue,
+  } = useForm({ defaultValues: { tags: [], status: "pending" } });
   const [categories, setCategories] = useState([]);
+  const [languages, setLanguages] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [tagInput, setTagInput] = useState("");
+  const [tagSuggestions, setTagSuggestions] = useState([]);
+  const [coverPreview, setCoverPreview] = useState(null);
+  const [bookFileName, setBookFileName] = useState("");
+  const [previewFiles, setPreviewFiles] = useState([]);
 
   useEffect(() => {
     const load = async () => {
@@ -18,18 +28,88 @@ export default function BookForm({ onSubmit }) {
       } catch (e) {
         console.error("Failed to load categories", e);
       }
+      try {
+        const langs = await getLanguages();
+        setLanguages(langs);
+      } catch (e) {
+        console.error("Failed to load languages", e);
+      }
     };
     load();
   }, []);
 
+  useEffect(() => {
+    register("tags", {
+      validate: (value) =>
+        value && value.length > 0 ? true : "At least one tag is required",
+    });
+  }, [register]);
+
+  useEffect(() => {
+    setValue("tags", tags);
+  }, [tags, setValue]);
+
+  useEffect(() => {
+    let ignore = false;
+    if (tagInput) {
+      fetchBookTags(tagInput).then((data) => {
+        if (!ignore) setTagSuggestions(data);
+      });
+    } else {
+      setTagSuggestions([]);
+    }
+    return () => {
+      ignore = true;
+    };
+  }, [tagInput]);
+
+  const addTag = (name) => {
+    const value = name.trim();
+    if (!value) return;
+    if (!tags.includes(value)) {
+      setTags([...tags, value]);
+      if (!tagSuggestions.find((t) => t.name === value)) {
+        createBookTag({ name: value }).then((newTag) =>
+          setTagSuggestions((prev) => [...prev, newTag])
+        );
+      }
+    }
+    setTagInput("");
+  };
+
+  const removeTag = (name) => {
+    setTags(tags.filter((t) => t !== name));
+  };
+
+  const handleFormSubmit = (data) => {
+    const formData = new FormData();
+    formData.append("title", data.title);
+    formData.append("category_id", data.category_id);
+    formData.append("tags", JSON.stringify(tags));
+    formData.append("short_description", data.short_description);
+    formData.append("detailed_description", data.detailed_description);
+    if (data.cover_image?.[0]) formData.append("cover_image", data.cover_image[0]);
+    if (data.book_file?.[0]) formData.append("book_file", data.book_file[0]);
+    if (data.preview_pages?.length) {
+      Array.from(data.preview_pages).forEach((file) =>
+        formData.append("preview_pages", file)
+      );
+    }
+    formData.append("price", data.price);
+    formData.append("language", data.language);
+    formData.append("license_type", data.license_type);
+    formData.append("status", "pending");
+    onSubmit(formData);
+  };
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+    <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-4">
       <div>
-        <label className="block text-sm font-medium mb-1">Title</label>
+        <label className="block text-sm font-medium mb-1">Book Title</label>
         <input
           type="text"
-          {...register("title", { required: "Title is required" })}
-          className="w-full border rounded p-2"
+          {...register("title", { required: "Book title is required" })}
+          className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
         />
         {errors.title && (
           <p className="text-red-500 text-sm mt-1">{errors.title.message}</p>
@@ -40,7 +120,7 @@ export default function BookForm({ onSubmit }) {
         <label className="block text-sm font-medium mb-1">Category</label>
         <select
           {...register("category_id", { required: "Category is required" })}
-          className="w-full border rounded p-2"
+          className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
         >
           <option value="">Select category</option>
           {categories.map((c) => (
@@ -56,9 +136,265 @@ export default function BookForm({ onSubmit }) {
         )}
       </div>
 
+      <div>
+        <label className="block text-sm font-medium mb-1">Tags</label>
+        <div className="relative">
+          <div className="flex flex-wrap gap-2 mb-2">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => removeTag(tag)}
+                  className="ml-1.5 inline-flex text-yellow-500 hover:text-yellow-700"
+                >
+                  &times;
+                </button>
+              </span>
+            ))}
+          </div>
+          <div className="flex gap-2 mt-1">
+            <input
+              type="text"
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addTag(tagInput);
+                }
+              }}
+              placeholder="Add tags..."
+              className="flex-1 p-2 border rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
+            />
+            <button
+              type="button"
+              onClick={() => addTag(tagInput)}
+              className="px-3 py-2 bg-yellow-500 text-white rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
+            >
+              Add
+            </button>
+          </div>
+          {tagSuggestions.length > 0 && tagInput && (
+            <div className="absolute z-10 mt-1 w-full rounded-md bg-white shadow-lg">
+              {tagSuggestions.map((t) => (
+                <div
+                  key={t.id}
+                  className="px-4 py-2 text-sm text-gray-700 hover:bg-yellow-50 cursor-pointer"
+                  onClick={() => addTag(t.name)}
+                >
+                  {t.name}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        {errors.tags && (
+          <p className="text-red-500 text-sm mt-1">{errors.tags.message}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Short Description</label>
+        <textarea
+          {...register("short_description", {
+            required: "Short description is required",
+          })}
+          className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+        />
+        {errors.short_description && (
+          <p className="text-red-500 text-sm mt-1">
+            {errors.short_description.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">
+          Detailed Description
+        </label>
+        <textarea
+          {...register("detailed_description", {
+            required: "Detailed description is required",
+          })}
+          className="w-full border rounded p-2 h-32 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+        />
+        {errors.detailed_description && (
+          <p className="text-red-500 text-sm mt-1">
+            {errors.detailed_description.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Cover Image</label>
+        {(() => {
+          const reg = register("cover_image", {
+            required: "Cover image is required",
+            validate: {
+              fileType: (files) =>
+                !files[0] ||
+                ["image/png", "image/jpeg"].includes(files[0].type) ||
+                "Only PNG or JPG",
+              fileSize: (files) =>
+                !files[0] || files[0].size <= 2 * 1024 * 1024 || "Max 2MB",
+            },
+          });
+          return (
+            <input
+              type="file"
+              accept=".png,.jpg,.jpeg"
+              {...reg}
+              onChange={(e) => {
+                reg.onChange(e);
+                const file = e.target.files?.[0];
+                setCoverPreview(file ? URL.createObjectURL(file) : null);
+              }}
+              className="w-full focus:outline-none focus:ring-2 focus:ring-yellow-400"
+            />
+          );
+        })()}
+        {coverPreview && (
+          <img
+            src={coverPreview}
+            alt="Cover preview"
+            className="mt-2 h-32 object-cover"
+          />
+        )}
+        {errors.cover_image && (
+          <p className="text-red-500 text-sm mt-1">
+            {errors.cover_image.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Book File (PDF)</label>
+        {(() => {
+          const reg = register("book_file", {
+            required: "Book file is required",
+            validate: {
+              fileType: (files) =>
+                !files[0] || files[0].type === "application/pdf" || "PDF only",
+              fileSize: (files) =>
+                !files[0] || files[0].size <= 50 * 1024 * 1024 || "Max 50MB",
+            },
+          });
+          return (
+            <input
+              type="file"
+              accept=".pdf"
+              {...reg}
+              onChange={(e) => {
+                reg.onChange(e);
+                const file = e.target.files?.[0];
+                setBookFileName(file ? file.name : "");
+              }}
+              className="w-full focus:outline-none focus:ring-2 focus:ring-yellow-400"
+            />
+          );
+        })()}
+        {bookFileName && (
+          <p className="text-sm mt-1">{bookFileName}</p>
+        )}
+        {errors.book_file && (
+          <p className="text-red-500 text-sm mt-1">
+            {errors.book_file.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">
+          Preview Pages (optional)
+        </label>
+        {(() => {
+          const reg = register("preview_pages");
+          return (
+            <input
+              type="file"
+              accept=".pdf,image/*"
+              multiple
+              {...reg}
+              onChange={(e) => {
+                reg.onChange(e);
+                const files = Array.from(e.target.files || []);
+                setPreviewFiles(files);
+              }}
+              className="w-full focus:outline-none focus:ring-2 focus:ring-yellow-400"
+            />
+          );
+        })()}
+        {previewFiles.length > 0 && (
+          <ul className="mt-2 list-disc pl-5">
+            {previewFiles.map((file, idx) => (
+              <li key={idx}>{file.name}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Price</label>
+        <input
+          type="number"
+          step="0.01"
+          {...register("price", { required: "Price is required" })}
+          className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+        />
+        {errors.price && (
+          <p className="text-red-500 text-sm mt-1">{errors.price.message}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Language</label>
+        <select
+          {...register("language", { required: "Language is required" })}
+          className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+        >
+          <option value="">Select language</option>
+          {languages.map((l) => (
+            <option key={l.code || l.id} value={l.code || l.id}>
+              {l.name}
+            </option>
+          ))}
+        </select>
+        {errors.language && (
+          <p className="text-red-500 text-sm mt-1">
+            {errors.language.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">License Type</label>
+        <select
+          {...register("license_type", {
+            required: "License type is required",
+          })}
+          className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+        >
+          <option value="">Select license type</option>
+          <option value="personal">Personal use</option>
+          <option value="educational">Educational use</option>
+          <option value="commercial">
+            Commercial resale not allowed
+          </option>
+        </select>
+        {errors.license_type && (
+          <p className="text-red-500 text-sm mt-1">
+            {errors.license_type.message}
+          </p>
+        )}
+      </div>
+
       <button
         type="submit"
-        className="px-4 py-2 bg-blue-600 text-white rounded"
+        className="px-4 py-2 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
       >
         Save
       </button>

--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -2,14 +2,18 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import api from "@/services/api/api";
 import BookForm from "@/components/books/BookForm";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 
-export default function CreateBook() {
+function CreateBookPage() {
   const router = useRouter();
 
-  const handleSubmit = async (values) => {
+  const handleSubmit = async (formData) => {
     try {
-      await api.post("/books", values);
-      toast.success("Book created");
+      await api.post("/books", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      toast.success("Book submitted for review");
       router.push("/dashboard/instructor/books");
     } catch (e) {
       console.error("Failed to create book", e);
@@ -18,9 +22,13 @@ export default function CreateBook() {
   };
 
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">Add New Book</h1>
-      <BookForm onSubmit={handleSubmit} />
-    </div>
+    <InstructorLayout>
+      <div className="p-4">
+        <h1 className="text-xl font-semibold mb-4">Add New Book</h1>
+        <BookForm onSubmit={handleSubmit} />
+      </div>
+    </InstructorLayout>
   );
 }
+
+export default withAuthProtection(CreateBookPage, ["instructor"]);

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -3,9 +3,13 @@ import Link from "next/link";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import BookCard from "@/components/books/BookCard";
 import { fetchInstructorBooks } from "@/services/instructor/bookService";
+import { fetchBookCategories } from "@/services/bookCategoryService";
+import withAuthProtection from "@/hooks/withAuthProtection";
 
-export default function InstructorBooksPage() {
+function InstructorBooksPage() {
   const [books, setBooks] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [filters, setFilters] = useState({ search: "", category: "", status: "" });
 
   useEffect(() => {
     const load = async () => {
@@ -15,9 +19,26 @@ export default function InstructorBooksPage() {
       } catch (err) {
         console.error("Failed to load books", err);
       }
+      try {
+        const cats = await fetchBookCategories();
+        setCategories(cats);
+      } catch (err) {
+        console.error("Failed to load categories", err);
+      }
     };
     load();
   }, []);
+
+  const filteredBooks = books.filter((b) => {
+    const matchesSearch = filters.search
+      ? b.title.toLowerCase().includes(filters.search.toLowerCase())
+      : true;
+    const matchesCategory = filters.category
+      ? b.category_id === Number(filters.category)
+      : true;
+    const matchesStatus = filters.status ? b.status === filters.status : true;
+    return matchesSearch && matchesCategory && matchesStatus;
+  });
 
   return (
     <InstructorLayout>
@@ -26,16 +47,49 @@ export default function InstructorBooksPage() {
           <h1 className="text-3xl font-bold">My Books</h1>
           <Link
             href="/dashboard/instructor/books/create"
-            className="px-4 py-2 bg-blue-600 text-white rounded"
+            className="px-4 py-2 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
           >
             Add Book
           </Link>
         </div>
-        {books.length === 0 ? (
+
+        <div className="flex flex-wrap gap-4 mb-6">
+          <input
+            type="text"
+            placeholder="Search by title"
+            value={filters.search}
+            onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+            className="border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          />
+          <select
+            value={filters.category}
+            onChange={(e) => setFilters({ ...filters, category: e.target.value })}
+            className="border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          >
+            <option value="">All Categories</option>
+            {categories.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <select
+            value={filters.status}
+            onChange={(e) => setFilters({ ...filters, status: e.target.value })}
+            className="border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          >
+            <option value="">All Statuses</option>
+            <option value="pending">Pending</option>
+            <option value="draft">Draft</option>
+            <option value="published">Published</option>
+          </select>
+        </div>
+
+        {filteredBooks.length === 0 ? (
           <p className="text-gray-500">No books found.</p>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {books.map((book) => (
+            {filteredBooks.map((book) => (
               <BookCard key={book.id} book={book} />
             ))}
           </div>
@@ -44,3 +98,5 @@ export default function InstructorBooksPage() {
     </InstructorLayout>
   );
 }
+
+export default withAuthProtection(InstructorBooksPage, ["instructor"]);

--- a/frontend/src/services/bookTagService.js
+++ b/frontend/src/services/bookTagService.js
@@ -1,0 +1,13 @@
+import api from "@/services/api/api";
+
+export const fetchBookTags = async (search) => {
+  const { data } = await api.get("/books/tags", { params: search ? { search } : {} });
+  return data?.data ?? [];
+};
+
+export const createBookTag = async (payload) => {
+  const { data } = await api.post("/books/tags", payload);
+  return data?.data;
+};
+
+export default { fetchBookTags, createBookTag };


### PR DESCRIPTION
## Summary
- require tags and languages loaded from backend with yellow focus styling
- submit books for admin review while persisting tags and notifying instructor
- add pending status filter to instructor book list

## Testing
- `cd backend && npm test` (fails: Jest worker encountered exceptions)
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f152d4c0c8328a6b2a86b68d23a25