### PR TITLE
fix: normalize ad title lookup

### DIFF
--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -19,9 +19,10 @@ exports.getAdById = async (id) => {
 };
 
 exports.findByTitle = async (title) => {
-  if (!title) return null;
+  const normalized = title?.trim();
+  if (!normalized) return null;
   return db("ads")
-    .whereRaw('LOWER(title) = ?', title.toLowerCase())
+    .whereRaw("LOWER(title) = LOWER(?)", [normalized])
     .first();
 };
 


### PR DESCRIPTION
## Summary
- normalize ad title lookup by trimming and lowercasing via SQL to avoid false duplicate detections

## Testing
- `cd backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68914d004afc83288ec6ae2ec641b907