### PR TITLE
Allow any ad image size

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -311,7 +311,6 @@
     "end_before_start": "End date cannot be before start date.",
     "failed": "Failed to create ad.",
     "title_exists": "Ad title already exists.",
-    "image_ratio_error": "يجب أن تكون الصورة بدقة 1600x1000 بكسل بالضبط لتناسب صندوق الإعلان في قسم البطل.",
     "invalid_image_type": "يُسمح بملفات الصور فقط.",
     "image_too_large": "يجب أن يكون حجم الصورة أقل من 5 ميغابايت.",
     "invalid_video_type": "يُسمح بملفات الفيديو فقط.",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -288,7 +288,6 @@
     "end_before_start": "Enddatum darf nicht vor dem Startdatum liegen.",
     "failed": "Anzeige konnte nicht erstellt werden.",
     "title_exists": "Anzeigetitel existiert bereits.",
-    "image_ratio_error": "Das Bild muss exakt 1600x1000 Pixel groß sein, damit es in die Hero-Anzeigenbox passt.",
     "invalid_image_type": "Es sind nur Bilddateien erlaubt.",
     "image_too_large": "Das Bild darf nicht größer als 5 MB sein.",
     "invalid_video_type": "Es sind nur Videodateien erlaubt.",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -324,7 +324,6 @@
     "end_before_start": "End date cannot be before start date.",
     "failed": "Failed to create ad.",
     "title_exists": "Ad title already exists.",
-    "image_ratio_error": "Image must be exactly 1600x1000 pixels to fit the hero ad box.",
     "invalid_image_type": "Only image files are allowed.",
     "image_too_large": "Image size must be under 5MB.",
     "invalid_video_type": "Only video files are allowed.",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -288,7 +288,6 @@
     "end_before_start": "La fecha de finalización no puede ser anterior a la de inicio.",
     "failed": "No se pudo crear el anuncio.",
     "title_exists": "El título del anuncio ya existe.",
-    "image_ratio_error": "La imagen debe ser exactamente de 1600x1000 píxeles para ajustarse al cuadro de anuncio del héroe.",
     "invalid_image_type": "Solo se permiten archivos de imagen.",
     "image_too_large": "La imagen debe ser menor de 5 MB.",
     "invalid_video_type": "Solo se permiten archivos de video.",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -299,7 +299,6 @@
     "end_before_start": "La date de fin ne peut pas précéder la date de début.",
     "failed": "Échec de la création de l'annonce.",
     "title_exists": "Le titre de l'annonce existe déjà.",
-    "image_ratio_error": "L'image doit être exactement de 1600x1000 pixels pour s'adapter à l'encart publicitaire du héros.",
     "invalid_image_type": "Seuls les fichiers image sont autorisés.",
     "image_too_large": "La taille de l'image doit être inférieure à 5 Mo.",
     "invalid_video_type": "Seuls les fichiers vidéo sont autorisés.",

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -55,20 +55,10 @@ export default function CreateAdPage() {
       return;
     }
     const url = URL.createObjectURL(file);
-    const img = new Image();
-    img.src = url;
-    img.onload = () => {
-      if (img.width === 1600 && img.height === 1000) {
-        setError(null);
-        setFormData((prev) => ({ ...prev, image: file }));
-        if (imagePreview) URL.revokeObjectURL(imagePreview);
-        setImagePreview(url);
-      } else {
-        setError(t('image_ratio_error'));
-        setFormData((prev) => ({ ...prev, image: null }));
-        URL.revokeObjectURL(url);
-      }
-    };
+    setError(null);
+    setFormData((prev) => ({ ...prev, image: file }));
+    if (imagePreview) URL.revokeObjectURL(imagePreview);
+    setImagePreview(url);
   };
 
   const handleChange = (e) => {


### PR DESCRIPTION
## Summary
- Accept any dimensions for admin ad images by removing 1600x1000 restriction
- Drop unused translation for image size error across locales

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68907dabb0c4832895e36ed895b177fb