### PR TITLE
fix: build preview links and show zero ratings

### DIFF
--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -53,7 +53,7 @@ export default function BookDetails({ book }) {
             {book.category_name}
           </p>
         )}
-        {book.rating && (
+        {book.rating != null && (
           <p className="mb-4 text-yellow-400">
             ⭐ {Number(book.rating).toFixed(1)} / 5
           </p>

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -36,6 +36,7 @@ const formatBook = (book) => {
     ...book,
     cover_image_url: buildUrl(book?.cover_image_url || book?.cover_image),
     pdf_url: buildUrl(book?.pdf_url),
+    preview_url: buildUrl(book?.preview_url),
     preview_pages: previewPages,
   };
 

--- a/frontend/src/tests/__tests__/BookDetails.test.js
+++ b/frontend/src/tests/__tests__/BookDetails.test.js
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import BookDetails from '@/components/books/BookDetails';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('../../store/cart/cartStore', () => () => ({ addItem: jest.fn() }));
+jest.mock('../../store/auth/authStore', () => () => ({ isAuthenticated: () => true, user: { role: 'student' } }));
+
+jest.mock('react-toastify', () => ({ toast: { info: jest.fn(), error: jest.fn(), success: jest.fn() } }));
+
+describe('BookDetails', () => {
+  it('displays rating even when zero', () => {
+    const book = { id: 1, title: 'Test', rating: 0, is_paid: false, pdf_url: null };
+    render(<BookDetails book={book} />);
+    expect(screen.getByText('⭐ 0.0 / 5')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -37,6 +37,7 @@ describe("bookService", () => {
           title: "A",
           cover_image_url: null,
           pdf_url: null,
+          preview_url: null,
           preview_pages: [],
         },
       ],
@@ -57,6 +58,7 @@ describe("bookService", () => {
           title: "A",
           cover_image_url: null,
           pdf_url: null,
+          preview_url: null,
           preview_pages: [],
         },
       ],
@@ -74,6 +76,7 @@ describe("bookService", () => {
       title: "A",
       cover_image_url: null,
       pdf_url: null,
+      preview_url: null,
       preview_pages: [],
     });
   });
@@ -88,6 +91,7 @@ describe("bookService", () => {
       title: "A",
       cover_image_url: null,
       pdf_url: null,
+      preview_url: null,
       preview_pages: [],
     });
   });
@@ -105,6 +109,7 @@ describe("bookService", () => {
       title: "A",
       cover_image_url: null,
       pdf_url: null,
+      preview_url: null,
       preview_pages: [],
     });
   });
@@ -114,6 +119,7 @@ describe("bookService", () => {
       id: 3,
       price: "19.99",
       preview_pages: '["/uploads/a.png"]',
+      preview_url: "/uploads/p.pdf",
     };
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const book = await fetchBook(3);
@@ -122,6 +128,7 @@ describe("bookService", () => {
       price: 19.99,
       cover_image_url: null,
       pdf_url: null,
+      preview_url: "/api/uploads/p.pdf",
       preview_pages: ["/api/uploads/a.png"],
     });
   });
@@ -140,6 +147,7 @@ describe("bookService", () => {
       id: 1,
       cover_image_url: null,
       pdf_url: null,
+      preview_url: null,
       preview_pages: [],
     });
   });
@@ -158,6 +166,7 @@ describe("bookService", () => {
       id: 2,
       cover_image_url: null,
       pdf_url: null,
+      preview_url: null,
       preview_pages: [],
     });
   });


### PR DESCRIPTION
## Summary
- normalize book preview links using `buildUrl`
- display book rating when it equals zero
- add tests for book service and details component

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68966ecedf388328b18f43a4a8efcb95