### PR TITLE
fix: normalize book cover image URL

### DIFF
--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -7,10 +7,10 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 const buildUrl = (path) => {
   if (!path) return null;
   if (/^https?:/i.test(path)) return path;
-  const relative = path.startsWith("/uploads")
-    ? path
-    : path.substring(path.indexOf("/uploads"));
-  return `${API_BASE}${relative}`;
+  const uploadsIndex = path.indexOf("/uploads");
+  const relative = uploadsIndex !== -1 ? path.substring(uploadsIndex) : path;
+  const normalized = relative.startsWith("/") ? relative : `/${relative}`;
+  return `${API_BASE}${normalized}`;
 };
 
 

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -5,10 +5,10 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 const buildUrl = (path) => {
   if (!path) return null;
   if (/^https?:/i.test(path)) return path;
-  const relative = path.startsWith("/uploads")
-    ? path
-    : path.substring(path.indexOf("/uploads"));
-  return `${API_BASE}${relative}`;
+  const uploadsIndex = path.indexOf("/uploads");
+  const relative = uploadsIndex !== -1 ? path.substring(uploadsIndex) : path;
+  const normalized = relative.startsWith("/") ? relative : `/${relative}`;
+  return `${API_BASE}${normalized}`;
 };
 
 const formatBook = (book) => ({


### PR DESCRIPTION
## Summary
- ensure book cover image paths always include leading slash
- normalize URLs for book cover images in admin dashboard

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: 48 errors, 244 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68939f4983b08328a0a8b5593d14af3e