### PR TITLE
feat: refresh notifications after book creation

### DIFF
--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -9,11 +9,15 @@ import withAuthProtection from "@/hooks/withAuthProtection";
 import { fetchBookCategories } from "@/services/bookCategoryService";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
 
 function CreateBookPage() {
   const router = useRouter();
   const { t } = useTranslation("dashboard");
   const [categories, setCategories] = useState([]);
+  const fetchNotifications = useNotificationStore((state) => state.fetch);
+  const fetchMessages = useMessageStore((state) => state.fetch);
 
   useEffect(() => {
     fetchBookCategories()
@@ -27,6 +31,8 @@ function CreateBookPage() {
         headers: { "Content-Type": "multipart/form-data" },
       });
       toast.success(t("booksCreate.success"));
+      fetchNotifications();
+      fetchMessages();
       router.push("/dashboard/instructor/books");
     } catch (e) {
       console.error("Failed to create book", e);


### PR DESCRIPTION
## Summary
- load book categories for instructor book creation form
- refresh global notifications and messages after creating a book

## Testing
- `npm test`
- `npm run lint` *(fails: 58 errors, 234 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688f41dcc52c8328b5c40e5699e5b563