### PR TITLE
feat: streamline admin ad image upload

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -309,7 +309,8 @@
     "dates_required": "Start and end dates are required.",
     "end_before_start": "End date cannot be before start date.",
     "failed": "Failed to create ad.",
-    "title_exists": "Ad title already exists."
+    "title_exists": "Ad title already exists.",
+    "image_ratio_error": "يجب أن تكون الصورة بنسبة 16:10 (مثل 1600x1000) لتناسب صندوق الإعلان في قسم البطل."
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -286,7 +286,8 @@
     "dates_required": "Start- und Enddatum sind erforderlich.",
     "end_before_start": "Enddatum darf nicht vor dem Startdatum liegen.",
     "failed": "Anzeige konnte nicht erstellt werden.",
-    "title_exists": "Anzeigetitel existiert bereits."
+    "title_exists": "Anzeigetitel existiert bereits.",
+    "image_ratio_error": "Das Bild muss ein Seitenverhältnis von 16:10 haben (z. B. 1600x1000), damit es in die Hero-Anzeigenbox passt."
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -309,7 +309,8 @@
     "dates_required": "Start and end dates are required.",
     "end_before_start": "End date cannot be before start date.",
     "failed": "Failed to create ad.",
-    "title_exists": "Ad title already exists."
+    "title_exists": "Ad title already exists.",
+    "image_ratio_error": "Image must have a 16:10 aspect ratio (e.g., 1600x1000) to fit the hero ad box."
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -286,7 +286,8 @@
     "dates_required": "Se requieren las fechas de inicio y finalización.",
     "end_before_start": "La fecha de finalización no puede ser anterior a la de inicio.",
     "failed": "No se pudo crear el anuncio.",
-    "title_exists": "El título del anuncio ya existe."
+    "title_exists": "El título del anuncio ya existe.",
+    "image_ratio_error": "La imagen debe tener una relación de aspecto de 16:10 (por ejemplo, 1600x1000) para ajustarse al cuadro de anuncio del héroe."
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -297,7 +297,8 @@
     "dates_required": "Les dates de début et de fin sont requises.",
     "end_before_start": "La date de fin ne peut pas précéder la date de début.",
     "failed": "Échec de la création de l'annonce.",
-    "title_exists": "Le titre de l'annonce existe déjà."
+    "title_exists": "Le titre de l'annonce existe déjà.",
+    "image_ratio_error": "L'image doit avoir un format 16:10 (par exemple 1600x1000) pour s'adapter à l'encart publicitaire du héros."
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import ImageCropUpload from "@/components/shared/ImageCropUpload";
 import PlanLimitHint from "@/components/shared/PlanLimitHint";
 import plansConfig from "@/config/plansConfig";
 import { createAd } from "@/services/admin/adService";
@@ -44,6 +43,25 @@ export default function CreateAdPage() {
   const [mediaType, setMediaType] = useState('image');
   const [videoFile, setVideoFile] = useState(null);
   const [videoPreview, setVideoPreview] = useState('');
+
+  const handleImageChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const img = new Image();
+    img.src = URL.createObjectURL(file);
+    img.onload = () => {
+      const aspect = img.width / img.height;
+      const expected = 16 / 10;
+      if (Math.abs(aspect - expected) > 0.01) {
+        setError(t('image_ratio_error'));
+        setFormData((prev) => ({ ...prev, image: null }));
+      } else {
+        setError(null);
+        setFormData((prev) => ({ ...prev, image: file }));
+      }
+    };
+  };
 
   const notify = async (message) => {
     try {
@@ -109,11 +127,7 @@ export default function CreateAdPage() {
       payload.append("link_url", formData.link);
 
       if (mediaType === 'image') {
-        const file =
-          formData.image instanceof File
-            ? formData.image
-            : new File([formData.image], "ad.jpg", { type: formData.image.type || "image/jpeg" });
-        payload.append("image", file);
+        payload.append('image', formData.image);
       } else if (mediaType === 'video') {
         payload.append('video', videoFile);
       }
@@ -191,9 +205,14 @@ export default function CreateAdPage() {
               {mediaType === 'image' ? (
                 <div>
                   <label className="block text-sm font-medium mb-1">{t('image_label')} *</label>
-                  <ImageCropUpload
-                    onChange={(file) => setFormData((prev) => ({ ...prev, image: file }))}
-                  />
+                  {formData.image && (
+                    <img
+                      src={URL.createObjectURL(formData.image)}
+                      alt="Preview"
+                      className="w-full h-48 object-cover rounded border mb-2"
+                    />
+                  )}
+                  <input type="file" accept="image/*" onChange={handleImageChange} />
                 </div>
               ) : (
                 <div>


### PR DESCRIPTION
## Summary
- remove cropper from admin ad creation and show a basic image picker with preview
- require ad images to use a 16:10 ratio so they fit the hero ad slot
- add i18n string for the new image ratio validation

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: Component definition is missing display name, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68906af6d7308328afab2057a5f5b6b9