### PR TITLE
Use toast for tutorial deletion

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -22,6 +22,7 @@ import {
 } from "@/services/instructor/tutorialService";
 import ProgressChecklistModal from "@/components/tutorials/ProgressChecklistModal";
 import ConfirmModal from "@/components/common/ConfirmModal";
+import { toast } from "react-toastify";
 
 export default function InstructorTutorialsPage() {
   const router = useRouter();
@@ -80,9 +81,12 @@ export default function InstructorTutorialsPage() {
         try {
           await deleteInstructorTutorial(id);
           setTutorials((prev) => prev.filter((tut) => tut.id !== id));
+          toast.success("Tutorial deleted successfully");
         } catch (err) {
           console.error(err);
-          alert("Failed to delete tutorial");
+          toast.error("Failed to delete tutorial");
+        } finally {
+          closeConfirmModal();
         }
       },
     });


### PR DESCRIPTION
## Summary
- replace deletion alert with react-toastify toast
- close confirmation modal even if deletion fails

## Testing
- `npm test`
- `npm run lint` *(fails: Assign object to a variable before exporting as module default; 48 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6896011ad8d48328a91370c0d98c84f7