### PR TITLE
Add book metadata columns and fix ad view handler

### DIFF
--- a/backend/src/migrations/20250806120000_add_metadata_fields_to_books_table.js
+++ b/backend/src/migrations/20250806120000_add_metadata_fields_to_books_table.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'books';
+
+exports.up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.renameColumn('description', 'detailed_description');
+    table.text('short_description');
+    table.string('language');
+    table.string('license_type');
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.renameColumn('detailed_description', 'description');
+    table.dropColumn('short_description');
+    table.dropColumn('language');
+    table.dropColumn('license_type');
+  });
+};

--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -328,15 +328,6 @@ exports.getAdAnalytics = catchAsync(async (req, res) => {
 });
 
 /**
- * Record a view for the given ad. Optionally accepts a userId to
- * track unique viewers.
- */
-exports.recordAdView = catchAsync(async (req, res) => {
-  await service.recordView(req.params.id, req.body.userId);
-  sendSuccess(res, null, "View recorded");
-});
-
-/**
  * Record a click for the given ad.
  */
 exports.recordAdClick = catchAsync(async (req, res) => {

--- a/backend/src/modules/search/search.service.js
+++ b/backend/src/modules/search/search.service.js
@@ -24,7 +24,9 @@ exports.searchBooks = async (q) => {
   return db("books")
     .where({ status: "approved" })
     .andWhere(function () {
-      this.whereRaw("title ILIKE ?", [term]).orWhereRaw("description ILIKE ?", [term]);
+      this.whereRaw("title ILIKE ?", [term])
+        .orWhereRaw("short_description ILIKE ?", [term])
+        .orWhereRaw("detailed_description ILIKE ?", [term]);
     })
     .select("id", "title", "cover_image_url as cover")
     .limit(5);

--- a/docs/book-workflow.md
+++ b/docs/book-workflow.md
@@ -7,10 +7,16 @@ Allow instructors to upload and sell PDF books, and allow students to browse, pu
 ### books
 - `id`
 - `title`
-- `description`
+- `short_description`
+- `detailed_description`
 - `price` (decimal)
 - `pdf_url`
 - `cover_image_url`
+- `category_id` (FK → categories)
+- `language`
+- `license_type`
+- `allow_preview`
+- `preview_pages`
 - `instructor_id` (FK → users)
 - `status` (pending, approved, rejected)
 - `created_at`


### PR DESCRIPTION
## Summary
- add migration to rename `description` to `detailed_description` and introduce `short_description`, `language`, and `license_type`
- extend book search to query new description fields
- document updated book schema and remove duplicate ad view controller

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891dfcb6f108328b06b593ce2e6e8b8