### PR TITLE
feat: track platform commission in payments

### DIFF
--- a/backend/src/migrations/20250811130000_add_platform_and_instructor_fee_to_payments.js
+++ b/backend/src/migrations/20250811130000_add_platform_and_instructor_fee_to_payments.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('payments', function(table) {
+    table.decimal('platform_fee', 10, 2).notNullable().defaultTo(0);
+    table.decimal('instructor_amount', 10, 2).notNullable().defaultTo(0);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('payments', function(table) {
+    table.dropColumns('platform_fee', 'instructor_amount');
+  });
+};

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -6,12 +6,18 @@ const { v4: uuidv4 } = require("uuid");
 const smsService = require("../../services/smsService");
 const userModel = require("../users/user.model");
 const libraryService = require("../library/library.service");
+const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 
 exports.createPayment = catchAsync(async (req, res) => {
   const { user_id, method_id, item_type, item_id, amount, currency, status, reference_id } = req.body;
   if (!user_id || !method_id || !item_type || !item_id || !amount) {
     throw new AppError("Missing required fields", 400);
   }
+
+  const settings = await paymentConfigService.getSettings();
+  const rate = settings?.platformCut?.[item_type] || 0;
+  const platform_fee = (amount * rate) / 100;
+  const instructor_amount = amount - platform_fee;
 
   const payment = await service.create({
     id: uuidv4(),
@@ -24,6 +30,8 @@ exports.createPayment = catchAsync(async (req, res) => {
     status: status || "pending",
     reference_id,
     paid_at: status === "paid" ? new Date() : null,
+    platform_fee,
+    instructor_amount,
   });
   try {
     const user = await userModel.findById(user_id);

--- a/backend/tests/paymentCommission.test.js
+++ b/backend/tests/paymentCommission.test.js
@@ -1,0 +1,81 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/payments/payments.service', () => ({
+  create: jest.fn(),
+  getAll: jest.fn(),
+  getByUser: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findById: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../src/modules/library/library.service', () => ({
+  recordPurchase: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/payments/payments.service');
+const configService = require('../src/modules/paymentConfig/paymentConfig.service');
+const routes = require('../src/modules/payments/payments.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payments/admin', routes);
+
+describe('payment commission calculations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calculates commission for class payments', async () => {
+    configService.getSettings.mockResolvedValue({ platformCut: { class: 10 } });
+    service.create.mockResolvedValue({ id: 'p1', reference_id: 'ref', status: 'paid' });
+
+    const res = await request(app).post('/api/payments/admin').send({
+      user_id: 'u1',
+      method_id: 'm1',
+      item_type: 'class',
+      item_id: 'i1',
+      amount: 100,
+      status: 'paid',
+    });
+
+    expect(res.status).toBe(200);
+    expect(service.create).toHaveBeenCalledWith(
+      expect.objectContaining({ platform_fee: 10, instructor_amount: 90 })
+    );
+  });
+
+  it('calculates commission for book payments', async () => {
+    configService.getSettings.mockResolvedValue({ platformCut: { book: 20 } });
+    service.create.mockResolvedValue({ id: 'p2', reference_id: 'ref', status: 'paid' });
+
+    const res = await request(app).post('/api/payments/admin').send({
+      user_id: 'u1',
+      method_id: 'm1',
+      item_type: 'book',
+      item_id: 'i2',
+      amount: 50,
+      status: 'paid',
+    });
+
+    expect(res.status).toBe(200);
+    expect(service.create).toHaveBeenCalledWith(
+      expect.objectContaining({ platform_fee: 10, instructor_amount: 40 })
+    );
+  });
+});

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -119,6 +119,8 @@ export default function AdminPaymentsPage() {
             role: t.user_role,
             method: t.method_name,
             type: t.item_type,
+            platformFee: parseFloat(t.platform_fee ?? 0),
+            instructorAmount: parseFloat(t.instructor_amount ?? t.amount),
           }))
         );
         setMethods(
@@ -320,6 +322,8 @@ export default function AdminPaymentsPage() {
                     <th className="px-4 py-2">{t('paymentsPage.type')}</th>
                     <th className="px-4 py-2">{t('paymentsPage.method')}</th>
                     <th className="px-4 py-2">{t('paymentsPage.amount')}</th>
+                    <th className="px-4 py-2">Platform Fee</th>
+                    <th className="px-4 py-2">Net Amount</th>
                     <th className="px-4 py-2">{t('paymentsPage.status')}</th>
                     <th className="px-4 py-2">{t('paymentsPage.actions')}</th>
                   </tr>
@@ -338,6 +342,8 @@ export default function AdminPaymentsPage() {
                       <td className="px-4 py-2">{txn.type}</td>
                       <td className="px-4 py-2">{txn.method}</td>
                       <td className="px-4 py-2 font-semibold text-green-600">${txn.amount.toFixed(2)}</td>
+                      <td className="px-4 py-2">${txn.platformFee.toFixed(2)}</td>
+                      <td className="px-4 py-2">${txn.instructorAmount.toFixed(2)}</td>
                       <td className="px-4 py-2">
                         <span
                           className={`px-2 py-1 rounded-full text-xs font-semibold ${txn.status === "Success"

--- a/frontend/src/pages/dashboard/instructor/payments/history.js
+++ b/frontend/src/pages/dashboard/instructor/payments/history.js
@@ -2,10 +2,10 @@ import { useState } from "react";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 
 const mockHistory = [
-  { id: 1, title: "React Basics", amount: 120, date: "2025-04-10", method: "Bank Transfer", status: "Paid" },
-  { id: 2, title: "Next.js Bootcamp", amount: 200, date: "2025-04-20", method: "PayPal", status: "Pending" },
-  { id: 3, title: "Node.js Fundamentals", amount: 150, date: "2025-05-01", method: "Bank Transfer", status: "Paid" },
-  { id: 4, title: "AI with Python", amount: 180, date: "2025-05-03", method: "PayPal", status: "Paid" },
+  { id: 1, title: "React Basics", amount: 120, platformFee: 24, netAmount: 96, date: "2025-04-10", method: "Bank Transfer", status: "Paid" },
+  { id: 2, title: "Next.js Bootcamp", amount: 200, platformFee: 40, netAmount: 160, date: "2025-04-20", method: "PayPal", status: "Pending" },
+  { id: 3, title: "Node.js Fundamentals", amount: 150, platformFee: 30, netAmount: 120, date: "2025-05-01", method: "Bank Transfer", status: "Paid" },
+  { id: 4, title: "AI with Python", amount: 180, platformFee: 36, netAmount: 144, date: "2025-05-03", method: "PayPal", status: "Paid" },
 ];
 
 export default function InstructorPaymentsHistoryPage() {
@@ -22,8 +22,16 @@ export default function InstructorPaymentsHistoryPage() {
   });
 
   const exportCSV = () => {
-    const headers = ["Class", "Amount", "Date", "Method", "Status"];
-    const rows = filteredHistory.map(({ title, amount, date, method, status }) => [title, amount, date, method, status]);
+    const headers = ["Class", "Amount", "Platform Fee", "Net Amount", "Date", "Method", "Status"];
+    const rows = filteredHistory.map(({ title, amount, platformFee, netAmount, date, method, status }) => [
+      title,
+      amount,
+      platformFee,
+      netAmount,
+      date,
+      method,
+      status,
+    ]);
     const csv = [headers, ...rows].map((row) => row.join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv" });
     const link = document.createElement("a");
@@ -84,6 +92,8 @@ export default function InstructorPaymentsHistoryPage() {
               <tr className="bg-gray-100 text-left">
                 <th className="p-3">Class</th>
                 <th className="p-3">Amount</th>
+                <th className="p-3">Platform Fee</th>
+                <th className="p-3">Net Amount</th>
                 <th className="p-3">Date</th>
                 <th className="p-3">Method</th>
                 <th className="p-3">Status</th>
@@ -94,6 +104,8 @@ export default function InstructorPaymentsHistoryPage() {
                 <tr key={entry.id} className="border-b hover:bg-gray-50">
                   <td className="p-3">{entry.title}</td>
                   <td className="p-3">${entry.amount}</td>
+                  <td className="p-3">${entry.platformFee}</td>
+                  <td className="p-3">${entry.netAmount}</td>
                   <td className="p-3">{entry.date}</td>
                   <td className="p-3">{entry.method}</td>
                   <td className={`p-3 font-medium ${entry.status === "Paid" ? "text-green-600" : "text-yellow-600"}`}>{entry.status}</td>


### PR DESCRIPTION
## Summary
- compute platform fees based on payment settings and store instructor payout amounts
- add database columns for platform fees and instructor amounts
- surface platform fees and net earnings in admin and instructor dashboards
- test commission calculations for multiple item types

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897884084a88328aa22a6442fa7917f