### PR TITLE
Limit book listings to active items and add admin route

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -104,6 +104,14 @@ exports.createBook = catchAsync(async (req, res) => {
 });
 
 exports.listBooks = catchAsync(async (req, res) => {
+  const result = await service.listBooks({
+    ...req.query,
+    status: req.query.status || "active",
+  });
+  sendSuccess(res, result.data, "Books fetched", result.meta);
+});
+
+exports.listBooksAdmin = catchAsync(async (req, res) => {
   const result = await service.listBooks(req.query);
   sendSuccess(res, result.data, "Books fetched", result.meta);
 });

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -11,6 +11,7 @@ const {
 router.get("/tags", verifyToken, isAdmin, tagController.listTags);
 router.post("/tags", verifyToken, isAdmin, tagController.createTag);
 router.get("/", controller.listBooks);
+router.get("/admin", verifyToken, isAdmin, controller.listBooksAdmin);
 router.get("/admin/:id", verifyToken, isAdmin, controller.getBookAdmin);
 router.get("/:id", controller.getBook);
 router.post("/", verifyToken, isAdmin, upload, controller.createBook);

--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -104,7 +104,7 @@ export default function BooksPage() {
         const { books: data } = await fetchBooks({
           page,
           perPage: 6,
-          filters: { ...filters, search: searchQuery },
+          filters: { ...filters, search: searchQuery, status: "active" },
           sort: sortBy !== "default" ? { sortBy } : {},
         });
         setBooks((prev) => (page === 1 ? data : [...prev, ...data]));


### PR DESCRIPTION
## Summary
- Restrict public book list to active items by default
- Add `/books/admin` endpoint for authenticated admin listings
- Ensure marketplace book page requests only active books

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68971a1ec95083289d1dcb3417d9b80c