### PR TITLE
Use functional updates for setFilters

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -265,14 +265,15 @@ function AdminBooksPage() {
   };
 
   const resetFilters = () => {
-    setFilters({
+    setFilters((prev) => ({
+      ...prev,
       search: "",
       category: "",
       status: "",
       priceRange: null,
       language: "",
       tags: []
-    });
+    }));
     setPage(1);
   };
 

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -250,14 +250,15 @@ function InstructorBooksPage() {
   };
 
   const resetFilters = () => {
-    setFilters({ 
-      search: "", 
-      category: "", 
-      status: "", 
-      priceRange: 0, 
-      language: "", 
-      tags: [] 
-    });
+    setFilters((prev) => ({
+      ...prev,
+      search: "",
+      category: "",
+      status: "",
+      priceRange: 0,
+      language: "",
+      tags: []
+    }));
     setPage(1);
   };
 

--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -55,21 +55,22 @@ export default function BooksPage() {
   }, []);
 
   const handleFilterChange = (newFilters) => {
-    setFilters({ ...filters, ...newFilters });
+    setFilters((prev) => ({ ...prev, ...newFilters }));
     setBooks([]);
     setPage(1);
     setHasMore(true);
   };
 
   const resetFilters = () => {
-    setFilters({
+    setFilters((prev) => ({
+      ...prev,
       categories: [],
       levels: [],
       price: 100,
       language: "",
       license: "",
       tags: [],
-    });
+    }));
     setBooks([]);
     setPage(1);
     setHasMore(true);

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -33,12 +33,12 @@ const TutorialsSection = () => {
   }, []);
 
   const handleFilterChange = (f) => {
-    setFilters(f);
+    setFilters((prev) => ({ ...prev, ...f }));
     setVisibleCount(6);
   };
 
   const resetFilters = () => {
-    setFilters({ categories: [], levels: [], price: 100 });
+    setFilters((prev) => ({ ...prev, categories: [], levels: [], price: 100 }));
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- update filter handlers to use functional `setFilters` updates ensuring latest state is used

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689666807d6c8328818bea0f31b21866