### PR TITLE
refactor: centralize book image url handling

### DIFF
--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -1,18 +1,7 @@
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
 import { FiEye, FiBookOpen, FiEdit, FiTrash2 } from "react-icons/fi";
-
-const rawApiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-const API_BASE = rawApiBase.replace(/\/api\/?$/, "");
-
-const buildUrl = (path) => {
-  if (!path) return null;
-  if (/^https?:/i.test(path)) return path;
-  const uploadsIndex = path.indexOf("/uploads");
-  const relative = uploadsIndex !== -1 ? path.substring(uploadsIndex) : path;
-  const normalized = relative.startsWith("/") ? relative : `/${relative}`;
-  return `${API_BASE}${normalized}`;
-};
+import { buildUrl } from "@/services/bookService";
 
 
 export default function BookCard({
@@ -26,7 +15,10 @@ export default function BookCard({
 }) {
   const { t } = useTranslation("dashboard");
 
-  const coverUrl = buildUrl(book.cover_image_url || book.cover_image);
+  const coverUrl =
+    book.cover_image_url ||
+    buildUrl(book.cover_image) ||
+    "/images/default-book-cover.jpg";
 
   const statusClasses = {
     pending: "bg-yellow-100 text-yellow-800",
@@ -53,14 +45,12 @@ export default function BookCard({
           {t(book.status)}
         </span>
       )}
-      {coverUrl && (
-        <img
-          src={coverUrl}
-          alt={book.title}
-          loading="lazy"
-          className="w-full h-40 object-cover"
-        />
-      )}
+      <img
+        src={coverUrl}
+        alt={book.title}
+        loading="lazy"
+        className="w-full h-40 object-cover"
+      />
       <div className="p-4">
         <h3 className="font-semibold mb-1 line-clamp-1">{book.title}</h3>
         <p className="text-sm mb-3">{`$${book.price}`}</p>

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -15,17 +15,6 @@ import { FiPlus, FiSearch, FiTrash2, FiChevronLeft, FiChevronRight, FiFilter, Fi
 import { Switch } from '@headlessui/react';
 import ConfirmModal from "@/components/common/ConfirmModal";
 import debounce from "lodash/debounce";
-
-const rawApiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-const API_BASE = rawApiBase.replace(/\/api\/?$/, "");
-const buildUrl = (path) => {
-  if (!path) return null;
-  if (/^https?:/i.test(path)) return path;
-  const uploadsIndex = path.indexOf("/uploads");
-  const relative = uploadsIndex !== -1 ? path.substring(uploadsIndex) : path;
-  const normalized = relative.startsWith("/") ? relative : `/${relative}`;
-  return `${API_BASE}${normalized}`;
-};
 function AdminBooksPage() {
   const { t } = useTranslation("dashboard");
 
@@ -718,8 +707,7 @@ function AdminBooksPage() {
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {books.map((book) => {
                 const coverUrl =
-                  buildUrl(book.cover_image_url || book.cover_image) ||
-                  "/images/default-book-cover.jpg";
+                  book.cover_image_url || "/images/default-book-cover.jpg";
                 return (
                   <div
                     key={book.id}

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -15,16 +15,7 @@ import { useTranslation } from "next-i18next";
 import { FiPlus, FiSearch, FiTrash2, FiChevronLeft, FiChevronRight, FiFilter, FiX, FiEdit, FiEye } from "react-icons/fi";
 // Switch removed as status is no longer a simple toggle
 import ConfirmModal from "@/components/common/ConfirmModal";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-const buildUrl = (path) => {
-  if (!path) return null;
-  if (/^https?:/i.test(path)) return path;
-  const uploadsIndex = path.indexOf("/uploads");
-  const relative = uploadsIndex !== -1 ? path.substring(uploadsIndex) : path;
-  const normalized = relative.startsWith("/") ? relative : `/${relative}`;
-  return `${API_BASE}${normalized}`;
-};
+import { buildUrl } from "@/services/bookService";
 
 function InstructorBooksPage() {
   const { t } = useTranslation("dashboard");

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -4,7 +4,7 @@ import api from "@/services/api/api";
 const rawApiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 const API_BASE = rawApiBase.replace(/\/api\/?$/, "");
 
-const buildUrl = (path) => {
+export const buildUrl = (path) => {
   if (!path) return null;
   if (/^https?:/i.test(path)) return path;
   const uploadsIndex = path.indexOf("/uploads");

--- a/frontend/src/tests/__tests__/instructorBookService.test.js
+++ b/frontend/src/tests/__tests__/instructorBookService.test.js
@@ -25,7 +25,7 @@ describe("instructor bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData, meta } });
     const res = await fetchInstructorBooks();
     expect(api.get).toHaveBeenCalledWith("/instructor/books");
-    expect(res).toEqual({ books: apiData, meta: {} });
+    expect(res).toEqual({ books: apiData, meta });
   });
 
   it("creates a book", async () => {


### PR DESCRIPTION
## Summary
- remove local image URL builder in admin books page and rely on `cover_image_url`
- centralize `buildUrl` helper in `bookService` and reuse in components
- update instructor book service test to match returned metadata

## Testing
- `npm test`
- `npm run lint` *(fails: 296 problems, 48 errors, 248 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68944c6ecb3c832894eec7a6f913d4f5