### PR TITLE
fix: ensure fresh regex for link detection

### DIFF
--- a/frontend/src/components/shared/LinkText.js
+++ b/frontend/src/components/shared/LinkText.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
-const urlRegex = /(https?:\/\/[^\s]+)/g;
+const urlRegex = /(https?:\/\/[^\s]+)/;
 
 export default function LinkText({ text }) {
   const parts = text.split(urlRegex);
   return (
     <>
       {parts.map((part, index) =>
-        urlRegex.test(part) ? (
+        new RegExp(urlRegex).test(part) ? (
           <a
             key={index}
             href={part}


### PR DESCRIPTION
## Summary
- use a fresh, non-global regex when converting URLs to anchor links

## Testing
- `npm test`
- `npm run lint` *(fails: 47 errors, 253 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689745b4a1b883289e81a9db033a4a42