### PR TITLE
Create book_tag_map table migration

### DIFF
--- a/backend/src/migrations/20250807120000_create_book_tag_map_table.js
+++ b/backend/src/migrations/20250807120000_create_book_tag_map_table.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('book_tag_map', function(table) {
+    table.integer('book_id').notNullable().references('id').inTable('books').onDelete('CASCADE');
+    table.uuid('tag_id').notNullable().references('id').inTable('tags').onDelete('CASCADE');
+    table.primary(['book_id', 'tag_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('book_tag_map');
+};


### PR DESCRIPTION
## Summary
- add migration to create book_tag_map join table for books and tags

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891fb515d8c83288517d1d94aa2647e