### PR TITLE
Track ad views and compute ad analytics

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -283,6 +283,16 @@ exports.deleteAd = catchAsync(async (req, res) => {
 });
 
 /**
+ * Record a view for the specified ad. Authentication is optional; if the
+ * request is unauthenticated the view will be stored without a user id.
+ */
+exports.recordAdView = catchAsync(async (req, res) => {
+  const userId = req.user?.id || null;
+  await service.recordAdView(req.params.id, userId);
+  sendSuccess(res, null, "View recorded");
+});
+
+/**
  * Return basic analytics for an ad.
  */
 exports.getAdAnalytics = catchAsync(async (req, res) => {

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -28,6 +28,7 @@ router.get(
   controller.getAllAds
 );
 router.get("/", controller.getAds);
+router.post("/:id/view", controller.recordAdView);
 router.get("/:id/analytics", controller.getAdAnalytics);
 router.get("/:id", controller.getAdById);
 router.put(

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -44,6 +44,39 @@ exports.deleteAd = (id) => {
   return db("ads").where({ id }).del();
 };
 
+// Record a single ad view. `userId` may be null for anonymous views.
+exports.recordAdView = async (adId, userId) => {
+  await db("ad_views").insert({ ad_id: adId, user_id: userId });
+};
+
+// Retrieve aggregated analytics for a given ad.
 exports.getAdAnalytics = async (adId) => {
-  return db("ad_analytics").where({ ad_id: adId }).first();
+  // Aggregate total views and unique viewers from ad_views table
+  const [agg] = await db("ad_views")
+    .where({ ad_id: adId })
+    .count("* as views")
+    .countDistinct("user_id as unique_viewers");
+
+  // Group views by day for line chart data
+  const daily = await db("ad_views")
+    .select(db.raw("DATE(viewed_at) as day"))
+    .count("* as views")
+    .where({ ad_id: adId })
+    .groupBy("day")
+    .orderBy("day", "asc");
+
+  // Optional stored analytics such as clicks/ctr
+  const row = await db("ad_analytics").where({ ad_id: adId }).first();
+  const clicks = row?.clicks ?? 0;
+  const ctr = row?.ctr ?? (agg.views ? clicks / agg.views : 0);
+
+  return {
+    views: Number(agg?.views) || 0,
+    clicks,
+    ctr: Number(ctr) || 0,
+    unique_viewers: Number(agg?.unique_viewers) || 0,
+    devices: [],
+    location_stats: [],
+    analytics: daily.map((d) => ({ day: d.day, views: Number(d.views) })),
+  };
 };

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -9,6 +9,7 @@ jest.mock('../src/modules/ads/ads.service', () => ({
   updateAd: jest.fn(),
   deleteAd: jest.fn(),
   getAdAnalytics: jest.fn(),
+  recordAdView: jest.fn(),
 }));
 
 jest.mock('../src/modules/notifications/notifications.service', () => ({
@@ -175,5 +176,14 @@ describe('GET /api/ads/:id/analytics', () => {
     expect(service.getAdAnalytics).toHaveBeenCalledWith('1');
     expect(res.body.data.views).toBe(5);
     expect(res.body.data.conversions).toBe(2);
+  });
+});
+
+describe('POST /api/ads/:id/view', () => {
+  it('records ad view', async () => {
+    service.recordAdView.mockResolvedValue();
+    const res = await request(app).post('/api/ads/1/view');
+    expect(res.status).toBe(200);
+    expect(service.recordAdView).toHaveBeenCalledWith('1', null);
   });
 });

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -24,7 +24,7 @@ import SidebarMenu from "@/components/shared/SidebarMenu";
 import Chatbot from "@/components/shared/Chatbot";
 import useAppConfigStore from "@/store/appConfigStore";
 import { API_BASE_URL } from "@/config/config";
-import { getAds } from "@/services/adsService";
+import { getAds, recordAdView } from "@/services/adsService";
 import { searchAll } from "@/services/searchService";
 import { useTranslation } from "next-i18next";
 import useAuthStore from "@/store/auth/authStore";
@@ -108,6 +108,13 @@ const Hero = () => {
     }, AD_ROTATION_INTERVAL);
     return () => clearInterval(interval);
   }, [ads, isAdPaused]);
+
+  // Record a view whenever the current ad changes
+  useEffect(() => {
+    if (ads[currentAd]) {
+      recordAdView(ads[currentAd].id);
+    }
+  }, [ads, currentAd]);
 
   // Auto search when user types with small debounce
   useEffect(() => {

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -41,3 +41,14 @@ export const getAds = async (role) => {
     return [];
   }
 };
+
+// Notify backend that an ad has been viewed
+export const recordAdView = async (id) => {
+  try {
+    await api.post(`/ads/${id}/view`);
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("Failed to record ad view", error);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- compute ad analytics from stored ad view events
- track ad views via new endpoint and frontend hook
- add tests for analytics and view logging

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891782ec3748328b0f0b2d11587a03f