### PR TITLE
fix: mark notifications and messages as read immediately

### DIFF
--- a/frontend/src/store/messages/messageStore.js
+++ b/frontend/src/store/messages/messageStore.js
@@ -41,10 +41,10 @@ const useMessageStore = create((set, get) => ({
   markRead: async (id) => {
     const res = await markMessageAsRead(id);
     const readAt = res.read_at || new Date().toISOString();
-    const numericId = Number(id);
+    const idStr = String(id);
     set((state) => ({
       items: state.items.map((m) =>
-        Number(m.id) === numericId ? { ...m, read: true, read_at: readAt } : m,
+        String(m.id) === idStr ? { ...m, read: true, read_at: readAt } : m,
       ),
     }));
 
@@ -53,7 +53,7 @@ const useMessageStore = create((set, get) => ({
         items: state.items.filter(
           (m) =>
             !(
-              Number(m.id) === numericId &&
+              String(m.id) === idStr &&
               m.read &&
               m.read_at &&
               new Date() - new Date(m.read_at) >= HOUR_MS
@@ -66,9 +66,9 @@ const useMessageStore = create((set, get) => ({
   delete: async (id) => {
     try {
       await apiDeleteMessage(id);
-      const numericId = Number(id);
+      const idStr = String(id);
       set((state) => ({
-        items: state.items.filter((m) => Number(m.id) !== numericId),
+        items: state.items.filter((m) => String(m.id) !== idStr),
       }));
     } catch (_) {}
   },

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -36,14 +36,14 @@ const useNotificationStore = create((set, get) => ({
   },
 
   markRead: async (id) => {
-    const numericId = Number(id);
+    const idStr = String(id);
     const prevItems = get().items;
     const tempReadAt = new Date().toISOString();
 
     // Optimistically update UI
     set((state) => ({
       items: state.items.map((n) =>
-        Number(n.id) === numericId ? { ...n, read: true, read_at: tempReadAt } : n,
+        String(n.id) === idStr ? { ...n, read: true, read_at: tempReadAt } : n,
       ),
     }));
 
@@ -52,7 +52,7 @@ const useNotificationStore = create((set, get) => ({
       const readAt = res.read_at || tempReadAt;
       set((state) => ({
         items: state.items.map((n) =>
-          Number(n.id) === numericId ? { ...n, read_at: readAt } : n,
+          String(n.id) === idStr ? { ...n, read_at: readAt } : n,
         ),
       }));
 
@@ -61,7 +61,7 @@ const useNotificationStore = create((set, get) => ({
           items: state.items.filter(
             (n) =>
               !(
-                Number(n.id) === numericId &&
+                String(n.id) === idStr &&
                 n.read &&
                 n.read_at &&
                 new Date() - new Date(n.read_at) >= HOUR_MS
@@ -81,8 +81,9 @@ const useNotificationStore = create((set, get) => ({
 
   remove: async (id) => {
     await deleteNotification(id);
+    const idStr = String(id);
     set((state) => ({
-      items: state.items.filter((n) => Number(n.id) !== Number(id)),
+      items: state.items.filter((n) => String(n.id) !== idStr),
     }));
   },
 


### PR DESCRIPTION
## Summary
- handle message IDs consistently to mark them read without refresh
- update notification store to compare IDs as strings

## Testing
- `npm test`
- `npm run lint` *(fails: 51 errors, 239 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68915158d0cc8328bbeaea3855ef46bc