### PR TITLE
Fix book dashboard pages to pull data from backend

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -78,8 +78,8 @@ exports.createBook = catchAsync(async (req, res) => {
   sendSuccess(res, book, "Book submitted for review");
 });
 
-exports.listBooks = catchAsync(async (_req, res) => {
-  const books = await service.listBooks();
+exports.listBooks = catchAsync(async (req, res) => {
+  const books = await service.listBooks(req.query.status);
   sendSuccess(res, books);
 });
 

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -5,10 +5,11 @@ exports.createBook = async (data) => {
   return row;
 };
 
-exports.listBooks = () =>
-  db("books")
-    .where({ status: "approved" })
-    .orderBy("created_at", "desc");
+exports.listBooks = (status) => {
+  const query = db("books").orderBy("created_at", "desc");
+  if (status) query.where({ status });
+  return query;
+};
 
 exports.getBookById = (id) => db("books").where({ id }).first();
 

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -82,8 +82,8 @@ function AdminBooksPage() {
           >
             <option value="">All Statuses</option>
             <option value="pending">Pending</option>
-            <option value="draft">Draft</option>
-            <option value="published">Published</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
           </select>
         </div>
 

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -80,8 +80,8 @@ function InstructorBooksPage() {
           >
             <option value="">All Statuses</option>
             <option value="pending">Pending</option>
-            <option value="draft">Draft</option>
-            <option value="published">Published</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
           </select>
         </div>
 

--- a/frontend/src/services/bookCategoryService.js
+++ b/frontend/src/services/bookCategoryService.js
@@ -1,10 +1,8 @@
 import api from "@/services/api/api";
 
 export const fetchBookCategories = async () => {
-  const { data } = await api.get("/users/categories", {
-    params: { status: "active", limit: 1000 },
-  });
-  return data?.data?.data ?? [];
+  const { data } = await api.get("/book-categories");
+  return data?.data ?? [];
 };
 
 export default { fetchBookCategories };

--- a/frontend/src/tests/__tests__/bookCategoryService.test.js
+++ b/frontend/src/tests/__tests__/bookCategoryService.test.js
@@ -6,13 +6,11 @@ jest.mock("../../services/api/api", () => ({ get: jest.fn() }));
 describe("bookCategoryService", () => {
   it("fetches book categories", async () => {
     const mock = [{ id: 1, name: "Fiction" }];
-    api.get.mockResolvedValue({ data: { data: { data: mock } } });
+    api.get.mockResolvedValue({ data: { data: mock } });
 
     const categories = await fetchBookCategories();
 
-    expect(api.get).toHaveBeenCalledWith("/users/categories", {
-      params: { status: "active", limit: 1000 },
-    });
+    expect(api.get).toHaveBeenCalledWith("/book-categories");
     expect(categories).toEqual(mock);
   });
 });


### PR DESCRIPTION
## Summary
- allow book listing API to filter by status and return all books
- point book category service to `/book-categories`
- align admin and instructor book dashboards with backend status values

## Testing
- `cd backend && npm test` *(fails: POST /api/ads/:id/view -> expected 200, received 500)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891857a2a208328ac07498bd49acdc0