### PR TITLE
feat: localize tutorials pages

### DIFF
--- a/frontend/public/locales/ar/tutorials.json
+++ b/frontend/public/locales/ar/tutorials.json
@@ -1,0 +1,45 @@
+{
+  "list": {
+    "loading": "جارٍ تحميل الدروس...",
+    "load_error": "فشل تحميل الدروس",
+    "heading": "📺 دروس مميزة",
+    "subheading": "أتقن مهارات جديدة من خلال مجموعتنا المختارة من الدروس بقيادة الخبراء",
+    "search_placeholder": "ابحث عن الدروس...",
+    "mobile_filters": "عوامل التصفية",
+    "desktop_search_placeholder": "ابحث عن الدروس أو المدرسين...",
+    "sort_by": "ترتيب حسب:",
+    "featured": "مميز",
+    "most_viewed": "الأكثر مشاهدة",
+    "top_rated": "الأعلى تقييماً",
+    "showing": "عرض",
+    "of": "من",
+    "tutorials": "درساً",
+    "clear_filters": "مسح جميع عوامل التصفية",
+    "premium_badge": "متميز",
+    "trending": "رائج",
+    "free": "مجاني",
+    "enrolled": "مسجل",
+    "empty_title": "لم يتم العثور على دروس",
+    "empty_description": "حاول تغيير عوامل التصفية أو كلمات البحث",
+    "reset_filters": "إعادة تعيين عوامل التصفية"
+  },
+  "detail": {
+    "login_first": "يرجى تسجيل الدخول أولاً",
+    "enroll_success": "تم التسجيل بنجاح!",
+    "enroll_fail": "فشل التسجيل",
+    "load_error": "فشل تحميل الدرس",
+    "not_found": "الدرس غير موجود",
+    "share": "مشاركة",
+    "share_message": "اطلع على هذا الدرس على SkillBridge!",
+    "share_success": "تمت المشاركة بنجاح!",
+    "quiz_locked": "الاختبار مقفل",
+    "enroll_to_access_quiz": "سجّل للوصول إلى الاختبار",
+    "start_assignment": "بدء الواجب",
+    "complete_quiz_unlock_assignments": "أكمل الاختبار لفتح الواجبات",
+    "claim_certificate": "احصل على الشهادة",
+    "pass_quiz_to_unlock_certificate": "اجتز الاختبار لفتح الشهادة",
+    "certificate_locked": "الشهادة مقفلة",
+    "free": "مجاني"
+  }
+}
+

--- a/frontend/public/locales/en/tutorials.json
+++ b/frontend/public/locales/en/tutorials.json
@@ -1,0 +1,45 @@
+{
+  "list": {
+    "loading": "Loading tutorials...",
+    "load_error": "Failed to load tutorials",
+    "heading": "📺 Premium Tutorials",
+    "subheading": "Master new skills with our curated collection of expert-led tutorials",
+    "search_placeholder": "Search tutorials...",
+    "mobile_filters": "Filters",
+    "desktop_search_placeholder": "Search tutorials, instructors...",
+    "sort_by": "Sort by:",
+    "featured": "Featured",
+    "most_viewed": "Most Viewed",
+    "top_rated": "Top Rated",
+    "showing": "Showing",
+    "of": "of",
+    "tutorials": "tutorials",
+    "clear_filters": "Clear all filters",
+    "premium_badge": "PREMIUM",
+    "trending": "Trending",
+    "free": "Free",
+    "enrolled": "ENROLLED",
+    "empty_title": "No tutorials found",
+    "empty_description": "Try adjusting your filters or search terms",
+    "reset_filters": "Reset Filters"
+  },
+  "detail": {
+    "login_first": "Please login first",
+    "enroll_success": "Enrolled successfully!",
+    "enroll_fail": "Enrollment failed",
+    "load_error": "Failed to load tutorial",
+    "not_found": "Tutorial not found",
+    "share": "Share",
+    "share_message": "Check out this tutorial on SkillBridge!",
+    "share_success": "Shared successfully!",
+    "quiz_locked": "Quiz locked",
+    "enroll_to_access_quiz": "Enroll to access quiz",
+    "start_assignment": "Start Assignment",
+    "complete_quiz_unlock_assignments": "Complete the quiz to unlock assignments",
+    "claim_certificate": "Claim Your Certificate",
+    "pass_quiz_to_unlock_certificate": "Pass quiz to unlock certificate",
+    "certificate_locked": "Certificate locked",
+    "free": "Free"
+  }
+}
+

--- a/frontend/public/locales/fr/tutorials.json
+++ b/frontend/public/locales/fr/tutorials.json
@@ -1,0 +1,45 @@
+{
+  "list": {
+    "loading": "Chargement des tutoriels...",
+    "load_error": "Échec du chargement des tutoriels",
+    "heading": "📺 Tutoriels Premium",
+    "subheading": "Maîtrisez de nouvelles compétences avec notre collection de tutoriels dirigés par des experts",
+    "search_placeholder": "Rechercher des tutoriels...",
+    "mobile_filters": "Filtres",
+    "desktop_search_placeholder": "Rechercher des tutoriels, des instructeurs...",
+    "sort_by": "Trier par :",
+    "featured": "En vedette",
+    "most_viewed": "Les plus vus",
+    "top_rated": "Les mieux notés",
+    "showing": "Affichage de",
+    "of": "sur",
+    "tutorials": "tutoriels",
+    "clear_filters": "Effacer tous les filtres",
+    "premium_badge": "PREMIUM",
+    "trending": "Tendance",
+    "free": "Gratuit",
+    "enrolled": "INSCRIT",
+    "empty_title": "Aucun tutoriel trouvé",
+    "empty_description": "Essayez d'ajuster vos filtres ou termes de recherche",
+    "reset_filters": "Réinitialiser les filtres"
+  },
+  "detail": {
+    "login_first": "Veuillez vous connecter d'abord",
+    "enroll_success": "Inscription réussie !",
+    "enroll_fail": "Échec de l'inscription",
+    "load_error": "Échec du chargement du tutoriel",
+    "not_found": "Tutoriel introuvable",
+    "share": "Partager",
+    "share_message": "Découvrez ce tutoriel sur SkillBridge !",
+    "share_success": "Partagé avec succès !",
+    "quiz_locked": "Quiz verrouillé",
+    "enroll_to_access_quiz": "Inscrivez-vous pour accéder au quiz",
+    "start_assignment": "Commencer le devoir",
+    "complete_quiz_unlock_assignments": "Terminez le quiz pour débloquer les devoirs",
+    "claim_certificate": "Réclamer votre certificat",
+    "pass_quiz_to_unlock_certificate": "Réussissez le quiz pour débloquer le certificat",
+    "certificate_locked": "Certificat verrouillé",
+    "free": "Gratuit"
+  }
+}
+

--- a/frontend/src/locales/ar.json
+++ b/frontend/src/locales/ar.json
@@ -98,5 +98,49 @@
     "students": "الطلاب",
     "tutorials": "الدروس التعليمية",
     "classes": "الفصول"
+  },
+  "tutorials": {
+    "list": {
+      "loading": "جارٍ تحميل الدروس...",
+      "load_error": "فشل تحميل الدروس",
+      "heading": "📺 دروس مميزة",
+      "subheading": "أتقن مهارات جديدة من خلال مجموعتنا المختارة من الدروس بقيادة الخبراء",
+      "search_placeholder": "ابحث عن الدروس...",
+      "mobile_filters": "عوامل التصفية",
+      "desktop_search_placeholder": "ابحث عن الدروس أو المدرسين...",
+      "sort_by": "ترتيب حسب:",
+      "featured": "مميز",
+      "most_viewed": "الأكثر مشاهدة",
+      "top_rated": "الأعلى تقييماً",
+      "showing": "عرض",
+      "of": "من",
+      "tutorials": "درساً",
+      "clear_filters": "مسح جميع عوامل التصفية",
+      "premium_badge": "متميز",
+      "trending": "رائج",
+      "free": "مجاني",
+      "enrolled": "مسجل",
+      "empty_title": "لم يتم العثور على دروس",
+      "empty_description": "حاول تغيير عوامل التصفية أو كلمات البحث",
+      "reset_filters": "إعادة تعيين عوامل التصفية"
+    },
+    "detail": {
+      "login_first": "يرجى تسجيل الدخول أولاً",
+      "enroll_success": "تم التسجيل بنجاح!",
+      "enroll_fail": "فشل التسجيل",
+      "load_error": "فشل تحميل الدرس",
+      "not_found": "الدرس غير موجود",
+      "share": "مشاركة",
+      "share_message": "اطلع على هذا الدرس على SkillBridge!",
+      "share_success": "تمت المشاركة بنجاح!",
+      "quiz_locked": "الاختبار مقفل",
+      "enroll_to_access_quiz": "سجّل للوصول إلى الاختبار",
+      "start_assignment": "بدء الواجب",
+      "complete_quiz_unlock_assignments": "أكمل الاختبار لفتح الواجبات",
+      "claim_certificate": "احصل على الشهادة",
+      "pass_quiz_to_unlock_certificate": "اجتز الاختبار لفتح الشهادة",
+      "certificate_locked": "الشهادة مقفلة",
+      "free": "مجاني"
+    }
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -21,5 +21,49 @@
   },
   "notifications": {
     "new_assignment": "New assignment \"{{title}}\" posted for class \"{{classTitle}}\"."
+  },
+  "tutorials": {
+    "list": {
+      "loading": "Loading tutorials...",
+      "load_error": "Failed to load tutorials",
+      "heading": "📺 Premium Tutorials",
+      "subheading": "Master new skills with our curated collection of expert-led tutorials",
+      "search_placeholder": "Search tutorials...",
+      "mobile_filters": "Filters",
+      "desktop_search_placeholder": "Search tutorials, instructors...",
+      "sort_by": "Sort by:",
+      "featured": "Featured",
+      "most_viewed": "Most Viewed",
+      "top_rated": "Top Rated",
+      "showing": "Showing",
+      "of": "of",
+      "tutorials": "tutorials",
+      "clear_filters": "Clear all filters",
+      "premium_badge": "PREMIUM",
+      "trending": "Trending",
+      "free": "Free",
+      "enrolled": "ENROLLED",
+      "empty_title": "No tutorials found",
+      "empty_description": "Try adjusting your filters or search terms",
+      "reset_filters": "Reset Filters"
+    },
+    "detail": {
+      "login_first": "Please login first",
+      "enroll_success": "Enrolled successfully!",
+      "enroll_fail": "Enrollment failed",
+      "load_error": "Failed to load tutorial",
+      "not_found": "Tutorial not found",
+      "share": "Share",
+      "share_message": "Check out this tutorial on SkillBridge!",
+      "share_success": "Shared successfully!",
+      "quiz_locked": "Quiz locked",
+      "enroll_to_access_quiz": "Enroll to access quiz",
+      "start_assignment": "Start Assignment",
+      "complete_quiz_unlock_assignments": "Complete the quiz to unlock assignments",
+      "claim_certificate": "Claim Your Certificate",
+      "pass_quiz_to_unlock_certificate": "Pass quiz to unlock certificate",
+      "certificate_locked": "Certificate locked",
+      "free": "Free"
+    }
   }
 }

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -21,5 +21,49 @@
   },
   "notifications": {
     "new_assignment": "Nouveau devoir \"{{title}}\" publié pour le cours \"{{classTitle}}\"."
+  },
+  "tutorials": {
+    "list": {
+      "loading": "Chargement des tutoriels...",
+      "load_error": "Échec du chargement des tutoriels",
+      "heading": "📺 Tutoriels Premium",
+      "subheading": "Maîtrisez de nouvelles compétences avec notre collection de tutoriels dirigés par des experts",
+      "search_placeholder": "Rechercher des tutoriels...",
+      "mobile_filters": "Filtres",
+      "desktop_search_placeholder": "Rechercher des tutoriels, des instructeurs...",
+      "sort_by": "Trier par :",
+      "featured": "En vedette",
+      "most_viewed": "Les plus vus",
+      "top_rated": "Les mieux notés",
+      "showing": "Affichage de",
+      "of": "sur",
+      "tutorials": "tutoriels",
+      "clear_filters": "Effacer tous les filtres",
+      "premium_badge": "PREMIUM",
+      "trending": "Tendance",
+      "free": "Gratuit",
+      "enrolled": "INSCRIT",
+      "empty_title": "Aucun tutoriel trouvé",
+      "empty_description": "Essayez d'ajuster vos filtres ou termes de recherche",
+      "reset_filters": "Réinitialiser les filtres"
+    },
+    "detail": {
+      "login_first": "Veuillez vous connecter d'abord",
+      "enroll_success": "Inscription réussie !",
+      "enroll_fail": "Échec de l'inscription",
+      "load_error": "Échec du chargement du tutoriel",
+      "not_found": "Tutoriel introuvable",
+      "share": "Partager",
+      "share_message": "Découvrez ce tutoriel sur SkillBridge !",
+      "share_success": "Partagé avec succès !",
+      "quiz_locked": "Quiz verrouillé",
+      "enroll_to_access_quiz": "Inscrivez-vous pour accéder au quiz",
+      "start_assignment": "Commencer le devoir",
+      "complete_quiz_unlock_assignments": "Terminez le quiz pour débloquer les devoirs",
+      "claim_certificate": "Réclamer votre certificat",
+      "pass_quiz_to_unlock_certificate": "Réussissez le quiz pour débloquer le certificat",
+      "certificate_locked": "Certificat verrouillé",
+      "free": "Gratuit"
+    }
   }
 }

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
@@ -49,11 +50,12 @@ export default function TutorialDetail() {
 
   const { progress, saveTime, completeChapter, setIndex, startTimeFor } =
     useTutorialProgress(id);
+  const { t } = useTranslation("tutorials", { keyPrefix: "detail" });
 
   const enroll = async () => {
     if (!tutorial) return;
     if (!isLoggedIn) {
-      toast.error("Please login first");
+      toast.error(t("login_first"));
       router.push("/auth/login");
       return;
     }
@@ -69,11 +71,11 @@ export default function TutorialDetail() {
           true,
       );
       setIsEnrolled(enrolledFlag);
-      if (enrolledFlag) toast.success("Enrolled successfully!");
-      else toast.error("Enrollment failed");
+      if (enrolledFlag) toast.success(t("enroll_success"));
+      else toast.error(t("enroll_fail"));
     } catch (err) {
       console.error("Enrollment failed", err);
-      toast.error("Enrollment failed");
+      toast.error(t("enroll_fail"));
     }
   };
 
@@ -86,7 +88,7 @@ export default function TutorialDetail() {
       try {
         const data = await fetchTutorialDetails(id);
         if (!data) {
-          setError("Tutorial not found");
+          setError(t("not_found"));
           setLoading(false);
           return;
         }
@@ -120,7 +122,7 @@ export default function TutorialDetail() {
         setRelated(others.slice(0, 3));
       } catch (err) {
         console.error(err);
-        setError("Failed to load tutorial");
+        setError(t("load_error"));
       } finally {
         setLoading(false);
       }
@@ -167,7 +169,7 @@ export default function TutorialDetail() {
   if (!tutorial) {
     return (
       <div className="bg-gray-900 text-white min-h-screen flex items-center justify-center">
-        <p className="text-lg text-gray-300">Tutorial not found</p>
+        <p className="text-lg text-gray-300">{t("not_found")}</p>
       </div>
     );
   }
@@ -234,21 +236,21 @@ export default function TutorialDetail() {
               navigator
                 .share({
                   title: tutorial.title,
-                  text: "Check out this tutorial on SkillBridge!",
+                  text: t("share_message"),
                   url: typeof window !== "undefined" ? window.location.href : "",
                 })
-                .then(() => toast.success("Shared successfully!"))
+                .then(() => toast.success(t("share_success")))
                 .catch(() => {})
             }
             className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition"
           >
-            🔗 Share
+            🔗 {t("share")}
           </button>
         </div>
 
         <TutorialHeader
           {...tutorial}
-          price={tutorial.is_paid && tutorial.price ? `$${tutorial.price}` : "Free"}
+          price={tutorial.is_paid && tutorial.price ? `$${tutorial.price}` : t("free")}
         />
         <InstructorBio
           name={tutorial.instructor}
@@ -273,8 +275,8 @@ export default function TutorialDetail() {
             }}
           />
         ) : (
-          <div className="text-center text-gray-400" title="Enroll to access quiz">
-            Quiz locked
+          <div className="text-center text-gray-400" title={t("enroll_to_access_quiz")}> 
+            {t("quiz_locked")}
           </div>
         )}
 
@@ -285,10 +287,10 @@ export default function TutorialDetail() {
                 href={`/dashboard/student/assignments/${assignments[0].id}`}
                 className="bg-blue-500 text-white px-6 py-3 rounded-full hover:bg-blue-600 transition"
               >
-                📚 Start Assignment
+                📚 {t("start_assignment")}
               </Link>
             ) : (
-              <div className="text-gray-400">Complete the quiz to unlock assignments</div>
+              <div className="text-gray-400">{t("complete_quiz_unlock_assignments")}</div>
             )}
           </div>
         )}
@@ -299,15 +301,15 @@ export default function TutorialDetail() {
               onClick={() => router.push(`/certificate/${tutorial.id}`)}
               className="bg-green-500 text-white px-6 py-3 rounded-full hover:bg-green-600 transition"
             >
-              🎉 Claim Your Certificate
+              🎉 {t("claim_certificate")}
             </button>
           </div>
         ) : (
           <div
             className="mt-6 text-center text-gray-400"
-            title="Pass quiz to unlock certificate"
+            title={t("pass_quiz_to_unlock_certificate")}
           >
-            Certificate locked
+            {t("certificate_locked")}
           </div>
         )}
 
@@ -326,7 +328,7 @@ import nextI18NextConfig from '../../../next-i18next.config.js';
 export async function getServerSideProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+      ...(await serverSideTranslations(locale, ['common', 'tutorials'], nextI18NextConfig)),
     },
   };
 }

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { motion } from "framer-motion";
 import { FaStar, FaClock, FaFire, FaEye, FaArrowUp, FaSearch, FaFilter } from "react-icons/fa";
+import { useTranslation } from "next-i18next";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import FilterSidebar from "@/components/tutorials/FilterSidebar";
@@ -23,6 +24,7 @@ const TutorialsSection = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const router = useRouter();
   const loader = useRef(null);
+  const { t } = useTranslation("tutorials", { keyPrefix: "list" });
 
   useEffect(() => {
     const handleScroll = () => {
@@ -48,7 +50,7 @@ const TutorialsSection = () => {
         setTutorials(data?.data || data || []);
       } catch (err) {
         console.error(err);
-        setError("Failed to load tutorials");
+        setError(t("load_error"));
       } finally {
         setLoading(false);
       }
@@ -106,7 +108,7 @@ const TutorialsSection = () => {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center text-yellow-400">
-        ⏳ Loading tutorials...
+        ⏳ {t("loading")}
       </div>
     );
   }
@@ -134,10 +136,10 @@ const TutorialsSection = () => {
             className="text-4xl md:text-5xl font-bold mb-4 text-transparent bg-clip-text bg-gradient-to-r from-yellow-400 via-amber-400 to-yellow-500"
             whileHover={{ scale: 1.02 }}
           >
-            📺 Premium Tutorials
+            {t("heading")}
           </motion.h2>
           <p className="text-lg text-gray-300 max-w-2xl mx-auto">
-            Master new skills with our curated collection of expert-led tutorials
+            {t("subheading")}
           </p>
         </motion.div>
 
@@ -149,7 +151,7 @@ const TutorialsSection = () => {
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search tutorials..."
+              placeholder={t("search_placeholder")}
               className="w-full pl-10 pr-4 py-2.5 rounded-lg bg-gray-800/60 backdrop-blur-sm border border-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-yellow-500"
             />
           </div>
@@ -167,7 +169,7 @@ const TutorialsSection = () => {
             className={`fixed lg:sticky top-0 left-0 lg:left-auto h-screen lg:h-auto w-full lg:w-1/4 bg-gray-900/80 backdrop-blur-lg lg:backdrop-blur-none lg:bg-transparent p-6 lg:p-0 z-30 transform lg:transform-none transition-transform duration-300 ${isSidebarOpen ? 'translate-x-0' : 'translate-x-full'} lg:translate-x-0`}
           >
             <div className="flex justify-between items-center mb-6 lg:hidden">
-              <h3 className="text-xl font-bold text-yellow-400">Filters</h3>
+              <h3 className="text-xl font-bold text-yellow-400">{t("mobile_filters")}</h3>
               <button
                 className="text-gray-400 hover:text-white"
                 onClick={() => setIsSidebarOpen(false)}
@@ -190,20 +192,20 @@ const TutorialsSection = () => {
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  placeholder="Search tutorials, instructors..."
+                  placeholder={t("desktop_search_placeholder")}
                   className="w-full pl-10 pr-4 py-2.5 rounded-lg bg-gray-800/60 backdrop-blur-sm border border-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-yellow-500"
                 />
               </div>
 
               <div className="flex items-center space-x-4">
-                <span className="text-gray-400">Sort by:</span>
+                <span className="text-gray-400">{t("sort_by")}</span>
                 <select
                   onChange={(e) => setSortBy(e.target.value)}
                   className="py-2.5 px-4 rounded-lg bg-gray-800/60 backdrop-blur-sm border border-gray-700 text-yellow-400 focus:outline-none focus:ring-2 focus:ring-yellow-500"
                 >
-                  <option value="default">Featured</option>
-                  <option value="views">Most Viewed</option>
-                  <option value="rating">Top Rated</option>
+                  <option value="default">{t("featured")}</option>
+                  <option value="views">{t("most_viewed")}</option>
+                  <option value="rating">{t("top_rated")}</option>
                 </select>
               </div>
             </div>
@@ -211,15 +213,14 @@ const TutorialsSection = () => {
             {/* Results Info */}
             <div className="flex justify-between items-center mb-6">
               <p className="text-gray-400">
-                Showing <span className="text-yellow-400 font-medium">{visibleTutorials.length}</span> of{" "}
-                <span className="text-yellow-400 font-medium">{sortedTutorials.length}</span> tutorials
+                {t("showing")} <span className="text-yellow-400 font-medium">{visibleTutorials.length}</span> {t("of")} <span className="text-yellow-400 font-medium">{sortedTutorials.length}</span> {t("tutorials")}
               </p>
               {filters.categories.length > 0 || filters.levels.length > 0 ? (
-                <button 
+                <button
                   onClick={resetFilters}
                   className="text-sm text-yellow-400 hover:text-yellow-300 flex items-center"
                 >
-                  Clear all filters
+                  {t("clear_filters")}
                 </button>
               ) : null}
             </div>
@@ -266,7 +267,7 @@ const TutorialsSection = () => {
                     {/* Premium Badge */}
                     {tut.is_paid && (
                       <div className="absolute top-3 right-3 z-10 bg-gradient-to-r from-amber-500 to-yellow-500 text-black text-xs font-bold px-2 py-1 rounded-full">
-                        PREMIUM
+                        {t("premium_badge")}
                       </div>
                     )}
                     
@@ -307,7 +308,7 @@ const TutorialsSection = () => {
                         </h3>
                         {tut.trending && (
                           <span className="flex-shrink-0 bg-gradient-to-r from-red-500 to-orange-500 text-white px-2 py-1 text-xs rounded-full ml-2">
-                            <FaFire className="inline mr-1" /> Trending
+                            <FaFire className="inline mr-1" /> {t("trending")}
                           </span>
                         )}
                       </div>
@@ -357,7 +358,7 @@ const TutorialsSection = () => {
                               ${tut.price}
                             </span>
                           ) : (
-                            <span className="text-green-400">Free</span>
+                            <span className="text-green-400">{t("free")}</span>
                           )}
                         </div>
                       </div>
@@ -366,7 +367,7 @@ const TutorialsSection = () => {
                     {/* Enrolled Badge */}
                     {enrolled && (
                       <div className="absolute top-3 left-3 bg-green-600 text-white text-xs font-bold px-2 py-1 rounded-full z-10">
-                        ENROLLED
+                        {t("enrolled")}
                       </div>
                     )}
                   </motion.div>
@@ -378,15 +379,15 @@ const TutorialsSection = () => {
                 <div className="col-span-full py-16 text-center">
                   <div className="bg-gray-800/60 backdrop-blur-sm rounded-xl p-8 max-w-md mx-auto border border-gray-700">
                     <div className="text-5xl mb-4">🔍</div>
-                    <h3 className="text-xl font-bold text-white mb-2">No tutorials found</h3>
+                    <h3 className="text-xl font-bold text-white mb-2">{t("empty_title")}</h3>
                     <p className="text-gray-400 mb-4">
-                      Try adjusting your filters or search terms
+                      {t("empty_description")}
                     </p>
                     <button
                       onClick={resetFilters}
                       className="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-500 rounded-lg text-black font-medium hover:opacity-90 transition-opacity"
                     >
-                      Reset Filters
+                      {t("reset_filters")}
                     </button>
                   </div>
                 </div>
@@ -432,7 +433,7 @@ import nextI18NextConfig from '../../../next-i18next.config.js';
 export async function getStaticProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+      ...(await serverSideTranslations(locale, ['common', 'tutorials'], nextI18NextConfig)),
     },
   };
 }


### PR DESCRIPTION
## Summary
- add translation support for tutorials listing and detail pages
- provide tutorials namespace entries for English, French, and Arabic

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useTranslation is called in function "fetch"...)*

------
https://chatgpt.com/codex/tasks/task_e_689794b5ffc08328b3709f8f8946f2ac