### PR TITLE
fix: include csrf token when managing ads

### DIFF
--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -2,9 +2,8 @@ import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
 
 export const createAd = async (payload) => {
-  const { data } = await api.post("/ads/admin", payload, {
-    headers: payload instanceof FormData ? { "Content-Type": "multipart/form-data" } : {},
-  });
+  const config = payload instanceof FormData ? { headers: { "Content-Type": "multipart/form-data" } } : {};
+  const { data } = await api.post("/ads/admin", payload, config);
   return data?.data;
 };
 
@@ -39,9 +38,8 @@ export const fetchAdById = async (id) => {
 };
 
 export const updateAd = async (id, payload) => {
-  const { data } = await api.put(`/ads/${id}`, payload, {
-    headers: payload instanceof FormData ? { "Content-Type": "multipart/form-data" } : {},
-  });
+  const config = payload instanceof FormData ? { headers: { "Content-Type": "multipart/form-data" } } : {};
+  const { data } = await api.put(`/ads/${id}`, payload, config);
   return data?.data;
 };
 

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -27,6 +27,8 @@ if (
 const api = axios.create({
   baseURL,
   withCredentials: true, // ✅ KEEP this to send cookies with requests
+  xsrfCookieName: "csrfToken", // ensure axios reads our CSRF cookie
+  xsrfHeaderName: "x-csrf-token", // and sends it in this header automatically
 });
 
 export default api;


### PR DESCRIPTION
## Summary
- ensure axios automatically attaches CSRF token via `x-csrf-token` header
- simplify ad service so create/update/delete rely on axios for CSRF handling

## Testing
- `npm test` (frontend)
- `npm test` (backend)

------
https://chatgpt.com/codex/tasks/task_e_688faa19bbf08328ae2d9e060da15628