### PR TITLE
Fix hero background and ad media display

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -55,13 +55,14 @@ const Hero = () => {
   useEffect(() => {
     const bg = settings.home_bg_url;
     if (bg) {
-      let base = API_BASE_URL;
+      let base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
       if (!base.startsWith("http") && typeof window !== "undefined") {
         base = window.location.origin + base;
       }
+      const apiBase = base.replace(/\/?api\/?$/, "");
       const normalizedBg = bg.startsWith("http")
         ? bg
-        : `${base}${bg.startsWith("/") ? bg : `/${bg}`}`;
+        : `${apiBase}${bg.startsWith("/") ? bg : `/${bg}`}`;
       setHeroBg(normalizedBg);
     } else {
       setHeroBg("");

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -16,9 +16,12 @@ export const getAds = async () => {
       return `${apiBase}${url}`;
     };
     return ads.map((ad) => ({
-      image: formatUrl(ad.image_url),
-      video: formatUrl(ad.video_url),
-      link: ad.link_url,
+      id: ad.id,
+      title: ad.title,
+      description: ad.description,
+      image: formatUrl(ad.image_url || ad.image),
+      video: formatUrl(ad.video_url || ad.video),
+      link: ad.link_url || ad.link,
     }));
   } catch (error) {
     if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
## Summary
- fix hero background image URL generation so page image loads
- return full ad details to display images and info

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890a16822148328a04a300a06a96439