### PR TITLE
fix: mark notifications and messages as read

### DIFF
--- a/frontend/src/store/messages/messageStore.js
+++ b/frontend/src/store/messages/messageStore.js
@@ -41,9 +41,10 @@ const useMessageStore = create((set, get) => ({
   markRead: async (id) => {
     const res = await markMessageAsRead(id);
     const readAt = res.read_at || new Date().toISOString();
+    const strId = String(id);
     set((state) => ({
       items: state.items.map((m) =>
-        m.id === id ? { ...m, read: true, read_at: readAt } : m,
+        m.id === strId ? { ...m, read: true, read_at: readAt } : m,
       ),
     }));
 
@@ -52,7 +53,7 @@ const useMessageStore = create((set, get) => ({
         items: state.items.filter(
           (m) =>
             !(
-              m.id === id &&
+              m.id === strId &&
               m.read &&
               m.read_at &&
               new Date() - new Date(m.read_at) >= HOUR_MS

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -36,10 +36,28 @@ const useNotificationStore = create((set, get) => ({
   },
 
   markRead: async (id) => {
-    await markNotificationAsRead(id);
+    const res = await markNotificationAsRead(id);
+    const readAt = res.read_at || new Date().toISOString();
+    const strId = String(id);
     set((state) => ({
-      items: state.items.filter((n) => n.id !== id),
+      items: state.items.map((n) =>
+        n.id === strId ? { ...n, read: true, read_at: readAt } : n,
+      ),
     }));
+
+    setTimeout(() => {
+      set((state) => ({
+        items: state.items.filter(
+          (n) =>
+            !(
+              n.id === strId &&
+              n.read &&
+              n.read_at &&
+              new Date() - new Date(n.read_at) >= HOUR_MS
+            ),
+        ),
+      }));
+    }, HOUR_MS);
   },
 
   remove: async (id) => {


### PR DESCRIPTION
## Summary
- ensure marking notifications sets `read` state and removes expired entries
- normalize message IDs when marking as read

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f900390d483289a9c7b3df8429062