### PR TITLE
Allow admin book edit to load unapproved entries

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -101,6 +101,15 @@ exports.getBook = catchAsync(async (req, res) => {
   sendSuccess(res, book);
 });
 
+exports.getBookAdmin = catchAsync(async (req, res) => {
+  const book = await service.getBookById(req.params.id);
+  if (!book) {
+    throw new AppError("Book not found", 404);
+  }
+  book.tags = await service.getBookTags(book.id);
+  sendSuccess(res, book);
+});
+
 exports.updateBook = catchAsync(async (req, res) => {
   const existing = await service.getBookById(req.params.id);
   if (!existing) throw new AppError("Book not found", 404);

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -10,6 +10,7 @@ const {
 router.get("/tags", verifyToken, isInstructorOrAdmin, tagController.listTags);
 router.post("/tags", verifyToken, isInstructorOrAdmin, tagController.createTag);
 router.get("/", controller.listBooks);
+router.get("/admin/:id", verifyToken, isInstructorOrAdmin, controller.getBookAdmin);
 router.get("/:id", controller.getBook);
 router.post("/", verifyToken, isInstructorOrAdmin, upload, controller.createBook);
 router.put("/:id", verifyToken, isInstructorOrAdmin, upload, controller.updateBook);

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -8,6 +8,7 @@ jest.mock('../src/modules/books/book.service', () => ({
   updateBook: jest.fn(),
   deleteBook: jest.fn(),
   clearBookTags: jest.fn(),
+  getBookTags: jest.fn(),
 }));
 
 jest.mock('../src/modules/messages/messages.service', () => ({
@@ -65,6 +66,20 @@ describe('GET /api/books/:id', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(book);
     expect(service.getBookById).toHaveBeenCalledWith('1');
+  });
+});
+
+describe('GET /api/books/admin/:id', () => {
+  it('returns a book for admin', async () => {
+    const book = { id: '1', title: 'One', status: 'pending' };
+    const tags = [{ id: 1, name: 'tag' }];
+    service.getBookById.mockResolvedValue(book);
+    service.getBookTags.mockResolvedValue(tags);
+    const res = await request(app).get('/api/books/admin/1');
+    expect(res.status).toBe(200);
+    expect(service.getBookById).toHaveBeenCalledWith('1');
+    expect(service.getBookTags).toHaveBeenCalledWith('1');
+    expect(res.body.data).toEqual({ ...book, tags });
   });
 });
 

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -37,7 +37,7 @@ function AdminEditBookPage() {
         setIsLoading(true);
         const [catRes, bookData] = await Promise.all([
           fetchAllCategories(),
-          fetchBook(id),
+          fetchBook(id, { admin: true }),
         ]);
         setCategories(catRes?.data || catRes || []);
         const parsedBook = {

--- a/frontend/src/pages/dashboard/instructor/books/[id].js
+++ b/frontend/src/pages/dashboard/instructor/books/[id].js
@@ -13,7 +13,7 @@ function InstructorBookDetailPage() {
     if (!id) return;
     const load = async () => {
       try {
-        const data = await fetchBook(id);
+        const data = await fetchBook(id, { admin: true });
         setBook(data);
       } catch (e) {
         console.error("Failed to load book", e);

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -37,8 +37,9 @@ export const fetchBooks = async ({
   };
 };
 
-export const fetchBook = async (id) => {
-  const { data } = await api.get(`/books/${id}`);
+export const fetchBook = async (id, { admin = false } = {}) => {
+  const endpoint = admin ? `/books/admin/${id}` : `/books/${id}`;
+  const { data } = await api.get(endpoint);
   return data?.data ? formatBook(data.data) : null;
 };
 

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -3,6 +3,10 @@ import { fetchBooks, fetchBook, updateBook } from "../../services/bookService";
 
 jest.mock("../../services/api/api", () => ({ get: jest.fn(), put: jest.fn() }));
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe("bookService", () => {
   it("fetches books", async () => {
     const apiData = [{ id: 1, title: "A" }];
@@ -28,6 +32,14 @@ describe("bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const book = await fetchBook(1);
     expect(api.get).toHaveBeenCalledWith("/books/1");
+    expect(book).toEqual({ id: 1, title: "A", cover_image_url: null, pdf_url: null });
+  });
+
+  it("fetches single book as admin", async () => {
+    const apiData = { id: 1, title: "A" };
+    api.get.mockResolvedValueOnce({ data: { data: apiData } });
+    const book = await fetchBook(1, { admin: true });
+    expect(api.get).toHaveBeenCalledWith("/books/admin/1");
     expect(book).toEqual({ id: 1, title: "A", cover_image_url: null, pdf_url: null });
   });
 


### PR DESCRIPTION
## Summary
- expose authenticated `/books/admin/:id` endpoint for fetching unapproved books
- update book service and dashboard pages to use admin endpoint
- cover service and route with tests

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6893a92a27b88328af71560d330baaa7