### PR TITLE
Fix message and notification actions

### DIFF
--- a/frontend/src/pages/notifications/index.js
+++ b/frontend/src/pages/notifications/index.js
@@ -10,6 +10,7 @@ const NotificationsPage = () => {
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const startPolling = useNotificationStore((state) => state.startPolling);
   const markRead = useNotificationStore((state) => state.markRead);
+  const remove = useNotificationStore((state) => state.remove);
 
   useEffect(() => {
     fetchNotifications();
@@ -81,16 +82,27 @@ const NotificationsPage = () => {
                       </div>
                     </div>
 
-                    {!notif.read && (
+                    <div className="flex items-center gap-2">
+                      {!notif.read && (
+                        <motion.button
+                          whileHover={{ scale: 1.1 }}
+                          whileTap={{ scale: 0.9 }}
+                          onClick={() => markRead(notif.id)}
+                          className="px-3 py-1 bg-yellow-500 text-black rounded-lg hover:bg-yellow-600 transition font-bold"
+                        >
+                          Mark as Read
+                        </motion.button>
+                      )}
                       <motion.button
                         whileHover={{ scale: 1.1 }}
                         whileTap={{ scale: 0.9 }}
-                        onClick={() => markRead(notif.id)}
-                        className="px-3 py-1 bg-yellow-500 text-black rounded-lg hover:bg-yellow-600 transition font-bold"
+                        onClick={() => remove(notif.id)}
+                        className="p-2 rounded-lg bg-red-600 hover:bg-red-700"
+                        title="Delete"
                       >
-                        Mark as Read
+                        <FaTrash />
                       </motion.button>
-                    )}
+                    </div>
                   </motion.li>
                 ))}
               </AnimatePresence>

--- a/frontend/src/store/messages/messageStore.js
+++ b/frontend/src/store/messages/messageStore.js
@@ -41,10 +41,10 @@ const useMessageStore = create((set, get) => ({
   markRead: async (id) => {
     const res = await markMessageAsRead(id);
     const readAt = res.read_at || new Date().toISOString();
-    const strId = String(id);
+    const numericId = Number(id);
     set((state) => ({
       items: state.items.map((m) =>
-        m.id === strId ? { ...m, read: true, read_at: readAt } : m,
+        Number(m.id) === numericId ? { ...m, read: true, read_at: readAt } : m,
       ),
     }));
 
@@ -53,7 +53,7 @@ const useMessageStore = create((set, get) => ({
         items: state.items.filter(
           (m) =>
             !(
-              m.id === strId &&
+              Number(m.id) === numericId &&
               m.read &&
               m.read_at &&
               new Date() - new Date(m.read_at) >= HOUR_MS
@@ -66,8 +66,9 @@ const useMessageStore = create((set, get) => ({
   delete: async (id) => {
     try {
       await apiDeleteMessage(id);
+      const numericId = Number(id);
       set((state) => ({
-        items: state.items.filter((m) => m.id !== id),
+        items: state.items.filter((m) => Number(m.id) !== numericId),
       }));
     } catch (_) {}
   },


### PR DESCRIPTION
## Summary
- ensure message store consistently handles numeric IDs when marking or deleting messages
- add notification removal button so alerts can be cleared individually

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fab4ed3d48328a13836c49adda25e