### PR TITLE
fix: avoid sanitizeUser redeclaration error

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -11,7 +11,8 @@ const {
   sendNewUserAdminEmail,
 } = require("../../../utils/email");
 const { generateOtp } = require("../utils/otp");
-const sanitizeUser = require("../utils/sanitizeUser");
+// Renamed to avoid potential identifier conflicts during runtime
+const sanitizeUserUtil = require("../utils/sanitizeUser");
 const { OTP_LENGTH } = require("../constants");
 const AppError = require("../../../utils/AppError");
 const notificationService = require("../../notifications/notifications.service");
@@ -132,7 +133,7 @@ exports.registerUser = async (data) => {
     console.error("Error sending registration emails:", err.message);
   }
 
-  const safeUser = sanitizeUser(newUser);
+  const safeUser = sanitizeUserUtil(newUser);
   return { user: { ...safeUser, roles } };
 };
 
@@ -193,7 +194,7 @@ exports.loginUser = async ({ email, password }) => {
     message: "You have logged in successfully",
   });
 
-  const safeUser = sanitizeUser(user);
+  const safeUser = sanitizeUserUtil(user);
   return { accessToken, refreshToken, csrfToken, user: { ...safeUser, roles } };
 };
 
@@ -378,7 +379,7 @@ exports.resetPassword = async ({ email, code, new_password }) => {
     receiver_id: user.id,
     message: "Your password was changed successfully",
   });
-  return sanitizeUser(user);
+  return sanitizeUserUtil(user);
 };
 
 /**


### PR DESCRIPTION
## Summary
- rename sanitizeUser import to sanitizeUserUtil to avoid identifier conflicts
- update all sanitization calls to use new alias

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68965e71f36c8328a10df0bfb69cbf70