### PR TITLE
Ensure instructor book service returns absolute cover images

### DIFF
--- a/frontend/src/services/instructor/bookService.js
+++ b/frontend/src/services/instructor/bookService.js
@@ -1,4 +1,5 @@
 import api from "@/services/api/api";
+import { buildUrl } from "@/services/bookService";
 
 // Fetch books belonging to the current instructor with
 // optional pagination, filtering and status parameters
@@ -24,7 +25,12 @@ export const fetchInstructorBooks = async ({
     response = await api.get("/instructor/books");
   }
   const { data } = response;
-  const list = data?.data || [];
+  const list = data?.data
+    ? data.data.map((book) => ({
+        ...book,
+        cover_image_url: buildUrl(book?.cover_image_url || book?.cover_image),
+      }))
+    : [];
   return { books: list, meta: data?.meta ?? {} };
 
 };
@@ -53,7 +59,13 @@ export const deleteBook = async (id) => {
 // Fetch a single book by ID for the current instructor
 export const fetchBook = async (id) => {
   const { data } = await api.get(`/books/${id}`);
-  return data?.data || null;
+  const book = data?.data || null;
+  return book
+    ? {
+        ...book,
+        cover_image_url: buildUrl(book?.cover_image_url || book?.cover_image),
+      }
+    : null;
 };
 
 // Fetch aggregated analytics about the instructor's books

--- a/frontend/src/tests/__tests__/instructorBookService.test.js
+++ b/frontend/src/tests/__tests__/instructorBookService.test.js
@@ -26,7 +26,10 @@ describe("instructor bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData, meta } });
     const res = await fetchInstructorBooks();
     expect(api.get).toHaveBeenCalledWith("/instructor/books");
-    expect(res).toEqual({ books: apiData, meta });
+    expect(res).toEqual({
+      books: [{ ...apiData[0], cover_image_url: null }],
+      meta,
+    });
   });
 
   it("creates a book", async () => {
@@ -75,7 +78,7 @@ describe("instructor bookService", () => {
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const res = await fetchBook(1);
     expect(api.get).toHaveBeenCalledWith("/books/1");
-    expect(res).toEqual(apiData);
+    expect(res).toEqual({ ...apiData, cover_image_url: null });
   });
 
   it("fetches analytics", async () => {


### PR DESCRIPTION
## Summary
- Ensure instructor book service returns books with absolute `cover_image_url`
- Apply same formatting to single-book fetches
- Align instructor book service tests with new cover image format

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68976b609d5883288dba1a2ee9501931