### PR TITLE
Notify admins of new ads

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -4,6 +4,8 @@ const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
 const service = require("./ads.service");
 const userModel = require("../users/user.model");
+const notificationService = require("../notifications/notifications.service");
+const messageService = require("../messages/messages.service");
 const {
   sendAdSubmissionEmail,
   sendAdApprovalEmail,
@@ -91,21 +93,31 @@ exports.createAd = catchAsync(async (req, res) => {
       );
     }
     const admins = await userModel.findAdmins();
+    const notificationMessage = `New ad created: ${ad.title}`;
     await Promise.all(
       admins.map((admin) =>
-        sendNewAdAdminEmail(
-          admin.email,
-          req.user.full_name || "Instructor",
-          ad.title
-        )
+        Promise.all([
+          sendNewAdAdminEmail(
+            admin.email,
+            req.user.full_name || "Instructor",
+            ad.title
+          ),
+          notificationService.createNotification({
+            user_id: admin.id,
+            type: "ad",
+            message: notificationMessage,
+          }),
+          messageService.createMessage({
+            sender_id: req.user.id,
+            receiver_id: admin.id,
+            message: notificationMessage,
+          }),
+        ])
       )
     );
   } catch (err) {
     console.error("Error sending ad creation emails:", err);
   }
-
-  // Notifications and messages to all users were removed to simplify ad creation
-  // and avoid spamming the platform with global alerts.
 
   sendSuccess(res, ad, "Ad created");
 });

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -49,6 +49,8 @@ const {
   sendAdApprovalEmail,
   sendNewAdAdminEmail,
 } = require('../src/utils/email');
+const notificationService = require('../src/modules/notifications/notifications.service');
+const messageService = require('../src/modules/messages/messages.service');
 const routes = require('../src/modules/ads/ads.routes');
 
 const app = express();
@@ -124,6 +126,16 @@ describe('POST /api/ads/admin', () => {
       'Instructor One',
       'Test'
     );
+    expect(notificationService.createNotification).toHaveBeenCalledWith({
+      user_id: 'admin1',
+      type: 'ad',
+      message: 'New ad created: Test',
+    });
+    expect(messageService.createMessage).toHaveBeenCalledWith({
+      sender_id: 'user1',
+      receiver_id: 'admin1',
+      message: 'New ad created: Test',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Send in-app notifications and messages to all admins when an instructor creates an ad
- Verify notification and message creation in ads route tests

## Testing
- `cd backend && npm test adsRoutes.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68917423fba48328aa2eb5452a1d7358