### PR TITLE
feat: handle errors on group request actions

### DIFF
--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -17,6 +17,7 @@ import {
   FaFolderOpen,
 } from 'react-icons/fa';
 import groupService from '@/services/groupService';
+import { toast } from 'react-toastify';
 
 // ...imports (same as before)...
 
@@ -397,8 +398,9 @@ export default function AdminGroupDetailsPage() {
                                 const next = requests.filter((r) => r.id !== req.id);
                                 setRequests(next);
                                 setPendingCount(next.length);
-                              } catch {
-                                // ignore
+                              } catch (err) {
+                                console.error('Failed to approve request', err);
+                                toast.error('Failed to approve request');
                               }
                             }
                           }}
@@ -414,8 +416,9 @@ export default function AdminGroupDetailsPage() {
                                 const next = requests.filter((r) => r.id !== req.id);
                                 setRequests(next);
                                 setPendingCount(next.length);
-                              } catch {
-                                // ignore
+                              } catch (err) {
+                                console.error('Failed to reject request', err);
+                                toast.error('Failed to reject request');
                               }
                             }
                           }}


### PR DESCRIPTION
## Summary
- log and toast errors when approving or rejecting group join requests
- ensure requests and pending counts unchanged on failure

## Testing
- `npm test` *(fails: instructorBookService.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68943b0a8cc08328b6b772d99ccc2e10