### PR TITLE
feat: support admin book listing

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -136,6 +136,7 @@ function AdminBooksPage() {
           perPage,
           filters: activeFilters,
           sort: { sortBy },
+          admin: true,
         });
         setBooks(list);
         setMeta(meta);

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -51,6 +51,7 @@ export const fetchBooks = async ({
   perPage,
   filters = {},
   sort = {},
+  admin = false,
 } = {}) => {
   const params = {
     ...(page !== undefined && { page }),
@@ -58,7 +59,8 @@ export const fetchBooks = async ({
     ...filters,
     ...sort,
   };
-  const { data } = await api.get("/books", { params });
+  const endpoint = admin ? "/books/admin" : "/books";
+  const { data } = await api.get(endpoint, { params });
   const list = data?.data ? data.data.map(formatBook) : [];
   return {
     books: list,

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -44,6 +44,26 @@ describe("bookService", () => {
     });
   });
 
+  it("fetches books as admin", async () => {
+    const apiData = [{ id: 1, title: "A" }];
+    const meta = { total: 1 };
+    api.get.mockResolvedValueOnce({ data: { data: apiData, meta } });
+    const res = await fetchBooks({ admin: true });
+    expect(api.get).toHaveBeenCalledWith("/books/admin", { params: {} });
+    expect(res).toEqual({
+      books: [
+        {
+          id: 1,
+          title: "A",
+          cover_image_url: null,
+          pdf_url: null,
+          preview_pages: [],
+        },
+      ],
+      meta,
+    });
+  });
+
   it("fetches single book", async () => {
     const apiData = { id: 1, title: "A" };
     api.get.mockResolvedValueOnce({ data: { data: apiData } });


### PR DESCRIPTION
## Summary
- allow bookService to fetch from admin endpoint
- pass admin flag for book listing page
- add tests for admin book listing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895f4946d9c8328924990ecad76c967