### PR TITLE
refactor: clean up admin book selection logic

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -131,7 +131,6 @@ function AdminBooksPage() {
     }
   }, [filters]);
 
-  const filteredBooks = books;
   const totalPages = meta?.totalPages ?? 1;
   const startIndex = books.length ? (page - 1) * perPage + 1 : 0;
   const endIndex = books.length ? startIndex + books.length - 1 : 0;
@@ -141,7 +140,7 @@ function AdminBooksPage() {
       const updated = prev.includes(id)
         ? prev.filter((x) => x !== id)
         : [...prev, id];
-      setAllSelected(updated.length === filteredBooks.length);
+      setAllSelected(updated.length === books.length);
       return updated;
     });
   };
@@ -151,17 +150,16 @@ function AdminBooksPage() {
       setSelectedBooks([]);
       setAllSelected(false);
     } else {
-      setSelectedBooks(filteredBooks.map((b) => b.id));
+      setSelectedBooks(books.map((b) => b.id));
       setAllSelected(true);
     }
   };
 
   useEffect(() => {
     setAllSelected(
-      filteredBooks.length > 0 &&
-        selectedBooks.length === filteredBooks.length
+      books.length > 0 && selectedBooks.length === books.length
     );
-  }, [filteredBooks, selectedBooks]);
+  }, [books, selectedBooks]);
 
   const handleBulkDelete = async () => {
     openConfirmModal({


### PR DESCRIPTION
## Summary
- remove redundant `filteredBooks` from admin dashboard books page
- update select-all logic and effect to operate on `books` directly

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: 48 errors, 245 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893b1e10b548328bed86f937efc05cd