### PR TITLE
fix: resolve cover image URL base path

### DIFF
--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -1,8 +1,8 @@
 import api from "@/services/api/api";
 
-// Strip a trailing "/api" segment so media URLs resolve correctly
+// Strip any trailing "/api" segment (with optional subpaths) so media URLs resolve correctly
 const rawApiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-const API_BASE = rawApiBase.replace(/\/api\/?$/, "");
+const API_BASE = rawApiBase.replace(/\/api(?:\/.*)?$/, "");
 
 export const buildUrl = (path) => {
   if (!path) return null;

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -77,4 +77,16 @@ describe("bookService", () => {
     );
     expect(book).toEqual({ id: 2, cover_image_url: null, pdf_url: null });
   });
+
+  it("buildUrl strips versioned API base paths", () => {
+    const originalBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+    jest.isolateModules(() => {
+      process.env.NEXT_PUBLIC_API_BASE_URL = "https://example.com/api/v1";
+      const { buildUrl } = require("../../services/bookService");
+      expect(buildUrl("/uploads/test.jpg")).toBe(
+        "https://example.com/uploads/test.jpg"
+      );
+    });
+    process.env.NEXT_PUBLIC_API_BASE_URL = originalBase;
+  });
 });


### PR DESCRIPTION
## Summary
- handle versioned `/api` paths when building media URLs so book cover images render
- add regression test for `buildUrl`

## Testing
- `npm test --silent`
- `npm run lint` *(fails: 295 problems, 48 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894598a247c83289b20335d492c6834