### PR TITLE
Wrap tutorial creation in transaction and add tag JSON validation

### DIFF
--- a/backend/src/modules/users/tutorials/chapters/tutorialChapter.service.js
+++ b/backend/src/modules/users/tutorials/chapters/tutorialChapter.service.js
@@ -1,7 +1,7 @@
 const db = require("../../../../config/database");
 
-exports.create = async (data) => {
-  await db("tutorial_chapters").insert(data);
+exports.create = async (data, trx = db) => {
+  await trx("tutorial_chapters").insert(data);
   return data;
 };
 

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -85,8 +85,8 @@ exports.createTutorial = catchAsync(async (req, res) => {
   const thumbnailFile = req.files?.thumbnail?.[0];
   const previewFile = req.files?.preview?.[0];
 
-  // Save tutorial
-  const tutorial = {
+  // Prepare tutorial data
+  const tutorialData = {
     id,
     title,
     slug,
@@ -105,42 +105,58 @@ exports.createTutorial = catchAsync(async (req, res) => {
       ? `/uploads/tutorials/${roleDir}/${previewFile.filename}`
       : null,
   };
-  await service.createTutorial(tutorial);
 
-  const tags = rawTags
-    ? typeof rawTags === "string"
-      ? JSON.parse(rawTags)
-      : rawTags
-    : [];
-  if (tags.length) {
-    const tagIds = [];
-    for (const name of tags) {
-      const existing = await tagService.findByName(name);
-      const tag =
-        existing ||
-        (await tagService.createTag({
-          name,
-          slug: slugify(name, { lower: true, strict: true }),
-        }));
-      tagIds.push(tag.id);
+  // Parse tags safely
+  let tags = [];
+  if (rawTags) {
+    if (typeof rawTags === "string") {
+      try {
+        tags = JSON.parse(rawTags);
+      } catch (err) {
+        return res.status(400).json({ message: "Invalid tags JSON" });
+      }
+    } else if (Array.isArray(rawTags)) {
+      tags = rawTags;
     }
-    await service.addTutorialTags(id, tagIds);
-    tutorial.tags = await service.getTutorialTags(id);
   }
 
-  // Save chapters (if any)
-  for (let i = 0; i < parsedChapters.length; i++) {
-    const ch = parsedChapters[i];
-    await chapterService.create({
-      id: uuidv4(),
-      tutorial_id: id,
-      title: ch.title,
-      video_url: ch.video_url,
-      duration: ch.duration,
-      order: ch.order ?? i + 1,
-      is_preview: ch.is_preview ?? false,
-    });
-  }
+  let tutorial;
+  await db.transaction(async (trx) => {
+    tutorial = await service.createTutorial(tutorialData, trx);
+
+    if (tags.length) {
+      const tagIds = [];
+      for (const name of tags) {
+        const existing = await tagService.findByName(name, trx);
+        const tag =
+          existing ||
+          (await tagService.createTag(
+            { name, slug: slugify(name, { lower: true, strict: true }) },
+            trx
+          ));
+        tagIds.push(tag.id);
+      }
+      await service.addTutorialTags(id, tagIds, trx);
+      tutorial.tags = await service.getTutorialTags(id, trx);
+    }
+
+    // Save chapters (if any)
+    for (let i = 0; i < parsedChapters.length; i++) {
+      const ch = parsedChapters[i];
+      await chapterService.create(
+        {
+          id: uuidv4(),
+          tutorial_id: id,
+          title: ch.title,
+          video_url: ch.video_url,
+          duration: ch.duration,
+          order: ch.order ?? i + 1,
+          is_preview: ch.is_preview ?? false,
+        },
+        trx
+      );
+    }
+  });
 
   await notificationService.createNotification({
     user_id: instructor_id,
@@ -225,7 +241,18 @@ exports.updateTutorial = catchAsync(async (req, res) => {
   }
   const tutorial = await service.updateTutorial(req.params.id, data);
 
-  const tags = rawTags ? (typeof rawTags === 'string' ? JSON.parse(rawTags) : rawTags) : null;
+  let tags = null;
+  if (rawTags) {
+    if (typeof rawTags === 'string') {
+      try {
+        tags = JSON.parse(rawTags);
+      } catch (err) {
+        return res.status(400).json({ message: "Invalid tags JSON" });
+      }
+    } else if (Array.isArray(rawTags)) {
+      tags = rawTags;
+    }
+  }
   if (tags) {
     await db('tutorial_tag_map').where({ tutorial_id: tutorial.id }).del();
     const tagIds = [];

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -1,8 +1,8 @@
 // 📁 src/modules/users/tutorials/tutorial.service.js
 const db = require("../../../config/database");
 
-exports.createTutorial = async (data) => {
-  const [tutorial] = await db("tutorials").insert(data).returning("*");
+exports.createTutorial = async (data, trx = db) => {
+  const [tutorial] = await trx("tutorials").insert(data).returning("*");
   return tutorial;
 };
 
@@ -262,14 +262,14 @@ exports.getPublicTutorialDetails = async (id) => {
   return { ...tutorial, chapters, views };
 };
 
-exports.addTutorialTags = async (tutorialId, tagIds) => {
+exports.addTutorialTags = async (tutorialId, tagIds, trx = db) => {
   if (!tagIds.length) return;
   const rows = tagIds.map((tag_id) => ({ tutorial_id: tutorialId, tag_id }));
-  await db("tutorial_tag_map").insert(rows);
+  await trx("tutorial_tag_map").insert(rows);
 };
 
-exports.getTutorialTags = async (tutorialId) => {
-  return db("tutorial_tag_map as m")
+exports.getTutorialTags = async (tutorialId, trx = db) => {
+  return trx("tutorial_tag_map as m")
     .join("tags as t", "m.tag_id", "t.id")
     .where("m.tutorial_id", tutorialId)
     .select("t.id", "t.name", "t.slug");

--- a/backend/src/modules/users/tutorials/tutorialTag.service.js
+++ b/backend/src/modules/users/tutorials/tutorialTag.service.js
@@ -4,14 +4,14 @@ exports.getAllTags = async () => {
   return db("tags").select("*").orderBy("created_at", "desc");
 };
 
-exports.findByName = async (name) => {
-  return db("tags")
+exports.findByName = async (name, trx = db) => {
+  return trx("tags")
     .whereRaw("LOWER(name) = ?", [name.toLowerCase()])
     .first();
 };
 
-exports.createTag = async (data) => {
-  const [row] = await db("tags").insert(data).returning("*");
+exports.createTag = async (data, trx = db) => {
+  const [row] = await trx("tags").insert(data).returning("*");
   return row;
 };
 


### PR DESCRIPTION
## Summary
- Wrap tutorial creation, tag mapping, and chapter inserts in a single database transaction
- Parse tag JSON with try/catch to return 400 on invalid input
- Allow service methods to run within provided transactions

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896011dfddc8328ac978134a5ccd433