### PR TITLE
Handle invalid tutorial progress

### DIFF
--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -17,7 +17,14 @@ export default function StudentTutorialsPage() {
         const data = await fetchPublishedTutorials();
         const enriched = data.map((tut) => {
           const saved = localStorage.getItem(`progress-tutorial-${tut.id}`);
-          const progress = saved ? JSON.parse(saved) : { completedChapters: [], completedQuiz: false };
+          let progress = { completedChapters: [], completedQuiz: false };
+          if (saved) {
+            try {
+              progress = JSON.parse(saved);
+            } catch {
+              progress = { completedChapters: [], completedQuiz: false };
+            }
+          }
           return {
             ...tut,
             completedLessons: progress.completedChapters.length,


### PR DESCRIPTION
## Summary
- safeguard local progress parsing with try/catch
- default to empty progress on invalid JSON

## Testing
- `npm test`
- `npm run lint` *(fails: 301 problems, 48 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6896011bffec8328bd64eaf6e828472a