### PR TITLE
feat: send SMS reminders for upcoming classes

### DIFF
--- a/backend/src/jobs/classReminderJob.js
+++ b/backend/src/jobs/classReminderJob.js
@@ -1,0 +1,31 @@
+const classService = require("../modules/classes/class.service");
+const enrollmentService = require("../modules/classes/enrollments/classEnrollment.service");
+const smsService = require("../services/smsService");
+
+function startClassReminderJob() {
+  setInterval(async () => {
+    const now = new Date();
+    const startWindow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    const endWindow = new Date(now.getTime() + 25 * 60 * 60 * 1000);
+    try {
+      const classes = await classService.getClassesStartingBetween(startWindow, endWindow);
+      for (const cls of classes) {
+        const students = await enrollmentService.getByClass(cls.id);
+        for (const student of students) {
+          if (!student.phone) continue;
+          const startTime = new Date(cls.start_date).toLocaleString();
+          const text = `Reminder: ${cls.title} starts at ${startTime}`;
+          try {
+            await smsService.sendSMS({ to: student.phone, text });
+          } catch (err) {
+            console.error("Error sending class reminder SMS:", err.message);
+          }
+        }
+      }
+    } catch (err) {
+      console.error("Class reminder job error:", err.message);
+    }
+  }, 60 * 60 * 1000); // hourly
+}
+
+module.exports = startClassReminderJob;

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -160,6 +160,12 @@ exports.getPublicClassDetails = async (id) => {
   return cls;
 };
 
+exports.getClassesStartingBetween = async (startTime, endTime) => {
+  return db("online_classes")
+    .select("id", "title", "start_date")
+    .whereBetween("start_date", [startTime, endTime]);
+};
+
 exports.getClassAnalytics = async (classId) => {
   const [totalRow] = await db("class_enrollments")
     .where({ class_id: classId })

--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -37,6 +37,7 @@ exports.getByClass = async (class_id) => {
       "u.id",
       "u.full_name",
       "u.email",
+      "u.phone",
       "ce.status",
       "ce.enrolled_at"
     )

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -14,6 +14,7 @@ const csrf = require("./middleware/csrf");
 const path = require("path");
 const startLessonReminderJob = require("./jobs/lessonReminderJob");
 const startCartReminderJob = require("./jobs/cartReminderJob");
+const startClassReminderJob = require("./jobs/classReminderJob");
 const startCleanupJob = require("./jobs/cleanupJob");
 require("dotenv").config();
 
@@ -304,6 +305,7 @@ async function startServer() {
       console.log(`✅ Server running on port ${PORT}`);
     });
     startLessonReminderJob();
+    startClassReminderJob();
     startCartReminderJob();
     startCleanupJob();
   } catch (err) {


### PR DESCRIPTION
## Summary
- query classes starting soon and return basic info
- expose student phone numbers in enrollment lookups
- schedule hourly job to text enrolled students about upcoming classes

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894fbc947a48328ae4d43d88ef09412