### PR TITLE
Fix missing parenthesis in instructor ad edit page

### DIFF
--- a/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
@@ -256,7 +256,10 @@ export default function EditAdPage() {
             </div>
             {formData.startAt && formData.endAt && (
               <p className="text-sm text-gray-600 mt-3">
-                Duration: {Math.ceil((new Date(formData.endAt) - new Date(formData.startAt)) / (1000 * 60 * 60 * 24)} days
+                Duration: {Math.ceil(
+                  (new Date(formData.endAt) - new Date(formData.startAt)) /
+                    (1000 * 60 * 60 * 24)
+                )} days
                 (Max: {maxAdDuration} days)
               </p>
             )}


### PR DESCRIPTION
## Summary
- fix syntax error in instructor ad edit page duration calculation

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: 48 errors, 240 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6891a6e031848328bef23f81288282df