### PR TITLE
Add ad analytics tracking

### DIFF
--- a/backend/src/middleware/csrf.js
+++ b/backend/src/middleware/csrf.js
@@ -11,7 +11,8 @@ const csrf = (req, res, next) => {
   ];
 
   const unsafe = ['POST', 'PUT', 'PATCH', 'DELETE'];
-  if (!unsafe.includes(req.method) || exempt.includes(req.path)) {
+  const isAdTracking = /^\/api\/ads\/[^/]+\/(view|click)$/.test(req.path);
+  if (!unsafe.includes(req.method) || exempt.includes(req.path) || isAdTracking) {
     return next();
   }
 

--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -310,3 +310,20 @@ exports.getAdAnalytics = catchAsync(async (req, res) => {
   };
   sendSuccess(res, response);
 });
+
+/**
+ * Record a view for the given ad. Optionally accepts a userId to
+ * track unique viewers.
+ */
+exports.recordAdView = catchAsync(async (req, res) => {
+  await service.recordView(req.params.id, req.body.userId);
+  sendSuccess(res, null, "View recorded");
+});
+
+/**
+ * Record a click for the given ad.
+ */
+exports.recordAdClick = catchAsync(async (req, res) => {
+  await service.recordClick(req.params.id);
+  sendSuccess(res, null, "Click recorded");
+});

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -29,6 +29,8 @@ router.get(
 );
 router.get("/", controller.getAds);
 router.get("/:id/analytics", controller.getAdAnalytics);
+router.post("/:id/view", controller.recordAdView);
+router.post("/:id/click", controller.recordAdClick);
 router.get("/:id", controller.getAdById);
 router.put(
   "/:id",

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -47,3 +47,67 @@ exports.deleteAd = (id) => {
 exports.getAdAnalytics = async (adId) => {
   return db("ad_analytics").where({ ad_id: adId }).first();
 };
+
+// Increment view count and track unique viewers
+exports.recordView = async (adId, userId) => {
+  return db.transaction(async (trx) => {
+    // Check if this viewer is unique before inserting the view record
+    let isUnique = false;
+    if (userId) {
+      const existing = await trx("ad_views")
+        .where({ ad_id: adId, user_id: userId })
+        .first();
+      if (!existing) {
+        isUnique = true;
+      }
+    }
+
+    // Log the view event
+    await trx("ad_views").insert({ ad_id: adId, user_id: userId || null });
+
+    const analytics = await trx("ad_analytics").where({ ad_id: adId }).first();
+    if (analytics) {
+      const views = analytics.views + 1;
+      const clicks = analytics.clicks;
+      const updates = {
+        views,
+        ctr: views ? (clicks / views) * 100 : 0,
+      };
+      if (isUnique) {
+        updates.unique_viewers = analytics.unique_viewers + 1;
+      }
+      await trx("ad_analytics").where({ ad_id: adId }).update(updates);
+    } else {
+      await trx("ad_analytics").insert({
+        ad_id: adId,
+        views: 1,
+        clicks: 0,
+        ctr: 0,
+        unique_viewers: isUnique ? 1 : 0,
+      });
+    }
+  });
+};
+
+// Increment click count and recompute CTR
+exports.recordClick = async (adId) => {
+  return db.transaction(async (trx) => {
+    const analytics = await trx("ad_analytics").where({ ad_id: adId }).first();
+    if (analytics) {
+      const clicks = analytics.clicks + 1;
+      const ctr = analytics.views ? (clicks / analytics.views) * 100 : 0;
+      await trx("ad_analytics").where({ ad_id: adId }).update({
+        clicks,
+        ctr,
+      });
+    } else {
+      await trx("ad_analytics").insert({
+        ad_id: adId,
+        views: 0,
+        clicks: 1,
+        ctr: 0,
+        unique_viewers: 0,
+      });
+    }
+  });
+};

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -24,7 +24,7 @@ import SidebarMenu from "@/components/shared/SidebarMenu";
 import Chatbot from "@/components/shared/Chatbot";
 import useAppConfigStore from "@/store/appConfigStore";
 import { API_BASE_URL } from "@/config/config";
-import { getAds } from "@/services/adsService";
+import { getAds, recordAdView, recordAdClick } from "@/services/adsService";
 import { searchAll } from "@/services/searchService";
 import { useTranslation } from "next-i18next";
 import useAuthStore from "@/store/auth/authStore";
@@ -52,6 +52,7 @@ const Hero = () => {
   const configLoaded = useAppConfigStore((s) => s.loaded);
   const { t } = useTranslation("website");
   const userRole = useAuthStore((s) => s.user?.roles?.[0] || s.user?.role);
+  const userId = useAuthStore((s) => s.user?.id);
 
   const [heroBg, setHeroBg] = useState("");
 
@@ -98,6 +99,12 @@ const Hero = () => {
     };
     fetchAds();
   }, [userRole]);
+
+  useEffect(() => {
+    if (ads.length) {
+      recordAdView(ads[currentAd].id, userId);
+    }
+  }, [ads, currentAd, userId]);
 
   const AD_ROTATION_INTERVAL = 10000; // ms
   // Auto-rotate Ads Every 10 Seconds, pause when focused/hovered
@@ -468,6 +475,7 @@ const Hero = () => {
                 </p>
                 <a
                   href={ads[currentAd].link}
+                  onClick={() => recordAdClick(ads[currentAd].id, userId)}
                   className="inline-flex items-center gap-2 px-5 py-2.5 bg-yellow-500 text-black rounded-lg hover:bg-yellow-600 transition font-semibold shadow-md"
                 >
                   {t('learn_more')} <FaArrowRight />

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -41,3 +41,23 @@ export const getAds = async (role) => {
     return [];
   }
 };
+
+export const recordAdView = async (id, userId) => {
+  try {
+    await api.post(`/ads/${id}/view`, { userId });
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("Failed to record ad view", error);
+    }
+  }
+};
+
+export const recordAdClick = async (id, userId) => {
+  try {
+    await api.post(`/ads/${id}/click`, { userId });
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("Failed to record ad click", error);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add endpoints to record ad views and clicks with CSRF exemptions
- track analytics metrics and expose them to admin dashboard
- send view and click events from hero ads component

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689176e6b0f883289f9d41d55b095f42