### PR TITLE
Fix instructor ads translations

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1159,6 +1159,21 @@
       "save": "Save SEO Settings"
     }
   },
+  "adsAnalyticsPage": {
+    "title_prefix": "تحليلات الإعلان",
+    "overview": "نظرة عامة على تحليلات حملتك الإعلانية",
+    "loading": "جارٍ تحميل تحليلات الإعلان...",
+    "error_loading": "فشل تحميل التحليلات",
+    "not_found": "الإعلان غير موجود",
+    "description": "الوصف",
+    "target_roles": "الجمهور",
+    "duration": "المدة",
+    "ad_type": "نوع الإعلان",
+    "status": "الحالة",
+    "performance_metrics": "مقاييس الأداء",
+    "views_over_time": "المشاهدات مع مرور الوقت",
+    "views_by_country": "المشاهدات حسب البلد"
+  },
   "adsEditPage": {
     "title": "تعديل الإعلان",
     "ad_details": "Ad Details",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -995,6 +995,21 @@
       "save": "Save SEO Settings"
     }
   },
+  "adsAnalyticsPage": {
+    "title_prefix": "Anzeigenanalyse",
+    "overview": "Analyseübersicht für Ihre Werbekampagne",
+    "loading": "Analysedaten werden geladen...",
+    "error_loading": "Analysen konnten nicht geladen werden",
+    "not_found": "Anzeige nicht gefunden",
+    "description": "Beschreibung",
+    "target_roles": "Zielgruppe",
+    "duration": "Dauer",
+    "ad_type": "Anzeigentyp",
+    "status": "Status",
+    "performance_metrics": "Leistungsmetriken",
+    "views_over_time": "Aufrufe im Zeitverlauf",
+    "views_by_country": "Aufrufe nach Land"
+  },
   "adsEditPage": {
     "title": "Anzeige bearbeiten",
     "ad_details": "Anzeigedetails",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1172,6 +1172,21 @@
       "save": "Save SEO Settings"
     }
   },
+  "adsAnalyticsPage": {
+    "title_prefix": "Ad Analytics",
+    "overview": "Analytics overview for your ad campaign",
+    "loading": "Loading ad analytics...",
+    "error_loading": "Failed to load analytics",
+    "not_found": "Ad not found",
+    "description": "Description",
+    "target_roles": "Audience",
+    "duration": "Duration",
+    "ad_type": "Ad Type",
+    "status": "Status",
+    "performance_metrics": "Performance Metrics",
+    "views_over_time": "Views Over Time",
+    "views_by_country": "Views by Country"
+  },
   "adsEditPage": {
     "title": "Edit Advertisement",
     "ad_details": "Ad Details",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -995,6 +995,21 @@
       "save": "Save SEO Settings"
     }
   },
+  "adsAnalyticsPage": {
+    "title_prefix": "Analítica de anuncios",
+    "overview": "Resumen analítico de tu campaña publicitaria",
+    "loading": "Cargando analíticas del anuncio...",
+    "error_loading": "Error al cargar las analíticas",
+    "not_found": "Anuncio no encontrado",
+    "description": "Descripción",
+    "target_roles": "Audiencia",
+    "duration": "Duración",
+    "ad_type": "Tipo de anuncio",
+    "status": "Estado",
+    "performance_metrics": "Métricas de rendimiento",
+    "views_over_time": "Vistas a lo largo del tiempo",
+    "views_by_country": "Vistas por país"
+  },
   "adsEditPage": {
     "title": "Editar anuncio",
     "ad_details": "Detalles del anuncio",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1147,6 +1147,21 @@
       "save": "Save SEO Settings"
     }
   },
+  "adsAnalyticsPage": {
+    "title_prefix": "Analytique des annonces",
+    "overview": "Aperçu des analyses de votre campagne publicitaire",
+    "loading": "Chargement des analyses de l'annonce...",
+    "error_loading": "Échec du chargement des analyses",
+    "not_found": "Annonce introuvable",
+    "description": "Description",
+    "target_roles": "Public cible",
+    "duration": "Durée",
+    "ad_type": "Type d'annonce",
+    "status": "Statut",
+    "performance_metrics": "Indicateurs de performance",
+    "views_over_time": "Vues au fil du temps",
+    "views_by_country": "Vues par pays"
+  },
   "adsEditPage": {
     "title": "Modifier l'annonce",
     "ad_details": "Détails de l'annonce",

--- a/frontend/src/components/admin/ads/PreviewModalinstrutor.js
+++ b/frontend/src/components/admin/ads/PreviewModalinstrutor.js
@@ -1,8 +1,10 @@
 // components/admin/PreviewModal.js
 import { FaChartBar } from 'react-icons/fa';
 import Link from 'next/link';
+import { useTranslation } from 'next-i18next';
 
 const PreviewModalinstrutor = ({ ad, onClose }) => {
+  const { t } = useTranslation('dashboard', { keyPrefix: 'adsPage' });
   if (!ad) return null;
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
@@ -14,19 +16,19 @@ const PreviewModalinstrutor = ({ ad, onClose }) => {
         <h2 className="text-xl font-bold mb-2">{ad.title}</h2>
         <p className="text-sm text-gray-700 mb-2">{ad.description}</p>
         <p className="text-xs text-gray-500 mb-1">
-          🎯 Target: {(ad.targetRoles || []).join(', ')}
+          🎯 {t('target_label')}: {(ad.targetRoles || []).join(', ')}
         </p>
         <p className="text-xs text-gray-500 mb-1">📅 {ad.startAt} → {ad.endAt}</p>
-        <p className="text-xs text-blue-500">👁️ {ad.views} views</p>
+        <p className="text-xs text-blue-500">👁️ {ad.views} {t('views')}</p>
         <p className="text-xs text-purple-500">📌 Type: {ad.adType}</p>
         <Link href={`/dashboard/instructor/ads/analytics/${ad.id}`}>
           <button className="mt-4 w-full bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded flex items-center justify-center gap-2 text-sm">
-            <FaChartBar /> View Analytics
+            <FaChartBar /> {t('view_analytics')}
           </button>
         </Link>
       </div>
     </div>
-  );  
+  );
 };
 
 export default PreviewModalinstrutor;

--- a/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
@@ -8,8 +8,13 @@ import {
   LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid,
   BarChart, Bar, ResponsiveContainer
 } from "recharts";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 export default function InstructorAdAnalyticsPage() {
+  const { t } = useTranslation("dashboard", { keyPrefix: "adsAnalyticsPage" });
+  const { t: tp } = useTranslation("dashboard", { keyPrefix: "adsPage" });
   const router = useRouter();
   const { id } = router.query;
   const [ad, setAd] = useState(null);
@@ -31,7 +36,7 @@ export default function InstructorAdAnalyticsPage() {
     return (
       <InstructorLayout>
         <div className="p-6 text-center text-sm text-muted-foreground">
-          Loading ad analytics...
+          {t('loading')}
         </div>
       </InstructorLayout>
     );
@@ -39,14 +44,14 @@ export default function InstructorAdAnalyticsPage() {
 
   return (
     <InstructorLayout>
-      <PageHead title={`Ad Analytics - ${ad.title}`} />
+      <PageHead title={`${t('title_prefix')} - ${ad.title}`} />
 
       <div className="p-4 sm:p-6 space-y-8 max-w-screen-xl mx-auto">
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">{ad.title}</h1>
             <p className="text-muted-foreground text-sm mt-1">
-              Analytics overview for your ad campaign
+              {t('overview')}
             </p>
           </div>
         </div>
@@ -56,16 +61,16 @@ export default function InstructorAdAnalyticsPage() {
             <img src={ad.image} alt={ad.title} className="w-full h-48 object-cover rounded-md border" />
           </div>
           <div className="flex flex-col gap-4 text-sm text-gray-700">
-            <div><strong>Description:</strong> {ad.description}</div>
-            <div><strong>Audience:</strong> {ad.targetRoles.join(", ")}</div>
-            <div><strong>Duration:</strong> {ad.startAt} → {ad.endAt}</div>
-            <div><strong>Ad Type:</strong> {ad.adType}</div>
-            <div><strong>Status:</strong> {ad.isActive ? "Active" : "Inactive"}</div>
+            <div><strong>{t('description')}:</strong> {ad.description}</div>
+            <div><strong>{t('target_roles')}:</strong> {ad.targetRoles.join(", ")}</div>
+            <div><strong>{t('duration')}:</strong> {ad.startAt} → {ad.endAt}</div>
+            <div><strong>{t('ad_type')}:</strong> {ad.adType}</div>
+            <div><strong>{t('status')}:</strong> {ad.isActive ? tp('active') : tp('inactive')}</div>
           </div>
         </div>
 
         <div className="bg-white rounded-lg shadow p-6 space-y-6">
-          <h2 className="text-xl font-semibold">📊 Performance Metrics</h2>
+          <h2 className="text-xl font-semibold">📊 {t('performance_metrics')}</h2>
           <div className="grid md:grid-cols-3 gap-4 text-sm text-gray-700">
             {["Views", "CTR", "Conversions", "Reach"].map((label) => (
               <div key={label} className="bg-gray-50 p-4 rounded border">
@@ -81,7 +86,7 @@ export default function InstructorAdAnalyticsPage() {
         </div>
 
         <div className="bg-white rounded-lg shadow p-6">
-          <h2 className="text-xl font-semibold mb-4">📈 Views Over Time</h2>
+          <h2 className="text-xl font-semibold mb-4">📈 {t('views_over_time')}</h2>
           <ResponsiveContainer width="100%" height={250}>
             <LineChart data={ad.analytics}>
               <CartesianGrid strokeDasharray="3 3" />
@@ -94,7 +99,7 @@ export default function InstructorAdAnalyticsPage() {
         </div>
 
         <div className="bg-white rounded-lg shadow p-6">
-          <h2 className="text-xl font-semibold mb-4">🌍 Views by Country</h2>
+          <h2 className="text-xl font-semibold mb-4">🌍 {t('views_by_country')}</h2>
           <ResponsiveContainer width="100%" height={250}>
             <BarChart data={ad.locationStats}>
               <CartesianGrid strokeDasharray="3 3" />
@@ -108,4 +113,16 @@ export default function InstructorAdAnalyticsPage() {
       </div>
     </InstructorLayout>
   );
+}
+
+export async function getStaticPaths() {
+  return { paths: [], fallback: true };
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }

--- a/frontend/src/pages/dashboard/instructor/ads/index.js
+++ b/frontend/src/pages/dashboard/instructor/ads/index.js
@@ -12,8 +12,12 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 
 export default function InstructorAdsPage() {
+  const { t } = useTranslation("dashboard", { keyPrefix: "adsPage" });
   const [ads, setAds] = useState([]);
   const [search, setSearch] = useState("");
   const [filterStatus, setFilterStatus] = useState("all");
@@ -58,14 +62,14 @@ export default function InstructorAdsPage() {
   };
 
   const handleDelete = async (ad) => {
-    if (confirm(`Delete "${ad.title}"?`)) {
+    if (confirm(t('confirm_delete', { title: ad.title }))) {
       try {
         await deleteAd(ad.id);
         setAds((prev) => prev.filter((a) => a.id !== ad.id));
-        toast.success("Ad deleted");
-        await notify("ad_deleted", `Ad "${ad.title}" deleted`);
+        toast.success(t('deleted'));
+        await notify('ad_deleted', `Ad "${ad.title}" deleted`);
       } catch {
-        toast.error("Failed to delete ad");
+        toast.error(t('delete_failed'));
       }
     }
   };
@@ -103,10 +107,10 @@ export default function InstructorAdsPage() {
     <InstructorLayout>
       <div className="p-6">
         <header className="flex justify-between items-center mb-6 flex-wrap gap-4">
-          <h1 className="text-3xl font-bold">📢 My Ads</h1>
+          <h1 className="text-3xl font-bold">📢 {t("title")}</h1>
           <Link href="/dashboard/instructor/ads/create">
             <button className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 flex items-center gap-2">
-              <FaPlus /> New Ad
+              <FaPlus /> {t("new_ad")}
             </button>
           </Link>
         </header>
@@ -114,7 +118,7 @@ export default function InstructorAdsPage() {
         <section className="flex flex-wrap gap-4 mb-6">
           <input
             type="search"
-            placeholder="Search ads..."
+            placeholder={t("search_placeholder")}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="px-4 py-2 border rounded w-full md:w-1/3"
@@ -124,24 +128,24 @@ export default function InstructorAdsPage() {
             onChange={(e) => setFilterType(e.target.value)}
             className="px-4 py-2 border rounded"
           >
-            <option value="all">All Types</option>
-            <option value="promotion">Promotion</option>
-            <option value="event">Event</option>
-            <option value="announcement">Announcement</option>
+            <option value="all">{t("all_types")}</option>
+            <option value="promotion">{t("promotion")}</option>
+            <option value="event">{t("event")}</option>
+            <option value="announcement">{t("announcement")}</option>
           </select>
           <select
             value={filterStatus}
             onChange={(e) => setFilterStatus(e.target.value)}
             className="px-4 py-2 border rounded"
           >
-            <option value="all">All Status</option>
-            <option value="active">Active</option>
-            <option value="inactive">Inactive</option>
+            <option value="all">{t("all_status")}</option>
+            <option value="active">{t("active")}</option>
+            <option value="inactive">{t("inactive")}</option>
           </select>
         </section>
 
         {paginatedAds.length === 0 ? (
-          <p className="text-gray-500 text-center mt-10">No ads found.</p>
+          <p className="text-gray-500 text-center mt-10">{t("no_ads")}</p>
         ) : (
           <>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -180,5 +184,13 @@ export default function InstructorAdsPage() {
       <PreviewModal ad={previewAd} onClose={() => setPreviewAd(null)} />
     </InstructorLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }
 


### PR DESCRIPTION
## Summary
- use localized strings and server-side translations on instructor ad pages
- add translations to ad preview modal
- include analytics translation keys for all locales

## Testing
- `npm test`
- `npm run lint` *(fails: Assign object to a variable before exporting as module default, 288 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6891b49778e4832889d72b2f75e6886f