### PR TITLE
Add book cart and wishlist endpoints for students

### DIFF
--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -7,11 +7,13 @@ const db = knex({
   pool: { min: 2, max: 10 },
 });
 
-db.raw("SELECT 1")
-  .then(() => console.log("✅ PostgreSQL Database Connected"))
-  .catch((err) => {
-    console.error("❌ Database Connection Error:", err);
-    process.exit(1);
-  });
+if (process.env.NODE_ENV !== "test") {
+  db.raw("SELECT 1")
+    .then(() => console.log("✅ PostgreSQL Database Connected"))
+    .catch((err) => {
+      console.error("❌ Database Connection Error:", err);
+      process.exit(1);
+    });
+}
 
 module.exports = db;

--- a/backend/src/migrations/20250810120000_create_book_cart_table.js
+++ b/backend/src/migrations/20250810120000_create_book_cart_table.js
@@ -1,0 +1,28 @@
+const TABLE_NAME = 'book_cart';
+
+exports.up = function(knex) {
+  return knex.schema.createTable(TABLE_NAME, (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table
+      .uuid('student_id')
+      .notNullable()
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table
+      .integer('book_id')
+      .unsigned()
+      .notNullable()
+      .references('id')
+      .inTable('books')
+      .onDelete('CASCADE');
+    table.integer('quantity').notNullable().defaultTo(1);
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['student_id','book_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists(TABLE_NAME);
+};
+

--- a/backend/src/migrations/20250810121000_create_book_wishlist_table.js
+++ b/backend/src/migrations/20250810121000_create_book_wishlist_table.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'book_wishlist';
+
+exports.up = function(knex) {
+  return knex.schema.createTable(TABLE_NAME, (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table
+      .uuid('student_id')
+      .notNullable()
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table
+      .integer('book_id')
+      .unsigned()
+      .notNullable()
+      .references('id')
+      .inTable('books')
+      .onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['student_id','book_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists(TABLE_NAME);
+};
+

--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -280,3 +280,29 @@ exports.updateBookStatus = catchAsync(async (req, res) => {
 
 sendSuccess(res, book, "Book status updated");
 });
+
+exports.updateCart = catchAsync(async (req, res) => {
+  const { bookId, action } = req.body || {};
+  if (action === 'remove') {
+    await service.removeFromCart(req.user.id, bookId);
+    return sendSuccess(res, null, 'Removed from cart');
+  }
+  const item = await service.addToCart(req.user.id, bookId);
+  sendSuccess(res, item, 'Added to cart');
+});
+
+exports.checkout = catchAsync(async (req, res) => {
+  const purchases = await service.checkout(req.user.id);
+  sendSuccess(res, purchases, 'Checkout complete');
+});
+
+exports.addWishlist = catchAsync(async (req, res) => {
+  await service.addToWishlist(req.user.id, req.body.bookId);
+  sendSuccess(res, null, 'Added to wishlist');
+});
+
+exports.removeWishlist = catchAsync(async (req, res) => {
+  await service.removeFromWishlist(req.user.id, req.body.bookId);
+  sendSuccess(res, null, 'Removed from wishlist');
+});
+

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -5,6 +5,7 @@ const upload = require("./bookUploadMiddleware");
 const {
   verifyToken,
   isAdmin,
+  isStudent,
 } = require("../../middleware/auth/authMiddleware");
 
 router.get("/tags", verifyToken, isAdmin, tagController.listTags);
@@ -15,6 +16,10 @@ router.get("/:id", controller.getBook);
 router.post("/", verifyToken, isAdmin, upload, controller.createBook);
 router.put("/:id", verifyToken, isAdmin, upload, controller.updateBook);
 router.patch("/:id/status", verifyToken, isAdmin, controller.updateBookStatus);
+router.post("/cart", verifyToken, isStudent, controller.updateCart);
+router.post("/checkout", verifyToken, isStudent, controller.checkout);
+router.post("/wishlist", verifyToken, isStudent, controller.addWishlist);
+router.delete("/wishlist", verifyToken, isStudent, controller.removeWishlist);
 router.delete("/:id", verifyToken, isAdmin, controller.deleteBook);
 
 module.exports = router;

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -144,3 +144,50 @@ exports.getInstructorBookAnalytics = async (instructorId) => {
     })),
   };
 };
+
+exports.addToCart = async (studentId, bookId) => {
+  const [row] = await db('book_cart')
+    .insert({ student_id: studentId, book_id: bookId })
+    .onConflict(['student_id', 'book_id'])
+    .merge({ quantity: db.raw('book_cart.quantity + 1') })
+    .returning('*');
+  return row;
+};
+
+exports.removeFromCart = (studentId, bookId) =>
+  db('book_cart').where({ student_id: studentId, book_id: bookId }).del();
+
+exports.checkout = async (studentId) => {
+  return db.transaction(async (trx) => {
+    const items = await trx('book_cart')
+      .where({ student_id: studentId })
+      .select('book_id');
+    if (!items.length) return [];
+    const books = await trx('books')
+      .whereIn('id', items.map((i) => i.book_id))
+      .select('id', 'price');
+    const rows = books.map((b) => ({
+      student_id: studentId,
+      book_id: b.id,
+      price_paid: b.price,
+    }));
+    const purchases = await trx('book_purchases')
+      .insert(rows)
+      .returning('*');
+    await trx('book_cart').where({ student_id: studentId }).del();
+    return purchases;
+  });
+};
+
+exports.addToWishlist = async (studentId, bookId) => {
+  const [row] = await db('book_wishlist')
+    .insert({ student_id: studentId, book_id: bookId })
+    .onConflict(['student_id', 'book_id'])
+    .ignore()
+    .returning('*');
+  return row;
+};
+
+exports.removeFromWishlist = (studentId, bookId) =>
+  db('book_wishlist').where({ student_id: studentId, book_id: bookId }).del();
+

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -11,6 +11,11 @@ jest.mock('../src/modules/books/book.service', () => ({
   getBookTags: jest.fn(),
   updateBookStatus: jest.fn(),
   getInstructorBookAnalytics: jest.fn(),
+  addToCart: jest.fn(),
+  removeFromCart: jest.fn(),
+  checkout: jest.fn(),
+  addToWishlist: jest.fn(),
+  removeFromWishlist: jest.fn(),
 }));
 
 jest.mock('../src/modules/messages/messages.service', () => ({
@@ -43,6 +48,7 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
     next();
   }),
   isAdmin: jest.fn((_req, _res, next) => next()),
+  isStudent: jest.fn((_req, _res, next) => next()),
 }));
 
 const service = require('../src/modules/books/book.service');
@@ -192,3 +198,73 @@ describe('PATCH /api/books/:id/status', () => {
     expect(service.updateBookStatus).not.toHaveBeenCalled();
   });
 });
+
+describe('POST /api/books/cart', () => {
+  it('adds to cart', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    const res = await request(app)
+      .post('/api/books/cart')
+      .send({ bookId: '10' });
+    expect(res.status).toBe(200);
+    expect(service.addToCart).toHaveBeenCalledWith('1', '10');
+  });
+
+  it('removes from cart', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    const res = await request(app)
+      .post('/api/books/cart')
+      .send({ bookId: '10', action: 'remove' });
+    expect(res.status).toBe(200);
+    expect(service.removeFromCart).toHaveBeenCalledWith('1', '10');
+  });
+});
+
+describe('POST /api/books/checkout', () => {
+  it('processes checkout', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    const purchases = [{ id: 1 }];
+    service.checkout.mockResolvedValue(purchases);
+    const res = await request(app).post('/api/books/checkout');
+    expect(res.status).toBe(200);
+    expect(service.checkout).toHaveBeenCalledWith('1');
+    expect(res.body.data).toEqual(purchases);
+  });
+});
+
+describe('POST /api/books/wishlist', () => {
+  it('adds to wishlist', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    const res = await request(app)
+      .post('/api/books/wishlist')
+      .send({ bookId: '10' });
+    expect(res.status).toBe(200);
+    expect(service.addToWishlist).toHaveBeenCalledWith('1', '10');
+  });
+});
+
+describe('DELETE /api/books/wishlist', () => {
+  it('removes from wishlist', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    const res = await request(app)
+      .delete('/api/books/wishlist')
+      .send({ bookId: '10' });
+    expect(res.status).toBe(200);
+    expect(service.removeFromWishlist).toHaveBeenCalledWith('1', '10');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add migrations for `book_cart` and `book_wishlist`
- extend book service with cart, checkout, and wishlist helpers
- expose student cart/checkout/wishlist routes and controllers
- prevent DB connection during tests
- cover new routes with tests

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895ec6d98808328834d876cbd7dadaf