### PR TITLE
Handle invalid JSON in payment provider config

### DIFF
--- a/frontend/src/components/payments/PaymentProviderConfig.js
+++ b/frontend/src/components/payments/PaymentProviderConfig.js
@@ -52,11 +52,25 @@ export default function PaymentProviderConfig({ providerId }) {
 
   const handleSave = async (e) => {
     e.preventDefault();
+
+    let parsed;
     try {
-      const parsed = settings ? JSON.parse(settings) : {};
+      parsed = settings ? JSON.parse(settings) : {};
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        toast.error("Invalid JSON format");
+        return;
+      }
+      throw err;
+    }
+
+    try {
       await updateMethod(providerId, { settings: parsed });
       toast.success(t('paymentsPage.config_saved'));
-      notify("payment_method_updated", `Payment method \"${providerId}\" configuration updated`);
+      notify(
+        "payment_method_updated",
+        `Payment method \"${providerId}\" configuration updated`
+      );
     } catch (err) {
       console.error("Failed to save settings", err);
       toast.error(t('paymentsPage.config_save_failed'));


### PR DESCRIPTION
## Summary
- guard `JSON.parse` in `PaymentProviderConfig` to handle syntax errors
- show a toast saying "Invalid JSON format" instead of submitting malformed settings

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook "useTranslation" is called in function "fetch" that is neither a React function component nor a custom React Hook function...)*

------
https://chatgpt.com/codex/tasks/task_e_6897884dcca48328aae2beeb31da8dca