### PR TITLE
fix: correct book media URL handling

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -707,9 +707,7 @@ function AdminBooksPage() {
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {books.map((book) => {
                 const coverUrl =
-                  book.cover_image_url ||
-                  buildUrl(book.cover_image) ||
-                  "/images/default-book-cover.jpg";
+                  book.cover_image_url || "/images/default-book-cover.jpg";
                 return (
                   <div
                     key={book.id}

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -7,16 +7,22 @@ const API_BASE = rawApiBase.replace(/\/api(?:\/.*)?$/, "");
 export const buildUrl = (path) => {
   if (!path) return null;
   if (/^https?:/i.test(path)) return path;
+  const base = API_BASE || (typeof window !== "undefined" ? window.location.origin : "");
   const uploadsIndex = path.indexOf("/uploads");
   const relative = uploadsIndex !== -1 ? path.substring(uploadsIndex) : path;
   const normalized = relative.startsWith("/") ? relative : `/${relative}`;
-  return `${API_BASE}${normalized}`;
+  return `${base}${normalized}`;
 };
 
 const formatBook = (book) => ({
   ...book,
   cover_image_url: buildUrl(book?.cover_image_url || book?.cover_image),
   pdf_url: buildUrl(book?.pdf_url),
+  preview_pages: Array.isArray(book?.preview_pages)
+    ? book.preview_pages.map((p) => buildUrl(p))
+    : typeof book?.preview_pages === "string" && book.preview_pages
+    ? JSON.parse(book.preview_pages).map((p) => buildUrl(p))
+    : [],
 });
 
 export const fetchBooks = async ({

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -31,7 +31,15 @@ describe("bookService", () => {
       params: { page: 2, perPage: 5, search: "test", sortBy: "title" },
     });
     expect(res).toEqual({
-      books: [{ id: 1, title: "A", cover_image_url: null, pdf_url: null }],
+      books: [
+        {
+          id: 1,
+          title: "A",
+          cover_image_url: null,
+          pdf_url: null,
+          preview_pages: [],
+        },
+      ],
       meta,
     });
   });
@@ -41,7 +49,13 @@ describe("bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const book = await fetchBook(1);
     expect(api.get).toHaveBeenCalledWith("/books/1");
-    expect(book).toEqual({ id: 1, title: "A", cover_image_url: null, pdf_url: null });
+    expect(book).toEqual({
+      id: 1,
+      title: "A",
+      cover_image_url: null,
+      pdf_url: null,
+      preview_pages: [],
+    });
   });
 
   it("fetches single book as admin", async () => {
@@ -49,7 +63,13 @@ describe("bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const book = await fetchBook(1, { admin: true });
     expect(api.get).toHaveBeenCalledWith("/books/admin/1");
-    expect(book).toEqual({ id: 1, title: "A", cover_image_url: null, pdf_url: null });
+    expect(book).toEqual({
+      id: 1,
+      title: "A",
+      cover_image_url: null,
+      pdf_url: null,
+      preview_pages: [],
+    });
   });
 
   it("updates a book", async () => {
@@ -62,7 +82,12 @@ describe("bookService", () => {
       formData,
       expect.objectContaining({ headers: { "Content-Type": "multipart/form-data" } })
     );
-    expect(book).toEqual({ id: 1, cover_image_url: null, pdf_url: null });
+    expect(book).toEqual({
+      id: 1,
+      cover_image_url: null,
+      pdf_url: null,
+      preview_pages: [],
+    });
   });
 
   it("creates a book", async () => {
@@ -75,7 +100,12 @@ describe("bookService", () => {
       formData,
       expect.objectContaining({ headers: { "Content-Type": "multipart/form-data" } })
     );
-    expect(book).toEqual({ id: 2, cover_image_url: null, pdf_url: null });
+    expect(book).toEqual({
+      id: 2,
+      cover_image_url: null,
+      pdf_url: null,
+      preview_pages: [],
+    });
   });
 
   it("buildUrl strips versioned API base paths", () => {


### PR DESCRIPTION
## Summary
- improve media URL builder and preview page normalization for books
- simplify admin book cover rendering to use prebuilt URL
- adjust book service tests for preview page handling

## Testing
- `npm test` (frontend)
- `npm run lint` (frontend) *(fails: 48 errors, 247 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68945d5ff2288328a65a906256c73575