### PR TITLE
Load admin dashboard alerts and license data from services

### DIFF
--- a/frontend/src/pages/dashboard/admin/index.js
+++ b/frontend/src/pages/dashboard/admin/index.js
@@ -14,6 +14,9 @@ import RevenueChart from "@/components/admin/charts/RevenueChart";
 import SignupsChart from "@/components/admin/charts/SignupsChart";
 import CategoryPieChart from "@/components/admin/charts/CategoryPieChart";
 import InstructorActivityChart from "@/components/admin/charts/InstructorActivityChart";
+import { fetchRecentAlerts } from "@/services/admin/alertService";
+import { fetchFlaggedMessages } from "@/services/admin/moderationService";
+import { fetchLicenseStatus } from "@/services/admin/licenseService";
 
 function AdminDashboardHome() {
   const { user } = useAuthStore();
@@ -21,6 +24,12 @@ function AdminDashboardHome() {
   const [hydrated, setHydrated] = useState(false);
   const [stats, setStats] = useState(null);
   const [statsLoading, setStatsLoading] = useState(false);
+  const [alerts, setAlerts] = useState([]);
+  const [alertsLoading, setAlertsLoading] = useState(false);
+  const [flaggedMessages, setFlaggedMessages] = useState([]);
+  const [flagsLoading, setFlagsLoading] = useState(false);
+  const [licenseStatus, setLicenseStatus] = useState(null);
+  const [licenseLoading, setLicenseLoading] = useState(false);
 
   // Wait for hydration to access Zustand state safely
   useEffect(() => {
@@ -38,19 +47,33 @@ function AdminDashboardHome() {
   }, [user, hydrated]);
 
   useEffect(() => {
-    const loadStats = async () => {
+    const loadData = async () => {
       setStatsLoading(true);
+      setAlertsLoading(true);
+      setFlagsLoading(true);
+      setLicenseLoading(true);
       try {
-        const data = await fetchAdminDashboardStats();
-        setStats(data);
+        const [statsData, alertsData, flagsData, licenseData] = await Promise.all([
+          fetchAdminDashboardStats(),
+          fetchRecentAlerts(),
+          fetchFlaggedMessages(),
+          fetchLicenseStatus(),
+        ]);
+        setStats(statsData);
+        setAlerts(alertsData);
+        setFlaggedMessages(flagsData);
+        setLicenseStatus(licenseData);
       } catch (err) {
-        console.error("Failed to load dashboard stats", err);
+        console.error("Failed to load dashboard data", err);
       } finally {
         setStatsLoading(false);
+        setAlertsLoading(false);
+        setFlagsLoading(false);
+        setLicenseLoading(false);
       }
     };
     if (hydrated && user && ["admin", "superadmin"].includes(user.role?.toLowerCase())) {
-      loadStats();
+      loadData();
     }
   }, [hydrated, user]);
 
@@ -76,28 +99,65 @@ function AdminDashboardHome() {
       <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">
         <div className="bg-white rounded-xl shadow p-4">
           <h3 className="font-semibold mb-2">🚨 Recent Alerts</h3>
-          <ul className="text-sm text-red-600 space-y-1">
-            <li>Unauthorized usage detected</li>
-            <li>Flagged chat in Python class</li>
-            <li>API key expiring soon</li>
-          </ul>
-          <Link href="/admin/alerts" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">View all alerts</Link>
+          {alertsLoading ? (
+            <p className="text-sm">Loading alerts...</p>
+          ) : alerts.length === 0 ? (
+            <p className="text-sm text-gray-600">No alerts</p>
+          ) : (
+            <ul className="text-sm text-red-600 space-y-1">
+              {alerts.slice(0, 3).map((alert, idx) => (
+                <li key={idx}>{alert.message || alert}</li>
+              ))}
+            </ul>
+          )}
+          <Link href="/admin/alerts" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">
+            View all alerts
+          </Link>
         </div>
 
         <div className="bg-white rounded-xl shadow p-4">
           <h3 className="font-semibold mb-2">🛡️ Flagged Messages</h3>
-          <ul className="text-sm text-red-500 space-y-1">
-            <li>@ayman: “This is stupid”</li>
-            <li>@maria: “Dumb answer...”</li>
-          </ul>
-          <Link href="/admin/moderation" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">Review messages</Link>
+          {flagsLoading ? (
+            <p className="text-sm">Loading messages...</p>
+          ) : flaggedMessages.length === 0 ? (
+            <p className="text-sm text-gray-600">No flagged messages</p>
+          ) : (
+            <ul className="text-sm text-red-500 space-y-1">
+              {flaggedMessages.slice(0, 2).map((msg) => (
+                <li key={msg.id || msg}>@{msg.user || msg.username}: “{msg.content || msg.message}”</li>
+              ))}
+            </ul>
+          )}
+          <Link href="/admin/moderation" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">
+            Review messages
+          </Link>
         </div>
 
         <div className="bg-white rounded-xl shadow p-4">
           <h3 className="font-semibold mb-2">🔒 License Check</h3>
-          <p className="text-sm text-gray-800">Last check: 1 hour ago</p>
-          <p className="text-sm text-red-600 mt-1">❌ 1 unauthorized instance detected</p>
-          <Link href="/admin/license-logs" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">See details</Link>
+          {licenseLoading ? (
+            <p className="text-sm">Checking license...</p>
+          ) : licenseStatus ? (
+            <>
+              <p className="text-sm text-gray-800">Last check: {licenseStatus.last_check || "N/A"}</p>
+              <p
+                className={`text-sm mt-1 ${
+                  licenseStatus.unauthorized_count ? "text-red-600" : "text-green-600"
+                }`}
+              >
+                {licenseStatus.unauthorized_count
+                  ? `❌ ${licenseStatus.unauthorized_count} unauthorized instance${
+                      licenseStatus.unauthorized_count > 1 ? "s" : ""
+                    } detected`
+                  : "✅ No unauthorized instances"}
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-gray-600">No license data</p>
+          )}
+          <Link href="/admin/license-logs" className="text-yellow-500 text-sm mt-2 inline-block hover:underline">
+            See details
+          </Link>
         </div>
       </section>
 

--- a/frontend/src/services/admin/alertService.js
+++ b/frontend/src/services/admin/alertService.js
@@ -1,0 +1,7 @@
+import api from "@/services/api/api";
+
+export const fetchRecentAlerts = async () => {
+  const { data } = await api.get("/system-errors");
+  return data?.data ?? [];
+};
+

--- a/frontend/src/services/admin/licenseService.js
+++ b/frontend/src/services/admin/licenseService.js
@@ -1,0 +1,7 @@
+import api from "@/services/api/api";
+
+export const fetchLicenseStatus = async () => {
+  const { data } = await api.get("/license/status");
+  return data?.data ?? {};
+};
+

--- a/frontend/src/services/admin/moderationService.js
+++ b/frontend/src/services/admin/moderationService.js
@@ -1,0 +1,7 @@
+import api from "@/services/api/api";
+
+export const fetchFlaggedMessages = async () => {
+  const { data } = await api.get("/moderation/flags");
+  return data?.data ?? [];
+};
+


### PR DESCRIPTION
## Summary
- add admin services to retrieve system alerts, flagged messages and license status
- display fetched data with loading and empty states on admin dashboard

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68961165a8988328b4ec33a03b155985