### PR TITLE
fix: expose ads listing API

### DIFF
--- a/frontend/src/pages/api/ads/index.js
+++ b/frontend/src/pages/api/ads/index.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+export default async function handler(req, res) {
+  try {
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5002/api";
+    const { data } = await axios.get(`${base}/ads`);
+    return res.status(200).json(data.data || data);
+  } catch (err) {
+    const status = err.response?.status || 500;
+    const message = err.response?.data?.message || "Failed to fetch ads";
+    return res.status(status).json({ error: message });
+  }
+}


### PR DESCRIPTION
## Summary
- expose ads listing through Next.js API route

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68905d5adc688328816315d2cc14e7ae