### PR TITLE
Fix admin book form navigation and cover image handling

### DIFF
--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -10,8 +10,11 @@ export default function BookForm({
   showCoverImage = true,
   defaultValues = {},
   isEdit = false,
+  submitText,
+  cancelText,
+  onCancel,
 }) {
-  const { t } = useTranslation("dashboard");
+  const { t } = useTranslation(["dashboard", "common"]);
   const {
     register,
     handleSubmit,
@@ -129,6 +132,9 @@ export default function BookForm({
     setUploadProgress(0);
     onSubmit(formData, setUploadProgress);
   };
+
+  const submitLabel = submitText || t("booksCreate.save");
+  const cancelLabel = cancelText || t("common.cancel");
 
   return (
     <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-4">
@@ -492,12 +498,23 @@ export default function BookForm({
         </div>
       )}
 
-      <button
-        type="submit"
-        className="px-4 py-2 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
-      >
-        {t("booksCreate.save")}
-      </button>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
+        >
+          {submitLabel}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          >
+            {cancelLabel}
+          </button>
+        )}
+      </div>
     </form>
   );
 }

--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -228,7 +228,7 @@ function AdminCreateBookPage() {
                 onSubmit={handleSubmit}
                 categories={categories}
                 showCoverImage={false}
-                submitText={t("booksCreate.submitButton")}
+                submitText={t("booksCreate.save")}
                 cancelText={t("common.cancel")}
                 onCancel={handleCancel}
                 maxFileSize={10 * 1024 * 1024}

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -262,6 +262,9 @@ function AdminEditBookPage() {
                 showCoverImage={false}
                 defaultValues={book}
                 isEdit
+                submitText={t("booksCreate.save")}
+                cancelText={t("common.cancel")}
+                onCancel={handleCancel}
               />
             </div>
           )}

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -1,5 +1,22 @@
 import api from "@/services/api/api";
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+
+const buildUrl = (path) => {
+  if (!path) return null;
+  if (/^https?:/i.test(path)) return path;
+  const relative = path.startsWith("/uploads")
+    ? path
+    : path.substring(path.indexOf("/uploads"));
+  return `${API_BASE}${relative}`;
+};
+
+const formatBook = (book) => ({
+  ...book,
+  cover_image_url: buildUrl(book?.cover_image_url),
+  pdf_url: buildUrl(book?.pdf_url),
+});
+
 export const fetchBooks = async ({
   page,
   perPage,
@@ -13,15 +30,16 @@ export const fetchBooks = async ({
     ...sort,
   };
   const { data } = await api.get("/books", { params });
+  const list = data?.data ? data.data.map(formatBook) : [];
   return {
-    books: data?.data ?? [],
+    books: list,
     meta: data?.meta ?? {},
   };
 };
 
 export const fetchBook = async (id) => {
   const { data } = await api.get(`/books/${id}`);
-  return data?.data;
+  return data?.data ? formatBook(data.data) : null;
 };
 
 export const deleteBook = async (id) => {
@@ -34,7 +52,7 @@ export const updateBook = async (id, formData, onUploadProgress) => {
     headers: { "Content-Type": "multipart/form-data" },
     onUploadProgress,
   });
-  return data?.data;
+  return data?.data ? formatBook(data.data) : null;
 };
 
 export const updateBookStatus = async (id, status) => {

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -5,9 +5,9 @@ jest.mock("../../services/api/api", () => ({ get: jest.fn(), put: jest.fn() }));
 
 describe("bookService", () => {
   it("fetches books", async () => {
-    const mock = [{ id: 1, title: "A" }];
+    const apiData = [{ id: 1, title: "A" }];
     const meta = { total: 1 };
-    api.get.mockResolvedValueOnce({ data: { data: mock, meta } });
+    api.get.mockResolvedValueOnce({ data: { data: apiData, meta } });
     const res = await fetchBooks({
       page: 2,
       perPage: 5,
@@ -17,20 +17,23 @@ describe("bookService", () => {
     expect(api.get).toHaveBeenCalledWith("/books", {
       params: { page: 2, perPage: 5, search: "test", sortBy: "title" },
     });
-    expect(res).toEqual({ books: mock, meta });
+    expect(res).toEqual({
+      books: [{ id: 1, title: "A", cover_image_url: null, pdf_url: null }],
+      meta,
+    });
   });
 
   it("fetches single book", async () => {
-    const mock = { id: 1, title: "A" };
-    api.get.mockResolvedValueOnce({ data: { data: mock } });
+    const apiData = { id: 1, title: "A" };
+    api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const book = await fetchBook(1);
     expect(api.get).toHaveBeenCalledWith("/books/1");
-    expect(book).toEqual(mock);
+    expect(book).toEqual({ id: 1, title: "A", cover_image_url: null, pdf_url: null });
   });
 
   it("updates a book", async () => {
-    const mock = { id: 1 };
-    api.put.mockResolvedValueOnce({ data: { data: mock } });
+    const apiData = { id: 1 };
+    api.put.mockResolvedValueOnce({ data: { data: apiData } });
     const formData = new FormData();
     const book = await updateBook(1, formData);
     expect(api.put).toHaveBeenCalledWith(
@@ -38,6 +41,6 @@ describe("bookService", () => {
       formData,
       expect.objectContaining({ headers: { "Content-Type": "multipart/form-data" } })
     );
-    expect(book).toEqual(mock);
+    expect(book).toEqual({ id: 1, cover_image_url: null, pdf_url: null });
   });
 });


### PR DESCRIPTION
## Summary
- add cancel support in BookForm and admin book pages
- normalize cover image URLs so uploaded media shows on book cards
- update book service tests for new fields

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 242 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893879d61548328b2ba53f6ff1e4d0b