### PR TITLE
fix: normalize ad title check

### DIFF
--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -23,8 +23,10 @@ exports.getAdById = async (id) => {
 exports.findByTitle = async (title) => {
   const normalized = title?.trim();
   if (!normalized) return null;
+  // Normalize both sides of the comparison to avoid false positives
+  // when titles contain extra whitespace or mixed casing.
   return db("ads")
-    .whereRaw("LOWER(title) = LOWER(?)", [normalized])
+    .whereRaw("LOWER(TRIM(title)) = ?", [normalized.toLowerCase()])
     .first();
 };
 


### PR DESCRIPTION
## Summary
- avoid false positives when checking for duplicate ad titles

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68915a30ab908328bd9cff1ba26807d0