### PR TITLE
Add eBook reader link to admin books list

### DIFF
--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -6,6 +6,7 @@ export default function BookCard({
   onSelect,
   onDelete,
   onEditLink,
+  showReadLink = false,
 }) {
   return (
     <div className="border rounded p-4 relative">
@@ -33,6 +34,16 @@ export default function BookCard({
         >
           View
         </Link>
+        {showReadLink && book.pdf_url && (
+          <a
+            href={book.pdf_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Read
+          </a>
+        )}
         {onEditLink && (
           <Link href={onEditLink} className="text-green-600 underline">
             Edit

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -210,6 +210,7 @@ function AdminBooksPage() {
                     }
                   }}
                   onEditLink={`/dashboard/admin/books/edit/${book.id}`}
+                  showReadLink
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- allow BookCard to optionally display a "Read" link pointing to the PDF
- enable read link on admin books page for quick eBook access

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 242 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893380ff2508328af25dd69a0fcdf7f