### PR TITLE
fix: correct asset base URLs for hero and ads

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -52,24 +52,19 @@ const Hero = () => {
 
   const [heroBg, setHeroBg] = useState("");
 
-  const getApiBaseUrl = () => {
-    let base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-    if (!base.startsWith("http") && typeof window !== "undefined") {
-      base = window.location.origin + base;
-    }
-    return base.replace(/\/api.*$/, "");
-  };
-
   useEffect(() => {
     const bg = settings.home_bg_url;
     if (!bg) {
       setHeroBg("");
       return;
     }
-    const apiBase = getApiBaseUrl();
+    let base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+    if (!base.startsWith("http") && typeof window !== "undefined") {
+      base = window.location.origin + base;
+    }
     const normalizedBg = bg.startsWith("http")
       ? bg
-      : `${apiBase}${bg.startsWith("/") ? bg : `/${bg}`}`;
+      : `${base.replace(/\/$/, "")}${bg.startsWith("/") ? bg : `/${bg}`}`;
     setHeroBg(normalizedBg);
   }, [settings.home_bg_url]);
 

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -7,14 +7,15 @@ export const getAds = async () => {
     // Backend already filters out inactive ads so simply map the returned list.
     const ads = data?.data ?? [];
 
-    // Derive a fully-qualified base URL so media links resolve regardless of
+    // Build a fully-qualified base URL so media links resolve regardless of
     // whether NEXT_PUBLIC_API_BASE_URL is absolute ("https://api.com/api") or
-    // relative ("/api").  When relative, fall back to the current origin.
+    // relative ("/api"). When relative, fall back to the current origin and
+    // retain the "/api" prefix so proxied media paths still work.
     let base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
     if (!base.startsWith("http") && typeof window !== "undefined") {
       base = window.location.origin + base;
     }
-    const apiBase = base.replace(/\/api.*$/, "");
+    base = base.replace(/\/$/, "");
 
     const formatUrl = (url) => {
       if (!url) return null;
@@ -22,7 +23,7 @@ export const getAds = async () => {
         return url;
       }
       const path = url.startsWith("/") ? url : `/${url}`;
-      return `${apiBase}${path}`;
+      return `${base}${path}`;
     };
     return ads.map((ad) => ({
       id: ad.id,


### PR DESCRIPTION
## Summary
- fix hero section background by keeping API base path when building image URL
- ensure ad media URLs retain API prefix so assets load correctly

## Testing
- `npm test`
- `npm run lint` *(fails: 51 errors, 241 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6890ba70a5e08328a49fdaaf42078207