### PR TITLE
feat: prefix class score routes with users

### DIFF
--- a/frontend/src/services/classScoreService.js
+++ b/frontend/src/services/classScoreService.js
@@ -1,23 +1,26 @@
 import api from "@/services/api/api";
 
 export const fetchClassScores = async (classId) => {
-  const { data } = await api.get(`/classes/scores/instructor/${classId}`);
+  const { data } = await api.get(`/users/classes/scores/instructor/${classId}`);
   return data?.data ?? [];
 };
 
 export const setScoringPolicy = async (classId, payload) => {
-  const { data } = await api.post(`/classes/scores/policy/${classId}`, payload);
+  const { data } = await api.post(
+    `/users/classes/scores/policy/${classId}`,
+    payload
+  );
   return data?.data;
 };
 
 export const issueClassCertificate = async (classId, studentId) => {
   const { data } = await api.post(
-    `/classes/scores/instructor/${classId}/students/${studentId}/issue`
+    `/users/classes/scores/instructor/${classId}/students/${studentId}/issue`
   );
   return data?.data;
 };
 
 export const fetchMyClassScore = async (classId) => {
-  const { data } = await api.get(`/classes/scores/student/${classId}`);
+  const { data } = await api.get(`/users/classes/scores/student/${classId}`);
   return data?.data;
 };


### PR DESCRIPTION
## Summary
- prepend `/users` to class score service routes

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689611bcc6fc8328b8e87b48b73df7bb