### PR TITLE
feat: validate ad image size with preview

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -310,7 +310,8 @@
     "end_before_start": "End date cannot be before start date.",
     "failed": "Failed to create ad.",
     "title_exists": "Ad title already exists.",
-    "image_ratio_error": "يجب أن تكون الصورة بنسبة 16:10 (مثل 1600x1000) لتناسب صندوق الإعلان في قسم البطل."
+    "image_ratio_error": "يجب أن تكون الصورة بدقة 1600x1000 بكسل بالضبط لتناسب صندوق الإعلان في قسم البطل.",
+    "preview_ad": "معاينة الإعلان"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -287,7 +287,8 @@
     "end_before_start": "Enddatum darf nicht vor dem Startdatum liegen.",
     "failed": "Anzeige konnte nicht erstellt werden.",
     "title_exists": "Anzeigetitel existiert bereits.",
-    "image_ratio_error": "Das Bild muss ein Seitenverhältnis von 16:10 haben (z. B. 1600x1000), damit es in die Hero-Anzeigenbox passt."
+    "image_ratio_error": "Das Bild muss exakt 1600x1000 Pixel groß sein, damit es in die Hero-Anzeigenbox passt.",
+    "preview_ad": "Anzeige Vorschau"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -310,7 +310,8 @@
     "end_before_start": "End date cannot be before start date.",
     "failed": "Failed to create ad.",
     "title_exists": "Ad title already exists.",
-    "image_ratio_error": "Image must have a 16:10 aspect ratio (e.g., 1600x1000) to fit the hero ad box."
+    "image_ratio_error": "Image must be exactly 1600x1000 pixels to fit the hero ad box.",
+    "preview_ad": "Preview Ad"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -287,7 +287,8 @@
     "end_before_start": "La fecha de finalización no puede ser anterior a la de inicio.",
     "failed": "No se pudo crear el anuncio.",
     "title_exists": "El título del anuncio ya existe.",
-    "image_ratio_error": "La imagen debe tener una relación de aspecto de 16:10 (por ejemplo, 1600x1000) para ajustarse al cuadro de anuncio del héroe."
+    "image_ratio_error": "La imagen debe ser exactamente de 1600x1000 píxeles para ajustarse al cuadro de anuncio del héroe.",
+    "preview_ad": "Vista previa del anuncio"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -298,7 +298,8 @@
     "end_before_start": "La date de fin ne peut pas précéder la date de début.",
     "failed": "Échec de la création de l'annonce.",
     "title_exists": "Le titre de l'annonce existe déjà.",
-    "image_ratio_error": "L'image doit avoir un format 16:10 (par exemple 1600x1000) pour s'adapter à l'encart publicitaire du héros."
+    "image_ratio_error": "L'image doit être exactement de 1600x1000 pixels pour s'adapter à l'encart publicitaire du héros.",
+    "preview_ad": "Aperçu de l'annonce"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/src/components/admin/ads/PreviewModal.js
+++ b/frontend/src/components/admin/ads/PreviewModal.js
@@ -21,13 +21,17 @@ const PreviewModal = ({ ad, onClose }) => {
           🎯 Target: {(ad.targetRoles || []).join(', ')}
         </p>
         <p className="text-xs text-gray-500 mb-1">📅 {ad.startAt} → {ad.endAt}</p>
-        <p className="text-xs text-blue-500">👁️ {ad.views} views</p>
+        {ad.views !== undefined && (
+          <p className="text-xs text-blue-500">👁️ {ad.views} views</p>
+        )}
         <p className="text-xs text-purple-500">📌 Type: {ad.adType}</p>
-        <Link href={`/dashboard/admin/ads/analytics/${ad.id}`}>
-          <button className="mt-4 w-full bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded flex items-center justify-center gap-2 text-sm">
-            <FaChartBar /> View Analytics
-          </button>
-        </Link>
+        {ad.id && (
+          <Link href={`/dashboard/admin/ads/analytics/${ad.id}`}>
+            <button className="mt-4 w-full bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded flex items-center justify-center gap-2 text-sm">
+              <FaChartBar /> View Analytics
+            </button>
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -15,6 +15,7 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import PreviewModal from "@/components/admin/ads/PreviewModal";
 const currentUserPlan = "basic";
 const { maxAdDuration, allowBranding: allowBrandingEnabled } = plansConfig[currentUserPlan];
 
@@ -43,6 +44,7 @@ export default function CreateAdPage() {
   const [mediaType, setMediaType] = useState('image');
   const [videoFile, setVideoFile] = useState(null);
   const [videoPreview, setVideoPreview] = useState('');
+  const [showPreview, setShowPreview] = useState(false);
 
   const handleImageChange = (e) => {
     const file = e.target.files?.[0];
@@ -51,14 +53,12 @@ export default function CreateAdPage() {
     const img = new Image();
     img.src = URL.createObjectURL(file);
     img.onload = () => {
-      const aspect = img.width / img.height;
-      const expected = 16 / 10;
-      if (Math.abs(aspect - expected) > 0.01) {
-        setError(t('image_ratio_error'));
-        setFormData((prev) => ({ ...prev, image: null }));
-      } else {
+      if (img.width === 1600 && img.height === 1000) {
         setError(null);
         setFormData((prev) => ({ ...prev, image: file }));
+      } else {
+        setError(t('image_ratio_error'));
+        setFormData((prev) => ({ ...prev, image: null }));
       }
     };
   };
@@ -319,7 +319,14 @@ export default function CreateAdPage() {
           </section>
 
           {/* Submit Button */}
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-4">
+            <button
+              type="button"
+              onClick={() => setShowPreview(true)}
+              className="px-6 py-3 rounded-xl font-medium text-sm border border-gray-300"
+            >
+              {t('preview_ad')}
+            </button>
             <button
               type="submit"
               disabled={isSubmitting}
@@ -341,6 +348,24 @@ export default function CreateAdPage() {
           </div>
         </form>
       </div>
+      {showPreview && (
+        <PreviewModal
+          ad={{
+            title: formData.title,
+            description: formData.description,
+            image:
+              mediaType === 'image' && formData.image
+                ? URL.createObjectURL(formData.image)
+                : null,
+            video: mediaType === 'video' ? videoPreview : null,
+            startAt: formData.startAt,
+            endAt: formData.endAt,
+            targetRoles: formData.targetRoles,
+            adType: formData.adType,
+          }}
+          onClose={() => setShowPreview(false)}
+        />
+      )}
     </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- enforce 1600x1000 requirement for ad images
- add preview modal and button to review ad before submission
- allow preview modal to hide analytics link when not applicable

## Testing
- `npm test`
- `npm run lint` *(fails: 58 errors, 235 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68906e44f708832885b6f944d6e6d86a