### PR TITLE
feat: add admin books module

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -3,7 +3,7 @@ import {
   LayoutDashboard, CreditCard, Users, BadgeCheck, BookOpen, Brain, FileText, CalendarCheck2,
   UserCog, Megaphone, Settings, Phone, Plug, Globe, Mail, ImageIcon, ShieldCheck,
   Key, MessageCircleQuestion, BellRing, FileSignature, LayoutTemplate, Contact,
-  SearchCheck, ClipboardList, FolderKanban, DollarSign, Home, MessageCircle, Network, BookMarked,            // For Blogs
+  SearchCheck, ClipboardList, FolderKanban, DollarSign, Home, MessageCircle, Network, Book, BookMarked,            // For Blogs
   HelpCircle,            // For FAQs
   LifeBuoy,
   BadgePercent
@@ -25,6 +25,7 @@ export const adminNavLinks = [
       { label: 'Assignments', href: '/dashboard/admin/assignments', icon: FileText },
       { label: 'Certificates', href: '/dashboard/admin/certificates', icon: LayoutTemplate },
       { label: 'Categories', href: '/dashboard/admin/categories', icon: FolderKanban },
+      { label: 'Books', href: '/dashboard/admin/books', icon: Book },
     ]
   },
   {

--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import api from "@/services/api/api";
+import BookForm from "@/components/books/BookForm";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
+import { fetchBookCategories } from "@/services/bookCategoryService";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
+
+function AdminCreateBookPage() {
+  const router = useRouter();
+  const { t } = useTranslation("dashboard");
+  const [categories, setCategories] = useState([]);
+  const fetchNotifications = useNotificationStore((state) => state.fetch);
+  const fetchMessages = useMessageStore((state) => state.fetch);
+
+  useEffect(() => {
+    fetchBookCategories()
+      .then(setCategories)
+      .catch((e) => console.error("Failed to load categories", e));
+  }, []);
+
+  const handleSubmit = async (formData, setProgress) => {
+    try {
+      await api.post("/books", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+        onUploadProgress: (event) => {
+          if (event.total) {
+            const progress = Math.round((event.loaded * 100) / event.total);
+            setProgress(progress);
+          }
+        },
+      });
+      toast.success(t("booksCreate.success"));
+      fetchNotifications();
+      fetchMessages();
+      router.push("/dashboard/admin/books");
+    } catch (e) {
+      console.error("Failed to create book", e);
+      toast.error(t("booksCreate.error"));
+    } finally {
+      setProgress(null);
+    }
+  };
+
+  return (
+    <AdminLayout>
+      <section className="py-10 px-4 max-w-3xl mx-auto">
+        <h1 className="text-2xl font-semibold mb-4">{t("booksCreate.title")}</h1>
+        <BookForm onSubmit={handleSubmit} categories={categories} />
+      </section>
+    </AdminLayout>
+  );
+}
+
+export default withAuthProtection(AdminCreateBookPage, ["admin", "superadmin"]);
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common", "dashboard"], nextI18NextConfig)),
+    },
+  };
+}
+

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -1,0 +1,113 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import BookCard from "@/components/books/BookCard";
+import { fetchBooks } from "@/services/bookService";
+import { fetchBookCategories } from "@/services/bookCategoryService";
+import withAuthProtection from "@/hooks/withAuthProtection";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
+
+function AdminBooksPage() {
+  const [books, setBooks] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [filters, setFilters] = useState({ search: "", category: "", status: "" });
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchBooks();
+        setBooks(data);
+      } catch (err) {
+        console.error("Failed to load books", err);
+      }
+      try {
+        const cats = await fetchBookCategories();
+        setCategories(cats);
+      } catch (err) {
+        console.error("Failed to load categories", err);
+      }
+    };
+    load();
+  }, []);
+
+  const filteredBooks = books.filter((b) => {
+    const matchesSearch = filters.search
+      ? b.title.toLowerCase().includes(filters.search.toLowerCase())
+      : true;
+    const matchesCategory = filters.category
+      ? b.category_id === Number(filters.category)
+      : true;
+    const matchesStatus = filters.status ? b.status === filters.status : true;
+    return matchesSearch && matchesCategory && matchesStatus;
+  });
+
+  return (
+    <AdminLayout>
+      <section className="py-10 px-4 max-w-4xl mx-auto">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-3xl font-bold">Books</h1>
+          <Link
+            href="/dashboard/admin/books/create"
+            className="px-4 py-2 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          >
+            Add Book
+          </Link>
+        </div>
+
+        <div className="flex flex-wrap gap-4 mb-6">
+          <input
+            type="text"
+            placeholder="Search by title"
+            value={filters.search}
+            onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+            className="border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          />
+          <select
+            value={filters.category}
+            onChange={(e) => setFilters({ ...filters, category: e.target.value })}
+            className="border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          >
+            <option value="">All Categories</option>
+            {categories.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <select
+            value={filters.status}
+            onChange={(e) => setFilters({ ...filters, status: e.target.value })}
+            className="border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          >
+            <option value="">All Statuses</option>
+            <option value="pending">Pending</option>
+            <option value="draft">Draft</option>
+            <option value="published">Published</option>
+          </select>
+        </div>
+
+        {filteredBooks.length === 0 ? (
+          <p className="text-gray-500">No books found.</p>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filteredBooks.map((book) => (
+              <BookCard key={book.id} book={book} />
+            ))}
+          </div>
+        )}
+      </section>
+    </AdminLayout>
+  );
+}
+
+export default withAuthProtection(AdminBooksPage, ["admin", "superadmin"]);
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
+}
+


### PR DESCRIPTION
## Summary
- allow admins to manage books with new dashboard pages
- secure book management routes for admin and super admin

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891711df604832882ec8f15e73f6dac