### PR TITLE
Wrap tutorial error state in StudentLayout

### DIFF
--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -86,7 +86,13 @@ export default function StudentTutorialsPage() {
   }
 
   if (error) {
-    return <div className="p-6 text-red-500">{error}</div>;
+    return (
+      <StudentLayout>
+        <div className="p-6 text-red-500" role="alert">
+          {error}
+        </div>
+      </StudentLayout>
+    );
   }
 
   return (

--- a/frontend/src/tests/__tests__/StudentTutorialsPage.test.js
+++ b/frontend/src/tests/__tests__/StudentTutorialsPage.test.js
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../../services/tutorialService', () => ({
+  fetchPublishedTutorials: jest.fn(() => Promise.reject(new Error('fail'))),
+}));
+
+jest.mock('../../components/layouts/StudentLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div data-testid="student-layout">{children}</div>,
+}));
+
+import StudentTutorialsPage from '@/pages/dashboard/student/tutorials';
+
+test('renders layout during error state', async () => {
+  render(<StudentTutorialsPage />);
+  const alert = await screen.findByRole('alert');
+  expect(alert).toHaveTextContent('Failed to load tutorials');
+  const layout = screen.getByTestId('student-layout');
+  expect(layout).toBeInTheDocument();
+  expect(layout).toContainElement(alert);
+});


### PR DESCRIPTION
## Summary
- Ensure student tutorials page shows headers and sidebar even when loading fails by wrapping error block in `StudentLayout` and adding `role="alert"` for accessibility.
- Add component test confirming `StudentLayout` renders during error state.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689794b3f024832884f4ffce1366afbe