### PR TITLE
Enable PayPal checkout and clarify admin payment toasts

### DIFF
--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -150,7 +150,8 @@ export default function AdminPaymentsPage() {
       setMethods((prev) =>
         prev.map((m) => (m.id === id ? { ...m, active: !m.active } : m))
       );
-      toast.success(t('paymentsPage.status_updated'));
+      const action = method.active ? 'deactivated' : 'activated';
+      toast.success(`Payment method "${method.name}" ${action}`);
       const msg = `Payment method "${method.name}" status changed`;
       notify('payment_method_status_changed', msg);
     } catch (err) {
@@ -174,7 +175,8 @@ export default function AdminPaymentsPage() {
             : m
         )
       );
-      toast.success(t('paymentsPage.default_updated'));
+      const action = newState ? 'set as default' : 'removed from default';
+      toast.success(`Payment method "${method.name}" ${action}`);
       const msg = `Payment method "${method.name}" set as default`;
       notify('payment_method_default_changed', msg);
     } catch (err) {
@@ -185,10 +187,11 @@ export default function AdminPaymentsPage() {
 
   const handleDelete = async (id) => {
     try {
+      const methodName = methods.find(m=>m.id===id)?.name;
       await deleteMethod(id);
       setMethods((prev) => prev.filter((m) => m.id !== id));
-      toast.success(t('paymentsPage.method_deleted'));
-      const msg = `Payment method "${methods.find(m=>m.id===id)?.name}" deleted.`;
+      toast.success(`Payment method "${methodName}" deleted`);
+      const msg = `Payment method "${methodName}" deleted.`;
       notify('payment_method_deleted', msg);
     } catch (err) {
       console.error('Failed to delete method', err);

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -36,6 +36,7 @@ export default function CheckoutPage() {
   const [error, setError] = useState('');
   const [paymentStatus, setPaymentStatus] = useState('idle');
   const [allowInstallments, setAllowInstallments] = useState(false);
+  const [paypalLoaded, setPaypalLoaded] = useState(false);
   const removeItem = useCartStore((state) => state.removeItem);
 
 
@@ -70,28 +71,67 @@ export default function CheckoutPage() {
     }
   };
 
+  const completePayment = async () => {
+    const enrolled = JSON.parse(localStorage.getItem("enrolledClasses") || "[]");
+    const newClass = {
+      id: classInfo.id,
+      title: classInfo.title,
+      instructor: classInfo.instructor,
+      startDate: new Date().toISOString(),
+      status: "Live",
+      joined: true,
+    };
+    localStorage.setItem("enrolledClasses", JSON.stringify([...enrolled, newClass]));
+    try {
+      await removeItem(classInfo.id);
+    } catch (err) {
+      console.error('Failed to remove from cart', err);
+    }
+    setPaymentStatus('success');
+    setTimeout(() => router.push(`/payments/success?classId=${classInfo.id}`), 1500);
+  };
+
   const handlePayment = () => {
     setPaymentStatus('processing');
-    setTimeout(async () => {
-      const enrolled = JSON.parse(localStorage.getItem("enrolledClasses") || "[]");
-      const newClass = {
-        id: classInfo.id,
-        title: classInfo.title,
-        instructor: classInfo.instructor,
-        startDate: new Date().toISOString(),
-        status: "Live",
-        joined: true,
-      };
-      localStorage.setItem("enrolledClasses", JSON.stringify([...enrolled, newClass]));
-      try {
-        await removeItem(classInfo.id);
-      } catch (err) {
-        console.error('Failed to remove from cart', err);
-      }
-      setPaymentStatus('success');
-      setTimeout(() => router.push(`/payments/success?classId=${classInfo.id}`), 1500);
-    }, 1500);
+    setTimeout(completePayment, 1500);
   };
+
+  const renderPayPalButton = (amount) => {
+    if (!window.paypal) return;
+    const container = document.getElementById('paypal-button-container');
+    if (container) container.innerHTML = '';
+    window.paypal.Buttons({
+      createOrder: (_, actions) =>
+        actions.order.create({
+          purchase_units: [{ amount: { value: amount } }],
+        }),
+      onApprove: async (_, actions) => {
+        setPaymentStatus('processing');
+        await actions.order.capture();
+        completePayment();
+      },
+      onError: (err) => {
+        console.error('PayPal error', err);
+        setPaymentStatus('idle');
+      },
+    }).render('#paypal-button-container');
+  };
+
+  useEffect(() => {
+    if (selectedMethod !== 'paypal' || !classInfo) return;
+    const amount = (classInfo.price - discount).toString();
+    if (!paypalLoaded) {
+      const script = document.createElement('script');
+      script.src = `https://www.paypal.com/sdk/js?client-id=${process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID || 'test'}`;
+      script.addEventListener('load', () => {
+        setPaypalLoaded(true);
+        renderPayPalButton(amount);
+      });
+      document.body.appendChild(script);
+    } else {
+      renderPayPalButton(amount);
+    }
+  }, [selectedMethod, classInfo, discount, paypalLoaded]);
 
   const handleFileChange = (e) => setReceipt(e.target.files[0]);
   const generatePDF = () => alert('Invoice PDF downloaded (mocked)');
@@ -212,20 +252,23 @@ export default function CheckoutPage() {
             <form onSubmit={(e) => { e.preventDefault(); handlePayment(); }}>
               <input type="text" placeholder="Full Name" required className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white" />
               <input type="email" placeholder="Email Address" required className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white" />
-              {selectedMethod !== 'bank' && (
+              {selectedMethod !== 'bank' && selectedMethod !== 'paypal' && (
                 <>
                   <input type="tel" placeholder="Card Number" required inputMode="numeric" className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white" />
                   <input type="text" placeholder="Expiration Date (MM/YY)" required className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white" />
                   <input type="text" placeholder="CVC" required className="w-full mb-6 p-3 text-sm rounded bg-gray-700 text-white" />
                 </>
               )}
-              <button type="submit" disabled={paymentStatus === 'processing'} className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all">
-                {paymentStatus === 'processing'
-                  ? 'Processing...'
-                  : allowInstallments
-                  ? `Pay $${perInstallment.toFixed(2)} (1/${installments}) with ${selectedMethod.charAt(0).toUpperCase() + selectedMethod.slice(1)}`
-                  : `Pay $${finalPrice} with ${selectedMethod.charAt(0).toUpperCase() + selectedMethod.slice(1)}`}
-              </button>
+              {selectedMethod === 'paypal' && <div id="paypal-button-container" className="mb-4"></div>}
+              {selectedMethod !== 'paypal' && (
+                <button type="submit" disabled={paymentStatus === 'processing'} className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all">
+                  {paymentStatus === 'processing'
+                    ? 'Processing...'
+                    : allowInstallments
+                    ? `Pay $${perInstallment.toFixed(2)} (1/${installments}) with ${selectedMethod.charAt(0).toUpperCase() + selectedMethod.slice(1)}`
+                    : `Pay $${finalPrice} with ${selectedMethod.charAt(0).toUpperCase() + selectedMethod.slice(1)}`}
+                </button>
+              )}
               <p className="text-sm text-gray-500 mt-2 text-center">You'll be redirected after successful payment.</p>
             </form>
           )}


### PR DESCRIPTION
## Summary
- Show specific toast messages when activating, setting default, or deleting payment methods in the admin dashboard
- Load PayPal SDK and render PayPal payment button on checkout so users can complete purchases with PayPal

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b9cf0264832890c8c878bed4f956