### PR TITLE
Guard notification dispatch from impacting responses

### DIFF
--- a/backend/src/modules/contact/contact.controller.js
+++ b/backend/src/modules/contact/contact.controller.js
@@ -26,7 +26,7 @@ exports.submitForm = catchAsync(async (req, res) => {
   });
   const admins = await userModel.findAdmins();
   const note = `New contact message from ${name} (${email})`;
-  await Promise.all(
+  const results = await Promise.allSettled(
     admins.map((admin) =>
       notificationService.createNotification({
         user_id: admin.id,
@@ -35,5 +35,13 @@ exports.submitForm = catchAsync(async (req, res) => {
       })
     )
   );
+  results.forEach((r, idx) => {
+    if (r.status === "rejected") {
+      console.error(
+        `Failed to notify admin ${admins[idx].id}:`,
+        r.reason?.message || r.reason
+      );
+    }
+  });
   sendSuccess(res, null, "Message sent");
 });

--- a/backend/src/modules/contactConfig/contactConfig.controller.js
+++ b/backend/src/modules/contactConfig/contactConfig.controller.js
@@ -16,20 +16,27 @@ exports.updateSettings = catchAsync(async (req, res) => {
 
   const admins = await userModel.findAdmins();
   const senderId = req.user?.id;
-  await Promise.all(
-    admins.map((admin) =>
-      Promise.all([
-        notificationService.createNotification({
-          user_id: admin.id,
-          type: "contact_settings_updated",
-          message: "Contact settings were updated",
-        }),
-        messageService.createMessage({
-          sender_id: senderId || admin.id,
-          receiver_id: admin.id,
-          message: "Contact settings were updated",
-        }),
-      ])
-    )
-  );
+  Promise.allSettled(
+    admins.flatMap((admin) => [
+      notificationService.createNotification({
+        user_id: admin.id,
+        type: "contact_settings_updated",
+        message: "Contact settings were updated",
+      }),
+      messageService.createMessage({
+        sender_id: senderId || admin.id,
+        receiver_id: admin.id,
+        message: "Contact settings were updated",
+      }),
+    ])
+  ).then((results) => {
+    results.forEach((r) => {
+      if (r.status === "rejected") {
+        console.error(
+          "Failed to dispatch contact settings update notification:",
+          r.reason?.message || r.reason
+        );
+      }
+    });
+  });
 });

--- a/backend/src/modules/popupAnnouncements/popupAnnouncements.controller.js
+++ b/backend/src/modules/popupAnnouncements/popupAnnouncements.controller.js
@@ -45,22 +45,29 @@ exports.create = catchAsync(async (req, res) => {
 
   const admins = await userModel.findAdmins();
   const senderId = req.user?.id;
-  await Promise.all(
-    admins.map((admin) =>
-      Promise.all([
-        notificationService.createNotification({
-          user_id: admin.id,
-          type: "popup_announcement_created",
-          message: `New popup announcement: ${title}`,
-        }),
-        messageService.createMessage({
-          sender_id: senderId || admin.id,
-          receiver_id: admin.id,
-          message: `New popup announcement: ${title}`,
-        }),
-      ])
-    )
-  );
+  Promise.allSettled(
+    admins.flatMap((admin) => [
+      notificationService.createNotification({
+        user_id: admin.id,
+        type: "popup_announcement_created",
+        message: `New popup announcement: ${title}`,
+      }),
+      messageService.createMessage({
+        sender_id: senderId || admin.id,
+        receiver_id: admin.id,
+        message: `New popup announcement: ${title}`,
+      }),
+    ])
+  ).then((results) => {
+    results.forEach((r) => {
+      if (r.status === "rejected") {
+        console.error(
+          "Failed to dispatch popup announcement notification:",
+          r.reason?.message || r.reason
+        );
+      }
+    });
+  });
 });
 
 exports.update = catchAsync(async (req, res) => {

--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -33,56 +33,92 @@ exports.createTicket = catchAsync(async (req, res) => {
   // ─────────────────────
   // 📣 Notify admins and user
   // ─────────────────────
-  try {
-    const admins = await userModel.findAdmins();
-    await Promise.all(
-      admins.map((a) =>
-        sendSupportTicketAdminEmail(
-          a.email,
-          req.user.full_name,
-          ticket.subject,
-          ticket.ticket_number
-        )
+  const admins = await userModel.findAdmins();
+  const adminEmailResults = await Promise.allSettled(
+    admins.map((a) =>
+      sendSupportTicketAdminEmail(
+        a.email,
+        req.user.full_name,
+        ticket.subject,
+        ticket.ticket_number
       )
-    );
+    )
+  );
+  adminEmailResults.forEach((r) => {
+    if (r.status === "rejected") {
+      console.error(
+        "Failed to send admin support email:",
+        r.reason?.message || r.reason
+      );
+    }
+  });
+
+  try {
     await sendSupportTicketUserEmail(
       req.user.email,
       req.user.full_name,
       ticket.subject,
       ticket.ticket_number
     );
-    // Create notifications/messages for admins
-    await Promise.all(
-      admins.map((admin) =>
-        notificationService.createNotification({
-          user_id: admin.id,
-          type: "new_support_ticket",
-          message: `New support ticket from ${req.user.full_name}: '${ticket.subject}'`,
-        })
-      )
-    );
-    await Promise.all(
-      admins.map((admin) =>
-        messageService.createMessage({
-          sender_id: req.user.id,
-          receiver_id: admin.id,
-          message: `New support ticket '${ticket.subject}' submitted`,
-        })
-      )
-    );
   } catch (err) {
-    console.error("Error sending support ticket emails:", err.message);
+    console.error("Failed to send user support email:", err.message);
   }
 
-  await notificationService.createNotification({
-    user_id: req.user.id,
-    type: "ticket_submitted",
-    message: `Ticket #${ticket.ticket_number} created`,
+  const adminNotifyResults = await Promise.allSettled(
+    admins.map((admin) =>
+      notificationService.createNotification({
+        user_id: admin.id,
+        type: "new_support_ticket",
+        message: `New support ticket from ${req.user.full_name}: '${ticket.subject}'`,
+      })
+    )
+  );
+  adminNotifyResults.forEach((r, idx) => {
+    if (r.status === "rejected") {
+      console.error(
+        `Failed to notify admin ${admins[idx].id} of support ticket:`,
+        r.reason?.message || r.reason
+      );
+    }
   });
-  await messageService.createMessage({
-    sender_id: req.user.id,
-    receiver_id: req.user.id,
-    message: `We received your support ticket #${ticket.ticket_number}`,
+
+  const adminMessageResults = await Promise.allSettled(
+    admins.map((admin) =>
+      messageService.createMessage({
+        sender_id: req.user.id,
+        receiver_id: admin.id,
+        message: `New support ticket '${ticket.subject}' submitted`,
+      })
+    )
+  );
+  adminMessageResults.forEach((r, idx) => {
+    if (r.status === "rejected") {
+      console.error(
+        `Failed to message admin ${admins[idx].id} about support ticket:`,
+        r.reason?.message || r.reason
+      );
+    }
+  });
+
+  const userDispatch = await Promise.allSettled([
+    notificationService.createNotification({
+      user_id: req.user.id,
+      type: "ticket_submitted",
+      message: `Ticket #${ticket.ticket_number} created`,
+    }),
+    messageService.createMessage({
+      sender_id: req.user.id,
+      receiver_id: req.user.id,
+      message: `We received your support ticket #${ticket.ticket_number}`,
+    }),
+  ]);
+  userDispatch.forEach((r) => {
+    if (r.status === "rejected") {
+      console.error(
+        "Failed to dispatch user notification/message for ticket creation:",
+        r.reason?.message || r.reason
+      );
+    }
   });
 
   sendSuccess(res, ticket, "Ticket created");

--- a/backend/src/modules/thirdPartyConfig/thirdPartyConfig.controller.js
+++ b/backend/src/modules/thirdPartyConfig/thirdPartyConfig.controller.js
@@ -16,20 +16,27 @@ exports.updateSettings = catchAsync(async (req, res) => {
 
   const admins = await userModel.findAdmins();
   const senderId = req.user?.id;
-  await Promise.all(
-    admins.map((admin) =>
-      Promise.all([
-        notificationService.createNotification({
-          user_id: admin.id,
-          type: "third_party_settings_updated",
-          message: "Third-party integration settings were updated",
-        }),
-        messageService.createMessage({
-          sender_id: senderId || admin.id,
-          receiver_id: admin.id,
-          message: "Third-party integration settings were updated",
-        }),
-      ])
-    )
-  );
+  Promise.allSettled(
+    admins.flatMap((admin) => [
+      notificationService.createNotification({
+        user_id: admin.id,
+        type: "third_party_settings_updated",
+        message: "Third-party integration settings were updated",
+      }),
+      messageService.createMessage({
+        sender_id: senderId || admin.id,
+        receiver_id: admin.id,
+        message: "Third-party integration settings were updated",
+      }),
+    ])
+  ).then((results) => {
+    results.forEach((r) => {
+      if (r.status === "rejected") {
+        console.error(
+          "Failed to dispatch third-party settings update notification:",
+          r.reason?.message || r.reason
+        );
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- wrap contact form notifications in `Promise.allSettled` and log failures
- dispatch admin update notifications asynchronously for contact, third-party config, and popup announcements
- safeguard support ticket notifications using `Promise.allSettled` with detailed error logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897884ff804832884c4c73b11ecf071