### PR TITLE
Gracefully handle missing social login settings

### DIFF
--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.service.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.service.js
@@ -5,11 +5,16 @@ const path = require("path");
 const SETTINGS_KEY = "social_login_settings";
 
 exports.getSettings = async () => {
-  const row = await db("settings").where({ key: SETTINGS_KEY }).first();
-  if (!row) return null;
   try {
-    return JSON.parse(row.value);
-  } catch (_err) {
+    const row = await db("settings").where({ key: SETTINGS_KEY }).first();
+    if (!row) return null;
+    try {
+      return JSON.parse(row.value);
+    } catch (_err) {
+      return null;
+    }
+  } catch (err) {
+    console.error("Failed to load social login settings", err);
     return null;
   }
 };

--- a/backend/tests/socialLoginConfigService.test.js
+++ b/backend/tests/socialLoginConfigService.test.js
@@ -1,0 +1,26 @@
+jest.mock('../src/config/database', () => {
+  const mockDb = jest.fn(() => ({
+    where: jest.fn().mockReturnThis(),
+    first: jest.fn().mockRejectedValue(new Error('relation "settings" does not exist')),
+  }));
+  return mockDb;
+});
+
+const service = require('../src/modules/socialLoginConfig/socialLoginConfig.service');
+
+describe('socialLoginConfigService.getSettings', () => {
+  it('returns null when settings table is missing', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await service.getSettings();
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load social login settings',
+      expect.any(Error)
+    );
+
+    consoleSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- guard social login settings lookup with try/catch and log on failure
- add service test for missing settings table

## Testing
- `npm test --prefix backend` *(fails: authSanitization.test.js: sanitizeUser is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689640ab54ac8328bedbad0428d97dbb