### PR TITLE
Use API service for AdSense config with safer error handling

### DIFF
--- a/frontend/src/components/shared/GoogleAd.js
+++ b/frontend/src/components/shared/GoogleAd.js
@@ -1,13 +1,22 @@
 import { useEffect, useState } from "react";
+import api from "@/services/api/api";
 
 const GoogleAd = ({ slot }) => {
   const [adConfig, setAdConfig] = useState(null);
 
   useEffect(() => {
-    fetch("/api/adsense")
-      .then((res) => res.json())
-      .then((data) => setAdConfig(data))
-      .catch((err) => console.error("Failed to load AdSense settings:", err));
+    const fetchConfig = async () => {
+      try {
+        const { data } = await api.get("/adsense");
+        setAdConfig(data);
+      } catch (err) {
+        if (process.env.NODE_ENV !== "production") {
+          console.error("Failed to load AdSense settings:", err);
+        }
+        setAdConfig(null);
+      }
+    };
+    fetchConfig();
   }, []);
 
   useEffect(() => {
@@ -28,7 +37,9 @@ const GoogleAd = ({ slot }) => {
       try {
         (window.adsbygoogle = window.adsbygoogle || []).push({});
       } catch (e) {
-        console.error("AdSense error:", e);
+        if (process.env.NODE_ENV !== "production") {
+          console.error("AdSense error:", e);
+        }
       }
     }
   }, [adConfig]);

--- a/frontend/src/shared/GoogleAd.js
+++ b/frontend/src/shared/GoogleAd.js
@@ -1,13 +1,22 @@
 import { useEffect, useState } from "react";
+import api from "@/services/api/api";
 
 const GoogleAd = ({ slot }) => {
   const [adConfig, setAdConfig] = useState(null);
 
   useEffect(() => {
-    fetch("/api/adsense")
-      .then((res) => res.json())
-      .then((data) => setAdConfig(data))
-      .catch((err) => console.error("Failed to load AdSense settings:", err));
+    const fetchConfig = async () => {
+      try {
+        const { data } = await api.get("/adsense");
+        setAdConfig(data);
+      } catch (err) {
+        if (process.env.NODE_ENV !== "production") {
+          console.error("Failed to load AdSense settings:", err);
+        }
+        setAdConfig(null);
+      }
+    };
+    fetchConfig();
   }, []);
 
   useEffect(() => {
@@ -15,7 +24,9 @@ const GoogleAd = ({ slot }) => {
       try {
         (window.adsbygoogle = window.adsbygoogle || []).push({});
       } catch (e) {
-        console.error("AdSense error:", e);
+        if (process.env.NODE_ENV !== "production") {
+          console.error("AdSense error:", e);
+        }
       }
     }
   }, [adConfig]);


### PR DESCRIPTION
## Summary
- Fetch AdSense configuration through shared API service
- Wrap AdSense config request in try/catch with environment-aware logging

## Testing
- `npm test`
- `npm run lint` *(fails: 48 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6896605b98e083288956c7f227a66f99