### PR TITLE
Fix video call invite event for chat overlay

### DIFF
--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -114,12 +114,27 @@ exports.startVideoCall = async ({ sender_id, receiver_id }) => {
 
   try {
     if (global.io && global.userSockets?.[receiver_id]) {
+      const caller = await db("users")
+        .select("full_name")
+        .where({ id: sender_id })
+        .first();
+
+      // Emit legacy event for compatibility
       global.io
         .to(global.userSockets[receiver_id])
         .emit("video-call-invite", { callId: call.id, roomId });
+
+      // Emit incoming-call event used by the frontend call overlay
+      global.io
+        .to(global.userSockets[receiver_id])
+        .emit("incoming-call", {
+          chatId: sender_id,
+          roomId,
+          name: caller?.full_name || "",
+        });
     }
   } catch (err) {
-    console.error("Failed to emit video-call-invite", err);
+    console.error("Failed to emit video call events", err);
   }
 
   return { callId: call.id, roomId };

--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -3,9 +3,6 @@ import { FaVideo, FaWhatsapp, FaEnvelope, FaCircle } from "react-icons/fa";
 import { API_BASE_URL } from "@/config/config";
 import formatRelativeTime from "@/utils/relativeTime";
 import ChatImage from "../shared/ChatImage";
-import { startVideoCall } from "@/services/messageService";
-import useCallStore from "@/store/call/callStore";
-import { toast } from "react-toastify";
 
 const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
   const router = useRouter();

--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -72,12 +72,12 @@ const ChatWindow = ({ selectedChat, refreshUsers }) => {
 
   const handleStartVideoCall = async (chatId) => {
     try {
-      await startVideoCall(chatId);
+      const res = await startVideoCall(chatId);
       toast.info("Calling...");
-      return true;
+      return res;
     } catch (_) {
       toast.error("Failed to start video call");
-      return false;
+      return null;
     }
   };
 


### PR DESCRIPTION
## Summary
- emit `incoming-call` event with caller info when starting video call
- return room information from chat window video call handler
- cleanup unused video call imports

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f427d6bcc8328afa019b47026451d