### PR TITLE
feat: add class assignment validator

### DIFF
--- a/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
+++ b/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
@@ -69,9 +69,27 @@ describe('Class assignment routes', () => {
     service.createAssignment.mockResolvedValue({ id: '1' });
     const res = await request(app)
       .post('/classes/assignments/class/abc')
-      .send({ title: 'New' });
+      .send({ title: 'New', due_date: '2024-01-01T00:00:00.000Z' });
     expect(res.statusCode).toBe(200);
     expect(service.createAssignment).toHaveBeenCalled();
+  });
+
+  test('create assignment fails with invalid date', async () => {
+    const res = await request(app)
+      .post('/classes/assignments/class/abc')
+      .send({ title: 'New', due_date: 'not-a-date' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe('Validation error');
+    expect(service.createAssignment).not.toHaveBeenCalled();
+  });
+
+  test('create assignment fails with missing title', async () => {
+    const res = await request(app)
+      .post('/classes/assignments/class/abc')
+      .send({ due_date: '2024-01-01T00:00:00.000Z' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe('Validation error');
+    expect(service.createAssignment).not.toHaveBeenCalled();
   });
 
   test('update assignment', async () => {

--- a/backend/src/modules/classes/assignments/classAssignment.routes.js
+++ b/backend/src/modules/classes/assignments/classAssignment.routes.js
@@ -1,10 +1,18 @@
 const router = require("express").Router();
 const ctrl = require("./classAssignment.controller");
 const { verifyToken, isInstructorOrAdmin } = require("../../../middleware/auth/authMiddleware");
+const validate = require("../../../middleware/validate");
+const validator = require("./classAssignment.validator");
 
 router.get("/admin", verifyToken, isInstructorOrAdmin, ctrl.getAllAssignments);
 router.get("/class/:classId", ctrl.getAssignmentsByClass);
-router.post("/class/:classId", verifyToken, isInstructorOrAdmin, ctrl.createAssignment);
+router.post(
+  "/class/:classId",
+  verifyToken,
+  isInstructorOrAdmin,
+  validate(validator.create),
+  ctrl.createAssignment
+);
 router.put("/:assignmentId", verifyToken, isInstructorOrAdmin, ctrl.updateAssignment);
 router.delete("/:assignmentId", verifyToken, isInstructorOrAdmin, ctrl.deleteAssignment);
 

--- a/backend/src/modules/classes/assignments/classAssignment.validator.js
+++ b/backend/src/modules/classes/assignments/classAssignment.validator.js
@@ -1,0 +1,17 @@
+const { z } = require("zod");
+
+exports.create = {
+  body: z.object({
+    title: z.string().min(3),
+    description: z.string().optional(),
+    due_date: z.string().datetime(),
+  }),
+};
+
+exports.update = {
+  body: z.object({
+    title: z.string().min(3).optional(),
+    description: z.string().optional(),
+    due_date: z.string().datetime().optional(),
+  }),
+};


### PR DESCRIPTION
## Summary
- validate class assignment creation payloads
- test assignment route validation errors

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689611c133d08328b0f84176e8e82607