### PR TITLE
feat: add locale-aware currency formatter

### DIFF
--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -9,14 +9,7 @@ import {
   FiShoppingCart,
 } from "react-icons/fi";
 import { buildUrl } from "@/services/bookService";
-
-
-const priceFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+import { formatCurrency } from "@/utils/currency";
 
 export default function BookCard({
   book,
@@ -69,9 +62,7 @@ export default function BookCard({
       />
       <div className="p-4">
         <h3 className="font-semibold mb-1 line-clamp-1">{book.title}</h3>
-        <p className="text-sm mb-3">
-          {priceFormatter.format(Number(book.price ?? 0))}
-        </p>
+        <p className="text-sm mb-3">{formatCurrency(book.price)}</p>
         <div className="flex gap-2">
           <Link
             href={viewLink || `/marketplace/books/${book.id}`}

--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -4,6 +4,7 @@ import { toast } from "react-toastify";
 import useBookCartStore from "@/store/books/cartStore";
 import useAuthStore from "@/store/auth/authStore";
 import { buildUrl } from "@/services/bookService";
+import { formatCurrency } from "@/utils/currency";
 
 const buildBookItem = (b) => ({
   book_id: b.id,
@@ -117,7 +118,7 @@ export default function BookDetails({ book }) {
         </p>
 
         <p className="text-xl font-semibold mb-6">
-          {Number(book.price) > 0 ? `$${book.price}` : "Free"}
+          {Number(book.price) > 0 ? formatCurrency(book.price) : "Free"}
         </p>
         {actionButtons}
       </div>

--- a/frontend/src/tests/__tests__/BookCard.test.js
+++ b/frontend/src/tests/__tests__/BookCard.test.js
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import BookCard from '@/components/books/BookCard';
+import useAppConfigStore from '@/store/appConfigStore';
 
+const mockI18n = { language: 'en-US' };
 jest.mock('next-i18next', () => ({
-  useTranslation: () => ({ t: (key) => key }),
+  useTranslation: () => ({ t: (key) => key, i18n: mockI18n }),
 }));
 
 jest.mock('next/link', () => ({
@@ -15,9 +17,22 @@ jest.mock('next/link', () => ({
 }));
 
 describe('BookCard', () => {
-  it('formats price to two decimal places', () => {
+  beforeEach(() => {
+    useAppConfigStore.setState({ settings: { currency: 'USD' } });
+    mockI18n.language = 'en-US';
+  });
+
+  it('formats price to two decimal places in USD', () => {
     const book = { id: 1, title: 'Test Book', price: 10 };
     render(<BookCard book={book} />);
     expect(screen.getByText('$10.00')).toBeInTheDocument();
+  });
+
+  it('formats price based on locale and currency', () => {
+    const book = { id: 1, title: 'Test Book', price: 10 };
+    useAppConfigStore.setState({ settings: { currency: 'GBP' } });
+    mockI18n.language = 'en-GB';
+    render(<BookCard book={book} />);
+    expect(screen.getByText('£10.00')).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/__tests__/BookDetails.test.js
+++ b/frontend/src/tests/__tests__/BookDetails.test.js
@@ -1,19 +1,45 @@
 import { render, screen } from '@testing-library/react';
 import BookDetails from '@/components/books/BookDetails';
+import useAppConfigStore from '@/store/appConfigStore';
+import useAuthStore from '@/store/auth/authStore';
+
+const mockI18n = { language: 'en-US' };
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key, i18n: mockI18n }),
+}));
 
 jest.mock('next/router', () => ({
   useRouter: () => ({ push: jest.fn() }),
 }));
 
-jest.mock('../../store/cart/cartStore', () => () => ({ addItem: jest.fn() }));
-jest.mock('../../store/auth/authStore', () => () => ({ isAuthenticated: () => true, user: { role: 'student' } }));
-
-jest.mock('react-toastify', () => ({ toast: { info: jest.fn(), error: jest.fn(), success: jest.fn() } }));
+jest.mock('react-toastify', () => ({
+  toast: { info: jest.fn(), error: jest.fn(), success: jest.fn() },
+}));
 
 describe('BookDetails', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ user: { role: 'student' }, accessToken: 'token' });
+    useAppConfigStore.setState({ settings: { currency: 'USD' } });
+    mockI18n.language = 'en-US';
+  });
+
   it('displays rating even when zero', () => {
     const book = { id: 1, title: 'Test', rating: 0, is_paid: false, pdf_url: null };
     render(<BookDetails book={book} />);
     expect(screen.getByText('⭐ 0.0 / 5')).toBeInTheDocument();
+  });
+
+  it('formats price in USD', () => {
+    const book = { id: 1, title: 'Test', price: 10, is_paid: true, user_has_access: false };
+    render(<BookDetails book={book} />);
+    expect(screen.getByText('$10.00')).toBeInTheDocument();
+  });
+
+  it('formats price based on locale and currency', () => {
+    const book = { id: 1, title: 'Test', price: 10, is_paid: true, user_has_access: false };
+    useAppConfigStore.setState({ settings: { currency: 'GBP' } });
+    mockI18n.language = 'en-GB';
+    render(<BookDetails book={book} />);
+    expect(screen.getByText('£10.00')).toBeInTheDocument();
   });
 });

--- a/frontend/src/utils/currency.js
+++ b/frontend/src/utils/currency.js
@@ -1,0 +1,41 @@
+import { i18n } from "next-i18next";
+import useAppConfigStore from "@/store/appConfigStore";
+import useAuthStore from "@/store/auth/authStore";
+
+/**
+ * Build an Intl.NumberFormat using the current locale and currency from
+ * configuration or user preferences.
+ *
+ * @param {Object} [override]
+ * @param {string} [override.locale] - Locale to override.
+ * @param {string} [override.currency] - Currency code to override.
+ */
+export const getCurrencyFormatter = (override = {}) => {
+  const locale =
+    override.locale ||
+    i18n?.language ||
+    useAppConfigStore.getState().settings?.locale ||
+    "en-US";
+
+  const currency =
+    override.currency ||
+    useAuthStore.getState().user?.currency ||
+    useAuthStore.getState().user?.pricing_currency ||
+    useAppConfigStore.getState().settings?.currency ||
+    "USD";
+
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};
+
+/**
+ * Format a numeric value as currency using locale and currency from
+ * configuration or user settings.
+ */
+export const formatCurrency = (value, override = {}) =>
+  getCurrencyFormatter(override).format(Number(value ?? 0));
+


### PR DESCRIPTION
## Summary
- add shared currency formatter using user or app settings
- replace hard-coded currency display in book components
- cover multiple locale/currency combinations in tests

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68975c6fe8108328a78a0c8a1caaa453