### PR TITLE
Add instructor book analytics endpoint and tests

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -134,6 +134,11 @@ exports.listInstructorBooks = catchAsync(async (req, res) => {
   sendSuccess(res, result.data, "Books fetched", result.meta);
 });
 
+exports.getInstructorBookAnalytics = catchAsync(async (req, res) => {
+  const data = await service.getInstructorBookAnalytics(req.user.id);
+  sendSuccess(res, data);
+});
+
 exports.getBook = catchAsync(async (req, res) => {
   const book = await service.getBookById(req.params.id);
   if (!book || book.status !== "approved") {

--- a/backend/src/modules/books/instructorBook.routes.js
+++ b/backend/src/modules/books/instructorBook.routes.js
@@ -4,6 +4,7 @@ const { verifyToken, isInstructorOrAdmin } = require("../../middleware/auth/auth
 
 router.use(verifyToken, isInstructorOrAdmin);
 
+router.get("/analytics", controller.getInstructorBookAnalytics);
 router.get("/", controller.listInstructorBooks);
 
 module.exports = router;

--- a/backend/tests/instructorBookRoutes.test.js
+++ b/backend/tests/instructorBookRoutes.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 jest.mock('../src/modules/books/book.service', () => ({
   listBooks: jest.fn(),
+  getInstructorBookAnalytics: jest.fn(),
 }));
 
 jest.mock('../src/modules/messages/messages.service', () => ({
@@ -53,6 +54,20 @@ describe('GET /api/instructor/books', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(list);
     expect(service.listBooks).toHaveBeenCalledWith({ instructorId: '1' });
+  });
+});
 
+describe('GET /api/instructor/books/analytics', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns analytics data', async () => {
+    const analytics = { totalSales: 5, totalRevenue: 100, topBooks: [] };
+    service.getInstructorBookAnalytics.mockResolvedValue(analytics);
+
+    const res = await request(app).get('/api/instructor/books/analytics');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(analytics);
+    expect(service.getInstructorBookAnalytics).toHaveBeenCalledWith('1');
   });
 });


### PR DESCRIPTION
## Summary
- implement instructor book analytics handler
- expose analytics route for instructors
- test analytics data retrieval

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894a6197a6c8328baecff744258f606