### PR TITLE
Verify enrollment before allowing tutorial reviews and comments

### DIFF
--- a/backend/src/modules/users/tutorials/comments/tutorialComment.controller.js
+++ b/backend/src/modules/users/tutorials/comments/tutorialComment.controller.js
@@ -2,12 +2,22 @@ const db = require("../../../../config/database");
 const catchAsync = require("../../../../utils/catchAsync");
 const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
+const AppError = require("../../../../utils/AppError");
 
 // Post a comment
 exports.createComment = catchAsync(async (req, res) => {
   const { tutorialId } = req.params;
   const { message, parent_id } = req.body;
   const user_id = req.user.id;
+
+  const enrolled = await db("tutorial_enrollments")
+    .where({ tutorial_id: tutorialId, user_id })
+    .first();
+  if (!enrolled)
+    throw new AppError(
+      "You must enroll in the tutorial before commenting.",
+      403
+    );
 
   const id = uuidv4();
   await db("tutorial_comments").insert({

--- a/backend/src/modules/users/tutorials/reviews/tutorialReview.controller.js
+++ b/backend/src/modules/users/tutorials/reviews/tutorialReview.controller.js
@@ -1,12 +1,23 @@
 const db = require("../../../../config/database");
 const catchAsync = require("../../../../utils/catchAsync");
 const { sendSuccess } = require("../../../../utils/response");
+const AppError = require("../../../../utils/AppError");
 
 // Submit or update a review
 exports.submitReview = catchAsync(async (req, res) => {
   const { tutorialId } = req.params;
   const { rating, comment } = req.body;
   const userId = req.user.id;
+
+  const enrolled = await db("tutorial_enrollments")
+    .where({ tutorial_id: tutorialId, user_id: userId })
+    .first();
+
+  if (!enrolled)
+    throw new AppError(
+      "You must enroll in the tutorial before submitting a review.",
+      403
+    );
 
   const exists = await db("tutorial_reviews")
     .where({ tutorial_id: tutorialId, user_id: userId })


### PR DESCRIPTION
## Summary
- Require existing tutorial enrollment before submitting reviews
- Block comments from users who aren't enrolled in a tutorial

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689777604ec8832882e12252965584f9