### PR TITLE
Set tutorials to pending moderation on publish

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -297,7 +297,7 @@ exports.permanentlyDeleteTutorial = catchAsync(async (req, res) => {
 
 exports.togglePublishStatus = catchAsync(async (req, res) => {
   const tutorialId = req.params.id;
-  await service.togglePublishStatus(tutorialId);
+  const updated = await service.togglePublishStatus(tutorialId);
 
   const tut = await service.getTutorialById(tutorialId);
   if (
@@ -320,7 +320,11 @@ exports.togglePublishStatus = catchAsync(async (req, res) => {
     ]);
   }
 
-  sendSuccess(res, { message: "Status toggled" });
+  sendSuccess(res, {
+    message: "Status toggled",
+    status: updated.status,
+    moderation_status: updated.moderation_status,
+  });
 });
 
 

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -150,7 +150,19 @@ exports.permanentlyDeleteTutorial = async (id) => {
 exports.togglePublishStatus = async (id) => {
   const tutorial = await db("tutorials").where({ id }).first();
   const newStatus = tutorial.status === "published" ? "draft" : "published";
-  return db("tutorials").where({ id }).update({ status: newStatus });
+  const updateData = { status: newStatus };
+
+  if (newStatus === "published") {
+    updateData.moderation_status = "Pending";
+    updateData.rejection_reason = null;
+  }
+
+  const [updated] = await db("tutorials")
+    .where({ id })
+    .update(updateData)
+    .returning(["status", "moderation_status"]);
+
+  return updated;
 };
 
 exports.updateModeration = async (id, status, reason = null) => {

--- a/frontend/src/components/tutorials/ProgressChecklistModal.js
+++ b/frontend/src/components/tutorials/ProgressChecklistModal.js
@@ -23,7 +23,7 @@ export default function ProgressChecklistModal({ isOpen, onClose, tutorial }) {
     { label: "Language & Level", valid: tutorial.language && tutorial.level },
     { label: "Price or Free", valid: tutorial.price !== undefined },
     { label: "Quiz/Test", valid: tutorial.has_quiz || tutorial.quiz_questions?.length > 0 },
-    { label: "Submitted/Approved", valid: ["Submitted", "Approved"].includes(tutorial.status) },
+    { label: "Pending/Approved", valid: ["Pending", "Approved"].includes(tutorial.status) },
   ];
 
   return (

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -134,7 +134,7 @@ export default function ViewTutorialPage() {
           <div className="flex flex-wrap gap-3 items-center text-xs sm:text-sm text-gray-500">
             <span className={`px-3 py-1 rounded-full text-xs font-semibold
               ${tutorial.status === 'Approved' ? 'bg-green-100 text-green-700' :
-                tutorial.status === 'Submitted' ? 'bg-blue-100 text-blue-700' :
+                tutorial.status === 'Pending' ? 'bg-blue-100 text-blue-700' :
                 tutorial.status === 'Draft' ? 'bg-yellow-100 text-yellow-700' :
                 'bg-red-100 text-red-700'}`}>
               {tutorial.status}
@@ -254,7 +254,7 @@ export default function ViewTutorialPage() {
               <button
                 onClick={async () => {
                   await submitTutorialForReview(tutorial.id);
-                  setTutorial({ ...tutorial, status: "Submitted" });
+                  setTutorial({ ...tutorial, status: "Pending" });
                 }}
                 className="mt-3 bg-purple-100 hover:bg-purple-200 text-purple-800 py-2 px-3 rounded-md text-sm"
               >
@@ -270,7 +270,7 @@ export default function ViewTutorialPage() {
           </div>
         )}
 
-        {tutorial.status === "Submitted" && (
+        {tutorial.status === "Pending" && (
           <div className="mt-4 bg-blue-50 text-blue-700 px-3 py-2 rounded-lg">
             ⏳ Pending Approval
           </div>

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -172,7 +172,7 @@ export default function InstructorTutorialsPage() {
               >
                 <option value="">All Statuses</option>
                 <option value="Draft">Draft</option>
-                <option value="Submitted">Submitted</option>
+                <option value="Pending">Pending</option>
                 <option value="Approved">Approved</option>
                 <option value="Rejected">Rejected</option>
               </select>
@@ -217,7 +217,7 @@ export default function InstructorTutorialsPage() {
           <div className="bg-white p-4 rounded-xl shadow-sm border border-gray-100">
             <div className="text-sm text-gray-500">Pending</div>
             <div className="text-2xl font-bold text-blue-600">
-              {tutorials.filter(t => t.status === 'Submitted').length}
+              {tutorials.filter(t => t.status === 'Pending').length}
             </div>
           </div>
         </div>
@@ -240,7 +240,7 @@ export default function InstructorTutorialsPage() {
                     className={`inline-block px-3 py-1 rounded-full text-xs font-bold ${
                       tutorial.status === "Approved"
                         ? "bg-green-100 text-green-800"
-                        : tutorial.status === "Submitted"
+                        : tutorial.status === "Pending"
                         ? "bg-blue-100 text-blue-800"
                         : tutorial.status === "Draft"
                         ? "bg-yellow-100 text-yellow-800"
@@ -330,7 +330,7 @@ export default function InstructorTutorialsPage() {
                   )}
                   
                   {/* Submission Banner */}
-                  {tutorial.status === "Submitted" && (
+                  {tutorial.status === "Pending" && (
                     <div className="mt-4 bg-blue-50 text-blue-700 text-xs font-medium px-3 py-2 rounded-lg">
                       ⏳ Pending Approval
                     </div>
@@ -380,7 +380,7 @@ export default function InstructorTutorialsPage() {
                         await submitTutorialForReview(tutorial.id);
                         setTutorials((prev) =>
                           prev.map((t) =>
-                            t.id === tutorial.id ? { ...t, status: "Submitted" } : t
+                            t.id === tutorial.id ? { ...t, status: "Pending" } : t
                           )
                         );
                       }}

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -22,7 +22,7 @@ const mapStatus = (tut) =>
     ? "Approved"
     : tut.moderation_status === "Rejected"
     ? "Rejected"
-    : "Submitted";
+    : "Pending";
 
 export const fetchInstructorTutorials = async () => {
   const { data } = await api.get("/users/tutorials/admin/my");


### PR DESCRIPTION
## Summary
- ensure publishing a tutorial resets moderation to Pending and clears rejection reason
- return updated status from togglePublishStatus controller
- show Pending state in instructor dashboard after submission

## Testing
- `npm test` (backend)
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_68977826875c832888410a87d6d64b16