### PR TITLE
Display all ads to admin users in hero section

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -87,7 +87,12 @@ const Hero = () => {
     const fetchAds = async () => {
       setLoadingAds(true);
       try {
-        const data = await getAds(userRole?.toLowerCase());
+        const normalizedRole = userRole?.toLowerCase();
+        const roleParam =
+          normalizedRole === "admin" || normalizedRole === "superadmin"
+            ? undefined
+            : normalizedRole;
+        const data = await getAds(roleParam);
         setAds(data);
         setAdsError(false);
       } catch (_err) {


### PR DESCRIPTION
## Summary
- Show all advertisements in the Hero section when the logged-in user has an admin or superadmin role

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689195c5da248328bc5f577b217e7fac