### PR TITLE
feat: add validation for preview files

### DIFF
--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -364,7 +364,32 @@ export default function BookForm({
           {t("booksCreate.previewPagesLabel")}
         </label>
         {(() => {
-          const reg = register("preview_pages");
+          const reg = register("preview_pages", {
+            validate: {
+              fileType: (files) => {
+                if (!files || files.length === 0) return true;
+                return (
+                  Array.from(files).every(
+                    (file) =>
+                      file.type === "application/pdf" ||
+                      file.type.startsWith("image/")
+                  ) || "Only PDF or image files are allowed"
+                );
+              },
+              fileSize: (files) => {
+                if (!files || files.length === 0) return true;
+                return (
+                  Array.from(files).every(
+                    (file) => file.size <= 50 * 1024 * 1024
+                  ) || "Each file must be less than 50MB"
+                );
+              },
+              fileCount: (files) => {
+                if (!files || files.length === 0) return true;
+                return files.length <= 10 || "You can upload up to 10 files";
+              },
+            },
+          });
           return (
             <input
               type="file"
@@ -386,6 +411,11 @@ export default function BookForm({
               <li key={idx}>{file.name}</li>
             ))}
           </ul>
+        )}
+        {errors.preview_pages && (
+          <p className="text-red-500 text-sm mt-1">
+            {errors.preview_pages.message}
+          </p>
         )}
       </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- validate preview file uploads for type, size, and count

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: 293 problems (48 errors, 245 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6893b1f0e1a08328a91e2a0cd40233c4