### PR TITLE
Fix hero background and ad media URL resolution

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -5,7 +5,18 @@ const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5002/a
 const { protocol, hostname, port } = new URL(apiBase);
 const nextConfig = {
   images: {
+    unoptimized: true,
     remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+        pathname: '/**',
+      },
+      {
+        protocol: 'http',
+        hostname: '**',
+        pathname: '/**',
+      },
       {
         protocol: protocol.replace(':', ''),
         hostname,

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -52,20 +52,25 @@ const Hero = () => {
 
   const [heroBg, setHeroBg] = useState("");
 
+  const getApiBaseUrl = () => {
+    let base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+    if (!base.startsWith("http") && typeof window !== "undefined") {
+      base = window.location.origin + base;
+    }
+    return base.replace(/\/api.*$/, "");
+  };
+
   useEffect(() => {
     const bg = settings.home_bg_url;
-    if (bg) {
-      let base = API_BASE_URL;
-      if (!base.startsWith("http") && typeof window !== "undefined") {
-        base = window.location.origin + base;
-      }
-      const normalizedBg = bg.startsWith("http")
-        ? bg
-        : `${base}${bg.startsWith("/") ? bg : `/${bg}`}`;
-      setHeroBg(normalizedBg);
-    } else {
+    if (!bg) {
       setHeroBg("");
+      return;
     }
+    const apiBase = getApiBaseUrl();
+    const normalizedBg = bg.startsWith("http")
+      ? bg
+      : `${apiBase}${bg.startsWith("/") ? bg : `/${bg}`}`;
+    setHeroBg(normalizedBg);
   }, [settings.home_bg_url]);
 
   // Always fetch latest configuration so hero background stays in sync

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -6,19 +6,31 @@ export const getAds = async () => {
     const { data } = await api.get("/ads");
     // Backend already filters out inactive ads so simply map the returned list.
     const ads = data?.data ?? [];
-    const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-    const apiBase = base.replace(/\/?api\/?$/, "");
+
+    // Derive a fully-qualified base URL so media links resolve regardless of
+    // whether NEXT_PUBLIC_API_BASE_URL is absolute ("https://api.com/api") or
+    // relative ("/api").  When relative, fall back to the current origin.
+    let base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+    if (!base.startsWith("http") && typeof window !== "undefined") {
+      base = window.location.origin + base;
+    }
+    const apiBase = base.replace(/\/api.*$/, "");
+
     const formatUrl = (url) => {
       if (!url) return null;
       if (url.startsWith("http") || url.startsWith("blob:") || url.startsWith("data:")) {
         return url;
       }
-      return `${apiBase}${url}`;
+      const path = url.startsWith("/") ? url : `/${url}`;
+      return `${apiBase}${path}`;
     };
     return ads.map((ad) => ({
-      image: formatUrl(ad.image_url),
-      video: formatUrl(ad.video_url),
-      link: ad.link_url,
+      id: ad.id,
+      title: ad.title,
+      description: ad.description,
+      image: formatUrl(ad.image_url || ad.image),
+      video: formatUrl(ad.video_url || ad.video),
+      link: ad.link_url || ad.link,
     }));
   } catch (error) {
     if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
## Summary
- strip `/api` and subsequent path segments from configured base URL so hero background builds with the correct host
- do the same in ad service so image and video links resolve properly
- allow loading images from any host and disable optimization so hero and ad media always display

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890a16822148328a04a300a06a96439