### PR TITLE
feat: add workbox service worker with warm cache

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,0 +1,31 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+
+const WARM_CACHE = 'SKILLBRIDGE-WARM-V1';
+const warmCache = new workbox.strategies.CacheFirst({ cacheName: WARM_CACHE });
+
+self.addEventListener('message', (event) => {
+  const { type, payload } = event.data || {};
+  if (type === 'WARM_UP_CACHE') {
+    event.waitUntil(
+      caches.open(WARM_CACHE).then((cache) => cache.addAll(payload || []))
+    );
+  }
+  if (type === 'CLEAR_WARM_CACHE') {
+    event.waitUntil(caches.delete(WARM_CACHE));
+  }
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      self.skipWaiting();
+      await clients.claim();
+      const clientList = await clients.matchAll({ type: 'window' });
+      clientList.forEach((client) =>
+        client.postMessage({ type: 'NEW_VERSION' })
+      );
+    })()
+  );
+});


### PR DESCRIPTION
## Summary
- add Workbox-powered service worker to precache assets and warm cache
- handle warm cache messages and broadcast new versions to clients

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 252 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689641546228832890c826d742a55518