### PR TITLE
feat: add admin book view page

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -804,8 +804,7 @@ function AdminBooksPage() {
                             <FiEdit className="text-lg" />
                           </Link>
                           <Link
-                            href={`/books/${book.slug}`}
-                            target="_blank"
+                            href={`/dashboard/admin/books/view/${book.id}`}
                             className="p-2 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-full transition-colors"
                             title={t("View")}
                           >

--- a/frontend/src/pages/dashboard/admin/books/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/view/[id].js
@@ -1,0 +1,125 @@
+// pages/dashboard/admin/books/view/[id].js
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { fetchBook } from "@/services/bookService";
+import { FiArrowLeft } from "react-icons/fi";
+
+export default function AdminViewBookPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [book, setBook] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      try {
+        const data = await fetchBook(id, { admin: true });
+        setBook(data);
+      } catch (err) {
+        console.error("Failed to load book", err);
+      }
+    };
+    load();
+  }, [id]);
+
+  if (!book) {
+    return (
+      <AdminLayout>
+        <div className="min-h-screen flex items-center justify-center text-gray-600">
+          Loading book...
+        </div>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <div className="min-h-screen px-6 py-10 bg-white text-gray-900">
+        <div className="max-w-4xl mx-auto space-y-6">
+          <button
+            onClick={() => router.push("/dashboard/admin/books")}
+            className="flex items-center text-gray-600 hover:text-gray-800"
+          >
+            <FiArrowLeft className="mr-2" /> Back to Books
+          </button>
+
+          <div className="flex flex-col md:flex-row gap-6 bg-gray-100 p-6 rounded-xl shadow-md">
+            {book.cover_image_url && (
+              <img
+                src={book.cover_image_url}
+                alt={book.title}
+                className="w-40 h-56 object-cover rounded-md"
+              />
+            )}
+            <div className="flex-1 space-y-2">
+              <h1 className="text-2xl font-bold">{book.title}</h1>
+              {book.description && (
+                <p className="text-gray-700 whitespace-pre-line">{book.description}</p>
+              )}
+              <p>
+                <strong>Status:</strong> {book.status || "pending"}
+              </p>
+              <p>
+                <strong>Language:</strong> {book.language || "N/A"}
+              </p>
+              <p>
+                <strong>Price:</strong> {book.is_free ? "Free" : book.price ? `$${book.price}` : "N/A"}
+              </p>
+              {book.license_type && (
+                <p>
+                  <strong>License:</strong> {book.license_type}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {book.tags && book.tags.length > 0 && (
+            <div>
+              <h2 className="font-semibold mb-1">Tags</h2>
+              <div className="flex flex-wrap gap-2">
+                {book.tags.map((tag) => (
+                  <span
+                    key={tag.id || tag}
+                    className="px-2 py-1 bg-gray-200 rounded text-sm"
+                  >
+                    {tag.name || tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {book.categories && book.categories.length > 0 && (
+            <div>
+              <h2 className="font-semibold mb-1">Categories</h2>
+              <div className="flex flex-wrap gap-2">
+                {book.categories.map((cat) => (
+                  <span
+                    key={cat.id || cat}
+                    className="px-2 py-1 bg-gray-200 rounded text-sm"
+                  >
+                    {cat.name || cat}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {book.pdf_url && (
+            <div>
+              <a
+                href={book.pdf_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                View PDF
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </AdminLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin dashboard page to view book details by id
- link book list actions to new view page

## Testing
- `cd frontend && CI=1 npm test > /tmp/test.log && tail -n 40 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6894663a7be4832886db6689fd43cca4