### PR TITLE
fix: ensure cropped images are submitted

### DIFF
--- a/frontend/src/utils/cropImage.js
+++ b/frontend/src/utils/cropImage.js
@@ -21,10 +21,5 @@ export default async function getCroppedImg(imageSrc, pixelCrop) {
       pixelCrop.height
     );
   
-    return new Promise((resolve) => {
-      canvas.toBlob((blob) => {
-        resolve(URL.createObjectURL(blob));
-      }, "image/jpeg");
-    });
+    return canvas.toDataURL("image/jpeg");
   }
-  


### PR DESCRIPTION
## Summary
- return cropped images as data URLs so image uploads work

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_688f8ae037808328a5493228cfd4d139