### PR TITLE
Fix admin book cover and enable status toggle

### DIFF
--- a/backend/src/migrations/20250808120000_extend_books_status_enum.js
+++ b/backend/src/migrations/20250808120000_extend_books_status_enum.js
@@ -1,0 +1,12 @@
+const TABLE_NAME = 'books';
+const ENUM_NAME = 'enum_books_status';
+
+exports.up = async function (knex) {
+  await knex.schema.raw(`ALTER TYPE ${ENUM_NAME} ADD VALUE IF NOT EXISTS 'active';`);
+  await knex.schema.raw(`ALTER TYPE ${ENUM_NAME} ADD VALUE IF NOT EXISTS 'inactive';`);
+};
+
+exports.down = async function (knex) {
+  // PostgreSQL does not support easily removing enum values
+  // so this migration is irreversible
+};

--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -189,3 +189,12 @@ exports.deleteBook = catchAsync(async (req, res) => {
   await service.deleteBook(req.params.id);
   sendSuccess(res, null, "Book deleted");
 });
+
+exports.updateBookStatus = catchAsync(async (req, res) => {
+  const { status } = req.body || {};
+  const book = await service.updateBookStatus(req.params.id, status);
+  if (!book) {
+    throw new AppError("Book not found", 404);
+  }
+  sendSuccess(res, book, "Book status updated");
+});

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -14,6 +14,7 @@ router.get("/admin/:id", verifyToken, isInstructorOrAdmin, controller.getBookAdm
 router.get("/:id", controller.getBook);
 router.post("/", verifyToken, isInstructorOrAdmin, upload, controller.createBook);
 router.put("/:id", verifyToken, isInstructorOrAdmin, upload, controller.updateBook);
+router.patch("/:id/status", verifyToken, isInstructorOrAdmin, controller.updateBookStatus);
 router.delete("/:id", verifyToken, isInstructorOrAdmin, controller.deleteBook);
 
 module.exports = router;

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -106,4 +106,9 @@ exports.updateBook = async (id, data) => {
   return row;
 };
 
+exports.updateBookStatus = async (id, status) => {
+  const [row] = await db("books").where({ id }).update({ status }).returning("*");
+  return row;
+};
+
 exports.deleteBook = (id) => db("books").where({ id }).del();

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -16,16 +16,6 @@ import { Switch } from '@headlessui/react';
 import ConfirmModal from "@/components/common/ConfirmModal";
 import debounce from "lodash/debounce";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-const buildUrl = (path) => {
-  if (!path) return null;
-  if (/^https?:/i.test(path)) return path;
-  const uploadsIndex = path.indexOf("/uploads");
-  const relative = uploadsIndex !== -1 ? path.substring(uploadsIndex) : path;
-  const normalized = relative.startsWith("/") ? relative : `/${relative}`;
-  return `${API_BASE}${normalized}`;
-};
-
 function AdminBooksPage() {
   const { t } = useTranslation("dashboard");
 
@@ -725,7 +715,6 @@ function AdminBooksPage() {
               {books.map((book) => {
                 const coverUrl =
                   book.cover_image_url ||
-                  buildUrl(book.cover_image) ||
                   "/images/default-book-cover.jpg";
                 return (
                   <div

--- a/frontend/src/services/instructor/bookService.js
+++ b/frontend/src/services/instructor/bookService.js
@@ -17,7 +17,13 @@ export const fetchInstructorBooks = async ({
     ...(status ? { status } : {}),
   };
 
-  const { data } = await api.get("/instructor/books", { params });
+  let response;
+  if (Object.keys(params).length) {
+    response = await api.get("/instructor/books", { params });
+  } else {
+    response = await api.get("/instructor/books");
+  }
+  const { data } = response;
   const list = data?.data || [];
   return { books: list, meta: data?.meta ?? {} };
 

--- a/frontend/src/tests/__tests__/instructorBookService.test.js
+++ b/frontend/src/tests/__tests__/instructorBookService.test.js
@@ -24,7 +24,7 @@ describe("instructor bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const res = await fetchInstructorBooks();
     expect(api.get).toHaveBeenCalledWith("/instructor/books");
-    expect(res).toEqual(apiData);
+    expect(res).toEqual({ books: apiData, meta: {} });
   });
 
   it("creates a book", async () => {


### PR DESCRIPTION
## Summary
- Ensure admin books list renders cover images using `cover_image_url`
- Add backend endpoint and migration to toggle book `status`
- Avoid sending empty query params in instructor book service and update tests

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68943c787b808328b7af629322d7e3cc