### PR TITLE
feat(frontend): clip book covers to rounded cards

### DIFF
--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -36,7 +36,7 @@ export default function BookCard({
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm hover:shadow-md transition-shadow relative">
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow relative">
       {onSelect && (
         <input
           type="checkbox"


### PR DESCRIPTION
## Summary
- ensure book cover images are clipped to rounded card corners

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook "useTranslation" is called in function "fetch"...)*
- `npx eslint src/components/books/BookCard.js`


------
https://chatgpt.com/codex/tasks/task_e_68976ba354f48328a8fcbbc5a035ddba