### PR TITLE
Configure WebSocket URL for production environment

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -3,3 +3,5 @@
 # For local development this can be http://localhost:5000/api
 # When deploying to production replace it with your live API URL.
 NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api
+# WebSocket server URL. Set to your API domain in production.
+NEXT_PUBLIC_SOCKET_URL=http://localhost:5000

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,3 @@
+# Production environment variables
+NEXT_PUBLIC_API_BASE_URL=https://api.eduskillbridge.net/api
+NEXT_PUBLIC_SOCKET_URL=https://api.eduskillbridge.net

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.local.example
+!.env.production
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- add production env file with NEXT_PUBLIC_SOCKET_URL pointing to API domain
- document socket URL in sample env and allow env.production in gitignore

## Testing
- `cd frontend && npm test`
- `curl -H 'Origin: https://eduskillbridge.net' -i 'https://api.eduskillbridge.net/socket.io/?EIO=4&transport=polling'`


------
https://chatgpt.com/codex/tasks/task_e_6896605e7b5083288170e4054304c18d