### PR TITLE
fix: expose csrf token cookie across subdomains

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -7,7 +7,7 @@ const recaptchaService = require("../../recaptcha/recaptcha.service");
 const authMiddleware = require("../../../middleware/auth/authMiddleware");
 
 // 🔧 Cookie options used in login and logout
-const { refreshCookieOptions } = require("../../../utils/cookie");
+const { refreshCookieOptions, csrfCookieOptions } = require("../../../utils/cookie");
 
 /**
  * @desc Register a new user
@@ -68,7 +68,7 @@ exports.login = catchAsync(async (req, res) => {
   const { accessToken, refreshToken, user, csrfToken } = await authService.loginUser(req.body);
   res
     .cookie("refreshToken", refreshToken, refreshCookieOptions)
-    .cookie("csrfToken", csrfToken, { httpOnly: false, sameSite: "Strict" })
+    .cookie("csrfToken", csrfToken, csrfCookieOptions)
     .json({ message: "Login successful", accessToken, user });
 });
 
@@ -89,7 +89,7 @@ exports.refreshToken = catchAsync(async (req, res) => {
     const csrfToken = authService.generateCsrfToken();
     res
       .cookie("refreshToken", newRefreshToken, refreshCookieOptions)
-      .cookie("csrfToken", csrfToken, { httpOnly: false, sameSite: "Strict" })
+      .cookie("csrfToken", csrfToken, csrfCookieOptions)
       .json({ message: "Token refreshed", accessToken });
   } catch (err) {
     console.error("❌ Refresh token error:", err.message);
@@ -121,7 +121,7 @@ exports.logout = catchAsync(async (req, res) => {
   }
   res
     .clearCookie("refreshToken", refreshCookieOptions)
-    .clearCookie("csrfToken")
+    .clearCookie("csrfToken", csrfCookieOptions)
     .json({ message: "Logged out successfully" });
 });
 

--- a/backend/src/utils/cookie.js
+++ b/backend/src/utils/cookie.js
@@ -15,8 +15,18 @@ const refreshCookieOptions = {
   maxAge: 7 * 24 * 60 * 60 * 1000,
 };
 
+// CSRF token needs to be readable by the client so `httpOnly` is false, but we
+// still apply the same domain, `secure` and `sameSite` rules as the refresh
+// token to ensure it is available across subdomains in production.
+const csrfCookieOptions = {
+  httpOnly: false,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
+};
+
 if (process.env.COOKIE_DOMAIN) {
   refreshCookieOptions.domain = process.env.COOKIE_DOMAIN;
+  csrfCookieOptions.domain = process.env.COOKIE_DOMAIN;
 }
 
-module.exports = { refreshCookieOptions };
+module.exports = { refreshCookieOptions, csrfCookieOptions };


### PR DESCRIPTION
## Summary
- ensure csrf cookie is accessible across subdomains and cleared consistently
- use shared cookie options for refresh and csrf tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb25f24b88328b25c8cdc988427b8