### PR TITLE
Optimize admin book setup with concurrent fetches

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -75,8 +75,10 @@ function AdminBooksPage() {
   useEffect(() => {
     const loadCategories = async () => {
       try {
-        const cats = await fetchBookCategories();
-        const langs = await getLanguages();
+        const [cats, langs] = await Promise.all([
+          fetchBookCategories(),
+          getLanguages(),
+        ]);
         setCategories(cats);
         setLanguages(langs);
       } catch (err) {


### PR DESCRIPTION
## Summary
- load book categories and languages in parallel to reduce page initialization time

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 252 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6895f4937d7c832897c196204b4657eb