### PR TITLE
Handle unverified phone for SMS OTPs

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -282,6 +282,13 @@ exports.generateOtp = async (email, via = "email") => {
     return;
   }
 
+  if (via === "sms" && (!user.phone || !user.is_phone_verified)) {
+    throw new AppError(
+      "A verified phone number is required before SMS OTPs can be sent",
+      400
+    );
+  }
+
   const code = generateOtp(OTP_LENGTH);
   const codeHash = await bcrypt.hash(code, SALT_ROUNDS);
 
@@ -296,7 +303,7 @@ exports.generateOtp = async (email, via = "email") => {
     created_at: db.fn.now(),
   });
 
-  if (via === "sms" && user.phone && user.is_phone_verified) {
+  if (via === "sms") {
     try {
       await smsService.sendSMS({
         to: user.phone,

--- a/backend/tests/authGenerateOtpService.test.js
+++ b/backend/tests/authGenerateOtpService.test.js
@@ -1,0 +1,87 @@
+jest.mock('../src/config/database', () => {
+  const insert = jest.fn().mockResolvedValue();
+  const mockDb = jest.fn((table) => {
+    if (table === 'password_resets') {
+      return { insert };
+    }
+    return {};
+  });
+  mockDb.raw = jest.fn();
+  mockDb.fn = { now: jest.fn() };
+  return mockDb;
+});
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findByEmail: jest.fn(),
+}));
+
+jest.mock('../src/utils/email', () => ({
+  sendOtpEmail: jest.fn(),
+  sendPasswordChangeEmail: jest.fn(),
+  sendWelcomeEmail: jest.fn(),
+  sendNewUserAdminEmail: jest.fn(),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/modules/verify/verify.service', () => ({
+  sendOtp: jest.fn(),
+  verifyOtp: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn().mockResolvedValue('hashed'),
+}));
+
+const authService = require('../src/modules/auth/services/auth.service');
+const userModel = require('../src/modules/users/user.model');
+const { sendOtpEmail } = require('../src/utils/email');
+const smsService = require('../src/services/smsService');
+
+describe('generateOtp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws error when phone is unverified for SMS OTP', async () => {
+    userModel.findByEmail.mockResolvedValue({
+      id: 1,
+      email: 'test@example.com',
+      phone: '+1234567890',
+      is_phone_verified: false,
+    });
+
+    await expect(authService.generateOtp('test@example.com', 'sms')).rejects.toThrow(
+      'A verified phone number is required before SMS OTPs can be sent'
+    );
+
+    expect(sendOtpEmail).not.toHaveBeenCalled();
+    expect(smsService.sendSMS).not.toHaveBeenCalled();
+  });
+
+  it('throws error when phone is missing for SMS OTP', async () => {
+    userModel.findByEmail.mockResolvedValue({
+      id: 1,
+      email: 'test@example.com',
+      phone: null,
+      is_phone_verified: false,
+    });
+
+    await expect(authService.generateOtp('test@example.com', 'sms')).rejects.toThrow(
+      'A verified phone number is required before SMS OTPs can be sent'
+    );
+
+    expect(sendOtpEmail).not.toHaveBeenCalled();
+    expect(smsService.sendSMS).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- prevent SMS OTP generation when the user has no verified phone
- add tests covering SMS OTP requests with missing or unverified phones

## Testing
- `cd backend && npm test` *(fails: tests/paymentCommission.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68978ff959b08328911918f24858a3ea