### PR TITLE
Ensure JWT secrets exist before login

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -24,13 +24,18 @@ const verificationService = require("../../verify/verify.service");
 const SALT_ROUNDS = 12;
 const ACCESS_EXPIRES_IN = "60m";
 const REFRESH_EXPIRES_IN = "30d";
-const REFRESH_TOKEN_SECRET =
-  process.env.REFRESH_TOKEN_SECRET || process.env.JWT_SECRET;
+const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET;
 const OTP_EXPIRY_MINUTES = 15;
 
 const failedLoginAttempts = new Map();
 const MAX_ATTEMPTS = 5;
 const LOCK_TIME = 15 * 60 * 1000;
+
+function sanitizeUser(user) {
+  if (!user) return user;
+  const { password_hash, ...safe } = user;
+  return safe;
+}
 
 function recordFailedAttempt(email) {
   const info = failedLoginAttempts.get(email) || { count: 0 };
@@ -141,6 +146,16 @@ exports.registerUser = async (data) => {
  * Login user and issue tokens
  */
 exports.loginUser = async ({ email, password }) => {
+  if (!process.env.JWT_SECRET || !REFRESH_TOKEN_SECRET) {
+    const missing = [];
+    if (!process.env.JWT_SECRET) missing.push("JWT_SECRET");
+    if (!REFRESH_TOKEN_SECRET) missing.push("REFRESH_TOKEN_SECRET");
+    throw new AppError(
+      `Missing environment variable(s): ${missing.join(", ")}`,
+      500
+    );
+  }
+
   const attempt = failedLoginAttempts.get(email);
   if (attempt && attempt.lockUntil && attempt.lockUntil > Date.now()) {
     throw new AppError("Too many failed login attempts. Try again later.", 429);
@@ -191,12 +206,18 @@ exports.loginUser = async ({ email, password }) => {
  * Generate JWT access token
  */
 function generateAccessToken(payload) {
+  if (!process.env.JWT_SECRET) {
+    throw new AppError("JWT_SECRET not configured", 500);
+  }
   return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: ACCESS_EXPIRES_IN });
 }
 
 exports.generateAccessToken = generateAccessToken;
 
 function generateRefreshToken(payload, jti) {
+  if (!REFRESH_TOKEN_SECRET) {
+    throw new AppError("REFRESH_TOKEN_SECRET not configured", 500);
+  }
   return jwt.sign({ ...payload, jti }, REFRESH_TOKEN_SECRET, {
     expiresIn: REFRESH_EXPIRES_IN,
   });
@@ -220,6 +241,9 @@ async function issueRefreshToken(userId, role) {
 exports.issueRefreshToken = issueRefreshToken;
 
 exports.verifyRefreshToken = async (token) => {
+  if (!REFRESH_TOKEN_SECRET) {
+    throw new AppError("REFRESH_TOKEN_SECRET not configured", 500);
+  }
   const decoded = jwt.verify(token, REFRESH_TOKEN_SECRET);
   const row = await db("refresh_tokens")
     .where({ id: decoded.jti, user_id: decoded.id })

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -18,6 +18,15 @@ const startClassReminderJob = require("./jobs/classReminderJob");
 const startCleanupJob = require("./jobs/cleanupJob");
 require("dotenv").config();
 
+// Ensure required environment secrets are present
+const requiredSecrets = ["JWT_SECRET", "REFRESH_TOKEN_SECRET"];
+const missingSecrets = requiredSecrets.filter((key) => !process.env[key]);
+if (missingSecrets.length) {
+  throw new Error(
+    `Missing required environment variables: ${missingSecrets.join(", ")}`
+  );
+}
+
 
 // ─── Express and HTTP Setup ───
 

--- a/backend/tests/authMissingSecrets.test.js
+++ b/backend/tests/authMissingSecrets.test.js
@@ -1,0 +1,81 @@
+const jwt = require('jsonwebtoken');
+
+// Mock database and dependencies to avoid side effects
+jest.mock('../src/config/database', () => ({
+  fn: { now: jest.fn() },
+}));
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findByEmail: jest.fn(),
+  updateUser: jest.fn(),
+  getUserRoles: jest.fn(),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/utils/email', () => ({
+  sendOtpEmail: jest.fn(),
+  sendPasswordChangeEmail: jest.fn(),
+  sendWelcomeEmail: jest.fn(),
+  sendNewUserAdminEmail: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+jest.mock('bcrypt', () => ({
+  compare: jest.fn().mockResolvedValue(true),
+  hash: jest.fn().mockResolvedValue('hashed'),
+}));
+
+const mockUser = {
+  id: 1,
+  email: 'test@example.com',
+  password_hash: 'hashedpw',
+  role: 'Student',
+  status: 'active',
+};
+
+describe('loginUser token secret validation', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('fails when JWT_SECRET is missing', async () => {
+    process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
+    delete process.env.JWT_SECRET;
+
+    const authService = require('../src/modules/auth/services/auth.service');
+    const userModel = require('../src/modules/users/user.model');
+    userModel.findByEmail.mockResolvedValue({ ...mockUser });
+    userModel.updateUser.mockResolvedValue();
+    userModel.getUserRoles.mockResolvedValue([]);
+
+    await expect(
+      authService.loginUser({ email: 'test@example.com', password: 'pass' })
+    ).rejects.toThrow('Missing environment variable(s): JWT_SECRET');
+  });
+
+  it('fails when REFRESH_TOKEN_SECRET is missing', async () => {
+    process.env.JWT_SECRET = 'testsecret';
+    delete process.env.REFRESH_TOKEN_SECRET;
+
+    const authService = require('../src/modules/auth/services/auth.service');
+    const userModel = require('../src/modules/users/user.model');
+    userModel.findByEmail.mockResolvedValue({ ...mockUser });
+    userModel.updateUser.mockResolvedValue();
+    userModel.getUserRoles.mockResolvedValue([]);
+
+    await expect(
+      authService.loginUser({ email: 'test@example.com', password: 'pass' })
+    ).rejects.toThrow('Missing environment variable(s): REFRESH_TOKEN_SECRET');
+  });
+});

--- a/backend/tests/authSanitization.test.js
+++ b/backend/tests/authSanitization.test.js
@@ -56,6 +56,7 @@ jest.mock('bcrypt', () => ({
 }));
 
 process.env.JWT_SECRET = 'testsecret';
+process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
 
 const authService = require('../src/modules/auth/services/auth.service');
 const authMiddleware = require('../src/middleware/auth/authMiddleware');
@@ -65,6 +66,7 @@ describe('Sensitive data sanitization', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.JWT_SECRET = 'testsecret';
+    process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
   });
 
   it('registerUser does not return password_hash', async () => {


### PR DESCRIPTION
## Summary
- validate required JWT secrets at server startup
- guard login and token generation when JWT secrets are missing
- add tests for missing JWT_SECRET or REFRESH_TOKEN_SECRET

## Testing
- `cd backend && JWT_SECRET=testsecret REFRESH_TOKEN_SECRET=refreshsecret npm test`


------
https://chatgpt.com/codex/tasks/task_e_689640ad3cc08328af2d827ada32164d