### PR TITLE
feat: include chapter counts in student tutorial list

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -211,15 +211,22 @@ exports.getPublishedTutorials = async () => {
     .avg({ avg_rating: "rating" })
     .groupBy("tutorial_id");
 
+  const chapterCountSubquery = db("tutorial_chapters")
+    .select("tutorial_id")
+    .count({ chapter_count: "id" })
+    .groupBy("tutorial_id");
+
   return db({ t: "tutorials" })
     .leftJoin("users as u", "t.instructor_id", "u.id")
     .leftJoin(ratingSubquery.as("r"), "r.tutorial_id", "t.id")
+    .leftJoin(chapterCountSubquery.as("c"), "c.tutorial_id", "t.id")
     .where({ "t.status": "published", "t.moderation_status": "Approved" })
     .select(
       "t.*",
       "u.full_name as instructor_name",
       "u.avatar_url as instructor_avatar",
-      db.raw("COALESCE(r.avg_rating, 0) as rating")
+      db.raw("COALESCE(r.avg_rating, 0) as rating"),
+      db.raw("COALESCE(c.chapter_count, 0) as chapter_count")
     )
     .orderBy("t.created_at", "desc");
 };

--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -28,7 +28,7 @@ export default function StudentTutorialsPage() {
           return {
             ...tut,
             completedLessons: progress.completedChapters.length,
-            totalLessons: tut.chapters?.length || 0,
+            totalLessons: tut.chapter_count || 0,
             isCompleted: progress.completedQuiz,
           };
         });


### PR DESCRIPTION
## Summary
- count chapters for each tutorial in `getPublishedTutorials`
- use returned `chapter_count` to calculate lesson progress on student dashboard

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897775ec6908328b4751d64ab29f0da