### PR TITLE
fix: parse slider value as number in filter sidebar

### DIFF
--- a/frontend/src/components/books/FilterSidebar.js
+++ b/frontend/src/components/books/FilterSidebar.js
@@ -61,7 +61,7 @@ const BookFilterSidebar = ({ onFilterChange, onResetFilters }) => {
           max="500"
           value={priceRange}
           onChange={(e) => {
-            const value = e.target.value;
+            const value = Number(e.target.value);
             setPriceRange(value);
             onFilterChange({ categories: selectedCategories, levels: selectedLevels, price: value });
           }}


### PR DESCRIPTION
## Summary
- ensure price slider uses numeric value for state and filter updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896667d048c8328ac2e08dadb6924df