### PR TITLE
feat: add admin book listing and filter active books

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -104,7 +104,12 @@ exports.createBook = catchAsync(async (req, res) => {
 });
 
 exports.listBooks = catchAsync(async (req, res) => {
-  const result = await service.listBooks(req.query);
+  const isAdminRequest = req.user && isAdminRole(req.user.roles || req.user.role);
+  const query = { ...req.query };
+  if (!isAdminRequest && !query.status) {
+    query.status = "active";
+  }
+  const result = await service.listBooks(query);
   sendSuccess(res, result.data, "Books fetched", result.meta);
 });
 

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -10,6 +10,7 @@ const {
 
 router.get("/tags", verifyToken, isAdmin, tagController.listTags);
 router.post("/tags", verifyToken, isAdmin, tagController.createTag);
+router.get("/admin", verifyToken, isAdmin, controller.listBooks);
 router.get("/", controller.listBooks);
 router.get("/admin/:id", verifyToken, isAdmin, controller.getBookAdmin);
 router.get("/:id", controller.getBook);

--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -104,7 +104,7 @@ export default function BooksPage() {
         const { books: data } = await fetchBooks({
           page,
           perPage: 6,
-          filters: { ...filters, search: searchQuery },
+          filters: { ...filters, search: searchQuery, status: "active" },
           sort: sortBy !== "default" ? { sortBy } : {},
         });
         setBooks((prev) => (page === 1 ? data : [...prev, ...data]));


### PR DESCRIPTION
## Summary
- add admin-specific book list endpoint
- default public book queries to active status only
- ensure marketplace only fetches active books

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68971a1ec95083289d1dcb3417d9b80c