### PR TITLE
fix: ensure media URLs work with relative API base

### DIFF
--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -1,8 +1,14 @@
 import api from "@/services/api/api";
 
-// Strip any trailing "/api" segment (with optional subpaths) so media URLs resolve correctly
-const rawApiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-const API_BASE = rawApiBase.replace(/\/api(?:\/.*)?$/, "");
+// Determine the base URL for media assets. If an absolute URL is provided
+// (e.g. "https://example.com/api"), strip any trailing API segment so media
+// files resolve correctly. For relative paths (like the default "/api" used
+// during development), keep the prefix so requests are routed through the same
+// proxy that handles API calls.
+const rawApiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+const API_BASE = rawApiBase.startsWith("http")
+  ? rawApiBase.replace(/\/api(?:\/.*)?$/, "")
+  : rawApiBase;
 
 export const buildUrl = (path) => {
   if (!path) return null;

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -89,4 +89,14 @@ describe("bookService", () => {
     });
     process.env.NEXT_PUBLIC_API_BASE_URL = originalBase;
   });
+
+  it("buildUrl keeps relative api prefixes by default", () => {
+    const originalBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+    jest.isolateModules(() => {
+      delete process.env.NEXT_PUBLIC_API_BASE_URL;
+      const { buildUrl } = require("../../services/bookService");
+      expect(buildUrl("/uploads/test.jpg")).toBe("/api/uploads/test.jpg");
+    });
+    process.env.NEXT_PUBLIC_API_BASE_URL = originalBase;
+  });
 });


### PR DESCRIPTION
## Summary
- adjust book service URL builder to respect relative `/api` base paths
- add tests for relative API base handling

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68945d5ff2288328a65a906256c73575