### PR TITLE
fix: export fetchBookAnalytics

### DIFF
--- a/frontend/src/services/instructor/bookService.js
+++ b/frontend/src/services/instructor/bookService.js
@@ -50,7 +50,8 @@ export const deleteBook = async (id) => {
   return true;
 };
 
-export const fetchAnalytics = async (params = {}) => {
+// Fetch analytics for instructor's books with optional query params
+export const fetchBookAnalytics = async (params = {}) => {
   const { data } = await api.get("/instructor/books/analytics", { params });
   return data?.data || [];
 };
@@ -60,5 +61,5 @@ export default {
   createBook,
   updateBook,
   deleteBook,
-  fetchAnalytics,
+  fetchBookAnalytics,
 };

--- a/frontend/src/tests/__tests__/instructorBookService.test.js
+++ b/frontend/src/tests/__tests__/instructorBookService.test.js
@@ -4,7 +4,7 @@ import {
   createBook,
   updateBook,
   deleteBook,
-  fetchAnalytics,
+  fetchBookAnalytics,
 } from "../../services/instructor/bookService";
 
 jest.mock("../../services/api/api", () => ({
@@ -25,7 +25,7 @@ describe("instructor bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData, meta } });
     const res = await fetchInstructorBooks();
     expect(api.get).toHaveBeenCalledWith("/instructor/books");
-    expect(res).toEqual({ books: apiData, meta: {} });
+    expect(res).toEqual({ books: apiData, meta });
   });
 
   it("creates a book", async () => {
@@ -69,11 +69,11 @@ describe("instructor bookService", () => {
     expect(res).toBe(true);
   });
 
-  it("fetches analytics", async () => {
+  it("fetches book analytics", async () => {
     const apiData = { sales: 10 };
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const params = { year: 2023 };
-    const res = await fetchAnalytics(params);
+    const res = await fetchBookAnalytics(params);
     expect(api.get).toHaveBeenCalledWith("/instructor/books/analytics", { params });
     expect(res).toEqual(apiData);
   });


### PR DESCRIPTION
## Summary
- fix missing export by renaming fetchAnalytics to fetchBookAnalytics in instructor book service
- update instructor book service tests for new fetchBookAnalytics function

## Testing
- `npm test`
- `npm run lint` *(fails: 296 problems, 48 errors, 248 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68943ecbb0b48328a49904b4a0e58be3