### PR TITLE
feat: add optimistic notification read handling

### DIFF
--- a/frontend/src/components/chat/ChatNotifications.js
+++ b/frontend/src/components/chat/ChatNotifications.js
@@ -12,11 +12,15 @@ const ChatNotifications = ({ users = [], groups = [], setSelectedChat, userId = 
   const [showAlerts, setShowAlerts] = useState(false);
 
   const handleMarkRead = async (id) => {
+    const prev = systemNotifs;
+    setSystemNotifs((p) => p.filter((n) => n.id !== id));
     try {
       await markNotificationAsRead(id);
       toast.success(t('mark_as_read'));
-    } catch (_) {}
-    setSystemNotifs((prev) => prev.filter((n) => n.id !== id));
+    } catch (_) {
+      setSystemNotifs(prev);
+      toast.error(t('mark_as_read_error', 'Failed to mark notification as read'));
+    }
   };
 
   useEffect(() => {

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -36,14 +36,31 @@ const useNotificationStore = create((set, get) => ({
   },
 
   markRead: async (id) => {
-    const res = await markNotificationAsRead(id);
-    const readAt = res.read_at || new Date().toISOString();
     const numericId = Number(id);
+    const prevItems = get().items;
+    const tempReadAt = new Date().toISOString();
+
+    // Optimistically update UI
     set((state) => ({
       items: state.items.map((n) =>
-        Number(n.id) === numericId ? { ...n, read: true, read_at: readAt } : n,
+        Number(n.id) === numericId ? { ...n, read: true, read_at: tempReadAt } : n,
       ),
     }));
+
+    try {
+      const res = await markNotificationAsRead(id);
+      const readAt = res.read_at || tempReadAt;
+      set((state) => ({
+        items: state.items.map((n) =>
+          Number(n.id) === numericId ? { ...n, read_at: readAt } : n,
+        ),
+      }));
+    } catch (err) {
+      // Revert on failure
+      set({ items: prevItems });
+      toast.error("Failed to mark notification as read");
+      return;
+    }
 
     setTimeout(() => {
       set((state) => ({


### PR DESCRIPTION
## Summary
- handle notification read updates optimistically in the UI
- revert changes and show an error toast when the API call fails

## Testing
- `npm test` (backend)
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_6890558aa92083288ebfdf2967bbdcc3