### PR TITLE
feat: add ad review notifications

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -3,6 +3,12 @@ const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
 const service = require("./ads.service");
+const userModel = require("../users/user.model");
+const {
+  sendAdSubmissionEmail,
+  sendAdApprovalEmail,
+  sendNewAdAdminEmail,
+} = require("../../utils/email");
 
 /**
  * Controller functions for managing advertisement banners.
@@ -76,6 +82,27 @@ exports.createAd = catchAsync(async (req, res) => {
   }
 
   const ad = await service.createAd(data);
+  try {
+    if (req.user?.email) {
+      await sendAdSubmissionEmail(
+        req.user.email,
+        req.user.full_name,
+        ad.title
+      );
+    }
+    const admins = await userModel.findAdmins();
+    await Promise.all(
+      admins.map((admin) =>
+        sendNewAdAdminEmail(
+          admin.email,
+          req.user.full_name || "Instructor",
+          ad.title
+        )
+      )
+    );
+  } catch (err) {
+    console.error("Error sending ad creation emails:", err);
+  }
 
   // Notifications and messages to all users were removed to simplify ad creation
   // and avoid spamming the platform with global alerts.
@@ -166,6 +193,19 @@ exports.updateAd = catchAsync(async (req, res) => {
     updates.is_active = is_active === true || is_active === "true";
   }
 
+  const roles = req.user.roles || [req.user.role];
+  const normalizedRoles = roles.map((r) => String(r).toLowerCase());
+  const isAdmin =
+    normalizedRoles.includes("admin") || normalizedRoles.includes("superadmin");
+
+  let previousAd;
+  if (updates.is_active !== undefined) {
+    if (!isAdmin) {
+      throw new AppError("Only admins can change ad status", 403);
+    }
+    previousAd = await service.getAdById(req.params.id);
+  }
+
   if (title) {
     const existing = await service.findByTitle(title);
     if (existing && existing.id !== req.params.id)
@@ -189,6 +229,22 @@ exports.updateAd = catchAsync(async (req, res) => {
 
   const updated = await service.updateAd(req.params.id, updates);
   if (!updated) throw new AppError("Ad not found", 404);
+
+  if (
+    updates.is_active === true &&
+    previousAd &&
+    previousAd.is_active === false &&
+    updated.created_by
+  ) {
+    try {
+      const creator = await userModel.findById(updated.created_by);
+      if (creator?.email) {
+        await sendAdApprovalEmail(creator.email, updated.title);
+      }
+    } catch (err) {
+      console.error("Error sending ad approval email:", err);
+    }
+  }
 
   // Global notifications/messages removed
 

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -942,3 +942,159 @@ exports.sendCartAddedEmail = async (to, itemName) => {
     console.error("Error sending cart added email: ", error);
   }
 };
+
+// Notify instructor that their ad was submitted for review
+exports.sendAdSubmissionEmail = async (to, name, adTitle) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Ad submission notice for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `Your ad "${adTitle}" was submitted`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello${name ? ` ${name}` : ""},</p>
+        <p>Your advertisement <strong>${adTitle}</strong> has been submitted successfully and is awaiting review.</p>
+        <p>You will receive another email once it has been approved.</p>
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Ad submission notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending ad submission email: ", error);
+  }
+};
+
+// Notify admins when a new ad is created by an instructor
+exports.sendNewAdAdminEmail = async (to, instructorName, adTitle) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] New ad notice to ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `New ad submitted: ${adTitle}`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>${instructorName || "An instructor"} submitted a new advertisement titled <strong>${adTitle}</strong>.</p>
+        <p>Please review and approve it at your earliest convenience.</p>
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Admin new ad notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending new ad admin email: ", error);
+  }
+};
+
+// Notify instructor when their ad is approved
+exports.sendAdApprovalEmail = async (to, adTitle) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Ad approval notice for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: `Your ad "${adTitle}" was approved`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>Hello,</p>
+        <p>Your advertisement <strong>${adTitle}</strong> has been reviewed and approved. It is now live on the platform.</p>
+        <p>Thank you for advertising with us!</p>
+        <p>Best regards,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Ad approval notice sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending ad approval email: ", error);
+  }
+};

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -20,18 +20,35 @@ jest.mock('../src/modules/messages/messages.service', () => ({
 }));
 
 jest.mock('../src/modules/users/user.model', () => ({
-  findAdmins: jest.fn(() => [{ id: 'admin1' }]),
+  findAdmins: jest.fn(() => [{ id: 'admin1', email: 'admin@example.com' }]),
+}));
+
+jest.mock('../src/utils/email', () => ({
+  sendAdSubmissionEmail: jest.fn(),
+  sendAdApprovalEmail: jest.fn(),
+  sendNewAdAdminEmail: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
-    req.user = { id: 'user1', role: 'instructor', roles: ['instructor'] };
+    req.user = {
+      id: 'user1',
+      role: 'instructor',
+      roles: ['instructor'],
+      email: 'inst@example.com',
+      full_name: 'Instructor One',
+    };
     next();
   },
   isInstructorOrAdmin: (_req, _res, next) => next(),
 }));
 
 const service = require('../src/modules/ads/ads.service');
+const {
+  sendAdSubmissionEmail,
+  sendAdApprovalEmail,
+  sendNewAdAdminEmail,
+} = require('../src/utils/email');
 const routes = require('../src/modules/ads/ads.routes');
 
 const app = express();
@@ -88,6 +105,16 @@ describe('POST /api/ads/admin', () => {
     const res = await request(app).post('/api/ads/admin').send(payload);
     expect(res.status).toBe(200);
     expect(service.createAd).toHaveBeenCalled();
+    expect(sendAdSubmissionEmail).toHaveBeenCalledWith(
+      'inst@example.com',
+      'Instructor One',
+      'Test'
+    );
+    expect(sendNewAdAdminEmail).toHaveBeenCalledWith(
+      'admin@example.com',
+      'Instructor One',
+      'Test'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- email instructor and admins after ad submission
- restrict ad activation to admins and email instructor on approval
- add tests covering ad submission notifications

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891645d103083289fee89ba97fee202