### PR TITLE
feat: cancel book fetch on unmount

### DIFF
--- a/frontend/src/pages/marketplace/books/[id].js
+++ b/frontend/src/pages/marketplace/books/[id].js
@@ -14,10 +14,15 @@ export default function BookDetailPage() {
 
   useEffect(() => {
     if (!id) return;
+
+    const controller = new AbortController();
+    let isMounted = true;
+
     const load = async () => {
       setLoading(true);
       try {
-        const data = await fetchBook(id);
+        const data = await fetchBook(id, { signal: controller.signal });
+        if (!isMounted) return;
         if (data) {
           setBook(data);
           setError(null);
@@ -25,13 +30,20 @@ export default function BookDetailPage() {
           setError("Book not found");
         }
       } catch (e) {
+        if (e.name === "AbortError" || e.name === "CanceledError") return;
         console.error("Failed to load book", e);
-        setError("Failed to load book");
+        if (isMounted) setError("Failed to load book");
       } finally {
-        setLoading(false);
+        if (isMounted) setLoading(false);
       }
     };
+
     load();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
   }, [id]);
 
   return (

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -68,14 +68,19 @@ export const fetchBooks = async ({
   };
 };
 
-export const fetchBook = async (id, { admin = false } = {}) => {
+export const fetchBook = async (id, { admin = false, ...config } = {}) => {
   const endpoint = admin ? `/books/admin/${id}` : `/books/${id}`;
+  const hasConfig = Object.keys(config).length > 0;
   try {
-    const { data } = await api.get(endpoint);
+    const { data } = hasConfig
+      ? await api.get(endpoint, config)
+      : await api.get(endpoint);
     return data?.data ? formatBook(data.data) : null;
   } catch (err) {
-    if (admin) {
-      const { data } = await api.get(`/books/${id}`);
+    if (admin && err.name !== "CanceledError" && err.name !== "AbortError") {
+      const { data } = hasConfig
+        ? await api.get(`/books/${id}`, config)
+        : await api.get(`/books/${id}`);
       return data?.data ? formatBook(data.data) : null;
     }
     throw err;


### PR DESCRIPTION
## Summary
- prevent stale updates in book detail page by aborting pending fetches on unmount
- allow `fetchBook` to accept AbortController signals and ignore canceled requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689666860f648328a78d12a6b7a4de63