### PR TITLE
Allow video-only ads

### DIFF
--- a/backend/src/migrations/20250805120000_make_image_url_nullable_in_ads.js
+++ b/backend/src/migrations/20250805120000_make_image_url_nullable_in_ads.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('ads', function (table) {
+    table.string('image_url').nullable().alter();
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('ads', function (table) {
+    table.string('image_url').notNullable().alter();
+  });
+};

--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -61,12 +61,19 @@ exports.createAd = catchAsync(async (req, res) => {
 
   if (req.files?.image?.[0]) {
     data.image_url = `/uploads/ads/${req.files.image[0].filename}`;
+    data.video_url = null;
   } else if (req.files?.video?.[0]) {
     data.video_url = `/uploads/ads/${req.files.video[0].filename}`;
+    data.image_url = null;
   }
 
-  if (req.body.image_url) data.image_url = req.body.image_url;
-  if (req.body.video_url) data.video_url = req.body.video_url;
+  if (req.body.image_url) {
+    data.image_url = req.body.image_url;
+    data.video_url = null;
+  } else if (req.body.video_url) {
+    data.video_url = req.body.video_url;
+    data.image_url = null;
+  }
 
   const ad = await service.createAd(data);
 
@@ -172,8 +179,13 @@ exports.updateAd = catchAsync(async (req, res) => {
     updates.video_url = `/uploads/ads/${req.files.video[0].filename}`;
     updates.image_url = null;
   }
-  if (req.body.image_url) updates.image_url = req.body.image_url;
-  if (req.body.video_url) updates.video_url = req.body.video_url;
+  if (req.body.image_url) {
+    updates.image_url = req.body.image_url;
+    updates.video_url = null;
+  } else if (req.body.video_url) {
+    updates.video_url = req.body.video_url;
+    updates.image_url = null;
+  }
 
   const updated = await service.updateAd(req.params.id, updates);
   if (!updated) throw new AppError("Ad not found", 404);


### PR DESCRIPTION
## Summary
- allow ads to store video without needing image
- ensure only one of image or video URLs is persisted

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68915d72a7788328ad655e9a5d0fbbf2