### PR TITLE
feat: add share fallback for tutorial page

### DIFF
--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -33,6 +33,29 @@ import { API_BASE_URL } from "@/config/config";
 import { safeEncodeURI } from "@/utils/url";
 import Link from "next/link";
 
+export async function handleShare(tutorial) {
+  const shareData = {
+    title: tutorial.title,
+    text: "Check out this tutorial on SkillBridge!",
+    url: typeof window !== "undefined" ? window.location.href : "",
+  };
+  if (navigator.share) {
+    try {
+      await navigator.share(shareData);
+      toast.success("Shared successfully!");
+    } catch {
+      // ignore errors
+    }
+  } else {
+    try {
+      await navigator.clipboard.writeText(shareData.url);
+      toast.success("Link copied to clipboard!");
+    } catch {
+      toast.error("Failed to copy link");
+    }
+  }
+}
+
 export default function TutorialDetail() {
   const router = useRouter();
   const { id } = router.query;
@@ -230,16 +253,7 @@ export default function TutorialDetail() {
         <div className="flex justify-end mb-4 gap-3">
 
           <button
-            onClick={() =>
-              navigator
-                .share({
-                  title: tutorial.title,
-                  text: "Check out this tutorial on SkillBridge!",
-                  url: typeof window !== "undefined" ? window.location.href : "",
-                })
-                .then(() => toast.success("Shared successfully!"))
-                .catch(() => {})
-            }
+            onClick={() => handleShare(tutorial)}
             className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition"
           >
             🔗 Share

--- a/frontend/src/tests/__tests__/shareFallback.test.js
+++ b/frontend/src/tests/__tests__/shareFallback.test.js
@@ -1,0 +1,26 @@
+import { handleShare } from '@/pages/tutorials/[id]';
+import toast from 'react-hot-toast';
+
+describe('handleShare fallback', () => {
+  it('copies link to clipboard when navigator.share is unavailable', async () => {
+    const writeText = jest.fn().mockResolvedValue();
+    Object.defineProperty(navigator, 'share', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+    const toastSpy = jest.spyOn(toast, 'success').mockImplementation(() => {});
+
+    await handleShare({ title: 'Test tutorial' });
+
+    expect(writeText).toHaveBeenCalledWith(window.location.href);
+    expect(toastSpy).toHaveBeenCalledWith('Link copied to clipboard!');
+
+    toastSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add handleShare utility with clipboard fallback
- test share fallback when Web Share API is unavailable

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689794b1b8a88328a58835e1c6754c1e