### PR TITLE
chore: remove production console log

### DIFF
--- a/frontend/src/components/shared/SidebarMenu.js
+++ b/frontend/src/components/shared/SidebarMenu.js
@@ -17,7 +17,9 @@ const SidebarMenu = ({ isOpen, onClose, showAds }) => {
   const { t } = useTranslation("common");
   const userRole = user?.role?.toLowerCase();
 
-  console.log("🔍 SidebarMenu Loaded | Role:", userRole, "| User:", user)
+  if (process.env.NODE_ENV === "development") {
+    console.log("🔍 SidebarMenu Loaded | Role:", userRole, "| User:", user);
+  }
 
   const [hydrated, setHydrated] = useState(false);
 


### PR DESCRIPTION
## Summary
- guard SidebarMenu logging so user info is only printed in development

## Testing
- `npx jest src/components/shared/__tests__/SidebarMenu.no-console.test.js`
- `npm test`
- `npm run lint` *(fails: Assign object to a variable before exporting as module default)*

------
https://chatgpt.com/codex/tasks/task_e_6896605963648328b85fc89ce48734e6