### PR TITLE
refactor: simplify ad notifications and branding

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -3,9 +3,6 @@ const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
 const service = require("./ads.service");
-const notificationService = require("../notifications/notifications.service");
-const messageService = require("../messages/messages.service");
-const userModel = require("../users/user.model");
 
 /**
  * Controller functions for managing advertisement banners.
@@ -48,33 +45,8 @@ exports.createAd = catchAsync(async (req, res) => {
 
   const ad = await service.createAd(data);
 
-  try {
-    const [admins, instructors, students] = await Promise.all([
-      userModel.findAdmins(),
-      userModel.findInstructors(),
-      userModel.findStudents(),
-    ]);
-    const users = [...admins, ...instructors, ...students];
-
-    await Promise.all(
-      users.map((u) =>
-        Promise.all([
-          notificationService.createNotification({
-            user_id: u.id,
-            type: "ad_created",
-            message: `New ad "${ad.title}" created`,
-          }),
-          messageService.createMessage({
-            sender_id: req.user.id,
-            receiver_id: u.id,
-            message: `New ad "${ad.title}" created`,
-          }),
-        ])
-      )
-    );
-  } catch (err) {
-    console.error("Failed to notify users of new ad", err);
-  }
+  // Notifications and messages to all users were removed to simplify ad creation
+  // and avoid spamming the platform with global alerts.
 
   sendSuccess(res, ad, "Ad created");
 });
@@ -125,33 +97,8 @@ exports.updateAd = catchAsync(async (req, res) => {
   const updated = await service.updateAd(req.params.id, updates);
   if (!updated) throw new AppError("Ad not found", 404);
 
-  try {
-    const [admins, instructors, students] = await Promise.all([
-      userModel.findAdmins(),
-      userModel.findInstructors(),
-      userModel.findStudents(),
-    ]);
-    const users = [...admins, ...instructors, ...students];
+  // Global notifications/messages removed
 
-    await Promise.all(
-      users.map((u) =>
-        Promise.all([
-          notificationService.createNotification({
-            user_id: u.id,
-            type: "ad_updated",
-            message: `Ad "${updated.title}" was updated`,
-          }),
-          messageService.createMessage({
-            sender_id: req.user.id,
-            receiver_id: u.id,
-            message: `Ad "${updated.title}" was updated`,
-          }),
-        ])
-      )
-    );
-  } catch (err) {
-    console.error("Failed to notify users of ad update", err);
-  }
   sendSuccess(res, updated, "Ad updated");
 });
 
@@ -159,37 +106,11 @@ exports.updateAd = catchAsync(async (req, res) => {
  * Delete an ad by id.
  */
 exports.deleteAd = catchAsync(async (req, res) => {
-  const ad = await service.getAdById(req.params.id);
   const count = await service.deleteAd(req.params.id);
   if (!count) throw new AppError("Ad not found", 404);
-  if (ad) {
-    try {
-      const [admins, instructors, students] = await Promise.all([
-        userModel.findAdmins(),
-        userModel.findInstructors(),
-        userModel.findStudents(),
-      ]);
-      const users = [...admins, ...instructors, ...students];
-      await Promise.all(
-        users.map((u) =>
-          Promise.all([
-            notificationService.createNotification({
-              user_id: u.id,
-              type: "ad_deleted",
-              message: `Ad "${ad.title}" was deleted`,
-            }),
-            messageService.createMessage({
-              sender_id: req.user.id,
-              receiver_id: u.id,
-              message: `Ad "${ad.title}" was deleted`,
-            }),
-          ])
-        )
-      );
-    } catch (err) {
-      console.error("Failed to notify users of ad deletion", err);
-    }
-  }
+
+  // Skip sending system-wide notifications when ads are removed
+
   sendSuccess(res, null, "Ad deleted");
 });
 

--- a/frontend/src/components/admin/ads/AdCard.js
+++ b/frontend/src/components/admin/ads/AdCard.js
@@ -31,12 +31,16 @@ export default function AdCard({
           className="w-full h-40 object-cover rounded-t-lg"
           controls
         />
-      ) : (
+      ) : ad.image ? (
         <img
           src={ad.image}
           alt={ad.title}
           className="w-full h-40 object-cover rounded-t-lg"
         />
+      ) : (
+        <div className="w-full h-40 flex items-center justify-center bg-gray-100 text-gray-500 rounded-t-lg">
+          No media
+        </div>
       )}
 
       {/* Ad Content */}

--- a/frontend/src/config/plansConfig.js
+++ b/frontend/src/config/plansConfig.js
@@ -12,7 +12,7 @@ const plansConfig = {
       maxAds: 3,
       maxAdDuration: 7,
       placements: ["dashboard", "homepage"],
-      allowBranding: true,
+      allowBranding: false,
       showAnalytics: true
     },
     prime: {

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -12,7 +12,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 const currentUserPlan = "basic";
-const { maxAdDuration } = plansConfig[currentUserPlan];
+const { maxAdDuration, allowBranding: allowBrandingEnabled } = plansConfig[currentUserPlan];
 
 export default function CreateAdPage() {
   const router = useRouter();
@@ -264,12 +264,19 @@ export default function CreateAdPage() {
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
                 />
               </div>
-              <div className="col-span-2 space-y-3">
-                <label className="flex items-center gap-2 text-sm">
-                  <input type="checkbox" name="allowBranding" checked={formData.allowBranding} onChange={handleChange} />
-                  {t('allow_branding')}
-                </label>
-              </div>
+              {allowBrandingEnabled && (
+                <div className="col-span-2 space-y-3">
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      name="allowBranding"
+                      checked={formData.allowBranding}
+                      onChange={handleChange}
+                    />
+                    {t('allow_branding')}
+                  </label>
+                </div>
+              )}
             </div>
           </section>
 


### PR DESCRIPTION
## Summary
- remove system-wide notifications/messages when ads are created, updated or deleted
- show placeholder when an ad lacks image or video
- restrict custom branding to Prime plan only and hide checkbox otherwise

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890518abb548328b0589cdafc8df8da