### PR TITLE
Add error handling for admin dashboard stats

### DIFF
--- a/frontend/src/pages/dashboard/admin/index.js
+++ b/frontend/src/pages/dashboard/admin/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../next-i18next.config.js";
@@ -21,6 +21,7 @@ function AdminDashboardHome() {
   const [hydrated, setHydrated] = useState(false);
   const [stats, setStats] = useState(null);
   const [statsLoading, setStatsLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   // Wait for hydration to access Zustand state safely
   useEffect(() => {
@@ -37,22 +38,25 @@ function AdminDashboardHome() {
     }
   }, [user, hydrated]);
 
+  const loadStats = useCallback(async () => {
+    setStatsLoading(true);
+    setError(null);
+    try {
+      const data = await fetchAdminDashboardStats();
+      setStats(data);
+    } catch (err) {
+      console.error("Failed to load dashboard stats", err);
+      setError(err.message || "Failed to load dashboard stats");
+    } finally {
+      setStatsLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
-    const loadStats = async () => {
-      setStatsLoading(true);
-      try {
-        const data = await fetchAdminDashboardStats();
-        setStats(data);
-      } catch (err) {
-        console.error("Failed to load dashboard stats", err);
-      } finally {
-        setStatsLoading(false);
-      }
-    };
     if (hydrated && user && ["admin", "superadmin"].includes(user.role?.toLowerCase())) {
       loadStats();
     }
-  }, [hydrated, user]);
+  }, [hydrated, user, loadStats]);
 
   if (!hydrated || !user || !["admin", "superadmin"].includes(user.role?.toLowerCase())) {
     return null;
@@ -122,7 +126,17 @@ function AdminDashboardHome() {
         </div>
 
         <h2 className="text-xl font-semibold text-gray-800 mb-4 mt-8">📊 Platform Insights</h2>
-        {statsLoading ? (
+        {error ? (
+          <div className="text-red-600">
+            <p>{error}</p>
+            <button
+              onClick={loadStats}
+              className="mt-2 text-sm text-blue-500 underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : statsLoading ? (
           <p>Loading stats...</p>
         ) : (
           <StatsGrid stats={statsArray} />


### PR DESCRIPTION
## Summary
- handle admin dashboard stat load errors with a new error state
- display error message with retry button when loading fails

## Testing
- `npm test`
- `npm run lint` *(fails: 301 problems, 48 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6896116826548328b6fb4d5b07bf986e