### PR TITLE
Add accessible labels to tutorial search and filters

### DIFF
--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -98,14 +98,22 @@ export default function StudentTutorialsPage() {
             <span className="text-sm text-gray-500">({sorted.length} found)</span>
           </div>
           <div className="flex gap-2 items-center">
+            <label htmlFor="student-tutorial-search" className="sr-only">
+              Search tutorials
+            </label>
             <input
+              id="student-tutorial-search"
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search tutorials..."
               className="px-3 py-2 border border-gray-300 rounded-md text-sm w-full md:w-64"
             />
+            <label htmlFor="student-tutorial-filter" className="sr-only">
+              Filter tutorials
+            </label>
             <select
+              id="student-tutorial-filter"
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
               className="border border-gray-300 px-2 py-2 rounded-md text-sm"
@@ -114,7 +122,11 @@ export default function StudentTutorialsPage() {
               <option value="completed">Completed</option>
               <option value="in-progress">In Progress</option>
             </select>
+            <label htmlFor="student-tutorial-sort" className="sr-only">
+              Sort tutorials
+            </label>
             <select
+              id="student-tutorial-sort"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value)}
               className="border border-gray-300 px-2 py-2 rounded-md text-sm"

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -144,8 +144,12 @@ const TutorialsSection = () => {
         {/* Mobile Filters Button */}
         <div className="lg:hidden mb-6 flex justify-between items-center">
           <div className="relative w-full max-w-md">
+            <label htmlFor="tutorial-search-mobile" className="sr-only">
+              Search tutorials
+            </label>
             <FaSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
             <input
+              id="tutorial-search-mobile"
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -185,8 +189,12 @@ const TutorialsSection = () => {
             {/* Desktop Search & Sort */}
             <div className="hidden lg:flex items-center justify-between gap-4 mb-8">
               <div className="relative w-full max-w-md">
+                <label htmlFor="tutorial-search-desktop" className="sr-only">
+                  Search tutorials
+                </label>
                 <FaSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
                 <input
+                  id="tutorial-search-desktop"
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
@@ -196,8 +204,11 @@ const TutorialsSection = () => {
               </div>
 
               <div className="flex items-center space-x-4">
-                <span className="text-gray-400">Sort by:</span>
+                <label htmlFor="tutorial-sort" className="text-gray-400">
+                  Sort by:
+                </label>
                 <select
+                  id="tutorial-sort"
                   onChange={(e) => setSortBy(e.target.value)}
                   className="py-2.5 px-4 rounded-lg bg-gray-800/60 backdrop-blur-sm border border-gray-700 text-yellow-400 focus:outline-none focus:ring-2 focus:ring-yellow-500"
                 >


### PR DESCRIPTION
## Summary
- add hidden labels to tutorial page search field and sort dropdown for screen reader support
- add hidden labels to student dashboard tutorial search, filter, and sort controls

## Testing
- `npm test`
- `npm run lint` *(fails: React hooks usage and display name errors)*

------
https://chatgpt.com/codex/tasks/task_e_689794b98bec8328ba0b42723d260836