### PR TITLE
feat: gate social login config logs

### DIFF
--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.routes.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.routes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const controller = require("./socialLoginConfig.controller");
 const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+const logger = require("../../utils/logger");
 
 // Middleware that verifies the user when secrets are requested
 const maybeAuth = (req, res, next) => {
@@ -16,10 +17,15 @@ const maybeAuth = (req, res, next) => {
 
 // Log incoming GET requests to debug potential auth or DB issues
 router.get("/", maybeAuth, (req, res, next) => {
-  console.log("[socialLoginConfig] GET /api/social-login/config", {
-    user: req.user,
-    includeSecrets: req.query.includeSecrets,
-  });
+  if (process.env.NODE_ENV !== "production") {
+    logger.debug(
+      "[socialLoginConfig] GET /api/social-login/config",
+      JSON.stringify({
+        userId: req.user ? req.user.id : null,
+        includeSecrets: !!req.query.includeSecrets,
+      })
+    );
+  }
   controller.getSettings(req, res, next);
 });
 router.use(verifyToken, isAdmin);


### PR DESCRIPTION
## Summary
- replace social login config route console.log with dev-only logger

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896605f98bc8328b0e828be37fdf549