### PR TITLE
Sanitize user data in auth responses

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -51,9 +51,10 @@ const verifyToken = async (req, res, next) => {
     }
     const roles = await userModel.getUserRoles(decoded.id);
     const userRoles = roles.length ? roles : [user.role];
+    const { password_hash, ...safeUser } = user;
     req.user = {
       ...decoded,
-      ...user,
+      ...safeUser,
       roles: userRoles,
       role: userRoles[0],
     };

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -16,6 +16,7 @@ const AppError = require("../../../utils/AppError");
 const notificationService = require("../../notifications/notifications.service");
 const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
+const sanitizeUser = require("../utils/sanitizeUser");
 
 // ─────────────────────────────────────────────────────────────
 // 🔧 Config Constants
@@ -131,7 +132,8 @@ exports.registerUser = async (data) => {
     console.error("Error sending registration emails:", err.message);
   }
 
-  return { user: { ...newUser, roles } };
+  const safeUser = sanitizeUser(newUser);
+  return { user: { ...safeUser, roles } };
 };
 
 
@@ -181,7 +183,8 @@ exports.loginUser = async ({ email, password }) => {
     message: "You have logged in successfully",
   });
 
-  return { accessToken, refreshToken, csrfToken, user: { ...user, roles } };
+  const safeUser = sanitizeUser(user);
+  return { accessToken, refreshToken, csrfToken, user: { ...safeUser, roles } };
 };
 
 /**
@@ -356,5 +359,5 @@ exports.resetPassword = async ({ email, code, new_password }) => {
     receiver_id: user.id,
     message: "Your password was changed successfully",
   });
-
+  return sanitizeUser(user);
 };

--- a/backend/src/modules/auth/services/socialAuth.service.js
+++ b/backend/src/modules/auth/services/socialAuth.service.js
@@ -2,6 +2,7 @@ const bcrypt = require("bcrypt");
 const userModel = require("../../users/user.model");
 const { generateAccessToken, issueRefreshToken } = require("./auth.service");
 const AppError = require("../../../utils/AppError");
+const sanitizeUser = require("../utils/sanitizeUser");
 
 const SALT_ROUNDS = 12;
 
@@ -58,5 +59,6 @@ exports.loginOrRegister = async ({
   const accessToken = generateAccessToken({ id: user.id, role: tokenRoles[0], roles: tokenRoles });
   const refreshToken = await issueRefreshToken(user.id, tokenRoles[0]);
 
-  return { accessToken, refreshToken, user: { ...user, roles } };
+  const safeUser = sanitizeUser({ ...user, roles });
+  return { accessToken, refreshToken, user: safeUser };
 };

--- a/backend/src/modules/auth/utils/sanitizeUser.js
+++ b/backend/src/modules/auth/utils/sanitizeUser.js
@@ -1,0 +1,17 @@
+const SENSITIVE_FIELDS = [
+  'password_hash',
+  'password',
+  'reset_token',
+  'verification_token',
+];
+
+function sanitizeUser(user) {
+  if (!user) return user;
+  const safe = { ...user };
+  for (const field of SENSITIVE_FIELDS) {
+    if (field in safe) delete safe[field];
+  }
+  return safe;
+}
+
+module.exports = sanitizeUser;

--- a/backend/tests/authSanitization.test.js
+++ b/backend/tests/authSanitization.test.js
@@ -1,0 +1,145 @@
+const request = require('supertest');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+// Mock database
+jest.mock('../src/config/database', () => {
+  const mockDb = jest.fn((table) => {
+    if (table === 'roles') {
+      return { where: jest.fn().mockReturnThis(), first: jest.fn().mockResolvedValue({ id: 1 }) };
+    }
+    if (table === 'user_roles') {
+      return { insert: jest.fn().mockResolvedValue() };
+    }
+    if (table === 'refresh_tokens') {
+      return { insert: jest.fn().mockResolvedValue() };
+    }
+    return {};
+  });
+  mockDb.fn = { now: jest.fn() };
+  return mockDb;
+});
+
+// Mock models and services
+jest.mock('../src/modules/users/user.model', () => ({
+  findByEmail: jest.fn(),
+  findByPhone: jest.fn(),
+  insertUser: jest.fn(),
+  updateUser: jest.fn(),
+  getUserRoles: jest.fn(),
+  findAdmins: jest.fn(),
+  findById: jest.fn(),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/utils/email', () => ({
+  sendOtpEmail: jest.fn(),
+  sendPasswordChangeEmail: jest.fn(),
+  sendWelcomeEmail: jest.fn(),
+  sendNewUserAdminEmail: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn().mockResolvedValue('hashedpw'),
+  compare: jest.fn().mockResolvedValue(true),
+}));
+
+process.env.JWT_SECRET = 'testsecret';
+
+const authService = require('../src/modules/auth/services/auth.service');
+const authMiddleware = require('../src/middleware/auth/authMiddleware');
+const userModel = require('../src/modules/users/user.model');
+
+describe('Sensitive data sanitization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.JWT_SECRET = 'testsecret';
+  });
+
+  it('registerUser does not return password_hash', async () => {
+    const mockUser = {
+      id: 1,
+      full_name: 'Test',
+      email: 'test@example.com',
+      phone: '123',
+      password_hash: 'hashedpw',
+      role: 'Student',
+      status: 'pending',
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+    userModel.findByEmail.mockResolvedValue(null);
+    userModel.findByPhone.mockResolvedValue(null);
+    userModel.insertUser.mockResolvedValue([mockUser]);
+    userModel.getUserRoles.mockResolvedValue([]);
+    userModel.findAdmins.mockResolvedValue([]);
+
+    const result = await authService.registerUser({
+      full_name: 'Test',
+      email: 'test@example.com',
+      phone: '123',
+      password: 'pass',
+    });
+
+    expect(result.user.password_hash).toBeUndefined();
+  });
+
+  it('loginUser does not return password_hash', async () => {
+    const mockUser = {
+      id: 1,
+      email: 'test@example.com',
+      password_hash: 'hashedpw',
+      role: 'Student',
+      status: 'active',
+    };
+    userModel.findByEmail.mockResolvedValue({ ...mockUser });
+    userModel.updateUser.mockResolvedValue([mockUser]);
+    userModel.getUserRoles.mockResolvedValue([]);
+
+    const issueSpy = jest
+      .spyOn(authService, 'issueRefreshToken')
+      .mockResolvedValue('refresh');
+
+    const result = await authService.loginUser({
+      email: 'test@example.com',
+      password: 'pass',
+    });
+
+    expect(result.user.password_hash).toBeUndefined();
+    issueSpy.mockRestore();
+  });
+
+  it('verifyToken attaches user without password_hash', async () => {
+    const token = jwt.sign({ id: 1 }, process.env.JWT_SECRET);
+    userModel.findById.mockResolvedValue({
+      id: 1,
+      email: 't@example.com',
+      password_hash: 'hashedpw',
+      role: 'Student',
+      status: 'active',
+    });
+    userModel.getUserRoles.mockResolvedValue([]);
+
+    const app = express();
+    app.get('/test', authMiddleware.verifyToken, (req, res) => {
+      res.json(req.user);
+    });
+
+    const res = await request(app)
+      .get('/test')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.body.password_hash).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- remove password hashes from user objects in auth services and middleware
- share sanitizeUser helper to strip sensitive fields
- test register/login flows and auth middleware to ensure sensitive data never leaks

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689631f068108328a6be493ebb69a434