### PR TITLE
Enable SMS option for password reset OTP

### DIFF
--- a/backend/src/modules/auth/validators/auth.validator.js
+++ b/backend/src/modules/auth/validators/auth.validator.js
@@ -33,6 +33,7 @@ exports.loginSchema = z.object({
  */
 exports.otpRequestSchema = z.object({
   email: z.string().email("Invalid email"),
+  via: z.enum(["email", "sms"]).optional(),
 });
 
 /**

--- a/backend/tests/authForgotPasswordRoutes.test.js
+++ b/backend/tests/authForgotPasswordRoutes.test.js
@@ -35,6 +35,16 @@ describe('POST /api/auth/forgot-password', () => {
     expect(res.body.message).toBeDefined();
   });
 
+  it('passes via sms when requested', async () => {
+    service.generateOtp.mockResolvedValue();
+    userModel.findByEmail.mockResolvedValue({ id: 1, email: 'test@example.com', phone: '+11234567890', is_phone_verified: true });
+    const res = await request(app)
+      .post('/api/auth/forgot-password')
+      .send({ email: 'test@example.com', via: 'sms' });
+    expect(res.status).toBe(200);
+    expect(service.generateOtp).toHaveBeenCalledWith('test@example.com', 'sms');
+  });
+
   it('returns generic message for unknown email', async () => {
     service.generateOtp.mockResolvedValue();
     userModel.findByEmail.mockResolvedValue(null);


### PR DESCRIPTION
## Summary
- Allow OTP request validation to accept `via` parameter for email or SMS
- Test SMS OTP requests on forgot-password route

## Testing
- `npm test` *(fails: tests/paymentCommission.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689795b8c0f08328af1ec7c9f5522501