### PR TITLE
feat: enrich student library data

### DIFF
--- a/backend/src/modules/library/library.service.js
+++ b/backend/src/modules/library/library.service.js
@@ -1,14 +1,64 @@
 const db = require("../../config/database");
 
-exports.listForStudent = (studentId) =>
-  db("book_purchases as bp")
+exports.listForStudent = async (studentId) => {
+  const rows = await db("book_purchases as bp")
     .join("books as b", "bp.book_id", "b.id")
+    .leftJoin("users as u", "b.instructor_id", "u.id")
+    .where("bp.student_id", studentId)
     .select(
       "b.id",
       "b.title",
+      "b.short_description",
+      "b.pdf_url",
       "b.cover_image_url",
+      "b.preview_pages",
+      "b.allow_preview",
+      "b.price",
       "bp.price_paid",
-      "bp.purchased_at"
+      "bp.purchased_at",
+      "u.full_name as author"
     )
-    .where("bp.student_id", studentId)
     .orderBy("bp.purchased_at", "desc");
+
+  const tagMap = {};
+  if (rows.length) {
+    const tagRows = await db("book_tag_map as btm")
+      .leftJoin("tags as t", "btm.tag_id", "t.id")
+      .whereIn(
+        "btm.book_id",
+        rows.map((row) => row.id)
+      )
+      .select("btm.book_id", "t.name");
+
+    tagRows.forEach((tag) => {
+      if (!tagMap[tag.book_id]) tagMap[tag.book_id] = [];
+      if (tag.name) tagMap[tag.book_id].push(tag.name);
+    });
+  }
+
+  return rows.map((row) => {
+    let previewPages;
+    try {
+      previewPages = Array.isArray(row.preview_pages)
+        ? row.preview_pages
+        : JSON.parse(row.preview_pages || "[]");
+    } catch {
+      previewPages = [];
+    }
+
+    return {
+      id: row.id,
+      title: row.title,
+      shortDescription: row.short_description,
+      author: row.author,
+      tags: tagMap[row.id] || [],
+      isFree: Number(row.price_paid) === 0,
+      price: Number(row.price_paid),
+      purchasedAt: row.purchased_at,
+      coverUrl: row.cover_image_url,
+      pdfUrl: row.pdf_url,
+      previewUrl:
+        row.allow_preview && previewPages.length ? previewPages[0] : null,
+    };
+  });
+};

--- a/backend/tests/libraryRoutes.test.js
+++ b/backend/tests/libraryRoutes.test.js
@@ -22,7 +22,21 @@ app.use('/api/library', routes);
 
 describe('GET /api/library', () => {
   it('returns purchased books', async () => {
-    const items = [{ id: '1', title: 'Book' }];
+    const items = [
+      {
+        id: '1',
+        title: 'Book',
+        shortDescription: 'A cool book',
+        author: 'Author',
+        tags: ['tag'],
+        isFree: false,
+        price: 10,
+        purchasedAt: '2024-01-01T00:00:00Z',
+        coverUrl: '/cover',
+        pdfUrl: '/file.pdf',
+        previewUrl: '/preview',
+      },
+    ];
     service.listForStudent.mockResolvedValue(items);
     const res = await request(app).get('/api/library');
     expect(res.status).toBe(200);

--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -1,11 +1,14 @@
-// components/books/BookCard.js
+import { useEffect, useState } from "react";
 import { FiDownload, FiEye, FiStar, FiHeart } from "react-icons/fi";
+import { fetchLibrary } from "@/services/libraryService";
 
-export default function BookCard({ book }) {
+function BookCard({ book }) {
+  const cover = book.coverUrl || "/images/default-book-cover.jpg";
+
   return (
     <div className="border rounded-xl shadow-sm p-4 bg-white flex flex-col justify-between h-full">
       <img
-        src={book.coverUrl}
+        src={cover}
         alt={book.title}
         className="w-full h-48 object-cover rounded-lg mb-4"
       />
@@ -58,6 +61,30 @@ export default function BookCard({ book }) {
           <FiHeart />
         </button>
       </div>
+    </div>
+  );
+}
+
+export default function BooksPage() {
+  const [books, setBooks] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchLibrary();
+        setBooks(data);
+      } catch (e) {
+        console.error("Failed to load books", e);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {books.map((book) => (
+        <BookCard key={book.id} book={book} />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- expose detailed student library items with author, pricing, tags and preview info
- cover library route with a test using enriched book objects
- remove postgres-only json aggregation and parse preview pages to prevent server errors
- fetch student library on the dashboard books page and fallback to a default cover image

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_689496713c048328b4d40d825ca7f3d9