### PR TITLE
feat: lazy load tutorial thumbnails

### DIFF
--- a/frontend/src/components/tutorials/StudentTutorialCard.js
+++ b/frontend/src/components/tutorials/StudentTutorialCard.js
@@ -12,6 +12,7 @@ export default function StudentTutorialCard({ tutorial }) {
         src={tutorial.thumbnail || "/default-thumbnail.jpg"}
         alt={tutorial.title}
         className="w-full h-40 object-cover rounded-md"
+        loading="lazy"
       />
       <h2 className="text-lg font-semibold flex items-center gap-2">
         <span className="inline-block text-xs bg-yellow-100 text-yellow-700 px-2 py-0.5 rounded-full">

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -286,6 +286,7 @@ const TutorialsSection = () => {
                           src={tut.thumbnail}
                           alt={tut.title}
                           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
+                          loading="lazy"
                         />
                       )}
                       
@@ -322,6 +323,7 @@ const TutorialsSection = () => {
                                 src={avatar}
                                 alt={tut.instructor}
                                 className="w-8 h-8 rounded-full border-2 border-yellow-500"
+                                loading="lazy"
                               />
                             );
                           })()}

--- a/frontend/src/tests/__tests__/StudentTutorialCard.test.js
+++ b/frontend/src/tests/__tests__/StudentTutorialCard.test.js
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import StudentTutorialCard from '@/components/tutorials/StudentTutorialCard';
+
+describe('StudentTutorialCard', () => {
+  const tutorial = {
+    id: 1,
+    title: 'Sample Tutorial',
+    category: 'Education',
+    instructor: 'Jane Doe',
+    thumbnail: '/sample-thumbnail.jpg',
+    totalLessons: 10,
+    completedLessons: 5,
+    isCompleted: false,
+    rating: 4.5,
+  };
+
+  it('renders thumbnail with lazy loading', () => {
+    render(<StudentTutorialCard tutorial={tutorial} />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('loading', 'lazy');
+  });
+});


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to tutorial card thumbnails and instructor avatars
- ensure student card thumbnails lazy load
- test for lazy loading behavior

## Testing
- `npm run lint` *(fails: React Hook "useTranslation" is called in function "fetch" etc)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689794b7206c83289dc9970aae87a937