### PR TITLE
Format ad analytics date range for readability

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -134,7 +134,7 @@ export default function AdAnalyticsPage({ ad: initialAd, error }) {
                 ))}
               </div>
             </div>
-            <div><strong>{t('duration')}:</strong> 📅 {ad.startAt} → {ad.endAt}</div>
+            <div><strong>{t('duration')}:</strong> 📅 {new Date(ad.startAt).toLocaleDateString()} → {new Date(ad.endAt).toLocaleDateString()}</div>
             <div><strong>{t('ad_type')}:</strong> 📌 <span className="bg-gray-100 px-2 py-0.5 rounded text-xs">{ad.adType}</span></div>
             <div>
               <strong>{t('status')}:</strong> ⚙️

--- a/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
@@ -58,7 +58,7 @@ export default function InstructorAdAnalyticsPage() {
           <div className="flex flex-col gap-4 text-sm text-gray-700">
             <div><strong>Description:</strong> {ad.description}</div>
             <div><strong>Audience:</strong> {ad.targetRoles.join(", ")}</div>
-            <div><strong>Duration:</strong> {ad.startAt} → {ad.endAt}</div>
+            <div><strong>Duration:</strong> {new Date(ad.startAt).toLocaleDateString()} → {new Date(ad.endAt).toLocaleDateString()}</div>
             <div><strong>Ad Type:</strong> {ad.adType}</div>
             <div><strong>Status:</strong> {ad.isActive ? "Active" : "Inactive"}</div>
           </div>


### PR DESCRIPTION
## Summary
- display ad analytics duration using localized date strings for easier reading

## Testing
- `npm test`
- `npm run lint` *(fails: import/no-anonymous-default-export and other warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68917d6fd4bc83288a8e98d61bf913a9