### PR TITLE
Fix instructor availability toggle

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -58,10 +58,15 @@ exports.toggleStatus = async (req, res) => {
     if (typeof is_online !== "boolean") {
         return res.status(400).json({ message: "is_online must be true or false." });
     }
+    const [updated] = await db("users")
+        .where({ id: userId })
+        .update({ is_online })
+        .returning(["id", "is_online"]);
 
-    await db("users").where({ id: userId }).update({ is_online });
-
-    res.json({ message: `Status set to ${is_online ? "online" : "offline"}` });
+    res.json({
+        message: `Status set to ${updated.is_online ? "online" : "offline"}`,
+        is_online: updated.is_online,
+    });
 };
 
 /**

--- a/backend/tests/instructorStatusRoutes.test.js
+++ b/backend/tests/instructorStatusRoutes.test.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database');
+const db = require('../src/config/database');
+
+db.mockImplementation(() => ({
+  where: () => ({
+    update: () => ({
+      returning: () => Promise.resolve([{ id: 'user1', is_online: true }])
+    })
+  })
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'user1' }; next(); },
+  isInstructor: (_req, _res, next) => next(),
+}));
+
+const routes = require('../src/modules/users/instructor/instructor.routes');
+const app = express();
+app.use(express.json());
+app.use('/api/users/instructor', routes);
+
+describe('PATCH /api/users/instructor/status', () => {
+  it('updates online status and returns new value', async () => {
+    const res = await request(app)
+      .patch('/api/users/instructor/status')
+      .send({ is_online: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      message: 'Status set to online',
+      is_online: true,
+    });
+  });
+});

--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -170,12 +170,13 @@ export default function Header() {
             onClick={async () => {
               const newStatus = !available;
               try {
-                await toggleInstructorStatus(newStatus);
-                setAvailable(newStatus);
+                const res = await toggleInstructorStatus(newStatus);
+                const updated = res?.is_online ?? newStatus;
+                setAvailable(updated);
                 const setUser = useAuthStore.getState().setUser;
-                setUser({ ...user, is_online: newStatus });
+                setUser({ ...user, is_online: updated });
                 toast.success(
-                  newStatus
+                  updated
                     ? t('available_now')
                     : t('unavailable_now')
                 );

--- a/frontend/src/pages/dashboard/instructor/availability.js
+++ b/frontend/src/pages/dashboard/instructor/availability.js
@@ -112,10 +112,11 @@ export default function InstructorAvailabilityPage() {
             onClick={async () => {
               const newStatus = !available;
               try {
-                await toggleInstructorStatus(newStatus);
-                setAvailable(newStatus);
-                setUser({ ...user, is_online: newStatus });
-                toast.success(newStatus ? 'You are now available' : 'You are now unavailable');
+                const res = await toggleInstructorStatus(newStatus);
+                const updated = res?.is_online ?? newStatus;
+                setAvailable(updated);
+                setUser({ ...user, is_online: updated });
+                toast.success(updated ? 'You are now available' : 'You are now unavailable');
               } catch (err) {
                 toast.error('Failed to update availability');
               }

--- a/frontend/src/services/instructor/instructorService.js
+++ b/frontend/src/services/instructor/instructorService.js
@@ -68,7 +68,7 @@ export const changeInstructorPassword = async (payload) => {
 // 🔹 Toggle online/offline status
 export const toggleInstructorStatus = async (is_online) => {
   const res = await api.patch("/users/instructor/status", { is_online });
-  return res.data;
+  return res.data; // { message, is_online }
 };
 
 // 🔹 Get profile completion status


### PR DESCRIPTION
## Summary
- return online status in instructor status toggle endpoint
- sync frontend header and availability page with API response when updating status
- cover instructor status toggle with a dedicated test

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977583cd188328aa454228eb1da4e2