### PR TITLE
fix: remove unused useRouter call in admin discussions page

### DIFF
--- a/frontend/src/pages/dashboard/admin/community/discussions/index.js
+++ b/frontend/src/pages/dashboard/admin/community/discussions/index.js
@@ -20,7 +20,6 @@ export default function AdminCommunityDiscussionsPage() {
   const [discussions, setDiscussions] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
-  const router = useRouter();
 
   useEffect(() => {
     const load = async () => {


### PR DESCRIPTION
## Summary
- remove unused `useRouter` call from admin community discussions page which caused build error

## Testing
- `npm test`
- `npm run lint` *(fails: 47 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6896697944bc8328ba20a2e129fdfe04