### PR TITLE
Fix message and notification actions

### DIFF
--- a/frontend/src/pages/notifications/index.js
+++ b/frontend/src/pages/notifications/index.js
@@ -10,6 +10,7 @@ const NotificationsPage = () => {
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const startPolling = useNotificationStore((state) => state.startPolling);
   const markRead = useNotificationStore((state) => state.markRead);
+  const remove = useNotificationStore((state) => state.remove);
 
   useEffect(() => {
     fetchNotifications();
@@ -81,16 +82,27 @@ const NotificationsPage = () => {
                       </div>
                     </div>
 
-                    {!notif.read && (
+                    <div className="flex items-center gap-2">
+                      {!notif.read && (
+                        <motion.button
+                          whileHover={{ scale: 1.1 }}
+                          whileTap={{ scale: 0.9 }}
+                          onClick={() => markRead(notif.id)}
+                          className="px-3 py-1 bg-yellow-500 text-black rounded-lg hover:bg-yellow-600 transition font-bold"
+                        >
+                          Mark as Read
+                        </motion.button>
+                      )}
                       <motion.button
                         whileHover={{ scale: 1.1 }}
                         whileTap={{ scale: 0.9 }}
-                        onClick={() => markRead(notif.id)}
-                        className="px-3 py-1 bg-yellow-500 text-black rounded-lg hover:bg-yellow-600 transition font-bold"
+                        onClick={() => remove(notif.id)}
+                        className="p-2 rounded-lg bg-red-600 hover:bg-red-700"
+                        title="Delete"
                       >
-                        Mark as Read
+                        <FaTrash />
                       </motion.button>
-                    )}
+                    </div>
                   </motion.li>
                 ))}
               </AnimatePresence>

--- a/frontend/src/services/api/csrf.js
+++ b/frontend/src/services/api/csrf.js
@@ -1,0 +1,7 @@
+export const getCsrfToken = () => {
+  if (typeof document === 'undefined') return null;
+  const value = `; ${document.cookie}`;
+  const parts = value.split('; csrfToken=');
+  if (parts.length === 2) return parts.pop().split(';').shift();
+  return null;
+};

--- a/frontend/src/services/notificationService.js
+++ b/frontend/src/services/notificationService.js
@@ -1,4 +1,5 @@
 import api from "@/services/api/api";
+import { getCsrfToken } from "@/services/api/csrf";
 
 export const getNotifications = async () => {
   const res = await api.get("/notifications");
@@ -6,12 +7,18 @@ export const getNotifications = async () => {
 };
 
 export const markNotificationAsRead = async (id) => {
-  const res = await api.patch(`/notifications/${id}/read`);
+  const headers = {};
+  const token = getCsrfToken();
+  if (token) headers["x-csrf-token"] = token;
+  const res = await api.patch(`/notifications/${id}/read`, {}, { headers });
   return res.data.data || res.data;
 };
 
 export const deleteNotification = async (id) => {
-  const res = await api.delete(`/notifications/${id}`);
+  const headers = {};
+  const token = getCsrfToken();
+  if (token) headers["x-csrf-token"] = token;
+  const res = await api.delete(`/notifications/${id}`, { headers });
   return res.data.data || res.data;
 };
 

--- a/frontend/src/store/messages/messageStore.js
+++ b/frontend/src/store/messages/messageStore.js
@@ -41,10 +41,10 @@ const useMessageStore = create((set, get) => ({
   markRead: async (id) => {
     const res = await markMessageAsRead(id);
     const readAt = res.read_at || new Date().toISOString();
-    const strId = String(id);
+    const numericId = Number(id);
     set((state) => ({
       items: state.items.map((m) =>
-        m.id === strId ? { ...m, read: true, read_at: readAt } : m,
+        Number(m.id) === numericId ? { ...m, read: true, read_at: readAt } : m,
       ),
     }));
 
@@ -53,7 +53,7 @@ const useMessageStore = create((set, get) => ({
         items: state.items.filter(
           (m) =>
             !(
-              m.id === strId &&
+              Number(m.id) === numericId &&
               m.read &&
               m.read_at &&
               new Date() - new Date(m.read_at) >= HOUR_MS
@@ -66,8 +66,9 @@ const useMessageStore = create((set, get) => ({
   delete: async (id) => {
     try {
       await apiDeleteMessage(id);
+      const numericId = Number(id);
       set((state) => ({
-        items: state.items.filter((m) => m.id !== id),
+        items: state.items.filter((m) => Number(m.id) !== numericId),
       }));
     } catch (_) {}
   },


### PR DESCRIPTION
## Summary
- ensure message store consistently handles numeric IDs when marking or deleting messages
- add notification removal button so alerts can be cleared individually
- include CSRF token when updating or deleting notifications to avoid 403 errors

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fab4ed3d48328a13836c49adda25e