### PR TITLE
feat: restrict chapter access to enrolled users

### DIFF
--- a/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
+++ b/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
@@ -4,6 +4,7 @@ const service = require("./tutorialChapter.service");
 const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 const uploadChapterVideo = require("./uploadChapterVideo");
+const db = require("../../../../config/database");
 
 // Handle chapter video uploads
 exports.uploadVideo = (req, res) => {
@@ -62,12 +63,22 @@ exports.deleteChapter = catchAsync(async (req, res) => {
 // List chapters by tutorial
 exports.getChaptersByTutorial = catchAsync(async (req, res) => {
   const { tutorialId } = req.params;
-  const isGuest = !req.user;
+  const tutorial = await db("tutorials")
+    .where({ id: tutorialId, status: "published" })
+    .first();
+
+  if (!tutorial) throw new AppError("Tutorial not found or not published", 404);
 
   let chapters = await service.getByTutorial(tutorialId);
 
-  // Filter only previews if guest
-  if (isGuest) {
+  if (req.user) {
+    const enrollment = await db("tutorial_enrollments")
+      .where({ tutorial_id: tutorialId, user_id: req.user.id })
+      .first();
+    if (!enrollment) {
+      chapters = chapters.filter((ch) => ch.is_preview);
+    }
+  } else {
     chapters = chapters.filter((ch) => ch.is_preview);
   }
 

--- a/backend/src/modules/users/tutorials/chapters/tutorialChapter.routes.js
+++ b/backend/src/modules/users/tutorials/chapters/tutorialChapter.routes.js
@@ -4,6 +4,17 @@ const ctrl = require("./tutorialChapter.controller");
 const { verifyToken, isInstructorOrAdmin } = require("../../../../middleware/auth/authMiddleware");
 const uploadChapterVideo = require("./uploadChapterVideo");
 
+// Optional auth middleware: attaches user if token provided, otherwise continues
+const optionalAuth = (req, res, next) => {
+  const hasToken =
+    (req.headers.authorization && req.headers.authorization.startsWith("Bearer ")) ||
+    (req.cookies && req.cookies.token);
+  if (hasToken) {
+    return verifyToken(req, res, next);
+  }
+  return next();
+};
+
 // Upload chapter video
 router.post(
   "/upload",
@@ -16,7 +27,7 @@ router.post(
 router.post("/", verifyToken, isInstructorOrAdmin, ctrl.createChapter);
 router.patch("/:id", verifyToken, isInstructorOrAdmin, ctrl.updateChapter);
 router.delete("/:id", verifyToken, isInstructorOrAdmin, ctrl.deleteChapter);
-router.get("/tutorial/:tutorialId", ctrl.getChaptersByTutorial); // public
+router.get("/tutorial/:tutorialId", optionalAuth, ctrl.getChaptersByTutorial); // allow guest or enrolled
 router.patch(
   "/tutorial/:tutorialId/reorder",
   verifyToken,


### PR DESCRIPTION
## Summary
- verify tutorial is published before fetching chapters
- serve full chapter list only to enrolled users; guests receive previews
- allow optional auth in chapter routes to attach user when token is provided

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897775c0758832899e14dbb9bbe9802