### PR TITLE
Filter ads by target role

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -99,9 +99,25 @@ exports.checkTitle = catchAsync(async (req, res) => {
 /**
  * Public endpoint: list only active ads.
  */
-exports.getAds = catchAsync(async (_req, res) => {
+exports.getAds = catchAsync(async (req, res) => {
+  const roles = req.user?.roles || (req.user?.role ? [req.user.role] : []);
+  const normalized = roles.map((r) => String(r).toLowerCase());
+
   const ads = await service.getAds(false);
-  sendSuccess(res, ads);
+
+  const filtered = normalized.length
+    ? ads.filter((ad) => {
+        const targets = Array.isArray(ad.target_roles)
+          ? ad.target_roles.map((r) => String(r).toLowerCase())
+          : [];
+        return (
+          targets.length === 0 ||
+          targets.some((role) => normalized.includes(role))
+        );
+      })
+    : ads;
+
+  sendSuccess(res, filtered);
 });
 
 /**

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -27,7 +27,7 @@ router.get(
   isInstructorOrAdmin,
   controller.getAllAds
 );
-router.get("/", controller.getAds);
+router.get("/", verifyToken, controller.getAds);
 router.get("/:id/analytics", controller.getAdAnalytics);
 router.get("/:id", controller.getAdById);
 router.put(

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -46,6 +46,23 @@ describe('GET /api/ads', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
   });
+
+  it('filters ads by target_roles for instructor', async () => {
+    const mock = [
+      { id: '1', target_roles: ['student'] },
+      { id: '2', target_roles: ['instructor'] },
+      { id: '3', target_roles: [] },
+      { id: '4', target_roles: ['student', 'instructor'] },
+    ];
+    service.getAds.mockResolvedValue(mock);
+    const res = await request(app).get('/api/ads');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([
+      mock[1],
+      mock[2],
+      mock[3],
+    ]);
+  });
 });
 
 describe('GET /api/ads/admin', () => {


### PR DESCRIPTION
## Summary
- require authentication for viewing ads
- filter active ads based on targeted user roles
- cover instructor filtering with unit tests

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891664078948328a7e76062768725a5