### PR TITLE
Fix admin book filtering and load active books

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -129,10 +129,19 @@ function AdminBooksPage() {
     async (currentPage = page) => {
       try {
         setLoading(true);
-        const activeFilters = { ...filters };
-        if (activeFilters.priceRange === null || activeFilters.priceRange <= 0) {
-          delete activeFilters.priceRange;
-        }
+        const activeFilters = Object.entries(filters).reduce((acc, [key, value]) => {
+          if (
+            value === "" ||
+            value === null ||
+            value === undefined ||
+            (Array.isArray(value) && value.length === 0) ||
+            (key === "priceRange" && (value === null || value <= 0))
+          ) {
+            return acc;
+          }
+          acc[key] = value;
+          return acc;
+        }, {});
         const { books: list, meta } = await fetchBooks({
           page: currentPage,
           perPage,

--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -104,7 +104,7 @@ export default function BooksPage() {
         const { books: data } = await fetchBooks({
           page,
           perPage: 6,
-          filters: { ...filters, search: searchQuery },
+          filters: { ...filters, search: searchQuery, status: "active" },
           sort: sortBy !== "default" ? { sortBy } : {},
         });
         setBooks((prev) => (page === 1 ? data : [...prev, ...data]));

--- a/frontend/src/store/library/libraryStore.js
+++ b/frontend/src/store/library/libraryStore.js
@@ -12,7 +12,10 @@ const useLibraryStore = create(
         set({ isLoading: true, error: null });
         try {
           const data = await apiFetchLibrary();
-          set({ books: data, isLoading: false });
+          const activeBooks = Array.isArray(data)
+            ? data.filter((b) => b?.status === "active")
+            : [];
+          set({ books: activeBooks, isLoading: false });
         } catch (err) {
           set({ error: err.message, isLoading: false });
         }

--- a/frontend/src/store/libraryStore.js
+++ b/frontend/src/store/libraryStore.js
@@ -8,7 +8,10 @@ const useLibraryStore = create((set) => ({
     set({ loading: true });
     try {
       const items = await apiFetchLibrary();
-      set({ items, loading: false });
+      const activeItems = Array.isArray(items)
+        ? items.filter((b) => b?.status === "active")
+        : [];
+      set({ items: activeItems, loading: false });
     } catch (err) {
       set({ loading: false });
     }


### PR DESCRIPTION
## Summary
- ensure admin book list omits empty filter values to avoid invalid queries
- fetch only active books on the marketplace page
- filter library stores to retain only active books

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68971a1ec95083289d1dcb3417d9b80c