### PR TITLE
Add verification OTP workflow

### DIFF
--- a/backend/src/modules/auth/routes/auth.routes.js
+++ b/backend/src/modules/auth/routes/auth.routes.js
@@ -79,6 +79,30 @@ router.post(
   authController.resetPassword
 );
 
+/**
+ * @route   POST /auth/send-verification
+ * @desc    Send OTP for email or phone verification
+ * @access  Public
+ */
+router.post(
+  "/send-verification",
+  limitAuthRequests,
+  validate(authValidation.verificationSendSchema),
+  authController.sendVerification
+);
+
+/**
+ * @route   POST /auth/confirm-verification
+ * @desc    Confirm verification OTP and update user status
+ * @access  Public
+ */
+router.post(
+  "/confirm-verification",
+  limitAuthRequests,
+  validate(authValidation.verificationConfirmSchema),
+  authController.confirmVerification
+);
+
 // ─────────────────────────────────────────────────────────────
 // Social login routes
 // ─────────────────────────────────────────────────────────────

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -16,6 +16,7 @@ const AppError = require("../../../utils/AppError");
 const notificationService = require("../../notifications/notifications.service");
 const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
+const verificationService = require("../../verify/verify.service");
 
 // ─────────────────────────────────────────────────────────────
 // 🔧 Config Constants
@@ -357,4 +358,23 @@ exports.resetPassword = async ({ email, code, new_password }) => {
     message: "Your password was changed successfully",
   });
 
+};
+
+/**
+ * Send an OTP for verifying a user's email or phone.
+ * Delegates to the verification service which handles storage and delivery.
+ * @param {{user_id:number,type:'email'|'phone'}} data
+ * @returns {Promise<void>}
+ */
+exports.sendVerificationOtp = async ({ user_id, type }) => {
+  await verificationService.sendOtp(user_id, type);
+};
+
+/**
+ * Confirm a verification OTP and mark the email or phone as verified.
+ * @param {{user_id:number,type:'email'|'phone',code:string}} data
+ * @returns {Promise<void>}
+ */
+exports.confirmVerificationOtp = async ({ user_id, type, code }) => {
+  await verificationService.verifyOtp(user_id, type, code);
 };

--- a/backend/src/modules/auth/validators/auth.validator.js
+++ b/backend/src/modules/auth/validators/auth.validator.js
@@ -60,3 +60,22 @@ exports.resetPasswordSchema = z.object({
       "Password must be at least 8 characters, include an uppercase letter and a special character"
     ),
 });
+
+/**
+ * @desc Validation for sending verification OTP
+ */
+exports.verificationSendSchema = z.object({
+  user_id: z.number().int().positive(),
+  type: z.enum(["email", "phone"]),
+});
+
+/**
+ * @desc Validation for confirming verification OTP
+ */
+exports.verificationConfirmSchema = z.object({
+  user_id: z.number().int().positive(),
+  type: z.enum(["email", "phone"]),
+  code: z
+    .string()
+    .length(OTP_LENGTH, `OTP code must be ${OTP_LENGTH} digits`),
+});

--- a/backend/tests/authVerificationRoutes.test.js
+++ b/backend/tests/authVerificationRoutes.test.js
@@ -1,0 +1,55 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database', () => ({
+  raw: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../src/modules/auth/services/auth.service', () => ({
+  sendVerificationOtp: jest.fn(),
+  confirmVerificationOtp: jest.fn(),
+}));
+
+const service = require('../src/modules/auth/services/auth.service');
+const routes = require('../src/modules/auth/routes/auth.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/auth', routes);
+
+const errorHandler = require('../src/middleware/errorHandler');
+app.use(errorHandler);
+
+describe('POST /api/auth/send-verification', () => {
+  it('triggers sendVerificationOtp service', async () => {
+    service.sendVerificationOtp.mockResolvedValue();
+    const res = await request(app)
+      .post('/api/auth/send-verification')
+      .send({ user_id: 1, type: 'email' });
+    expect(res.status).toBe(200);
+    expect(service.sendVerificationOtp).toHaveBeenCalledWith({ user_id: 1, type: 'email' });
+    expect(res.body.message).toMatch(/sent/i);
+  });
+});
+
+describe('POST /api/auth/confirm-verification', () => {
+  it('confirms verification OTP', async () => {
+    service.confirmVerificationOtp.mockResolvedValue();
+    const res = await request(app)
+      .post('/api/auth/confirm-verification')
+      .send({ user_id: 1, type: 'email', code: '123456' });
+    expect(res.status).toBe(200);
+    expect(service.confirmVerificationOtp).toHaveBeenCalledWith({ user_id: 1, type: 'email', code: '123456' });
+    expect(res.body.message).toMatch(/successful/i);
+  });
+
+  it('returns error for invalid OTP', async () => {
+    const AppError = require('../src/utils/AppError');
+    service.confirmVerificationOtp.mockRejectedValue(new AppError('Invalid or expired OTP', 400));
+    const res = await request(app)
+      .post('/api/auth/confirm-verification')
+      .send({ user_id: 1, type: 'email', code: '000000' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/invalid/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Add service helpers to send and confirm verification OTPs via email or SMS
- Expose verification endpoints and validation schemas for sending and confirming OTPs
- Test the verification OTP routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689631f2576c8328abe38c2584849a6b