### PR TITLE
feat: allow cancelling group join requests

### DIFF
--- a/frontend/src/pages/dashboard/student/groups/requests.js
+++ b/frontend/src/pages/dashboard/student/groups/requests.js
@@ -2,6 +2,7 @@ import StudentLayout from '@/components/layouts/StudentLayout';
 import { Clock } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import groupService from '@/services/groupService';
+import { toast } from 'react-hot-toast';
 
 export default function JoinRequestsPage() {
   const [requests, setRequests] = useState([]);
@@ -14,6 +15,16 @@ export default function JoinRequestsPage() {
       })
       .catch(() => setRequests([]));
   }, []);
+
+  const handleCancel = async (id) => {
+    try {
+      await groupService.cancelJoinRequest(id);
+      setRequests((prev) => prev.filter((g) => g.id !== id));
+      toast.success('Join request cancelled');
+    } catch (e) {
+      toast.error('Failed to cancel join request');
+    }
+  };
   return (
     <StudentLayout>
       <div className="max-w-6xl mx-auto p-4 space-y-6">
@@ -33,10 +44,10 @@ export default function JoinRequestsPage() {
                 </div>
                 <p className="text-sm text-gray-600">{group.description}</p>
                 <button
-                  disabled
-                  className="mt-2 w-full px-4 py-2 rounded bg-gray-300 cursor-not-allowed"
+                  onClick={() => handleCancel(group.id)}
+                  className="mt-2 w-full px-4 py-2 rounded bg-red-500 text-white hover:bg-red-600"
                 >
-                  Awaiting Approval
+                  Cancel Request
                 </button>
               </div>
             ))}

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -64,6 +64,11 @@ const groupService = {
     return data?.data;
   },
 
+  cancelJoinRequest: async (groupId) => {
+    await api.delete(`/groups/${groupId}/join`);
+    return true;
+  },
+
   createGroup: async (payload) => {
     const { data } = await api.post("/groups", payload, {
       headers:

--- a/frontend/src/tests/__tests__/instructorBookService.test.js
+++ b/frontend/src/tests/__tests__/instructorBookService.test.js
@@ -21,10 +21,11 @@ beforeEach(() => {
 describe("instructor bookService", () => {
   it("fetches instructor books", async () => {
     const apiData = [{ id: 1 }];
-    api.get.mockResolvedValueOnce({ data: { data: apiData } });
+    const meta = { page: 1 };
+    api.get.mockResolvedValueOnce({ data: { data: apiData, meta } });
     const res = await fetchInstructorBooks();
-    expect(api.get).toHaveBeenCalledWith("/instructor/books");
-    expect(res).toEqual(apiData);
+    expect(api.get).toHaveBeenCalledWith("/instructor/books", { params: {} });
+    expect(res).toEqual({ books: apiData, meta });
   });
 
   it("creates a book", async () => {


### PR DESCRIPTION
## Summary
- let students cancel pending group join requests
- expose `cancelJoinRequest` in group service
- fix instructor book service tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68943b0f17f88328af0392c12ebb2957