### PR TITLE
fix: remove duplicate instructor filter

### DIFF
--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -43,7 +43,6 @@ exports.listBooks = async (params = {}) => {
         .whereIn("t.name", tagArr);
     });
   }
-  if (instructorId) query.where("b.instructor_id", instructorId);
 
   switch (sortBy) {
     case "oldest":


### PR DESCRIPTION
## Summary
- remove redundant instructor filter in book list service

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894a15820f88328bb90fcf12b6f040e