### PR TITLE
feat: add role-based ad targeting

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -126,8 +126,9 @@ exports.checkTitle = catchAsync(async (req, res) => {
 /**
  * Public endpoint: list only active ads.
  */
-exports.getAds = catchAsync(async (_req, res) => {
-  const ads = await service.getAds(false);
+exports.getAds = catchAsync(async (req, res) => {
+  const role = req.query.role?.toLowerCase();
+  const ads = await service.getAds(false, undefined, role);
   sendSuccess(res, ads);
 });
 

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -6,12 +6,17 @@ exports.createAd = async (data) => {
 };
 
 // Fetch ads with optional inclusion of inactive ones and ability to
-// restrict results to a specific creator
-exports.getAds = async (includeInactive = false, createdBy) => {
+// restrict results to a specific creator or target role
+exports.getAds = async (includeInactive = false, createdBy, targetRole) => {
   return db("ads")
     .modify((qb) => {
       if (!includeInactive) qb.where({ is_active: true });
       if (createdBy) qb.where({ created_by: createdBy });
+      if (targetRole) {
+        qb.where(function () {
+          this.whereRaw("target_roles = '{}' OR ? = ANY(target_roles)", [targetRole]);
+        });
+      }
     })
     .orderBy("created_at", "desc");
 };

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -63,6 +63,15 @@ describe('GET /api/ads', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
   });
+
+  it('filters ads by role', async () => {
+    const mock = [{ id: '1' }];
+    service.getAds.mockResolvedValue(mock);
+    const res = await request(app).get('/api/ads').query({ role: 'student' });
+    expect(res.status).toBe(200);
+    expect(service.getAds).toHaveBeenCalledWith(false, undefined, 'student');
+    expect(res.body.data).toEqual(mock);
+  });
 });
 
 describe('GET /api/ads/admin', () => {

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -27,6 +27,7 @@ import { API_BASE_URL } from "@/config/config";
 import { getAds } from "@/services/adsService";
 import { searchAll } from "@/services/searchService";
 import { useTranslation } from "next-i18next";
+import useAuthStore from "@/store/auth/authStore";
 
 
 const Hero = () => {
@@ -50,6 +51,7 @@ const Hero = () => {
   const fetchAppConfig = useAppConfigStore((s) => s.fetch);
   const configLoaded = useAppConfigStore((s) => s.loaded);
   const { t } = useTranslation("website");
+  const userRole = useAuthStore((s) => s.user?.roles?.[0] || s.user?.role);
 
   const [heroBg, setHeroBg] = useState("");
 
@@ -84,7 +86,7 @@ const Hero = () => {
     const fetchAds = async () => {
       setLoadingAds(true);
       try {
-        const data = await getAds();
+        const data = await getAds(userRole?.toLowerCase());
         setAds(data);
         setAdsError(false);
       } catch (_err) {
@@ -95,7 +97,7 @@ const Hero = () => {
       }
     };
     fetchAds();
-  }, []);
+  }, [userRole]);
 
   const AD_ROTATION_INTERVAL = 10000; // ms
   // Auto-rotate Ads Every 10 Seconds, pause when focused/hovered

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -1,9 +1,10 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
 
-export const getAds = async () => {
+export const getAds = async (role) => {
   try {
-    const { data } = await api.get("/ads");
+    const config = role ? { params: { role } } : undefined;
+    const { data } = await api.get("/ads", config);
     // Backend already filters out inactive ads so simply map the returned list.
     const ads = data?.data ?? [];
 


### PR DESCRIPTION
## Summary
- restrict public ads by target roles in backend service/controller
- send user role when fetching ads on frontend
- cover role filtering with unit test

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891684d66d8832881891a58d39a96e4