### PR TITLE
fix: ensure hero background path formats correctly

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -55,8 +55,10 @@ const Hero = () => {
   useEffect(() => {
     const bg = settings.home_bg_url;
     if (bg) {
-      const finalBg = bg.startsWith("http") ? bg : `${API_BASE_URL}${bg}`;
-      setHeroBg(finalBg);
+      const normalizedBg = bg.startsWith("http")
+        ? bg
+        : `${API_BASE_URL}${bg.startsWith("/") ? bg : `/${bg}`}`;
+      setHeroBg(normalizedBg);
     } else {
       setHeroBg("");
     }


### PR DESCRIPTION
## Summary
- fix hero section image not loading by normalizing background path with leading slash

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68909b373c78832896f4e4b9942f7ab5