### PR TITLE
feat: expand book management

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -89,8 +89,8 @@ exports.createBook = catchAsync(async (req, res) => {
 });
 
 exports.listBooks = catchAsync(async (req, res) => {
-  const books = await service.listBooks(req.query.status);
-  sendSuccess(res, books);
+  const result = await service.listBooks(req.query);
+  sendSuccess(res, result.data, "Books fetched", result.meta);
 });
 
 exports.getBook = catchAsync(async (req, res) => {
@@ -99,4 +99,64 @@ exports.getBook = catchAsync(async (req, res) => {
     throw new AppError("Book not found", 404);
   }
   sendSuccess(res, book);
+});
+
+exports.updateBook = catchAsync(async (req, res) => {
+  const existing = await service.getBookById(req.params.id);
+  if (!existing) throw new AppError("Book not found", 404);
+
+  const { tags: rawTags, ...body } = req.body || {};
+  const data = { ...body };
+  if (req.files?.cover_image?.[0]) data.cover_image_url = req.files.cover_image[0].path;
+  if (req.files?.book_file?.[0]) data.pdf_url = req.files.book_file[0].path;
+  if (req.files?.preview_pages?.length) {
+    data.preview_pages = JSON.stringify(
+      req.files.preview_pages.map((f) => f.path)
+    );
+  }
+  if (data.allow_preview !== undefined) {
+    data.allow_preview =
+      data.allow_preview === "1" ||
+      data.allow_preview === 1 ||
+      data.allow_preview === true ||
+      data.allow_preview === "true";
+  }
+
+  const book = await service.updateBook(req.params.id, data);
+
+  let tags = [];
+  if (rawTags) {
+    try {
+      tags = typeof rawTags === "string" ? JSON.parse(rawTags) : rawTags;
+      if (!Array.isArray(tags)) tags = [];
+    } catch {
+      tags = [];
+    }
+  }
+  await service.clearBookTags(book.id);
+  if (tags.length) {
+    const tagIds = [];
+    for (const name of tags) {
+      const existingTag = await tagService.findByName(name);
+      const tag =
+        existingTag ||
+        (await tagService.createTag({
+          name,
+          slug: slugify(name, { lower: true, strict: true }),
+        }));
+      tagIds.push(tag.id);
+    }
+    await service.addBookTags(book.id, tagIds);
+    book.tags = await service.getBookTags(book.id);
+  } else {
+    book.tags = [];
+  }
+
+  sendSuccess(res, book, "Book updated");
+});
+
+exports.deleteBook = catchAsync(async (req, res) => {
+  await service.clearBookTags(req.params.id);
+  await service.deleteBook(req.params.id);
+  sendSuccess(res, null, "Book deleted");
 });

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -12,5 +12,7 @@ router.post("/tags", verifyToken, isInstructorOrAdmin, tagController.createTag);
 router.get("/", controller.listBooks);
 router.get("/:id", controller.getBook);
 router.post("/", verifyToken, isInstructorOrAdmin, upload, controller.createBook);
+router.put("/:id", verifyToken, isInstructorOrAdmin, upload, controller.updateBook);
+router.delete("/:id", verifyToken, isInstructorOrAdmin, controller.deleteBook);
 
 module.exports = router;

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -5,10 +5,83 @@ exports.createBook = async (data) => {
   return row;
 };
 
-exports.listBooks = (status) => {
-  const query = db("books").orderBy("created_at", "desc");
-  if (status) query.where({ status });
-  return query;
+exports.listBooks = async (params = {}) => {
+  const {
+    page = 1,
+    perPage = 10,
+    search,
+    category,
+    status,
+    priceRange,
+    language,
+    tags = [],
+    sortBy = "newest",
+  } = params;
+
+  const query = db("books as b");
+
+  if (search) {
+    query.where(function () {
+      this.whereILike("b.title", `%${search}%`).orWhereILike(
+        "b.author",
+        `%${search}%`
+      );
+    });
+  }
+  if (category) query.where("b.category_id", category);
+  if (status) query.where("b.status", status);
+  if (priceRange) query.where("b.price", "<=", priceRange);
+  if (language) query.where("b.language", language);
+  const tagArr = Array.isArray(tags) ? tags : tags ? [tags] : [];
+  if (tagArr.length) {
+    query.whereIn("b.id", function () {
+      this.select("m.book_id")
+        .from("book_tag_map as m")
+        .join("tags as t", "m.tag_id", "t.id")
+        .whereIn("t.name", tagArr);
+    });
+  }
+
+  switch (sortBy) {
+    case "oldest":
+      query.orderBy("b.created_at", "asc");
+      break;
+    case "title":
+      query.orderBy("b.title", "asc");
+      break;
+    case "price-high":
+      query.orderBy("b.price", "desc");
+      break;
+    case "price-low":
+      query.orderBy("b.price", "asc");
+      break;
+    default:
+      query.orderBy("b.created_at", "desc");
+  }
+
+  const countQuery = query
+    .clone()
+    .clearSelect()
+    .clearOrder()
+    .countDistinct("b.id as count")
+    .first();
+  const { count } = await countQuery;
+  const total = Number(count) || 0;
+
+  const books = await query
+    .clone()
+    .offset((page - 1) * perPage)
+    .limit(perPage);
+
+  return {
+    data: books,
+    meta: {
+      page: Number(page),
+      perPage: Number(perPage),
+      total,
+      totalPages: Math.ceil(total / perPage),
+    },
+  };
 };
 
 exports.getBookById = (id) => db("books").where({ id }).first();
@@ -24,3 +97,13 @@ exports.getBookTags = (bookId) =>
     .join("tags as t", "m.tag_id", "t.id")
     .where("m.book_id", bookId)
     .select("t.id", "t.name", "t.slug");
+
+exports.clearBookTags = (bookId) =>
+  db("book_tag_map").where({ book_id: bookId }).del();
+
+exports.updateBook = async (id, data) => {
+  const [row] = await db("books").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.deleteBook = (id) => db("books").where({ id }).del();

--- a/backend/src/utils/response.js
+++ b/backend/src/utils/response.js
@@ -1,7 +1,8 @@
-exports.sendSuccess = (res, data, message = "Success") => {
+exports.sendSuccess = (res, data, message = "Success", meta) => {
   res.status(200).json({
     status: "success",
     message,
     data,
+    ...(meta ? { meta } : {}),
   });
 };

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -5,6 +5,9 @@ jest.mock('../src/modules/books/book.service', () => ({
   createBook: jest.fn(),
   listBooks: jest.fn(),
   getBookById: jest.fn(),
+  updateBook: jest.fn(),
+  deleteBook: jest.fn(),
+  clearBookTags: jest.fn(),
 }));
 
 jest.mock('../src/modules/messages/messages.service', () => ({
@@ -44,10 +47,12 @@ app.use('/api/books', routes);
 describe('GET /api/books', () => {
   it('returns book list', async () => {
     const list = [{ id: '1', title: 'Test' }];
-    service.listBooks.mockResolvedValue(list);
+    const meta = { total: 1, page: 1, perPage: 10, totalPages: 1 };
+    service.listBooks.mockResolvedValue({ data: list, meta });
     const res = await request(app).get('/api/books');
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(list);
+    expect(res.body.meta).toEqual(meta);
     expect(service.listBooks).toHaveBeenCalled();
   });
 });
@@ -70,5 +75,24 @@ describe('POST /api/books', () => {
     const res = await request(app).post('/api/books').send(payload);
     expect(res.status).toBe(200);
     expect(service.createBook).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/books/:id', () => {
+  it('updates a book', async () => {
+    const payload = { title: 'Updated' };
+    service.updateBook.mockResolvedValue({ id: '1', ...payload });
+    const res = await request(app).put('/api/books/1').send(payload);
+    expect(res.status).toBe(200);
+    expect(service.updateBook).toHaveBeenCalledWith('1', expect.any(Object));
+  });
+});
+
+describe('DELETE /api/books/:id', () => {
+  it('deletes a book', async () => {
+    const res = await request(app).delete('/api/books/1');
+    expect(res.status).toBe(200);
+    expect(service.clearBookTags).toHaveBeenCalledWith('1');
+    expect(service.deleteBook).toHaveBeenCalledWith('1');
   });
 });


### PR DESCRIPTION
## Summary
- support pagination, filters, and sorting for books API
- allow updating and deleting books with tag maintenance
- expose optional metadata in success responses and cover new API routes with tests

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68937d7355f883288cc5152b39dff980