### PR TITLE
feat: implement assignment submission routes

### DIFF
--- a/backend/src/modules/classes/assignments/__tests__/submission.routes.test.js
+++ b/backend/src/modules/classes/assignments/__tests__/submission.routes.test.js
@@ -1,0 +1,72 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn(() => Promise.resolve(null));
+  db.select = jest.fn(() => db);
+  db.insert = jest.fn(() => db);
+  db.update = jest.fn(() => db);
+  db.del = jest.fn(() => db);
+  return db;
+});
+
+jest.mock('../submission.service', () => ({
+  getByAssignment: jest.fn(),
+  createSubmission: jest.fn(),
+  updateSubmission: jest.fn(),
+  deleteSubmission: jest.fn(),
+}));
+const service = require('../submission.service');
+
+jest.mock('../../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'test-user' }; next(); },
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+  isStudent: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+  isInstructor: (_req, _res, next) => next(),
+}));
+
+const routes = require('../../class.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/classes', routes);
+
+describe('Assignment submission routes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('list submissions by assignment', async () => {
+    const list = [{ id: '1' }];
+    service.getByAssignment.mockResolvedValue(list);
+    const res = await request(app).get('/classes/assignments/submissions/assignment/abc');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual(list);
+  });
+
+  test('create submission', async () => {
+    service.createSubmission.mockResolvedValue({ id: '1' });
+    const res = await request(app)
+      .post('/classes/assignments/submissions/assignment/abc')
+      .send({ file_url: 'url' });
+    expect(res.statusCode).toBe(200);
+    expect(service.createSubmission).toHaveBeenCalled();
+  });
+
+  test('update submission', async () => {
+    service.updateSubmission.mockResolvedValue({ id: '1' });
+    const res = await request(app)
+      .put('/classes/assignments/submissions/1')
+      .send({ grade: 90 });
+    expect(res.statusCode).toBe(200);
+    expect(service.updateSubmission).toHaveBeenCalled();
+  });
+
+  test('delete submission', async () => {
+    service.deleteSubmission.mockResolvedValue();
+    const res = await request(app).delete('/classes/assignments/submissions/1');
+    expect(res.statusCode).toBe(200);
+    expect(service.deleteSubmission).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/classes/assignments/submission.controller.js
+++ b/backend/src/modules/classes/assignments/submission.controller.js
@@ -1,0 +1,33 @@
+const { v4: uuidv4 } = require("uuid");
+const catchAsync = require("../../../utils/catchAsync");
+const { sendSuccess } = require("../../../utils/response");
+const service = require("./submission.service");
+
+exports.getByAssignment = catchAsync(async (req, res) => {
+  const submissions = await service.getByAssignment(req.params.assignmentId);
+  sendSuccess(res, submissions);
+});
+
+exports.createSubmission = catchAsync(async (req, res) => {
+  const data = {
+    ...req.body,
+    id: uuidv4(),
+    assignment_id: req.params.assignmentId,
+    user_id: req.user.id,
+  };
+  const submission = await service.createSubmission(data);
+  sendSuccess(res, submission, "Submission created");
+});
+
+exports.updateSubmission = catchAsync(async (req, res) => {
+  const submission = await service.updateSubmission(
+    req.params.submissionId,
+    req.body
+  );
+  sendSuccess(res, submission, "Submission updated");
+});
+
+exports.deleteSubmission = catchAsync(async (req, res) => {
+  await service.deleteSubmission(req.params.submissionId);
+  sendSuccess(res, null, "Submission deleted");
+});

--- a/backend/src/modules/classes/assignments/submission.routes.js
+++ b/backend/src/modules/classes/assignments/submission.routes.js
@@ -1,0 +1,34 @@
+const router = require("express").Router();
+const ctrl = require("./submission.controller");
+const {
+  verifyToken,
+  isStudent,
+  isInstructorOrAdmin,
+} = require("../../../middleware/auth/authMiddleware");
+
+router.get(
+  "/assignment/:assignmentId",
+  verifyToken,
+  isInstructorOrAdmin,
+  ctrl.getByAssignment
+);
+router.post(
+  "/assignment/:assignmentId",
+  verifyToken,
+  isStudent,
+  ctrl.createSubmission
+);
+router.put(
+  "/:submissionId",
+  verifyToken,
+  isInstructorOrAdmin,
+  ctrl.updateSubmission
+);
+router.delete(
+  "/:submissionId",
+  verifyToken,
+  isInstructorOrAdmin,
+  ctrl.deleteSubmission
+);
+
+module.exports = router;

--- a/backend/src/modules/classes/assignments/submission.service.js
+++ b/backend/src/modules/classes/assignments/submission.service.js
@@ -1,0 +1,26 @@
+const db = require("../../../config/database");
+
+exports.getByAssignment = async (assignment_id) => {
+  return db("assignment_submissions")
+    .where({ assignment_id })
+    .orderBy("created_at", "asc");
+};
+
+exports.createSubmission = async (data) => {
+  const [row] = await db("assignment_submissions")
+    .insert(data)
+    .returning("*");
+  return row;
+};
+
+exports.updateSubmission = async (id, data) => {
+  const [row] = await db("assignment_submissions")
+    .where({ id })
+    .update(data)
+    .returning("*");
+  return row;
+};
+
+exports.deleteSubmission = async (id) => {
+  return db("assignment_submissions").where({ id }).del();
+};

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -17,6 +17,7 @@ const {
 router.use("/enroll", require("./enrollments/classEnrollment.routes"));
 // Class lessons and assignments
 router.use("/lessons", require("./lessons/classLesson.routes"));
+router.use("/assignments/submissions", require("./assignments/submission.routes"));
 router.use("/assignments", require("./assignments/classAssignment.routes"));
 router.use("/wishlist", require("./wishlist/classWishlist.routes"));
 router.use("/likes", require("./likes/classLike.routes"));


### PR DESCRIPTION
## Summary
- add service, controller and routes for assignment submissions
- register submission routes under class routes
- cover submission CRUD endpoints with Jest tests

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689611bb9a28832890aa8531aa863d4e