### PR TITLE
Restrict instructor ad list to own ads

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -98,10 +98,16 @@ exports.getAds = catchAsync(async (_req, res) => {
 });
 
 /**
- * Admin endpoint: list all ads including inactive ones.
+ * Admin/Instructor endpoint: list ads including inactive ones.
+ *
+ * - Admins receive all ads.
+ * - Instructors receive only the ads they created.
  */
-exports.getAllAds = catchAsync(async (_req, res) => {
-  const ads = await service.getAds(true);
+exports.getAllAds = catchAsync(async (req, res) => {
+  const roles = req.user.roles || [req.user.role];
+  const normalized = roles.map((r) => String(r).toLowerCase());
+  const isAdmin = normalized.includes("admin") || normalized.includes("superadmin");
+  const ads = await service.getAds(true, isAdmin ? undefined : req.user.id);
   sendSuccess(res, ads);
 });
 

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -5,11 +5,13 @@ exports.createAd = async (data) => {
   return row;
 };
 
-// Fetch ads with optional inclusion of inactive ones
-exports.getAds = async (includeInactive = false) => {
+// Fetch ads with optional inclusion of inactive ones and ability to
+// restrict results to a specific creator
+exports.getAds = async (includeInactive = false, createdBy) => {
   return db("ads")
     .modify((qb) => {
       if (!includeInactive) qb.where({ is_active: true });
+      if (createdBy) qb.where({ created_by: createdBy });
     })
     .orderBy("created_at", "desc");
 };

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -25,7 +25,7 @@ jest.mock('../src/modules/users/user.model', () => ({
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
-    req.user = { id: 'user1' };
+    req.user = { id: 'user1', role: 'instructor', roles: ['instructor'] };
     next();
   },
   isInstructorOrAdmin: (_req, _res, next) => next(),
@@ -44,6 +44,17 @@ describe('GET /api/ads', () => {
     service.getAds.mockResolvedValue(mock);
     const res = await request(app).get('/api/ads');
     expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+  });
+});
+
+describe('GET /api/ads/admin', () => {
+  it('returns ads for the authenticated instructor', async () => {
+    const mock = [{ id: '1', created_by: 'user1' }];
+    service.getAds.mockResolvedValue(mock);
+    const res = await request(app).get('/api/ads/admin');
+    expect(res.status).toBe(200);
+    expect(service.getAds).toHaveBeenCalledWith(true, 'user1');
     expect(res.body.data).toEqual(mock);
   });
 });


### PR DESCRIPTION
## Summary
- limit `GET /api/ads/admin` so instructors only receive their own ads
- allow filtering in ads service by creator id
- add regression test for instructor ad filtering

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68914f3abbdc83289d762683964632a0