### PR TITLE
Fix Socket.IO WebSocket routing

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -16,6 +16,21 @@ server {
     add_header Access-Control-Allow-Credentials true always;
   }
 
+  # Forward Socket.IO traffic to backend and enable WebSocket upgrades
+  location /socket.io/ {
+    proxy_pass http://backend:5002;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    # Ensure a single Access-Control-Allow-Origin header
+    proxy_hide_header Access-Control-Allow-Origin;
+    add_header Access-Control-Allow-Origin $http_origin always;
+    add_header Access-Control-Allow-Credentials true always;
+  }
+
   location ^~ /api/ {
     # forward API requests without rewriting the path
     proxy_pass http://backend:5002;


### PR DESCRIPTION
## Summary
- forward `/socket.io/` requests to backend in nginx config
- enable `Upgrade` and `Connection` headers for WebSocket support

## Testing
- `npm test`
- `nginx -t -c $(pwd)/nginx/nginx.conf`


------
https://chatgpt.com/codex/tasks/task_e_68945085fb148328856cf83af2d8677b