### PR TITLE
feat: load admin chart data from API

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -218,3 +218,23 @@ exports.getDashboardStats = async (_req, res) => {
   const data = await require("./admin.service").getDashboardStats();
   res.status(200).json({ data });
 };
+
+/**
+ * @desc Get monthly revenue totals
+ * @route GET /api/users/admin/monthly-revenue
+ * @access Admin
+ */
+exports.getMonthlyRevenue = async (_req, res) => {
+  const data = await require("./admin.service").getMonthlyRevenue();
+  res.status(200).json({ data });
+};
+
+/**
+ * @desc Get monthly user signups
+ * @route GET /api/users/admin/monthly-signups
+ * @access Admin
+ */
+exports.getMonthlySignups = async (_req, res) => {
+  const data = await require("./admin.service").getMonthlySignups();
+  res.status(200).json({ data });
+};

--- a/backend/src/modules/users/admin/admin.routes.js
+++ b/backend/src/modules/users/admin/admin.routes.js
@@ -54,6 +54,8 @@ router.post(
 // 📊 Dashboard stats
 // ---------------------------------------------------------------------------
 router.get("/dashboard-stats", controller.getDashboardStats);
+router.get("/monthly-revenue", controller.getMonthlyRevenue);
+router.get("/monthly-signups", controller.getMonthlySignups);
 
 
 

--- a/backend/src/modules/users/admin/admin.service.js
+++ b/backend/src/modules/users/admin/admin.service.js
@@ -57,3 +57,30 @@ exports.getDashboardStats = async () => {
     classes: parseInt(classRow.count, 10) || 0,
   };
 };
+
+// ---------------------------------------------------------------------------
+// 📈 Charts data
+// ---------------------------------------------------------------------------
+
+/**
+ * Get total paid revenue grouped by month
+ */
+exports.getMonthlyRevenue = () => {
+  return db("payments")
+    .select(db.raw("TO_CHAR(DATE_TRUNC('month', paid_at), 'Mon') as month"))
+    .sum({ revenue: "amount" })
+    .where({ status: "paid" })
+    .groupByRaw("DATE_TRUNC('month', paid_at)")
+    .orderByRaw("DATE_TRUNC('month', paid_at)");
+};
+
+/**
+ * Count user signups grouped by month
+ */
+exports.getMonthlySignups = () => {
+  return db("users")
+    .select(db.raw("TO_CHAR(DATE_TRUNC('month', created_at), 'Mon') as month"))
+    .count("id as users")
+    .groupByRaw("DATE_TRUNC('month', created_at)")
+    .orderByRaw("DATE_TRUNC('month', created_at)");
+};

--- a/frontend/src/components/admin/charts/RevenueChart.js
+++ b/frontend/src/components/admin/charts/RevenueChart.js
@@ -1,16 +1,23 @@
 // components/admin/charts/RevenueChart.js
+import { useEffect, useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
-
-const data = [
-  { month: 'Jan', revenue: 4200 },
-  { month: 'Feb', revenue: 5320 },
-  { month: 'Mar', revenue: 6150 },
-  { month: 'Apr', revenue: 7120 },
-  { month: 'May', revenue: 8300 },
-  { month: 'Jun', revenue: 9250 },
-];
+import { fetchMonthlyRevenue } from '@/services/admin/adminService';
 
 export default function RevenueChart() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetchMonthlyRevenue();
+        setData(res || []);
+      } catch (err) {
+        console.error('Failed to load revenue data', err);
+      }
+    };
+    load();
+  }, []);
+
   return (
     <div className="bg-white p-6 rounded-xl shadow mt-8">
       <h2 className="text-xl font-semibold mb-4">📈 Monthly Revenue</h2>

--- a/frontend/src/components/admin/charts/SignupsChart.js
+++ b/frontend/src/components/admin/charts/SignupsChart.js
@@ -1,16 +1,23 @@
 // components/admin/charts/SignupsChart.js
+import { useEffect, useState } from 'react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
-
-const data = [
-  { month: 'Jan', users: 120 },
-  { month: 'Feb', users: 180 },
-  { month: 'Mar', users: 200 },
-  { month: 'Apr', users: 230 },
-  { month: 'May', users: 310 },
-  { month: 'Jun', users: 400 },
-];
+import { fetchMonthlySignups } from '@/services/admin/adminService';
 
 export default function SignupsChart() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetchMonthlySignups();
+        setData(res || []);
+      } catch (err) {
+        console.error('Failed to load signups data', err);
+      }
+    };
+    load();
+  }, []);
+
   return (
     <div className="bg-white p-6 rounded-xl shadow mt-8">
       <h2 className="text-xl font-semibold mb-4">👥 Monthly Signups</h2>

--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -95,3 +95,29 @@ export const fetchAdminDashboardStats = async () => {
     throw err;
   }
 };
+
+/**
+ * 📈 Fetch monthly revenue totals
+ */
+export const fetchMonthlyRevenue = async () => {
+  try {
+    const res = await api.get("/users/admin/monthly-revenue");
+    return res.data?.data;
+  } catch (err) {
+    console.error("Failed to fetch monthly revenue", err);
+    throw err;
+  }
+};
+
+/**
+ * 👥 Fetch monthly user signups
+ */
+export const fetchMonthlySignups = async () => {
+  try {
+    const res = await api.get("/users/admin/monthly-signups");
+    return res.data?.data;
+  } catch (err) {
+    console.error("Failed to fetch monthly signups", err);
+    throw err;
+  }
+};


### PR DESCRIPTION
## Summary
- add backend endpoints to aggregate monthly revenue and signups
- fetch chart data in admin dashboard from new services

## Testing
- `npm test` (backend) *(fails: sanitizeUser is not defined)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68963a1d4a0c83288814c5a4e86f9b52