### PR TITLE
chore: improve admin ads management

### DIFF
--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -280,7 +280,20 @@
     "status_updated": "Status updated",
     "confirm_delete": "Delete ad: {{title}}?",
     "selected": "selected",
-    "delete_selected": "Delete Selected"
+    "delete_selected": "Delete Selected",
+    "confirm_bulk_delete": "Delete selected ads?",
+    "delete_failed": "Failed to delete ad(s)",
+    "error_generic": "Something went wrong",
+    "no_media": "No media",
+    "on": "On",
+    "off": "Off",
+    "view_analytics": "View Analytics",
+    "preview_ad": "Preview Ad",
+    "edit_ad": "Edit Ad",
+    "delete_ad": "Delete Ad",
+    "close": "Close",
+    "target_label": "Target",
+    "views": "Views"
   },
   "adsCreatePage": {
     "title": "Create Advertisement",
@@ -311,7 +324,35 @@
     "failed": "Failed to create ad.",
     "title_exists": "Ad title already exists.",
     "image_ratio_error": "Image must be exactly 1600x1000 pixels to fit the hero ad box.",
-    "preview_ad": "Preview Ad"
+    "preview_ad": "Preview Ad",
+    "notification_failed": "Failed to send notification"
+  },
+  "adsEditPage": {
+    "not_found": "Ad not found.",
+    "error_load": "Failed to load ad",
+    "required_fields": "Please fill in all required fields.",
+    "end_before_start": "End date must be after start date.",
+    "duration_exceeded": "Your plan only allows ads for up to {{days}} days.",
+    "update_success": "Ad updated successfully!",
+    "update_failed": "Failed to update ad",
+    "loading": "Loading ad data..."
+  },
+  "adsAnalyticsPage": {
+    "loading": "Loading ad analytics...",
+    "title_prefix": "Ad Analytics",
+    "overview": "Analytics overview for this campaign",
+    "edit": "Edit",
+    "activate": "Activate",
+    "deactivate": "Deactivate",
+    "delete": "Delete",
+    "description": "Description",
+    "target_roles": "Target Roles",
+    "duration": "Duration",
+    "ad_type": "Ad Type",
+    "status": "Status",
+    "performance_metrics": "Performance Metrics",
+    "views_over_time": "Views Over Time",
+    "views_by_country": "Views by Country"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/src/components/admin/ads/AdCard.js
+++ b/frontend/src/components/admin/ads/AdCard.js
@@ -1,5 +1,6 @@
 // components/admin/ads/AdCard.js
 import { FaEye, FaEdit, FaTrashAlt, FaChartBar } from "react-icons/fa";
+import { useTranslation } from "next-i18next";
 
 export default function AdCard({
   ad,
@@ -11,6 +12,7 @@ export default function AdCard({
   isSelected,
   toggleSelect
 }) {
+  const { t } = useTranslation('dashboard', { keyPrefix: 'adsPage' });
   return (
     <div className={`relative bg-white rounded-lg shadow border transition ${isSelected ? "ring-2 ring-blue-500" : ""}`}>
       {/* Select Checkbox */}
@@ -39,7 +41,7 @@ export default function AdCard({
         />
       ) : (
         <div className="w-full h-40 flex items-center justify-center bg-gray-100 text-gray-500 rounded-t-lg">
-          No media
+          {t('no_media')}
         </div>
       )}
 
@@ -48,7 +50,7 @@ export default function AdCard({
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold">{ad.title}</h3>
           <span className={`text-xs px-2 py-0.5 rounded-full ${ad.isActive ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-600"}`}>
-            {ad.isActive ? "Active" : "Inactive"}
+            {ad.isActive ? t('active') : t('inactive')}
           </span>
         </div>
         <p className="text-sm text-gray-600 line-clamp-2">{ad.description}</p>
@@ -68,16 +70,16 @@ export default function AdCard({
       {/* Actions */}
       <div className="flex justify-between items-center border-t px-4 py-2 bg-gray-50 rounded-b-lg">
         <div className="flex gap-2 text-gray-600 text-sm">
-          <button onClick={() => handlePreview(ad)} aria-label="Preview Ad">
+          <button onClick={() => handlePreview(ad)} aria-label={t('preview_ad')}>
             <FaEye className="hover:text-blue-600" />
           </button>
-          <button onClick={() => handleEdit(ad)} aria-label="Edit Ad">
+          <button onClick={() => handleEdit(ad)} aria-label={t('edit_ad')}>
             <FaEdit className="hover:text-yellow-600" />
           </button>
-          <button onClick={() => handleDelete(ad)} aria-label="Delete Ad">
+          <button onClick={() => handleDelete(ad)} aria-label={t('delete_ad')}>
             <FaTrashAlt className="hover:text-red-600" />
           </button>
-          <button onClick={() => handleAnalytics(ad)} aria-label="View Analytics">
+          <button onClick={() => handleAnalytics(ad)} aria-label={t('view_analytics')}>
             <FaChartBar className="hover:text-purple-600" />
           </button>
         </div>
@@ -88,7 +90,7 @@ export default function AdCard({
             onChange={() => toggleAdStatus(ad.id)}
             className="w-3 h-3"
           />
-          <span>{ad.isActive ? "On" : "Off"}</span>
+          <span>{ad.isActive ? t('on') : t('off')}</span>
         </label>
       </div>
     </div>

--- a/frontend/src/components/admin/ads/PreviewModal.js
+++ b/frontend/src/components/admin/ads/PreviewModal.js
@@ -1,13 +1,24 @@
 // components/admin/PreviewModal.js
 import { FaChartBar } from 'react-icons/fa';
 import Link from 'next/link';
+import { useTranslation } from 'next-i18next';
+import { useEffect } from 'react';
 
 const PreviewModal = ({ ad, onClose }) => {
+  const { t } = useTranslation('dashboard', { keyPrefix: 'adsPage' });
+  const { t: tc } = useTranslation('dashboard', { keyPrefix: 'adsCreatePage' });
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
   if (!ad) return null;
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50" role="dialog" aria-modal="true">
       <div className="bg-white max-w-md w-full rounded-lg shadow-lg p-6 relative">
-        <button onClick={onClose} className="absolute top-2 right-2 text-gray-500 hover:text-black">
+        <button onClick={onClose} className="absolute top-2 right-2 text-gray-500 hover:text-black" aria-label={t('close')}>
           ✕
         </button>
         {ad.video ? (
@@ -17,24 +28,22 @@ const PreviewModal = ({ ad, onClose }) => {
         )}
         <h2 className="text-xl font-bold mb-2">{ad.title}</h2>
         <p className="text-sm text-gray-700 mb-2">{ad.description}</p>
-        <p className="text-xs text-gray-500 mb-1">
-          🎯 Target: {(ad.targetRoles || []).join(', ')}
-        </p>
+        <p className="text-xs text-gray-500 mb-1">🎯 {t('target_label')}: {(ad.targetRoles || []).join(', ')}</p>
         <p className="text-xs text-gray-500 mb-1">📅 {ad.startAt} → {ad.endAt}</p>
         {ad.views !== undefined && (
-          <p className="text-xs text-blue-500">👁️ {ad.views} views</p>
+          <p className="text-xs text-blue-500">👁️ {t('views')}: {ad.views}</p>
         )}
-        <p className="text-xs text-purple-500">📌 Type: {ad.adType}</p>
+        <p className="text-xs text-purple-500">📌 {tc('ad_type')}: {ad.adType}</p>
         {ad.id && (
           <Link href={`/dashboard/admin/ads/analytics/${ad.id}`}>
             <button className="mt-4 w-full bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded flex items-center justify-center gap-2 text-sm">
-              <FaChartBar /> View Analytics
+              <FaChartBar /> {t('view_analytics')}
             </button>
           </Link>
         )}
       </div>
     </div>
   );
-};  
+};
 
 export default PreviewModal;

--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -3,7 +3,11 @@ import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useEffect, useState } from "react";
 import PageHead from "@/components/common/PageHead";
-import { fetchAdById, fetchAdAnalytics } from "@/services/admin/adService";
+import { fetchAdById, fetchAdAnalytics, updateAd, deleteAd } from "@/services/admin/adService";
+import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import {
   LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid,
   BarChart, Bar, ResponsiveContainer
@@ -12,6 +16,8 @@ import {
 export default function AdAnalyticsPage() {
   const router = useRouter();
   const { id } = router.query;
+  const { t } = useTranslation('dashboard', { keyPrefix: 'adsAnalyticsPage' });
+  const { t: tp } = useTranslation('dashboard', { keyPrefix: 'adsPage' });
   const [ad, setAd] = useState(null);
 
   useEffect(() => {
@@ -30,62 +36,81 @@ export default function AdAnalyticsPage() {
   if (!ad) {
     return (
       <AdminLayout>
-        <div className="p-6 text-center text-sm text-muted-foreground">Loading ad analytics...</div>
+        <div className="p-6 text-center text-sm text-muted-foreground">{t('loading')}</div>
       </AdminLayout>
     );
   }
 
+  const handleEdit = () => router.push(`/dashboard/admin/ads/edit/${id}`);
+  const toggleStatus = async () => {
+    try {
+      await updateAd(id, { is_active: !ad.isActive });
+      setAd((prev) => ({ ...prev, isActive: !prev.isActive }));
+      toast.success(tp('status_updated'));
+    } catch {
+      toast.error(tp('error_generic'));
+    }
+  };
+  const handleDelete = async () => {
+    if (!confirm(tp('confirm_delete', { title: ad.title }))) return;
+    try {
+      await deleteAd(id);
+      toast.success(tp('deleted'));
+      router.push('/dashboard/admin/ads');
+    } catch {
+      toast.error(tp('delete_failed'));
+    }
+  };
+
   return (
     <AdminLayout>
-      <PageHead title={`Ad Analytics - ${ad.title}`} />
+      <PageHead title={`${t('title_prefix')} - ${ad.title}`} />
   
       <div className="p-4 sm:p-6 space-y-8 max-w-screen-xl mx-auto">
         {/* Header */}
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">{ad.title}</h1>
-            <p className="text-muted-foreground text-sm mt-1">
-              Analytics overview for this campaign
-            </p>
+            <p className="text-muted-foreground text-sm mt-1">{t('overview')}</p>
           </div>
           <div className="flex gap-2 flex-wrap">
-            <button className="border border-gray-300 px-4 py-2 rounded hover:bg-gray-100 text-sm">Edit</button>
-            <button className={`px-4 py-2 rounded text-sm text-white ${ad.isActive ? 'bg-gray-600 hover:bg-gray-700' : 'bg-blue-600 hover:bg-blue-700'}`}>
-              {ad.isActive ? "Deactivate" : "Activate"}
-            </button>
-            <button className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded text-sm">Delete</button>
+            <button onClick={handleEdit} className="border border-gray-300 px-4 py-2 rounded hover:bg-gray-100 text-sm">{t('edit')}</button>
+            <button onClick={toggleStatus} className={`px-4 py-2 rounded text-sm text-white ${ad.isActive ? 'bg-gray-600 hover:bg-gray-700' : 'bg-blue-600 hover:bg-blue-700'}`}>{ad.isActive ? t('deactivate') : t('activate')}</button>
+            <button onClick={handleDelete} className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded text-sm">{t('delete')}</button>
           </div>
         </div>
   
         {/* Ad Info */}
         <div className="bg-white rounded-lg shadow p-6 grid md:grid-cols-2 gap-6">
           <div>
-            <img src={ad.image} alt={ad.title} className="w-full h-48 object-cover rounded-md border" />
+            {ad.video ? (
+              <video src={ad.video} className="w-full h-48 object-cover rounded-md border" controls />
+            ) : (
+              <img src={ad.image} alt={ad.title} className="w-full h-48 object-cover rounded-md border" />
+            )}
           </div>
           <div className="flex flex-col gap-4 text-sm text-gray-700">
-            <div><strong>Description:</strong> {ad.description}</div>
+            <div><strong>{t('description')}:</strong> {ad.description}</div>
             <div>
-              <strong>Target Roles:</strong>
+              <strong>{t('target_roles')}:</strong>
               <div className="mt-1 flex gap-2 flex-wrap">
                 {ad.targetRoles.map(role => (
                   <span key={role} className="bg-gray-100 px-2 py-0.5 rounded text-xs capitalize">{role}</span>
                 ))}
               </div>
             </div>
-            <div><strong>Duration:</strong> 📅 {ad.startAt} → {ad.endAt}</div>
-            <div><strong>Ad Type:</strong> 📌 <span className="bg-gray-100 px-2 py-0.5 rounded text-xs">{ad.adType}</span></div>
+            <div><strong>{t('duration')}:</strong> 📅 {ad.startAt} → {ad.endAt}</div>
+            <div><strong>{t('ad_type')}:</strong> 📌 <span className="bg-gray-100 px-2 py-0.5 rounded text-xs">{ad.adType}</span></div>
             <div>
-              <strong>Status:</strong> ⚙️
-              <span className={`ml-2 px-2 py-0.5 rounded text-xs ${ad.isActive ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-600'}`}>
-                {ad.isActive ? "Active" : "Inactive"}
-              </span>
+              <strong>{t('status')}:</strong> ⚙️
+              <span className={`ml-2 px-2 py-0.5 rounded text-xs ${ad.isActive ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-600'}`}>{ad.isActive ? tp('active') : tp('inactive')}</span>
             </div>
           </div>
         </div>
   
         {/* Performance Metrics */}
         <div className="bg-white rounded-lg shadow p-6 space-y-6">
-          <h2 className="text-xl font-semibold">📊 Performance Metrics</h2>
+          <h2 className="text-xl font-semibold">📊 {t('performance_metrics')}</h2>
           <div className="grid md:grid-cols-3 gap-4 text-sm text-gray-700">
             {[
               { label: "Views", value: ad.views, icon: "👁️" },
@@ -104,7 +129,7 @@ export default function AdAnalyticsPage() {
   
         {/* Chart: Views Over Time */}
         <div className="bg-white rounded-lg shadow p-6">
-          <h2 className="text-xl font-semibold mb-4">📈 Views Over Time</h2>
+          <h2 className="text-xl font-semibold mb-4">📈 {t('views_over_time')}</h2>
           <ResponsiveContainer width="100%" height={250}>
             <LineChart data={ad.analytics}>
               <CartesianGrid strokeDasharray="3 3" />
@@ -118,7 +143,7 @@ export default function AdAnalyticsPage() {
   
         {/* Chart: Views by Country */}
         <div className="bg-white rounded-lg shadow p-6">
-          <h2 className="text-xl font-semibold mb-4">🌍 Views by Country</h2>
+          <h2 className="text-xl font-semibold mb-4">🌍 {t('views_by_country')}</h2>
           <ResponsiveContainer width="100%" height={250}>
             <BarChart data={ad.locationStats}>
               <CartesianGrid strokeDasharray="3 3" />
@@ -132,5 +157,17 @@ export default function AdAnalyticsPage() {
       </div>
     </AdminLayout>
   );
-  
+
+}
+
+export async function getStaticPaths() {
+  return { paths: [], fallback: 'blocking' };
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -1,5 +1,5 @@
 // pages/admin/ads/create.js
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
@@ -15,14 +15,14 @@ import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import PreviewModal from "@/components/admin/ads/PreviewModal";
-const currentUserPlan = "basic";
-const { allowBranding: allowBrandingEnabled } = plansConfig[currentUserPlan];
 
 export default function CreateAdPage() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'adsCreatePage' });
   const { t: tp } = useTranslation('dashboard', { keyPrefix: 'adsPage' });
   const user = useAuthStore((s) => s.user);
+  const currentUserPlan = user?.plan || 'basic';
+  const { allowBranding: allowBrandingEnabled } = plansConfig[currentUserPlan] || {};
   const refreshNotifications = useNotificationStore((s) => s.fetch);
   const refreshMessages = useMessageStore((s) => s.fetch);
   const [formData, setFormData] = useState({
@@ -43,21 +43,25 @@ export default function CreateAdPage() {
   const [mediaType, setMediaType] = useState('image');
   const [videoFile, setVideoFile] = useState(null);
   const [videoPreview, setVideoPreview] = useState('');
+  const [imagePreview, setImagePreview] = useState('');
   const [showPreview, setShowPreview] = useState(false);
 
   const handleImageChange = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
+    const previewUrl = URL.createObjectURL(file);
     const img = new Image();
-    img.src = URL.createObjectURL(file);
+    img.src = previewUrl;
     img.onload = () => {
       if (img.width === 1600 && img.height === 1000) {
         setError(null);
         setFormData((prev) => ({ ...prev, image: file }));
+        setImagePreview(previewUrl);
       } else {
         setError(t('image_ratio_error'));
         setFormData((prev) => ({ ...prev, image: null }));
+        URL.revokeObjectURL(previewUrl);
       }
     };
   };
@@ -70,6 +74,7 @@ export default function CreateAdPage() {
       refreshMessages?.();
     } catch (err) {
       console.error(err);
+      toast.error(t('notification_failed'));
     }
   };
 
@@ -95,10 +100,18 @@ export default function CreateAdPage() {
   const handleVideoChange = (e) => {
     const file = e.target.files?.[0];
     if (file) {
+      const previewUrl = URL.createObjectURL(file);
       setVideoFile(file);
-      setVideoPreview(URL.createObjectURL(file));
+      setVideoPreview(previewUrl);
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (videoPreview) URL.revokeObjectURL(videoPreview);
+      if (imagePreview) URL.revokeObjectURL(imagePreview);
+    };
+  }, [videoPreview, imagePreview]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -204,9 +217,9 @@ export default function CreateAdPage() {
               {mediaType === 'image' ? (
                 <div>
                   <label className="block text-sm font-medium mb-1">{t('image_label')} *</label>
-                  {formData.image && (
+                  {imagePreview && (
                     <img
-                      src={URL.createObjectURL(formData.image)}
+                      src={imagePreview}
                       alt="Preview"
                       className="w-full h-48 object-cover rounded border mb-2"
                     />
@@ -349,10 +362,7 @@ export default function CreateAdPage() {
           ad={{
             title: formData.title,
             description: formData.description,
-            image:
-              mediaType === 'image' && formData.image
-                ? URL.createObjectURL(formData.image)
-                : null,
+            image: mediaType === 'image' ? imagePreview : null,
             video: mediaType === 'video' ? videoPreview : null,
             startAt: formData.startAt,
             endAt: formData.endAt,

--- a/frontend/src/pages/dashboard/admin/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/edit/[id].js
@@ -5,13 +5,19 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import ImageCropUpload from "@/components/shared/ImageCropUpload";
 import plansConfig from "@/config/plansConfig";
 import { fetchAdById, updateAd } from "@/services/admin/adService";
-
-const currentUserPlan = "basic";
-const { maxAdDuration } = plansConfig[currentUserPlan];
+import { toast } from "react-toastify";
+import useAuthStore from "@/store/auth/authStore";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 
 export default function EditAdPage() {
   const router = useRouter();
   const { id } = router.query;
+  const { t } = useTranslation('dashboard', { keyPrefix: 'adsEditPage' });
+  const user = useAuthStore((s) => s.user);
+  const currentUserPlan = user?.plan || 'basic';
+  const { maxAdDuration } = plansConfig[currentUserPlan] || {};
   const [formData, setFormData] = useState(null);
   const [error, setError] = useState(null);
   const [mediaType, setMediaType] = useState('image');
@@ -28,11 +34,19 @@ export default function EditAdPage() {
               setMediaType('video');
               setVideoPreview(ad.video);
             }
-          } else setError("Ad not found.");
+          } else setError(t('not_found'));
         })
-        .catch(() => setError("Failed to load ad"));
+        .catch(() => setError(t('error_load')));
     }
-  }, [id]);
+  }, [id, t]);
+
+  useEffect(() => {
+    return () => {
+      if (videoPreview && videoPreview.startsWith('blob:')) {
+        URL.revokeObjectURL(videoPreview);
+      }
+    };
+  }, [videoPreview]);
   
   
 
@@ -70,15 +84,15 @@ export default function EditAdPage() {
     const diffInDays = Math.ceil((end - start) / (1000 * 60 * 60 * 24));
 
     if (!formData.title || (mediaType === 'image' && !formData.image) || (mediaType === 'video' && !videoFile && !formData.video) || !formData.startAt || !formData.endAt) {
-      setError("Please fill in all required fields.");
+      setError(t('required_fields'));
       return;
     }
     if (start > end) {
-      setError("End date must be after start date.");
+      setError(t('end_before_start'));
       return;
     }
     if (diffInDays > maxAdDuration) {
-      setError(`Your plan only allows ads for up to ${maxAdDuration} days.`);
+      setError(t('duration_exceeded', { days: maxAdDuration }));
       return;
     }
 
@@ -100,17 +114,18 @@ export default function EditAdPage() {
       payload.append("link_url", formData.link);
 
       await updateAd(id, payload);
-      alert("Ad updated successfully!");
+      toast.success(t('update_success'));
       router.push("/dashboard/admin/ads");
     } catch (err) {
-      setError("Failed to update ad");
+      setError(t('update_failed'));
+      toast.error(t('update_failed'));
     }
   };
 
   if (!formData) {
     return (
       <AdminLayout>
-        <div className="p-6">Loading ad data...</div>
+        <div className="p-6">{t('loading')}</div>
       </AdminLayout>
     );
   }
@@ -204,4 +219,16 @@ export default function EditAdPage() {
       </div>
     </AdminLayout>
   );
+}
+
+export async function getStaticPaths() {
+  return { paths: [], fallback: 'blocking' };
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }

--- a/frontend/src/pages/dashboard/admin/ads/index.js
+++ b/frontend/src/pages/dashboard/admin/ads/index.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
-import { FaPlus, FaChartBar } from "react-icons/fa";
+import { FaPlus } from "react-icons/fa";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { CSVLink } from "react-csv";
 import AdCard from "@/components/admin/ads/AdCard"; // Extract AdCard for maintainability
@@ -16,6 +17,7 @@ export default function AdminAdsPage() {
     // State Management
     // ─────────────────────
     const { t } = useTranslation('dashboard', { keyPrefix: 'adsPage' });
+    const router = useRouter();
     const [ads, setAds] = useState([]);
     const [search, setSearch] = useState("");
     const [filterStatus, setFilterStatus] = useState("all");
@@ -48,13 +50,13 @@ export default function AdminAdsPage() {
                 await updateAd(id, { is_active: !ad.isActive });
                 toast.success(t('status_updated'));
             } catch {
-                toast.error('Error');
+                toast.error(t('error_generic'));
             }
         }
     };
 
     const handleEdit = (ad) => {
-        window.location.href = `/dashboard/admin/ads/edit/${ad.id}`;
+        router.push(`/dashboard/admin/ads/edit/${ad.id}`);
       };
       
     const handleDelete = async (ad) => {
@@ -64,13 +66,13 @@ export default function AdminAdsPage() {
                 setAds((prev) => prev.filter((a) => a.id !== ad.id));
                 toast.success(t('deleted'));
             } catch {
-                toast.error('Error');
+                toast.error(t('error_generic'));
             }
         }
     };
 
     const handleAnalytics = (ad) => {
-        window.location.href = `/dashboard/admin/ads/analytics/${ad.id}`;
+        router.push(`/dashboard/admin/ads/analytics/${ad.id}`);
       };
       
     const handlePreview = (ad) => setPreviewAd(ad);
@@ -81,10 +83,15 @@ export default function AdminAdsPage() {
         );
     };
 
-    const bulkDelete = () => {
-        if (confirm("Delete selected ads?")) {
+    const bulkDelete = async () => {
+        if (!confirm(t('confirm_bulk_delete'))) return;
+        try {
+            await Promise.all(selectedAds.map((id) => deleteAd(id)));
             setAds((prev) => prev.filter((ad) => !selectedAds.includes(ad.id)));
             setSelectedAds([]);
+            toast.success(t('deleted'));
+        } catch {
+            toast.error(t('delete_failed'));
         }
     };
 


### PR DESCRIPTION
## Summary
- switch admin ad listing to router navigation and server-side bulk deletion
- honor user plan limits and clean up media URLs on ad forms
- localize ad analytics and card previews with video support

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6890707913e08328a511a80bce6e8f0d