### PR TITLE
feat: localize book upload validation messages

### DIFF
--- a/frontend/public/locales/ar/validation.json
+++ b/frontend/public/locales/ar/validation.json
@@ -1,0 +1,9 @@
+{
+  "fileTooLarge": "يجب أن يكون حجم الملف أقل من {{size}}",
+  "pngJpgWebpOnly": "يسمح فقط بملفات PNG أو JPG أو WEBP",
+  "pdfOnly": "PDF فقط",
+  "pdfOrImageOnly": "يسمح فقط بملفات PDF أو الصور",
+  "eachFileLessThan": "يجب أن يكون كل ملف أقل من {{size}}",
+  "maxFiles": "يمكنك تحميل ما يصل إلى {{count}} ملفات",
+  "invalidFileType": "نوع ملف غير صالح"
+}

--- a/frontend/public/locales/de/validation.json
+++ b/frontend/public/locales/de/validation.json
@@ -1,0 +1,9 @@
+{
+  "fileTooLarge": "Dateigröße muss kleiner als {{size}} sein",
+  "pngJpgWebpOnly": "Nur PNG-, JPG- oder WEBP-Dateien sind erlaubt",
+  "pdfOnly": "Nur PDF",
+  "pdfOrImageOnly": "Es sind nur PDF- oder Bilddateien erlaubt",
+  "eachFileLessThan": "Jede Datei muss kleiner als {{size}} sein",
+  "maxFiles": "Sie können bis zu {{count}} Dateien hochladen",
+  "invalidFileType": "Ungültiger Dateityp"
+}

--- a/frontend/public/locales/en/validation.json
+++ b/frontend/public/locales/en/validation.json
@@ -1,0 +1,9 @@
+{
+  "fileTooLarge": "File size must be less than {{size}}",
+  "pngJpgWebpOnly": "Only PNG, JPG or WEBP files are allowed",
+  "pdfOnly": "PDF only",
+  "pdfOrImageOnly": "Only PDF or image files are allowed",
+  "eachFileLessThan": "Each file must be less than {{size}}",
+  "maxFiles": "You can upload up to {{count}} files",
+  "invalidFileType": "Invalid file type"
+}

--- a/frontend/public/locales/es/validation.json
+++ b/frontend/public/locales/es/validation.json
@@ -1,0 +1,9 @@
+{
+  "fileTooLarge": "El tamaño del archivo debe ser menor que {{size}}",
+  "pngJpgWebpOnly": "Solo se permiten archivos PNG, JPG o WEBP",
+  "pdfOnly": "Solo PDF",
+  "pdfOrImageOnly": "Solo se permiten archivos PDF o de imagen",
+  "eachFileLessThan": "Cada archivo debe ser menor que {{size}}",
+  "maxFiles": "Puedes subir hasta {{count}} archivos",
+  "invalidFileType": "Tipo de archivo no válido"
+}

--- a/frontend/public/locales/fr/validation.json
+++ b/frontend/public/locales/fr/validation.json
@@ -1,0 +1,9 @@
+{
+  "fileTooLarge": "La taille du fichier doit être inférieure à {{size}}",
+  "pngJpgWebpOnly": "Seuls les fichiers PNG, JPG ou WEBP sont autorisés",
+  "pdfOnly": "PDF uniquement",
+  "pdfOrImageOnly": "Seuls les fichiers PDF ou image sont autorisés",
+  "eachFileLessThan": "Chaque fichier doit être inférieur à {{size}}",
+  "maxFiles": "Vous pouvez télécharger jusqu'à {{count}} fichiers",
+  "invalidFileType": "Type de fichier invalide"
+}

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -17,7 +17,7 @@ export default function BookForm({
   onCancel,
   showStatusSelector = false,
 }) {
-  const { t } = useTranslation(["dashboard", "common"]);
+  const { t } = useTranslation(["dashboard", "common", "validation"]);
   const {
     register,
     handleSubmit,
@@ -321,7 +321,7 @@ export default function BookForm({
                   "image/jpeg",
                   "image/webp",
                 ].includes(files[0].type) ||
-                "Only PNG, JPG or WEBP",
+                t("validation.pngJpgWebpOnly"),
               fileSize: (files) =>
                 !files[0] ||
                 files[0].size <= MAX_IMAGE_SIZE ||
@@ -366,9 +366,11 @@ export default function BookForm({
             required: !isEdit && t("booksCreate.bookFileRequired"),
             validate: {
               fileType: (files) =>
-                !files[0] || files[0].type === "application/pdf" || "PDF only",
+                !files[0] || files[0].type === "application/pdf" || t("validation.pdfOnly"),
               fileSize: (files) =>
-                !files[0] || files[0].size <= 50 * 1024 * 1024 || "Max 50MB",
+                !files[0] ||
+                files[0].size <= 50 * 1024 * 1024 ||
+                t("validation.fileTooLarge", { size: "50MB" }),
             },
           });
           return (
@@ -409,7 +411,7 @@ export default function BookForm({
                     (file) =>
                       file.type === "application/pdf" ||
                       file.type.startsWith("image/")
-                  ) || "Only PDF or image files are allowed"
+                  ) || t("validation.pdfOrImageOnly")
                 );
               },
               fileSize: (files) => {
@@ -417,12 +419,15 @@ export default function BookForm({
                 return (
                   Array.from(files).every(
                     (file) => file.size <= 50 * 1024 * 1024
-                  ) || "Each file must be less than 50MB"
+                  ) || t("validation.eachFileLessThan", { size: "50MB" })
                 );
               },
               fileCount: (files) => {
                 if (!files || files.length === 0) return true;
-                return files.length <= 10 || "You can upload up to 10 files";
+                return (
+                  files.length <= 10 ||
+                  t("validation.maxFiles", { count: 10 })
+                );
               },
             },
           });


### PR DESCRIPTION
## Summary
- replace hardcoded book upload validation strings with i18n lookups
- add validation locale files for supported languages

## Testing
- `npm test`
- `npm run lint` *(fails: 47 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689745b6569483289e36206b40b6678f