### PR TITLE
feat: enhance ad creation workflow

### DIFF
--- a/backend/src/migrations/20250802121000_add_fields_to_ads.js
+++ b/backend/src/migrations/20250802121000_add_fields_to_ads.js
@@ -1,0 +1,21 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('ads', function(table) {
+    table.timestamp('start_at');
+    table.timestamp('end_at');
+    table.specificType('target_roles', 'text[]').defaultTo('{}');
+    table.string('ad_type');
+    table.integer('priority').defaultTo(0);
+    table.boolean('allow_branding').defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('ads', function(table) {
+    table.dropColumn('start_at');
+    table.dropColumn('end_at');
+    table.dropColumn('target_roles');
+    table.dropColumn('ad_type');
+    table.dropColumn('priority');
+    table.dropColumn('allow_branding');
+  });
+};

--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -12,7 +12,17 @@ const service = require("./ads.service");
  * Create a new advertisement.
  */
 exports.createAd = catchAsync(async (req, res) => {
-  const { title, description, link_url } = req.body;
+  const {
+    title,
+    description,
+    link_url,
+    start_at,
+    end_at,
+    target_roles,
+    ad_type,
+    priority,
+    allow_branding,
+  } = req.body;
 
   if (await service.findByTitle(title)) {
     throw new AppError("Ad title already exists", 409);
@@ -30,9 +40,22 @@ exports.createAd = catchAsync(async (req, res) => {
     title,
     description,
     link_url,
+    start_at,
+    end_at,
+    ad_type,
+    priority: priority ? Number(priority) : 0,
+    allow_branding: allow_branding === "true" || allow_branding === true,
     created_by: req.user.id,
     is_active: false,
   };
+
+  if (target_roles) {
+    try {
+      data.target_roles = JSON.parse(target_roles);
+    } catch {
+      data.target_roles = Array.isArray(target_roles) ? target_roles : [target_roles];
+    }
+  }
 
   if (req.files?.image?.[0]) {
     data.image_url = `/uploads/ads/${req.files.image[0].filename}`;
@@ -71,11 +94,39 @@ exports.getAdById = catchAsync(async (req, res) => {
  * Update an existing ad.
  */
 exports.updateAd = catchAsync(async (req, res) => {
-  const { title, description, link_url, is_active } = req.body;
-  const updates = { title, description, link_url };
+  const {
+    title,
+    description,
+    link_url,
+    is_active,
+    start_at,
+    end_at,
+    target_roles,
+    ad_type,
+    priority,
+    allow_branding,
+  } = req.body;
+  const updates = {
+    title,
+    description,
+    link_url,
+    start_at,
+    end_at,
+    ad_type,
+    priority: priority ? Number(priority) : undefined,
+    allow_branding: allow_branding === "true" || allow_branding === true,
+  };
 
-  if (typeof is_active === "boolean") {
-    updates.is_active = is_active;
+  if (target_roles) {
+    try {
+      updates.target_roles = JSON.parse(target_roles);
+    } catch {
+      updates.target_roles = Array.isArray(target_roles) ? target_roles : [target_roles];
+    }
+  }
+
+  if (typeof is_active === "boolean" || is_active === "true" || is_active === "false") {
+    updates.is_active = is_active === true || is_active === "true";
   }
 
   if (title) {

--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -7,5 +7,11 @@ exports.create = z.object({
     image_url: z.string().min(1).optional(),
     video_url: z.string().min(1).optional(),
     link_url: z.string().url().optional(),
+    start_at: z.string().datetime().optional(),
+    end_at: z.string().datetime().optional(),
+    target_roles: z.string().optional(),
+    ad_type: z.string().optional(),
+    priority: z.coerce.number().optional(),
+    allow_branding: z.coerce.boolean().optional(),
   })
 });

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -301,6 +301,7 @@
     "optional_link": "Optional Link",
     "link_placeholder": "https://example.com",
     "allow_branding": "Enable Custom Branding (Prime only)",
+    "target_audience": "الجمهور المستهدف",
     "create_ad": "Create Advertisement",
     "creating": "Creating...",
     "success": "Advertisement created successfully!",
@@ -311,6 +312,10 @@
     "failed": "Failed to create ad.",
     "title_exists": "Ad title already exists.",
     "image_ratio_error": "يجب أن تكون الصورة بدقة 1600x1000 بكسل بالضبط لتناسب صندوق الإعلان في قسم البطل.",
+    "invalid_image_type": "يُسمح بملفات الصور فقط.",
+    "image_too_large": "يجب أن يكون حجم الصورة أقل من 5 ميغابايت.",
+    "invalid_video_type": "يُسمح بملفات الفيديو فقط.",
+    "video_too_large": "يجب أن يكون حجم الفيديو أقل من 50 ميغابايت.",
     "preview_ad": "معاينة الإعلان"
   },
   "plansPage": {

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -278,6 +278,7 @@
     "optional_link": "Optionaler Link",
     "link_placeholder": "https://example.com",
     "allow_branding": "Benutzerdefiniertes Branding aktivieren (nur Prime)",
+    "target_audience": "Zielgruppe",
     "create_ad": "Anzeige erstellen",
     "creating": "Erstelle...",
     "success": "Anzeige erfolgreich erstellt!",
@@ -288,6 +289,10 @@
     "failed": "Anzeige konnte nicht erstellt werden.",
     "title_exists": "Anzeigetitel existiert bereits.",
     "image_ratio_error": "Das Bild muss exakt 1600x1000 Pixel groß sein, damit es in die Hero-Anzeigenbox passt.",
+    "invalid_image_type": "Es sind nur Bilddateien erlaubt.",
+    "image_too_large": "Das Bild darf nicht größer als 5 MB sein.",
+    "invalid_video_type": "Es sind nur Videodateien erlaubt.",
+    "video_too_large": "Das Video darf nicht größer als 50 MB sein.",
     "preview_ad": "Anzeige Vorschau"
   },
   "plansPage": {

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -301,6 +301,7 @@
     "optional_link": "Optional Link",
     "link_placeholder": "https://example.com",
     "allow_branding": "Enable Custom Branding (Prime only)",
+    "target_audience": "Target Audience",
     "create_ad": "Create Advertisement",
     "creating": "Creating...",
     "success": "Advertisement created successfully!",
@@ -311,6 +312,10 @@
     "failed": "Failed to create ad.",
     "title_exists": "Ad title already exists.",
     "image_ratio_error": "Image must be exactly 1600x1000 pixels to fit the hero ad box.",
+    "invalid_image_type": "Only image files are allowed.",
+    "image_too_large": "Image size must be under 5MB.",
+    "invalid_video_type": "Only video files are allowed.",
+    "video_too_large": "Video size must be under 50MB.",
     "preview_ad": "Preview Ad"
   },
   "plansPage": {

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -278,6 +278,7 @@
     "optional_link": "Enlace opcional",
     "link_placeholder": "https://example.com",
     "allow_branding": "Habilitar marca personalizada (solo Prime)",
+    "target_audience": "Público objetivo",
     "create_ad": "Crear anuncio",
     "creating": "Creando...",
     "success": "¡Anuncio creado con éxito!",
@@ -288,6 +289,10 @@
     "failed": "No se pudo crear el anuncio.",
     "title_exists": "El título del anuncio ya existe.",
     "image_ratio_error": "La imagen debe ser exactamente de 1600x1000 píxeles para ajustarse al cuadro de anuncio del héroe.",
+    "invalid_image_type": "Solo se permiten archivos de imagen.",
+    "image_too_large": "La imagen debe ser menor de 5 MB.",
+    "invalid_video_type": "Solo se permiten archivos de video.",
+    "video_too_large": "El video debe ser menor de 50 MB.",
     "preview_ad": "Vista previa del anuncio"
   },
   "plansPage": {

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -289,6 +289,7 @@
     "optional_link": "Lien optionnel",
     "link_placeholder": "https://example.com",
     "allow_branding": "Activer la personnalisation de la marque (Prime uniquement)",
+    "target_audience": "Public cible",
     "create_ad": "Créer l'annonce",
     "creating": "Création...",
     "success": "Annonce créée avec succès !",
@@ -299,6 +300,10 @@
     "failed": "Échec de la création de l'annonce.",
     "title_exists": "Le titre de l'annonce existe déjà.",
     "image_ratio_error": "L'image doit être exactement de 1600x1000 pixels pour s'adapter à l'encart publicitaire du héros.",
+    "invalid_image_type": "Seuls les fichiers image sont autorisés.",
+    "image_too_large": "La taille de l'image doit être inférieure à 5 Mo.",
+    "invalid_video_type": "Seuls les fichiers vidéo sont autorisés.",
+    "video_too_large": "La taille de la vidéo doit être inférieure à 50 Mo.",
     "preview_ad": "Aperçu de l'annonce"
   },
   "plansPage": {

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -1,5 +1,5 @@
 // pages/admin/ads/create.js
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
@@ -9,22 +9,19 @@ import { FaSpinner } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
-import { createNotification } from "@/services/notificationService";
-import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
-import useNotificationStore from "@/store/notifications/notificationStore";
-import useMessageStore from "@/store/messages/messageStore";
 import PreviewModal from "@/components/admin/ads/PreviewModal";
-const currentUserPlan = "basic";
-const { allowBranding: allowBrandingEnabled } = plansConfig[currentUserPlan];
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_VIDEO_SIZE = 50 * 1024 * 1024; // 50MB
 
 export default function CreateAdPage() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'adsCreatePage' });
   const { t: tp } = useTranslation('dashboard', { keyPrefix: 'adsPage' });
   const user = useAuthStore((s) => s.user);
-  const refreshNotifications = useNotificationStore((s) => s.fetch);
-  const refreshMessages = useMessageStore((s) => s.fetch);
+
+  const planKey = user?.plan || 'basic';
+  const { allowBranding: allowBrandingEnabled } = plansConfig[planKey] || { allowBranding: false };
   const [formData, setFormData] = useState({
     title: "",
     description: "",
@@ -43,34 +40,35 @@ export default function CreateAdPage() {
   const [mediaType, setMediaType] = useState('image');
   const [videoFile, setVideoFile] = useState(null);
   const [videoPreview, setVideoPreview] = useState('');
+  const [imagePreview, setImagePreview] = useState('');
   const [showPreview, setShowPreview] = useState(false);
 
   const handleImageChange = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
-
+    if (!file.type.startsWith('image/')) {
+      setError(t('invalid_image_type'));
+      return;
+    }
+    if (file.size > MAX_IMAGE_SIZE) {
+      setError(t('image_too_large'));
+      return;
+    }
+    const url = URL.createObjectURL(file);
     const img = new Image();
-    img.src = URL.createObjectURL(file);
+    img.src = url;
     img.onload = () => {
       if (img.width === 1600 && img.height === 1000) {
         setError(null);
         setFormData((prev) => ({ ...prev, image: file }));
+        if (imagePreview) URL.revokeObjectURL(imagePreview);
+        setImagePreview(url);
       } else {
         setError(t('image_ratio_error'));
         setFormData((prev) => ({ ...prev, image: null }));
+        URL.revokeObjectURL(url);
       }
     };
-  };
-
-  const notify = async (message) => {
-    try {
-      await createNotification({ user_id: user.id, type: "ad_created", message });
-      await sendChatMessage(user.id, { text: message });
-      refreshNotifications?.();
-      refreshMessages?.();
-    } catch (err) {
-      console.error(err);
-    }
   };
 
   const handleChange = (e) => {
@@ -94,10 +92,20 @@ export default function CreateAdPage() {
 
   const handleVideoChange = (e) => {
     const file = e.target.files?.[0];
-    if (file) {
-      setVideoFile(file);
-      setVideoPreview(URL.createObjectURL(file));
+    if (!file) return;
+    if (!file.type.startsWith('video/')) {
+      setError(t('invalid_video_type'));
+      return;
     }
+    if (file.size > MAX_VIDEO_SIZE) {
+      setError(t('video_too_large'));
+      return;
+    }
+    if (videoPreview) URL.revokeObjectURL(videoPreview);
+    setVideoFile(file);
+    const url = URL.createObjectURL(file);
+    setVideoPreview(url);
+    setError(null);
   };
 
   const handleSubmit = async (e) => {
@@ -124,6 +132,12 @@ export default function CreateAdPage() {
       payload.append("title", formData.title);
       payload.append("description", formData.description);
       payload.append("link_url", formData.link);
+      payload.append("start_at", formData.startAt);
+      payload.append("end_at", formData.endAt);
+      payload.append("ad_type", formData.adType);
+      payload.append("priority", String(formData.priority));
+      payload.append("allow_branding", formData.allowBranding ? "true" : "false");
+      payload.append("target_roles", JSON.stringify(formData.targetRoles));
 
       if (mediaType === 'image') {
         payload.append('image', formData.image);
@@ -133,7 +147,6 @@ export default function CreateAdPage() {
 
       await createAd(payload);
       toast.success(t('success'));
-      notify(t('ad_created_notification', { title: formData.title }));
       router.push("/dashboard/admin/ads");
     } catch (err) {
       const message = err?.response?.data?.message || t('failed');
@@ -147,6 +160,13 @@ export default function CreateAdPage() {
       setIsSubmitting(false);
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (imagePreview) URL.revokeObjectURL(imagePreview);
+      if (videoPreview) URL.revokeObjectURL(videoPreview);
+    };
+  }, [imagePreview, videoPreview]);
 
   return (
     <AdminLayout>
@@ -204,9 +224,9 @@ export default function CreateAdPage() {
               {mediaType === 'image' ? (
                 <div>
                   <label className="block text-sm font-medium mb-1">{t('image_label')} *</label>
-                  {formData.image && (
+                  {imagePreview && (
                     <img
-                      src={URL.createObjectURL(formData.image)}
+                      src={imagePreview}
                       alt="Preview"
                       className="w-full h-48 object-cover rounded border mb-2"
                     />
@@ -251,6 +271,35 @@ export default function CreateAdPage() {
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
                 />
               </div>
+            </div>
+          </section>
+
+          {/* Target Audience */}
+          <section className="bg-white rounded-2xl shadow border border-gray-200">
+            <header className="px-5 py-4 border-b border-gray-100">
+              <h2 className="text-xl font-semibold text-gray-800">👥 {t('target_audience')}</h2>
+            </header>
+            <div className="px-5 py-6 space-y-3">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  name="targetRoles"
+                  value="student"
+                  checked={formData.targetRoles.includes('student')}
+                  onChange={handleChange}
+                />
+                {tp('student')}
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  name="targetRoles"
+                  value="instructor"
+                  checked={formData.targetRoles.includes('instructor')}
+                  onChange={handleChange}
+                />
+                {tp('instructor')}
+              </label>
             </div>
           </section>
 
@@ -350,8 +399,8 @@ export default function CreateAdPage() {
             title: formData.title,
             description: formData.description,
             image:
-              mediaType === 'image' && formData.image
-                ? URL.createObjectURL(formData.image)
+              mediaType === 'image' && imagePreview
+                ? imagePreview
                 : null,
             video: mediaType === 'video' ? videoPreview : null,
             startAt: formData.startAt,

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -30,6 +30,11 @@ export const fetchAds = async () => {
     video: ad.video_url ? `${base}${ad.video_url}` : null,
     link: ad.link_url,
     targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
+    startAt: ad.start_at ?? ad.startAt,
+    endAt: ad.end_at ?? ad.endAt,
+    adType: ad.ad_type ?? ad.adType,
+    priority: ad.priority ?? 0,
+    allowBranding: ad.allow_branding ?? false,
     isActive: ad.is_active ?? ad.isActive ?? false,
   }));
 };
@@ -45,6 +50,11 @@ export const fetchAdById = async (id) => {
     video: ad.video_url ? `${base}${ad.video_url}` : null,
     link: ad.link_url,
     targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
+    startAt: ad.start_at ?? ad.startAt,
+    endAt: ad.end_at ?? ad.endAt,
+    adType: ad.ad_type ?? ad.adType,
+    priority: ad.priority ?? 0,
+    allowBranding: ad.allow_branding ?? false,
     isActive: ad.is_active ?? ad.isActive ?? false,
   };
 };


### PR DESCRIPTION
## Summary
- enrich admin ad creator with targeting, scheduling, and media validation
- surface new ad fields throughout services and UI
- extend ads backend to support scheduling, priority, roles, and branding flags

## Testing
- `npm test`
- `npm run lint` (fails: Component definition is missing display name)
- `cd ../backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890704473808328b8d65d7b96b079fb