### PR TITLE
fix: align book filters with backend

### DIFF
--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -101,8 +101,10 @@ export default function BooksPage() {
       try {
         setLoading(true);
         const apiFilters = {
-          ...(filters.categories.length && { category: filters.categories[0] }),
-          ...(filters.price !== undefined && { priceRange: filters.price }),
+          ...(filters.category && { category: filters.category }),
+          ...(filters.priceRange !== undefined && {
+            priceRange: filters.priceRange,
+          }),
           ...(filters.language && { language: filters.language }),
           ...(filters.license && { license: filters.license }),
           ...(filters.tags.length && { tags: filters.tags }),

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -24,7 +24,7 @@ describe("bookService", () => {
     const res = await fetchBooks({
       page: 2,
       perPage: 5,
-      filters: { search: "test" },
+      filters: { search: "test", category: "c1", priceRange: 25 },
       sort: { sortBy: "title" },
     });
     expect(api.get).toHaveBeenCalledWith("/books", {
@@ -32,6 +32,8 @@ describe("bookService", () => {
         page: 2,
         perPage: 5,
         search: "test",
+        category: "c1",
+        priceRange: 25,
         sortBy: "title",
         status: "active",
       },


### PR DESCRIPTION
## Summary
- replace outdated `categories`/`price` keys with `category` and `priceRange`
- verify `fetchBooks` forwards new filter params

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68975c733cd88328b1b9954471b808f3