### PR TITLE
feat: add book creation service

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
 import toast from "react-hot-toast";
 import { useTranslation } from "next-i18next";
-import api from "@/services/api/api";
+import { createBook } from "@/services/bookService";
 import BookForm from "@/components/books/BookForm";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
@@ -83,15 +83,12 @@ function AdminCreateBookPage() {
     }
     try {
       setProgress(0);
-      await api.post("/books", formData, {
-        headers: { "Content-Type": "multipart/form-data" },
-        onUploadProgress: (event) => {
-          if (event.total) {
-            const progress = Math.round((event.loaded * 100) / event.total);
-            setProgress(progress);
-            setUploadProgress(progress);
-          }
-        },
+      await createBook(formData, (event) => {
+        if (event.total) {
+          const progress = Math.round((event.loaded * 100) / event.total);
+          setProgress(progress);
+          setUploadProgress(progress);
+        }
       });
 
       toast.success(t("booksCreate.success"));

--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
-import api from "@/services/api/api";
+import { createBook } from "@/services/bookService";
 import BookForm from "@/components/books/BookForm";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
@@ -85,15 +85,12 @@ function CreateBookPage() {
     }
     try {
       setProgress(0);
-      await api.post("/books", formData, {
-        headers: { "Content-Type": "multipart/form-data" },
-        onUploadProgress: (event) => {
-          if (event.total) {
-            const progress = Math.round((event.loaded * 100) / event.total);
-            setProgress(progress);
-            setUploadProgress(progress);
-          }
-        },
+      await createBook(formData, (event) => {
+        if (event.total) {
+          const progress = Math.round((event.loaded * 100) / event.total);
+          setProgress(progress);
+          setUploadProgress(progress);
+        }
       });
 
       toast.success(t("booksCreate.success"));

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -48,6 +48,14 @@ export const deleteBook = async (id) => {
   return true;
 };
 
+export const createBook = async (formData, onUploadProgress) => {
+  const { data } = await api.post("/books", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+    onUploadProgress,
+  });
+  return data?.data ? formatBook(data.data) : null;
+};
+
 export const updateBook = async (id, formData, onUploadProgress) => {
   const { data } = await api.put(`/books/${id}`, formData, {
     headers: { "Content-Type": "multipart/form-data" },
@@ -65,6 +73,7 @@ export default {
   fetchBooks,
   fetchBook,
   deleteBook,
+  createBook,
   updateBook,
   updateBookStatus,
 };

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -1,7 +1,16 @@
 import api from "../../services/api/api";
-import { fetchBooks, fetchBook, updateBook } from "../../services/bookService";
+import {
+  fetchBooks,
+  fetchBook,
+  updateBook,
+  createBook,
+} from "../../services/bookService";
 
-jest.mock("../../services/api/api", () => ({ get: jest.fn(), put: jest.fn() }));
+jest.mock("../../services/api/api", () => ({
+  get: jest.fn(),
+  put: jest.fn(),
+  post: jest.fn(),
+}));
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -54,5 +63,18 @@ describe("bookService", () => {
       expect.objectContaining({ headers: { "Content-Type": "multipart/form-data" } })
     );
     expect(book).toEqual({ id: 1, cover_image_url: null, pdf_url: null });
+  });
+
+  it("creates a book", async () => {
+    const apiData = { id: 2 };
+    api.post.mockResolvedValueOnce({ data: { data: apiData } });
+    const formData = new FormData();
+    const book = await createBook(formData);
+    expect(api.post).toHaveBeenCalledWith(
+      "/books",
+      formData,
+      expect.objectContaining({ headers: { "Content-Type": "multipart/form-data" } })
+    );
+    expect(book).toEqual({ id: 2, cover_image_url: null, pdf_url: null });
   });
 });


### PR DESCRIPTION
## Summary
- add createBook API helper and expose via bookService
- refactor admin and instructor create-book pages to use service
- test createBook behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893b937698883288dd0125396d840d9