### PR TITLE
Allow setting and submitting book status

### DIFF
--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -13,6 +13,7 @@ export default function BookForm({
   submitText,
   cancelText,
   onCancel,
+  showStatusSelector = false,
 }) {
   const { t } = useTranslation(["dashboard", "common"]);
   const {
@@ -25,10 +26,10 @@ export default function BookForm({
   } = useForm({
     defaultValues: {
       tags: [],
-      status: "pending",
       is_free: false,
       allow_preview: false,
       ...(defaultValues || {}),
+      status: defaultValues?.status ?? "pending",
     },
   });
   const [languages, setLanguages] = useState([]);
@@ -45,10 +46,10 @@ export default function BookForm({
     if (defaultValues) {
       reset({
         tags: defaultValues.tags || [],
-        status: "pending",
         is_free: defaultValues.is_free ?? false,
         allow_preview: defaultValues.allow_preview ?? false,
         ...defaultValues,
+        status: defaultValues.status ?? "pending",
       });
       setTags(defaultValues.tags || []);
     }
@@ -128,7 +129,7 @@ export default function BookForm({
     formData.append("license_type", data.license_type);
     formData.append("is_free", isFree ? 1 : 0);
     formData.append("allow_preview", data.allow_preview ? 1 : 0);
-    formData.append("status", "pending");
+    formData.append("status", data.status);
     setUploadProgress(0);
     onSubmit(formData, setUploadProgress);
   };
@@ -488,6 +489,30 @@ export default function BookForm({
           </p>
         )}
       </div>
+
+      {showStatusSelector ? (
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            {t("booksCreate.statusLabel", "Status")}
+          </label>
+          <select
+            {...register("status")}
+            className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          >
+            <option value="pending">
+              {t("booksCreate.statusPending", "Pending")}
+            </option>
+            <option value="approved">
+              {t("booksCreate.statusApproved", "Approved")}
+            </option>
+            <option value="rejected">
+              {t("booksCreate.statusRejected", "Rejected")}
+            </option>
+          </select>
+        </div>
+      ) : (
+        <input type="hidden" {...register("status")} />
+      )}
 
       {uploadProgress !== null && (
         <div className="w-full bg-gray-200 rounded h-2 mb-4">


### PR DESCRIPTION
## Summary
- Default BookForm status to provided value and include in reset
- Append current status in submission instead of hardcoded pending
- Optional status selector for admins

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 245 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893b1e8fc1883288bd54cd102948093