### PR TITLE
fix: include csrf token in ad admin requests

### DIFF
--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -11,8 +11,11 @@ const getCsrfToken = () => {
 };
 
 export const createAd = async (payload) => {
-  const config = payload instanceof FormData ? { headers: { "Content-Type": "multipart/form-data" } } : {};
-  const { data } = await api.post("/ads/admin", payload, config);
+  const headers = {};
+  const csrfToken = getCsrfToken();
+  if (csrfToken) headers["x-csrf-token"] = csrfToken;
+  if (payload instanceof FormData) headers["Content-Type"] = "multipart/form-data";
+  const { data } = await api.post("/ads/admin", payload, { headers });
   return data?.data;
 };
 
@@ -47,8 +50,11 @@ export const fetchAdById = async (id) => {
 };
 
 export const updateAd = async (id, payload) => {
-  const config = payload instanceof FormData ? { headers: { "Content-Type": "multipart/form-data" } } : {};
-  const { data } = await api.put(`/ads/${id}`, payload, config);
+  const headers = {};
+  const csrfToken = getCsrfToken();
+  if (csrfToken) headers["x-csrf-token"] = csrfToken;
+  if (payload instanceof FormData) headers["Content-Type"] = "multipart/form-data";
+  const { data } = await api.put(`/ads/${id}`, payload, { headers });
   return data?.data;
 };
 


### PR DESCRIPTION
## Summary
- include CSRF token header when creating or updating ads to satisfy backend middleware

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb4c769308328aff88b2dbd3f2d33