### PR TITLE
chore: remove unused admin change password schema

### DIFF
--- a/backend/src/modules/users/admin/admin.routes.js
+++ b/backend/src/modules/users/admin/admin.routes.js
@@ -6,7 +6,6 @@ const router = express.Router();
 const controller = require("./admin.controller");
 const validate = require("../../../middleware/validate");
 const { adminProfileSchema } = require("./admin.validator");
-const { adminChangePasswordSchema } = require("./admin.validator");
 const { verifyToken, isAdmin, isSuperAdmin } = require("../../../middleware/auth/authMiddleware");
 const upload = require("./adminUploadMiddleware");
 const categoryRoutes = require("../categories/category.routes");


### PR DESCRIPTION
## Summary
- remove unused adminChangePasswordSchema import from admin routes

## Testing
- `npx eslint --no-config-lookup --rule 'no-unused-vars: error' --format json src/modules/users/admin/admin.routes.js`

------
https://chatgpt.com/codex/tasks/task_e_6895fdb644a48328854598c2675eb32c