### PR TITLE
Ensure only active ads appear on website hero

### DIFF
--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -6,7 +6,11 @@ exports.createAd = async (data) => {
 };
 
 exports.getAds = async () => {
-  return db("ads").orderBy("created_at", "desc");
+  // Only return ads that are marked as active so the frontend
+  // doesn't display unpublished or draft ads in the hero section.
+  return db("ads")
+    .where({ is_active: true })
+    .orderBy("created_at", "desc");
 };
 
 exports.getAdById = async (id) => {

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -4,7 +4,9 @@ import { API_BASE_URL } from "@/config/config";
 export const getAds = async () => {
   const { data } = await api.get("/ads");
 
-  const ads = data?.data ?? [];
+  // Filter out inactive ads to ensure the hero section only displays
+  // campaigns that are intended for the public site.
+  const ads = (data?.data ?? []).filter((ad) => ad.is_active);
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
   return ads.map((ad) => ({
     ...ad,


### PR DESCRIPTION
## Summary
- Serve only active ads from the backend so inactive campaigns aren't exposed
- Filter ads service on the frontend to show active ads in the hero carousel

## Testing
- `cd backend && npm test`
- `cd frontend && npm test | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6890609d3a5083288215c1d136f6be0a