### PR TITLE
feat: email notifications for class reminders

### DIFF
--- a/backend/src/jobs/classReminderJob.js
+++ b/backend/src/jobs/classReminderJob.js
@@ -1,6 +1,7 @@
 const classService = require("../modules/classes/class.service");
 const enrollmentService = require("../modules/classes/enrollments/classEnrollment.service");
 const smsService = require("../services/smsService");
+const { sendClassReminderEmail } = require("../utils/email");
 
 function startClassReminderJob() {
   setInterval(async () => {
@@ -12,13 +13,26 @@ function startClassReminderJob() {
       for (const cls of classes) {
         const students = await enrollmentService.getByClass(cls.id);
         for (const student of students) {
-          if (!student.phone) continue;
           const startTime = new Date(cls.start_date).toLocaleString();
           const text = `Reminder: ${cls.title} starts at ${startTime}`;
-          try {
-            await smsService.sendSMS({ to: student.phone, text });
-          } catch (err) {
-            console.error("Error sending class reminder SMS:", err.message);
+          if (student.phone) {
+            try {
+              await smsService.sendSMS({ to: student.phone, text });
+            } catch (err) {
+              console.error("Error sending class reminder SMS:", err.message);
+            }
+          }
+          if (student.email) {
+            try {
+              await sendClassReminderEmail(
+                student.email,
+                cls.title,
+                cls.start_date,
+                student.locale
+              );
+            } catch (err) {
+              console.error("Error sending class reminder email:", err.message);
+            }
           }
         }
       }

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -384,6 +384,88 @@ exports.sendLessonReminderEmail = async (
   }
 };
 
+// Reminder email 24h before a class starts
+exports.sendClassReminderEmail = async (
+  to,
+  classTitle,
+  dateTime,
+  locale = "en-US"
+) => {
+  const cfg = (await emailConfigService.getSettings()) || {};
+  const app = (await appConfigService.getSettings()) || {};
+  const transporter = await createTransporter();
+
+  if (EMAILS_DISABLED) {
+    console.log(`[EMAIL DISABLED] Class reminder for ${to}`);
+    return;
+  }
+
+  const fromEmail = (
+    cfg.fromEmail ||
+    process.env.SMTP_USER ||
+    "support@eduskillbridge.net"
+  ).trim();
+
+  const fromName = (
+    cfg.fromName ||
+    process.env.SMTP_NAME ||
+    app.appName ||
+    "SkillBridge"
+  ).trim();
+
+  const logo = app.logo_url
+    ? `${frontendBase}${app.logo_url}`
+    : "https://eduskillbridge.net/logo.png";
+
+  const templates = {
+    "en-US": {
+      subject: `Upcoming class reminder for ${classTitle}`,
+      greeting: "Hello,",
+      body: `This is a reminder that your class <strong>${classTitle}</strong> is scheduled to begin in 24 hours.`,
+      start: "Start Time",
+      closing: "Please be prepared and ensure all materials are ready.",
+    },
+    "es-ES": {
+      subject: `Recordatorio de la clase ${classTitle}`,
+      greeting: "Hola,",
+      body: `Este es un recordatorio de que su clase <strong>${classTitle}</strong> comenzará en 24 horas.`,
+      start: "Hora de inicio",
+      closing: "Por favor, prepárese y asegúrese de que todo el material esté listo.",
+    },
+  };
+
+  const t = templates[locale] || templates["en-US"];
+
+  const formatted = new Date(dateTime).toLocaleString(locale, {
+    dateStyle: "long",
+    timeStyle: "short",
+  });
+
+  const mailOptions = {
+    from: `${fromName} <${fromEmail}>`,
+    replyTo: cfg.replyTo || fromEmail,
+    to,
+    subject: t.subject,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:600px;margin:0 auto">
+        <img src="${logo}" alt="${fromName}" style="max-width:150px;margin-bottom:20px"/>
+        <p>${t.greeting}</p>
+        <p>${t.body}</p>
+        <p><strong>${t.start}:</strong> ${formatted}</p>
+        <p>${t.closing}</p>
+        <p>Thank you,<br/>The ${fromName} Team</p>
+        ${EMAIL_FOOTER}
+      </div>`,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Class reminder sent to ${to}`);
+  } catch (error) {
+    console.error("Error sending class reminder email: ", error);
+  }
+};
+
 /**
  * Notify admins when a user submits a support ticket
  * @param {string} to - Admin email address

--- a/backend/tests/classReminderJob.test.js
+++ b/backend/tests/classReminderJob.test.js
@@ -1,0 +1,59 @@
+jest.mock('../src/modules/classes/class.service', () => ({
+  getClassesStartingBetween: jest.fn(),
+}));
+
+jest.mock('../src/modules/classes/enrollments/classEnrollment.service', () => ({
+  getByClass: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+jest.mock('../src/utils/email', () => ({
+  sendClassReminderEmail: jest.fn(),
+}));
+
+const classService = require('../src/modules/classes/class.service');
+const enrollmentService = require('../src/modules/classes/enrollments/classEnrollment.service');
+const smsService = require('../src/services/smsService');
+const { sendClassReminderEmail } = require('../src/utils/email');
+const startClassReminderJob = require('../src/jobs/classReminderJob');
+
+describe('classReminderJob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(global, 'setInterval').mockImplementation((fn) => {
+      fn();
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    global.setInterval.mockRestore();
+  });
+
+  test('dispatches email and sms to enrolled students', async () => {
+    const cls = { id: 1, title: 'Math', start_date: '2023-01-01T00:00:00Z' };
+    const student = { email: 's@example.com', phone: '123', locale: 'en-US' };
+    classService.getClassesStartingBetween.mockResolvedValue([cls]);
+    enrollmentService.getByClass.mockResolvedValue([student]);
+
+    startClassReminderJob();
+    await new Promise(setImmediate);
+
+    expect(classService.getClassesStartingBetween).toHaveBeenCalled();
+    expect(enrollmentService.getByClass).toHaveBeenCalledWith(cls.id);
+    expect(smsService.sendSMS).toHaveBeenCalledWith({
+      to: '123',
+      text: expect.stringContaining('Reminder'),
+    });
+    expect(sendClassReminderEmail).toHaveBeenCalledWith(
+      's@example.com',
+      'Math',
+      cls.start_date,
+      'en-US'
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- send class reminder emails with localized templates
- send emails alongside SMS in classReminderJob
- test job dispatches both email and SMS

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68978842e144832887f7772444c9f9a9