### PR TITLE
Localize admin dashboard labels

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1292,4 +1292,25 @@
     "update_success": "تم تحديث الإعلان بنجاح!",
     "update_failed": "فشل تحديث الإعلان"
   }
+,
+  "adminDashboardHome": {
+    "recentAlerts": "التنبيهات الأخيرة",
+    "unauthorizedUsageDetected": "تم اكتشاف استخدام غير مصرح به",
+    "flaggedChatInPythonClass": "دردشة تم الإبلاغ عنها في صف بايثون",
+    "apiKeyExpiringSoon": "مفتاح API سينتهي قريبًا",
+    "viewAllAlerts": "عرض جميع التنبيهات",
+    "flaggedMessages": "الرسائل المبلغ عنها",
+    "reviewMessages": "مراجعة الرسائل",
+    "licenseCheck": "فحص الترخيص",
+    "lastCheck": "آخر فحص: قبل ساعة",
+    "unauthorizedInstanceDetected": "تم اكتشاف مثال غير مصرح به واحد",
+    "seeDetails": "عرض التفاصيل",
+    "platformInsights": "رؤى المنصة",
+    "loadingStats": "جارٍ تحميل الإحصاءات...",
+    "totalUsers": "إجمالي المستخدمين",
+    "instructors": "المدربون",
+    "students": "الطلاب",
+    "tutorials": "الدروس التعليمية",
+    "classes": "الفصول"
+  }
 }

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1305,4 +1305,25 @@
     "update_success": "Advertisement updated successfully!",
     "update_failed": "Failed to update advertisement"
   }
+,
+  "adminDashboardHome": {
+    "recentAlerts": "Recent Alerts",
+    "unauthorizedUsageDetected": "Unauthorized usage detected",
+    "flaggedChatInPythonClass": "Flagged chat in Python class",
+    "apiKeyExpiringSoon": "API key expiring soon",
+    "viewAllAlerts": "View all alerts",
+    "flaggedMessages": "Flagged Messages",
+    "reviewMessages": "Review messages",
+    "licenseCheck": "License Check",
+    "lastCheck": "Last check: 1 hour ago",
+    "unauthorizedInstanceDetected": "1 unauthorized instance detected",
+    "seeDetails": "See details",
+    "platformInsights": "Platform Insights",
+    "loadingStats": "Loading stats...",
+    "totalUsers": "Total Users",
+    "instructors": "Instructors",
+    "students": "Students",
+    "tutorials": "Tutorials",
+    "classes": "Classes"
+  }
 }

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1280,4 +1280,25 @@
     "update_success": "Annonce mise à jour avec succès !",
     "update_failed": "Échec de la mise à jour de l'annonce"
   }
+,
+  "adminDashboardHome": {
+    "recentAlerts": "Alertes récentes",
+    "unauthorizedUsageDetected": "Utilisation non autorisée détectée",
+    "flaggedChatInPythonClass": "Discussion signalée dans le cours Python",
+    "apiKeyExpiringSoon": "Clé API expirant bientôt",
+    "viewAllAlerts": "Voir toutes les alertes",
+    "flaggedMessages": "Messages signalés",
+    "reviewMessages": "Examiner les messages",
+    "licenseCheck": "Vérification de licence",
+    "lastCheck": "Dernière vérification : il y a 1 heure",
+    "unauthorizedInstanceDetected": "1 instance non autorisée détectée",
+    "seeDetails": "Voir les détails",
+    "platformInsights": "Aperçus de la plateforme",
+    "loadingStats": "Chargement des statistiques...",
+    "totalUsers": "Utilisateurs totaux",
+    "instructors": "Instructeurs",
+    "students": "Étudiants",
+    "tutorials": "Tutoriels",
+    "classes": "Cours"
+  }
 }

--- a/frontend/src/locales/ar.json
+++ b/frontend/src/locales/ar.json
@@ -77,4 +77,25 @@
     "assignment_submitted": "تم تسليم الواجب بنجاح",
     "class_joined": "تم الانضمام إلى الدورة"
   }
+,
+  "adminDashboardHome": {
+    "recentAlerts": "التنبيهات الأخيرة",
+    "unauthorizedUsageDetected": "تم اكتشاف استخدام غير مصرح به",
+    "flaggedChatInPythonClass": "دردشة تم الإبلاغ عنها في صف بايثون",
+    "apiKeyExpiringSoon": "مفتاح API سينتهي قريبًا",
+    "viewAllAlerts": "عرض جميع التنبيهات",
+    "flaggedMessages": "الرسائل المبلغ عنها",
+    "reviewMessages": "مراجعة الرسائل",
+    "licenseCheck": "فحص الترخيص",
+    "lastCheck": "آخر فحص: قبل ساعة",
+    "unauthorizedInstanceDetected": "تم اكتشاف مثال غير مصرح به واحد",
+    "seeDetails": "عرض التفاصيل",
+    "platformInsights": "رؤى المنصة",
+    "loadingStats": "جارٍ تحميل الإحصاءات...",
+    "totalUsers": "إجمالي المستخدمين",
+    "instructors": "المدربون",
+    "students": "الطلاب",
+    "tutorials": "الدروس التعليمية",
+    "classes": "الفصول"
+  }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,0 +1,22 @@
+{
+  "adminDashboardHome": {
+    "recentAlerts": "Recent Alerts",
+    "unauthorizedUsageDetected": "Unauthorized usage detected",
+    "flaggedChatInPythonClass": "Flagged chat in Python class",
+    "apiKeyExpiringSoon": "API key expiring soon",
+    "viewAllAlerts": "View all alerts",
+    "flaggedMessages": "Flagged Messages",
+    "reviewMessages": "Review messages",
+    "licenseCheck": "License Check",
+    "lastCheck": "Last check: 1 hour ago",
+    "unauthorizedInstanceDetected": "1 unauthorized instance detected",
+    "seeDetails": "See details",
+    "platformInsights": "Platform Insights",
+    "loadingStats": "Loading stats...",
+    "totalUsers": "Total Users",
+    "instructors": "Instructors",
+    "students": "Students",
+    "tutorials": "Tutorials",
+    "classes": "Classes"
+  }
+}

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -1,0 +1,22 @@
+{
+  "adminDashboardHome": {
+    "recentAlerts": "Alertes récentes",
+    "unauthorizedUsageDetected": "Utilisation non autorisée détectée",
+    "flaggedChatInPythonClass": "Discussion signalée dans le cours Python",
+    "apiKeyExpiringSoon": "Clé API expirant bientôt",
+    "viewAllAlerts": "Voir toutes les alertes",
+    "flaggedMessages": "Messages signalés",
+    "reviewMessages": "Examiner les messages",
+    "licenseCheck": "Vérification de licence",
+    "lastCheck": "Dernière vérification : il y a 1 heure",
+    "unauthorizedInstanceDetected": "1 instance non autorisée détectée",
+    "seeDetails": "Voir les détails",
+    "platformInsights": "Aperçus de la plateforme",
+    "loadingStats": "Chargement des statistiques...",
+    "totalUsers": "Utilisateurs totaux",
+    "instructors": "Instructeurs",
+    "students": "Étudiants",
+    "tutorials": "Tutoriels",
+    "classes": "Cours"
+  }
+}

--- a/frontend/src/pages/dashboard/admin/index.js
+++ b/frontend/src/pages/dashboard/admin/index.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useTranslation } from "next-i18next";
 import nextI18NextConfig from "../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import useAuthStore from "@/store/auth/authStore";
@@ -17,6 +18,7 @@ import InstructorActivityChart from "@/components/admin/charts/InstructorActivit
 
 function AdminDashboardHome() {
   const { user } = useAuthStore();
+  const { t } = useTranslation(['common', 'dashboard']);
   const router = useRouter();
   const [hydrated, setHydrated] = useState(false);
   const [stats, setStats] = useState(null);
@@ -60,11 +62,11 @@ function AdminDashboardHome() {
 
   const statsArray = stats
     ? [
-        { icon: <FaUsers />, label: "Total Users", value: stats.totalUsers, color: "text-blue-500" },
-        { icon: <FaChalkboardTeacher />, label: "Instructors", value: stats.instructors, color: "text-purple-500" },
-        { icon: <FaUsers />, label: "Students", value: stats.students, color: "text-green-500" },
-        { icon: <FaBook />, label: "Tutorials", value: stats.tutorials, color: "text-indigo-500" },
-        { icon: <FaVideo />, label: "Classes", value: stats.classes, color: "text-yellow-500" },
+        { icon: <FaUsers />, label: t('totalUsers'), value: stats.totalUsers, color: "text-blue-500" },
+        { icon: <FaChalkboardTeacher />, label: t('instructors'), value: stats.instructors, color: "text-purple-500" },
+        { icon: <FaUsers />, label: t('students'), value: stats.students, color: "text-green-500" },
+        { icon: <FaBook />, label: t('tutorials'), value: stats.tutorials, color: "text-indigo-500" },
+        { icon: <FaVideo />, label: t('classes'), value: stats.classes, color: "text-yellow-500" },
       ]
     : [];
 
@@ -75,29 +77,29 @@ function AdminDashboardHome() {
       {/* Alerts Summary */}
       <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">
         <div className="bg-white rounded-xl shadow p-4">
-          <h3 className="font-semibold mb-2">🚨 Recent Alerts</h3>
+          <h3 className="font-semibold mb-2">🚨 {t('recentAlerts')}</h3>
           <ul className="text-sm text-red-600 space-y-1">
-            <li>Unauthorized usage detected</li>
-            <li>Flagged chat in Python class</li>
-            <li>API key expiring soon</li>
+            <li>{t('unauthorizedUsageDetected')}</li>
+            <li>{t('flaggedChatInPythonClass')}</li>
+            <li>{t('apiKeyExpiringSoon')}</li>
           </ul>
-          <Link href="/admin/alerts" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">View all alerts</Link>
+          <Link href="/admin/alerts" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">{t('viewAllAlerts')}</Link>
         </div>
 
         <div className="bg-white rounded-xl shadow p-4">
-          <h3 className="font-semibold mb-2">🛡️ Flagged Messages</h3>
+          <h3 className="font-semibold mb-2">🛡️ {t('flaggedMessages')}</h3>
           <ul className="text-sm text-red-500 space-y-1">
             <li>@ayman: “This is stupid”</li>
             <li>@maria: “Dumb answer...”</li>
           </ul>
-          <Link href="/admin/moderation" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">Review messages</Link>
+          <Link href="/admin/moderation" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">{t('reviewMessages')}</Link>
         </div>
 
         <div className="bg-white rounded-xl shadow p-4">
-          <h3 className="font-semibold mb-2">🔒 License Check</h3>
-          <p className="text-sm text-gray-800">Last check: 1 hour ago</p>
-          <p className="text-sm text-red-600 mt-1">❌ 1 unauthorized instance detected</p>
-          <Link href="/admin/license-logs" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">See details</Link>
+          <h3 className="font-semibold mb-2">🔒 {t('licenseCheck')}</h3>
+          <p className="text-sm text-gray-800">{t('lastCheck')}</p>
+          <p className="text-sm text-red-600 mt-1">❌ {t('unauthorizedInstanceDetected')}</p>
+          <Link href="/admin/license-logs" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">{t('seeDetails')}</Link>
         </div>
       </section>
 
@@ -121,9 +123,9 @@ function AdminDashboardHome() {
           </div>
         </div>
 
-        <h2 className="text-xl font-semibold text-gray-800 mb-4 mt-8">📊 Platform Insights</h2>
+        <h2 className="text-xl font-semibold text-gray-800 mb-4 mt-8">📊 {t('platformInsights')}</h2>
         {statsLoading ? (
-          <p>Loading stats...</p>
+          <p>{t('loadingStats')}</p>
         ) : (
           <StatsGrid stats={statsArray} />
         )}


### PR DESCRIPTION
## Summary
- use next-i18next to translate admin dashboard labels
- add translation keys to locale files for alerts, stats, and insights

## Testing
- `npm run lint` (fails: 48 errors)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68961167d8f88328a21c1f486c96e8b8