### PR TITLE
feat: track tutorial progress by chapter id

### DIFF
--- a/frontend/src/components/tutorials/detail/ChapterList.js
+++ b/frontend/src/components/tutorials/detail/ChapterList.js
@@ -15,12 +15,12 @@ const ChapterList = ({
       <ul className="space-y-4">
         {chapters.map((chapter, index) => {
           const isActive = index === currentIndex;
-          const isCompleted = completedChapters.includes(index);
+          const isCompleted = completedChapters.includes(chapter.id);
           const locked = !isEnrolled && index > 0;
 
           return (
             <li
-              key={index}
+              key={chapter.id ?? index}
               onClick={() => !locked && onSelect(index)}
               title={locked ? "Enroll to unlock" : ""}
               className={`flex items-start gap-3 p-4 rounded-lg transition border ${

--- a/frontend/src/components/tutorials/detail/TutorialPlayerWrapper.js
+++ b/frontend/src/components/tutorials/detail/TutorialPlayerWrapper.js
@@ -5,16 +5,19 @@ import ChapterList from "./ChapterList";
 
 const chaptersData = [
   {
+    id: 1,
     title: "Intro to React",
     duration: "4",
     videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
   },
   {
+    id: 2,
     title: "JSX and Components",
     duration: "8",
     videoUrl: "https://www.w3schools.com/html/movie.mp4",
   },
   {
+    id: 3,
     title: "Hooks Deep Dive",
     duration: "5",
     videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
@@ -29,13 +32,24 @@ const TutorialPlayerWrapper = () => {
 
   // Load completed chapters from localStorage
   useEffect(() => {
-    const saved = JSON.parse(localStorage.getItem(`completed-${tutorialId}`) || "[]");
-    setCompleted(saved);
+    const saved = JSON.parse(
+      localStorage.getItem(`completed-${tutorialId}`) || "[]",
+    );
+    if (saved.length && typeof saved[0] === "number") {
+      const ids = saved
+        .map((idx) => chaptersData[idx]?.id)
+        .filter(Boolean);
+      setCompleted(ids);
+      localStorage.setItem(`completed-${tutorialId}`, JSON.stringify(ids));
+    } else {
+      setCompleted(saved);
+    }
   }, []);
 
   const handleComplete = () => {
-    if (!completed.includes(currentIndex)) {
-      const updated = [...completed, currentIndex];
+    const chId = chaptersData[currentIndex].id;
+    if (!completed.includes(chId)) {
+      const updated = [...completed, chId];
       setCompleted(updated);
       localStorage.setItem(`completed-${tutorialId}`, JSON.stringify(updated));
     }

--- a/frontend/src/components/tutorials/detail/VideoPreviewList.js
+++ b/frontend/src/components/tutorials/detail/VideoPreviewList.js
@@ -9,7 +9,7 @@ const VideoPreviewList = ({ videos = [], onSelect = () => {}, currentIndex = 0, 
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {videos.map((vid, idx) => (
           <div
-            key={idx}
+            key={vid.id ?? idx}
             onClick={() => onSelect(idx)}
             className={`cursor-pointer rounded overflow-hidden border ${currentIndex === idx ? "border-yellow-400" : "border-gray-700"}`}
           >
@@ -19,7 +19,7 @@ const VideoPreviewList = ({ videos = [], onSelect = () => {}, currentIndex = 0, 
                 muted
                 className="w-full h-32 object-cover"
               />
-              {completed.includes(idx) && (
+              {completed.includes(vid.id) && (
                 <span className="absolute top-1 right-1 bg-green-600 text-white text-xs px-1 rounded">✓</span>
               )}
             </div>

--- a/frontend/src/hooks/useTutorialProgress.js
+++ b/frontend/src/hooks/useTutorialProgress.js
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 
-export default function useTutorialProgress(tutorialId) {
+export default function useTutorialProgress(tutorialId, chapters = []) {
   const [progress, setProgress] = useState({
-    completedChapters: [],
+    completedChapters: [], // will now store chapter IDs
     lastIndex: 0,
     times: {},
   });
@@ -12,12 +12,32 @@ export default function useTutorialProgress(tutorialId) {
     const stored = localStorage.getItem(`progress-tutorial-${tutorialId}`);
     if (stored) {
       try {
-        setProgress(JSON.parse(stored));
+        const parsed = JSON.parse(stored);
+        // Migration: if old numeric indices are stored, convert to chapter IDs
+        if (
+          Array.isArray(parsed.completedChapters) &&
+          parsed.completedChapters.length > 0 &&
+          typeof parsed.completedChapters[0] === "number" &&
+          Array.isArray(chapters) &&
+          chapters.length
+        ) {
+          const ids = parsed.completedChapters
+            .map((idx) => chapters[idx]?.id)
+            .filter(Boolean);
+          const migrated = { ...parsed, completedChapters: ids };
+          setProgress(migrated);
+          localStorage.setItem(
+            `progress-tutorial-${tutorialId}`,
+            JSON.stringify(migrated),
+          );
+        } else {
+          setProgress(parsed);
+        }
       } catch {
         // ignore parse errors
       }
     }
-  }, [tutorialId]);
+  }, [tutorialId, chapters]);
 
   const persist = (data) => {
     setProgress(data);
@@ -37,7 +57,10 @@ export default function useTutorialProgress(tutorialId) {
   };
 
   const completeChapter = (index, chapterId) => {
-    const updated = Array.from(new Set([...progress.completedChapters, index]));
+    if (!chapterId && chapterId !== 0) return;
+    const updated = Array.from(
+      new Set([...progress.completedChapters, chapterId]),
+    );
     persist({ ...progress, completedChapters: updated, lastIndex: index });
   };
 

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -48,7 +48,7 @@ export default function TutorialDetail() {
   const [startTime, setStartTime] = useState(0);
 
   const { progress, saveTime, completeChapter, setIndex, startTimeFor } =
-    useTutorialProgress(id);
+    useTutorialProgress(id, tutorial?.chapters);
 
   const enroll = async () => {
     if (!tutorial) return;
@@ -181,6 +181,7 @@ export default function TutorialDetail() {
     : tutorial.chapters.slice(0, 1);
 
   const videoList = accessibleChapters.map((ch) => ({
+    id: ch.id,
     src: ch.videoUrl,
     title: ch.title,
   }));
@@ -216,7 +217,8 @@ export default function TutorialDetail() {
           onTimeUpdate={handleVideoTimeUpdate}
           locked={!isEnrolled}
           onEnded={(idx) => {
-            completeChapter(idx);
+            const ch = tutorial.chapters[idx];
+            completeChapter(idx, ch?.id);
           }}
         />
 


### PR DESCRIPTION
## Summary
- track completed chapters by ID instead of index
- update tutorial components to expect arrays of chapter IDs
- migrate existing index-based progress data on load

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689794ba6db483289286deb0d2156dd8