### PR TITLE
feat: add optional SMS OTP delivery for password reset

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -130,9 +130,9 @@ exports.logout = catchAsync(async (req, res) => {
  * @access Public
  */
 exports.requestReset = catchAsync(async (req, res) => {
-  const { email } = req.body;
+  const { email, via } = req.body;
   try {
-    await authService.generateOtp(email);
+    await authService.generateOtp(email, via);
   } catch (err) {
     // swallow errors to avoid user enumeration
   }

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -15,6 +15,7 @@ const { OTP_LENGTH } = require("../constants");
 const AppError = require("../../../utils/AppError");
 const notificationService = require("../../notifications/notifications.service");
 const messageService = require("../../messages/messages.service");
+const smsService = require("../../../services/smsService");
 
 // ─────────────────────────────────────────────────────────────
 // 🔧 Config Constants
@@ -252,7 +253,7 @@ exports.generateCsrfToken = generateCsrfToken;
  * @param {string} email - User email address
  * @returns {Promise<void>}
  */
-exports.generateOtp = async (email) => {
+exports.generateOtp = async (email, via = "email") => {
   const user = await userModel.findByEmail(email);
   if (!user) {
     // simulate work to prevent user enumeration timing attacks
@@ -274,7 +275,18 @@ exports.generateOtp = async (email) => {
     created_at: db.fn.now(),
   });
 
-  await sendOtpEmail(email, code);
+  if (via === "sms" && user.phone && user.is_phone_verified) {
+    try {
+      await smsService.sendSMS({
+        to: user.phone,
+        text: `Your SkillBridge OTP is: ${code}`,
+      });
+    } catch (err) {
+      console.error("Error sending OTP SMS:", err.message);
+    }
+  } else {
+    await sendOtpEmail(email, code);
+  }
 };
 
 /**

--- a/backend/tests/authForgotPasswordRoutes.test.js
+++ b/backend/tests/authForgotPasswordRoutes.test.js
@@ -31,7 +31,7 @@ describe('POST /api/auth/forgot-password', () => {
       .post('/api/auth/forgot-password')
       .send({ email: 'test@example.com' });
     expect(res.status).toBe(200);
-    expect(service.generateOtp).toHaveBeenCalledWith('test@example.com');
+    expect(service.generateOtp).toHaveBeenCalledWith('test@example.com', undefined);
     expect(res.body.message).toBeDefined();
   });
 

--- a/frontend/src/pages/auth/forgot-password.js
+++ b/frontend/src/pages/auth/forgot-password.js
@@ -11,6 +11,7 @@ import nextI18NextConfig from '../../../next-i18next.config.js';
 export default function ForgotPassword() {
   const [email, setEmail] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [sendViaSms, setSendViaSms] = useState(false);
   const router = useRouter();
   const { t } = useTranslation("auth");
 
@@ -24,10 +25,12 @@ export default function ForgotPassword() {
 
     setIsSubmitting(true);
     try {
-      await authService.requestPasswordReset(email);
+      const via = sendViaSms ? "sms" : "email";
+      await authService.requestPasswordReset({ email, via });
       toast.success(t("otp_sent_success"));
       localStorage.setItem("otp_email", email);
-      router.push({ pathname: "/auth/verify-otp", query: { email } });
+      localStorage.setItem("otp_via", via);
+      router.push({ pathname: "/auth/verify-otp", query: { email, via } });
     } catch (err) {
       const status = err?.response?.status;
       const message = err?.response?.data?.message || "";
@@ -71,6 +74,20 @@ export default function ForgotPassword() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
           />
+        </div>
+
+        {/* Send via SMS Option */}
+        <div className="w-full mb-4 flex items-center">
+          <input
+            id="viaSms"
+            type="checkbox"
+            className="mr-2"
+            checked={sendViaSms}
+            onChange={(e) => setSendViaSms(e.target.checked)}
+          />
+          <label htmlFor="viaSms" className="text-gray-400 text-sm">
+            Send via SMS (if phone verified)
+          </label>
         </div>
 
         {/* Send OTP Button */}

--- a/frontend/src/pages/auth/verify-otp.js
+++ b/frontend/src/pages/auth/verify-otp.js
@@ -19,6 +19,7 @@ import { otpSchema as createOtpSchema } from "@/utils/auth/validationSchemas";
 export default function VerifyOTP() {
   const router = useRouter();
   const [email, setEmail] = useState("");
+  const [via, setVia] = useState("email");
   const [resendTimer, setResendTimer] = useState(30);
   const [canResend, setCanResend] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
@@ -44,7 +45,7 @@ export default function VerifyOTP() {
     }
   }, [resendTimer]);
 
-  // 🔁 Load email from query or storage
+  // 🔁 Load email and delivery method from query or storage
   useEffect(() => {
     const fromQuery = router.query.email;
     const fromStorage = localStorage.getItem("otp_email");
@@ -54,7 +55,12 @@ export default function VerifyOTP() {
       toast.error(t("email_not_found_start_reset"));
       router.push("/auth/forgot-password");
     }
-  }, [router.query.email]);
+
+    const viaQuery = router.query.via;
+    const viaStorage = localStorage.getItem("otp_via");
+    if (viaQuery) setVia(viaQuery);
+    else if (viaStorage) setVia(viaStorage);
+  }, [router.query.email, router.query.via]);
 
   // ✅ Handle OTP verification
   const onSubmit = async ({ code }) => {
@@ -84,7 +90,7 @@ export default function VerifyOTP() {
   // 🔁 Handle resend OTP
   const handleResendOTP = async () => {
     try {
-      await requestPasswordReset(email);
+      await requestPasswordReset({ email, via });
       toast.success(t("new_otp_sent"));
       setCanResend(false);
       setResendTimer(30);

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -35,11 +35,11 @@ export const registerUser = async (payload) => {
 /**
  * 📧 Request OTP to reset password (step 1).
  * 
- * @param {string} email - Email to send OTP to
+ * @param {{email: string, via?: string}} payload
  * @returns {Promise<{ message: string }>}
  */
-export const requestPasswordReset = async (email) => {
-  const res = await api.post("/auth/forgot-password", { email });
+export const requestPasswordReset = async ({ email, via = "email" }) => {
+  const res = await api.post("/auth/forgot-password", { email, via });
   return res.data;
 };
 


### PR DESCRIPTION
## Summary
- allow `generateOtp` to deliver codes via SMS when requested and phone is verified
- support SMS option in password reset controller and frontend flow
- update frontend pages and service to pass delivery method

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894fbcf00088328bbb1624c66133fca