### PR TITLE
Handle per-student errors when calculating class scores

### DIFF
--- a/backend/src/modules/classes/scores/__tests__/classScore.service.test.js
+++ b/backend/src/modules/classes/scores/__tests__/classScore.service.test.js
@@ -1,0 +1,40 @@
+jest.mock('../../../../config/database', () => jest.fn());
+
+const db = require('../../../../config/database');
+const service = require('../classScore.service');
+
+describe('calculateForClass', () => {
+  beforeEach(() => {
+    db.mockReset();
+  });
+
+  it('resolves all student scores and captures errors', async () => {
+    const enrollments = [
+      { user_id: 's1', full_name: 'Student One' },
+      { user_id: 's2', full_name: 'Student Two' },
+    ];
+
+    db.mockImplementation(() => ({
+      join: () => ({
+        where: () => ({
+          select: () => Promise.resolve(enrollments),
+        }),
+      }),
+    }));
+
+    const original = service.calculateForStudent;
+    service.calculateForStudent = jest
+      .fn()
+      .mockResolvedValueOnce({ total_score: 80 })
+      .mockRejectedValueOnce(new Error('failure'));
+
+    const results = await service.calculateForClass('class1');
+
+    expect(results).toEqual([
+      { total_score: 80, student_id: 's1', full_name: 'Student One' },
+      { student_id: 's2', full_name: 'Student Two', error: 'failure' },
+    ]);
+
+    service.calculateForStudent = original;
+  });
+});

--- a/backend/src/modules/classes/scores/classScore.service.js
+++ b/backend/src/modules/classes/scores/classScore.service.js
@@ -83,13 +83,17 @@ const calculateForClass = async (classId) => {
     .join('users as u', 'ce.user_id', 'u.id')
     .where('ce.class_id', classId)
     .select('u.id as user_id', 'u.full_name');
-  const results = [];
-  for (const enr of enrollments) {
-    const score = await calculateForStudent(classId, enr.user_id);
-    results.push({ ...score, student_id: enr.user_id, full_name: enr.full_name });
 
-  }
-  return results;
+  const promises = enrollments.map(async (enr) => {
+    try {
+      const score = await module.exports.calculateForStudent(classId, enr.user_id);
+      return { ...score, student_id: enr.user_id, full_name: enr.full_name };
+    } catch (error) {
+      return { student_id: enr.user_id, full_name: enr.full_name, error: error.message };
+    }
+  });
+
+  return Promise.all(promises);
 };
 
 const getStudentScore = async (classId, studentId) => {


### PR DESCRIPTION
## Summary
- refactor class score calculation to process students in parallel and tolerate individual failures
- add unit test covering error handling during batch scoring

## Testing
- `npm test src/modules/classes/scores/__tests__/classScore.service.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689611c1b8f483289ce8a41fe591d8ae