### PR TITLE
fix config path in admin book edit page

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -12,7 +12,7 @@ import useMessageStore from "@/store/messages/messageStore";
 import { FiArrowLeft, FiX } from "react-icons/fi";
 import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 function AdminEditBookPage() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- fix incorrect relative path to next-i18next configuration in admin book edit page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68935d128c748328a1131851691468a8