### PR TITLE
feat: improve book creation page

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -973,5 +973,11 @@
     "user_flagged": "User flagged for review.",
     "flag_failed": "Failed to flag user.",
     "loading": "Loading offer..."
+  },
+  "booksCreate": {
+    "title": "إضافة كتاب جديد",
+    "success": "تم إرسال الكتاب للمراجعة",
+    "error": "فشل في إنشاء الكتاب",
+    "save": "حفظ"
   }
 }

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -975,6 +975,12 @@
     "user_flagged": "User flagged for review.",
     "flag_failed": "Failed to flag user.",
     "loading": "Loading offer..."
+  },
+  "booksCreate": {
+    "title": "Add New Book",
+    "success": "Book submitted for review",
+    "error": "Failed to create book",
+    "save": "Save"
   }
 
 }

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -962,5 +962,11 @@
     "user_flagged": "User flagged for review.",
     "flag_failed": "Failed to flag user.",
     "loading": "Loading offer..."
+  },
+  "booksCreate": {
+    "title": "Ajouter un nouveau livre",
+    "success": "Livre soumis pour examen",
+    "error": "Échec de la création du livre",
+    "save": "Enregistrer"
   }
 }

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -1,17 +1,17 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { fetchBookCategories } from "@/services/bookCategoryService";
+import { useTranslation } from "next-i18next";
 import { fetchBookTags, createBookTag } from "@/services/bookTagService";
 import { getLanguages } from "@/services/languageService";
 
-export default function BookForm({ onSubmit }) {
+export default function BookForm({ onSubmit, categories = [] }) {
+  const { t } = useTranslation("dashboard");
   const {
     register,
     handleSubmit,
     formState: { errors },
     setValue,
   } = useForm({ defaultValues: { tags: [], status: "pending" } });
-  const [categories, setCategories] = useState([]);
   const [languages, setLanguages] = useState([]);
   const [tags, setTags] = useState([]);
   const [tagInput, setTagInput] = useState("");
@@ -22,12 +22,6 @@ export default function BookForm({ onSubmit }) {
 
   useEffect(() => {
     const load = async () => {
-      try {
-        const data = await fetchBookCategories();
-        setCategories(data);
-      } catch (e) {
-        console.error("Failed to load categories", e);
-      }
       try {
         const langs = await getLanguages();
         setLanguages(langs);
@@ -396,7 +390,7 @@ export default function BookForm({ onSubmit }) {
         type="submit"
         className="px-4 py-2 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
       >
-        Save
+        {t("booksCreate.save")}
       </button>
     </form>
   );

--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -1,34 +1,55 @@
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
 import api from "@/services/api/api";
 import BookForm from "@/components/books/BookForm";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
+import { fetchBookCategories } from "@/services/bookCategoryService";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 
 function CreateBookPage() {
   const router = useRouter();
+  const { t } = useTranslation("dashboard");
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    fetchBookCategories()
+      .then(setCategories)
+      .catch((e) => console.error("Failed to load categories", e));
+  }, []);
 
   const handleSubmit = async (formData) => {
     try {
       await api.post("/books", formData, {
         headers: { "Content-Type": "multipart/form-data" },
       });
-      toast.success("Book submitted for review");
+      toast.success(t("booksCreate.success"));
       router.push("/dashboard/instructor/books");
     } catch (e) {
       console.error("Failed to create book", e);
-      toast.error("Failed to create book");
+      toast.error(t("booksCreate.error"));
     }
   };
 
   return (
     <InstructorLayout>
-      <div className="p-4">
-        <h1 className="text-xl font-semibold mb-4">Add New Book</h1>
-        <BookForm onSubmit={handleSubmit} />
-      </div>
+      <section className="py-10 px-4 max-w-3xl mx-auto">
+        <h1 className="text-2xl font-semibold mb-4">{t("booksCreate.title")}</h1>
+        <BookForm onSubmit={handleSubmit} categories={categories} />
+      </section>
     </InstructorLayout>
   );
 }
 
 export default withAuthProtection(CreateBookPage, ["instructor"]);
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common", "dashboard"], nextI18NextConfig)),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- make instructor book creation page responsive
- load categories from API and pass to form
- add i18n translations for book creation messages

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_688f2488dfc48328965a3e49fd2a902c