### PR TITLE
fix: revoke object URLs in profile image steps

### DIFF
--- a/frontend/src/components/profile/steps/PersonalDetails.js
+++ b/frontend/src/components/profile/steps/PersonalDetails.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage"; // Helper function for cropping
 import { FaUpload, FaTimesCircle, FaCrop, FaCheck } from "react-icons/fa";
@@ -22,6 +22,9 @@ const PersonalDetails = ({ formData, setFormData, nextStep }) => {
   const handleImageUpload = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
       const imageUrl = URL.createObjectURL(file);
       setPreview(imageUrl);
       setFile(file);
@@ -38,6 +41,9 @@ const PersonalDetails = ({ formData, setFormData, nextStep }) => {
   const handleCropSave = async () => {
     try {
       const blob = await getCroppedImg(preview, croppedAreaPixels);
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
       const url = URL.createObjectURL(blob);
       setPreview(url);
       setFormData({ ...formData, profilePicture: blob });
@@ -48,10 +54,21 @@ const PersonalDetails = ({ formData, setFormData, nextStep }) => {
   };
 
   // ✅ Remove Profile Picture
-  const removeImage = () => {
+  const handleRemoveImage = () => {
+    if (preview) {
+      URL.revokeObjectURL(preview);
+    }
     setPreview("");
     setFormData({ ...formData, profilePicture: null });
   };
+
+  useEffect(() => {
+    return () => {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview]);
 
   return (
     <div>
@@ -62,7 +79,7 @@ const PersonalDetails = ({ formData, setFormData, nextStep }) => {
         {preview && !showCropper ? (
           <div className="relative">
             <img src={preview} alt="Profile Preview" className="w-24 h-24 rounded-full border-2 border-yellow-500" />
-            <button onClick={removeImage} className="absolute top-0 right-0 bg-red-600 text-white p-1 rounded-full">
+            <button onClick={handleRemoveImage} className="absolute top-0 right-0 bg-red-600 text-white p-1 rounded-full">
               <FaTimesCircle />
             </button>
             <button

--- a/frontend/src/pages/dashboard/instructor/profile/steps/PersonalDetails.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/PersonalDetails.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage"; // Helper function for cropping
 import { FaUpload, FaTimesCircle, FaCrop, FaCheck } from "react-icons/fa";
@@ -26,6 +26,9 @@ const PersonalDetails = ({
   const handleImageUpload = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
       const imageUrl = URL.createObjectURL(file);
       setPreview(imageUrl);
       setFile(file);
@@ -42,6 +45,9 @@ const PersonalDetails = ({
   const handleCropSave = async () => {
     try {
       const blob = await getCroppedImg(preview, croppedAreaPixels);
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
       const url = URL.createObjectURL(blob);
       setPreview(url);
       setFormData({ ...formData, profilePicture: blob });
@@ -52,10 +58,21 @@ const PersonalDetails = ({
   };
 
   // ✅ Remove Profile Picture
-  const removeImage = () => {
+  const handleRemoveImage = () => {
+    if (preview) {
+      URL.revokeObjectURL(preview);
+    }
     setPreview("");
     setFormData({ ...formData, profilePicture: null });
   };
+
+  useEffect(() => {
+    return () => {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview]);
 
   return (
     <div>
@@ -66,7 +83,7 @@ const PersonalDetails = ({
         {preview && !showCropper ? (
           <div className="relative">
             <img src={preview} alt="Profile Preview" className="w-24 h-24 rounded-full border-2 border-yellow-500" />
-            <button onClick={removeImage} className="absolute top-0 right-0 bg-red-600 text-white p-1 rounded-full">
+            <button onClick={handleRemoveImage} className="absolute top-0 right-0 bg-red-600 text-white p-1 rounded-full">
               <FaTimesCircle />
             </button>
             <button

--- a/frontend/src/pages/dashboard/student/profile/steps/PersonalDetails.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/PersonalDetails.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
 import { FaUpload, FaTimesCircle, FaCrop, FaCheck } from "react-icons/fa";
@@ -24,6 +24,9 @@ const PersonalDetails = ({
   const handleImageUpload = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
       const imageUrl = URL.createObjectURL(file);
       setPreview(imageUrl);
       setFile(file);
@@ -38,6 +41,9 @@ const PersonalDetails = ({
   const handleCropSave = async () => {
     try {
       const blob = await getCroppedImg(preview, croppedAreaPixels);
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
       const url = URL.createObjectURL(blob);
       setPreview(url);
       setFormData({ ...formData, profilePicture: blob });
@@ -47,10 +53,21 @@ const PersonalDetails = ({
     }
   };
 
-  const removeImage = () => {
+  const handleRemoveImage = () => {
+    if (preview) {
+      URL.revokeObjectURL(preview);
+    }
     setPreview("");
     setFormData({ ...formData, profilePicture: null });
   };
+
+  useEffect(() => {
+    return () => {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview]);
 
   const validateAndNext = () => {
     const newErrors = {};
@@ -81,7 +98,7 @@ const PersonalDetails = ({
                 className="w-24 h-24 rounded-full border-4 border-yellow-500 shadow-md"
               />
               <button
-                onClick={removeImage}
+                onClick={handleRemoveImage}
                 className="absolute -top-2 -right-2 bg-red-500 text-white p-1 rounded-full shadow hover:bg-red-600"
               >
                 <FaTimesCircle size={14} />


### PR DESCRIPTION
## Summary
- prevent memory leaks by revoking image object URLs in profile steps
- clean up object URLs when cropping or removing preview images

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6893b4c8d250832896f140e537a687c0