### PR TITLE
fix: align end time field styling in booking modal

### DIFF
--- a/frontend/src/components/student/instructors/BookingRequestModal.js
+++ b/frontend/src/components/student/instructors/BookingRequestModal.js
@@ -197,7 +197,7 @@ export default function BookingRequestModal({ instructor, onClose }) {
                 value={endTime}
                 onChange={(e) => setEndTime(e.target.value)}
                 required
-                className="w-full border-black-300 rounded-lg px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-400"
+                className="w-full border-gray-300 rounded-lg px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-400"
               />
             </div>
 


### PR DESCRIPTION
## Summary
- match end-time input styling with start-time field in booking request modal

## Testing
- `npm test` (fails: instructorBookService.test.js)`

------
https://chatgpt.com/codex/tasks/task_e_68943b09c4788328ac22122236d39a2d