### PR TITLE
feat: add book cart and detail components

### DIFF
--- a/docs/book-workflow.md
+++ b/docs/book-workflow.md
@@ -41,7 +41,7 @@ Allow instructors to upload and sell PDF books, and allow students to browse, pu
 
 ### Student
 - `/cart` → View cart
-- `/checkout` → Pay for books
+- `/payments/checkout` → Pay for books
 - `/dashboard/student/library` → Purchased books list (download access)
 
 ### Instructor
@@ -81,7 +81,7 @@ Allow instructors to upload and sell PDF books, and allow students to browse, pu
 - `<BookCard />` – Title, price, instructor, thumbnail
 - `<BookForm />` – Form to create/edit book
 - `<BookDetails />` – Full view + “Add to Cart” button
-- `<CartItem />` – Book row in cart
+- `<CartItem />` – Book row in cart with quantity controls
 - `<LibraryItem />` – Book row in student library
 - `<SecureDownload />` – Button for PDF access (with auth token check)
 - `<AdminBookRow />` – Approve/reject actions

--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -1,0 +1,110 @@
+import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+import useCartStore from "@/store/cart/cartStore";
+import useAuthStore from "@/store/auth/authStore";
+
+export default function BookDetails({ book }) {
+  const router = useRouter();
+  const addItem = useCartStore((state) => state.addItem);
+  const { isAuthenticated, user } = useAuthStore();
+
+  const handleAddToCart = async () => {
+    if (!isAuthenticated()) {
+      toast.info("Please log in to purchase");
+      router.push("/auth/login");
+      return;
+    }
+    if (user?.role?.toLowerCase() !== "student") {
+      toast.error("Only students can purchase books");
+      return;
+    }
+    try {
+      await addItem({ id: book.id, name: book.title, price: book.price });
+      toast.success("Added to cart");
+      router.push("/cart");
+    } catch (err) {
+      console.error("Failed to add to cart", err);
+      toast.error("Failed to add to cart");
+    }
+  };
+
+  return (
+    <div className="flex flex-col md:flex-row gap-8 bg-gray-800/60 p-6 rounded-xl shadow-lg">
+      {book.cover_image_url && (
+        <img
+          src={book.cover_image_url}
+          alt={book.title}
+          className="w-full md:w-1/3 rounded-lg object-cover"
+        />
+      )}
+
+      <div className="flex-1">
+        <h1 className="text-3xl font-bold mb-2">{book.title}</h1>
+        {book.author && (
+          <p className="text-yellow-400 mb-4">by {book.author}</p>
+        )}
+        {book.category_name && (
+          <p className="text-sm uppercase tracking-wide text-gray-400 mb-2">
+            {book.category_name}
+          </p>
+        )}
+        {book.rating && (
+          <p className="mb-4 text-yellow-400">
+            ⭐ {Number(book.rating).toFixed(1)} / 5
+          </p>
+        )}
+        <p className="mb-6">{book.description}</p>
+
+        <p className="text-xl font-semibold mb-6">
+          {book.is_paid ? `$${book.price}` : "Free"}
+        </p>
+
+        {book.pdf_url && (
+          <>
+            {book.is_paid ? (
+              book.user_has_access ? (
+                <a
+                  href={book.pdf_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-block px-6 py-3 rounded-lg bg-green-500 text-white font-semibold hover:bg-green-600 transition-colors"
+                >
+                  Download Book
+                </a>
+              ) : (
+                <div className="flex flex-wrap gap-4">
+                  {book.preview_url && (
+                    <a
+                      href={book.preview_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-block px-6 py-3 rounded-lg bg-yellow-500 text-gray-900 font-semibold hover:bg-yellow-400 transition-colors"
+                    >
+                      Preview
+                    </a>
+                  )}
+                  <button
+                    onClick={handleAddToCart}
+                    className="inline-block px-6 py-3 rounded-lg bg-blue-500 text-white font-semibold hover:bg-blue-600 transition-colors"
+                  >
+                    Add to Cart
+                  </button>
+                </div>
+              )
+            ) : (
+              <a
+                href={book.pdf_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block px-6 py-3 rounded-lg bg-yellow-500 text-gray-900 font-semibold hover:bg-yellow-400 transition-colors"
+              >
+                Read Now
+              </a>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/books/CartItem.js
+++ b/frontend/src/components/books/CartItem.js
@@ -1,0 +1,60 @@
+import { FaTrash, FaPlus, FaMinus, FaGift } from "react-icons/fa";
+import { motion } from "framer-motion";
+
+export default function CartItem({
+  item,
+  index,
+  onIncrease,
+  onDecrease,
+  onRemove,
+}) {
+  return (
+    <motion.li
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -10 }}
+      transition={{ duration: 0.3 }}
+      className="flex justify-between items-center border-b border-gray-700 pb-4"
+    >
+      <div className="flex items-center space-x-4">
+        <FaGift className="text-yellow-500 text-4xl" />
+        <div>
+          <h3 className="text-lg font-semibold">
+            {index + 1}. {item.name}
+          </h3>
+          <p className="text-gray-400">${item.price} per item</p>
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-4">
+        <motion.button
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+          onClick={onDecrease}
+          className="p-2 bg-gray-800 hover:bg-gray-700 rounded-full"
+        >
+          <FaMinus />
+        </motion.button>
+        <span className="text-lg font-bold">{item.quantity}</span>
+        <motion.button
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+          onClick={onIncrease}
+          className="p-2 bg-gray-800 hover:bg-gray-700 rounded-full"
+        >
+          <FaPlus />
+        </motion.button>
+      </div>
+
+      <motion.button
+        whileHover={{ scale: 1.2 }}
+        whileTap={{ scale: 0.9 }}
+        onClick={onRemove}
+        className="p-2 text-red-500 hover:text-red-600"
+      >
+        <FaTrash />
+      </motion.button>
+    </motion.li>
+  );
+}
+

--- a/frontend/src/pages/cart/index.js
+++ b/frontend/src/pages/cart/index.js
@@ -2,9 +2,10 @@ import { useState, useEffect } from "react";
 import Navbar from "@/components/website/sections/Navbar";
 import useCartStore from "@/store/cart/cartStore";
 import { motion, AnimatePresence } from "framer-motion"; // ✅ Import animations
-import { FaTrash, FaPlus, FaMinus, FaTag, FaGift } from "react-icons/fa";
+import { FaTag, FaGift } from "react-icons/fa";
 import Link from "next/link";
 import { toast } from "react-toastify";
+import CartItem from "@/components/books/CartItem";
 
 const CartPage = () => {
   const {
@@ -87,55 +88,14 @@ const CartPage = () => {
             <ul className="space-y-6">
               <AnimatePresence>
                 {cartItems.map((item, index) => (
-                  <motion.li
+                  <CartItem
                     key={item.id}
-                    initial={{ opacity: 0, y: -10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -10 }}
-                    transition={{ duration: 0.3 }}
-                    className="flex justify-between items-center border-b border-gray-700 pb-4"
-                  >
-                    <div className="flex items-center space-x-4">
-                      <FaGift className="text-yellow-500 text-4xl" />
-                      <div>
-                        <h3 className="text-lg font-semibold">
-                          {index + 1}. {item.name}
-                        </h3>
-                        <p className="text-gray-400">${item.price} per item</p>
-                      </div>
-                    </div>
-
-                    {/* Quantity Controls */}
-                    <div className="flex items-center space-x-4">
-                      <motion.button
-                        whileHover={{ scale: 1.1 }}
-                        whileTap={{ scale: 0.9 }}
-                        onClick={() => updateQuantity(item.id, "decrease")}
-                        className="p-2 bg-gray-800 hover:bg-gray-700 rounded-full"
-                      >
-                        <FaMinus />
-                      </motion.button>
-                      <span className="text-lg font-bold">{item.quantity}</span>
-                      <motion.button
-                        whileHover={{ scale: 1.1 }}
-                        whileTap={{ scale: 0.9 }}
-                        onClick={() => updateQuantity(item.id, "increase")}
-                        className="p-2 bg-gray-800 hover:bg-gray-700 rounded-full"
-                      >
-                        <FaPlus />
-                      </motion.button>
-                    </div>
-
-                    {/* Remove Button */}
-                    <motion.button
-                      whileHover={{ scale: 1.2 }}
-                      whileTap={{ scale: 0.9 }}
-                      onClick={() => removeItem(item.id)}
-                      className="p-2 text-red-500 hover:text-red-600"
-                    >
-                      <FaTrash />
-                    </motion.button>
-                  </motion.li>
+                    item={item}
+                    index={index}
+                    onIncrease={() => updateQuantity(item.id, "increase")}
+                    onDecrease={() => updateQuantity(item.id, "decrease")}
+                    onRemove={() => removeItem(item.id)}
+                  />
                 ))}
               </AnimatePresence>
             </ul>

--- a/frontend/src/pages/marketplace/books/[id].js
+++ b/frontend/src/pages/marketplace/books/[id].js
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import { fetchBook } from "@/services/bookService";
+import BookDetails from "@/components/books/BookDetails";
 
 export default function BookDetailPage() {
   const router = useRouter();
@@ -57,83 +58,7 @@ export default function BookDetailPage() {
           </div>
         )}
 
-        {!loading && !error && book && (
-          <div className="flex flex-col md:flex-row gap-8 bg-gray-800/60 p-6 rounded-xl shadow-lg">
-            {book.cover_image_url && (
-              <img
-                src={book.cover_image_url}
-                alt={book.title}
-                className="w-full md:w-1/3 rounded-lg object-cover"
-              />
-            )}
-
-            <div className="flex-1">
-              <h1 className="text-3xl font-bold mb-2">{book.title}</h1>
-              {book.author && (
-                <p className="text-yellow-400 mb-4">by {book.author}</p>
-              )}
-              {book.category_name && (
-                <p className="text-sm uppercase tracking-wide text-gray-400 mb-2">
-                  {book.category_name}
-                </p>
-              )}
-              {book.rating && (
-                <p className="mb-4 text-yellow-400">
-                  ⭐ {Number(book.rating).toFixed(1)} / 5
-                </p>
-              )}
-              <p className="mb-6">{book.description}</p>
-
-              <p className="text-xl font-semibold mb-6">
-                {book.is_paid ? `$${book.price}` : "Free"}
-              </p>
-
-              {/* CTA based on access & paid status */}
-              {book.pdf_url && (
-                <>
-                  {book.is_paid ? (
-                    book.user_has_access ? (
-                      <a
-                        href={book.pdf_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-block px-6 py-3 rounded-lg bg-green-500 text-white font-semibold hover:bg-green-600 transition-colors"
-                      >
-                        Download Book
-                      </a>
-                    ) : (
-                      <div className="flex flex-wrap gap-4">
-                        <a
-                          href={book.preview_url || book.pdf_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-block px-6 py-3 rounded-lg bg-yellow-500 text-gray-900 font-semibold hover:bg-yellow-400 transition-colors"
-                        >
-                          Preview
-                        </a>
-                        <button
-                          onClick={() => router.push(`/checkout/book/${book.id}`)}
-                          className="inline-block px-6 py-3 rounded-lg bg-blue-500 text-white font-semibold hover:bg-blue-600 transition-colors"
-                        >
-                          Buy Now
-                        </button>
-                      </div>
-                    )
-                  ) : (
-                    <a
-                      href={book.pdf_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-block px-6 py-3 rounded-lg bg-yellow-500 text-gray-900 font-semibold hover:bg-yellow-400 transition-colors"
-                    >
-                      Read Now
-                    </a>
-                  )}
-                </>
-              )}
-            </div>
-          </div>
-        )}
+        {!loading && !error && book && <BookDetails book={book} />}
       </div>
       <Footer />
     </section>


### PR DESCRIPTION
## Summary
- add reusable `CartItem` for cart rows with quantity and removal controls
- introduce `BookDetails` component with authenticated add-to-cart action
- wire up cart and book detail pages to new components and document checkout route

## Testing
- `npm test`
- `npm run lint` *(fails: import/no-anonymous-default-export across repository)*

------
https://chatgpt.com/codex/tasks/task_e_6895ec6ff3ec8328b0ac29ff0fa16317