### PR TITLE
feat: enforce book ownership

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -9,6 +9,14 @@ const messageService = require("../messages/messages.service");
 const mailService = require("../../services/mailService");
 const userModel = require("../users/user.model");
 
+const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
+const isAdminRole = (roles = []) => {
+  const arr = Array.isArray(roles) ? roles : [roles];
+  return arr
+    .map((r) => normalizeRole(r))
+    .some((r) => ["admin", "superadmin"].includes(r));
+};
+
 exports.createBook = catchAsync(async (req, res) => {
   const { tags: rawTags, ...body } = req.body || {};
   const data = {
@@ -154,6 +162,12 @@ exports.getBookAdmin = catchAsync(async (req, res) => {
 exports.updateBook = catchAsync(async (req, res) => {
   const existing = await service.getBookById(req.params.id);
   if (!existing) throw new AppError("Book not found", 404);
+  if (
+    !isAdminRole(req.user.roles || req.user.role) &&
+    existing.instructor_id !== req.user.id
+  ) {
+    throw new AppError("Access denied", 403);
+  }
 
   const { tags: rawTags, ...body } = req.body || {};
   const data = { ...body };
@@ -229,6 +243,14 @@ exports.updateBook = catchAsync(async (req, res) => {
 });
 
 exports.deleteBook = catchAsync(async (req, res) => {
+  const existing = await service.getBookById(req.params.id);
+  if (!existing) throw new AppError("Book not found", 404);
+  if (
+    !isAdminRole(req.user.roles || req.user.role) &&
+    existing.instructor_id !== req.user.id
+  ) {
+    throw new AppError("Access denied", 403);
+  }
   await service.clearBookTags(req.params.id);
   await service.deleteBook(req.params.id);
   sendSuccess(res, null, "Book deleted");
@@ -236,6 +258,14 @@ exports.deleteBook = catchAsync(async (req, res) => {
 
 exports.updateBookStatus = catchAsync(async (req, res) => {
   const { status } = req.body || {};
+  const existing = await service.getBookById(req.params.id);
+  if (!existing) throw new AppError("Book not found", 404);
+  if (
+    !isAdminRole(req.user.roles || req.user.role) &&
+    existing.instructor_id !== req.user.id
+  ) {
+    throw new AppError("Access denied", 403);
+  }
   const book = await service.updateBookStatus(req.params.id, status);
   if (!book) {
     throw new AppError("Book not found", 404);

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -38,11 +38,11 @@ jest.mock('../src/modules/users/user.model', () => ({
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
-  verifyToken: (req, _res, next) => {
-    req.user = { id: '1' };
+  verifyToken: jest.fn((req, _res, next) => {
+    req.user = { id: '1', role: 'admin', roles: ['admin'] };
     next();
-  },
-  isAdmin: (_req, _res, next) => next(),
+  }),
+  isAdmin: jest.fn((_req, _res, next) => next()),
 }));
 
 const service = require('../src/modules/books/book.service');
@@ -50,6 +50,7 @@ const routes = require('../src/modules/books/book.routes');
 const messageService = require('../src/modules/messages/messages.service');
 const notificationService = require('../src/modules/notifications/notifications.service');
 const userModel = require('../src/modules/users/user.model');
+const auth = require('../src/middleware/auth/authMiddleware');
 
 const app = express();
 app.use(express.json());
@@ -127,20 +128,45 @@ describe('PUT /api/books/:id', () => {
       message: expect.stringContaining('Updated'),
     });
   });
+
+  it("returns 403 when instructor updates another instructor's book", async () => {
+    const payload = { title: 'Updated' };
+    service.getBookById.mockResolvedValue({ id: '1', instructor_id: '2', title: 'Old' });
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'instructor', roles: ['instructor'] };
+      next();
+    });
+    const res = await request(app).put('/api/books/1').send(payload);
+    expect(res.status).toBe(403);
+    expect(service.updateBook).not.toHaveBeenCalled();
+  });
 });
 
 describe('DELETE /api/books/:id', () => {
   it('deletes a book', async () => {
+    service.getBookById.mockResolvedValue({ id: '1', instructor_id: '2' });
     const res = await request(app).delete('/api/books/1');
     expect(res.status).toBe(200);
     expect(service.clearBookTags).toHaveBeenCalledWith('1');
     expect(service.deleteBook).toHaveBeenCalledWith('1');
+  });
+
+  it("returns 403 when instructor deletes another instructor's book", async () => {
+    service.getBookById.mockResolvedValue({ id: '1', instructor_id: '2' });
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'instructor', roles: ['instructor'] };
+      next();
+    });
+    const res = await request(app).delete('/api/books/1');
+    expect(res.status).toBe(403);
+    expect(service.deleteBook).not.toHaveBeenCalled();
   });
 });
 
 describe('PATCH /api/books/:id/status', () => {
   it('updates book status', async () => {
     const book = { id: '1', status: 'active', instructor_id: '2', title: 'Book' };
+    service.getBookById.mockResolvedValue(book);
     service.updateBookStatus.mockResolvedValue(book);
     userModel.findAdmins.mockResolvedValue([]);
     userModel.findById.mockResolvedValue({ id: '2', email: 'user@example.com' });
@@ -150,5 +176,19 @@ describe('PATCH /api/books/:id/status', () => {
     expect(res.status).toBe(200);
     expect(service.updateBookStatus).toHaveBeenCalledWith('1', 'active');
     expect(res.body.data).toEqual(book);
+  });
+
+  it("returns 403 when instructor updates another instructor's book status", async () => {
+    const book = { id: '1', status: 'active', instructor_id: '2', title: 'Book' };
+    service.getBookById.mockResolvedValue(book);
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'instructor', roles: ['instructor'] };
+      next();
+    });
+    const res = await request(app)
+      .patch('/api/books/1/status')
+      .send({ status: 'active' });
+    expect(res.status).toBe(403);
+    expect(service.updateBookStatus).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- require book ownership or admin role for update, delete, and status change endpoints
- add test coverage for unauthorized instructor access to other instructors' books

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894a61bf8b48328b6317529f1ba3f53