### PR TITLE
feat: add reusable confirmation modal for book deletions

### DIFF
--- a/frontend/src/components/common/ConfirmModal.js
+++ b/frontend/src/components/common/ConfirmModal.js
@@ -1,33 +1,48 @@
 // src/components/common/ConfirmModal.js
 
 import React from "react";
+import { useTranslation } from "next-i18next";
+import { Button } from "@/components/ui/button";
 
-export default function ConfirmModal({ isOpen, onClose, onConfirm, message }) {
+export default function ConfirmModal({
+  isOpen,
+  title,
+  message,
+  onClose,
+  onConfirm,
+  confirmText,
+  cancelText,
+}) {
+  const { t } = useTranslation();
+
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg p-6 w-full max-w-md shadow-lg">
-        <h2 className="text-xl font-semibold mb-4 text-gray-800">Are you sure?</h2>
+        <h2 className="text-xl font-semibold mb-4 text-gray-800">
+          {title || t("Confirm Deletion")}
+        </h2>
         <p className="text-gray-600 mb-6">{message}</p>
         <div className="flex justify-end gap-4">
-          <button
+          <Button
             onClick={onClose}
-            className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 text-black transition"
+            className="bg-gray-300 text-black hover:bg-gray-400"
           >
-            Cancel
-          </button>
-          <button
+            {cancelText || t("Cancel")}
+          </Button>
+          <Button
             onClick={() => {
-              onConfirm();
+              onConfirm?.();
               onClose();
             }}
-            className="px-4 py-2 rounded bg-red-500 hover:bg-red-600 text-white transition"
+            className="bg-red-500 text-white hover:bg-red-600"
           >
-            Confirm
-          </button>
+            {confirmText || t("Confirm")}
+          </Button>
         </div>
       </div>
     </div>
   );
 }
+

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -10,6 +10,7 @@ import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import toast from "react-hot-toast";
 import { useTranslation } from "next-i18next";
 import { FiPlus, FiSearch, FiTrash2, FiChevronLeft, FiChevronRight } from "react-icons/fi";
+import ConfirmModal from "@/components/common/ConfirmModal";
 
 function AdminBooksPage() {
   const { t } = useTranslation("dashboard");
@@ -22,6 +23,20 @@ function AdminBooksPage() {
   const [sortBy, setSortBy] = useState("newest");
   const [page, setPage] = useState(1);
   const perPage = 9;
+  const [confirmModal, setConfirmModal] = useState({
+    isOpen: false,
+    title: "",
+    message: "",
+    onConfirm: null,
+  });
+
+  const openConfirmModal = ({ title, message, onConfirm }) => {
+    setConfirmModal({ isOpen: true, title, message, onConfirm });
+  };
+
+  const closeConfirmModal = () => {
+    setConfirmModal((prev) => ({ ...prev, isOpen: false }));
+  };
 
   useEffect(() => {
     const load = async () => {
@@ -82,18 +97,24 @@ function AdminBooksPage() {
     );
   };
 
-  const handleBulkDelete = async () => {
-    if (!confirm(t("Are you sure you want to delete selected books?"))) return;
-
-    try {
-      const deletePromises = selectedBooks.map(id => deleteBook(id));
-      await Promise.all(deletePromises);
-      setBooks((prev) => prev.filter((b) => !selectedBooks.includes(b.id)));
-      setSelectedBooks([]);
-      toast.success(t("Books deleted successfully"));
-    } catch (err) {
-      toast.error(t("Failed to delete some books"));
-    }
+  const handleBulkDelete = () => {
+    openConfirmModal({
+      title: t("Confirm Deletion"),
+      message: t("Are you sure you want to delete selected books?"),
+      onConfirm: async () => {
+        try {
+          const deletePromises = selectedBooks.map((id) => deleteBook(id));
+          await Promise.all(deletePromises);
+          setBooks((prev) =>
+            prev.filter((b) => !selectedBooks.includes(b.id))
+          );
+          setSelectedBooks([]);
+          toast.success(t("Books deleted successfully"));
+        } catch (err) {
+          toast.error(t("Failed to delete some books"));
+        }
+      },
+    });
   };
 
   return (
@@ -199,16 +220,25 @@ function AdminBooksPage() {
                   book={book}
                   isSelected={selectedBooks.includes(book.id)}
                   onSelect={() => handleSelectBook(book.id)}
-                  onDelete={async () => {
-                    if (!confirm(t("Are you sure?"))) return;
-                    try {
-                      await deleteBook(book.id);
-                      setBooks((prev) => prev.filter((b) => b.id !== book.id));
-                      toast.success(t("Book deleted"));
-                    } catch {
-                      toast.error(t("Failed to delete"));
-                    }
-                  }}
+                  onDelete={() =>
+                    openConfirmModal({
+                      title: t("Confirm Deletion"),
+                      message: t(
+                        "Are you sure you want to delete this book?"
+                      ),
+                      onConfirm: async () => {
+                        try {
+                          await deleteBook(book.id);
+                          setBooks((prev) =>
+                            prev.filter((b) => b.id !== book.id)
+                          );
+                          toast.success(t("Book deleted"));
+                        } catch {
+                          toast.error(t("Failed to delete"));
+                        }
+                      },
+                    })
+                  }
                   onEditLink={`/dashboard/admin/books/edit/${book.id}`}
                   showReadLink
                 />
@@ -268,6 +298,13 @@ function AdminBooksPage() {
           </>
         )}
       </section>
+      <ConfirmModal
+        isOpen={confirmModal.isOpen}
+        title={confirmModal.title}
+        message={confirmModal.message}
+        onClose={closeConfirmModal}
+        onConfirm={confirmModal.onConfirm}
+      />
     </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable ConfirmModal component with translation support
- replace native confirms with modal for single and bulk book deletions

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 242 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689356000b0883288cc4508b2306f2bd