### PR TITLE
feat: persist cart items

### DIFF
--- a/backend/src/jobs/cartReminderJob.js
+++ b/backend/src/jobs/cartReminderJob.js
@@ -1,4 +1,4 @@
-const cartService = require("../modules/cart/cart.service");
+const db = require("../config/database");
 const notificationService = require("../modules/notifications/notifications.service");
 const messageService = require("../modules/messages/messages.service");
 const userModel = require("../modules/users/user.model");
@@ -6,35 +6,33 @@ const { sendCartReminderEmail } = require("../utils/email");
 
 function startCartReminderJob() {
   setInterval(async () => {
-    const items = cartService.getAll();
-    const now = Date.now();
+    const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000);
+    const items = await db("cart_items")
+      .where("reminder_sent", false)
+      .andWhere("added_at", "<=", fourHoursAgo);
     const admins = await userModel.findAdmins();
     const sender = admins[0];
     for (const item of items) {
-      if (item.reminder_sent) continue;
-      const added = new Date(item.added_at).getTime();
-      if (now - added >= 4 * 60 * 60 * 1000) {
-        const message = `Don't forget about ${item.name || "item"} in your cart!`;
-        await notificationService.createNotification({
-          user_id: item.user_id,
-          type: "cart_reminder",
+      const message = `Don't forget about ${item.name || "item"} in your cart!`;
+      await notificationService.createNotification({
+        user_id: item.user_id,
+        type: "cart_reminder",
+        message,
+      });
+      if (sender) {
+        await messageService.createMessage({
+          sender_id: sender.id,
+          receiver_id: item.user_id,
           message,
         });
-        if (sender) {
-          await messageService.createMessage({
-            sender_id: sender.id,
-            receiver_id: item.user_id,
-            message,
-          });
-        }
-        try {
-          const user = await userModel.findById(item.user_id);
-          if (user?.email) await sendCartReminderEmail(user.email, item.name);
-        } catch (err) {
-          console.error("Error sending cart reminder email:", err.message);
-        }
-        item.reminder_sent = true;
       }
+      try {
+        const user = await userModel.findById(item.user_id);
+        if (user?.email) await sendCartReminderEmail(user.email, item.name);
+      } catch (err) {
+        console.error("Error sending cart reminder email:", err.message);
+      }
+      await db("cart_items").where({ id: item.id }).update({ reminder_sent: true });
     }
   }, 60 * 60 * 1000); // hourly
 }

--- a/backend/src/migrations/20250810122000_create_carts_table.js
+++ b/backend/src/migrations/20250810122000_create_carts_table.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'carts';
+
+exports.up = function(knex) {
+  return knex.schema.createTable(TABLE_NAME, (table) => {
+    table.string('user_id').primary();
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists(TABLE_NAME);
+};
+

--- a/backend/src/migrations/20250810122100_create_cart_items_table.js
+++ b/backend/src/migrations/20250810122100_create_cart_items_table.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'cart_items';
+
+exports.up = function(knex) {
+  return knex.schema.createTable(TABLE_NAME, (table) => {
+    table.increments('id').primary();
+    table.string('user_id').notNullable().references('user_id').inTable('carts').onDelete('CASCADE');
+    table.string('item_id').notNullable();
+    table.string('name');
+    table.integer('quantity').notNullable().defaultTo(1);
+    table.timestamp('added_at').defaultTo(knex.fn.now());
+    table.boolean('reminder_sent').defaultTo(false);
+    table.unique(['user_id', 'item_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists(TABLE_NAME);
+};
+

--- a/backend/src/modules/cart/cart.controller.js
+++ b/backend/src/modules/cart/cart.controller.js
@@ -7,7 +7,7 @@ const userModel = require("../users/user.model");
 const { sendCartAddedEmail } = require("../../utils/email");
 
 exports.addItem = catchAsync(async (req, res) => {
-  const item = service.add(req.user.id, req.body);
+  const item = await service.add(req.user.id, req.body);
 
   const message = `Added ${item.name || "item"} to your cart`;
   await notificationService.createNotification({
@@ -35,18 +35,18 @@ exports.addItem = catchAsync(async (req, res) => {
 });
 
 exports.getItems = catchAsync(async (req, res) => {
-  const items = service.list(req.user.id);
+  const items = await service.list(req.user.id);
   sendSuccess(res, items);
 });
 
 exports.updateItem = catchAsync(async (req, res) => {
-  const item = service.update(req.user.id, req.params.id, req.body.quantity);
+  const item = await service.update(req.user.id, req.params.id, req.body.quantity);
   if (!item) return res.status(404).json({ message: "Item not found" });
   sendSuccess(res, item, "Cart updated");
 });
 
 exports.removeItem = catchAsync(async (req, res) => {
-  const item = service.remove(req.user.id, req.params.id);
+  const item = await service.remove(req.user.id, req.params.id);
   if (!item) return res.status(404).json({ message: "Item not found" });
   if (item) {
     const message = `Removed ${item.name || "item"} from your cart`;

--- a/backend/src/modules/cart/cart.service.js
+++ b/backend/src/modules/cart/cart.service.js
@@ -1,35 +1,65 @@
-const cart = [];
+const db = require("../../config/database");
 
-exports.list = (userId) => cart.filter((c) => c.user_id === userId);
+exports.list = async (userId) => {
+  return db("cart_items")
+    .where({ user_id: userId })
+    .select("item_id as id", "name", "quantity", "added_at", "reminder_sent");
+};
 
-exports.getAll = () => cart;
+exports.add = async (userId, item) => {
+  return db.transaction(async (trx) => {
+    const cartExists = await trx("carts").where({ user_id: userId }).first();
+    if (!cartExists) {
+      await trx("carts").insert({ user_id: userId });
+    }
+    const existing = await trx("cart_items").where({ user_id: userId, item_id: item.id }).first();
+    if (existing) {
+      const quantity = existing.quantity + (item.quantity || 1);
+      await trx("cart_items").where({ id: existing.id }).update({ quantity });
+    } else {
+      await trx("cart_items").insert({
+        user_id: userId,
+        item_id: item.id,
+        name: item.name,
+        quantity: item.quantity || 1,
+        added_at: new Date(),
+        reminder_sent: false,
+      });
+    }
+    const row = await trx("cart_items").where({ user_id: userId, item_id: item.id }).first();
+    return {
+      id: row.item_id,
+      name: row.name,
+      quantity: row.quantity,
+      added_at: row.added_at,
+      reminder_sent: row.reminder_sent,
+    };
+  });
+};
 
-exports.add = (userId, item) => {
-  const existing = cart.find((c) => c.id === item.id && c.user_id === userId);
-  if (existing) {
-    existing.quantity += item.quantity || 1;
-    return existing;
-  }
-  const newItem = {
-    ...item,
-    user_id: userId,
-    quantity: item.quantity || 1,
-    added_at: new Date(),
-    reminder_sent: false,
+exports.update = async (userId, id, quantity) => {
+  const existing = await db("cart_items").where({ user_id: userId, item_id: id }).first();
+  if (!existing) return null;
+  await db("cart_items").where({ id: existing.id }).update({ quantity });
+  const updated = await db("cart_items").where({ id: existing.id }).first();
+  return {
+    id: updated.item_id,
+    name: updated.name,
+    quantity: updated.quantity,
+    added_at: updated.added_at,
+    reminder_sent: updated.reminder_sent,
   };
-  cart.push(newItem);
-  return newItem;
 };
 
-exports.update = (userId, id, quantity) => {
-  const item = cart.find((c) => c.id === id && c.user_id === userId);
-  if (!item) return null;
-  item.quantity = quantity;
-  return item;
-};
-
-exports.remove = (userId, id) => {
-  const index = cart.findIndex((c) => c.id === id && c.user_id === userId);
-  if (index === -1) return null;
-  return cart.splice(index, 1)[0];
+exports.remove = async (userId, id) => {
+  const existing = await db("cart_items").where({ user_id: userId, item_id: id }).first();
+  if (!existing) return null;
+  await db("cart_items").where({ id: existing.id }).del();
+  return {
+    id: existing.item_id,
+    name: existing.name,
+    quantity: existing.quantity,
+    added_at: existing.added_at,
+    reminder_sent: existing.reminder_sent,
+  };
 };

--- a/backend/tests/cartService.test.js
+++ b/backend/tests/cartService.test.js
@@ -1,0 +1,62 @@
+const knex = require('knex');
+
+const mockDb = knex({
+  client: 'sqlite3',
+  connection: {
+    filename: ':memory:'
+  },
+  useNullAsDefault: true
+});
+
+jest.mock('../src/config/database.js', () => mockDb);
+
+const cartsMigration = require('../src/migrations/20250810122000_create_carts_table');
+const cartItemsMigration = require('../src/migrations/20250810122100_create_cart_items_table');
+
+const service = require('../src/modules/cart/cart.service');
+
+describe('Cart service with DB', () => {
+  beforeAll(async () => {
+    await cartsMigration.up(mockDb);
+    await cartItemsMigration.up(mockDb);
+  });
+
+  afterAll(async () => {
+    await cartItemsMigration.down(mockDb);
+    await cartsMigration.down(mockDb);
+    await mockDb.destroy();
+  });
+
+  beforeEach(async () => {
+    await mockDb('cart_items').del();
+    await mockDb('carts').del();
+  });
+
+  test('adds and lists items per user', async () => {
+    await service.add('u1', { id: 'p1', name: 'Prod1' });
+    await service.add('u1', { id: 'p2', name: 'Prod2' });
+    await service.add('u2', { id: 'p3', name: 'Prod3' });
+    const u1Items = await service.list('u1');
+    const u2Items = await service.list('u2');
+    expect(u1Items).toHaveLength(2);
+    expect(u2Items).toHaveLength(1);
+  });
+
+  test('increments quantity when adding same item', async () => {
+    await service.add('u1', { id: 'p1', name: 'Prod1' });
+    await service.add('u1', { id: 'p1', name: 'Prod1' });
+    const items = await service.list('u1');
+    expect(items[0].quantity).toBe(2);
+  });
+
+  test('updates and removes items', async () => {
+    await service.add('u1', { id: 'p1', name: 'Prod1' });
+    await service.update('u1', 'p1', 5);
+    let items = await service.list('u1');
+    expect(items[0].quantity).toBe(5);
+    const removed = await service.remove('u1', 'p1');
+    expect(removed).toMatchObject({ id: 'p1' });
+    items = await service.list('u1');
+    expect(items).toHaveLength(0);
+  });
+});

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,18 @@
+-- carts table
+CREATE TABLE IF NOT EXISTS carts (
+  user_id VARCHAR PRIMARY KEY,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- cart_items table
+CREATE TABLE IF NOT EXISTS cart_items (
+  id SERIAL PRIMARY KEY,
+  user_id VARCHAR NOT NULL REFERENCES carts(user_id) ON DELETE CASCADE,
+  item_id VARCHAR NOT NULL,
+  name VARCHAR,
+  quantity INTEGER NOT NULL DEFAULT 1,
+  added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  reminder_sent BOOLEAN DEFAULT FALSE,
+  UNIQUE (user_id, item_id)
+);
+


### PR DESCRIPTION
## Summary
- add carts and cart_items tables
- use Knex-backed cart service and reminder job
- add tests for database cart operations

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897883e4e5c8328a4389cc6678ae439