### PR TITLE
feat: debounce book tag fetch with cancellation

### DIFF
--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "next-i18next";
 import { fetchBookTags, createBookTag } from "@/services/bookTagService";
 import { getLanguages } from "@/services/languageService";
+import debounce from "lodash/debounce";
 
 export default function BookForm({
   onSubmit,
@@ -77,19 +78,42 @@ export default function BookForm({
     setValue("tags", tags);
   }, [tags, setValue]);
 
+  const tagAbortRef = useRef(null);
+
+  const debouncedFetchTags = useMemo(
+    () =>
+      debounce(async (input, signal) => {
+        try {
+          const data = await fetchBookTags(input, { signal });
+          setTagSuggestions(data);
+        } catch (err) {
+          if (err.name !== "CanceledError" && err.name !== "AbortError") {
+            console.error("Failed to fetch tags", err);
+          }
+        }
+      }, 300),
+    []
+  );
+
   useEffect(() => {
-    let ignore = false;
-    if (tagInput) {
-      fetchBookTags(tagInput).then((data) => {
-        if (!ignore) setTagSuggestions(data);
-      });
-    } else {
+    if (!tagInput) {
       setTagSuggestions([]);
+      tagAbortRef.current?.abort();
+      debouncedFetchTags.cancel();
+      return;
     }
+
+    tagAbortRef.current?.abort();
+    debouncedFetchTags.cancel();
+    const controller = new AbortController();
+    tagAbortRef.current = controller;
+    debouncedFetchTags(tagInput, controller.signal);
+
     return () => {
-      ignore = true;
+      controller.abort();
+      debouncedFetchTags.cancel();
     };
-  }, [tagInput]);
+  }, [tagInput, debouncedFetchTags]);
 
   const addTag = (name) => {
     const value = name.trim();
@@ -97,9 +121,13 @@ export default function BookForm({
     if (!tags.includes(value)) {
       setTags([...tags, value]);
       if (!tagSuggestions.find((t) => t.name === value)) {
-        createBookTag({ name: value }).then((newTag) =>
-          setTagSuggestions((prev) => [...prev, newTag])
-        );
+        createBookTag({ name: value })
+          .then((newTag) =>
+            setTagSuggestions((prev) => [...prev, newTag])
+          )
+          .catch((err) =>
+            console.error("Failed to create tag", err)
+          );
       }
     }
     setTagInput("");

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import BookCardSkeleton from "@/components/books/BookCardSkeleton";
@@ -14,6 +14,7 @@ import { useTranslation } from "next-i18next";
 import { FiPlus, FiSearch, FiTrash2, FiChevronLeft, FiChevronRight, FiFilter, FiX, FiEdit, FiEye } from "react-icons/fi";
 import { Switch } from '@headlessui/react';
 import ConfirmModal from "@/components/common/ConfirmModal";
+import debounce from "lodash/debounce";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 const buildUrl = (path) => {
@@ -91,16 +92,42 @@ function AdminBooksPage() {
     loadCategories();
   }, [t]);
 
+  const tagAbortRef = useRef(null);
+
+  const debouncedFetchTags = useMemo(
+    () =>
+      debounce(async (input, signal) => {
+        try {
+          const data = await fetchBookTags(input, { signal });
+          setTagSuggestions(data);
+        } catch (err) {
+          if (err.name !== "CanceledError" && err.name !== "AbortError") {
+            console.error("Failed to fetch tags", err);
+          }
+        }
+      }, 300),
+    []
+  );
+
   useEffect(() => {
     if (!tagInput) {
       setTagSuggestions([]);
+      tagAbortRef.current?.abort();
+      debouncedFetchTags.cancel();
       return;
     }
 
-    fetchBookTags(tagInput)
-      .then(setTagSuggestions)
-      .catch(() => {});
-  }, [tagInput]);
+    tagAbortRef.current?.abort();
+    debouncedFetchTags.cancel();
+    const controller = new AbortController();
+    tagAbortRef.current = controller;
+    debouncedFetchTags(tagInput, controller.signal);
+
+    return () => {
+      controller.abort();
+      debouncedFetchTags.cancel();
+    };
+  }, [tagInput, debouncedFetchTags]);
 
   useEffect(() => {
     const loadBooks = async () => {

--- a/frontend/src/services/bookTagService.js
+++ b/frontend/src/services/bookTagService.js
@@ -1,12 +1,15 @@
 import api from "@/services/api/api";
 
-export const fetchBookTags = async (search) => {
-  const { data } = await api.get("/books/tags", { params: search ? { search } : {} });
+export const fetchBookTags = async (search, config = {}) => {
+  const { data } = await api.get("/books/tags", {
+    params: search ? { search } : {},
+    ...config,
+  });
   return data?.data ?? [];
 };
 
-export const createBookTag = async (payload) => {
-  const { data } = await api.post("/books/tags", payload);
+export const createBookTag = async (payload, config = {}) => {
+  const { data } = await api.post("/books/tags", payload, config);
   return data?.data;
 };
 


### PR DESCRIPTION
## Summary
- debounce book tag searches to avoid rapid requests
- add error logging for tag fetches and creation
- cancel in-flight tag searches when input changes

## Testing
- `npm test`
- `npm run lint` *(fails: Assign object to a variable before exporting as module default, plus other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893b1eee11883289969b780bdddeca5