### PR TITLE
Add refresh token secret to backend env configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,7 @@
 PORT=5002
 DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge
 JWT_SECRET=your_jwt_secret
+REFRESH_TOKEN_SECRET=your_refresh_token_secret
 CLOUDINARY_API_KEY=your_key
 SMTP_HOST=smtp.mailtrap.io
 SMTP_PORT=587

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - PORT=5002
       - DATABASE_URL=postgres://postgres:postgres@db:5432/eduSkillbridge
       - JWT_SECRET=SkillBr1dge-!Secure.JWT-Key!
+      - REFRESH_TOKEN_SECRET=SkillBr1dge-!Refresh.JWT-Key!
       - FRONTEND_URL=https://eduskillbridge.net
     depends_on:
       - db


### PR DESCRIPTION
## Summary
- include REFRESH_TOKEN_SECRET in backend service docker environment
- document REFRESH_TOKEN_SECRET in backend `.env.example`

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68965dac9f28832888e02f7d4369dad7