### PR TITLE
Handle submission errors on instructor tutorials

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -377,12 +377,18 @@ export default function InstructorTutorialsPage() {
                   {tutorial.status === "Draft" && tutorial.progress === 100 && (
                     <button
                       onClick={async () => {
-                        await submitTutorialForReview(tutorial.id);
-                        setTutorials((prev) =>
-                          prev.map((t) =>
-                            t.id === tutorial.id ? { ...t, status: "Pending" } : t
-                          )
-                        );
+                        try {
+                          await submitTutorialForReview(tutorial.id);
+                          setTutorials((prev) =>
+                            prev.map((t) =>
+                              t.id === tutorial.id ? { ...t, status: "Pending" } : t
+                            )
+                          );
+                          toast.success("Tutorial submitted for review successfully");
+                        } catch (err) {
+                          console.error(err);
+                          toast.error("Failed to submit tutorial for review");
+                        }
                       }}
                       className="bg-purple-100 hover:bg-purple-200 text-purple-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
                     >

--- a/frontend/src/tests/__tests__/InstructorTutorialsPage.test.js
+++ b/frontend/src/tests/__tests__/InstructorTutorialsPage.test.js
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import InstructorTutorialsPage from '../../pages/dashboard/instructor/tutorials';
+import { fetchInstructorTutorials, submitTutorialForReview } from '../../services/instructor/tutorialService';
+import { toast } from 'react-toastify';
+
+jest.mock('../../components/layouts/InstructorLayout', () => ({ children }) => <div>{children}</div>);
+jest.mock('../../components/tutorials/ProgressChecklistModal', () => () => null);
+jest.mock('../../components/common/ConfirmModal', () => () => null);
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('../../services/instructor/tutorialService');
+
+jest.mock('react-toastify', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+describe('InstructorTutorialsPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows error toast on failed submission', async () => {
+    fetchInstructorTutorials.mockResolvedValue([
+      {
+        id: 1,
+        title: 'Test Tutorial',
+        status: 'Draft',
+        progress: 100,
+        updatedAt: new Date().toISOString(),
+        language: 'English',
+        category_name: 'General',
+        level: 'All Levels',
+        tags: [],
+        views: 0,
+        enrollments: 0,
+        rating: 0,
+        comments: 0,
+      },
+    ]);
+    submitTutorialForReview.mockRejectedValue(new Error('fail'));
+
+    render(<InstructorTutorialsPage />);
+    const submitButton = await screen.findByText('Submit');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(submitTutorialForReview).toHaveBeenCalledWith(1);
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to submit tutorial for review');
+    expect(toast.success).not.toHaveBeenCalled();
+    // Button remains because state wasn't updated
+    expect(screen.getByText('Submit')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap submit tutorial call in try/catch
- display success or error toast accordingly
- test submission failure to ensure error toast and no state update

## Testing
- `cd frontend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_689794b7ec2c8328a6f8dc9e8ddb687a