### PR TITLE
Make price range filter optional

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -32,12 +32,12 @@ function AdminBooksPage() {
   const [categories, setCategories] = useState([]);
   const [languages, setLanguages] = useState([]);
   const [filters, setFilters] = useState({
-    search: "", 
-    category: "", 
-    status: "", 
-    priceRange: 0, 
-    language: "", 
-    tags: [] 
+    search: "",
+    category: "",
+    status: "",
+    priceRange: null,
+    language: "",
+    tags: []
   });
   const [tagInput, setTagInput] = useState("");
   const [tagSuggestions, setTagSuggestions] = useState([]);
@@ -106,10 +106,14 @@ function AdminBooksPage() {
     const loadBooks = async () => {
       try {
         setLoading(true);
+        const activeFilters = { ...filters };
+        if (activeFilters.priceRange === null || activeFilters.priceRange <= 0) {
+          delete activeFilters.priceRange;
+        }
         const { books: list, meta } = await fetchBooks({
           page,
           perPage,
-          filters,
+          filters: activeFilters,
           sort: { sortBy },
         });
         setBooks(list);
@@ -227,13 +231,13 @@ function AdminBooksPage() {
   };
 
   const resetFilters = () => {
-    setFilters({ 
-      search: "", 
-      category: "", 
-      status: "", 
-      priceRange: 0, 
-      language: "", 
-      tags: [] 
+    setFilters({
+      search: "",
+      category: "",
+      status: "",
+      priceRange: null,
+      language: "",
+      tags: []
     });
     setPage(1);
   };
@@ -347,14 +351,14 @@ function AdminBooksPage() {
 
             <div className="min-w-[180px]">
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                {t("Max Price")}: ${filters.priceRange}
+                {t("Max Price")}: ${filters.priceRange ?? 0}
               </label>
               <input
                 type="range"
                 min="0"
                 max="500"
                 step="10"
-                value={filters.priceRange}
+                value={filters.priceRange ?? 0}
                 onChange={(e) => {
                   setFilters({ ...filters, priceRange: Number(e.target.value) });
                   setPage(1);
@@ -538,14 +542,14 @@ function AdminBooksPage() {
 
               <div>
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  {t("Max Price")}: ${filters.priceRange}
+                  {t("Max Price")}: ${filters.priceRange ?? 0}
                 </label>
                 <input
                   type="range"
                   min="0"
                   max="500"
                   step="10"
-                  value={filters.priceRange}
+                  value={filters.priceRange ?? 0}
                   onChange={(e) => {
                     setFilters({ ...filters, priceRange: Number(e.target.value) });
                     setPage(1);


### PR DESCRIPTION
## Summary
- default price range filter to null and persist to storage
- include price range in book queries only when greater than zero
- reset filters to restore price range to null and handle slider defaults

## Testing
- `npm test`
- `npm run lint` *(fails: 293 problems)*
- `npx eslint src/pages/dashboard/admin/books/index.js`


------
https://chatgpt.com/codex/tasks/task_e_6893b1dbf4588328847b819abdef83c4