### PR TITLE
fix: remove duplicate AppError import

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -3,7 +3,6 @@ const catchAsync = require("../../../../utils/catchAsync");
 const AppError = require("../../../../utils/AppError");
 const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
-const AppError = require("../../../../utils/AppError");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {


### PR DESCRIPTION
## Summary
- remove duplicate AppError import in tutorial enrollment controller

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689780f9f54c8328a9fb29caf6f2edce