### PR TITLE
fix: correct i18n config path for admin ad pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -7,7 +7,7 @@ import { fetchAdById, fetchAdAnalytics, updateAd, deleteAd } from "@/services/ad
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import {
   LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid,
   BarChart, Bar, ResponsiveContainer

--- a/frontend/src/pages/dashboard/admin/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/edit/[id].js
@@ -9,7 +9,7 @@ import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 export default function EditAdPage() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- fix incorrect import path for `next-i18next.config.js` in admin ad analytics and edit pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890772bff5c83288e634338c2244da4