### PR TITLE
Use Promise.all for bulk group member removal

### DIFF
--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -87,12 +87,15 @@ export default function AdminGroupDetailsPage() {
   const bulkRemove = async () => {
     if (!group) return;
     if (confirm('Are you sure you want to remove the selected members?')) {
-      for (const mid of selectedMembers) {
-        try {
-          await groupService.manageMember(group.id, mid, 'kick');
-        } catch {
-          // ignore errors per member
-        }
+      try {
+        await Promise.all(
+          selectedMembers.map((mid) =>
+            groupService.manageMember(group.id, mid, 'kick')
+          )
+        );
+      } catch (error) {
+        console.error('Bulk removal failed:', error);
+        alert('Some members could not be removed.');
       }
       setMembers(members.filter((m) => !selectedMembers.includes(m.id)));
       setSelectedMembers([]);


### PR DESCRIPTION
## Summary
- Refactor admin group member bulk removal to use Promise.all for kicking members in parallel
- Add error handling for bulk removal failures

## Testing
- `npm test` *(fails: instructorBookService.test.js)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68943b0ba5208328aabef2ed7233022c