### PR TITLE
fix: add getStaticPaths for book detail page

### DIFF
--- a/frontend/src/pages/marketplace/books/[id].js
+++ b/frontend/src/pages/marketplace/books/[id].js
@@ -48,7 +48,7 @@ export default function BookDetailPage() {
       isMounted = false;
       controller.abort();
     };
-  }, [id]);
+  }, [id, t]);
 
   return (
     <section className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-gray-100">
@@ -86,5 +86,12 @@ export async function getStaticProps({ locale }) {
     props: {
       ...(await serverSideTranslations(locale, ["common", "website"], nextI18NextConfig)),
     },
+  };
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: "blocking",
   };
 }


### PR DESCRIPTION
## Summary
- add getStaticPaths with blocking fallback for dynamic book detail page
- include translation hook in effect dependencies

## Testing
- `npm test` *(fails: 1 failed, 14 passed)*
- `npx eslint src/pages/marketplace/books/[id].js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897631344a4832889c4f2b2e5ea19dd