### PR TITLE
Improve website responsiveness

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -193,6 +193,7 @@ function MyApp({ Component, pageProps, router }) {
           >
             <Head>
               <title>{defaultTitle}</title>
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
               {settings.metaDescription && (
                 <meta name="description" content={settings.metaDescription} />
               )}

--- a/frontend/src/pages/website/index.js
+++ b/frontend/src/pages/website/index.js
@@ -63,7 +63,7 @@ export default function Home() {
   };
 
   return (
-    <div>
+    <div className="overflow-x-hidden">
       <Navbar />
       <IncompleteAlertModal />
 
@@ -74,7 +74,7 @@ export default function Home() {
       ))}
 
       {/* Scroll Progress Bar */}
-      <div className="fixed right-4 top-1/2 transform -translate-y-1/2 w-2 h-40 bg-gray-800 rounded-full z-50">
+      <div className="fixed right-4 top-1/2 transform -translate-y-1/2 w-2 h-40 bg-gray-800 rounded-full z-50 hidden md:block">
         <motion.div
           style={{ height: `${scrollProgress}%` }}
           className="w-full bg-white rounded-full"
@@ -82,7 +82,7 @@ export default function Home() {
       </div>
 
       {/* Smooth Scroll Buttons */}
-      <div className="fixed bottom-8 right-8 flex flex-col gap-4 z-50">
+      <div className="fixed bottom-8 right-8 z-50 gap-4 hidden md:flex md:flex-col">
         {currentSection > 0 && (
           <motion.button whileHover={{ scale: 1.2 }} onClick={() => scrollToSection(currentSection - 1)}
             className="bg-gray-800 text-white p-3 rounded-full shadow-lg hover:bg-gray-700 transition">


### PR DESCRIPTION
## Summary
- add viewport meta tag for responsive rendering
- hide scroll controls on small screens and prevent horizontal overflow

## Testing
- `npm test`
- `npm run lint` *(fails: 300 problems (47 errors, 253 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68966fa013a883288580006100537076