### PR TITLE
feat: support paginated book queries and admin pagination

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import BookCard from "@/components/books/BookCard";
@@ -21,16 +21,33 @@ function AdminBooksPage() {
   const [selectedBooks, setSelectedBooks] = useState([]);
   const [sortBy, setSortBy] = useState("newest");
   const [page, setPage] = useState(1);
+  const [meta, setMeta] = useState({ totalPages: 1, total: 0 });
   const perPage = 9;
 
   useEffect(() => {
-    const load = async () => {
+    const loadCategories = async () => {
       try {
-        setLoading(true);
-        const data = await fetchBooks();
-        setBooks(data);
         const cats = await fetchBookCategories();
         setCategories(cats);
+      } catch (err) {
+        toast.error(t("Failed to load data"));
+      }
+    };
+    loadCategories();
+  }, [t]);
+
+  useEffect(() => {
+    const loadBooks = async () => {
+      try {
+        setLoading(true);
+        const { books: list, meta } = await fetchBooks({
+          page,
+          perPage,
+          filters,
+          sort: { sortBy },
+        });
+        setBooks(list);
+        setMeta(meta);
       } catch (err) {
         toast.error(t("Failed to load data"));
         console.error("Error loading:", err);
@@ -38,43 +55,10 @@ function AdminBooksPage() {
         setLoading(false);
       }
     };
-    load();
-  }, []);
+    loadBooks();
+  }, [page, filters, sortBy, perPage, t]);
 
-  const filteredBooks = useMemo(() => {
-    let result = books;
-
-    if (filters.search) {
-      result = result.filter((b) =>
-        b.title.toLowerCase().includes(filters.search.toLowerCase())
-      );
-    }
-
-    if (filters.category) {
-      result = result.filter((b) => b.category_id === Number(filters.category));
-    }
-
-    if (filters.status) {
-      result = result.filter((b) => b.status === filters.status);
-    }
-
-    if (sortBy === "title") {
-      result = [...result].sort((a, b) => a.title.localeCompare(b.title));
-    } else if (sortBy === "oldest") {
-      result = [...result].sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
-    } else {
-      result = [...result].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-    }
-
-    return result;
-  }, [books, filters, sortBy]);
-
-  const paginatedBooks = useMemo(() => {
-    const start = (page - 1) * perPage;
-    return filteredBooks.slice(start, start + perPage);
-  }, [filteredBooks, page]);
-
-  const totalPages = Math.ceil(filteredBooks.length / perPage);
+  const totalPages = meta?.totalPages ?? 1;
 
   const handleSelectBook = (id) => {
     setSelectedBooks((prev) =>
@@ -89,6 +73,7 @@ function AdminBooksPage() {
       const deletePromises = selectedBooks.map(id => deleteBook(id));
       await Promise.all(deletePromises);
       setBooks((prev) => prev.filter((b) => !selectedBooks.includes(b.id)));
+      setMeta((m) => ({ ...m, total: (m.total ?? 0) - selectedBooks.length }));
       setSelectedBooks([]);
       toast.success(t("Books deleted successfully"));
     } catch (err) {
@@ -103,7 +88,7 @@ function AdminBooksPage() {
           <div>
             <h1 className="text-2xl md:text-3xl font-bold text-gray-800">{t("Books")}</h1>
             <p className="text-gray-500 text-sm mt-1">
-              {t("Showing")} {paginatedBooks.length} {t("of")} {filteredBooks.length} {t("books")}
+              {t("Showing")} {books.length} {t("of")} {meta.total ?? books.length} {t("books")}
             </p>
           </div>
           <Link
@@ -123,14 +108,20 @@ function AdminBooksPage() {
               type="text"
               placeholder={t("Search by title")}
               value={filters.search}
-              onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+              onChange={(e) => {
+                setFilters({ ...filters, search: e.target.value });
+                setPage(1);
+              }}
               className="border border-gray-300 rounded-lg p-2 pl-10 w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition"
             />
           </div>
           
           <select
             value={filters.category}
-            onChange={(e) => setFilters({ ...filters, category: e.target.value })}
+            onChange={(e) => {
+              setFilters({ ...filters, category: e.target.value });
+              setPage(1);
+            }}
             className="border border-gray-300 rounded-lg p-2 w-full sm:w-40 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition"
           >
             <option value="">{t("All Categories")}</option>
@@ -143,7 +134,10 @@ function AdminBooksPage() {
           
           <select
             value={filters.status}
-            onChange={(e) => setFilters({ ...filters, status: e.target.value })}
+            onChange={(e) => {
+              setFilters({ ...filters, status: e.target.value });
+              setPage(1);
+            }}
             className="border border-gray-300 rounded-lg p-2 w-full sm:w-40 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition"
           >
             <option value="">{t("All Statuses")}</option>
@@ -154,7 +148,10 @@ function AdminBooksPage() {
           
           <select
             value={sortBy}
-            onChange={(e) => setSortBy(e.target.value)}
+            onChange={(e) => {
+              setSortBy(e.target.value);
+              setPage(1);
+            }}
             className="border border-gray-300 rounded-lg p-2 w-full sm:w-40 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition"
           >
             <option value="newest">{t("Newest First")}</option>
@@ -178,7 +175,7 @@ function AdminBooksPage() {
           <div className="flex justify-center items-center h-64">
             <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
           </div>
-        ) : filteredBooks.length === 0 ? (
+        ) : books.length === 0 ? (
           <div className="text-center py-12">
             <div className="mx-auto w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mb-4">
               <FiSearch className="text-3xl text-gray-400" />
@@ -193,7 +190,7 @@ function AdminBooksPage() {
         ) : (
           <>
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-              {paginatedBooks.map((book) => (
+              {books.map((book) => (
                 <BookCard
                   key={book.id}
                   book={book}

--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -9,7 +9,7 @@ export default function StudentBooksPage() {
   useEffect(() => {
     const load = async () => {
       try {
-        const data = await fetchBooks();
+        const { books: data } = await fetchBooks();
         setBooks(data);
       } catch (e) {
         console.error("Failed to load books", e);

--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -42,7 +42,7 @@ const BooksPage = () => {
   useEffect(() => {
     const loadBooks = async () => {
       try {
-        const data = await fetchBooks();
+        const { books: data } = await fetchBooks();
         setBooks(data);
       } catch (err) {
         console.error(err);

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -1,8 +1,22 @@
 import api from "@/services/api/api";
 
-export const fetchBooks = async () => {
-  const { data } = await api.get("/books");
-  return data?.data ?? [];
+export const fetchBooks = async ({
+  page,
+  perPage,
+  filters = {},
+  sort = {},
+} = {}) => {
+  const params = {
+    ...(page !== undefined && { page }),
+    ...(perPage !== undefined && { perPage }),
+    ...filters,
+    ...sort,
+  };
+  const { data } = await api.get("/books", { params });
+  return {
+    books: data?.data ?? [],
+    meta: data?.meta ?? {},
+  };
 };
 
 export const fetchBook = async (id) => {

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -6,10 +6,18 @@ jest.mock("../../services/api/api", () => ({ get: jest.fn() }));
 describe("bookService", () => {
   it("fetches books", async () => {
     const mock = [{ id: 1, title: "A" }];
-    api.get.mockResolvedValueOnce({ data: { data: mock } });
-    const books = await fetchBooks();
-    expect(api.get).toHaveBeenCalledWith("/books");
-    expect(books).toEqual(mock);
+    const meta = { total: 1 };
+    api.get.mockResolvedValueOnce({ data: { data: mock, meta } });
+    const res = await fetchBooks({
+      page: 2,
+      perPage: 5,
+      filters: { search: "test" },
+      sort: { sortBy: "title" },
+    });
+    expect(api.get).toHaveBeenCalledWith("/books", {
+      params: { page: 2, perPage: 5, search: "test", sortBy: "title" },
+    });
+    expect(res).toEqual({ books: mock, meta });
   });
 
   it("fetches single book", async () => {


### PR DESCRIPTION
## Summary
- allow bookService.fetchBooks to send pagination, filter, and sort params to backend and return meta data
- fetch books on admin dashboard using backend pagination and update UI to use API total pages
- adjust student and marketplace book pages to use new service response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689355fc886c83289db5973e62bc178a