### PR TITLE
chore: guard auth logging for production

### DIFF
--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -90,7 +90,9 @@ export default function Login() {
   // ─────────────────────────────
   const onSubmit = async (data) => {
   try {
-    console.log("➡️ login onSubmit", data.email);
+    if (process.env.NODE_ENV !== "production") {
+      console.log("➡️ login onSubmit invoked");
+    }
     let cfg = recaptchaCfg;
     if (!cfg && cfgLoading) {
       cfg = await fetchSocialLoginConfig().catch(() => null);
@@ -123,7 +125,9 @@ export default function Login() {
       router.push(targetPath);
     }, 500);
   } catch (err) {
-    console.error("❌ login onSubmit error", err);
+    if (process.env.NODE_ENV !== "production") {
+      console.error("❌ login onSubmit error", { message: err?.message });
+    }
     let msg =
       err?.response?.data?.message ||
       err?.response?.data?.error ||

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -12,11 +12,21 @@ import api from "@/services/api/api";
  */
 export const loginUser = async ({ email, password, recaptchaToken }) => {
   try {
-    console.log("🔐 loginUser requesting", api.defaults.baseURL + "/auth/login");
+    if (process.env.NODE_ENV !== "production") {
+      console.log(
+        "🔐 loginUser requesting",
+        `${api.defaults.baseURL}/auth/login`
+      );
+    }
     const res = await api.post("/auth/login", { email, password, recaptchaToken });
     return res.data;
   } catch (err) {
-    console.error("❌ loginUser error", err?.response || err);
+    if (process.env.NODE_ENV !== "production") {
+      console.error("❌ loginUser error", {
+        message: err?.message,
+        status: err?.response?.status,
+      });
+    }
     throw err;
   }
 };

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -19,7 +19,9 @@ const useAuthStore = create(
       isAuthenticated: () => !!get().accessToken && !!get().user,
 
       login: async (credentials) => {
-        console.log("🔑 authStore.login", credentials.email);
+        if (process.env.NODE_ENV !== "production") {
+          console.log("🔑 authStore.login invoked");
+        }
         const { accessToken, user } = await authService.loginUser(credentials);
         if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
           user.avatar_url = null;
@@ -45,7 +47,9 @@ const useAuthStore = create(
           fetchNotifications?.();
           return user;
         } catch (err) {
-          console.error("❌ loginWithToken error", err);
+          if (process.env.NODE_ENV !== "production") {
+            console.error("❌ loginWithToken error", { message: err?.message });
+          }
           set({ accessToken: null, user: null });
         }
       },
@@ -60,7 +64,9 @@ const useAuthStore = create(
           set({ user: fresh });
           return fresh;
         } catch (err) {
-          console.error("❌ refreshUser error", err);
+          if (process.env.NODE_ENV !== "production") {
+            console.error("❌ refreshUser error", { message: err?.message });
+          }
         }
       },
 
@@ -85,7 +91,9 @@ const useAuthStore = create(
       name: "auth",
       onRehydrateStorage: () => {
         return (state) => {
-          console.log("🔥 Zustand hydrated");
+          if (process.env.NODE_ENV !== "production") {
+            console.log("🔥 Zustand hydrated");
+          }
           set({ hasHydrated: true });
         };
       },


### PR DESCRIPTION
## Summary
- add environment-aware login logging
- sanitize errors in auth services
- avoid leaking user data from auth store logs

## Testing
- `cd frontend
npm test >/tmp/unit_test.log && tail -n 20 /tmp/unit_test.log`

------
https://chatgpt.com/codex/tasks/task_e_6896605839d08328aacad2ec008b646c