### PR TITLE
feat: add instructor book detail page

### DIFF
--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -8,6 +8,7 @@ export default function BookCard({
   onDelete,
   onEditLink,
   showReadLink = false,
+  viewLink,
 }) {
   const { t } = useTranslation("dashboard");
 
@@ -48,7 +49,7 @@ export default function BookCard({
       <p className="text-sm mb-2">{`$${book.price}`}</p>
       <div className="flex gap-2">
         <Link
-          href={`/marketplace/books/${book.id}`}
+          href={viewLink || `/marketplace/books/${book.id}`}
           className="text-blue-600 underline"
         >
           {t("view")}

--- a/frontend/src/pages/dashboard/instructor/books/[id].js
+++ b/frontend/src/pages/dashboard/instructor/books/[id].js
@@ -1,0 +1,49 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
+import { fetchBook } from "@/services/bookService";
+
+function InstructorBookDetailPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [book, setBook] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      try {
+        const data = await fetchBook(id);
+        setBook(data);
+      } catch (e) {
+        console.error("Failed to load book", e);
+      }
+    };
+    load();
+  }, [id]);
+
+  return (
+    <InstructorLayout>
+      <section className="py-10 px-4 max-w-3xl mx-auto">
+        {!book ? (
+          <p>Loading...</p>
+        ) : (
+          <>
+            {book.cover_image_url && (
+              <img
+                src={book.cover_image_url}
+                alt={book.title}
+                className="mb-4 w-full max-w-sm"
+              />
+            )}
+            <h1 className="text-2xl font-semibold mb-2">{book.title}</h1>
+            {book.description && <p className="mb-2">{book.description}</p>}
+            <p className="font-medium">{`$${book.price}`}</p>
+          </>
+        )}
+      </section>
+    </InstructorLayout>
+  );
+}
+
+export default withAuthProtection(InstructorBookDetailPage, ["instructor"]);

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -90,7 +90,11 @@ function InstructorBooksPage() {
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {filteredBooks.map((book) => (
-              <BookCard key={book.id} book={book} />
+              <BookCard
+                key={book.id}
+                book={book}
+                viewLink={`/dashboard/instructor/books/${book.id}`}
+              />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- support custom view links in book cards
- link instructor book list to new dashboard book detail page
- add instructor book detail view with dashboard layout

## Testing
- `npm test`
- `npm run lint` (fails: 48 errors, 243 warnings)
- `npx eslint src/components/books/BookCard.js src/pages/dashboard/instructor/books/index.js src/pages/dashboard/instructor/books/[id].js`

------
https://chatgpt.com/codex/tasks/task_e_689391c4546c8328a9c53daeef456132