### PR TITLE
Allow admin book edit to load unapproved entries

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -101,6 +101,15 @@ exports.getBook = catchAsync(async (req, res) => {
   sendSuccess(res, book);
 });
 
+exports.getBookAdmin = catchAsync(async (req, res) => {
+  const book = await service.getBookById(req.params.id);
+  if (!book) {
+    throw new AppError("Book not found", 404);
+  }
+  book.tags = await service.getBookTags(book.id);
+  sendSuccess(res, book);
+});
+
 exports.updateBook = catchAsync(async (req, res) => {
   const existing = await service.getBookById(req.params.id);
   if (!existing) throw new AppError("Book not found", 404);
@@ -150,6 +159,26 @@ exports.updateBook = catchAsync(async (req, res) => {
     book.tags = await service.getBookTags(book.id);
   } else {
     book.tags = [];
+  }
+
+  if (
+    req.user.role !== "instructor" &&
+    existing.instructor_id &&
+    existing.instructor_id !== req.user.id
+  ) {
+    const message = `Your book "${book.title}" was updated by an admin.`;
+    await Promise.all([
+      notificationService.createNotification({
+        user_id: existing.instructor_id,
+        type: "book_updated",
+        message,
+      }),
+      messageService.createMessage({
+        sender_id: req.user.id,
+        receiver_id: existing.instructor_id,
+        message,
+      }),
+    ]);
   }
 
   sendSuccess(res, book, "Book updated");

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -10,6 +10,7 @@ const {
 router.get("/tags", verifyToken, isInstructorOrAdmin, tagController.listTags);
 router.post("/tags", verifyToken, isInstructorOrAdmin, tagController.createTag);
 router.get("/", controller.listBooks);
+router.get("/admin/:id", verifyToken, isInstructorOrAdmin, controller.getBookAdmin);
 router.get("/:id", controller.getBook);
 router.post("/", verifyToken, isInstructorOrAdmin, upload, controller.createBook);
 router.put("/:id", verifyToken, isInstructorOrAdmin, upload, controller.updateBook);

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -8,6 +8,7 @@ jest.mock('../src/modules/books/book.service', () => ({
   updateBook: jest.fn(),
   deleteBook: jest.fn(),
   clearBookTags: jest.fn(),
+  getBookTags: jest.fn(),
 }));
 
 jest.mock('../src/modules/messages/messages.service', () => ({
@@ -39,10 +40,16 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
 
 const service = require('../src/modules/books/book.service');
 const routes = require('../src/modules/books/book.routes');
+const messageService = require('../src/modules/messages/messages.service');
+const notificationService = require('../src/modules/notifications/notifications.service');
 
 const app = express();
 app.use(express.json());
 app.use('/api/books', routes);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('GET /api/books', () => {
   it('returns book list', async () => {
@@ -68,6 +75,20 @@ describe('GET /api/books/:id', () => {
   });
 });
 
+describe('GET /api/books/admin/:id', () => {
+  it('returns a book for admin', async () => {
+    const book = { id: '1', title: 'One', status: 'pending' };
+    const tags = [{ id: 1, name: 'tag' }];
+    service.getBookById.mockResolvedValue(book);
+    service.getBookTags.mockResolvedValue(tags);
+    const res = await request(app).get('/api/books/admin/1');
+    expect(res.status).toBe(200);
+    expect(service.getBookById).toHaveBeenCalledWith('1');
+    expect(service.getBookTags).toHaveBeenCalledWith('1');
+    expect(res.body.data).toEqual({ ...book, tags });
+  });
+});
+
 describe('POST /api/books', () => {
   it('creates a book', async () => {
     const payload = { title: 'New' };
@@ -81,10 +102,21 @@ describe('POST /api/books', () => {
 describe('PUT /api/books/:id', () => {
   it('updates a book', async () => {
     const payload = { title: 'Updated' };
+    service.getBookById.mockResolvedValue({ id: '1', instructor_id: '2', title: 'Old' });
     service.updateBook.mockResolvedValue({ id: '1', ...payload });
     const res = await request(app).put('/api/books/1').send(payload);
     expect(res.status).toBe(200);
     expect(service.updateBook).toHaveBeenCalledWith('1', expect.any(Object));
+    expect(notificationService.createNotification).toHaveBeenCalledWith({
+      user_id: '2',
+      type: 'book_updated',
+      message: expect.stringContaining('Updated'),
+    });
+    expect(messageService.createMessage).toHaveBeenCalledWith({
+      sender_id: '1',
+      receiver_id: '2',
+      message: expect.stringContaining('Updated'),
+    });
   });
 });
 

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -37,7 +37,7 @@ function AdminEditBookPage() {
         setIsLoading(true);
         const [catRes, bookData] = await Promise.all([
           fetchAllCategories(),
-          fetchBook(id),
+          fetchBook(id, { admin: true }),
         ]);
         setCategories(catRes?.data || catRes || []);
         const parsedBook = {

--- a/frontend/src/pages/dashboard/instructor/books/[id].js
+++ b/frontend/src/pages/dashboard/instructor/books/[id].js
@@ -13,7 +13,7 @@ function InstructorBookDetailPage() {
     if (!id) return;
     const load = async () => {
       try {
-        const data = await fetchBook(id);
+        const data = await fetchBook(id, { admin: true });
         setBook(data);
       } catch (e) {
         console.error("Failed to load book", e);

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -37,8 +37,9 @@ export const fetchBooks = async ({
   };
 };
 
-export const fetchBook = async (id) => {
-  const { data } = await api.get(`/books/${id}`);
+export const fetchBook = async (id, { admin = false } = {}) => {
+  const endpoint = admin ? `/books/admin/${id}` : `/books/${id}`;
+  const { data } = await api.get(endpoint);
   return data?.data ? formatBook(data.data) : null;
 };
 

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -3,6 +3,10 @@ import { fetchBooks, fetchBook, updateBook } from "../../services/bookService";
 
 jest.mock("../../services/api/api", () => ({ get: jest.fn(), put: jest.fn() }));
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe("bookService", () => {
   it("fetches books", async () => {
     const apiData = [{ id: 1, title: "A" }];
@@ -28,6 +32,14 @@ describe("bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const book = await fetchBook(1);
     expect(api.get).toHaveBeenCalledWith("/books/1");
+    expect(book).toEqual({ id: 1, title: "A", cover_image_url: null, pdf_url: null });
+  });
+
+  it("fetches single book as admin", async () => {
+    const apiData = { id: 1, title: "A" };
+    api.get.mockResolvedValueOnce({ data: { data: apiData } });
+    const book = await fetchBook(1, { admin: true });
+    expect(api.get).toHaveBeenCalledWith("/books/admin/1");
     expect(book).toEqual({ id: 1, title: "A", cover_image_url: null, pdf_url: null });
   });
 


### PR DESCRIPTION
## Summary
- expose authenticated `/books/admin/:id` endpoint for fetching unapproved books
- update book service and dashboard pages to use admin endpoint
- notify original instructor via message and notification when an admin updates a book
- cover service and route with tests

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6893a92a27b88328af71560d330baaa7