### PR TITLE
Use main categories for book creation and add preview support

### DIFF
--- a/backend/src/migrations/20250729020000_add_preview_fields_to_books_table.js
+++ b/backend/src/migrations/20250729020000_add_preview_fields_to_books_table.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'books';
+
+exports.up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.boolean('allow_preview').notNullable().defaultTo(false);
+    table.jsonb('preview_pages');
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn('allow_preview');
+    table.dropColumn('preview_pages');
+  });
+};

--- a/backend/src/migrations/20250729030000_alter_books_category_to_main_categories.js
+++ b/backend/src/migrations/20250729030000_alter_books_category_to_main_categories.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'books';
+
+exports.up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn('category_id');
+  });
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table
+      .uuid('category_id')
+      .references('id')
+      .inTable('categories')
+      .onDelete('SET NULL');
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn('category_id');
+  });
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table
+      .uuid('category_id')
+      .references('id')
+      .inTable('book_categories')
+      .onDelete('SET NULL');
+  });
+};

--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -20,9 +20,17 @@ exports.createBook = catchAsync(async (req, res) => {
     category_id: body.category_id,
     instructor_id: req.user.id,
     status: "pending",
+    allow_preview:
+      body.allow_preview === "1" ||
+      body.allow_preview === 1 ||
+      body.allow_preview === true ||
+      body.allow_preview === "true",
   };
   if (req.files?.cover_image?.[0]) data.cover_image_url = req.files.cover_image[0].path;
   if (req.files?.book_file?.[0]) data.pdf_url = req.files.book_file[0].path;
+  if (req.files?.preview_pages?.length) {
+    data.preview_pages = req.files.preview_pages.map((f) => f.path);
+  }
 
   const book = await service.createBook(data);
 

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -1,6 +1,7 @@
 const router = require("express").Router();
 const controller = require("./book.controller");
 const tagController = require("./bookTag.controller");
+const upload = require("./bookUploadMiddleware");
 const {
   verifyToken,
   isInstructorOrAdmin,
@@ -10,6 +11,6 @@ router.get("/tags", verifyToken, isInstructorOrAdmin, tagController.listTags);
 router.post("/tags", verifyToken, isInstructorOrAdmin, tagController.createTag);
 router.get("/", controller.listBooks);
 router.get("/:id", controller.getBook);
-router.post("/", verifyToken, isInstructorOrAdmin, controller.createBook);
+router.post("/", verifyToken, isInstructorOrAdmin, upload, controller.createBook);
 
 module.exports = router;

--- a/backend/src/modules/books/bookUploadMiddleware.js
+++ b/backend/src/modules/books/bookUploadMiddleware.js
@@ -1,0 +1,34 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const uploadDir = path.join(__dirname, '../../../uploads/books');
+if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    const base = path.basename(file.originalname, ext).replace(/\s+/g, '-');
+    cb(null, `${Date.now()}-${base}${ext}`);
+  },
+});
+
+const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
+const fileFilter = (_req, file, cb) => {
+  if (allowedTypes.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(new Error('Invalid file type'), false);
+  }
+};
+
+module.exports = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: 50 * 1024 * 1024 },
+}).fields([
+  { name: 'cover_image', maxCount: 1 },
+  { name: 'book_file', maxCount: 1 },
+  { name: 'preview_pages', maxCount: 10 },
+]);

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1039,6 +1039,7 @@
     "bookFileLabel": "ملف الكتاب (PDF)",
     "bookFileRequired": "ملف الكتاب مطلوب",
     "previewPagesLabel": "صفحات معاينة (اختياري)",
+    "allowPreview": "Allow Preview",
     "isFree": "مجاني",
     "priceLabel": "السعر",
     "priceRequired": "السعر مطلوب",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1052,6 +1052,7 @@
     "bookFileLabel": "Book File (PDF)",
     "bookFileRequired": "Book file is required",
     "previewPagesLabel": "Preview Pages (optional)",
+    "allowPreview": "Allow Preview",
     "isFree": "Free",
     "priceLabel": "Price",
     "priceRequired": "Price is required",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1027,6 +1027,7 @@
     "bookFileLabel": "Fichier du livre (PDF)",
     "bookFileRequired": "Le fichier du livre est obligatoire",
     "previewPagesLabel": "Pages d'aperçu (optionnel)",
+    "allowPreview": "Allow Preview",
     "isFree": "Gratuit",
     "priceLabel": "Prix",
     "priceRequired": "Le prix est obligatoire",

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -4,7 +4,7 @@ import { useTranslation } from "next-i18next";
 import { fetchBookTags, createBookTag } from "@/services/bookTagService";
 import { getLanguages } from "@/services/languageService";
 
-export default function BookForm({ onSubmit, categories = [] }) {
+export default function BookForm({ onSubmit, categories = [], showCoverImage = true }) {
   const { t } = useTranslation("dashboard");
   const {
     register,
@@ -12,7 +12,7 @@ export default function BookForm({ onSubmit, categories = [] }) {
     watch,
     formState: { errors },
     setValue,
-  } = useForm({ defaultValues: { tags: [], status: "pending", is_free: false } });
+  } = useForm({ defaultValues: { tags: [], status: "pending", is_free: false, allow_preview: false} });
   const [languages, setLanguages] = useState([]);
   const [tags, setTags] = useState([]);
   const [tagInput, setTagInput] = useState("");
@@ -96,6 +96,7 @@ export default function BookForm({ onSubmit, categories = [] }) {
     formData.append("language", data.language);
     formData.append("license_type", data.license_type);
     formData.append("is_free", isFree ? 1 : 0);
+    formData.append("allow_preview", data.allow_preview ? 1 : 0);
     formData.append("status", "pending");
     setUploadProgress(0);
     onSubmit(formData, setUploadProgress);
@@ -240,6 +241,7 @@ export default function BookForm({ onSubmit, categories = [] }) {
         )}
       </div>
 
+        {showCoverImage && (
       <div>
         <label className="block text-sm font-medium mb-1">
           {t("booksCreate.coverImageLabel")}
@@ -283,6 +285,7 @@ export default function BookForm({ onSubmit, categories = [] }) {
           </p>
         )}
       </div>
+        )}
 
       <div>
         <label className="block text-sm font-medium mb-1">
@@ -351,6 +354,22 @@ export default function BookForm({ onSubmit, categories = [] }) {
           </ul>
         )}
       </div>
+        <div className="flex items-center gap-2">
+          {(() => {
+            const reg = register("allow_preview");
+            return (
+              <input
+                type="checkbox"
+                {...reg}
+                className="h-4 w-4 text-yellow-500 border-gray-300 rounded"
+              />
+            );
+          })()}
+          <label className="text-sm font-medium">
+            {t("booksCreate.allowPreview")}
+          </label>
+        </div>
+
 
       <div className="flex items-center gap-2">
         {(() => {

--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -6,7 +6,7 @@ import api from "@/services/api/api";
 import BookForm from "@/components/books/BookForm";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
-import { fetchBookCategories } from "@/services/bookCategoryService";
+import { fetchAllCategories } from "@/services/admin/categoryService";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import useNotificationStore from "@/store/notifications/notificationStore";
@@ -31,8 +31,8 @@ function AdminCreateBookPage() {
     const loadCategories = async () => {
       try {
         setIsLoading(true);
-        const data = await fetchBookCategories();
-        setCategories(data);
+        const result = await fetchAllCategories();
+        setCategories(result?.data || result || []);
       } catch (err) {
         console.error("Failed to load categories", err);
         setError(t("errors.categoryLoad"));
@@ -78,6 +78,10 @@ function AdminCreateBookPage() {
   }, []);
 
   const handleSubmit = async (formData, setProgress) => {
+    const fileInput = document.getElementById("coverImage");
+    if (fileInput?.files?.[0]) {
+      formData.append("cover_image", fileInput.files[0]);
+    }
     try {
       setProgress(0);
       await api.post("/books", formData, {
@@ -223,6 +227,7 @@ function AdminCreateBookPage() {
               <BookForm
                 onSubmit={handleSubmit}
                 categories={categories}
+                showCoverImage={false}
                 submitText={t("booksCreate.submitButton")}
                 cancelText={t("common.cancel")}
                 onCancel={handleCancel}

--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -6,7 +6,7 @@ import api from "@/services/api/api";
 import BookForm from "@/components/books/BookForm";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
-import { fetchBookCategories } from "@/services/bookCategoryService";
+import { fetchAllCategories } from "@/services/instructor/categoryService";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import useNotificationStore from "@/store/notifications/notificationStore";
@@ -20,8 +20,8 @@ function CreateBookPage() {
   const fetchMessages = useMessageStore((state) => state.fetch);
 
   useEffect(() => {
-    fetchBookCategories()
-      .then(setCategories)
+    fetchAllCategories()
+      .then((res) => setCategories(res?.data || res || []))
       .catch((e) => console.error("Failed to load categories", e));
   }, []);
 


### PR DESCRIPTION
## Summary
- Switch book creation to use platform categories and remove redundant cover image field
- Allow uploading preview pages and saving preview preference
- Add migrations and middleware for preview file handling

## Testing
- `npm test` (backend) *(fails: tests/adsRoutes.test.js)*
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_6891cb2745fc8328b70c61efde65773a