### PR TITLE
feat: add optimistic notification read handling

### DIFF
--- a/frontend/src/components/chat/ChatNotifications.js
+++ b/frontend/src/components/chat/ChatNotifications.js
@@ -1,22 +1,29 @@
 import { useEffect, useState } from "react";
 import { FaEnvelopeOpenText, FaUsers, FaBell } from "react-icons/fa";
 import { toast } from "react-toastify";
-import { getNotifications, markNotificationAsRead } from "@/services/notificationService";
+import { getNotifications } from "@/services/notificationService";
 import formatRelativeTime from "@/utils/relativeTime";
 import LinkText from "@/components/shared/LinkText";
 import { useTranslation } from "next-i18next";
+import useNotificationStore from "@/store/notifications/notificationStore";
 
 const ChatNotifications = ({ users = [], groups = [], setSelectedChat, userId = 1 }) => {
   const { t } = useTranslation("common");
   const [systemNotifs, setSystemNotifs] = useState([]);
   const [showAlerts, setShowAlerts] = useState(false);
 
+  const markRead = useNotificationStore((s) => s.markRead);
+
   const handleMarkRead = async (id) => {
-    try {
-      await markNotificationAsRead(id);
+    const prev = systemNotifs;
+    setSystemNotifs((p) => p.filter((n) => n.id !== id));
+    const success = await markRead(id);
+    if (success) {
       toast.success(t('mark_as_read'));
-    } catch (_) {}
-    setSystemNotifs((prev) => prev.filter((n) => n.id !== id));
+    } else {
+      setSystemNotifs(prev);
+      toast.error(t('mark_as_read_error', 'Failed to mark notification as read'));
+    }
   };
 
   useEffect(() => {

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -36,28 +36,47 @@ const useNotificationStore = create((set, get) => ({
   },
 
   markRead: async (id) => {
-    const res = await markNotificationAsRead(id);
-    const readAt = res.read_at || new Date().toISOString();
     const numericId = Number(id);
+    const prevItems = get().items;
+    const tempReadAt = new Date().toISOString();
+
+    // Optimistically update UI
     set((state) => ({
       items: state.items.map((n) =>
-        Number(n.id) === numericId ? { ...n, read: true, read_at: readAt } : n,
+        Number(n.id) === numericId ? { ...n, read: true, read_at: tempReadAt } : n,
       ),
     }));
 
-    setTimeout(() => {
+    try {
+      const res = await markNotificationAsRead(id);
+      const readAt = res.read_at || tempReadAt;
       set((state) => ({
-        items: state.items.filter(
-          (n) =>
-            !(
-              Number(n.id) === numericId &&
-              n.read &&
-              n.read_at &&
-              new Date() - new Date(n.read_at) >= HOUR_MS
-            ),
+        items: state.items.map((n) =>
+          Number(n.id) === numericId ? { ...n, read_at: readAt } : n,
         ),
       }));
-    }, HOUR_MS);
+
+      setTimeout(() => {
+        set((state) => ({
+          items: state.items.filter(
+            (n) =>
+              !(
+                Number(n.id) === numericId &&
+                n.read &&
+                n.read_at &&
+                new Date() - new Date(n.read_at) >= HOUR_MS
+              ),
+          ),
+        }));
+      }, HOUR_MS);
+
+      return true;
+    } catch (err) {
+      // Revert on failure
+      set({ items: prevItems });
+      toast.error("Failed to mark notification as read");
+      return false;
+    }
   },
 
   remove: async (id) => {


### PR DESCRIPTION
## Summary
- handle notification read updates optimistically in the UI
- revert changes and show an error toast when the API call fails
- keep notification store in sync when marking reads

## Testing
- `npm test` (backend)
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_6890558aa92083288ebfdf2967bbdcc3