### PR TITLE
Allow admins to create books and fix admin book create page

### DIFF
--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -1,12 +1,15 @@
 const router = require("express").Router();
 const controller = require("./book.controller");
 const tagController = require("./bookTag.controller");
-const { verifyToken, isInstructor } = require("../../middleware/auth/authMiddleware");
+const {
+  verifyToken,
+  isInstructorOrAdmin,
+} = require("../../middleware/auth/authMiddleware");
 
-router.get("/tags", verifyToken, isInstructor, tagController.listTags);
-router.post("/tags", verifyToken, isInstructor, tagController.createTag);
+router.get("/tags", verifyToken, isInstructorOrAdmin, tagController.listTags);
+router.post("/tags", verifyToken, isInstructorOrAdmin, tagController.createTag);
 router.get("/", controller.listBooks);
 router.get("/:id", controller.getBook);
-router.post("/", verifyToken, isInstructor, controller.createBook);
+router.post("/", verifyToken, isInstructorOrAdmin, controller.createBook);
 
 module.exports = router;

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -31,7 +31,7 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
     req.user = { id: '1' };
     next();
   },
-  isInstructor: (_req, _res, next) => next(),
+  isInstructorOrAdmin: (_req, _res, next) => next(),
 }));
 
 const service = require('../src/modules/books/book.service');

--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -11,7 +11,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
-import { FiArrowLeft, FiUpload, FiX } from "react-icons/fi";
+import { FiArrowLeft, FiX } from "react-icons/fi";
 import Head from "next/head";
 
 function AdminCreateBookPage() {


### PR DESCRIPTION
## Summary
- Allow admins to create books and tags by using `isInstructorOrAdmin` middleware on book routes
- Remove unused icon import on admin book create page and ensure categories load from book categories API

## Testing
- `cd backend && npm test` (fails: POST /api/ads/:id/view received 500)
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891c14a720c83289da03b05bae1a0e0