### PR TITLE
fix: adjust instructor ads management

### DIFF
--- a/frontend/src/components/admin/ads/AdCard.js
+++ b/frontend/src/components/admin/ads/AdCard.js
@@ -83,15 +83,17 @@ export default function AdCard({
             <FaChartBar className="hover:text-purple-600" />
           </button>
         </div>
-        <label className="flex items-center gap-1 text-xs cursor-pointer">
-          <input
-            type="checkbox"
-            checked={ad.isActive}
-            onChange={() => toggleAdStatus(ad.id)}
-            className="w-3 h-3"
-          />
-          <span>{ad.isActive ? t('on') : t('off')}</span>
-        </label>
+        {typeof toggleAdStatus === 'function' && (
+          <label className="flex items-center gap-1 text-xs cursor-pointer">
+            <input
+              type="checkbox"
+              checked={ad.isActive}
+              onChange={() => toggleAdStatus(ad.id)}
+              className="w-3 h-3"
+            />
+            <span>{ad.isActive ? t('on') : t('off')}</span>
+          </label>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
@@ -1,10 +1,16 @@
-// pages/admin/ads/edit/[id].js
+// pages/dashboard/instructor/ads/edit/[id].js
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import AdminLayout from "@/components/layouts/AdminLayout";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
 import ImageCropUpload from "@/components/shared/ImageCropUpload";
 import plansConfig from "@/config/plansConfig";
 import { fetchAdById, updateAd } from "@/services/admin/adService";
+import { toast } from "react-toastify";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
+import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
 
 const currentUserPlan = "basic";
 const { maxAdDuration } = plansConfig[currentUserPlan];
@@ -14,6 +20,20 @@ export default function EditAdPage() {
   const { id } = router.query;
   const [formData, setFormData] = useState(null);
   const [error, setError] = useState(null);
+  const user = useAuthStore((s) => s.user);
+  const refreshNotifications = useNotificationStore((s) => s.fetch);
+  const refreshMessages = useMessageStore((s) => s.fetch);
+
+  const notify = async (type, message) => {
+    try {
+      await createNotification({ user_id: user.id, type, message });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
+    } catch (err) {
+      console.error("[EditAdPage] notification error", err);
+    }
+  };
 
   useEffect(() => {
     if (id) {
@@ -80,23 +100,25 @@ export default function EditAdPage() {
       payload.append("link_url", formData.link);
 
       await updateAd(id, payload);
-      alert("Ad updated successfully!");
+      toast.success("Ad updated successfully!");
+      await notify("ad_updated", `Ad "${formData.title}" updated`);
       router.push("/dashboard/instructor/ads");
     } catch (err) {
       setError("Failed to update ad");
+      toast.error("Failed to update ad");
     }
   };
 
   if (!formData) {
     return (
-      <AdminLayout>
+      <InstructorLayout>
         <div className="p-6">Loading ad data...</div>
-      </AdminLayout>
+      </InstructorLayout>
     );
   }
 
   return (
-    <AdminLayout>
+    <InstructorLayout>
       <div className="max-w-3xl mx-auto p-6">
         <h1 className="text-3xl font-bold mb-6">✏️ Edit Advertisement</h1>
         {error && <div className="bg-red-100 border border-red-300 text-red-800 px-4 py-3 rounded mb-6">{error}</div>}
@@ -151,10 +173,6 @@ export default function EditAdPage() {
               <input type="checkbox" name="allowBranding" checked={formData.allowBranding} onChange={handleChange} />
               <span className="text-sm">Enable Custom Branding</span>
             </label>
-            <label className="flex items-center gap-2">
-              <input type="checkbox" name="isActive" checked={formData.isActive} onChange={handleChange} />
-              <span className="text-sm">Activate this ad</span>
-            </label>
           </section>
 
           <button type="submit" className="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">
@@ -162,6 +180,6 @@ export default function EditAdPage() {
           </button>
         </form>
       </div>
-    </AdminLayout>
+    </InstructorLayout>
   );
 }

--- a/frontend/src/pages/dashboard/instructor/ads/index.js
+++ b/frontend/src/pages/dashboard/instructor/ads/index.js
@@ -3,9 +3,15 @@ import { useState, useEffect, useMemo } from "react";
 import { FaPlus } from "react-icons/fa";
 import Link from "next/link";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
-import AdCard from "@/components/admin/ads/AdCard"; // You can reuse this
+import AdCard from "@/components/admin/ads/AdCard";
 import PreviewModal from "@/components/admin/ads/PreviewModalinstrutor";
-import { fetchAds, deleteAd, updateAd } from "@/services/admin/adService";
+import { fetchAds, deleteAd } from "@/services/admin/adService";
+import { toast } from "react-toastify";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
+import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
 
 export default function InstructorAdsPage() {
   const [ads, setAds] = useState([]);
@@ -16,22 +22,32 @@ export default function InstructorAdsPage() {
   const [selectedAds, setSelectedAds] = useState([]);
   const [previewAd, setPreviewAd] = useState(null);
   const ITEMS_PER_PAGE = 6;
+  const user = useAuthStore((s) => s.user);
+  const refreshNotifications = useNotificationStore((s) => s.fetch);
+  const refreshMessages = useMessageStore((s) => s.fetch);
 
-  useEffect(() => {
-    fetchAds().then(setAds).catch(() => setAds([]));
-  }, []);
-
-  const toggleAdStatus = async (id) => {
-    setAds((prev) =>
-      prev.map((ad) =>
-        ad.id === id ? { ...ad, isActive: !ad.isActive } : ad
-      )
-    );
-    const ad = ads.find((a) => a.id === id);
-    if (ad) {
-      await updateAd(id, { is_active: !ad.isActive }).catch(() => {});
+  const notify = async (type, message) => {
+    try {
+      await createNotification({ user_id: user.id, type, message });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
+    } catch (err) {
+      console.error("[InstructorAdsPage] notification error", err);
     }
   };
+
+  useEffect(() => {
+    if (!user?.id) return;
+    fetchAds()
+      .then((data) => {
+        const mine = data.filter(
+          (ad) => ad.created_by === user.id || ad.createdBy === user.id
+        );
+        setAds(mine);
+      })
+      .catch(() => setAds([]));
+  }, [user?.id]);
 
   const handleEdit = (ad) => {
     window.location.href = `/dashboard/instructor/ads/edit/${ad.id}`;
@@ -43,8 +59,14 @@ export default function InstructorAdsPage() {
 
   const handleDelete = async (ad) => {
     if (confirm(`Delete "${ad.title}"?`)) {
-      await deleteAd(ad.id).catch(() => {});
-      setAds((prev) => prev.filter((a) => a.id !== ad.id));
+      try {
+        await deleteAd(ad.id);
+        setAds((prev) => prev.filter((a) => a.id !== ad.id));
+        toast.success("Ad deleted");
+        await notify("ad_deleted", `Ad "${ad.title}" deleted`);
+      } catch {
+        toast.error("Failed to delete ad");
+      }
     }
   };
 
@@ -127,7 +149,6 @@ export default function InstructorAdsPage() {
                 <AdCard
                   key={ad.id}
                   ad={ad}
-                  toggleAdStatus={toggleAdStatus}
                   handleEdit={handleEdit}
                   handleDelete={handleDelete}
                   handlePreview={handlePreview}


### PR DESCRIPTION
## Summary
- show only current instructor's ads in dashboard
- remove ability for instructors to toggle ad active status
- add toasts and notifications for ad updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891701344908328ba1cb2405cff7b4b