### PR TITLE
Localize book license options

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1054,7 +1054,10 @@
     "languageRequired": "اللغة مطلوبة",
     "licenseTypeLabel": "نوع الترخيص",
     "selectLicenseType": "اختر نوع الترخيص",
-    "licenseTypeRequired": "نوع الترخيص مطلوب"
+    "licenseTypeRequired": "نوع الترخيص مطلوب",
+    "licensePersonal": "للاستخدام الشخصي",
+    "licenseEducational": "للاستخدام التعليمي",
+    "licenseCommercial": "إعادة البيع التجاري غير مسموح بها"
   },
   "booksEdit": {
     "pageTitle": "تعديل الكتاب",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1085,5 +1085,13 @@
     "duration_exceeded": "Dauer darf {{days}} Tage nicht überschreiten.",
     "update_success": "Anzeige erfolgreich aktualisiert!",
     "update_failed": "Anzeige konnte nicht aktualisiert werden"
+  },
+  "booksCreate": {
+    "licenseTypeLabel": "Lizenztyp",
+    "selectLicenseType": "Lizenztyp auswählen",
+    "licenseTypeRequired": "Lizenztyp ist erforderlich",
+    "licensePersonal": "Persönliche Nutzung",
+    "licenseEducational": "Bildungsnutzung",
+    "licenseCommercial": "Kommerzieller Weiterverkauf nicht erlaubt"
   }
 }

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1067,7 +1067,10 @@
     "languageRequired": "Language is required",
     "licenseTypeLabel": "License Type",
     "selectLicenseType": "Select license type",
-    "licenseTypeRequired": "License type is required"
+    "licenseTypeRequired": "License type is required",
+    "licensePersonal": "Personal use",
+    "licenseEducational": "Educational use",
+    "licenseCommercial": "Commercial resale not allowed"
   },
   "booksEdit": {
     "pageTitle": "Edit Book",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1085,5 +1085,13 @@
     "duration_exceeded": "La duración no puede exceder {{days}} días.",
     "update_success": "¡Anuncio actualizado correctamente!",
     "update_failed": "No se pudo actualizar el anuncio"
+  },
+  "booksCreate": {
+    "licenseTypeLabel": "Tipo de licencia",
+    "selectLicenseType": "Selecciona el tipo de licencia",
+    "licenseTypeRequired": "El tipo de licencia es obligatorio",
+    "licensePersonal": "Uso personal",
+    "licenseEducational": "Uso educativo",
+    "licenseCommercial": "Reventa comercial no permitida"
   }
 }

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1042,7 +1042,10 @@
     "languageRequired": "La langue est obligatoire",
     "licenseTypeLabel": "Type de licence",
     "selectLicenseType": "Sélectionnez le type de licence",
-    "licenseTypeRequired": "Le type de licence est obligatoire"
+    "licenseTypeRequired": "Le type de licence est obligatoire",
+    "licensePersonal": "Usage personnel",
+    "licenseEducational": "Usage éducatif",
+    "licenseCommercial": "Revente commerciale interdite"
   },
   "booksEdit": {
     "pageTitle": "Modifier le livre",

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -478,9 +478,9 @@ export default function BookForm({
           className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
         >
           <option value="">{t("booksCreate.selectLicenseType")}</option>
-          <option value="personal">Personal use</option>
-          <option value="educational">Educational use</option>
-          <option value="commercial">Commercial resale not allowed</option>
+          <option value="personal">{t("booksCreate.licensePersonal")}</option>
+          <option value="educational">{t("booksCreate.licenseEducational")}</option>
+          <option value="commercial">{t("booksCreate.licenseCommercial")}</option>
         </select>
         {errors.license_type && (
           <p className="text-red-500 text-sm mt-1">


### PR DESCRIPTION
## Summary
- add license option translations for personal, educational, and commercial use across all locales
- replace hard-coded license option labels in `BookForm` with localized strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b1eaa4cc832886f9c526c7ad3e6e