### PR TITLE
Add live lesson notifications and join links

### DIFF
--- a/backend/src/jobs/lessonLiveJob.js
+++ b/backend/src/jobs/lessonLiveJob.js
@@ -1,0 +1,75 @@
+const classLessonService = require('../modules/classes/lessons/classLesson.service');
+const enrollmentService = require('../modules/classes/enrollments/classEnrollment.service');
+const userModel = require('../modules/users/user.model');
+const notificationService = require('../modules/notifications/notifications.service');
+const smsService = require('../services/smsService');
+const { sendLessonReminderEmail } = require('../utils/email');
+const { createLessonRoomLink } = require('../utils/roomLink');
+
+const sent = new Set();
+
+async function processLessons() {
+  const now = new Date();
+  const end = new Date(now.getTime() + 5 * 60 * 1000);
+  try {
+    const lessons = await classLessonService.getLessonsStartingBetween(now, end);
+    for (const lesson of lessons) {
+      if (sent.has(lesson.id)) continue;
+      const { url } = createLessonRoomLink(lesson.id);
+      const message = `Your lesson "${lesson.title}" is starting soon. Join: ${url}`;
+      const instructor = await userModel.findById(lesson.instructor_id);
+      if (instructor) {
+        await notificationService.createNotification({
+          user_id: instructor.id,
+          type: 'lesson_live',
+          message,
+        });
+        if (instructor.phone) {
+          await smsService.sendSMS({ to: instructor.phone, text: message });
+        }
+        try {
+          await sendLessonReminderEmail(
+            instructor.email,
+            lesson.title,
+            lesson.start_time,
+            lesson.class_title + `\nJoin: ${url}`
+          );
+        } catch (err) {
+          console.error('Failed to send lesson live email', err.message);
+        }
+      }
+      const students = await enrollmentService.getByClass(lesson.class_id);
+      for (const student of students) {
+        await notificationService.createNotification({
+          user_id: student.id,
+          type: 'lesson_live',
+          message,
+        });
+        if (student.phone) {
+          await smsService.sendSMS({ to: student.phone, text: message });
+        }
+        if (student.email) {
+          try {
+            await sendLessonReminderEmail(
+              student.email,
+              lesson.title,
+              lesson.start_time,
+              lesson.class_title + `\nJoin: ${url}`
+            );
+          } catch (err) {
+            console.error('Failed to send lesson live email', err.message);
+          }
+        }
+      }
+      sent.add(lesson.id);
+    }
+  } catch (err) {
+    console.error('Lesson live job error:', err.message);
+  }
+}
+
+function startLessonLiveJob() {
+  setInterval(processLessons, 60 * 1000); // run every minute
+}
+
+module.exports = { startLessonLiveJob, processLessons };

--- a/backend/src/modules/classes/lessons/classLesson.service.js
+++ b/backend/src/modules/classes/lessons/classLesson.service.js
@@ -21,3 +21,18 @@ exports.updateLesson = async (id, data) => {
 exports.deleteLesson = async (id) => {
   return db("class_lessons").where({ id }).del();
 };
+
+// Find lessons starting between a time window, including class and instructor details
+exports.getLessonsStartingBetween = async (start, end) => {
+  return db("class_lessons as l")
+    .join("online_classes as c", "l.class_id", "c.id")
+    .select(
+      "l.id",
+      "l.class_id",
+      "l.title",
+      "l.start_time",
+      "c.title as class_title",
+      "c.instructor_id"
+    )
+    .whereBetween("l.start_time", [start, end]);
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,9 +13,11 @@ const { verifyToken } = require("./middleware/auth/authMiddleware");
 const csrf = require("./middleware/csrf");
 const path = require("path");
 const startLessonReminderJob = require("./jobs/lessonReminderJob");
+const { startLessonLiveJob } = require("./jobs/lessonLiveJob");
 const startCartReminderJob = require("./jobs/cartReminderJob");
 const startClassReminderJob = require("./jobs/classReminderJob");
 const startCleanupJob = require("./jobs/cleanupJob");
+const { createLessonRoomLink } = require("./utils/roomLink");
 require("dotenv").config();
 
 // Ensure required environment secrets are present
@@ -148,6 +150,33 @@ app.use("/api/books", require("./modules/books/book.routes"));
 app.use("/api/instructor/books", require("./modules/books/instructorBook.routes"));
 app.use("/api/library", require("./modules/library/library.routes"));
 app.use("/api/search", require("./modules/search/search.routes"));
+
+// Generate secure video room link for a lesson
+app.post("/api/users/classes/lessons/:lessonId/room", verifyToken, async (req, res) => {
+  try {
+    const { lessonId } = req.params;
+    const lesson = await db("class_lessons as l")
+      .join("online_classes as c", "l.class_id", "c.id")
+      .select("l.class_id", "c.instructor_id")
+      .where("l.id", lessonId)
+      .first();
+    if (!lesson) return res.status(404).json({ message: "Lesson not found" });
+    const isInstructor = lesson.instructor_id === req.user.id;
+    let isStudent = false;
+    if (!isInstructor) {
+      const enrollment = await db("class_enrollments")
+        .where({ class_id: lesson.class_id, user_id: req.user.id })
+        .first();
+      if (enrollment) isStudent = true;
+    }
+    if (!isInstructor && !isStudent)
+      return res.status(403).json({ message: "Not allowed" });
+    const link = createLessonRoomLink(lessonId);
+    res.json(link);
+  } catch (err) {
+    res.status(500).json({ message: "Failed to generate room link" });
+  }
+});
 
 app.get("/", (req, res) => res.send("🚀 SkillBridge API is live."));
 
@@ -314,6 +343,7 @@ async function startServer() {
       console.log(`✅ Server running on port ${PORT}`);
     });
     startLessonReminderJob();
+    startLessonLiveJob();
     startClassReminderJob();
     startCartReminderJob();
     startCleanupJob();

--- a/backend/src/utils/roomLink.js
+++ b/backend/src/utils/roomLink.js
@@ -1,0 +1,10 @@
+const { v4: uuidv4 } = require('uuid');
+const jwt = require('jsonwebtoken');
+
+exports.createLessonRoomLink = (lessonId) => {
+  const roomId = uuidv4();
+  const token = jwt.sign({ lessonId, roomId }, process.env.JWT_SECRET, { expiresIn: '2h' });
+  const base = (process.env.FRONTEND_URL || 'http://localhost:3000').replace(/\/$/, '');
+  const url = `${base}/video-call/${roomId}?token=${token}`;
+  return { roomId, url, token };
+};

--- a/backend/tests/lessonLiveJob.test.js
+++ b/backend/tests/lessonLiveJob.test.js
@@ -1,0 +1,54 @@
+const { processLessons } = require('../src/jobs/lessonLiveJob');
+
+jest.mock('../src/modules/classes/lessons/classLesson.service', () => ({
+  getLessonsStartingBetween: jest.fn(() => [
+    {
+      id: 'lesson1',
+      class_id: 'class1',
+      title: 'Lesson 1',
+      start_time: new Date().toISOString(),
+      class_title: 'Test Class',
+      instructor_id: 'inst1',
+    },
+  ]),
+}));
+
+jest.mock('../src/modules/classes/enrollments/classEnrollment.service', () => ({
+  getByClass: jest.fn(() => [
+    { id: 'stu1', email: 's1@test.com', phone: '222' },
+  ]),
+}));
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findById: jest.fn(() => ({ id: 'inst1', email: 'i@test.com', phone: '111' })),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+jest.mock('../src/utils/email', () => ({
+  sendLessonReminderEmail: jest.fn(),
+}));
+
+jest.mock('../src/utils/roomLink', () => ({
+  createLessonRoomLink: jest.fn(() => ({ url: 'http://room' })),
+}));
+
+describe('lesson live job', () => {
+  it('sends notifications and generates link', async () => {
+    await processLessons();
+    const notif = require('../src/modules/notifications/notifications.service');
+    const sms = require('../src/services/smsService');
+    const email = require('../src/utils/email');
+    const room = require('../src/utils/roomLink');
+    expect(room.createLessonRoomLink).toHaveBeenCalledWith('lesson1');
+    expect(notif.createNotification).toHaveBeenCalledTimes(2);
+    expect(sms.sendSMS).toHaveBeenCalled();
+    expect(email.sendLessonReminderEmail).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/dashboard/instructor/schedule.js
+++ b/frontend/src/pages/dashboard/instructor/schedule.js
@@ -3,6 +3,7 @@ import InstructorLayout from "@/components/layouts/InstructorLayout";
 import CalendarView from "@/components/shared/CalendarView";
 import { fetchInstructorScheduleEvents } from "@/services/instructor/classService";
 import useScheduleStore from "@/store/schedule/scheduleStore";
+import { getLessonRoomLink } from "@/services/lessonService";
 
 export default function InstructorSchedule() {
   const { events, clear, addEvents, prunePastEvents } = useScheduleStore();
@@ -33,7 +34,23 @@ export default function InstructorSchedule() {
       <CalendarView
         title="My Teaching Schedule"
         events={events}
-        onEventClick={(info) => {
+        onEventClick={async (info) => {
+          const id = info.event.id || "";
+          if (id.startsWith("lesson-")) {
+            const lessonId = id.replace("lesson-", "");
+            const start = new Date(info.event.start);
+            const end = new Date(start.getTime() + 60 * 60 * 1000);
+            const now = new Date();
+            if (now >= start && now <= end) {
+              try {
+                const url = await getLessonRoomLink(lessonId);
+                window.open(url, "_blank");
+              } catch (err) {
+                alert("Failed to start live session");
+              }
+              return;
+            }
+          }
           const sub = info.event.extendedProps?.subject;
           const student = info.event.extendedProps?.student;
           if (sub && student) {

--- a/frontend/src/pages/dashboard/student/schedule.js
+++ b/frontend/src/pages/dashboard/student/schedule.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import CalendarView from "@/components/shared/CalendarView";
 import { fetchStudentBookings } from "@/services/student/bookingService";
+import { getLessonRoomLink } from "@/services/lessonService";
 
 export default function StudentSchedule() {
   const [events, setEvents] = useState([]);
@@ -35,7 +36,23 @@ export default function StudentSchedule() {
       <CalendarView
         title="My Booked Lessons"
         events={events}
-        onEventClick={(info) => {
+        onEventClick={async (info) => {
+          const id = info.event.id || "";
+          if (id.startsWith("lesson-")) {
+            const lessonId = id.replace("lesson-", "");
+            const start = new Date(info.event.start);
+            const end = new Date(start.getTime() + 60 * 60 * 1000);
+            const now = new Date();
+            if (now >= start && now <= end) {
+              try {
+                const url = await getLessonRoomLink(lessonId);
+                window.open(url, "_blank");
+              } catch (err) {
+                alert("Failed to join live session");
+              }
+              return;
+            }
+          }
           alert(`📚 ${info.event.extendedProps.subject}\n👨‍🏫 Instructor: ${info.event.extendedProps.instructor}`);
         }}
       />

--- a/frontend/src/services/lessonService.js
+++ b/frontend/src/services/lessonService.js
@@ -1,0 +1,6 @@
+import api from '@/services/api/api';
+
+export const getLessonRoomLink = async (lessonId) => {
+  const { data } = await api.post(`/users/classes/lessons/${lessonId}/room`);
+  return data.url;
+};

--- a/frontend/src/tests/__tests__/JoinLiveSession.test.js
+++ b/frontend/src/tests/__tests__/JoinLiveSession.test.js
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import InstructorSchedule from '@/pages/dashboard/instructor/schedule';
+
+jest.mock('../../services/instructor/classService', () => ({
+  fetchInstructorScheduleEvents: jest.fn(() => Promise.resolve([
+    { id: 'lesson-1', title: 'L1', start: new Date().toISOString() },
+  ])),
+}));
+
+jest.mock('../../services/lessonService', () => ({
+  getLessonRoomLink: jest.fn(() => Promise.resolve('http://room')),
+}));
+const { getLessonRoomLink } = require('../../services/lessonService');
+
+jest.mock('../../components/shared/CalendarView', () => ({ onEventClick }) => (
+  <button onClick={() => onEventClick({ event: { id: 'lesson-1', start: new Date().toISOString(), extendedProps: {} } })}>cal</button>
+));
+
+jest.mock('../../components/layouts/InstructorLayout', () => ({ children }) => <div>{children}</div>);
+
+describe('Join live session link', () => {
+  it('requests room link when lesson is live', async () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    render(<InstructorSchedule />);
+    fireEvent.click(screen.getByText('cal'));
+    await waitFor(() => expect(getLessonRoomLink).toHaveBeenCalledWith('1'));
+    openSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add job to notify instructors and students shortly before lessons with secure room links
- expose endpoint to generate lesson-specific video room URLs
- surface "Join Live Session" links on instructor and student schedules
- include tests for live lesson job and join link UI

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689788424b98832894316134a4ce75a8