### PR TITLE
Refactor cover image inputs to use React refs

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
@@ -23,6 +23,7 @@ function AdminCreateBookPage() {
   const [coverPreview, setCoverPreview] = useState(null);
   const [fileError, setFileError] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(null);
+  const fileInputRef = useRef(null);
 
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const fetchMessages = useMessageStore((state) => state.fetch);
@@ -73,14 +74,12 @@ function AdminCreateBookPage() {
   const handleRemoveImage = useCallback(() => {
     setCoverPreview(null);
     setFileError(null);
-    const fileInput = document.getElementById("cover_image");
-    if (fileInput) fileInput.value = "";
+    if (fileInputRef.current) fileInputRef.current.value = "";
   }, []);
 
   const handleSubmit = async (formData, setProgress) => {
-    const fileInput = document.getElementById("cover_image");
-    if (fileInput?.files?.[0]) {
-      formData.append("cover_image", fileInput.files[0]);
+    if (fileInputRef.current?.files?.[0]) {
+      formData.append("cover_image", fileInputRef.current.files[0]);
     }
     try {
       setProgress(0);
@@ -198,6 +197,7 @@ function AdminCreateBookPage() {
                             name="cover_image"
                             type="file"
                             className="sr-only"
+                            ref={fileInputRef}
                             onChange={handleFileChange}
                             accept="image/jpeg, image/png, image/webp"
                           />

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
@@ -26,6 +26,7 @@ function AdminEditBookPage() {
   const [coverPreview, setCoverPreview] = useState(null);
   const [fileError, setFileError] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(null);
+  const fileInputRef = useRef(null);
 
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const fetchMessages = useMessageStore((state) => state.fetch);
@@ -94,14 +95,12 @@ function AdminEditBookPage() {
   const handleRemoveImage = useCallback(() => {
     setCoverPreview(null);
     setFileError(null);
-    const fileInput = document.getElementById("coverImage");
-    if (fileInput) fileInput.value = "";
+    if (fileInputRef.current) fileInputRef.current.value = "";
   }, []);
 
   const handleSubmit = async (formData, setProgress) => {
-    const fileInput = document.getElementById("coverImage");
-    if (fileInput?.files?.[0]) {
-      formData.append("cover_image", fileInput.files[0]);
+    if (fileInputRef.current?.files?.[0]) {
+      formData.append("cover_image", fileInputRef.current.files[0]);
     }
     try {
       setProgress(0);
@@ -229,6 +228,7 @@ function AdminEditBookPage() {
                             name="coverImage"
                             type="file"
                             className="sr-only"
+                            ref={fileInputRef}
                             onChange={handleFileChange}
                             accept="image/jpeg, image/png, image/webp"
                           />

--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
@@ -23,6 +23,7 @@ function CreateBookPage() {
   const [coverPreview, setCoverPreview] = useState(null);
   const [fileError, setFileError] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(null);
+  const fileInputRef = useRef(null);
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const fetchMessages = useMessageStore((state) => state.fetch);
 
@@ -75,14 +76,12 @@ function CreateBookPage() {
   const handleRemoveImage = useCallback(() => {
     setCoverPreview(null);
     setFileError(null);
-    const fileInput = document.getElementById("cover_image");
-    if (fileInput) fileInput.value = "";
+    if (fileInputRef.current) fileInputRef.current.value = "";
   }, []);
 
   const handleSubmit = async (formData, setProgress) => {
-    const fileInput = document.getElementById("cover_image");
-    if (fileInput?.files?.[0]) {
-      formData.append("cover_image", fileInput.files[0]);
+    if (fileInputRef.current?.files?.[0]) {
+      formData.append("cover_image", fileInputRef.current.files[0]);
     }
     try {
       setProgress(0);
@@ -204,6 +203,7 @@ function CreateBookPage() {
                             name="cover_image"
                             type="file"
                             className="sr-only"
+                            ref={fileInputRef}
                             onChange={handleFileChange}
                             accept="image/jpeg, image/png, image/webp"
                           />


### PR DESCRIPTION
## Summary
- replace direct DOM queries for cover image uploads with `useRef`
- access files via `ref.current.files[0]` and clear with `ref.current.value = ""`
- pass refs into file input elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893b1e57af88328bf617f56dfe4c5d4