### PR TITLE
Add i18n support for instructor tutorial dashboard pages

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/analytics.js
@@ -4,6 +4,9 @@ import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 const EMPTY_STATS = {
   totalStudents: 0,
@@ -14,6 +17,7 @@ const EMPTY_STATS = {
 
 export default function TutorialAnalyticsPage() {
   const router = useRouter();
+  const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const { id } = router.query;
   const [stats, setStats] = useState(null);
 
@@ -28,7 +32,7 @@ export default function TutorialAnalyticsPage() {
   if (!stats) {
     return (
       <InstructorLayout>
-        <div className="p-6 text-center text-sm text-muted-foreground">Loading analytics...</div>
+        <div className="p-6 text-center text-sm text-muted-foreground">{t('loading', { ns: 'common' })}</div>
       </InstructorLayout>
     );
   }
@@ -71,4 +75,16 @@ export default function TutorialAnalyticsPage() {
       </div>
     </InstructorLayout>
   );
+}
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(
+        locale,
+        ["common", "dashboard", "tutorials"],
+        nextI18NextConfig
+      )),
+    },
+  };
 }

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -15,9 +15,13 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 export default function EditTutorialPage() {
   const router = useRouter();
+  const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const { id } = router.query;
 
   const [step, setStep] = useState(1);
@@ -61,7 +65,7 @@ export default function EditTutorialPage() {
         setCategories(cats?.data || cats || []);
       } catch (err) {
         console.error(err);
-        setError("Failed to load tutorial");
+        setError(t('detail.load_error', { ns: 'tutorials' }));
       } finally {
         setLoading(false);
       }
@@ -78,9 +82,9 @@ export default function EditTutorialPage() {
   const onNext = () => setStep((prev) => prev + 1);
   const onPrev = () => setStep((prev) => prev - 1);
 
-  if (loading) return <div className="p-6">Loading tutorial...</div>;
+  if (loading) return <div className="p-6">{t('loading', { ns: 'common' })}</div>;
   if (error) return <div className="p-6 text-red-500">{error}</div>;
-  if (!tutorialData) return <div className="p-6">Tutorial not found.</div>;
+  if (!tutorialData) return <div className="p-6">{t('detail.not_found', { ns: 'tutorials' })}</div>;
 
   return (
     <InstructorLayout>
@@ -161,7 +165,7 @@ export default function EditTutorialPage() {
                 router.push("/dashboard/instructor/tutorials");
               } catch (err) {
                 console.error(err);
-                toast.error("Failed to update tutorial");
+                toast.error(t('tutorialEditPage.update_failed', { ns: 'dashboard' }));
               }
             }}
           />
@@ -169,6 +173,18 @@ export default function EditTutorialPage() {
       </div>
     </InstructorLayout>
   );
+}
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(
+        locale,
+        ["common", "dashboard", "tutorials"],
+        nextI18NextConfig
+      )),
+    },
+  };
 }
 
 

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -15,9 +15,13 @@ import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
 import { safeEncodeURI } from "@/utils/url";
 import ProgressChecklistModal from '@/components/tutorials/ProgressChecklistModal';
 import { fetchInstructorTutorialById, submitTutorialForReview, deleteInstructorTutorial } from "@/services/instructor/tutorialService";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 export default function ViewTutorialPage() {
   const router = useRouter();
+  const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const { id } = router.query;
   const [tutorial, setTutorial] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -33,7 +37,7 @@ export default function ViewTutorialPage() {
         setTutorial(data?.data || data || null);
       } catch (err) {
         console.error(err);
-        setError("Failed to load tutorial");
+        setError(t('detail.load_error', { ns: 'tutorials' }));
       } finally {
         setLoading(false);
       }
@@ -41,13 +45,13 @@ export default function ViewTutorialPage() {
     load();
   }, [id]);
 
-  if (loading) return <div className="p-6">Loading tutorial...</div>;
+  if (loading) return <div className="p-6">{t('loading', { ns: 'common' })}</div>;
   if (error) return <div className="p-6 text-red-500">{error}</div>;
-  if (!tutorial) return <div className="p-6">Tutorial not found.</div>;
+  if (!tutorial) return <div className="p-6">{t('detail.not_found', { ns: 'tutorials' })}</div>;
 
   return (
     <InstructorLayout>
-      <motion.div 
+      <motion.div
         className="p-6 space-y-8 max-w-5xl mx-auto" 
         initial={{ opacity: 0, y: 30 }}
         animate={{ opacity: 1, y: 0 }}
@@ -85,13 +89,13 @@ export default function ViewTutorialPage() {
           </button>
           <button
             onClick={async () => {
-              if (!window.confirm('Are you sure you want to delete this tutorial?')) return;
+              if (!window.confirm(t('tutorialsPage.confirm_delete', { ns: 'dashboard' }))) return;
               try {
                 await deleteInstructorTutorial(tutorial.id);
                 router.push('/dashboard/instructor/tutorials');
               } catch (err) {
                 console.error(err);
-                alert('Failed to delete tutorial');
+                alert(t('tutorialsPage.delete_failed', { ns: 'dashboard' }));
               }
             }}
             className="bg-red-100 hover:bg-red-200 text-red-800 px-4 py-2 rounded-md font-semibold flex items-center gap-2"
@@ -283,5 +287,17 @@ export default function ViewTutorialPage() {
       />
     </InstructorLayout>
   );
+}
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(
+        locale,
+        ["common", "dashboard", "tutorials"],
+        nextI18NextConfig
+      )),
+    },
+  };
 }
 

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -9,10 +9,14 @@ import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
 import MediaStep from "@/components/tutorials/create/MediaStep";
 import ReviewStep from "@/components/tutorials/create/ReviewStep";
 import StepProgressBar from "@/components/tutorials/create/StepProgressBar";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 
 export default function CreateTutorialPage() {
   const [step, setStep] = useState(1);
   const router = useRouter();
+  const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const [tutorialData, setTutorialData] = useState({
     title: "",
     shortDescription: "",
@@ -51,7 +55,7 @@ export default function CreateTutorialPage() {
         setCategories(result?.data || []);
 
       } catch (err) {
-        console.error("Failed to load categories", err);
+        console.error(t('tutorialCreatePage.load_categories_failed', { ns: 'dashboard' }), err);
       }
     };
 
@@ -63,7 +67,7 @@ export default function CreateTutorialPage() {
 
   const submitTutorial = async (status) => {
     if (tutorialData.chapters.some((ch) => !ch.videoUrl)) {
-      toast.error("Please upload a video for each lesson before submitting.");
+      toast.error(t('tutorialCreatePage.video_required', { ns: 'dashboard' }));
       return;
     }
     const formData = new FormData();
@@ -97,14 +101,17 @@ export default function CreateTutorialPage() {
       await createTutorial(formData);
       toast.success(
         status === "draft"
-          ? "Tutorial saved as draft!"
-          : "Tutorial submitted successfully! Waiting for admin approval."
+          ? t('tutorialCreatePage.draft_success', { ns: 'dashboard' })
+          : t('tutorialCreatePage.submit_success', { ns: 'dashboard' })
       );
       localStorage.removeItem("tutorialDraft");
       router.push("/dashboard/instructor/tutorials");
     } catch (err) {
       console.error(err);
-      toast.error(err.response?.data?.message || "Failed to create tutorial");
+      toast.error(
+        err.response?.data?.message ||
+          t('tutorialCreatePage.creation_failed', { ns: 'dashboard' })
+      );
     }
   };
 
@@ -115,7 +122,7 @@ export default function CreateTutorialPage() {
   return (
     <InstructorLayout>
       <div className="p-8 bg-gray-100 min-h-screen">
-        <h1 className="text-3xl font-bold text-gray-800 mb-8">🎬 Create New Tutorial</h1>
+        <h1 className="text-3xl font-bold text-gray-800 mb-8">🎬 {t('tutorialCreatePage.title', { ns: 'dashboard' })}</h1>
 
         {/* Step Progress */}
         <StepProgressBar
@@ -191,4 +198,16 @@ export default function CreateTutorialPage() {
       </div>
     </InstructorLayout>
   );
+}
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(
+        locale,
+        ["common", "dashboard", "tutorials"],
+        nextI18NextConfig
+      )),
+    },
+  };
 }

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -1,6 +1,9 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import {
   FaPlus,
   FaEdit,
@@ -26,6 +29,7 @@ import { toast } from "react-toastify";
 
 export default function InstructorTutorialsPage() {
   const router = useRouter();
+  const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const [tutorials, setTutorials] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -57,7 +61,7 @@ export default function InstructorTutorialsPage() {
         setTutorials(data?.data || data || []);
       } catch (err) {
         console.error(err);
-        setError("Failed to load tutorials");
+        setError(t('tutorialsPage.load_error', { ns: 'dashboard' }));
       } finally {
         setLoading(false);
       }
@@ -75,16 +79,16 @@ export default function InstructorTutorialsPage() {
 
   const handleDelete = (id) => {
     openConfirmModal({
-      title: "Confirm Deletion",
-      message: "Are you sure you want to delete this tutorial?",
+      title: t('tutorialsPage.confirm_title', { ns: 'dashboard' }),
+      message: t('tutorialsPage.confirm_delete', { ns: 'dashboard' }),
       onConfirm: async () => {
         try {
           await deleteInstructorTutorial(id);
           setTutorials((prev) => prev.filter((tut) => tut.id !== id));
-          toast.success("Tutorial deleted successfully");
+          toast.success(t('tutorialsPage.deleted', { ns: 'dashboard' }));
         } catch (err) {
           console.error(err);
-          toast.error("Failed to delete tutorial");
+          toast.error(t('tutorialsPage.delete_failed', { ns: 'dashboard' }));
         } finally {
           closeConfirmModal();
         }
@@ -111,6 +115,7 @@ export default function InstructorTutorialsPage() {
       <InstructorLayout>
         <div className="p-6 flex justify-center items-center h-screen">
           <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-yellow-500"></div>
+          <span className="sr-only">{t('loading', { ns: 'common' })}</span>
         </div>
       </InstructorLayout>
     );
@@ -133,17 +138,17 @@ export default function InstructorTutorialsPage() {
         <div className="flex flex-col md:flex-row md:justify-between items-center mb-8 gap-4">
           <div className="text-center md:text-left">
             <h1 className="text-3xl font-bold text-gray-800 bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
-              My Tutorials
+              {t('instructorDashboardPage.my_tutorials', { ns: 'dashboard' })}
             </h1>
             <p className="text-gray-600 mt-1">
-              Manage and create your educational content
+              {t('tutorialsPage.description', { ns: 'dashboard' })}
             </p>
           </div>
           <button
             onClick={() => router.push("/dashboard/instructor/tutorials/create")}
             className="bg-gradient-to-r from-yellow-400 to-yellow-500 hover:from-yellow-500 hover:to-yellow-600 text-black font-bold py-3 px-6 rounded-xl flex items-center shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
           >
-            <FaPlus className="mr-2" /> Create Tutorial
+            <FaPlus className="mr-2" /> {t('instructorDashboardPage.create_tutorial', { ns: 'dashboard' })}
           </button>
         </div>
 
@@ -156,7 +161,7 @@ export default function InstructorTutorialsPage() {
               </div>
               <input
                 type="text"
-                placeholder="Search tutorials..."
+                placeholder={t('list.search_placeholder', { ns: 'tutorials' })}
                 className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                 onChange={(e) => handleSearch(e.target.value)}
               />
@@ -461,4 +466,16 @@ export default function InstructorTutorialsPage() {
       />
     </InstructorLayout>
   );
+}
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(
+        locale,
+        ["common", "dashboard", "tutorials"],
+        nextI18NextConfig
+      )),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- add server-side translation loading and useTranslation to instructor tutorial pages
- wire up getServerSideProps with common, dashboard and tutorials namespaces

## Testing
- `npm test --silent 2>&1 | tail -n 20`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6897c1fdeadc8328b9e0b01b7c2279cb