### PR TITLE
Fix GroupCard join request method

### DIFF
--- a/frontend/src/components/groups/GroupCard.js
+++ b/frontend/src/components/groups/GroupCard.js
@@ -5,8 +5,12 @@ export default function GroupCard({ group }) {
   const [requested, setRequested] = useState(false);
 
   const handleJoin = async () => {
-    await groupService.sendJoinRequest(group.id);
-    setRequested(true);
+    try {
+      await groupService.joinGroup(group.id);
+      setRequested(true);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- call the proper join API in GroupCard
- handle errors when joining a group

## Testing
- `npm test` (frontend)
- `npm run lint` (frontend) *(fails: 47 errors, 253 warnings)*
- `npm test` (backend)`

------
https://chatgpt.com/codex/tasks/task_e_6896746d9ed483288c8866a22008e15c