### PR TITLE
fix: ensure cropped images are submitted

### DIFF
--- a/frontend/src/components/profile/steps/PersonalDetails.js
+++ b/frontend/src/components/profile/steps/PersonalDetails.js
@@ -37,9 +37,10 @@ const PersonalDetails = ({ formData, setFormData, nextStep }) => {
   // ✅ Apply Cropping
   const handleCropSave = async () => {
     try {
-      const croppedImage = await getCroppedImg(preview, croppedAreaPixels);
-      setPreview(croppedImage);
-      setFormData({ ...formData, profilePicture: croppedImage });
+      const blob = await getCroppedImg(preview, croppedAreaPixels);
+      const url = URL.createObjectURL(blob);
+      setPreview(url);
+      setFormData({ ...formData, profilePicture: blob });
       setShowCropper(false);
     } catch (error) {
       console.error("Crop Error:", error);
@@ -49,7 +50,7 @@ const PersonalDetails = ({ formData, setFormData, nextStep }) => {
   // ✅ Remove Profile Picture
   const removeImage = () => {
     setPreview("");
-    setFormData({ ...formData, profilePicture: "" });
+    setFormData({ ...formData, profilePicture: null });
   };
 
   return (

--- a/frontend/src/components/shared/ImageCropUpload.js
+++ b/frontend/src/components/shared/ImageCropUpload.js
@@ -1,15 +1,19 @@
 // components/shared/ImageCropUpload.jsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
 import { Slider } from "@/components/ui/slider";
 
-export default function ImageCropUpload({ value, onChange }) {
+export default function ImageCropUpload({ value = null, onChange }) {
   const [imageSrc, setImageSrc] = useState(null);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
   const [preview, setPreview] = useState(value);
+
+  useEffect(() => {
+    setPreview(value);
+  }, [value]);
 
   const onFileChange = async (e) => {
     const file = e.target.files?.[0];
@@ -20,7 +24,7 @@ export default function ImageCropUpload({ value, onChange }) {
         const dataUrl = reader.result;
         setImageSrc(dataUrl);
         setPreview(dataUrl);
-        onChange(dataUrl); // prefill with original image in case cropping is skipped
+        onChange(file); // prefill with original image in case cropping is skipped
       };
     }
   };
@@ -30,9 +34,10 @@ export default function ImageCropUpload({ value, onChange }) {
   };
 
   const handleCrop = async () => {
-    const croppedImage = await getCroppedImg(imageSrc, croppedAreaPixels);
-    setPreview(croppedImage);
-    onChange(croppedImage);
+    const blob = await getCroppedImg(imageSrc, croppedAreaPixels);
+    const url = URL.createObjectURL(blob);
+    setPreview(url);
+    onChange(blob);
     setImageSrc(null);
   };
 

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -46,7 +46,7 @@ export default function CreateAdPage() {
   const [formData, setFormData] = useState({
     title: "",
     description: "",
-    image: "",
+    image: null,
     startAt: "",
     endAt: "",
     targetRoles: [],
@@ -116,8 +116,10 @@ export default function CreateAdPage() {
       payload.append("link_url", formData.link);
 
       if (mediaType === 'image') {
-        const blob = await fetch(formData.image).then((r) => r.blob());
-        const file = new File([blob], "ad.jpg", { type: blob.type });
+        const file =
+          formData.image instanceof File
+            ? formData.image
+            : new File([formData.image], "ad.jpg", { type: formData.image.type || "image/jpeg" });
         payload.append("image", file);
       } else if (mediaType === 'video') {
         payload.append('video', videoFile);
@@ -199,8 +201,7 @@ export default function CreateAdPage() {
                 <div>
                   <label className="block text-sm font-medium mb-1">{t('image_label')} *</label>
                   <ImageCropUpload
-                    value={formData.image}
-                    onChange={(url) => setFormData((prev) => ({ ...prev, image: url }))}
+                    onChange={(file) => setFormData((prev) => ({ ...prev, image: file }))}
                   />
                 </div>
               ) : (

--- a/frontend/src/pages/dashboard/admin/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/edit/[id].js
@@ -86,9 +86,11 @@ export default function EditAdPage() {
     try {
       const payload = new FormData();
       if (mediaType === 'image') {
-        if (formData.image && formData.image.startsWith("data:")) {
-          const blob = await fetch(formData.image).then((r) => r.blob());
-          const file = new File([blob], "ad.jpg", { type: blob.type });
+        if (formData.image instanceof Blob) {
+          const file =
+            formData.image instanceof File
+              ? formData.image
+              : new File([formData.image], "ad.jpg", { type: formData.image.type || "image/jpeg" });
           payload.append("image", file);
         }
       } else if (mediaType === 'video') {
@@ -140,8 +142,8 @@ export default function EditAdPage() {
               </div>
               {mediaType === 'image' ? (
                 <ImageCropUpload
-                  value={formData.image}
-                  onChange={(url) => setFormData((prev) => ({ ...prev, image: url }))}
+                  value={typeof formData.image === 'string' ? formData.image : undefined}
+                  onChange={(file) => setFormData((prev) => ({ ...prev, image: file }))}
                 />
               ) : (
                 <div>

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -185,8 +185,7 @@ useEffect(() => {
     if (!tempAvatar || !croppedAreaPixels) return;
     setIsSubmitting(true);
     try {
-      const croppedUrl = await getCroppedImg(tempAvatar, croppedAreaPixels);
-      const blob = await fetch(croppedUrl).then((r) => r.blob());
+      const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
       const file = new File([blob], tempFileName || "avatar.jpg", {
         type: blob.type,
       });

--- a/frontend/src/pages/dashboard/instructor/ads/create.js
+++ b/frontend/src/pages/dashboard/instructor/ads/create.js
@@ -15,7 +15,7 @@ export default function CreateAdPage() {
   const [formData, setFormData] = useState({
     title: "",
     description: "",
-    image: "",
+    image: null,
     startAt: "",
     endAt: "",
     targetRoles: [],
@@ -55,9 +55,11 @@ export default function CreateAdPage() {
     }
 
     try {
-      const blob = await fetch(formData.image).then((r) => r.blob());
-      const file = new File([blob], "ad.jpg", { type: blob.type });
       const payload = new FormData();
+      const file =
+        formData.image instanceof File
+          ? formData.image
+          : new File([formData.image], "ad.jpg", { type: formData.image.type || "image/jpeg" });
       payload.append("title", formData.title);
       payload.append("description", formData.description);
       payload.append("link_url", formData.link);
@@ -112,8 +114,7 @@ export default function CreateAdPage() {
               <div>
                 <label className="block font-medium">Banner Image *</label>
                 <ImageCropUpload
-                  value={formData.image}
-                  onChange={(url) => setFormData((prev) => ({ ...prev, image: url }))}
+                  onChange={(file) => setFormData((prev) => ({ ...prev, image: file }))}
                 />
               </div>
             </div>

--- a/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
@@ -69,9 +69,11 @@ export default function EditAdPage() {
 
     try {
       const payload = new FormData();
-      if (formData.image && formData.image.startsWith("data:")) {
-        const blob = await fetch(formData.image).then((r) => r.blob());
-        const file = new File([blob], "ad.jpg", { type: blob.type });
+      if (formData.image instanceof Blob) {
+        const file =
+          formData.image instanceof File
+            ? formData.image
+            : new File([formData.image], "ad.jpg", { type: formData.image.type || "image/jpeg" });
         payload.append("image", file);
       }
       payload.append("title", formData.title);
@@ -108,8 +110,8 @@ export default function EditAdPage() {
               <textarea name="description" value={formData.description} onChange={handleChange}
                 className="w-full border border-gray-300 rounded px-3 py-2" rows={3} placeholder="Description" />
               <ImageCropUpload
-                value={formData.image}
-                onChange={(url) => setFormData((prev) => ({ ...prev, image: url }))}
+                value={typeof formData.image === 'string' ? formData.image : undefined}
+                onChange={(file) => setFormData((prev) => ({ ...prev, image: file }))}
               />
             </div>
           </section>

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -306,8 +306,7 @@ export default function InstructorProfileEdit() {
     if (!tempAvatar || !croppedAreaPixels) return;
     setIsSubmitting(true);
     try {
-      const croppedUrl = await getCroppedImg(tempAvatar, croppedAreaPixels);
-      const blob = await fetch(croppedUrl).then((r) => r.blob());
+      const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
       const file = new File([blob], tempFileName || "avatar.jpg", { type: blob.type });
       const res = await uploadInstructorAvatar(user.id, file);
       const { setUser } = useAuthStore.getState();

--- a/frontend/src/pages/dashboard/instructor/profile/steps/PersonalDetails.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/PersonalDetails.js
@@ -41,9 +41,10 @@ const PersonalDetails = ({
   // ✅ Apply Cropping
   const handleCropSave = async () => {
     try {
-      const croppedImage = await getCroppedImg(preview, croppedAreaPixels);
-      setPreview(croppedImage);
-      setFormData({ ...formData, profilePicture: croppedImage });
+      const blob = await getCroppedImg(preview, croppedAreaPixels);
+      const url = URL.createObjectURL(blob);
+      setPreview(url);
+      setFormData({ ...formData, profilePicture: blob });
       setShowCropper(false);
     } catch (error) {
       console.error("Crop Error:", error);
@@ -53,7 +54,7 @@ const PersonalDetails = ({
   // ✅ Remove Profile Picture
   const removeImage = () => {
     setPreview("");
-    setFormData({ ...formData, profilePicture: "" });
+    setFormData({ ...formData, profilePicture: null });
   };
 
   return (

--- a/frontend/src/pages/dashboard/student/profile/steps/PersonalDetails.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/PersonalDetails.js
@@ -37,9 +37,10 @@ const PersonalDetails = ({
 
   const handleCropSave = async () => {
     try {
-      const croppedImage = await getCroppedImg(preview, croppedAreaPixels);
-      setPreview(croppedImage);
-      setFormData({ ...formData, profilePicture: croppedImage });
+      const blob = await getCroppedImg(preview, croppedAreaPixels);
+      const url = URL.createObjectURL(blob);
+      setPreview(url);
+      setFormData({ ...formData, profilePicture: blob });
       setShowCropper(false);
     } catch (error) {
       console.error("Crop Error:", error);
@@ -48,7 +49,7 @@ const PersonalDetails = ({
 
   const removeImage = () => {
     setPreview("");
-    setFormData({ ...formData, profilePicture: "" });
+    setFormData({ ...formData, profilePicture: null });
   };
 
   const validateAndNext = () => {

--- a/frontend/src/utils/cropImage.js
+++ b/frontend/src/utils/cropImage.js
@@ -23,8 +23,7 @@ export default async function getCroppedImg(imageSrc, pixelCrop) {
   
     return new Promise((resolve) => {
       canvas.toBlob((blob) => {
-        resolve(URL.createObjectURL(blob));
+        resolve(blob);
       }, "image/jpeg");
     });
   }
-  


### PR DESCRIPTION
## Summary
- return cropped images as blobs so forms can upload final images
- update image cropper and ad forms to handle blob-based uploads
- sync ImageCropUpload preview with provided value so edit pages show the existing image

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_688f8ae037808328a5493228cfd4d139