### PR TITLE
Add Books link for superadmin in admin sidebar

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -14,6 +14,7 @@ import { studentNavLinks } from './SidebarLinks/studentLinks';
 
 const navMap = {
   admin: adminNavLinks,
+  superadmin: adminNavLinks,
   instructor: instructorNavLinks,
   student: studentNavLinks
 };


### PR DESCRIPTION
## Summary
- ensure superadmins use admin navigation so Books and other management links are visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689177b316748328a6eb38b3eeef8327