### PR TITLE
fix: complete translations for ad creation page

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -332,7 +332,17 @@
     "image_too_large": "يجب أن يكون حجم الصورة أقل من 5 ميغابايت.",
     "invalid_video_type": "يُسمح بملفات الفيديو فقط.",
     "video_too_large": "يجب أن يكون حجم الفيديو أقل من 50 ميغابايت.",
-    "preview_ad": "معاينة الإعلان"
+    "preview_ad": "معاينة الإعلان",
+    "back_to_ads": "العودة إلى الإعلانات",
+    "title_placeholder": "أدخل عنوان الإعلان",
+    "description_placeholder": "أدخل وصف الإعلان",
+    "remove_image": "إزالة الصورة",
+    "click_to_upload": "اضغط للرفع",
+    "image_requirements": "PNG, JPG, WEBP حتى 5MB",
+    "remove_video": "إزالة الفيديو",
+    "video_requirements": "MP4, WEBM حتى 50MB",
+    "target_audience_help": "اختر من سيشاهد هذا الإعلان",
+    "allow_branding_help": "عرض علامة المنظمة على هذا الإعلان"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -309,7 +309,17 @@
     "image_too_large": "Das Bild darf nicht größer als 5 MB sein.",
     "invalid_video_type": "Es sind nur Videodateien erlaubt.",
     "video_too_large": "Das Video darf nicht größer als 50 MB sein.",
-    "preview_ad": "Anzeige Vorschau"
+    "preview_ad": "Anzeige Vorschau",
+    "back_to_ads": "Zurück zu Anzeigen",
+    "title_placeholder": "Anzeigentitel eingeben",
+    "description_placeholder": "Anzeigenbeschreibung eingeben",
+    "remove_image": "Bild entfernen",
+    "click_to_upload": "Zum Hochladen klicken",
+    "image_requirements": "PNG, JPG, WEBP bis 5MB",
+    "remove_video": "Video entfernen",
+    "video_requirements": "MP4, WEBM bis 50MB",
+    "target_audience_help": "Wählen Sie aus, wer diese Anzeige sieht",
+    "allow_branding_help": "Marke der Organisation in dieser Anzeige anzeigen"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -345,7 +345,17 @@
     "image_too_large": "Image size must be under 5MB.",
     "invalid_video_type": "Only video files are allowed.",
     "video_too_large": "Video size must be under 50MB.",
-    "preview_ad": "Preview Ad"
+    "preview_ad": "Preview Ad",
+    "back_to_ads": "Back to Ads",
+    "title_placeholder": "Enter ad title",
+    "description_placeholder": "Enter ad description",
+    "remove_image": "Remove Image",
+    "click_to_upload": "Click to upload",
+    "image_requirements": "PNG, JPG, WEBP up to 5MB",
+    "remove_video": "Remove Video",
+    "video_requirements": "MP4, WEBM up to 50MB",
+    "target_audience_help": "Select who will see this advertisement",
+    "allow_branding_help": "Show organization branding on this ad"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -309,7 +309,17 @@
     "image_too_large": "La imagen debe ser menor de 5 MB.",
     "invalid_video_type": "Solo se permiten archivos de video.",
     "video_too_large": "El video debe ser menor de 50 MB.",
-    "preview_ad": "Vista previa del anuncio"
+    "preview_ad": "Vista previa del anuncio",
+    "back_to_ads": "Volver a anuncios",
+    "title_placeholder": "Ingrese el título del anuncio",
+    "description_placeholder": "Ingrese la descripción del anuncio",
+    "remove_image": "Eliminar imagen",
+    "click_to_upload": "Haz clic para subir",
+    "image_requirements": "PNG, JPG, WEBP hasta 5MB",
+    "remove_video": "Eliminar video",
+    "video_requirements": "MP4, WEBM hasta 50MB",
+    "target_audience_help": "Selecciona quién verá este anuncio",
+    "allow_branding_help": "Mostrar la marca de la organización en este anuncio"
   },
   "plansPage": {
     "title": "Subscription Plans",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -320,7 +320,17 @@
     "image_too_large": "La taille de l'image doit être inférieure à 5 Mo.",
     "invalid_video_type": "Seuls les fichiers vidéo sont autorisés.",
     "video_too_large": "La taille de la vidéo doit être inférieure à 50 Mo.",
-    "preview_ad": "Aperçu de l'annonce"
+    "preview_ad": "Aperçu de l'annonce",
+    "back_to_ads": "Retour aux annonces",
+    "title_placeholder": "Entrer le titre de l'annonce",
+    "description_placeholder": "Entrer la description de l'annonce",
+    "remove_image": "Supprimer l'image",
+    "click_to_upload": "Cliquez pour téléverser",
+    "image_requirements": "PNG, JPG, WEBP jusqu'à 5 Mo",
+    "remove_video": "Supprimer la vidéo",
+    "video_requirements": "MP4, WEBM jusqu'à 50 Mo",
+    "target_audience_help": "Sélectionnez qui verra cette annonce",
+    "allow_branding_help": "Afficher la marque de l'organisation sur cette annonce"
   },
   "plansPage": {
     "title": "Subscription Plans",


### PR DESCRIPTION
## Summary
- add missing translation keys for instructor ad creation across all locales
- ensure upload instructions and placeholders display properly

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891b48b24d08328a177e2974186dd5b