### PR TITLE
fix: align cover image field name

### DIFF
--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -8,7 +8,7 @@ export default function BookForm({
   onSubmit,
   categories = [],
   showCoverImage = true,
-  defaultValues = {},
+  defaultValues = null,
   isEdit = false,
   submitText,
   cancelText,
@@ -28,11 +28,11 @@ export default function BookForm({
       status: "pending",
       is_free: false,
       allow_preview: false,
-      ...defaultValues,
+      ...(defaultValues || {}),
     },
   });
   const [languages, setLanguages] = useState([]);
-  const [tags, setTags] = useState(defaultValues.tags || []);
+  const [tags, setTags] = useState(defaultValues?.tags || []);
   const [tagInput, setTagInput] = useState("");
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [coverPreview, setCoverPreview] = useState(null);

--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -73,12 +73,12 @@ function AdminCreateBookPage() {
   const handleRemoveImage = useCallback(() => {
     setCoverPreview(null);
     setFileError(null);
-    const fileInput = document.getElementById("coverImage");
+    const fileInput = document.getElementById("cover_image");
     if (fileInput) fileInput.value = "";
   }, []);
 
   const handleSubmit = async (formData, setProgress) => {
-    const fileInput = document.getElementById("coverImage");
+    const fileInput = document.getElementById("cover_image");
     if (fileInput?.files?.[0]) {
       formData.append("cover_image", fileInput.files[0]);
     }
@@ -162,7 +162,7 @@ function AdminCreateBookPage() {
           ) : (
             <div className="space-y-6">
               <div className="space-y-2">
-                <label htmlFor="coverImage" className="block text-sm font-medium text-gray-700">
+                <label htmlFor="cover_image" className="block text-sm font-medium text-gray-700">
                   {t("booksCreate.coverImage")}
                 </label>
 
@@ -189,13 +189,13 @@ function AdminCreateBookPage() {
                     <div className="space-y-1 text-center">
                       <div className="flex text-sm text-gray-600 justify-center">
                         <label
-                          htmlFor="coverImage"
+                          htmlFor="cover_image"
                           className="relative cursor-pointer bg-white rounded-md font-medium text-primary hover:text-primary-dark focus-within:outline-none"
                         >
                           <span>{t("booksCreate.uploadImage")}</span>
                           <input
-                            id="coverImage"
-                            name="coverImage"
+                            id="cover_image"
+                            name="cover_image"
                             type="file"
                             className="sr-only"
                             onChange={handleFileChange}
@@ -242,7 +242,8 @@ function AdminCreateBookPage() {
   );
 }
 
-export default withAuthProtection(AdminCreateBookPage, ["admin", "superadmin"]);
+const ProtectedAdminCreateBookPage = withAuthProtection(AdminCreateBookPage, ["admin", "superadmin"]);
+export default ProtectedAdminCreateBookPage;
 
 export async function getStaticProps({ locale }) {
   return {


### PR DESCRIPTION
## Summary
- fix admin book form cover image inputs id and name
- prevent book form inputs from clearing by stabilizing default values
- export admin book creation page via variable to satisfy lint rule

## Testing
- `npm test`
- `npm run lint` *(fails: Assign object to a variable before exporting as module default)*

------
https://chatgpt.com/codex/tasks/task_e_68938bff8594832891b45d17e58ed973