### PR TITLE
Validate origin and secure social auth redirects

### DIFF
--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -1,7 +1,7 @@
 // Import the configured passport instance
 const { passport } = require('../../../config/passport');
 const { refreshCookieOptions } = require('../../../utils/cookie');
-const { frontendBase } = require('../../../utils/frontend');
+const { frontendBase, allowedOrigins } = require('../../../utils/frontend');
 
 
 // Google OAuth
@@ -14,10 +14,14 @@ exports.googleCallback = (req, res, next) => {
     if (err || !result) {
       return res.redirect(`${frontendBase}/auth/login?error=social`);
     }
-    const { accessToken, refreshToken } = result;
+    const { refreshToken } = result;
     res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    const host = req.query.origin || req.get('origin') || frontendBase;
-    const redirectUrl = `${host}/auth/social-success?token=${accessToken}`;
+    let origin = req.query.origin;
+    if (!allowedOrigins.includes(origin)) {
+      const headerOrigin = req.get('origin');
+      origin = allowedOrigins.includes(headerOrigin) ? headerOrigin : frontendBase;
+    }
+    const redirectUrl = `${origin}/auth/social-success`;
     res.redirect(redirectUrl);
   })(req, res, next);
 };
@@ -70,10 +74,14 @@ exports.githubCallback = (req, res, next) => {
     if (err || !result) {
       return res.redirect(`${frontendBase}/auth/login?error=social`);
     }
-    const { accessToken, refreshToken } = result;
+    const { refreshToken } = result;
     res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    const host = req.query.origin || req.get('origin') || frontendBase;
-    const redirectUrl = `${host}/auth/social-success?token=${accessToken}`;
+    let origin = req.query.origin;
+    if (!allowedOrigins.includes(origin)) {
+      const headerOrigin = req.get('origin');
+      origin = allowedOrigins.includes(headerOrigin) ? headerOrigin : frontendBase;
+    }
+    const redirectUrl = `${origin}/auth/social-success`;
     res.redirect(redirectUrl);
   })(req, res, next);
 };

--- a/backend/src/utils/frontend.js
+++ b/backend/src/utils/frontend.js
@@ -2,5 +2,8 @@ let url = process.env.FRONTEND_URL || 'http://localhost:3000';
 if (url.startsWith('FRONTEND_URL=')) {
   url = url.replace(/^FRONTEND_URL=/, '');
 }
-const frontendBase = url.split(',')[0].trim().replace(/\/$/, '');
-module.exports = { frontendBase };
+const entries = url.split(',').map((o) => o.trim().replace(/\/$/, '')).filter(Boolean);
+const defaultOrigins = ['https://eduskillbridge.net', 'https://www.eduskillbridge.net'];
+const allowedOrigins = Array.from(new Set([...defaultOrigins, ...entries]));
+const frontendBase = entries[0] || 'http://localhost:3000';
+module.exports = { frontendBase, allowedOrigins };

--- a/backend/tests/authSocialRedirect.test.js
+++ b/backend/tests/authSocialRedirect.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/passport', () => ({
+  passport: { authenticate: jest.fn() },
+}));
+
+jest.mock('../src/utils/frontend', () => ({
+  frontendBase: 'http://frontend.com',
+  allowedOrigins: ['http://frontend.com', 'https://allowed.com'],
+}));
+
+const { passport } = require('../src/config/passport');
+const { googleCallback } = require('../src/modules/auth/controllers/socialAuth.controller');
+
+const app = express();
+app.get('/api/auth/google/callback', googleCallback);
+
+describe('social auth redirect', () => {
+  beforeEach(() => {
+    passport.authenticate.mockImplementation((strategy, opts, cb) => {
+      return (req, res, next) => cb(null, { accessToken: 'a', refreshToken: 'r' });
+    });
+  });
+
+  it('redirects to allowed origin without exposing token', async () => {
+    const res = await request(app)
+      .get('/api/auth/google/callback')
+      .query({ origin: 'https://allowed.com' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://allowed.com/auth/social-success');
+    expect(res.headers.location).not.toContain('token=');
+  });
+
+  it('falls back to frontendBase for unapproved origin', async () => {
+    const res = await request(app)
+      .get('/api/auth/google/callback')
+      .query({ origin: 'https://evil.com' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('http://frontend.com/auth/social-success');
+    expect(res.headers.location).not.toContain('token=');
+  });
+});

--- a/frontend/src/pages/auth/social-success.js
+++ b/frontend/src/pages/auth/social-success.js
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify';
 import useAuthStore from '@/store/auth/authStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import { getFullProfile } from '@/services/profile/profileService';
+import { refreshAccessToken } from '@/services/auth/authService';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
@@ -16,11 +17,10 @@ export default function SocialSuccess() {
   const { t } = useTranslation('auth');
 
   useEffect(() => {
-    const { token } = router.query;
-    if (!token) return;
     async function finalize() {
-      setToken(token);
       try {
+        const { accessToken } = await refreshAccessToken();
+        setToken(accessToken);
         const res = await getFullProfile();
         setUser(res.data);
         fetchNotifications();


### PR DESCRIPTION
## Summary
- whitelist redirect origins for social login flows
- deliver access token via refresh endpoint instead of query string
- update frontend social login callback and add tests for redirect handling

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689631fea3d08328aa7ac111850ae646