### PR TITLE
Fix admin book route

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -8,7 +8,6 @@ const messageService = require("../messages/messages.service");
 const mailService = require("../../services/mailService");
 const smsService = require("../../services/smsService");
 const userModel = require("../users/user.model");
-const smsService = require("../../services/smsService");
 
 const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
 const isAdminRole = (roles = []) => {

--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -11,7 +11,6 @@ const {
 
 router.get("/tags", verifyToken, isAdmin, tagController.listTags);
 router.post("/tags", verifyToken, isAdmin, tagController.createTag);
-router.get("/admin", verifyToken, isAdmin, controller.listBooks);
 router.get("/", controller.listBooks);
 router.get("/admin", verifyToken, isAdmin, controller.listBooksAdmin);
 router.get("/admin/:id", verifyToken, isAdmin, controller.getBookAdmin);


### PR DESCRIPTION
## Summary
- remove duplicate `/admin` route and point to admin-specific book listing
- remove duplicate `smsService` import in book controller

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689745b2568c8328a11f3b4a8af4f1bf