### PR TITLE
Add ad title uniqueness check

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -77,6 +77,19 @@ exports.createAd = catchAsync(async (req, res) => {
 });
 
 /**
+ * Check if a given ad title already exists.
+ */
+exports.checkTitle = catchAsync(async (req, res) => {
+  const title = req.query.title?.trim();
+  if (!title) {
+    sendSuccess(res, { exists: false });
+    return;
+  }
+  const existing = await service.findByTitle(title);
+  sendSuccess(res, { exists: !!existing });
+});
+
+/**
  * Public endpoint: list only active ads.
  */
 exports.getAds = catchAsync(async (_req, res) => {

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -6,6 +6,13 @@ const { verifyToken, isInstructorOrAdmin } = require("../../middleware/auth/auth
 const validator = require("./ads.validator");
 const upload = require("./adsUploadMiddleware");
 
+router.get(
+  "/admin/check-title",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.checkTitle
+);
+
 router.post(
   "/admin",
   verifyToken,

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -48,6 +48,28 @@ describe('GET /api/ads', () => {
   });
 });
 
+describe('GET /api/ads/admin/check-title', () => {
+  it('returns exists true when title found', async () => {
+    service.findByTitle.mockResolvedValue({ id: '1', title: 'Test' });
+    const res = await request(app)
+      .get('/api/ads/admin/check-title')
+      .query({ title: 'Test' });
+    expect(res.status).toBe(200);
+    expect(service.findByTitle).toHaveBeenCalledWith('Test');
+    expect(res.body.data.exists).toBe(true);
+  });
+
+  it('returns exists false when title not found', async () => {
+    service.findByTitle.mockResolvedValue(null);
+    const res = await request(app)
+      .get('/api/ads/admin/check-title')
+      .query({ title: 'Unknown' });
+    expect(res.status).toBe(200);
+    expect(service.findByTitle).toHaveBeenCalledWith('Unknown');
+    expect(res.body.data.exists).toBe(false);
+  });
+});
+
 describe('POST /api/ads/admin', () => {
   it('creates ad', async () => {
     const payload = { title: 'Test', image_url: 'img.jpg' };

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -4,7 +4,7 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import plansConfig from "@/config/plansConfig";
-import { createAd } from "@/services/admin/adService";
+import { createAd, checkAdTitle } from "@/services/admin/adService";
 import { FaSpinner } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -42,6 +42,23 @@ export default function CreateAdPage() {
   const [videoPreview, setVideoPreview] = useState('');
   const [imagePreview, setImagePreview] = useState('');
   const [showPreview, setShowPreview] = useState(false);
+
+  useEffect(() => {
+    if (!formData.title) {
+      setTitleError(null);
+      return;
+    }
+    const timeout = setTimeout(async () => {
+      try {
+        const exists = await checkAdTitle(formData.title);
+        if (exists) setTitleError(t('title_exists'));
+        else setTitleError(null);
+      } catch {
+        /* ignore */
+      }
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, [formData.title, t]);
 
   const handleImageChange = (e) => {
     const file = e.target.files?.[0];
@@ -119,6 +136,11 @@ export default function CreateAdPage() {
     }
     if (new Date(formData.endAt) < new Date(formData.startAt)) {
       setError(t('end_before_start'));
+      return;
+    }
+
+    if (await checkAdTitle(formData.title)) {
+      setTitleError(t('title_exists'));
       return;
     }
 

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -19,6 +19,11 @@ export const createAd = async (payload) => {
   return data?.data;
 };
 
+export const checkAdTitle = async (title) => {
+  const { data } = await api.get("/ads/admin/check-title", { params: { title } });
+  return data?.data?.exists;
+};
+
 export const fetchAds = async () => {
   const { data } = await api.get("/ads/admin");
 


### PR DESCRIPTION
## Summary
- add backend endpoint to check if an ad title already exists
- validate ad titles on the admin create page before submission
- expose checkAdTitle service for frontend

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6891448cb20c8328941ad571ac20a8ae