### PR TITLE
feat(chat): add message validation and tests

### DIFF
--- a/backend/src/modules/chat/chat.routes.js
+++ b/backend/src/modules/chat/chat.routes.js
@@ -3,12 +3,28 @@ const router = express.Router();
 const controller = require("./chat.controller");
 const { verifyToken } = require("../../middleware/auth/authMiddleware");
 const upload = require("./chatUpload.middleware");
+const validate = require("../../middleware/validate");
+const validator = require("./chat.validator");
+
+const mapFilesToBody = (req, _res, next) => {
+  const file = req.files?.file?.[0];
+  const audio = req.files?.audio?.[0];
+  if (file) req.body.file = { mimetype: file.mimetype, size: file.size };
+  if (audio) req.body.audio = { mimetype: audio.mimetype, size: audio.size };
+  next();
+};
 
 router.use(verifyToken);
 
 router.get("/users", controller.searchUsers);
 router.get("/:userId", controller.getConversation);
-router.post("/:userId", upload, controller.sendMessage);
+router.post(
+  "/:userId",
+  upload,
+  mapFilesToBody,
+  validate(validator.sendMessage),
+  controller.sendMessage
+);
 router.delete("/messages/:id", controller.deleteMessage);
 router.patch("/messages/:id/pin", controller.togglePin);
 

--- a/backend/src/modules/chat/chat.validator.js
+++ b/backend/src/modules/chat/chat.validator.js
@@ -1,0 +1,50 @@
+const { z } = require("zod");
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const fileTypes = ["image/jpeg", "image/png", "application/pdf"];
+const audioTypes = ["audio/mpeg", "audio/wav"];
+
+const baseUploadSchema = z.object({
+  mimetype: z.string(),
+  size: z.number(),
+});
+
+const fileSchema = baseUploadSchema
+  .extend({
+    mimetype: z.enum(fileTypes),
+  })
+  .refine((f) => f.size <= MAX_FILE_SIZE, {
+    message: "File too large",
+  });
+
+const audioSchema = baseUploadSchema
+  .extend({
+    mimetype: z.enum(audioTypes),
+  })
+  .refine((f) => f.size <= MAX_FILE_SIZE, {
+    message: "File too large",
+  });
+
+exports.sendMessage = {
+  body: z
+    .object({
+      message: z.string().trim().min(1, "Message cannot be empty").optional(),
+      file: fileSchema.optional(),
+      audio: audioSchema.optional(),
+      replyTo: z.string().optional(),
+    })
+    .refine(
+      (data) =>
+        !!(data.message && data.message.trim()) ||
+        !!data.file ||
+        !!data.audio,
+      {
+        message: "Message or attachment required",
+        path: ["message"],
+      }
+    )
+    .refine((data) => !(data.file && data.audio), {
+      message: "Only one attachment allowed",
+      path: ["file"],
+    }),
+};

--- a/backend/src/modules/chat/chatUpload.middleware.js
+++ b/backend/src/modules/chat/chatUpload.middleware.js
@@ -20,7 +20,9 @@ const fileFilter = (_req, file, cb) => {
   };
   const allowed = fileTypes[file.fieldname] || [];
   if (allowed.includes(file.mimetype)) return cb(null, true);
-  cb(new Error("Invalid file type"));
+  const err = new Error("Invalid file type");
+  err.status = 400;
+  cb(err);
 };
 
 const upload = multer({

--- a/backend/tests/chatRoutes.test.js
+++ b/backend/tests/chatRoutes.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest');
 const express = require('express');
+const errorHandler = require('../src/middleware/errorHandler');
 
 jest.mock('../src/modules/chat/chat.service', () => ({
   searchUsers: jest.fn(),
@@ -19,6 +20,11 @@ const routes = require('../src/modules/chat/chat.routes');
 const app = express();
 app.use(express.json());
 app.use('/api/chat', routes);
+app.use(errorHandler);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('GET /api/chat/users', () => {
   it('searches users', async () => {
@@ -58,6 +64,31 @@ describe('POST /api/chat/:userId', () => {
       audio_url: null,
       reply_to_id: null,
     });
+  });
+
+  it('rejects empty message without attachments', async () => {
+    const res = await request(app).post('/api/chat/2').send({ message: '' });
+    expect(res.status).toBe(400);
+    expect(service.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized file uploads', async () => {
+    const bigBuffer = Buffer.alloc(10 * 1024 * 1024 + 1);
+    const res = await request(app)
+      .post('/api/chat/2')
+      .attach('file', bigBuffer, { filename: 'big.png', contentType: 'image/png' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('File too large');
+    expect(service.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects disallowed mime types', async () => {
+    const res = await request(app)
+      .post('/api/chat/2')
+      .attach('file', Buffer.from('test'), { filename: 'bad.txt', contentType: 'text/plain' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Invalid file type');
+    expect(service.sendMessage).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- add Zod validator to ensure chat messages include text or a single attachment with size/type limits
- apply validation middleware on chat send endpoint
- extend route tests to cover invalid payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893b91444b0832882865ef759ac7c75