### PR TITLE
Add book purchase tracking and secure download support

### DIFF
--- a/backend/src/modules/library/library.controller.js
+++ b/backend/src/modules/library/library.controller.js
@@ -1,8 +1,27 @@
 const service = require("./library.service");
 const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
+const path = require("path");
+const fs = require("fs");
 
 exports.listLibrary = catchAsync(async (req, res) => {
   const items = await service.listForStudent(req.user.id);
   sendSuccess(res, items);
+});
+
+exports.downloadBook = catchAsync(async (req, res) => {
+  const { bookId } = req.params;
+  const book = await service.getBookForDownload(req.user.id, bookId);
+  if (!book) {
+    return res.status(403).json({ message: "Access denied" });
+  }
+  const filePath = path.join(
+    __dirname,
+    "../../../uploads",
+    path.basename(book.pdf_url)
+  );
+  if (!fs.existsSync(filePath)) {
+    return res.status(404).json({ message: "File not found" });
+  }
+  res.download(filePath, `${book.title || "book"}.pdf`);
 });

--- a/backend/src/modules/library/library.routes.js
+++ b/backend/src/modules/library/library.routes.js
@@ -3,5 +3,6 @@ const controller = require("./library.controller");
 const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware");
 
 router.get("/", verifyToken, isStudent, controller.listLibrary);
+router.get("/download/:bookId", verifyToken, isStudent, controller.downloadBook);
 
 module.exports = router;

--- a/backend/src/modules/library/library.service.js
+++ b/backend/src/modules/library/library.service.js
@@ -62,3 +62,22 @@ exports.listForStudent = async (studentId) => {
     };
   });
 };
+
+exports.recordPurchase = async (studentId, bookId, pricePaid) => {
+  const [row] = await db("book_purchases")
+    .insert({
+      student_id: studentId,
+      book_id: bookId,
+      price_paid: pricePaid,
+    })
+    .returning("*");
+  return row;
+};
+
+exports.getBookForDownload = async (studentId, bookId) => {
+  return db("book_purchases as bp")
+    .join("books as b", "bp.book_id", "b.id")
+    .where({ "bp.student_id": studentId, "bp.book_id": bookId })
+    .select("b.pdf_url", "b.title")
+    .first();
+};

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -5,6 +5,7 @@ const service = require("./payments.service");
 const { v4: uuidv4 } = require("uuid");
 const smsService = require("../../services/smsService");
 const userModel = require("../users/user.model");
+const libraryService = require("../library/library.service");
 
 exports.createPayment = catchAsync(async (req, res) => {
   const { user_id, method_id, item_type, item_id, amount, currency, status, reference_id } = req.body;
@@ -32,6 +33,14 @@ exports.createPayment = catchAsync(async (req, res) => {
     }
   } catch (err) {
     console.error("Failed to send payment SMS:", err);
+  }
+
+  if (item_type === "book" && payment.status === "paid") {
+    try {
+      await libraryService.recordPurchase(user_id, item_id, amount);
+    } catch (err) {
+      console.error("Failed to record book purchase:", err);
+    }
   }
 
   sendSuccess(res, payment, "Payment created");

--- a/backend/tests/libraryRoutes.test.js
+++ b/backend/tests/libraryRoutes.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 jest.mock('../src/modules/library/library.service', () => ({
   listForStudent: jest.fn(),
+  getBookForDownload: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -42,5 +43,38 @@ describe('GET /api/library', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(items);
     expect(service.listForStudent).toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/library/download/:bookId', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const uploadsDir = path.join(__dirname, '../uploads');
+
+  beforeAll(() => {
+    if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir);
+    fs.writeFileSync(path.join(uploadsDir, 'test.pdf'), 'test');
+  });
+
+  afterAll(() => {
+    try {
+      fs.unlinkSync(path.join(uploadsDir, 'test.pdf'));
+    } catch (_) {}
+  });
+
+  it('allows download for purchased book', async () => {
+    service.getBookForDownload.mockResolvedValue({
+      pdf_url: 'test.pdf',
+      title: 'Test Book',
+    });
+    const res = await request(app).get('/api/library/download/1');
+    expect(res.status).toBe(200);
+    expect(service.getBookForDownload).toHaveBeenCalledWith('1', '1');
+  });
+
+  it('blocks download if not purchased', async () => {
+    service.getBookForDownload.mockResolvedValue(null);
+    const res = await request(app).get('/api/library/download/2');
+    expect(res.status).toBe(403);
   });
 });

--- a/frontend/src/pages/cart/confirmation.js
+++ b/frontend/src/pages/cart/confirmation.js
@@ -1,7 +1,15 @@
 import Link from "next/link";
+import { useEffect } from "react";
 import { FaCheckCircle } from "react-icons/fa";
+import useLibraryStore from "@/store/libraryStore";
 
 const ConfirmationPage = () => {
+  const fetchLibrary = useLibraryStore((state) => state.fetchLibrary);
+
+  useEffect(() => {
+    fetchLibrary();
+  }, [fetchLibrary]);
+
   return (
     <div className="bg-black min-h-screen text-white flex flex-col justify-center items-center">
       <FaCheckCircle className="text-6xl text-green-500 mb-4" />

--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { FiDownload, FiEye, FiStar, FiHeart } from "react-icons/fi";
-import { fetchLibrary } from "@/services/libraryService";
+import useLibraryStore from "@/store/libraryStore";
 
 function BookCard({ book }) {
   const cover = book.coverUrl || "/images/default-book-cover.jpg";
@@ -66,19 +66,11 @@ function BookCard({ book }) {
 }
 
 export default function BooksPage() {
-  const [books, setBooks] = useState([]);
+  const { items: books, fetchLibrary } = useLibraryStore();
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const data = await fetchLibrary();
-        setBooks(data);
-      } catch (e) {
-        console.error("Failed to load books", e);
-      }
-    };
-    load();
-  }, []);
+    fetchLibrary();
+  }, [fetchLibrary]);
 
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/frontend/src/pages/dashboard/student/library.js
+++ b/frontend/src/pages/dashboard/student/library.js
@@ -1,21 +1,13 @@
-import { useEffect, useState } from "react";
-import { fetchLibrary } from "@/services/libraryService";
+import { useEffect } from "react";
 import LibraryItem from "@/components/books/LibraryItem";
+import useLibraryStore from "@/store/libraryStore";
 
 export default function LibraryPage() {
-  const [items, setItems] = useState([]);
+  const { items, fetchLibrary } = useLibraryStore();
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const data = await fetchLibrary();
-        setItems(data);
-      } catch (e) {
-        console.error("Failed to load library", e);
-      }
-    };
-    load();
-  }, []);
+    fetchLibrary();
+  }, [fetchLibrary]);
 
   return (
     <div>

--- a/frontend/src/pages/payments/success.js
+++ b/frontend/src/pages/payments/success.js
@@ -8,31 +8,35 @@ import { FaCheckCircle, FaArrowRight, FaCalendarAlt, FaChalkboardTeacher, FaDown
 import { enrollInClass, fetchClassDetails } from '@/services/classService';
 import useCartStore from '@/store/cart/cartStore';
 import { toast } from 'react-toastify';
+import useLibraryStore from '@/store/libraryStore';
 
 export default function PaymentSuccessPage() {
   const router = useRouter();
   const { classId } = router.query;
   const [classInfo, setClassInfo] = useState(null);
   const removeItem = useCartStore((state) => state.removeItem);
+  const { fetchLibrary } = useLibraryStore();
 
   useEffect(() => {
-    if (!classId) return;
     const enroll = async () => {
-      try {
-        await enrollInClass(classId);
-        await removeItem(classId);
-      } catch (_) {
-        toast.error('Failed to register for class');
+      if (classId) {
+        try {
+          await enrollInClass(classId);
+          await removeItem(classId);
+        } catch (_) {
+          toast.error('Failed to register for class');
+        }
+        try {
+          const details = await fetchClassDetails(classId);
+          setClassInfo(details?.data ?? details);
+        } catch (_) {
+          setClassInfo(null);
+        }
       }
-      try {
-        const details = await fetchClassDetails(classId);
-        setClassInfo(details?.data ?? details);
-      } catch (_) {
-        setClassInfo(null);
-      }
+      await fetchLibrary();
     };
     enroll();
-  }, [classId]);
+  }, [classId, fetchLibrary, removeItem]);
 
   if (!classInfo) return <div className="text-white text-center mt-32">Loading...</div>;
 

--- a/frontend/src/store/libraryStore.js
+++ b/frontend/src/store/libraryStore.js
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { fetchLibrary as apiFetchLibrary } from "@/services/libraryService";
+
+const useLibraryStore = create((set) => ({
+  items: [],
+  loading: false,
+  fetchLibrary: async () => {
+    set({ loading: true });
+    try {
+      const items = await apiFetchLibrary();
+      set({ items, loading: false });
+    } catch (err) {
+      set({ loading: false });
+    }
+  },
+}));
+
+export default useLibraryStore;
+


### PR DESCRIPTION
## Summary
- record completed book payments in `book_purchases`
- refresh student library data after checkout via a new Zustand store
- secure `/library/download/:bookId` endpoint validates purchases before serving PDFs

## Testing
- `npm test` (backend) *(fails: Jest worker encountered 4 child process exceptions)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6895ec6e327483289282a3951575f65d