### PR TITLE
Use Next.js Image for tutorial thumbnails

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -1,6 +1,7 @@
 // ViewTutorialPage.js
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { motion } from "framer-motion"; // Smooth animation
 import {
@@ -121,9 +122,11 @@ export default function ViewTutorialPage() {
 
         {/* Thumbnail */}
         <div className="w-full h-52 sm:h-80 md:h-96 overflow-hidden rounded-2xl shadow-lg">
-          <img
+          <Image
             src={tutorial.thumbnail}
             alt={tutorial.title}
+            width={1280}
+            height={720}
             className="w-full h-full object-cover"
           />
         </div>

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { motion } from "framer-motion";
+import Image from "next/image";
 import { FaStar, FaClock, FaFire, FaEye, FaArrowUp, FaSearch, FaFilter } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import Navbar from "@/components/website/sections/Navbar";
@@ -312,11 +313,12 @@ const TutorialsSection = () => {
                           loop
                         />
                       ) : (
-                        <img
+                        <Image
                           src={tut.thumbnail}
                           alt={tut.title}
+                          width={640}
+                          height={256}
                           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
-                          loading="lazy"
                         />
                       )}
                       


### PR DESCRIPTION
## Summary
- Use Next.js Image for tutorial thumbnails on public listing and instructor view page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897c1fa5e308328b7f0078fd686880e