### PR TITLE
feat: add cover image upload hook

### DIFF
--- a/frontend/src/hooks/useCoverImageUpload.js
+++ b/frontend/src/hooks/useCoverImageUpload.js
@@ -1,0 +1,53 @@
+import { useState, useRef, useCallback } from 'react';
+import { MAX_IMAGE_SIZE, MAX_IMAGE_SIZE_MB } from '@/utils/constants';
+
+/**
+ * Hook to handle cover image uploads with validation and preview.
+ * @param {function} t - translation function for error messages
+ */
+export default function useCoverImageUpload(t) {
+  const [coverPreview, setCoverPreview] = useState(null);
+  const [fileError, setFileError] = useState(null);
+  const fileInputRef = useRef(null);
+
+  const handleFileChange = useCallback(
+    (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+
+      const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+      if (!allowedTypes.includes(file.type)) {
+        setFileError(t('validation.invalidFileType'));
+        return;
+      }
+
+      if (file.size > MAX_IMAGE_SIZE) {
+        setFileError(t('validation.fileTooLarge', { size: `${MAX_IMAGE_SIZE_MB}MB` }));
+        return;
+      }
+
+      setFileError(null);
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setCoverPreview(reader.result);
+      };
+      reader.readAsDataURL(file);
+    },
+    [t]
+  );
+
+  const handleRemoveImage = useCallback(() => {
+    setCoverPreview(null);
+    setFileError(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }, []);
+
+  return {
+    coverPreview,
+    fileError,
+    fileInputRef,
+    handleFileChange,
+    handleRemoveImage,
+    setCoverPreview,
+  };
+}

--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import toast from "react-hot-toast";
 import { useTranslation } from "next-i18next";
@@ -13,7 +13,8 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import { FiArrowLeft, FiX } from "react-icons/fi";
 import Head from "next/head";
-import { MAX_IMAGE_SIZE, MAX_IMAGE_SIZE_MB } from "@/utils/constants";
+import useCoverImageUpload from "@/hooks/useCoverImageUpload";
+import { MAX_IMAGE_SIZE_MB } from "@/utils/constants";
 
 function AdminCreateBookPage() {
   const router = useRouter();
@@ -21,10 +22,14 @@ function AdminCreateBookPage() {
   const [categories, setCategories] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [coverPreview, setCoverPreview] = useState(null);
-  const [fileError, setFileError] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(null);
-  const fileInputRef = useRef(null);
+  const {
+    coverPreview,
+    fileError,
+    fileInputRef,
+    handleFileChange,
+    handleRemoveImage,
+  } = useCoverImageUpload(t);
 
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const fetchMessages = useMessageStore((state) => state.fetch);
@@ -46,38 +51,6 @@ function AdminCreateBookPage() {
 
     loadCategories();
   }, [t]);
-
-  const handleFileChange = useCallback((e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-
-    const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
-    if (!allowedTypes.includes(file.type)) {
-      setFileError(t("validation.invalidFileType"));
-      return;
-    }
-
-    if (file.size > MAX_IMAGE_SIZE) {
-      setFileError(
-        t("validation.fileTooLarge", { size: `${MAX_IMAGE_SIZE_MB}MB` })
-      );
-      return;
-    }
-
-    setFileError(null);
-
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      setCoverPreview(reader.result);
-    };
-    reader.readAsDataURL(file);
-  }, [t]);
-
-  const handleRemoveImage = useCallback(() => {
-    setCoverPreview(null);
-    setFileError(null);
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  }, []);
 
   const handleSubmit = async (formData, setProgress) => {
     if (fileInputRef.current?.files?.[0]) {

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import toast from "react-hot-toast";
 import { useTranslation } from "next-i18next";
@@ -13,7 +13,8 @@ import { FiArrowLeft, FiX } from "react-icons/fi";
 import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
-import { MAX_IMAGE_SIZE, MAX_IMAGE_SIZE_MB } from "@/utils/constants";
+import useCoverImageUpload from "@/hooks/useCoverImageUpload";
+import { MAX_IMAGE_SIZE_MB } from "@/utils/constants";
 
 function AdminEditBookPage() {
   const router = useRouter();
@@ -24,10 +25,15 @@ function AdminEditBookPage() {
   const [book, setBook] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [coverPreview, setCoverPreview] = useState(null);
-  const [fileError, setFileError] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(null);
-  const fileInputRef = useRef(null);
+  const {
+    coverPreview,
+    fileError,
+    fileInputRef,
+    handleFileChange,
+    handleRemoveImage,
+    setCoverPreview,
+  } = useCoverImageUpload(t);
 
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const fetchMessages = useMessageStore((state) => state.fetch);
@@ -65,46 +71,9 @@ function AdminEditBookPage() {
     load();
   }, [id, t]);
 
-  const handleFileChange = useCallback(
-    (e) => {
-      const file = e.target.files[0];
-      if (!file) return;
-
-      const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
-      if (!allowedTypes.includes(file.type)) {
-        setFileError(t("validation.invalidFileType"));
-        return;
-      }
-
-      if (file.size > MAX_IMAGE_SIZE) {
-        setFileError(
-          t("validation.fileTooLarge", { size: `${MAX_IMAGE_SIZE_MB}MB` })
-        );
-        return;
-      }
-
-      setFileError(null);
-
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setCoverPreview(reader.result);
-      };
-      reader.readAsDataURL(file);
-    },
-    [t]
-  );
-
-  const handleRemoveImage = useCallback(() => {
-    setCoverPreview(null);
-    setFileError(null);
-    const fileInput = document.getElementById("cover_image");
-    if (fileInput) fileInput.value = "";
-  }, []);
-
   const handleSubmit = async (formData, setProgress) => {
-    const fileInput = document.getElementById("cover_image");
-    if (fileInput?.files?.[0]) {
-      formData.append("cover_image", fileInput.files[0]);
+    if (fileInputRef.current?.files?.[0]) {
+      formData.append("cover_image", fileInputRef.current.files[0]);
     }
     try {
       setProgress(0);


### PR DESCRIPTION
## Summary
- add reusable `useCoverImageUpload` hook for validation and preview
- refactor admin book create and edit pages to use new hook

## Testing
- `npm test --silent | tail -n 20`
- `npm run lint` *(fails: 48 errors, 251 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6894a158cfe4832882a38b07eb769a00