### PR TITLE
Fix duplicate sanitizeUser definition causing SyntaxError

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -32,12 +32,6 @@ const failedLoginAttempts = new Map();
 const MAX_ATTEMPTS = 5;
 const LOCK_TIME = 15 * 60 * 1000;
 
-function sanitizeUser(user) {
-  if (!user) return user;
-  const { password_hash, ...safe } = user;
-  return safe;
-}
-
 function recordFailedAttempt(email) {
   const info = failedLoginAttempts.get(email) || { count: 0 };
   const count = info.count + 1;


### PR DESCRIPTION
## Summary
- remove redundant sanitizeUser function from auth service to avoid duplicate declaration error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68965c56ed008328bd9f0dcd8b4b1d73