### PR TITLE
Handle GA config fetch errors

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -104,7 +104,10 @@ function MyApp({ Component, pageProps, router, seoSettings }) {
 
   useEffect(() => {
     fetch('/api/google-analytics')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error(`Request failed with ${res.status}`);
+        return res.json();
+      })
       .then((cfg) => {
         if (cfg.enabled && cfg.measurementId) {
           if (!document.querySelector(`script[data-ga-measurement-id="${cfg.measurementId}"]`)) {


### PR DESCRIPTION
## Summary
- avoid JSON parse failure when google analytics config endpoint returns an error

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: 292 problems)*
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890452500c883289435de525603f9ec