### PR TITLE
Add missing instructor book service functions

### DIFF
--- a/frontend/src/services/instructor/bookService.js
+++ b/frontend/src/services/instructor/bookService.js
@@ -50,15 +50,25 @@ export const deleteBook = async (id) => {
   return true;
 };
 
-export const fetchAnalytics = async (params = {}) => {
+// Fetch a single book by ID for the current instructor
+export const fetchBook = async (id) => {
+  const { data } = await api.get(`/books/${id}`);
+  return data?.data || null;
+};
+
+// Fetch aggregated analytics about the instructor's books
+export const fetchBookAnalytics = async (params = {}) => {
   const { data } = await api.get("/instructor/books/analytics", { params });
   return data?.data || [];
 };
 
-export default {
+const instructorBookService = {
   fetchInstructorBooks,
   createBook,
   updateBook,
   deleteBook,
-  fetchAnalytics,
+  fetchBook,
+  fetchBookAnalytics,
 };
+
+export default instructorBookService;

--- a/frontend/src/tests/__tests__/instructorBookService.test.js
+++ b/frontend/src/tests/__tests__/instructorBookService.test.js
@@ -4,7 +4,8 @@ import {
   createBook,
   updateBook,
   deleteBook,
-  fetchAnalytics,
+  fetchBook,
+  fetchBookAnalytics,
 } from "../../services/instructor/bookService";
 
 jest.mock("../../services/api/api", () => ({
@@ -69,11 +70,19 @@ describe("instructor bookService", () => {
     expect(res).toBe(true);
   });
 
+  it("fetches a book", async () => {
+    const apiData = { id: 1 };
+    api.get.mockResolvedValueOnce({ data: { data: apiData } });
+    const res = await fetchBook(1);
+    expect(api.get).toHaveBeenCalledWith("/books/1");
+    expect(res).toEqual(apiData);
+  });
+
   it("fetches analytics", async () => {
     const apiData = { sales: 10 };
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const params = { year: 2023 };
-    const res = await fetchAnalytics(params);
+    const res = await fetchBookAnalytics(params);
     expect(api.get).toHaveBeenCalledWith("/instructor/books/analytics", { params });
     expect(res).toEqual(apiData);
   });


### PR DESCRIPTION
## Summary
- expose `fetchBook` and `fetchBookAnalytics` in the instructor book service
- cover new service helpers with tests

## Testing
- `npm test src/tests/__tests__/instructorBookService.test.js`
- `npx eslint src/services/instructor/bookService.js src/tests/__tests__/instructorBookService.test.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68944ff344f88328a9aa7a1529b75045