### PR TITLE
Fix ad title uniqueness handling

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -13,7 +13,7 @@ const service = require("./ads.service");
  */
 exports.createAd = catchAsync(async (req, res) => {
   const {
-    title,
+    title: rawTitle,
     description,
     link_url,
     start_at,
@@ -23,6 +23,8 @@ exports.createAd = catchAsync(async (req, res) => {
     priority,
     allow_branding,
   } = req.body;
+
+  const title = rawTitle?.trim();
 
   if (await service.findByTitle(title)) {
     throw new AppError("Ad title already exists", 409);
@@ -103,7 +105,7 @@ exports.getAdById = catchAsync(async (req, res) => {
  */
 exports.updateAd = catchAsync(async (req, res) => {
   const {
-    title,
+    title: rawTitle,
     description,
     link_url,
     is_active,
@@ -114,6 +116,7 @@ exports.updateAd = catchAsync(async (req, res) => {
     priority,
     allow_branding,
   } = req.body;
+  const title = rawTitle?.trim();
   const updates = {
     title,
     description,

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -19,7 +19,10 @@ exports.getAdById = async (id) => {
 };
 
 exports.findByTitle = async (title) => {
-  return db("ads").where({ title }).first();
+  if (!title) return null;
+  return db("ads")
+    .whereRaw('LOWER(title) = ?', title.toLowerCase())
+    .first();
 };
 
 exports.updateAd = async (id, data) => {


### PR DESCRIPTION
## Summary
- Trim ad titles before checking for duplicates
- Skip duplicate check when title is missing and compare titles case-insensitively

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890cf4d80b483289eb18cb897b9b923