### PR TITLE
fix: ensure ad title lookup is bound

### DIFF
--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -21,7 +21,7 @@ exports.getAdById = async (id) => {
 exports.findByTitle = async (title) => {
   if (!title) return null;
   return db("ads")
-    .whereRaw('LOWER(title) = ?', title.toLowerCase())
+    .whereRaw('LOWER(title) = ?', [title.toLowerCase()])
     .first();
 };
 


### PR DESCRIPTION
## Summary
- fix 'Ad title already exists' false positives by properly binding the title in the lookup query

## Testing
- `cd backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68914d004afc83288ec6ae2ec641b907