### PR TITLE
Fix third-party integration toggles

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
@@ -70,10 +70,13 @@ export default function ThirdPartyIntegrationsPage() {
     }
   };
 
-  const toggleIntegration = (key) => {
+  // Toggle the enabled/disabled state of an integration. This is async so we
+  // can await the save operation and ensure local state reflects the latest
+  // server response before the user interacts again.
+  const toggleIntegration = async (key) => {
     const current = settings[key] || {};
     const isActive = current.active !== false;
-    saveSection(key, { ...current, active: !isActive });
+    await saveSection(key, { ...current, active: !isActive });
   };
 
   const integrations = [

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -27,6 +27,12 @@ if (
 const api = axios.create({
   baseURL,
   withCredentials: true, // ✅ KEEP this to send cookies with requests
+  // Ensure CSRF protection headers are sent automatically. The backend
+  // expects a `csrfToken` cookie and `x-csrf-token` header on state changing
+  // requests (POST/PUT/PATCH/DELETE). Axios can handle this if we specify the
+  // cookie and header names here.
+  xsrfCookieName: "csrfToken",
+  xsrfHeaderName: "x-csrf-token",
 });
 
 export default api;


### PR DESCRIPTION
## Summary
- ensure axios sends CSRF token headers automatically
- await third-party integration toggles so UI updates after saving

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f68874e0c8328bcc71e3d35380517