### PR TITLE
feat: add lesson SMS reminders

### DIFF
--- a/backend/src/jobs/lessonReminderJob.js
+++ b/backend/src/jobs/lessonReminderJob.js
@@ -2,6 +2,8 @@ const db = require("../config/database");
 const notificationService = require("../modules/notifications/notifications.service");
 const messageService = require("../modules/messages/messages.service");
 const userModel = require("../modules/users/user.model");
+const enrollmentService = require("../modules/classes/enrollments/classEnrollment.service");
+const smsService = require("../services/smsService");
 const { sendLessonReminderEmail } = require("../utils/email");
 
 function startLessonReminderJob() {
@@ -14,6 +16,7 @@ function startLessonReminderJob() {
         .join("online_classes as c", "l.class_id", "c.id")
         .select(
           "l.id",
+          "l.class_id",
           "l.title",
           "l.start_time",
           "c.title as class_title",
@@ -51,6 +54,31 @@ function startLessonReminderJob() {
           );
         } catch (err) {
           console.error("Error sending reminder email:", err.message);
+        }
+
+        const startTime = new Date(lesson.start_time).toLocaleString();
+        const text = `Reminder: Lesson "${lesson.title}" starts at ${startTime}`;
+
+        if (instructor.phone) {
+          try {
+            await smsService.sendSMS({ to: instructor.phone, text });
+          } catch (err) {
+            console.error("Error sending instructor reminder SMS:", err.message);
+          }
+        }
+
+        let students = [];
+        try {
+          students = await enrollmentService.getPhonesByClass(lesson.class_id);
+        } catch (err) {
+          console.error("Error fetching enrolled students for lesson:", err.message);
+        }
+        for (const student of students) {
+          try {
+            await smsService.sendSMS({ to: student.phone, text });
+          } catch (err) {
+            console.error("Error sending lesson reminder SMS:", err.message);
+          }
         }
       }
     } catch (err) {

--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -44,6 +44,15 @@ exports.getByClass = async (class_id) => {
     .orderBy("ce.enrolled_at");
 };
 
+// Get phone numbers of students enrolled in a class
+exports.getPhonesByClass = async (class_id) => {
+  return db("class_enrollments as ce")
+    .join("users as u", "ce.user_id", "u.id")
+    .where("ce.class_id", class_id)
+    .whereNotNull("u.phone")
+    .select("u.id", "u.phone");
+};
+
 // Get a single student's enrollment details in a class
 exports.getStudent = async (class_id, user_id) => {
   return db("class_enrollments as ce")

--- a/backend/src/modules/classes/lessons/__tests__/lessonReminderJob.test.js
+++ b/backend/src/modules/classes/lessons/__tests__/lessonReminderJob.test.js
@@ -1,0 +1,76 @@
+const mockLessons = [
+  {
+    id: 1,
+    class_id: 42,
+    title: 'Lesson A',
+    start_time: new Date().toISOString(),
+    class_title: 'Class A',
+    instructor_id: 7,
+  },
+];
+
+jest.mock('../../../../config/database', () => {
+  const fn = jest.fn(() => fn);
+  fn.join = jest.fn(() => fn);
+  fn.select = jest.fn(() => fn);
+  fn.whereBetween = jest.fn(() => Promise.resolve(mockLessons));
+  return fn;
+});
+
+jest.mock('../../../../modules/users/user.model', () => ({
+  findAdmins: jest.fn(),
+  findById: jest.fn(),
+}));
+
+jest.mock('../../../../modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../../../../modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../../../../utils/email', () => ({
+  sendLessonReminderEmail: jest.fn(),
+}));
+
+jest.mock('../../enrollments/classEnrollment.service', () => ({
+  getPhonesByClass: jest.fn(),
+}));
+
+jest.mock('../../../../services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+const smsService = require('../../../../services/smsService');
+const enrollmentService = require('../../enrollments/classEnrollment.service');
+const userModel = require('../../../../modules/users/user.model');
+const startLessonReminderJob = require('../../../../jobs/lessonReminderJob');
+
+describe('lessonReminderJob SMS', () => {
+  it('sends SMS to instructor and enrolled students', async () => {
+    userModel.findAdmins.mockResolvedValue([{ id: 99 }]);
+    userModel.findById.mockResolvedValue({ id: 7, email: 'instr@example.com', phone: '+333' });
+    enrollmentService.getPhonesByClass.mockResolvedValue([
+      { id: 2, phone: '+111' },
+      { id: 3, phone: '+222' },
+    ]);
+
+    let intervalFn;
+    jest.spyOn(global, 'setInterval').mockImplementation((cb) => {
+      intervalFn = cb;
+      return 0;
+    });
+
+    startLessonReminderJob();
+    await intervalFn();
+
+    expect(smsService.sendSMS).toHaveBeenCalledWith({
+      to: '+333',
+      text: expect.stringContaining('Lesson "Lesson A" starts at'),
+    });
+    expect(smsService.sendSMS).toHaveBeenCalledWith({ to: '+111', text: expect.any(String) });
+    expect(smsService.sendSMS).toHaveBeenCalledWith({ to: '+222', text: expect.any(String) });
+    expect(smsService.sendSMS).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- send SMS reminders to instructors and enrolled students when lessons approach
- expose helper to fetch enrolled students' phone numbers
- cover lesson reminder job with tests verifying SMS dispatch

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897883b63a883289372003c4ebb2ff7