### PR TITLE
chore: remove redundant payment config notify

### DIFF
--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -236,7 +236,6 @@ export default function AdminPaymentsPage() {
     try {
       await updatePaymentConfig(form);
       toast.success(t('paymentsPage.config_saved'));
-      notify("payment_config_updated", "Payment configuration updated");
     } catch (err) {
       toast.error(err?.response?.data?.message || t('paymentsPage.config_save_failed'));
     }


### PR DESCRIPTION
## Summary
- avoid duplicate notifications by removing frontend notify call after updating payment config

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978850e624832882cea4983210edbf