### PR TITLE
refactor: centralize book tag processing

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -1,9 +1,8 @@
 const service = require("./book.service");
-const tagService = require("./bookTag.service");
+const { processTags } = require("./book.utils");
 const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
-const slugify = require("slugify");
 const notificationService = require("../notifications/notifications.service");
 const messageService = require("../messages/messages.service");
 const mailService = require("../../services/mailService");
@@ -40,32 +39,7 @@ exports.createBook = catchAsync(async (req, res) => {
 
   const book = await service.createBook(data);
 
-  let tags = [];
-  if (rawTags) {
-    try {
-      tags = typeof rawTags === "string" ? JSON.parse(rawTags) : rawTags;
-      if (!Array.isArray(tags)) tags = [];
-    } catch {
-      tags = [];
-    }
-  }
-  if (tags.length) {
-    const tagIds = [];
-    for (const name of tags) {
-      const existing = await tagService.findByName(name);
-      const tag =
-        existing ||
-        (await tagService.createTag({
-          name,
-          slug: slugify(name, { lower: true, strict: true }),
-        }));
-      tagIds.push(tag.id);
-    }
-    await service.addBookTags(book.id, tagIds);
-    book.tags = await service.getBookTags(book.id);
-  } else {
-    book.tags = [];
-  }
+  book.tags = await processTags(rawTags, book.id);
 
   const userMessage =
     "Your book was submitted successfully and is under review.";
@@ -177,33 +151,8 @@ exports.updateBook = catchAsync(async (req, res) => {
 
   const book = await service.updateBook(req.params.id, data);
 
-  let tags = [];
-  if (rawTags) {
-    try {
-      tags = typeof rawTags === "string" ? JSON.parse(rawTags) : rawTags;
-      if (!Array.isArray(tags)) tags = [];
-    } catch {
-      tags = [];
-    }
-  }
   await service.clearBookTags(book.id);
-  if (tags.length) {
-    const tagIds = [];
-    for (const name of tags) {
-      const existingTag = await tagService.findByName(name);
-      const tag =
-        existingTag ||
-        (await tagService.createTag({
-          name,
-          slug: slugify(name, { lower: true, strict: true }),
-        }));
-      tagIds.push(tag.id);
-    }
-    await service.addBookTags(book.id, tagIds);
-    book.tags = await service.getBookTags(book.id);
-  } else {
-    book.tags = [];
-  }
+  book.tags = await processTags(rawTags, book.id);
 
   if (
     req.user.role !== "instructor" &&

--- a/backend/src/modules/books/book.utils.js
+++ b/backend/src/modules/books/book.utils.js
@@ -1,0 +1,29 @@
+const service = require("./book.service");
+const tagService = require("./bookTag.service");
+const slugify = require("slugify");
+
+exports.processTags = async (rawTags, bookId) => {
+  let tags = [];
+  if (rawTags) {
+    try {
+      tags = typeof rawTags === "string" ? JSON.parse(rawTags) : rawTags;
+      if (!Array.isArray(tags)) tags = [];
+    } catch {
+      tags = [];
+    }
+  }
+  if (!tags.length) return [];
+  const tagIds = [];
+  for (const name of tags) {
+    const existing = await tagService.findByName(name);
+    const tag =
+      existing ||
+      (await tagService.createTag({
+        name,
+        slug: slugify(name, { lower: true, strict: true }),
+      }));
+    tagIds.push(tag.id);
+  }
+  await service.addBookTags(bookId, tagIds);
+  return await service.getBookTags(bookId);
+};


### PR DESCRIPTION
## Summary
- add `processTags` utility to handle parsing and tag mapping
- reuse `processTags` in createBook and updateBook controllers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894a6190b8c8328ad39da4223d5b0c8