### PR TITLE
Add admin book edit page with update service

### DIFF
--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -4,7 +4,13 @@ import { useTranslation } from "next-i18next";
 import { fetchBookTags, createBookTag } from "@/services/bookTagService";
 import { getLanguages } from "@/services/languageService";
 
-export default function BookForm({ onSubmit, categories = [], showCoverImage = true }) {
+export default function BookForm({
+  onSubmit,
+  categories = [],
+  showCoverImage = true,
+  defaultValues = {},
+  isEdit = false,
+}) {
   const { t } = useTranslation("dashboard");
   const {
     register,
@@ -12,9 +18,18 @@ export default function BookForm({ onSubmit, categories = [], showCoverImage = t
     watch,
     formState: { errors },
     setValue,
-  } = useForm({ defaultValues: { tags: [], status: "pending", is_free: false, allow_preview: false} });
+    reset,
+  } = useForm({
+    defaultValues: {
+      tags: [],
+      status: "pending",
+      is_free: false,
+      allow_preview: false,
+      ...defaultValues,
+    },
+  });
   const [languages, setLanguages] = useState([]);
-  const [tags, setTags] = useState([]);
+  const [tags, setTags] = useState(defaultValues.tags || []);
   const [tagInput, setTagInput] = useState("");
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [coverPreview, setCoverPreview] = useState(null);
@@ -22,6 +37,19 @@ export default function BookForm({ onSubmit, categories = [], showCoverImage = t
   const [previewFiles, setPreviewFiles] = useState([]);
   const [uploadProgress, setUploadProgress] = useState(null);
   const isFree = watch("is_free");
+
+  useEffect(() => {
+    if (defaultValues) {
+      reset({
+        tags: defaultValues.tags || [],
+        status: "pending",
+        is_free: defaultValues.is_free ?? false,
+        allow_preview: defaultValues.allow_preview ?? false,
+        ...defaultValues,
+      });
+      setTags(defaultValues.tags || []);
+    }
+  }, [defaultValues, reset]);
 
   useEffect(() => {
     const load = async () => {
@@ -248,7 +276,7 @@ export default function BookForm({ onSubmit, categories = [], showCoverImage = t
         </label>
         {(() => {
           const reg = register("cover_image", {
-            required: t("booksCreate.coverImageRequired"),
+            required: !isEdit && t("booksCreate.coverImageRequired"),
             validate: {
               fileType: (files) =>
                 !files[0] ||
@@ -293,7 +321,7 @@ export default function BookForm({ onSubmit, categories = [], showCoverImage = t
         </label>
         {(() => {
           const reg = register("book_file", {
-            required: t("booksCreate.bookFileRequired"),
+            required: !isEdit && t("booksCreate.bookFileRequired"),
             validate: {
               fileType: (files) =>
                 !files[0] || files[0].type === "application/pdf" || "PDF only",

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -1,0 +1,286 @@
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import BookForm from "@/components/books/BookForm";
+import withAuthProtection from "@/hooks/withAuthProtection";
+import { fetchAllCategories } from "@/services/admin/categoryService";
+import { fetchBook, updateBook } from "@/services/bookService";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
+import { FiArrowLeft, FiX } from "react-icons/fi";
+import Head from "next/head";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
+
+function AdminEditBookPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { t } = useTranslation(["common", "dashboard", "validation", "errors"]);
+
+  const [categories, setCategories] = useState([]);
+  const [book, setBook] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [coverPreview, setCoverPreview] = useState(null);
+  const [fileError, setFileError] = useState(null);
+  const [uploadProgress, setUploadProgress] = useState(null);
+
+  const fetchNotifications = useNotificationStore((state) => state.fetch);
+  const fetchMessages = useMessageStore((state) => state.fetch);
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      try {
+        setIsLoading(true);
+        const [catRes, bookData] = await Promise.all([
+          fetchAllCategories(),
+          fetchBook(id),
+        ]);
+        setCategories(catRes?.data || catRes || []);
+        const parsedBook = {
+          ...bookData,
+          tags: bookData?.tags?.map((t) => t.name || t) || [],
+          is_free:
+            bookData?.is_free === 1 ||
+            bookData?.is_free === true,
+          allow_preview:
+            bookData?.allow_preview === 1 ||
+            bookData?.allow_preview === true,
+        };
+        setBook(parsedBook);
+        setCoverPreview(bookData?.cover_image_url || null);
+      } catch (err) {
+        console.error("Failed to load book", err);
+        setError(t("errors.bookLoad"));
+        toast.error(t("errors.bookLoad"));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    load();
+  }, [id, t]);
+
+  const handleFileChange = useCallback(
+    (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+
+      const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
+      if (!allowedTypes.includes(file.type)) {
+        setFileError(t("validation.invalidFileType"));
+        return;
+      }
+
+      const maxSize = 10 * 1024 * 1024;
+      if (file.size > maxSize) {
+        setFileError(t("validation.fileTooLarge", { size: "10MB" }));
+        return;
+      }
+
+      setFileError(null);
+
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setCoverPreview(reader.result);
+      };
+      reader.readAsDataURL(file);
+    },
+    [t]
+  );
+
+  const handleRemoveImage = useCallback(() => {
+    setCoverPreview(null);
+    setFileError(null);
+    const fileInput = document.getElementById("coverImage");
+    if (fileInput) fileInput.value = "";
+  }, []);
+
+  const handleSubmit = async (formData, setProgress) => {
+    const fileInput = document.getElementById("coverImage");
+    if (fileInput?.files?.[0]) {
+      formData.append("cover_image", fileInput.files[0]);
+    }
+    try {
+      setProgress(0);
+      await updateBook(id, formData, (event) => {
+        if (event.total) {
+          const progress = Math.round((event.loaded * 100) / event.total);
+          setProgress(progress);
+          setUploadProgress(progress);
+        }
+      });
+      toast.success(
+        t("booksEdit.success", { defaultValue: "Book updated successfully" })
+      );
+      await Promise.all([fetchNotifications(), fetchMessages()]);
+      router.push("/dashboard/admin/books");
+    } catch (err) {
+      console.error("Failed to update book", err);
+      let errorMessage = t("booksEdit.error", {
+        defaultValue: "Failed to update book",
+      });
+      if (err.response) {
+        if (err.response.data?.errors) {
+          errorMessage = Object.values(err.response.data.errors).join(", ");
+        } else if (err.response.data?.message) {
+          errorMessage = err.response.data.message;
+        }
+      }
+      toast.error(errorMessage);
+    } finally {
+      setProgress(null);
+      setUploadProgress(null);
+    }
+  };
+
+  const handleCancel = () => {
+    handleRemoveImage();
+    router.push("/dashboard/admin/books");
+  };
+
+  return (
+    <AdminLayout>
+      <Head>
+        <title>
+          {t("booksEdit.pageTitle", { defaultValue: "Edit Book" })} | {t("common.adminPanel")}
+        </title>
+      </Head>
+
+      <section className="py-8 px-4 max-w-4xl mx-auto">
+        <div className="mb-6">
+          <button
+            onClick={handleCancel}
+            className="flex items-center text-primary hover:text-primary-dark transition-colors"
+          >
+            <FiArrowLeft className="mr-2" />
+            {t("common.backToList")}
+          </button>
+        </div>
+
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <h1 className="text-2xl font-bold text-gray-800 mb-6">
+            {t("booksEdit.title", { defaultValue: "Edit Book" })}
+          </h1>
+
+          {error ? (
+            <div className="bg-red-50 border-l-4 border-red-500 p-4 mb-6">
+              <div className="flex">
+                <div className="flex-shrink-0">
+                  <svg
+                    className="h-5 w-5 text-red-500"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div className="ml-3">
+                  <p className="text-sm text-red-700">{error}</p>
+                </div>
+              </div>
+            </div>
+          ) : isLoading ? (
+            <div className="flex justify-center py-8">
+              <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <label htmlFor="coverImage" className="block text-sm font-medium text-gray-700">
+                  {t("booksCreate.coverImage")}
+                </label>
+
+                {coverPreview ? (
+                  <div className="relative group">
+                    <div className="w-64 h-64 rounded-md overflow-hidden border border-gray-200">
+                      <img
+                        src={coverPreview}
+                        alt="Cover preview"
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleRemoveImage}
+                      className="absolute top-2 right-2 bg-red-500 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                      aria-label={t("common.removeImage")}
+                    >
+                      <FiX className="h-4 w-4" />
+                    </button>
+                  </div>
+                ) : (
+                  <div className="mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md">
+                    <div className="space-y-1 text-center">
+                      <div className="flex text-sm text-gray-600 justify-center">
+                        <label
+                          htmlFor="coverImage"
+                          className="relative cursor-pointer bg-white rounded-md font-medium text-primary hover:text-primary-dark focus-within:outline-none"
+                        >
+                          <span>{t("booksCreate.uploadImage")}</span>
+                          <input
+                            id="coverImage"
+                            name="coverImage"
+                            type="file"
+                            className="sr-only"
+                            onChange={handleFileChange}
+                            accept="image/jpeg, image/png, image/webp"
+                          />
+                        </label>
+                      </div>
+                      <p className="text-xs text-gray-500">
+                        {t("booksCreate.imageRequirements", { size: "10MB" })}
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                {fileError && (
+                  <p className="mt-2 text-sm text-red-600">{fileError}</p>
+                )}
+              </div>
+
+              {uploadProgress !== null && (
+                <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+                  <div
+                    className="bg-blue-600 h-2.5 rounded-full"
+                    style={{ width: `${uploadProgress}%` }}
+                  ></div>
+                </div>
+              )}
+
+              <BookForm
+                key={book?.id || 'form'}
+                onSubmit={handleSubmit}
+                categories={categories}
+                showCoverImage={false}
+                defaultValues={book}
+                isEdit
+              />
+            </div>
+          )}
+        </div>
+      </section>
+    </AdminLayout>
+  );
+}
+
+export default withAuthProtection(AdminEditBookPage, ["admin", "superadmin"]);
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(
+        locale,
+        ["common", "dashboard", "validation", "errors"],
+        nextI18NextConfig
+      )),
+    },
+  };
+}

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -15,4 +15,12 @@ export const deleteBook = async (id) => {
   return true;
 };
 
-export default { fetchBooks, fetchBook, deleteBook };
+export const updateBook = async (id, formData, onUploadProgress) => {
+  const { data } = await api.put(`/books/${id}`, formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+    onUploadProgress,
+  });
+  return data?.data;
+};
+
+export default { fetchBooks, fetchBook, deleteBook, updateBook };

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -1,7 +1,7 @@
 import api from "../../services/api/api";
-import { fetchBooks, fetchBook } from "../../services/bookService";
+import { fetchBooks, fetchBook, updateBook } from "../../services/bookService";
 
-jest.mock("../../services/api/api", () => ({ get: jest.fn() }));
+jest.mock("../../services/api/api", () => ({ get: jest.fn(), put: jest.fn() }));
 
 describe("bookService", () => {
   it("fetches books", async () => {
@@ -17,6 +17,19 @@ describe("bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: mock } });
     const book = await fetchBook(1);
     expect(api.get).toHaveBeenCalledWith("/books/1");
+    expect(book).toEqual(mock);
+  });
+
+  it("updates a book", async () => {
+    const mock = { id: 1 };
+    api.put.mockResolvedValueOnce({ data: { data: mock } });
+    const formData = new FormData();
+    const book = await updateBook(1, formData);
+    expect(api.put).toHaveBeenCalledWith(
+      "/books/1",
+      formData,
+      expect.objectContaining({ headers: { "Content-Type": "multipart/form-data" } })
+    );
     expect(book).toEqual(mock);
   });
 });


### PR DESCRIPTION
## Summary
- add updateBook service for updating existing books
- allow BookForm to preload values and relax file requirements when editing
- add admin book edit page that loads existing data and saves via updateBook
- cover updateBook in unit tests

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689355fc4a68832882f69d1022dfc648