### PR TITLE
Protect instructor avatar upload

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -187,6 +187,34 @@ exports.getProfileStatus = async (req, res) => {
 
 
 /**
+ * @desc Update instructor avatar
+ * @route PATCH /api/users/instructor/:id/avatar
+ * @access Instructor
+ */
+exports.updateAvatar = async (req, res) => {
+    console.log("📥 Incoming avatar upload");
+
+    try {
+        if (!req.file) {
+            return res.status(400).json({ error: "No file uploaded" });
+        }
+
+        if (req.params.id !== req.user.id) {
+            return res.status(403).json({ error: "Unauthorized" });
+        }
+
+        const avatarUrl = `/uploads/avatars/instructor/${req.file.filename}`;
+
+        await db("users").where({ id: req.user.id }).update({ avatar_url: avatarUrl });
+
+        res.json({ avatar_url: avatarUrl });
+    } catch (err) {
+        console.error("❌ Avatar upload error:", err.message);
+        res.status(500).json({ error: "Failed to upload avatar" });
+    }
+};
+
+/**
  * @desc Delete instructor avatar
  * @route DELETE /api/users/instructor/:id/avatar
  * @access Instructor

--- a/backend/src/modules/users/instructor/instructor.routes.js
+++ b/backend/src/modules/users/instructor/instructor.routes.js
@@ -36,24 +36,10 @@ router.put(
  */
 router.patch(
   "/:id/avatar",
-  (req, res, next) => {
-    console.log("📥 Incoming avatar upload");
-    next();
-  },
+  verifyToken,
+  isInstructor,
   avatarUpload.single("avatar"),
-  async (req, res) => {
-    try {
-      if (!req.file) return res.status(400).json({ error: "No file uploaded" });
-
-      const avatarUrl = `/uploads/avatars/instructor/${req.file.filename}`;
-      await db("users").where({ id: req.params.id }).update({ avatar_url: avatarUrl });
-
-      res.json({ avatar_url: avatarUrl });
-    } catch (err) {
-      console.error("❌ Avatar upload error:", err.message);
-      res.status(500).json({ error: err.message });
-    }
-  }
+  controller.updateAvatar
 );
 
 // Upload certificate


### PR DESCRIPTION
## Summary
- secure instructor avatar upload route with verifyToken and isInstructor middleware
- move avatar upload logic into instructor controller and enforce user ID check

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895fda6e3fc8328bf8d4e993de6b805