### PR TITLE
refactor: extract admin notice hook

### DIFF
--- a/frontend/src/components/payments/PaymentProviderConfig.js
+++ b/frontend/src/components/payments/PaymentProviderConfig.js
@@ -5,29 +5,7 @@ import {
   updateMethod,
 } from "@/services/admin/paymentMethodService";
 import { toast } from "react-toastify";
-import { createNotification } from "@/services/notificationService";
-import { sendChatMessage } from "@/services/messageService";
-import useAuthStore from "@/store/auth/authStore";
-import useNotificationStore from "@/store/notifications/notificationStore";
-import useMessageStore from "@/store/messages/messageStore";
-
-const useAdminNotice = () => {
-  const user = useAuthStore((s) => s.user);
-  const refreshNotifications = useNotificationStore((s) => s.fetch);
-  const refreshMessages = useMessageStore((s) => s.fetch);
-  return async (type, message) => {
-    try {
-      await createNotification({ user_id: user.id, type, message });
-      await sendChatMessage(user.id, { text: message });
-      refreshNotifications?.();
-      refreshMessages?.();
-    } catch (err) {
-      console.error(err);
-      const msg = err.response?.data?.message || "Failed to send notification";
-      toast.error(msg);
-    }
-  };
-};
+import useAdminNotice from "@/hooks/useAdminNotice";
 
 export default function PaymentProviderConfig({ providerId }) {
   const [settings, setSettings] = useState("{}");

--- a/frontend/src/hooks/useAdminNotice.js
+++ b/frontend/src/hooks/useAdminNotice.js
@@ -1,0 +1,25 @@
+import { toast } from "react-toastify";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
+import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
+
+export default function useAdminNotice() {
+  const user = useAuthStore((s) => s.user);
+  const refreshNotifications = useNotificationStore((s) => s.fetch);
+  const refreshMessages = useMessageStore((s) => s.fetch);
+
+  return async (type, message) => {
+    try {
+      await createNotification({ user_id: user.id, type, message });
+      await sendChatMessage(user.id, { text: message });
+      refreshNotifications?.();
+      refreshMessages?.();
+    } catch (err) {
+      console.error(err);
+      const msg = err.response?.data?.message || "Failed to send notification";
+      toast.error(msg);
+    }
+  };
+}

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -31,24 +31,7 @@ import { sendChatMessage } from '@/services/messageService';
 import useAuthStore from '@/store/auth/authStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
-
-const useAdminNotice = () => {
-  const user = useAuthStore((s) => s.user);
-  const refreshNotifications = useNotificationStore((s) => s.fetch);
-  const refreshMessages = useMessageStore((s) => s.fetch);
-  return async (type, message) => {
-    try {
-      await createNotification({ user_id: user.id, type, message });
-      await sendChatMessage(user.id, { text: message });
-      refreshNotifications?.();
-      refreshMessages?.();
-    } catch (err) {
-      console.error(err);
-      const msg = err.response?.data?.message || 'Failed to send notification';
-      toast.error(msg);
-    }
-  };
-};
+import useAdminNotice from '@/hooks/useAdminNotice';
 
 
 const defaultConfig = {


### PR DESCRIPTION
## Summary
- centralize admin notification logic in new `useAdminNotice` hook
- use the shared hook in payment provider config and admin payments page

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook "useTranslation" called in non-hook function)*

------
https://chatgpt.com/codex/tasks/task_e_6897884cd88c832898fcd786323c999f