### PR TITLE
feat: add tutorial notifications translations

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -728,11 +728,13 @@
     "submit_success": "تم إرسال الدرس بنجاح! بانتظار موافقة المسؤول.",
     "video_required": "يرجى تحميل فيديو لكل درس قبل الإرسال.",
     "creation_failed": "فشل إنشاء الدرس",
+    "creation_notification": "تم إنشاء الدرس \"{{title}}\".",
     "load_categories_failed": "فشل تحميل التصنيفات"
   },
   "tutorialEditPage": {
     "update_success": "تم تحديث الدرس بنجاح!",
-    "update_failed": "فشل تحديث الدرس"
+    "update_failed": "فشل تحديث الدرس",
+    "update_notification": "تم تحديث الدرس \"{{title}}\"."
   },
   "usersPage": {
     "title": "إدارة المستخدمين",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -741,11 +741,13 @@
     "submit_success": "Tutorial submitted successfully! Waiting for admin approval.",
     "video_required": "Please upload a video for each lesson before submitting.",
     "creation_failed": "Failed to create tutorial",
+    "creation_notification": "Your tutorial \"{{title}}\" was created.",
     "load_categories_failed": "Failed to load categories"
   },
   "tutorialEditPage": {
     "update_success": "Tutorial updated successfully!",
-    "update_failed": "Failed to update tutorial"
+    "update_failed": "Failed to update tutorial",
+    "update_notification": "Your tutorial \"{{title}}\" was updated."
   },
   "usersPage": {
     "title": "User Management",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -734,11 +734,13 @@
     "submit_success": "Tutoriel soumis avec succès ! En attente de l'approbation de l'admin.",
     "video_required": "Veuillez télécharger une vidéo pour chaque leçon avant de soumettre.",
     "creation_failed": "Échec de la création du tutoriel",
+    "creation_notification": "Votre tutoriel \"{{title}}\" a été créé.",
     "load_categories_failed": "Échec du chargement des catégories"
   },
   "tutorialEditPage": {
     "update_success": "Tutoriel mis à jour avec succès !",
-    "update_failed": "Échec de la mise à jour du tutoriel"
+    "update_failed": "Échec de la mise à jour du tutoriel",
+    "update_notification": "Votre tutoriel \"{{title}}\" a été mis à jour."
   },
   "usersPage": {
     "title": "Gestion des utilisateurs",

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -15,6 +15,7 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import { useTranslation } from "next-i18next";
 
 export default function EditTutorialPage() {
   const router = useRouter();
@@ -29,6 +30,7 @@ export default function EditTutorialPage() {
   const user = useAuthStore((state) => state.user);
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
+  const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialEditPage' });
 
   useEffect(() => {
     if (!id) return;
@@ -146,22 +148,32 @@ export default function EditTutorialPage() {
 
               try {
                 await updateTutorial(id, formData);
-                toast.success("Tutorial updated successfully!");
-                await createNotification({
-                  user_id: user.id,
-                  type: "tutorial_updated",
-                  message: `Your tutorial "${tutorialData.title}" was updated.`,
-                });
-                await sendChatMessage(user.id, {
-                  text: `Your tutorial "${tutorialData.title}" was updated.`,
-                });
-                refreshNotifications?.();
-                refreshMessages?.();
+                toast.success(t('update_success'));
+                const message = t('update_notification', { title: tutorialData.title });
+
+                try {
+                  await createNotification({
+                    user_id: user.id,
+                    type: "tutorial_updated",
+                    message,
+                  });
+                  refreshNotifications?.();
+                } catch (notifyErr) {
+                  console.error(notifyErr);
+                }
+
+                try {
+                  await sendChatMessage(user.id, { text: message });
+                  refreshMessages?.();
+                } catch (msgErr) {
+                  console.error(msgErr);
+                }
+
                 localStorage.removeItem(`editTutorialDraft-${id}`);
                 router.push("/dashboard/instructor/tutorials");
               } catch (err) {
                 console.error(err);
-                toast.error("Failed to update tutorial");
+                toast.error(t('update_failed'));
               }
             }}
           />

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -3,6 +3,12 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { fetchAllCategories } from "@/services/admin/categoryService";
 import { createTutorial } from "@/services/admin/tutorialService";
+import { createNotification } from "@/services/notificationService";
+import { sendChatMessage } from "@/services/messageService";
+import useAuthStore from "@/store/auth/authStore";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
+import { useTranslation } from "next-i18next";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
@@ -30,6 +36,10 @@ export default function CreateTutorialPage() {
   });
 
   const [categories, setCategories] = useState([]);
+  const user = useAuthStore((state) => state.user);
+  const refreshNotifications = useNotificationStore((state) => state.fetch);
+  const refreshMessages = useMessageStore((state) => state.fetch);
+  const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialCreatePage' });
 
   useEffect(() => {
     const savedDraft = localStorage.getItem("tutorialDraft");
@@ -63,7 +73,7 @@ export default function CreateTutorialPage() {
 
   const submitTutorial = async (status) => {
     if (tutorialData.chapters.some((ch) => !ch.videoUrl)) {
-      toast.error("Please upload a video for each lesson before submitting.");
+      toast.error(t('video_required'));
       return;
     }
     const formData = new FormData();
@@ -95,16 +105,32 @@ export default function CreateTutorialPage() {
 
     try {
       await createTutorial(formData);
-      toast.success(
-        status === "draft"
-          ? "Tutorial saved as draft!"
-          : "Tutorial submitted successfully! Waiting for admin approval."
-      );
+      toast.success(status === "draft" ? t('draft_success') : t('submit_success'));
+      const message = t('creation_notification', { title: tutorialData.title });
+
+      try {
+        await createNotification({
+          user_id: user.id,
+          type: "tutorial_created",
+          message,
+        });
+        refreshNotifications?.();
+      } catch (notifyErr) {
+        console.error(notifyErr);
+      }
+
+      try {
+        await sendChatMessage(user.id, { text: message });
+        refreshMessages?.();
+      } catch (msgErr) {
+        console.error(msgErr);
+      }
+
       localStorage.removeItem("tutorialDraft");
       router.push("/dashboard/instructor/tutorials");
     } catch (err) {
       console.error(err);
-      toast.error(err.response?.data?.message || "Failed to create tutorial");
+      toast.error(err.response?.data?.message || t('creation_failed'));
     }
   };
 


### PR DESCRIPTION
## Summary
- localize instructor tutorial update messages
- send translated notifications and chats on tutorial creation
- add locale keys for tutorial update/create notifications (en/fr/ar)

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, import/no-anonymous-default-export)*

------
https://chatgpt.com/codex/tasks/task_e_6897c1e828f88328927c37799cf620ff