### PR TITLE
Fix admin book view loading and add cover image fallback

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/view/[id].js
@@ -3,7 +3,14 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchBook, deleteBook } from "@/services/bookService";
-import { FiArrowLeft, FiEdit, FiTrash2, FiFileText, FiEye } from "react-icons/fi";
+import {
+  FiArrowLeft,
+  FiEdit,
+  FiTrash2,
+  FiFileText,
+  FiEye,
+  FiImage,
+} from "react-icons/fi";
 import Link from "next/link";
 import toast from "react-hot-toast";
 
@@ -93,13 +100,17 @@ export default function AdminViewBookPage() {
 
           <div className="bg-white rounded-xl shadow-md overflow-hidden">
             <div className="p-6 md:p-8 flex flex-col md:flex-row gap-6">
-              {book.cover_image_url && (
+              {book.cover_image_url ? (
                 <div className="flex-shrink-0 w-full md:w-48 lg:w-56 h-64 md:h-auto">
                   <img
                     src={book.cover_image_url}
                     alt={book.title}
                     className="w-full h-full object-cover rounded-lg shadow-sm"
                   />
+                </div>
+              ) : (
+                <div className="flex-shrink-0 w-full md:w-48 lg:w-56 h-64 md:h-auto bg-gray-100 flex items-center justify-center rounded-lg shadow-sm">
+                  <FiImage className="h-16 w-16 text-gray-300" />
                 </div>
               )}
               <div className="flex-1 space-y-4">

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -53,8 +53,16 @@ export const fetchBooks = async ({
 
 export const fetchBook = async (id, { admin = false } = {}) => {
   const endpoint = admin ? `/books/admin/${id}` : `/books/${id}`;
-  const { data } = await api.get(endpoint);
-  return data?.data ? formatBook(data.data) : null;
+  try {
+    const { data } = await api.get(endpoint);
+    return data?.data ? formatBook(data.data) : null;
+  } catch (err) {
+    if (admin) {
+      const { data } = await api.get(`/books/${id}`);
+      return data?.data ? formatBook(data.data) : null;
+    }
+    throw err;
+  }
 };
 
 export const deleteBook = async (id) => {

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -72,6 +72,23 @@ describe("bookService", () => {
     });
   });
 
+  it("falls back to public endpoint if admin fetch fails", async () => {
+    const apiData = { id: 1, title: "A" };
+    api.get
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce({ data: { data: apiData } });
+    const book = await fetchBook(1, { admin: true });
+    expect(api.get).toHaveBeenNthCalledWith(1, "/books/admin/1");
+    expect(api.get).toHaveBeenNthCalledWith(2, "/books/1");
+    expect(book).toEqual({
+      id: 1,
+      title: "A",
+      cover_image_url: null,
+      pdf_url: null,
+      preview_pages: [],
+    });
+  });
+
   it("updates a book", async () => {
     const apiData = { id: 1 };
     api.put.mockResolvedValueOnce({ data: { data: apiData } });


### PR DESCRIPTION
## Summary
- ensure admin book details fall back to public endpoint when privileged route fails
- display placeholder when a book lacks a cover image
- add regression tests for new bookService fallback logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68946cfc69708328bd98928d20592b8f