### PR TITLE
Surface SMS and email disable errors to API clients

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -131,11 +131,7 @@ exports.logout = catchAsync(async (req, res) => {
  */
 exports.requestReset = catchAsync(async (req, res) => {
   const { email, via } = req.body;
-  try {
-    await authService.generateOtp(email, via);
-  } catch (err) {
-    // swallow errors to avoid user enumeration
-  }
+  await authService.generateOtp(email, via);
   res.json({ message: "If that email exists, an OTP has been sent" });
 });
 

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -303,10 +303,14 @@ exports.generateOtp = async (email, via = "email") => {
         text: `Your SkillBridge OTP is: ${code}`,
       });
     } catch (err) {
-      console.error("Error sending OTP SMS:", err.message);
+      throw new AppError(err.message, 503);
     }
   } else {
-    await sendOtpEmail(email, code);
+    try {
+      await sendOtpEmail(email, code);
+    } catch (err) {
+      throw new AppError(err.message, 503);
+    }
   }
 };
 

--- a/backend/src/modules/verify/verify.service.js
+++ b/backend/src/modules/verify/verify.service.js
@@ -5,6 +5,7 @@ const messageService = require("../messages/messages.service");
 const userModel = require("../users/user.model");
 const { sendOtpEmail } = require("../../utils/email");
 const smsService = require("../../services/smsService");
+const AppError = require("../../utils/AppError");
 
 const generateCode = () =>
   Math.floor(100000 + Math.random() * 900000).toString();
@@ -32,7 +33,7 @@ exports.sendOtp = async (userId, type) => {
     try {
       await sendOtpEmail(user.email, code);
     } catch (err) {
-      console.error("Error sending OTP email:", err.message);
+      throw new AppError(err.message, 503);
     }
   } else {
     try {
@@ -41,7 +42,7 @@ exports.sendOtp = async (userId, type) => {
         text: `Your SkillBridge OTP is: ${code}`,
       });
     } catch (err) {
-      console.error("Error sending OTP SMS:", err.message);
+      throw new AppError(err.message, 503);
     }
   }
 

--- a/backend/src/services/smsService.js
+++ b/backend/src/services/smsService.js
@@ -15,14 +15,12 @@ async function getActiveProvider() {
 
 exports.sendSMS = async ({ to, text }) => {
   if (SMS_DISABLED) {
-    console.log(`[SMS DISABLED] to ${to}: ${text}`);
-    return;
+    throw new Error("SMS service is disabled");
   }
 
   const provider = await getActiveProvider();
   if (!provider) {
-    console.log(`[SMS] No active provider. Message to ${to}: ${text}`);
-    return;
+    throw new Error("No active SMS gateway provider configured");
   }
 
   if (provider.name === 'Infobip') {

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -12,6 +12,9 @@ const EMAIL_FOOTER =
 const EMAILS_DISABLED = process.env.DISABLE_EMAILS === "true";
 
 async function createTransporter() {
+  if (EMAILS_DISABLED) {
+    throw new Error("Email service is disabled");
+  }
   const cfg = (await emailConfigService.getSettings()) || {};
 
   const host = (cfg.smtpHost || process.env.SMTP_HOST || "").trim();
@@ -40,11 +43,6 @@ exports.sendOtpEmail = async (to, otp) => {
   const cfg = (await emailConfigService.getSettings()) || {};
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
-
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] OTP for ${to}: ${otp}`);
-    return;
-  }
 
   const fromEmail = (
     cfg.fromEmail ||
@@ -97,11 +95,6 @@ exports.sendPasswordChangeEmail = async (to) => {
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Password change notice for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -152,11 +145,6 @@ exports.sendWelcomeEmail = async (to, name) => {
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Welcome email for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -205,11 +193,6 @@ exports.sendNewUserAdminEmail = async (to, user) => {
   const cfg = (await emailConfigService.getSettings()) || {};
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
-
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] New user notice to ${to}`);
-    return;
-  }
 
   const fromEmail = (
     cfg.fromEmail ||
@@ -265,11 +248,6 @@ exports.sendLessonScheduledEmail = async (
   const cfg = (await emailConfigService.getSettings()) || {};
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
-
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Lesson scheduled notice for ${to}`);
-    return;
-  }
 
   const fromEmail = (
     cfg.fromEmail ||
@@ -330,11 +308,6 @@ exports.sendLessonReminderEmail = async (
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Lesson reminder for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -394,11 +367,6 @@ exports.sendAssignmentEmail = async (
   const cfg = (await emailConfigService.getSettings()) || {};
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
-
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Assignment notice for ${to}`);
-    return;
-  }
 
   const fromEmail = (
     cfg.fromEmail ||
@@ -464,11 +432,6 @@ exports.sendSupportTicketAdminEmail = async (
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Support ticket notice to ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -529,11 +492,6 @@ exports.sendSupportTicketUserEmail = async (
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Support ticket receipt for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -587,11 +545,6 @@ exports.sendSupportTicketUpdateEmail = async (
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Support ticket update for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -643,11 +596,6 @@ exports.sendTutorialCreatedAdminEmail = async (
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Tutorial created notice to ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -696,11 +644,6 @@ exports.sendTutorialCreatedInstructorEmail = async (to, tutorialTitle) => {
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Tutorial creation notice for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -748,11 +691,6 @@ exports.sendTutorialApprovedEmail = async (to, tutorialTitle) => {
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Tutorial approved notice for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -799,11 +737,6 @@ exports.sendTutorialRejectedEmail = async (to, tutorialTitle, reason) => {
   const cfg = (await emailConfigService.getSettings()) || {};
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
-
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Tutorial rejection notice for ${to}`);
-    return;
-  }
 
   const fromEmail = (
     cfg.fromEmail ||
@@ -855,11 +788,6 @@ exports.sendNewDiscussionEmail = async (to, askerName, questionTitle) => {
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] New discussion notice for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -908,11 +836,6 @@ exports.sendCartReminderEmail = async (to, itemName) => {
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Cart reminder for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -959,11 +882,6 @@ exports.sendCartAddedEmail = async (to, itemName) => {
   const cfg = (await emailConfigService.getSettings()) || {};
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
-
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Cart added notice for ${to}`);
-    return;
-  }
 
   const fromEmail = (
     cfg.fromEmail ||
@@ -1012,11 +930,6 @@ exports.sendAdSubmissionEmail = async (to, name, adTitle) => {
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Ad submission notice for ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -1064,11 +977,6 @@ exports.sendNewAdAdminEmail = async (to, instructorName, adTitle) => {
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
 
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] New ad notice to ${to}`);
-    return;
-  }
-
   const fromEmail = (
     cfg.fromEmail ||
     process.env.SMTP_USER ||
@@ -1115,11 +1023,6 @@ exports.sendAdApprovalEmail = async (to, adTitle) => {
   const cfg = (await emailConfigService.getSettings()) || {};
   const app = (await appConfigService.getSettings()) || {};
   const transporter = await createTransporter();
-
-  if (EMAILS_DISABLED) {
-    console.log(`[EMAIL DISABLED] Ad approval notice for ${to}`);
-    return;
-  }
 
   const fromEmail = (
     cfg.fromEmail ||


### PR DESCRIPTION
## Summary
- Throw when SMS sending is disabled or no provider is configured
- Fail fast in email utils when emails are disabled
- Propagate OTP delivery failures through auth services/controllers

## Testing
- `cd backend && npm test` *(fails: tests/paymentCommission.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68978ff8e95c83288bccadaa04392ee6