### PR TITLE
fix: avoid sanitizeUser redeclaration in auth service

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -11,7 +11,7 @@ const {
   sendNewUserAdminEmail,
 } = require("../../../utils/email");
 const { generateOtp } = require("../utils/otp");
-const sanitizeUser = require("../utils/sanitizeUser");
+const sanitizeUserFields = require("../utils/sanitizeUser");
 const { OTP_LENGTH } = require("../constants");
 const AppError = require("../../../utils/AppError");
 const notificationService = require("../../notifications/notifications.service");
@@ -132,7 +132,7 @@ exports.registerUser = async (data) => {
     console.error("Error sending registration emails:", err.message);
   }
 
-  const safeUser = sanitizeUser(newUser);
+  const safeUser = sanitizeUserFields(newUser);
   return { user: { ...safeUser, roles } };
 };
 
@@ -193,7 +193,7 @@ exports.loginUser = async ({ email, password }) => {
     message: "You have logged in successfully",
   });
 
-  const safeUser = sanitizeUser(user);
+  const safeUser = sanitizeUserFields(user);
   return { accessToken, refreshToken, csrfToken, user: { ...safeUser, roles } };
 };
 
@@ -378,7 +378,7 @@ exports.resetPassword = async ({ email, code, new_password }) => {
     receiver_id: user.id,
     message: "Your password was changed successfully",
   });
-  return sanitizeUser(user);
+  return sanitizeUserFields(user);
 };
 
 /**


### PR DESCRIPTION
## Summary
- rename imported sanitizeUser helper to sanitizeUserFields
- update auth service to use sanitizeUserFields for user sanitization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68965e71f36c8328a10df0bfb69cbf70