### PR TITLE
feat: enforce tutorial ownership

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -9,6 +9,7 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const userModel = require("../user.model");
 const analyticsService = require("../../../services/analyticsService");
+const AppError = require("../../../utils/AppError");
 const {
   sendTutorialCreatedAdminEmail,
   sendTutorialCreatedInstructorEmail,
@@ -41,6 +42,13 @@ const generateUniqueSlug = async (title) => {
   }
 
   return slug;
+};
+
+// Ensure the acting instructor owns the tutorial
+const assertInstructorOwnsTutorial = async (userId, tutorialId) => {
+  const tut = await service.getTutorialById(tutorialId);
+  if (!tut) throw new AppError("Tutorial not found", 404);
+  if (tut.instructor_id !== userId) throw new AppError("Access denied", 403);
 };
 
 exports.createTutorial = catchAsync(async (req, res) => {
@@ -231,6 +239,9 @@ exports.getTutorialById = catchAsync(async (req, res) => {
 
 
 exports.updateTutorial = catchAsync(async (req, res) => {
+  if (req.user.role === "instructor") {
+    await assertInstructorOwnsTutorial(req.user.id, req.params.id);
+  }
   const { tags: rawTags, ...data } = req.body;
   const roleDir = getRoleDir(req);
   if (req.files?.thumbnail) {
@@ -289,6 +300,9 @@ exports.restoreTutorial = catchAsync(async (req, res) => {
 
 
 exports.permanentlyDeleteTutorial = catchAsync(async (req, res) => {
+  if (req.user.role === "instructor") {
+    await assertInstructorOwnsTutorial(req.user.id, req.params.id);
+  }
   await service.permanentlyDeleteTutorial(req.params.id);
 
   sendSuccess(res, { message: "Permanently deleted" });
@@ -297,6 +311,9 @@ exports.permanentlyDeleteTutorial = catchAsync(async (req, res) => {
 
 exports.togglePublishStatus = catchAsync(async (req, res) => {
   const tutorialId = req.params.id;
+  if (req.user.role === "instructor") {
+    await assertInstructorOwnsTutorial(req.user.id, tutorialId);
+  }
   await service.togglePublishStatus(tutorialId);
 
   const tut = await service.getTutorialById(tutorialId);

--- a/backend/tests/tutorialRoutes.test.js
+++ b/backend/tests/tutorialRoutes.test.js
@@ -8,10 +8,17 @@ jest.mock('../src/config/database', () => ({
 jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({
   getTutorialsByCategory: jest.fn(),
   getTutorialAnalytics: jest.fn(),
+  getTutorialById: jest.fn(),
+  updateTutorial: jest.fn(),
+  permanentlyDeleteTutorial: jest.fn(),
+  togglePublishStatus: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
-  verifyToken: (_req, _res, next) => next(),
+  verifyToken: jest.fn((req, _res, next) => {
+    req.user = { id: 'admin', role: 'admin', roles: ['admin'] };
+    next();
+  }),
   isInstructorOrAdmin: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),
   isStudent: (_req, _res, next) => next(),
@@ -19,10 +26,15 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
 
 const service = require('../src/modules/users/tutorials/tutorial.service');
 const routes = require('../src/modules/users/tutorials/tutorial.routes');
+const auth = require('../src/middleware/auth/authMiddleware');
 
 const app = express();
 app.use(express.json());
 app.use('/api/users/tutorials', routes);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('GET /api/users/tutorials/category/:categoryId', () => {
   it('returns tutorials for the given category', async () => {
@@ -46,5 +58,47 @@ describe('GET /api/users/tutorials/admin/:id/analytics', () => {
     expect(res.status).toBe(200);
     expect(service.getTutorialAnalytics).toHaveBeenCalledWith('1');
     expect(res.body.data).toEqual(analytics);
+  });
+});
+
+describe('PUT /api/users/tutorials/admin/:id', () => {
+  it("returns 403 when instructor updates another instructor's tutorial", async () => {
+    service.getTutorialById.mockResolvedValue({ id: '1', instructor_id: 'owner' });
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: 'other', role: 'instructor', roles: ['instructor'] };
+      next();
+    });
+    const payload = { title: 'New', category_id: 'cat', level: 'beginner' };
+    const res = await request(app)
+      .put('/api/users/tutorials/admin/1')
+      .send(payload);
+    expect(res.status).toBe(403);
+    expect(service.updateTutorial).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/users/tutorials/admin/:id', () => {
+  it("returns 403 when instructor deletes another instructor's tutorial", async () => {
+    service.getTutorialById.mockResolvedValue({ id: '1', instructor_id: 'owner' });
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: 'other', role: 'instructor', roles: ['instructor'] };
+      next();
+    });
+    const res = await request(app).delete('/api/users/tutorials/admin/1');
+    expect(res.status).toBe(403);
+    expect(service.permanentlyDeleteTutorial).not.toHaveBeenCalled();
+  });
+});
+
+describe('PATCH /api/users/tutorials/admin/:id/status', () => {
+  it("returns 403 when instructor toggles another instructor's tutorial", async () => {
+    service.getTutorialById.mockResolvedValue({ id: '1', instructor_id: 'owner' });
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: 'other', role: 'instructor', roles: ['instructor'] };
+      next();
+    });
+    const res = await request(app).patch('/api/users/tutorials/admin/1/status');
+    expect(res.status).toBe(403);
+    expect(service.togglePublishStatus).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- ensure only a tutorial's instructor can update, delete or change publish status
- add unit tests covering cross-instructor modifications

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977824fd948328a7e30675833ce5b4