### PR TITLE
Restrict book routes to admin

### DIFF
--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -4,17 +4,17 @@ const tagController = require("./bookTag.controller");
 const upload = require("./bookUploadMiddleware");
 const {
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
 } = require("../../middleware/auth/authMiddleware");
 
-router.get("/tags", verifyToken, isInstructorOrAdmin, tagController.listTags);
-router.post("/tags", verifyToken, isInstructorOrAdmin, tagController.createTag);
+router.get("/tags", verifyToken, isAdmin, tagController.listTags);
+router.post("/tags", verifyToken, isAdmin, tagController.createTag);
 router.get("/", controller.listBooks);
-router.get("/admin/:id", verifyToken, isInstructorOrAdmin, controller.getBookAdmin);
+router.get("/admin/:id", verifyToken, isAdmin, controller.getBookAdmin);
 router.get("/:id", controller.getBook);
-router.post("/", verifyToken, isInstructorOrAdmin, upload, controller.createBook);
-router.put("/:id", verifyToken, isInstructorOrAdmin, upload, controller.updateBook);
-router.patch("/:id/status", verifyToken, isInstructorOrAdmin, controller.updateBookStatus);
-router.delete("/:id", verifyToken, isInstructorOrAdmin, controller.deleteBook);
+router.post("/", verifyToken, isAdmin, upload, controller.createBook);
+router.put("/:id", verifyToken, isAdmin, upload, controller.updateBook);
+router.patch("/:id/status", verifyToken, isAdmin, controller.updateBookStatus);
+router.delete("/:id", verifyToken, isAdmin, controller.deleteBook);
 
 module.exports = router;

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -42,7 +42,7 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
     req.user = { id: '1' };
     next();
   },
-  isInstructorOrAdmin: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
 }));
 
 const service = require('../src/modules/books/book.service');


### PR DESCRIPTION
## Summary
- require admin role on book routes
- update book route tests for admin-only access

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894a1576eb48328bbaf05feb1c6d4be