### PR TITLE
Add instructor book routes and analytics

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -204,3 +204,16 @@ exports.updateBookStatus = catchAsync(async (req, res) => {
   }
   sendSuccess(res, book, "Book status updated");
 });
+
+exports.listInstructorBooks = catchAsync(async (req, res) => {
+  const result = await service.listBooks({
+    ...req.query,
+    instructorId: req.user.id,
+  });
+  sendSuccess(res, result.data, "Books fetched", result.meta);
+});
+
+exports.getBookAnalytics = catchAsync(async (req, res) => {
+  const stats = await service.getInstructorBookAnalytics(req.user.id);
+  sendSuccess(res, stats, "Analytics fetched");
+});

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -16,6 +16,7 @@ exports.listBooks = async (params = {}) => {
     language,
     tags = [],
     sortBy = "newest",
+    instructorId,
   } = params;
 
   const query = db("books as b");
@@ -32,6 +33,7 @@ exports.listBooks = async (params = {}) => {
   if (status) query.where("b.status", status);
   if (priceRange) query.where("b.price", "<=", priceRange);
   if (language) query.where("b.language", language);
+  if (instructorId) query.where("b.instructor_id", instructorId);
   const tagArr = Array.isArray(tags) ? tags : tags ? [tags] : [];
   if (tagArr.length) {
     query.whereIn("b.id", function () {
@@ -112,3 +114,36 @@ exports.updateBookStatus = async (id, status) => {
 };
 
 exports.deleteBook = (id) => db("books").where({ id }).del();
+
+exports.getInstructorBookAnalytics = async (instructorId) => {
+  const totalSalesRow = await db("book_purchases as p")
+    .join("books as b", "p.book_id", "b.id")
+    .where("b.instructor_id", instructorId)
+    .count("* as totalSales")
+    .first();
+
+  const totalRevenueRow = await db("book_purchases as p")
+    .join("books as b", "p.book_id", "b.id")
+    .where("b.instructor_id", instructorId)
+    .sum("p.price_paid as totalRevenue")
+    .first();
+
+  const topBooks = await db("book_purchases as p")
+    .join("books as b", "p.book_id", "b.id")
+    .where("b.instructor_id", instructorId)
+    .select("b.id", "b.title")
+    .count("* as sales")
+    .groupBy("b.id", "b.title")
+    .orderBy("sales", "desc")
+    .limit(5);
+
+  return {
+    totalSales: Number(totalSalesRow?.totalSales || 0),
+    totalRevenue: Number(totalRevenueRow?.totalRevenue || 0),
+    topBooks: topBooks.map((b) => ({
+      id: b.id,
+      title: b.title,
+      sales: Number(b.sales),
+    })),
+  };
+};

--- a/backend/src/modules/books/instructor.routes.js
+++ b/backend/src/modules/books/instructor.routes.js
@@ -1,0 +1,8 @@
+const router = require("express").Router();
+const controller = require("./book.controller");
+const { verifyToken, isInstructorOrAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.get("/", verifyToken, isInstructorOrAdmin, controller.listInstructorBooks);
+router.get("/analytics", verifyToken, isInstructorOrAdmin, controller.getBookAnalytics);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -135,6 +135,7 @@ app.use("/api/tickets", require("./modules/tickets/tickets.routes"));
 app.use("/api/media", require("./modules/media/media.routes"));
 app.use("/api/book-categories", require("./modules/bookCategories/bookCategories.routes"));
 app.use("/api/books", require("./modules/books/book.routes"));
+app.use("/api/instructor/books", require("./modules/books/instructor.routes"));
 app.use("/api/library", require("./modules/library/library.routes"));
 app.use("/api/search", require("./modules/search/search.routes"));
 

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -10,6 +10,7 @@ jest.mock('../src/modules/books/book.service', () => ({
   clearBookTags: jest.fn(),
   getBookTags: jest.fn(),
   updateBookStatus: jest.fn(),
+  getInstructorBookAnalytics: jest.fn(),
 }));
 
 jest.mock('../src/modules/messages/messages.service', () => ({

--- a/backend/tests/instructorBookRoutes.test.js
+++ b/backend/tests/instructorBookRoutes.test.js
@@ -1,0 +1,66 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/books/book.service', () => ({
+  listBooks: jest.fn(),
+  getInstructorBookAnalytics: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/services/mailService', () => ({
+  sendMail: jest.fn(),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/books/bookTag.service', () => ({
+  findByName: jest.fn(),
+  createTag: jest.fn(),
+  getAllTags: jest.fn(),
+  searchTags: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: '1' };
+    next();
+  },
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/books/book.service');
+const routes = require('../src/modules/books/instructor.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/instructor/books', routes);
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /api/instructor/books', () => {
+  it('returns books for instructor', async () => {
+    const list = [{ id: '1', title: 'Test' }];
+    const meta = { total: 1, page: 1, perPage: 10, totalPages: 1 };
+    service.listBooks.mockResolvedValue({ data: list, meta });
+    const res = await request(app).get('/api/instructor/books');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(list);
+    expect(service.listBooks).toHaveBeenCalledWith(expect.objectContaining({ instructorId: '1' }));
+  });
+});
+
+describe('GET /api/instructor/books/analytics', () => {
+  it('returns analytics', async () => {
+    const stats = { totalSales: 0, totalRevenue: 0, topBooks: [] };
+    service.getInstructorBookAnalytics.mockResolvedValue(stats);
+    const res = await request(app).get('/api/instructor/books/analytics');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(stats);
+    expect(service.getInstructorBookAnalytics).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- add instructor-scoped book listing and analytics endpoints
- filter book queries by instructor id
- expose new `/api/instructor/books` API route with tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894570afbd48328844c85b82d9e5bb0