### PR TITLE
fix: avoid erroneous book creation failure toast

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -67,7 +67,13 @@ function AdminCreateBookPage() {
       });
 
       toast.success(t("booksCreate.success"));
-      await Promise.all([fetchNotifications(), fetchMessages()]);
+
+      try {
+        await Promise.all([fetchNotifications(), fetchMessages()]);
+      } catch (notifyErr) {
+        console.error("Failed to refresh notifications or messages", notifyErr);
+      }
+
       router.push("/dashboard/admin/books");
     } catch (err) {
       console.error("Failed to create book", err);


### PR DESCRIPTION
## Summary
- prevent error toast when refreshing notifications fails after creating book
- log notification/ message refresh errors without interrupting book creation flow

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689759c0fbdc83289a27a9a4b1853d0d