### PR TITLE
Ensure public book listings show only active books

### DIFF
--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -104,7 +104,7 @@ export default function BooksPage() {
         const { books: data } = await fetchBooks({
           page,
           perPage: 6,
-          filters: { ...filters, search: searchQuery },
+          filters: { ...filters, search: searchQuery, status: "active" },
           sort: sortBy !== "default" ? { sortBy } : {},
         });
         setBooks((prev) => (page === 1 ? data : [...prev, ...data]));

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -60,6 +60,9 @@ export const fetchBooks = async ({
     ...filters,
     ...sort,
   };
+  if (!admin && params.status === undefined) {
+    params.status = "active";
+  }
   const endpoint = admin ? "/books/admin" : "/books";
   const { data } = await api.get(endpoint, { params });
   const list = data?.data ? data.data.map(formatBook) : [];

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -28,7 +28,13 @@ describe("bookService", () => {
       sort: { sortBy: "title" },
     });
     expect(api.get).toHaveBeenCalledWith("/books", {
-      params: { page: 2, perPage: 5, search: "test", sortBy: "title" },
+      params: {
+        page: 2,
+        perPage: 5,
+        search: "test",
+        sortBy: "title",
+        status: "active",
+      },
     });
     expect(res).toEqual({
       books: [


### PR DESCRIPTION
## Summary
- Default bookService to request only active books for non-admins
- Enforce active status filter on marketplace book page
- Update bookService tests for active book filtering

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68971a1ec95083289d1dcb3417d9b80c