### PR TITLE
Handle tutorials missing chapter videos

### DIFF
--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -184,7 +184,9 @@ export default function TutorialDetail() {
     src: ch.videoUrl,
     title: ch.title,
   }));
-  const currentVideo = videoList[currentIndex]?.src;
+  const currentVideoObj = videoList[currentIndex];
+  const currentVideo = currentVideoObj?.src || null;
+  const playerVideos = currentVideo ? [{ src: currentVideo }] : [];
 
   const progressPercentage = tutorial.chapters.length
     ? (progress.completedChapters.length / tutorial.chapters.length) * 100
@@ -209,16 +211,25 @@ export default function TutorialDetail() {
 
         {!isEnrolled && <EnrollBanner onEnroll={enroll} />}
 
-        <CustomVideoPlayer
-          key={currentIndex}
-          videos={[{ src: currentVideo }]}
-          startTime={startTime}
-          onTimeUpdate={handleVideoTimeUpdate}
-          locked={!isEnrolled}
-          onEnded={(idx) => {
-            completeChapter(idx);
-          }}
-        />
+        {playerVideos.length > 0 ? (
+          <CustomVideoPlayer
+            key={currentIndex}
+            videos={playerVideos}
+            startTime={startTime}
+            onTimeUpdate={handleVideoTimeUpdate}
+            locked={!isEnrolled}
+            onEnded={(idx) => {
+              completeChapter(idx);
+            }}
+          />
+        ) : (
+          <div
+            className="bg-gray-800 text-gray-400 p-4 rounded"
+            data-testid="no-video"
+          >
+            No video available
+          </div>
+        )}
 
         <VideoPreviewList
           videos={videoList}

--- a/frontend/src/tests/__tests__/TutorialPageNoChapters.test.js
+++ b/frontend/src/tests/__tests__/TutorialPageNoChapters.test.js
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import TutorialDetail from '../../pages/tutorials/[id]';
+import useAuthStore from '@/store/auth/authStore';
+import * as tutorialService from '../../services/tutorialService';
+
+jest.mock('../../components/website/sections/Navbar', () => () => <div />);
+jest.mock('../../components/website/sections/Footer', () => () => <div />);
+jest.mock('../../components/shared/CustomVideoPlayer', () => () => <div data-testid="player" />);
+jest.mock('../../components/tutorials/detail/TutorialHeader', () => () => <div />);
+jest.mock('../../components/tutorials/detail/TutorialOverview', () => () => <div />);
+jest.mock('../../components/tutorials/detail/InstructorBio', () => () => <div />);
+jest.mock('../../components/tutorials/detail/ChapterList', () => () => <div />);
+jest.mock('../../components/tutorials/detail/EnrollBanner', () => () => <div />);
+jest.mock('../../components/tutorials/detail/LoginPrompt', () => () => <div />);
+jest.mock('../../components/tutorials/detail/VideoPreviewList', () => () => <div />);
+jest.mock('../../components/tutorials/detail/TestQuiz', () => () => <div />);
+jest.mock('../../components/tutorials/detail/BackButton', () => () => <div />);
+jest.mock('../../components/tutorials/detail/ReviewsSection', () => () => <div />);
+jest.mock('../../components/tutorials/detail/CommentsSection', () => () => <div />);
+jest.mock('../../components/tutorials/detail/RelatedTutorials', () => () => <div />);
+jest.mock('../../components/classes/CourseProgress', () => () => <div />);
+jest.mock('../../components/tutorials/detail/TutorialSkeleton', () => () => <div />);
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { id: '1' }, push: jest.fn() }),
+}));
+
+jest.mock('../../hooks/useTutorialProgress', () => jest.fn(() => ({
+  progress: { completedChapters: [], lastIndex: 0 },
+  saveTime: jest.fn(),
+  completeChapter: jest.fn(),
+  setIndex: jest.fn(),
+  startTimeFor: jest.fn(() => 0),
+})));
+
+jest.mock('../../services/tutorialService');
+
+const { fetchTutorialDetails, fetchPublishedTutorials, fetchTutorialAssignments } = tutorialService;
+
+describe('TutorialDetail page with no chapters', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ user: { id: 1 }, accessToken: 'token' });
+    fetchPublishedTutorials.mockResolvedValue([]);
+    fetchTutorialAssignments.mockResolvedValue([]);
+  });
+
+  it('shows placeholder when tutorial has no chapters', async () => {
+    fetchTutorialDetails.mockResolvedValue({
+      id: 1,
+      title: 'Empty tutorial',
+      description: '',
+      chapters: [],
+    });
+
+    render(<TutorialDetail />);
+
+    expect(await screen.findByTestId('no-video')).toBeInTheDocument();
+    expect(screen.queryByTestId('player')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Avoid crashing when a tutorial has no chapters by validating current video and showing a placeholder
- Safeguard video list before passing to player
- Add test covering tutorials without chapters

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689794b289788328a540c8ea261f62ba