### PR TITLE
Improve admin book edit page translations

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1038,7 +1038,9 @@
     "shortDescriptionRequired": "الوصف القصير مطلوب",
     "detailedDescriptionLabel": "وصف مفصل",
     "detailedDescriptionRequired": "الوصف المفصل مطلوب",
-    "coverImageLabel": "صورة الغلاف",
+    "coverImage": "صورة الغلاف",
+    "uploadImage": "رفع صورة",
+    "imageRequirements": "PNG أو JPG أو WEBP بحد أقصى {{size}}",
     "coverImageRequired": "صورة الغلاف مطلوبة",
     "bookFileLabel": "ملف الكتاب (PDF)",
     "bookFileRequired": "ملف الكتاب مطلوب",
@@ -1053,6 +1055,12 @@
     "licenseTypeLabel": "نوع الترخيص",
     "selectLicenseType": "اختر نوع الترخيص",
     "licenseTypeRequired": "نوع الترخيص مطلوب"
+  },
+  "booksEdit": {
+    "pageTitle": "تعديل الكتاب",
+    "title": "تعديل الكتاب",
+    "success": "تم تحديث الكتاب بنجاح",
+    "error": "فشل في تحديث الكتاب"
   },
   "seoPage": {
     "title": "SEO Control Panel",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1051,7 +1051,9 @@
     "shortDescriptionRequired": "Short description is required",
     "detailedDescriptionLabel": "Detailed Description",
     "detailedDescriptionRequired": "Detailed description is required",
-    "coverImageLabel": "Cover Image",
+    "coverImage": "Cover Image",
+    "uploadImage": "Upload Image",
+    "imageRequirements": "PNG, JPG or WEBP up to {{size}}",
     "coverImageRequired": "Cover image is required",
     "bookFileLabel": "Book File (PDF)",
     "bookFileRequired": "Book file is required",
@@ -1066,6 +1068,12 @@
     "licenseTypeLabel": "License Type",
     "selectLicenseType": "Select license type",
     "licenseTypeRequired": "License type is required"
+  },
+  "booksEdit": {
+    "pageTitle": "Edit Book",
+    "title": "Edit Book",
+    "success": "Book updated successfully",
+    "error": "Failed to update book"
   },
   "seoPage": {
     "title": "SEO Control Panel",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1026,7 +1026,9 @@
     "shortDescriptionRequired": "La description courte est obligatoire",
     "detailedDescriptionLabel": "Description détaillée",
     "detailedDescriptionRequired": "La description détaillée est obligatoire",
-    "coverImageLabel": "Image de couverture",
+    "coverImage": "Image de couverture",
+    "uploadImage": "Téléverser une image",
+    "imageRequirements": "PNG, JPG ou WEBP jusqu'à {{size}}",
     "coverImageRequired": "L'image de couverture est obligatoire",
     "bookFileLabel": "Fichier du livre (PDF)",
     "bookFileRequired": "Le fichier du livre est obligatoire",
@@ -1041,6 +1043,12 @@
     "licenseTypeLabel": "Type de licence",
     "selectLicenseType": "Sélectionnez le type de licence",
     "licenseTypeRequired": "Le type de licence est obligatoire"
+  },
+  "booksEdit": {
+    "pageTitle": "Modifier le livre",
+    "title": "Modifier le livre",
+    "success": "Livre mis à jour avec succès",
+    "error": "Échec de la mise à jour du livre"
   },
   "seoPage": {
     "title": "SEO Control Panel",

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -278,7 +278,7 @@ export default function BookForm({
         {showCoverImage && (
       <div>
         <label className="block text-sm font-medium mb-1">
-          {t("booksCreate.coverImageLabel")}
+          {t("booksCreate.coverImage")}
         </label>
         {(() => {
           const reg = register("cover_image", {


### PR DESCRIPTION
## Summary
- add missing translations for admin book edit page
- document cover image upload text
- align BookForm with new translation key

## Testing
- `npm test`
- `npm run lint` *(fails: Assign object to a variable before exporting as module default)*

------
https://chatgpt.com/codex/tasks/task_e_68939b5e9da883288923fdbd876c8e82