### PR TITLE
Add validation to admin payments config form

### DIFF
--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -212,6 +212,26 @@ export default function AdminPaymentsPage() {
   };
 
   const [form, setForm] = useState(defaultConfig);
+  const [errors, setErrors] = useState({});
+
+  const validate = (data) => {
+    const errs = {};
+    if (!data.currency) errs.currency = "Currency is required";
+    Object.entries(data.platformCut).forEach(([key, val]) => {
+      if (val === "" || isNaN(val)) {
+        errs[`platformCut.${key}`] = "Required";
+      } else if (val < 0 || val > 100) {
+        errs[`platformCut.${key}`] = "Must be between 0 and 100";
+      }
+    });
+    if (!data.refundPolicy) errs.refundPolicy = "Refund policy is required";
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  useEffect(() => {
+    validate(form);
+  }, [form]);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -219,7 +239,10 @@ export default function AdminPaymentsPage() {
       const key = name.split(".")[1];
       setForm((prev) => ({
         ...prev,
-        platformCut: { ...prev.platformCut, [key]: parseFloat(value) },
+        platformCut: {
+          ...prev.platformCut,
+          [key]: value === "" ? "" : parseFloat(value),
+        },
       }));
     } else if (name.includes("invoice")) {
       const key = name.split(".")[1];
@@ -228,11 +251,15 @@ export default function AdminPaymentsPage() {
         invoice: { ...prev.invoice, [key]: type === "checkbox" ? checked : value },
       }));
     } else {
-      setForm((prev) => ({ ...prev, [name]: value }));
+      setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
     }
   };
 
   const handleSave = async () => {
+    if (!validate(form)) {
+      toast.error("Please correct the errors before saving");
+      return;
+    }
     try {
       await updatePaymentConfig(form);
       toast.success(t('paymentsPage.config_saved'));
@@ -241,6 +268,8 @@ export default function AdminPaymentsPage() {
       toast.error(err?.response?.data?.message || t('paymentsPage.config_save_failed'));
     }
   };
+
+  const isFormValid = Object.keys(errors).length === 0;
 
   const [payouts, setPayouts] = useState([]);
 
@@ -459,6 +488,9 @@ export default function AdminPaymentsPage() {
                 <option value="SAR">SAR - Saudi Riyal</option>
                 <option value="EUR">EUR - Euro</option>
               </select>
+              {errors.currency && (
+                <p className="text-red-500 text-sm mt-1">{errors.currency}</p>
+              )}
             </div>
 
             <div>
@@ -476,6 +508,9 @@ export default function AdminPaymentsPage() {
                       onChange={handleChange}
                       className="border px-3 py-2 rounded w-full"
                     />
+                    {errors[`platformCut.${key}`] && (
+                      <p className="text-red-500 text-sm mt-1">{errors[`platformCut.${key}`]}</p>
+                    )}
                   </div>
                 ))}
               </div>
@@ -519,9 +554,18 @@ export default function AdminPaymentsPage() {
                 className="border px-3 py-2 rounded w-full"
                 rows={4}
               />
+              {errors.refundPolicy && (
+                <p className="text-red-500 text-sm mt-1">{errors.refundPolicy}</p>
+              )}
             </div>
 
-            <button onClick={handleSave} className="bg-indigo-600 text-white px-6 py-2 rounded shadow">{t('paymentsPage.save_configuration')}</button>
+            <button
+              onClick={handleSave}
+              disabled={!isFormValid}
+              className={`bg-indigo-600 text-white px-6 py-2 rounded shadow ${!isFormValid ? 'opacity-50 cursor-not-allowed' : ''}`}
+            >
+              {t('paymentsPage.save_configuration')}
+            </button>
           </div>
         );
 


### PR DESCRIPTION
## Summary
- validate admin payment configuration fields and enforce numeric bounds
- show inline errors and disable save until configuration is valid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897884f5fdc832884ff6579badc2dfd