### PR TITLE
Fix admin books page cover image display

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -682,7 +682,11 @@ function AdminBooksPage() {
                   
                   <div className="relative">
                     <img
-                      src={book.coverImage || "/images/default-book-cover.jpg"}
+                      src={
+                        book.cover_image_url ||
+                        book.cover_image ||
+                        "/images/default-book-cover.jpg"
+                      }
                       alt={book.title}
                       className="w-full h-48 object-cover"
                     />


### PR DESCRIPTION
## Summary
- ensure book cover images on admin books page use correct fields

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_6893a5e9eacc8328a927bbcdb51744c4