### PR TITLE
Use debug logger for admin identity upload

### DIFF
--- a/backend/src/modules/users/admin/admin.routes.js
+++ b/backend/src/modules/users/admin/admin.routes.js
@@ -12,6 +12,7 @@ const upload = require("./adminUploadMiddleware");
 const categoryRoutes = require("../categories/category.routes");
 const instructorAdminRoutes = require("./instructors/instructorAdmin.routes");
 // const classRoutes = require("../classes/class.routes");
+const logger = require("../../../utils/logger");
 
 
 
@@ -43,8 +44,7 @@ router.post(
         console.error("Multer upload error:", err.message);
         return res.status(400).json({ message: err.message });
       }
-
-      console.log("✅ File received:", req.file); // add this line
+      logger.debug("Identity document upload request received");
       next();
     });
   },

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -23,6 +23,10 @@ module.exports = {
     append("INFO", args);
     console.log("[LOG]", ...args);
   },
+  debug: (...args) => {
+    append("DEBUG", args);
+    console.debug("[DEBUG]", ...args);
+  },
   warn: (...args) => {
     append("WARN", args);
     console.warn("[WARN]", ...args);


### PR DESCRIPTION
## Summary
- add debug method to logger utility
- use debug logger in admin identity document upload instead of console.log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895fdc08a4c8328ab1ea69a805af5f1