### PR TITLE
Track attendance by lesson

### DIFF
--- a/backend/src/migrations/20250811120000_add_class_id_to_class_attendance.js
+++ b/backend/src/migrations/20250811120000_add_class_id_to_class_attendance.js
@@ -1,0 +1,35 @@
+exports.up = async function(knex) {
+  // add class_id column to class_attendance if not exists
+  const hasClassId = await knex.schema.hasColumn('class_attendance', 'class_id');
+  if (!hasClassId) {
+    await knex.schema.table('class_attendance', function(table) {
+      table
+        .uuid('class_id')
+        .references('id')
+        .inTable('online_classes')
+        .onDelete('CASCADE');
+    });
+
+    // populate class_id based on lesson_id
+    await knex.raw(`
+      UPDATE class_attendance AS ca
+      SET class_id = cl.class_id
+      FROM class_lessons AS cl
+      WHERE ca.lesson_id = cl.id
+    `);
+
+    // ensure not nullable after population
+    await knex.schema.alterTable('class_attendance', function(table) {
+      table.uuid('class_id').notNullable().alter();
+    });
+  }
+};
+
+exports.down = async function(knex) {
+  const hasClassId = await knex.schema.hasColumn('class_attendance', 'class_id');
+  if (hasClassId) {
+    await knex.schema.table('class_attendance', function(table) {
+      table.dropColumn('class_id');
+    });
+  }
+};

--- a/backend/src/modules/classes/attendance/__tests__/classAttendance.service.test.js
+++ b/backend/src/modules/classes/attendance/__tests__/classAttendance.service.test.js
@@ -1,0 +1,94 @@
+const knex = require('knex');
+
+// In-memory SQLite database for testing
+const mockDb = knex({
+  client: 'sqlite3',
+  connection: { filename: ':memory:' },
+  useNullAsDefault: true,
+});
+
+jest.mock('../../../../config/database', () => mockDb);
+
+const db = require('../../../../config/database');
+const service = require('../classAttendance.service');
+const { v4: uuidv4 } = require('uuid');
+
+beforeAll(async () => {
+  await db.schema.createTable('users', table => {
+    table.uuid('id').primary();
+    table.string('full_name');
+  });
+  await db.schema.createTable('online_classes', table => {
+    table.uuid('id').primary();
+    table.string('title');
+  });
+  await db.schema.createTable('class_enrollments', table => {
+    table.uuid('class_id');
+    table.uuid('user_id');
+  });
+  await db.schema.createTable('class_lessons', table => {
+    table.uuid('id').primary();
+    table.uuid('class_id');
+    table.string('title');
+  });
+  await db.schema.createTable('class_attendance', table => {
+    table.uuid('id').primary();
+    table.uuid('class_id');
+    table.uuid('lesson_id');
+    table.uuid('user_id');
+    table.boolean('attended');
+    table.timestamp('timestamp');
+  });
+
+  const classId = 'class1';
+  const lesson1 = 'lesson1';
+  const lesson2 = 'lesson2';
+  await db('online_classes').insert({ id: classId, title: 'Class' });
+  await db('class_lessons').insert([
+    { id: lesson1, class_id: classId, title: 'L1' },
+    { id: lesson2, class_id: classId, title: 'L2' },
+  ]);
+  await db('users').insert([
+    { id: 'u1', full_name: 'User 1' },
+    { id: 'u2', full_name: 'User 2' },
+  ]);
+  await db('class_enrollments').insert([
+    { class_id: classId, user_id: 'u1' },
+    { class_id: classId, user_id: 'u2' },
+  ]);
+  await db('class_attendance').insert({
+    id: uuidv4(),
+    class_id: classId,
+    lesson_id: lesson1,
+    user_id: 'u1',
+    attended: true,
+    timestamp: new Date(),
+  });
+  await db('class_attendance').insert({
+    id: uuidv4(),
+    class_id: classId,
+    lesson_id: lesson2,
+    user_id: 'u2',
+    attended: true,
+    timestamp: new Date(),
+  });
+});
+
+afterAll(async () => {
+  await db.destroy();
+});
+
+describe('classAttendance.service', () => {
+  test('getByClass returns attendance per lesson', async () => {
+    const res1 = await service.getByClass('lesson1');
+    const res2 = await service.getByClass('lesson2');
+
+    expect(res1).toHaveLength(2);
+    expect(res1.find((r) => r.user_id === 'u1').attended).toBe(1);
+    expect(res1.find((r) => r.user_id === 'u2').attended).toBeNull();
+
+    expect(res2).toHaveLength(2);
+    expect(res2.find((r) => r.user_id === 'u2').attended).toBe(1);
+    expect(res2.find((r) => r.user_id === 'u1').attended).toBeNull();
+  });
+});

--- a/backend/src/modules/classes/attendance/classAttendance.controller.js
+++ b/backend/src/modules/classes/attendance/classAttendance.controller.js
@@ -3,13 +3,13 @@ const { sendSuccess } = require("../../../utils/response");
 const service = require("./classAttendance.service");
 
 exports.listByClass = catchAsync(async (req, res) => {
-  const data = await service.getByClass(req.params.classId);
+  const data = await service.getByClass(req.params.lessonId);
   sendSuccess(res, data);
 });
 
 exports.updateAttendance = catchAsync(async (req, res) => {
-  const { classId, userId } = req.params;
+  const { lessonId, userId } = req.params;
   const { attended } = req.body;
-  const row = await service.setAttendance(classId, userId, attended);
+  const row = await service.setAttendance(lessonId, userId, attended);
   sendSuccess(res, row, "Attendance updated");
 });

--- a/backend/src/modules/classes/attendance/classAttendance.routes.js
+++ b/backend/src/modules/classes/attendance/classAttendance.routes.js
@@ -2,7 +2,7 @@ const router = require("express").Router();
 const ctrl = require("./classAttendance.controller");
 const { verifyToken, isInstructorOrAdmin } = require("../../../middleware/auth/authMiddleware");
 
-router.get("/:classId", verifyToken, isInstructorOrAdmin, ctrl.listByClass);
-router.post("/:classId/:userId", verifyToken, isInstructorOrAdmin, ctrl.updateAttendance);
+router.get("/:lessonId", verifyToken, isInstructorOrAdmin, ctrl.listByClass);
+router.post("/:lessonId/:userId", verifyToken, isInstructorOrAdmin, ctrl.updateAttendance);
 
 module.exports = router;

--- a/backend/src/modules/classes/attendance/classAttendance.service.js
+++ b/backend/src/modules/classes/attendance/classAttendance.service.js
@@ -1,33 +1,38 @@
 const db = require("../../../config/database");
 const { v4: uuidv4 } = require("uuid");
 
-// Get attendance list for a class (per current lesson id = classId for now)
-exports.getByClass = async (class_id) => {
-  return db("class_enrollments as ce")
+// Get attendance list for a lesson
+exports.getByClass = async (lesson_id) => {
+  return db("class_lessons as cl")
+    .join("class_enrollments as ce", "ce.class_id", "cl.class_id")
     .join("users as u", "ce.user_id", "u.id")
     .leftJoin("class_attendance as ca", function () {
-      this.on("ca.lesson_id", "=", "ce.class_id").andOn("ca.user_id", "=", "u.id");
+      this.on("ca.lesson_id", "=", "cl.id").andOn("ca.user_id", "=", "u.id");
     })
-    .where("ce.class_id", class_id)
+    .where("cl.id", lesson_id)
     .select("u.id as user_id", "u.full_name", "ca.attended");
 };
 
-// Upsert attendance record
-exports.setAttendance = async (class_id, user_id, attended) => {
+// Upsert attendance record for a lesson
+exports.setAttendance = async (lesson_id, user_id, attended) => {
+  const lesson = await db("class_lessons").where({ id: lesson_id }).first();
+  if (!lesson) throw new Error("Lesson not found");
+  const class_id = lesson.class_id;
+
   const existing = await db("class_attendance")
-    .where({ lesson_id: class_id, user_id })
+    .where({ lesson_id, user_id })
     .first();
 
   if (existing) {
     const [row] = await db("class_attendance")
-      .where({ lesson_id: class_id, user_id })
-      .update({ attended, timestamp: db.fn.now() })
+      .where({ lesson_id, user_id })
+      .update({ attended, timestamp: db.fn.now(), class_id })
       .returning("*");
     return row;
   }
 
   const [row] = await db("class_attendance")
-    .insert({ id: uuidv4(), lesson_id: class_id, user_id, attended })
+    .insert({ id: uuidv4(), lesson_id, class_id, user_id, attended })
     .returning("*");
   return row;
 };

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -190,7 +190,7 @@ exports.getClassAnalytics = async (classId) => {
     .countDistinct({ count: "user_id" });
 
   const [attendanceRow] = await db("class_attendance")
-    .where({ lesson_id: classId, attended: true })
+    .where({ class_id: classId, attended: true })
     .countDistinct({ count: "user_id" });
 
   const viewAgents = await db("class_views")

--- a/frontend/src/components/instructors/StudentAttendancePanel.js
+++ b/frontend/src/components/instructors/StudentAttendancePanel.js
@@ -5,27 +5,27 @@ import {
   updateClassAttendance,
 } from "@/services/instructor/classAttendanceService";
 
-export default function StudentAttendancePanel({ classId }) {
+export default function StudentAttendancePanel({ lessonId }) {
   const [students, setStudents] = useState([]);
 
   useEffect(() => {
-    if (!classId) return;
+    if (!lessonId) return;
     const load = async () => {
       try {
-        const list = await fetchClassAttendance(classId);
+        const list = await fetchClassAttendance(lessonId);
         setStudents(list);
       } catch (err) {
         console.error("Failed to load attendance", err);
       }
     };
     load();
-  }, [classId]);
+  }, [lessonId]);
 
   const toggleAttendance = async (index) => {
     const student = students[index];
     const attended = !student.attended;
     try {
-      await updateClassAttendance(classId, student.user_id, attended);
+      await updateClassAttendance(lessonId, student.user_id, attended);
       const updated = [...students];
       updated[index].attended = attended;
       setStudents(updated);

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id].js
@@ -105,7 +105,7 @@ function InstructorClassRoom() {
         {/* Attendance Panel */}
         <div className="bg-gray-800 p-4 rounded-lg shadow-md">
           <h2 className="text-lg font-semibold text-yellow-300 mb-2">🧑‍🎓 Attendance</h2>
-          <StudentAttendancePanel classId={id} />
+          <StudentAttendancePanel lessonId={lessons[0]?.id} />
         </div>
 
         {/* Certificate Issuance */}

--- a/frontend/src/services/instructor/classAttendanceService.js
+++ b/frontend/src/services/instructor/classAttendanceService.js
@@ -1,13 +1,13 @@
 import api from "@/services/api/api";
 
-export const fetchClassAttendance = async (classId) => {
-  const { data } = await api.get(`/users/classes/attendance/${classId}`);
+export const fetchClassAttendance = async (lessonId) => {
+  const { data } = await api.get(`/users/classes/attendance/${lessonId}`);
   return data?.data ?? [];
 };
 
-export const updateClassAttendance = async (classId, userId, attended) => {
+export const updateClassAttendance = async (lessonId, userId, attended) => {
   const { data } = await api.post(
-    `/users/classes/attendance/${classId}/${userId}`,
+    `/users/classes/attendance/${lessonId}/${userId}`,
     { attended }
   );
   return data?.data;


### PR DESCRIPTION
## Summary
- add migration to store class_id alongside lesson_id for attendance
- fetch and update attendance by lesson id
- adjust instructor panel and tests for per-lesson attendance

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897883ce9c88328b0c3d02e0905eeaa