### PR TITLE
fix: show newly created ads in admin dashboard

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -75,10 +75,18 @@ exports.createAd = catchAsync(async (req, res) => {
 });
 
 /**
- * List all ads ordered by creation date.
+ * Public endpoint: list only active ads.
  */
 exports.getAds = catchAsync(async (_req, res) => {
-  const ads = await service.getAds();
+  const ads = await service.getAds(false);
+  sendSuccess(res, ads);
+});
+
+/**
+ * Admin endpoint: list all ads including inactive ones.
+ */
+exports.getAllAds = catchAsync(async (_req, res) => {
+  const ads = await service.getAds(true);
   sendSuccess(res, ads);
 });
 

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -14,6 +14,12 @@ router.post(
   validate(validator.create),
   controller.createAd
 );
+router.get(
+  "/admin",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.getAllAds
+);
 router.get("/", controller.getAds);
 router.get("/:id/analytics", controller.getAdAnalytics);
 router.get("/:id", controller.getAdById);

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -5,11 +5,12 @@ exports.createAd = async (data) => {
   return row;
 };
 
-exports.getAds = async () => {
-  // Only return ads that are marked as active so the frontend
-  // doesn't display unpublished or draft ads in the hero section.
+// Fetch ads with optional inclusion of inactive ones
+exports.getAds = async (includeInactive = false) => {
   return db("ads")
-    .where({ is_active: true })
+    .modify((qb) => {
+      if (!includeInactive) qb.where({ is_active: true });
+    })
     .orderBy("created_at", "desc");
 };
 

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -20,7 +20,7 @@ export const createAd = async (payload) => {
 };
 
 export const fetchAds = async () => {
-  const { data } = await api.get("/ads");
+  const { data } = await api.get("/ads/admin");
 
   const ads = data?.data ?? [];
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;


### PR DESCRIPTION
## Summary
- expose admin API to list all ads including inactive ones
- fetch admin ads from new endpoint so drafts appear in dashboard

## Testing
- `npm test` (backend)
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_6890806ee7a08328a1f42e0b708b4312