### PR TITLE
Fix instructor books page error and layout

### DIFF
--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -43,6 +43,7 @@ function InstructorBooksPage() {
   const [tagInput, setTagInput] = useState("");
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [selectedBooks, setSelectedBooks] = useState([]);
   const [allSelected, setAllSelected] = useState(false);
   const [sortBy, setSortBy] = useState("newest");
@@ -114,6 +115,7 @@ function InstructorBooksPage() {
         setLanguages(langs);
       } catch (err) {
         toast.error(t("Failed to load data"));
+        setError(t("Failed to load data"));
       }
     };
     loadCategories();
@@ -134,6 +136,7 @@ function InstructorBooksPage() {
     const loadBooks = async () => {
       try {
         setLoading(true);
+        setError(null);
         const { books: list, meta } = await fetchInstructorBooks({
           page,
           perPage,
@@ -143,8 +146,10 @@ function InstructorBooksPage() {
         setBooks(list);
         setMeta(meta);
       } catch (err) {
-        toast.error(t("Failed to load data"));
+        const message = t("Failed to load data");
+        toast.error(message);
         console.error("Error loading:", err);
+        setError(message);
       } finally {
         setLoading(false);
       }
@@ -290,7 +295,7 @@ function InstructorBooksPage() {
   if (error) return <div className="min-h-screen flex items-center justify-center text-red-500">{error}</div>;
 
   return (
-    <InstructorLayout>
+    <>
       <section className="py-8 px-4 max-w-7xl mx-auto">
         {/* Header Section */}
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-6 gap-4">
@@ -915,11 +920,17 @@ function InstructorBooksPage() {
         onClose={closeConfirmModal}
         onConfirm={confirmModal.onConfirm}
       />
-    </InstructorLayout>
+    </>
   );
 };
 
-export default withAuthProtection(InstructorBooksPage, ["instructor"]);
+const ProtectedInstructorBooksPage = withAuthProtection(InstructorBooksPage, ["instructor"]);
+
+ProtectedInstructorBooksPage.getLayout = (page) => (
+  <InstructorLayout>{page}</InstructorLayout>
+);
+
+export default ProtectedInstructorBooksPage;
 
 export async function getStaticProps({ locale }) {
   return {

--- a/frontend/src/tests/__tests__/instructorBookService.test.js
+++ b/frontend/src/tests/__tests__/instructorBookService.test.js
@@ -25,7 +25,7 @@ describe("instructor bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData, meta } });
     const res = await fetchInstructorBooks();
     expect(api.get).toHaveBeenCalledWith("/instructor/books");
-    expect(res).toEqual({ books: apiData, meta: {} });
+    expect(res).toEqual({ books: apiData, meta });
   });
 
   it("creates a book", async () => {


### PR DESCRIPTION
## Summary
- add error state and set error handling for instructor books page
- apply InstructorLayout via getLayout
- adjust instructor book service tests for meta response

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 248 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689446f6278883289659a129b26276f7