### PR TITLE
feat: enhance book detail page styling

### DIFF
--- a/frontend/src/pages/marketplace/books/[id].js
+++ b/frontend/src/pages/marketplace/books/[id].js
@@ -20,20 +20,65 @@ export default function BookDetailPage() {
     load();
   }, [id]);
 
-  if (!book) return <p>Loading...</p>;
+  if (!book)
+    return (
+      <div className="min-h-screen flex items-center justify-center text-yellow-400">
+        Loading...
+      </div>
+    );
 
   return (
-    <div>
-      {book.cover_image_url && (
-        <img
-          src={book.cover_image_url}
-          alt={book.title}
-          className="mb-4 w-full max-w-sm"
-        />
-      )}
-      <h1 className="text-2xl font-semibold mb-2">{book.title}</h1>
-      <p className="mb-2">{book.description}</p>
-      <p className="font-medium">{`$${book.price}`}</p>
-    </div>
+    <section className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-gray-100">
+      <div className="max-w-4xl mx-auto px-4 py-16">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="mb-6 text-sm text-yellow-400 hover:underline"
+        >
+          ← Back to books
+        </button>
+
+        <div className="flex flex-col md:flex-row gap-8 bg-gray-800/60 p-6 rounded-xl shadow-lg">
+          {book.cover_image_url && (
+            <img
+              src={book.cover_image_url}
+              alt={book.title}
+              className="w-full md:w-1/3 rounded-lg object-cover"
+            />
+          )}
+
+          <div className="flex-1">
+            <h1 className="text-3xl font-bold mb-2">{book.title}</h1>
+            {book.author && (
+              <p className="text-yellow-400 mb-4">by {book.author}</p>
+            )}
+            {book.category_name && (
+              <p className="text-sm uppercase tracking-wide text-gray-400 mb-4">
+                {book.category_name}
+              </p>
+            )}
+            {book.rating && (
+              <p className="mb-4 text-yellow-400">
+                ⭐ {Number(book.rating).toFixed(1)} / 5
+              </p>
+            )}
+            <p className="mb-6">{book.description}</p>
+            <p className="text-xl font-semibold mb-6">
+              {book.is_paid ? `$${book.price}` : "Free"}
+            </p>
+            {book.pdf_url && (
+              <a
+                href={book.pdf_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block px-6 py-3 rounded-lg bg-yellow-500 text-gray-900 font-semibold hover:bg-yellow-400 transition-colors"
+              >
+                {book.is_paid ? "Preview" : "Read Now"}
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- polish marketplace book detail page with full-page layout, richer metadata, and preview link

## Testing
- `npm test`
- `npm run lint` *(fails: import/no-anonymous-default-export errors)*

------
https://chatgpt.com/codex/tasks/task_e_68939b8c438c83288b0d2192c74b7c84