### PR TITLE
Pause ad slider when viewing media

### DIFF
--- a/frontend/src/components/website/AdMediaModal.js
+++ b/frontend/src/components/website/AdMediaModal.js
@@ -4,7 +4,13 @@ import { FaTimes } from "react-icons/fa";
 
 export default function AdMediaModal({ ad, onClose }) {
   const closeRef = useRef(null);
+
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
+
   if (!ad) return null;
+
   const handleBackdrop = (e) => {
     if (e.target === e.currentTarget) onClose();
   };
@@ -12,10 +18,6 @@ export default function AdMediaModal({ ad, onClose }) {
   const handleKeyDown = (e) => {
     if (e.key === "Escape") onClose();
   };
-
-  useEffect(() => {
-    closeRef.current?.focus();
-  }, []);
 
   return (
     <div

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -24,7 +24,7 @@ import SidebarMenu from "@/components/shared/SidebarMenu";
 import Chatbot from "@/components/shared/Chatbot";
 import useAppConfigStore from "@/store/appConfigStore";
 import { API_BASE_URL } from "@/config/config";
-import { getAds, recordAdView } from "@/services/adsService";
+import { getAds, recordAdView, recordAdClick } from "@/services/adsService";
 import { searchAll } from "@/services/searchService";
 import { useTranslation } from "next-i18next";
 import useAuthStore from "@/store/auth/authStore";
@@ -471,7 +471,10 @@ const Hero = () => {
             )}
             {/* View Media Button */}
             <button
-              onClick={() => setShowMedia(true)}
+              onClick={() => {
+                setIsAdPaused(true);
+                setShowMedia(true);
+              }}
               className="absolute top-4 right-4 z-20 p-2 bg-black/50 hover:bg-black/70 rounded-full text-white"
               aria-label={t('view_media')}
             >
@@ -540,7 +543,13 @@ const Hero = () => {
           <p className="text-white text-sm mt-2">{t('scroll_down')}</p>
         </motion.div>
         {showMedia && (
-          <AdMediaModal ad={ads[currentAd]} onClose={() => setShowMedia(false)} />
+          <AdMediaModal
+            ad={ads[currentAd]}
+            onClose={() => {
+              setShowMedia(false);
+              setIsAdPaused(false);
+            }}
+          />
         )}
       </section>
     </motion.section>

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -52,3 +52,14 @@ export const recordAdView = async (id) => {
     }
   }
 };
+
+// Notify backend that an ad was clicked
+export const recordAdClick = async (id) => {
+  try {
+    await api.post(`/ads/${id}/click`);
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("Failed to record ad click", error);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- Pause homepage ad rotation when opening zoomed media and resume on close
- Add recordAdClick API helper and import into hero section
- Clean up AdMediaModal hook usage to keep close button focused

## Testing
- `npm test`
- `npx eslint src/components/website/sections/Hero.js src/services/adsService.js src/components/website/AdMediaModal.js`

------
https://chatgpt.com/codex/tasks/task_e_68965f972a0c8328895fbfb77e6ab135