### PR TITLE
feat(chat): add video call accept/decline controls

### DIFF
--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/router";
 import ChatImage from "../shared/ChatImage";
 import formatRelativeTime from "@/utils/relativeTime";
 import ChatHeader from "./ChatHeader";
@@ -14,8 +15,10 @@ import {
   togglePinMessage as apiTogglePinMessage,
   startVideoCall,
 } from "@/services/messageService";
+import socket from "@/services/socketService";
 
 const ChatWindow = ({ selectedChat, refreshUsers }) => {
+  const router = useRouter();
   const currentUser = useAuthStore((state) => state.user);
   const [messages, setMessages] = useState([]);
   const [typing, setTyping] = useState(false);
@@ -79,6 +82,18 @@ const ChatWindow = ({ selectedChat, refreshUsers }) => {
       toast.error("Failed to start video call");
       return null;
     }
+  };
+
+  const handleAcceptCall = (msg) => {
+    socket.emit("call-accepted", {
+      chatId: msg.sender_id,
+      roomId: msg.message,
+    });
+    router.push(`/video-call?roomId=${msg.message}`);
+  };
+
+  const handleDeclineCall = (msg) => {
+    socket.emit("call-declined", { chatId: msg.sender_id });
   };
 
   const sendMessage = async (newMessage) => {
@@ -159,16 +174,16 @@ const ChatWindow = ({ selectedChat, refreshUsers }) => {
         </div>
       )}
 
-     <div
-  ref={chatRef}
-  className="flex-1 overflow-y-auto px-3 py-2 space-y-3 bg-gray-700 rounded-md"
->
-  {messages.length === 0 && (
-    <p className="text-center text-gray-300 mt-4">
-      No messages yet. Type below to start the conversation.
-    </p>
-  )}
-  {messages.map((msg, index) => {
+      <div
+        ref={chatRef}
+        className="flex-1 overflow-y-auto px-3 py-2 space-y-3 bg-gray-700 rounded-md"
+      >
+        {messages.length === 0 && (
+          <p className="text-center text-gray-300 mt-4">
+            No messages yet. Type below to start the conversation.
+          </p>
+        )}
+        {messages.map((msg, index) => {
     const isYou = msg.sender_id === currentUser?.id;
     return (
       <div
@@ -198,65 +213,99 @@ const ChatWindow = ({ selectedChat, refreshUsers }) => {
           </div>
 
 
-          {msg.reply_message && (
-            <div className="text-xs mb-1 border-l-2 border-yellow-400 pl-2 text-gray-200">
-              <span className="italic">{msg.reply_message}</span>
+          {msg.type === "video-call" ? (
+            <div className="mt-1 flex flex-col items-center">
+              <p className="text-[13px] leading-snug break-words">
+                {isYou ? "Video call started" : "Incoming video call"}
+              </p>
+              <div className="flex gap-2 mt-1">
+                {isYou ? (
+                  <button
+                    onClick={() => router.push(`/video-call?roomId=${msg.message}`)}
+                    className="px-2 py-1 bg-green-600 rounded hover:bg-green-700 text-xs"
+                  >
+                    Join
+                  </button>
+                ) : (
+                  <>
+                    <button
+                      onClick={() => handleAcceptCall(msg)}
+                      className="px-2 py-1 bg-green-600 rounded hover:bg-green-700 text-xs"
+                    >
+                      Accept
+                    </button>
+                    <button
+                      onClick={() => handleDeclineCall(msg)}
+                      className="px-2 py-1 bg-red-600 rounded hover:bg-red-700 text-xs"
+                    >
+                      Decline
+                    </button>
+                  </>
+                )}
+              </div>
             </div>
-          )}
-          {msg.reply_file_url && isImage(msg.reply_file_url) && (
-            <div className="mb-1 border-l-2 border-yellow-400 pl-2">
-              <ChatImage
-                src={getMediaUrl(msg.reply_file_url)}
-                alt="reply"
-                className="max-w-xs rounded-md"
-                width={200}
-                height={200}
-              />
-            </div>
-          )}
-          {msg.reply_file_url && !isImage(msg.reply_file_url) && (
-            <div className="text-xs mb-1 border-l-2 border-yellow-400 pl-2">
-              <a
-                href={getMediaUrl(msg.reply_file_url)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline"
-              >
-                {msg.reply_file_url.split('/').pop()}
-              </a>
-            </div>
-          )}
-          {msg.reply_audio_url && (
-            <div className="mb-1 border-l-2 border-yellow-400 pl-2">
-              <audio controls src={getMediaUrl(msg.reply_audio_url)} className="w-48" />
-            </div>
-          )}
+          ) : (
+            <>
+              {msg.reply_message && (
+                <div className="text-xs mb-1 border-l-2 border-yellow-400 pl-2 text-gray-200">
+                  <span className="italic">{msg.reply_message}</span>
+                </div>
+              )}
+              {msg.reply_file_url && isImage(msg.reply_file_url) && (
+                <div className="mb-1 border-l-2 border-yellow-400 pl-2">
+                  <ChatImage
+                    src={getMediaUrl(msg.reply_file_url)}
+                    alt="reply"
+                    className="max-w-xs rounded-md"
+                    width={200}
+                    height={200}
+                  />
+                </div>
+              )}
+              {msg.reply_file_url && !isImage(msg.reply_file_url) && (
+                <div className="text-xs mb-1 border-l-2 border-yellow-400 pl-2">
+                  <a
+                    href={getMediaUrl(msg.reply_file_url)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    {msg.reply_file_url.split('/').pop()}
+                  </a>
+                </div>
+              )}
+              {msg.reply_audio_url && (
+                <div className="mb-1 border-l-2 border-yellow-400 pl-2">
+                  <audio controls src={getMediaUrl(msg.reply_audio_url)} className="w-48" />
+                </div>
+              )}
 
-          {msg.file_url && isImage(msg.file_url) && (
-
-            <ChatImage
-              src={getMediaUrl(msg.file_url)}
-              alt="Sent image"
-              className="max-w-xs rounded-md mt-1"
-              width={200}
-              height={200}
-            />
-          )}
-          {msg.file_url && !isImage(msg.file_url) && (
-            <a
-              href={getMediaUrl(msg.file_url)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline text-blue-200 text-sm break-all"
-            >
-              {msg.file_url.split('/').pop()}
-            </a>
-          )}
-          {msg.audio_url && (
-            <audio controls src={getMediaUrl(msg.audio_url)} className="mt-1 w-48" />
-          )}
-          {msg.message && (
-            <p className="text-[13px] leading-snug break-words mt-1">{msg.message}</p>
+              {msg.file_url && isImage(msg.file_url) && (
+                <ChatImage
+                  src={getMediaUrl(msg.file_url)}
+                  alt="Sent image"
+                  className="max-w-xs rounded-md mt-1"
+                  width={200}
+                  height={200}
+                />
+              )}
+              {msg.file_url && !isImage(msg.file_url) && (
+                <a
+                  href={getMediaUrl(msg.file_url)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline text-blue-200 text-sm break-all"
+                >
+                  {msg.file_url.split('/').pop()}
+                </a>
+              )}
+              {msg.audio_url && (
+                <audio controls src={getMediaUrl(msg.audio_url)} className="mt-1 w-48" />
+              )}
+              {msg.message && (
+                <p className="text-[13px] leading-snug break-words mt-1">{msg.message}</p>
+              )}
+            </>
           )}
 
           {/* Meta info + actions */}


### PR DESCRIPTION
## Summary
- allow chat recipients to accept or decline incoming video calls
- add socket listeners and handlers for call responses
- show buttons to join, accept, or decline video calls in chat messages

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_688f4a831e948328b849de5c3427acaf