### PR TITLE
feat: enhance admin ads and instructors

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -165,6 +165,7 @@
     "delete_failed": "فشل حذف المدرب",
     "selected_deleted": "تم حذف المدربين المحددين",
     "delete_selected_failed": "فشل حذف المحددين",
+    "confirm_bulk_delete": "حذف المدربين المحددين؟",
     "joined": "انضم في: {{date}}",
     "classes": "الدورات",
     "save_changes": "حفظ التغييرات",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -142,6 +142,7 @@
     "delete_failed": "Failed to delete instructor",
     "selected_deleted": "Selected instructors deleted",
     "delete_selected_failed": "Failed to delete selected",
+    "confirm_bulk_delete": "Ausgewählte Dozenten löschen?",
     "joined": "Joined: {{date}}",
     "classes": "Classes",
     "save_changes": "Save Changes",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -165,6 +165,7 @@
     "delete_failed": "Failed to delete instructor",
     "selected_deleted": "Selected instructors deleted",
     "delete_selected_failed": "Failed to delete selected",
+    "confirm_bulk_delete": "Delete selected instructors?",
     "joined": "Joined: {{date}}",
     "classes": "Classes",
     "save_changes": "Save Changes",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -142,6 +142,7 @@
     "delete_failed": "Failed to delete instructor",
     "selected_deleted": "Selected instructors deleted",
     "delete_selected_failed": "Failed to delete selected",
+    "confirm_bulk_delete": "¿Eliminar instructores seleccionados?",
     "joined": "Joined: {{date}}",
     "classes": "Classes",
     "save_changes": "Save Changes",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -153,6 +153,7 @@
     "delete_failed": "Failed to delete instructor",
     "selected_deleted": "Selected instructors deleted",
     "delete_selected_failed": "Failed to delete selected",
+    "confirm_bulk_delete": "Supprimer les instructeurs sélectionnés ?",
     "joined": "Joined: {{date}}",
     "classes": "Classes",
     "save_changes": "Save Changes",

--- a/frontend/src/components/admin/instructors/BulkActions.js
+++ b/frontend/src/components/admin/instructors/BulkActions.js
@@ -27,7 +27,11 @@ export default function BulkActions({ selectedIds, onSelectAll, onDeleteSelected
 
       {selectedIds.length > 0 && (
         <button
-          onClick={onDeleteSelected}
+          onClick={() => {
+            if (confirm(t('confirm_bulk_delete'))) {
+              onDeleteSelected();
+            }
+          }}
           className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 text-sm"
         >
           {t('delete_selected')} ({selectedIds.length})

--- a/frontend/src/components/admin/instructors/FilterBar.js
+++ b/frontend/src/components/admin/instructors/FilterBar.js
@@ -1,8 +1,23 @@
 import { FaSearch, FaSortAlphaDown } from 'react-icons/fa';
 import { useTranslation } from 'next-i18next';
+import { useEffect, useState } from 'react';
 
 export default function FilterBar({ search, onSearchChange, sort, onSortChange, statusFilter, onStatusFilter }) {
   const { t } = useTranslation('dashboard', { keyPrefix: 'instructorsPage' });
+
+  const [localSearch, setLocalSearch] = useState(search);
+
+  useEffect(() => {
+    setLocalSearch(search);
+  }, [search]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onSearchChange(localSearch);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [localSearch, onSearchChange]);
+
   return (
     <div className="flex flex-wrap items-center gap-4 mb-6">
       <div className="flex items-center gap-2">
@@ -10,8 +25,8 @@ export default function FilterBar({ search, onSearchChange, sort, onSortChange, 
         <input
           type="text"
           placeholder={t('search_placeholder')}
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
+          value={localSearch}
+          onChange={(e) => setLocalSearch(e.target.value)}
           className="border px-4 py-2 rounded w-full max-w-xs"
         />
       </div>

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -37,27 +37,41 @@ export default function CreateAdPage() {
   const [error, setError] = useState(null);
   const [titleError, setTitleError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCheckingTitle, setIsCheckingTitle] = useState(false);
   const [mediaType, setMediaType] = useState('image');
   const [videoFile, setVideoFile] = useState(null);
   const [videoPreview, setVideoPreview] = useState('');
   const [imagePreview, setImagePreview] = useState('');
   const [showPreview, setShowPreview] = useState(false);
 
+  const isFormValid =
+    formData.title &&
+    formData.startAt &&
+    formData.endAt &&
+    ((mediaType === 'image' && formData.image) || (mediaType === 'video' && videoFile));
+  const disableSubmit = !isFormValid || isSubmitting || isCheckingTitle || titleError;
+
   useEffect(() => {
     if (!formData.title) {
       setTitleError(null);
+      setIsCheckingTitle(false);
       return;
     }
+    setIsCheckingTitle(true);
     const timeout = setTimeout(async () => {
       try {
         const exists = await checkAdTitle(formData.title);
-        if (exists) setTitleError(t('title_exists'));
-        else setTitleError(null);
+        setTitleError(exists ? t('title_exists') : null);
       } catch {
         /* ignore */
+      } finally {
+        setIsCheckingTitle(false);
       }
     }, 500);
-    return () => clearTimeout(timeout);
+    return () => {
+      clearTimeout(timeout);
+      setIsCheckingTitle(false);
+    };
   }, [formData.title, t]);
 
   const handleImageChange = (e) => {
@@ -115,6 +129,20 @@ export default function CreateAdPage() {
     setError(null);
   };
 
+  const handleMediaTypeChange = (e) => {
+    const type = e.target.value;
+    setMediaType(type);
+    if (type === 'image') {
+      if (videoPreview) URL.revokeObjectURL(videoPreview);
+      setVideoFile(null);
+      setVideoPreview('');
+    } else {
+      if (imagePreview) URL.revokeObjectURL(imagePreview);
+      setFormData((prev) => ({ ...prev, image: null }));
+      setImagePreview('');
+    }
+  };
+
   useEffect(() => {
     return () => {
       if (videoPreview) URL.revokeObjectURL(videoPreview);
@@ -138,11 +166,7 @@ export default function CreateAdPage() {
       setError(t('end_before_start'));
       return;
     }
-
-    if (await checkAdTitle(formData.title)) {
-      setTitleError(t('title_exists'));
-      return;
-    }
+    if (titleError || isCheckingTitle) return;
 
     setIsSubmitting(true);
 
@@ -180,13 +204,6 @@ export default function CreateAdPage() {
     }
   };
 
-  useEffect(() => {
-    return () => {
-      if (imagePreview) URL.revokeObjectURL(imagePreview);
-      if (videoPreview) URL.revokeObjectURL(videoPreview);
-    };
-  }, [imagePreview, videoPreview]);
-
   return (
     <AdminLayout>
       <div className="max-w-4xl mx-auto p-6" dir={i18n.dir()}>
@@ -207,16 +224,19 @@ export default function CreateAdPage() {
             <div className="px-5 py-6 space-y-4">
               <div>
                 <label className="block text-sm font-medium mb-1">{t('title_label')} *</label>
-                <input
-                  type="text"
-                  name="title"
-                  value={formData.title}
-                  onChange={(e) => {
-                    setTitleError(null);
-                    handleChange(e);
-                  }}
-                  className={`w-full border px-3 py-2 rounded-lg shadow-sm text-sm focus:outline-none focus:ring-2 focus:ring-yellow-500 ${titleError ? 'border-red-500' : 'border-gray-300'}`}
-                />
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    name="title"
+                    value={formData.title}
+                    onChange={(e) => {
+                      setTitleError(null);
+                      handleChange(e);
+                    }}
+                    className={`w-full border px-3 py-2 rounded-lg shadow-sm text-sm focus:outline-none focus:ring-2 focus:ring-yellow-500 ${titleError ? 'border-red-500' : 'border-gray-300'}`}
+                  />
+                  {isCheckingTitle && <FaSpinner className="animate-spin text-gray-400" />}
+                </div>
                 {titleError && <p className="text-sm text-red-600 mt-1">{titleError}</p>}
               </div>
               <div>
@@ -233,7 +253,7 @@ export default function CreateAdPage() {
                 <label className="block text-sm font-medium mb-1">{t('media_type')}</label>
                 <select
                   value={mediaType}
-                  onChange={(e) => setMediaType(e.target.value)}
+                  onChange={handleMediaTypeChange}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
                 >
                   <option value="image">{t('image')}</option>
@@ -393,9 +413,9 @@ export default function CreateAdPage() {
             </button>
             <button
               type="submit"
-              disabled={isSubmitting}
+              disabled={disableSubmit}
               className={`px-6 py-3 rounded-xl font-medium text-white text-sm transition-all ${
-                isSubmitting
+                disableSubmit
                   ? "bg-yellow-400 cursor-not-allowed"
                   : "bg-yellow-600 hover:bg-yellow-700"
               }`}


### PR DESCRIPTION
## Summary
- debounce instructor search and add confirmation for bulk deletes
- improve ad creation form with title checks, media-type reset, and safer submit

## Testing
- `npm test`
- `npm run lint` *(fails: Assign object to a variable before exporting as module default)*

------
https://chatgpt.com/codex/tasks/task_e_6891474db7808328b5f2f7eba10aa351