### PR TITLE
Scope notification cleanup to user

### DIFF
--- a/backend/src/modules/notifications/notifications.service.js
+++ b/backend/src/modules/notifications/notifications.service.js
@@ -9,8 +9,10 @@ exports.createNotification = async ({ user_id, type, message }) => {
 
 exports.getUserNotifications = async (userId) => {
   const threshold = new Date(Date.now() - 60 * 60 * 1000);
+  // Cleanup read notifications older than an hour for this user
+  // If system-wide deletion is needed, consider moving cleanup to a scheduled job
   await db("notifications")
-    .where({ read: true })
+    .where({ read: true, user_id: userId })
     .andWhere("read_at", "<", threshold)
     .del();
   return db("notifications")


### PR DESCRIPTION
## Summary
- restrict notification cleanup to the requesting user
- note that system-wide cleanup should run as a scheduled job

## Testing
- `npm test` *(fails: bookRoutes.test.js, instructorBookRoutes.test.js – Identifier 'smsService' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_689745b37bd08328bc0009819115af75