### PR TITLE
Ensure hero background loads for all roles

### DIFF
--- a/frontend/src/services/appConfigService.js
+++ b/frontend/src/services/appConfigService.js
@@ -1,18 +1,12 @@
-import axios from "axios";
-import { API_BASE_URL } from "@/config/config";
+import api from "@/services/api/api";
 
 /**
  * Fetch global application configuration.
- *
- * This endpoint is public and should work for guests as well as
- * authenticated users.  We intentionally omit credentials so that
- * browsers don't enforce stricter CORS rules, which previously caused
- * the request to fail for unauthenticated visitors and hid the hero
- * background image.
  */
 export const getAppConfig = async () => {
-  const { data } = await axios.get(`${API_BASE_URL}/app-config`, {
-    withCredentials: false,
-  });
+  // Use the shared API instance so cookies (CSRF, session, etc.) are sent
+  // consistently for all users, ensuring the hero background loads for every
+  // role.
+  const { data } = await api.get("/app-config");
   return data?.data ?? data ?? {};
 };


### PR DESCRIPTION
## Summary
- use shared API client in `getAppConfig` so cookies are sent consistently
- prevents hero background from disappearing for non-admin roles

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: Assign object to a variable before exporting as module default; 287 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68919c91b6508328b478864871ae8121