### PR TITLE
Handle invalid AdSense fetch responses

### DIFF
--- a/frontend/src/components/shared/GoogleAd.js
+++ b/frontend/src/components/shared/GoogleAd.js
@@ -5,9 +5,20 @@ const GoogleAd = ({ slot }) => {
 
   useEffect(() => {
     fetch("/api/adsense")
-      .then((res) => res.json())
-      .then((data) => setAdConfig(data))
-      .catch((err) => console.error("Failed to load AdSense settings:", err));
+      .then((res) => {
+        const contentType = res.headers.get("content-type");
+        if (!res.ok || !contentType || !contentType.includes("application/json")) {
+          setAdConfig(null);
+          return null;
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (data) setAdConfig(data);
+      })
+      .catch(() => {
+        setAdConfig(null);
+      });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- guard GoogleAd fetch against non-JSON or error responses
- disable ads quietly if fetch fails

## Testing
- `npm test`
- `npm run lint` *(fails: 301 problems, 48 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6896608bd2a8832887eb0754106f0d28