### PR TITLE
feat: add instructor-only classes endpoint

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -48,6 +48,7 @@ jest.mock('../../../middleware/auth/authMiddleware', () => ({
   isStudent: (_req, _res, next) => next(),
   isInstructorOrAdmin: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
+  isInstructor: (_req, _res, next) => next(),
 }));
 
 const routes = require('../class.routes');

--- a/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
+++ b/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
@@ -37,6 +37,7 @@ jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   isInstructorOrAdmin: (_req, _res, next) => next(),
   isStudent: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
+  isInstructor: (_req, _res, next) => next(),
 }));
 
 const routes = require('../../class.routes');

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -10,6 +10,7 @@ const {
   verifyToken,
   isInstructorOrAdmin,
   isAdmin,
+  isInstructor,
 } = require("../../middleware/auth/authMiddleware");
 
 // Student enrollments
@@ -40,6 +41,12 @@ router.get(
   "/admin/my",
   verifyToken,
   isInstructorOrAdmin,
+  controller.getMyClasses
+);
+router.get(
+  "/instructor/my",
+  verifyToken,
+  isInstructor,
   controller.getMyClasses
 );
 router.get(

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -31,6 +31,7 @@ jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   isStudent: (_req, _res, next) => next(),
   isInstructorOrAdmin: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
+  isInstructor: (_req, _res, next) => next(),
 }));
 
 const routes = require('../../class.routes');

--- a/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
+++ b/backend/src/modules/classes/lessons/__tests__/classLesson.routes.test.js
@@ -46,6 +46,7 @@ jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   isInstructorOrAdmin: (_req, _res, next) => next(),
   isStudent: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
+  isInstructor: (_req, _res, next) => next(),
 }));
 
 const routes = require('../../class.routes');

--- a/backend/src/modules/classes/scores/__tests__/classScore.routes.test.js
+++ b/backend/src/modules/classes/scores/__tests__/classScore.routes.test.js
@@ -18,6 +18,7 @@ jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   isInstructorOrAdmin: (_req, _res, next) => next(),
   isStudent: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
+  isInstructor: (_req, _res, next) => next(),
 }));
 
 const service = require('../classScore.service');

--- a/backend/tests/classAnalyticsRoutes.test.js
+++ b/backend/tests/classAnalyticsRoutes.test.js
@@ -20,6 +20,7 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
   isStudent: (_req, _res, next) => next(),
   isInstructorOrAdmin: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
+  isInstructor: (_req, _res, next) => next(),
 }));
 
 const service = require('../src/modules/classes/class.service');

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -37,8 +37,8 @@ const computeScheduleStatus = (start, end) => {
 
 export const fetchInstructorClasses = async () => {
   // Fetch only classes belonging to the current instructor
-  // using the dedicated "/admin/my" endpoint
-  const { data } = await api.get("/users/classes/admin/my");
+  // using the dedicated "/instructor/my" endpoint
+  const { data } = await api.get("/users/classes/instructor/my");
   const list = data?.data ?? [];
   return list.map(formatClass);
 };


### PR DESCRIPTION
## Summary
- add `/users/classes/instructor/my` route protected by instructor middleware
- update instructor class service to use new dedicated endpoint

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895fdc0f0248328b4d0821402460049