### PR TITLE
Allow instructors to create books

### DIFF
--- a/backend/src/modules/books/instructorBook.routes.js
+++ b/backend/src/modules/books/instructorBook.routes.js
@@ -1,10 +1,15 @@
 const router = require("express").Router();
 const controller = require("./book.controller");
-const { verifyToken, isInstructorOrAdmin } = require("../../middleware/auth/authMiddleware");
+const upload = require("./bookUploadMiddleware");
+const {
+  verifyToken,
+  isInstructorOrAdmin,
+} = require("../../middleware/auth/authMiddleware");
 
 router.use(verifyToken, isInstructorOrAdmin);
 
 router.get("/analytics", controller.getInstructorBookAnalytics);
 router.get("/", controller.listInstructorBooks);
+router.post("/", upload, controller.createBook);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- expose POST `/api/instructor/books` endpoint so instructors can create books

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689740ff27848328b4d189f6e04001ef