### PR TITLE
feat: add global page loader

### DIFF
--- a/frontend/src/components/PageLoader.js
+++ b/frontend/src/components/PageLoader.js
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import Router from 'next/router';
+
+const PageLoader = () => {
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const handleStart = () => setLoading(true);
+    const handleEnd = () => setLoading(false);
+
+    Router.events.on('routeChangeStart', handleStart);
+    Router.events.on('routeChangeComplete', handleEnd);
+    Router.events.on('routeChangeError', handleEnd);
+
+    return () => {
+      Router.events.off('routeChangeStart', handleStart);
+      Router.events.off('routeChangeComplete', handleEnd);
+      Router.events.off('routeChangeError', handleEnd);
+    };
+  }, []);
+
+  if (!loading) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-yellow-500 bg-opacity-80">
+      <div className="h-16 w-16 animate-spin rounded-full border-4 border-white border-t-transparent"></div>
+    </div>
+  );
+};
+
+export default PageLoader;

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -25,6 +25,7 @@ import { getFullProfile } from "@/services/profile/profileService";
 import Head from "next/head";
 import { getLanguages } from "@/services/languageService";
 import SeoTags from "@/components/common/SeoTags";
+import PageLoader from "@/components/PageLoader";
 
 const langFetcher = () => getLanguages();
 
@@ -207,6 +208,7 @@ function MyApp({ Component, pageProps, router, seoSettings }) {
           )}
         </Head>
         <SeoTags />
+        <PageLoader />
         {/* Render page with layout */}
         {getLayout(<Component {...pageProps} />)}
 


### PR DESCRIPTION
## Summary
- show yellow page loader while navigating between routes

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f2360f8848328af12bd9970e05039