### PR TITLE
Disable Add to Cart button while adding items

### DIFF
--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { toast } from "react-toastify";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
@@ -7,6 +8,7 @@ export default function BookDetails({ book }) {
   const router = useRouter();
   const addItem = useCartStore((state) => state.addItem);
   const { isAuthenticated, user } = useAuthStore();
+  const [isAdding, setIsAdding] = useState(false);
 
   const handleAddToCart = async () => {
     if (!isAuthenticated()) {
@@ -18,6 +20,7 @@ export default function BookDetails({ book }) {
       toast.error("Only students can purchase books");
       return;
     }
+    setIsAdding(true);
     try {
       await addItem({ id: book.id, name: book.title, price: book.price });
       toast.success("Added to cart");
@@ -25,6 +28,8 @@ export default function BookDetails({ book }) {
     } catch (err) {
       console.error("Failed to add to cart", err);
       toast.error("Failed to add to cart");
+    } finally {
+      setIsAdding(false);
     }
   };
 
@@ -85,7 +90,8 @@ export default function BookDetails({ book }) {
                   )}
                   <button
                     onClick={handleAddToCart}
-                    className="inline-block px-6 py-3 rounded-lg bg-blue-500 text-white font-semibold hover:bg-blue-600 transition-colors"
+                    disabled={isAdding}
+                    className="inline-block px-6 py-3 rounded-lg bg-blue-500 text-white font-semibold hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Add to Cart
                   </button>


### PR DESCRIPTION
## Summary
- track Add to Cart progress with local `isAdding` state
- disable the Add to Cart button while cart update is pending
- reset loading state in a `finally` block after attempting to add

## Testing
- `npm test`
- `npm run lint` *(fails: 47 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68966683c35483289b6195d6a5266b48