### PR TITLE
fix: allow active books to be fetched

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -123,7 +123,7 @@ exports.getInstructorBookAnalytics = catchAsync(async (req, res) => {
 
 exports.getBook = catchAsync(async (req, res) => {
   const book = await service.getBookById(req.params.id);
-  if (!book || book.status !== "approved") {
+  if (!book || !["approved", "active"].includes(book.status)) {
     throw new AppError("Book not found", 404);
   }
   sendSuccess(res, book);


### PR DESCRIPTION
## Summary
- allow active books to be retrieved by public book endpoint

## Testing
- `npm test` (backend) *(fails: studentPaymentRoutes.test.js and adminPaymentRoutes.test.js - Database Connection Error)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6895e28cfb0c832888d5ead962010b44