### PR TITLE
feat: sync user unread badges with message store

### DIFF
--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -15,6 +15,30 @@ import useMessageStore from "@/store/messages/messageStore";
 import { API_BASE_URL } from "@/config/config";
 import { toast } from "react-toastify";
 
+// Helper to merge unread counts from the message store into a user list
+export const computeUnreadCounts = (list = [], messages = []) => {
+  if (!Array.isArray(list)) return list;
+
+  const counts = messages.reduce((acc, msg) => {
+    if (msg && !msg.read) {
+      const senderId = Number(msg.sender_id);
+      if (!Number.isNaN(senderId)) {
+        acc[senderId] = (acc[senderId] || 0) + 1;
+      }
+    }
+    return acc;
+  }, {});
+
+  return list.map((user) => {
+    const unread = counts[user.id] || 0;
+    return {
+      ...user,
+      unread,
+      unreadMessages: unread,
+    };
+  });
+};
+
 const MessagesPage = () => {
   const { t } = useTranslation("common");
   const { t: tDash } = useTranslation("dashboard");
@@ -50,7 +74,7 @@ const MessagesPage = () => {
   const router = useRouter();
 
   // Keep unread counts from the backend so new chats show up in the sidebar
-  const adjustCounts = useCallback((list) => list, []);
+  const adjustCounts = useCallback((list) => computeUnreadCounts(list, messages), [messages]);
 
   const fetchUsersList = useCallback(() => {
     return getUsers()

--- a/frontend/src/tests/__tests__/adjustCounts.test.js
+++ b/frontend/src/tests/__tests__/adjustCounts.test.js
@@ -1,0 +1,28 @@
+import { computeUnreadCounts } from '@/pages/messages/index';
+
+describe('computeUnreadCounts', () => {
+  it('updates user unread counts when new messages arrive', () => {
+    const users = [
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ];
+
+    // Start with no messages
+    let updated = computeUnreadCounts(users, []);
+    expect(updated.find(u => u.id === 1).unreadMessages).toBe(0);
+    expect(updated.find(u => u.id === 2).unreadMessages).toBe(0);
+
+    // Add an unread message from Alice
+    const messages = [
+      { id: 10, sender_id: 1, read: false },
+    ];
+
+    updated = computeUnreadCounts(users, messages);
+    const alice = updated.find(u => u.id === 1);
+    const bob = updated.find(u => u.id === 2);
+
+    expect(alice.unreadMessages).toBe(1);
+    expect(alice.unread).toBe(1);
+    expect(bob.unreadMessages).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- compute unread counts for each chat user using message store data
- apply count adjustment after fetching users and whenever messages change
- add unit test covering unread badge updates

## Testing
- `npm test src/tests/__tests__/adjustCounts.test.js`
- `npm run lint` *(fails: 48 errors, 247 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893b9278db08328afa501b2adb488ac