### PR TITLE
Format book price display using Intl.NumberFormat

### DIFF
--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -11,6 +11,13 @@ import {
 import { buildUrl } from "@/services/bookService";
 
 
+const priceFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
 export default function BookCard({
   book,
   isSelected = false,
@@ -62,7 +69,9 @@ export default function BookCard({
       />
       <div className="p-4">
         <h3 className="font-semibold mb-1 line-clamp-1">{book.title}</h3>
-        <p className="text-sm mb-3">{`$${book.price}`}</p>
+        <p className="text-sm mb-3">
+          {priceFormatter.format(Number(book.price ?? 0))}
+        </p>
         <div className="flex gap-2">
           <Link
             href={viewLink || `/marketplace/books/${book.id}`}

--- a/frontend/src/tests/__tests__/BookCard.test.js
+++ b/frontend/src/tests/__tests__/BookCard.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import BookCard from '@/components/books/BookCard';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('BookCard', () => {
+  it('formats price to two decimal places', () => {
+    const book = { id: 1, title: 'Test Book', price: 10 };
+    render(<BookCard book={book} />);
+    expect(screen.getByText('$10.00')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- use Intl.NumberFormat to format book prices in BookCard
- add Jest test confirming price is formatted to two decimals

## Testing
- `npm test`
- `npm run lint` *(fails: 47 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68966682c8b8832894818f8d163de708