### PR TITLE
feat: allow admin ad filtering by role

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -147,14 +147,20 @@ exports.getAds = catchAsync(async (req, res) => {
 /**
  * Admin/Instructor endpoint: list ads including inactive ones.
  *
- * - Admins receive all ads.
- * - Instructors receive only the ads they created.
+ * - Admins receive all ads (optionally filtered by the `role` query).
+ * - Instructors receive only the ads they created, also supporting the `role` filter.
  */
 exports.getAllAds = catchAsync(async (req, res) => {
   const roles = req.user.roles || [req.user.role];
   const normalized = roles.map((r) => String(r).toLowerCase());
-  const isAdmin = normalized.includes("admin") || normalized.includes("superadmin");
-  const ads = await service.getAds(true, isAdmin ? undefined : req.user.id);
+  const isAdmin =
+    normalized.includes("admin") || normalized.includes("superadmin");
+  const role = req.query.role?.toLowerCase();
+  const ads = await service.getAds(
+    true,
+    isAdmin ? undefined : req.user.id,
+    role
+  );
   sendSuccess(res, ads);
 });
 

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -82,8 +82,16 @@ describe('GET /api/ads/admin', () => {
     service.getAds.mockResolvedValue(mock);
     const res = await request(app).get('/api/ads/admin');
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(true, 'user1');
+    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', undefined);
     expect(res.body.data).toEqual(mock);
+  });
+
+  it('filters ads by target role', async () => {
+    const mock = [{ id: '1', created_by: 'user1' }];
+    service.getAds.mockResolvedValue(mock);
+    const res = await request(app).get('/api/ads/admin').query({ role: 'student' });
+    expect(res.status).toBe(200);
+    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', 'student');
   });
 });
 

--- a/docs/admin-ads-management.md
+++ b/docs/admin-ads-management.md
@@ -6,6 +6,8 @@ This page describes how advertisement banners are managed within the admin dashb
 
 - Routes and controllers live in `backend/src/modules/ads`.
 - Creating, updating or deleting an ad now sends a notification to the ad creator and to all admin users.
+- The `GET /api/ads/admin` endpoint accepts an optional `role` query to
+  filter ads targeted to `student` or `instructor` roles.
 
 ## Frontend
 


### PR DESCRIPTION
## Summary
- support optional role filter on admin ads endpoint
- document role filter in admin ads guide
- test ads admin endpoint filtering

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891767bc9ac8328bd7da5d3bc37fbc4