### PR TITLE
refactor: use react-toastify in book filter sidebar

### DIFF
--- a/frontend/src/components/books/FilterSidebar.js
+++ b/frontend/src/components/books/FilterSidebar.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { FaTimesCircle } from "react-icons/fa";
 import { fetchBookCategories } from "@/services/bookCategoryService";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 
 const BookFilterSidebar = ({ onFilterChange, onResetFilters }) => {
   const [categories, setCategories] = useState([]);

--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -9,7 +9,8 @@ import BookFilterSidebar from "@/components/books/FilterSidebar";
 import { fetchBooks, buildUrl } from "@/services/bookService";
 import useBookWishlistStore from "@/store/books/wishlistStore";
 import useBookCartStore from "@/store/books/cartStore";
-import { toast } from "react-toastify";
+import { toast, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 const buildBookItem = (book) => ({
   book_id: book.id,
@@ -163,6 +164,7 @@ export default function BooksPage() {
     <section className="min-h-screen relative bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
       <div className="absolute inset-0 bg-[url('/grid-pattern.svg')] bg-center opacity-10" />
       <Navbar />
+      <ToastContainer position="top-right" autoClose={3000} />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 relative z-10">
         <motion.div


### PR DESCRIPTION
## Summary
- replace react-hot-toast with react-toastify in book filter sidebar
- add ToastContainer to books marketplace page for toast display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68975c6ecdb4832894a0caadc7661e8c