### PR TITLE
Allow instructors to manage books and send SMS alerts

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -7,6 +7,7 @@ const notificationService = require("../notifications/notifications.service");
 const messageService = require("../messages/messages.service");
 const mailService = require("../../services/mailService");
 const userModel = require("../users/user.model");
+const smsService = require("../../services/smsService");
 
 const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
 const isAdminRole = (roles = []) => {
@@ -77,6 +78,9 @@ exports.createBook = catchAsync(async (req, res) => {
           html: `<p>${userMessage} We will notify you when it is published.</p>`,
         })
       : Promise.resolve(),
+    req.user.phone
+      ? smsService.sendSMS({ to: req.user.phone, text: userMessage })
+      : Promise.resolve(),
     ...admins.map((admin) =>
       Promise.all([
         notificationService.createNotification({
@@ -95,6 +99,9 @@ exports.createBook = catchAsync(async (req, res) => {
               subject: "New book submitted",
               html: `<p>${adminMessage}</p>`,
             })
+          : Promise.resolve(),
+        admin.phone
+          ? smsService.sendSMS({ to: admin.phone, text: adminMessage })
           : Promise.resolve(),
       ])
     ),
@@ -261,6 +268,12 @@ exports.updateBookStatus = catchAsync(async (req, res) => {
                 html: `<p>${instructorMessage}</p>`,
               })
             : Promise.resolve(),
+          instructor.phone
+            ? smsService.sendSMS({
+                to: instructor.phone,
+                text: instructorMessage,
+              })
+            : Promise.resolve(),
         ])
       : Promise.resolve(),
     ...admins.map((admin) =>
@@ -281,6 +294,9 @@ exports.updateBookStatus = catchAsync(async (req, res) => {
               subject: "Book status updated",
               html: `<p>${adminMessage}</p>`,
             })
+          : Promise.resolve(),
+        admin.phone
+          ? smsService.sendSMS({ to: admin.phone, text: adminMessage })
           : Promise.resolve(),
       ])
     ),

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -6,6 +6,7 @@ const {
   verifyToken,
   isAdmin,
   isStudent,
+  isInstructorOrAdmin,
 } = require("../../middleware/auth/authMiddleware");
 
 router.get("/tags", verifyToken, isAdmin, tagController.listTags);
@@ -15,13 +16,13 @@ router.get("/", controller.listBooks);
 router.get("/admin", verifyToken, isAdmin, controller.listBooksAdmin);
 router.get("/admin/:id", verifyToken, isAdmin, controller.getBookAdmin);
 router.get("/:id", controller.getBook);
-router.post("/", verifyToken, isAdmin, upload, controller.createBook);
-router.put("/:id", verifyToken, isAdmin, upload, controller.updateBook);
-router.patch("/:id/status", verifyToken, isAdmin, controller.updateBookStatus);
+router.post("/", verifyToken, isInstructorOrAdmin, upload, controller.createBook);
+router.put("/:id", verifyToken, isInstructorOrAdmin, upload, controller.updateBook);
+router.patch("/:id/status", verifyToken, isInstructorOrAdmin, controller.updateBookStatus);
 router.post("/cart", verifyToken, isStudent, controller.updateCart);
 router.post("/checkout", verifyToken, isStudent, controller.checkout);
 router.post("/wishlist", verifyToken, isStudent, controller.addWishlist);
 router.delete("/wishlist", verifyToken, isStudent, controller.removeWishlist);
-router.delete("/:id", verifyToken, isAdmin, controller.deleteBook);
+router.delete("/:id", verifyToken, isInstructorOrAdmin, controller.deleteBook);
 
 module.exports = router;

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -49,6 +49,7 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
   }),
   isAdmin: jest.fn((_req, _res, next) => next()),
   isStudent: jest.fn((_req, _res, next) => next()),
+  isInstructorOrAdmin: jest.fn((_req, _res, next) => next()),
 }));
 
 const service = require('../src/modules/books/book.service');


### PR DESCRIPTION
## Summary
- Allow instructors to create, update, and delete books via instructor-or-admin routes
- Send SMS notifications to instructors and admins on book creation and status changes

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689740ff27848328b4d189f6e04001ef