### PR TITLE
Handle 404 when loading book details

### DIFF
--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -78,6 +78,9 @@ export const fetchBook = async (id, { admin = false, ...config } = {}) => {
       : await api.get(endpoint);
     return data?.data ? formatBook(data.data) : null;
   } catch (err) {
+    // If the book doesn't exist, return null so callers can handle gracefully
+    if (err?.response?.status === 404) return null;
+
     if (admin && err.name !== "CanceledError" && err.name !== "AbortError") {
       const { data } = hasConfig
         ? await api.get(`/books/${id}`, config)

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -133,6 +133,14 @@ describe("bookService", () => {
     });
   });
 
+  it("returns null when book is not found", async () => {
+    const error = { response: { status: 404 } };
+    api.get.mockRejectedValueOnce(error);
+    const book = await fetchBook(999);
+    expect(api.get).toHaveBeenCalledWith("/books/999");
+    expect(book).toBeNull();
+  });
+
   it("updates a book", async () => {
     const apiData = { id: 1 };
     api.put.mockResolvedValueOnce({ data: { data: apiData } });


### PR DESCRIPTION
## Summary
- Return `null` from `fetchBook` when backend responds with 404
- Add test covering missing book

## Testing
- `npm test` (frontend)
- `npm test` (backend)
- `npm run lint` (frontend) *(fails: 47 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689673d7e1ec8328af262ee06da6b31c