### PR TITLE
Allow admin to assign instructor when creating tutorials

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -54,6 +54,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     status = "draft",
     tags: rawTags,
     chapters = [],
+    instructor_id: bodyInstructorId,
   } = req.body;
 
   // In case chapters came as a serialized JSON string, parse it
@@ -77,7 +78,21 @@ exports.createTutorial = catchAsync(async (req, res) => {
     return res.status(400).json({ message: "Tutorial title already exists" });
   }
 
-  const instructor_id = req.user.id;
+  let instructor = null;
+  let instructor_id;
+  if (
+    ["admin", "superadmin"].includes(req.user.role) &&
+    bodyInstructorId
+  ) {
+    instructor = await userModel.findById(bodyInstructorId);
+    if (!instructor) {
+      return res.status(404).json({ message: "Instructor not found" });
+    }
+    instructor_id = bodyInstructorId;
+  } else {
+    instructor_id = req.user.id;
+  }
+
   const slug = await generateUniqueSlug(title);
   const id = uuidv4();
 
@@ -165,7 +180,9 @@ exports.createTutorial = catchAsync(async (req, res) => {
       "New tutorial added successfully. It's under review and will be available after we approve it",
   });
 
-  const instructor = await userModel.findById(instructor_id);
+  if (!instructor) {
+    instructor = await userModel.findById(instructor_id);
+  }
   const admins = await userModel.findAdmins();
   await Promise.all(
     admins.map((admin) =>

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -23,6 +23,7 @@ exports.create = z.object({
     title: z.string().min(3),
     description: z.string().optional(),
     category_id: z.string(), // assuming UUID
+    instructor_id: z.string().uuid().optional(),
     level: z.string(),
     status: z.enum(["draft", "published", "archived"]).optional(),
     price: z.preprocess(

--- a/backend/tests/tutorialCreate.test.js
+++ b/backend/tests/tutorialCreate.test.js
@@ -1,0 +1,109 @@
+jest.mock('../src/config/database', () => {
+  const mockDb = jest.fn(() => ({
+    where: jest.fn().mockReturnThis(),
+    first: jest.fn().mockResolvedValue(null),
+  }));
+  mockDb.transaction = jest.fn(async (cb) => {
+    await cb({});
+  });
+  mockDb.raw = jest.fn();
+  return mockDb;
+});
+
+jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({
+  createTutorial: jest.fn(),
+  addTutorialTags: jest.fn(),
+  getTutorialTags: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/tutorials/chapters/tutorialChapter.service', () => ({
+  create: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/tutorials/tutorialTag.service', () => ({
+  findByName: jest.fn(),
+  createTag: jest.fn(),
+  getTutorialTags: jest.fn(),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findById: jest.fn(),
+  findAdmins: jest.fn(),
+}));
+
+jest.mock('../src/utils/email', () => ({
+  sendTutorialCreatedAdminEmail: jest.fn(),
+  sendTutorialCreatedInstructorEmail: jest.fn(),
+  sendTutorialApprovedEmail: jest.fn(),
+  sendTutorialRejectedEmail: jest.fn(),
+}));
+
+const controller = require('../src/modules/users/tutorials/tutorial.controller');
+const service = require('../src/modules/users/tutorials/tutorial.service');
+const userModel = require('../src/modules/users/user.model');
+
+
+describe('createTutorial', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    userModel.findAdmins.mockResolvedValue([]);
+  });
+
+  it('allows admin to create tutorial for another instructor', async () => {
+    const instructorId = '11111111-1111-1111-1111-111111111111';
+    userModel.findById.mockResolvedValue({ id: instructorId, full_name: 'Other Instructor', email: 'other@example.com' });
+    service.createTutorial.mockResolvedValue({ id: 'tut1' });
+
+    const req = {
+      body: {
+        title: 'Test Tut',
+        category_id: 'cat',
+        level: 'beginner',
+        instructor_id: instructorId,
+      },
+      user: { id: 'admin1', role: 'admin' },
+      files: {},
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await controller.createTutorial(req, res, jest.fn());
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(userModel.findById).toHaveBeenCalledWith(instructorId);
+    expect(service.createTutorial).toHaveBeenCalled();
+    const data = service.createTutorial.mock.calls[0][0];
+    expect(data.instructor_id).toBe(instructorId);
+  });
+
+  it('prevents instructor from creating tutorial for another instructor', async () => {
+    const otherId = '11111111-1111-1111-1111-111111111112';
+    const myId = '22222222-2222-2222-2222-222222222222';
+    userModel.findById.mockResolvedValue({ id: myId, full_name: 'Me', email: 'me@example.com' });
+    service.createTutorial.mockResolvedValue({ id: 'tut1' });
+
+    const req = {
+      body: {
+        title: 'Another Tut',
+        category_id: 'cat',
+        level: 'beginner',
+        instructor_id: otherId,
+      },
+      user: { id: myId, role: 'instructor' },
+      files: {},
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await controller.createTutorial(req, res, jest.fn());
+    await new Promise((resolve) => setImmediate(resolve));
+    const data = service.createTutorial.mock.calls[0][0];
+    expect(data.instructor_id).toBe(myId);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Enable `createTutorial` to optionally accept an `instructor_id` for admins and verify the instructor exists
- Extend tutorial validation schema with optional `instructor_id`
- Test tutorial creation for admin-assigned and instructor-owned scenarios

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689778275b948328bc39019cf3684d8d