### PR TITLE
Add class reminder subscription flow

### DIFF
--- a/backend/src/migrations/20250902000000_create_class_reminder_subscriptions.js
+++ b/backend/src/migrations/20250902000000_create_class_reminder_subscriptions.js
@@ -1,0 +1,23 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('class_reminder_subscriptions', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table
+      .uuid('user_id')
+      .notNullable()
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table
+      .uuid('class_id')
+      .notNullable()
+      .references('id')
+      .inTable('online_classes')
+      .onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'class_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('class_reminder_subscriptions');
+};

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -21,6 +21,7 @@ router.use("/assignments/submissions", require("./assignments/submission.routes"
 router.use("/assignments", require("./assignments/classAssignment.routes"));
 router.use("/wishlist", require("./wishlist/classWishlist.routes"));
 router.use("/likes", require("./likes/classLike.routes"));
+router.use("/notifications", require("./notifications/classNotification.routes"));
 // Attendance tracking
 router.use("/attendance", require("./attendance/classAttendance.routes"));
 // Reviews and comments

--- a/backend/src/modules/classes/notifications/classNotification.controller.js
+++ b/backend/src/modules/classes/notifications/classNotification.controller.js
@@ -1,0 +1,15 @@
+const catchAsync = require('../../../utils/catchAsync');
+const { sendSuccess } = require('../../../utils/response');
+const service = require('./classNotification.service');
+const startClassReminderJob = require('../../../jobs/classReminderJob');
+
+let jobStarted = false;
+
+exports.subscribe = catchAsync(async (req, res) => {
+  await service.subscribe(req.user.id, req.params.classId);
+  if (!jobStarted) {
+    startClassReminderJob();
+    jobStarted = true;
+  }
+  sendSuccess(res, null, 'Class reminder subscribed');
+});

--- a/backend/src/modules/classes/notifications/classNotification.routes.js
+++ b/backend/src/modules/classes/notifications/classNotification.routes.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const ctrl = require('./classNotification.controller');
+const { verifyToken, isStudent } = require('../../../middleware/auth/authMiddleware');
+
+router.post('/:classId', verifyToken, isStudent, ctrl.subscribe);
+
+module.exports = router;

--- a/backend/src/modules/classes/notifications/classNotification.service.js
+++ b/backend/src/modules/classes/notifications/classNotification.service.js
@@ -1,0 +1,11 @@
+const db = require('../../../config/database');
+const { v4: uuidv4 } = require('uuid');
+
+exports.subscribe = async (userId, classId) => {
+  const [item] = await db('class_reminder_subscriptions')
+    .insert({ id: uuidv4(), user_id: userId, class_id: classId })
+    .onConflict(['user_id', 'class_id'])
+    .ignore()
+    .returning('*');
+  return item;
+};

--- a/frontend/src/pages/dashboard/student/online-classes/index.js
+++ b/frontend/src/pages/dashboard/student/online-classes/index.js
@@ -15,7 +15,8 @@ import {
   FaSortAmountDown
 } from 'react-icons/fa';
 import StudentLayout from '@/components/layouts/StudentLayout';
-import { fetchMyEnrolledClasses } from '@/services/classService';
+import { fetchMyEnrolledClasses, subscribeToClassReminder } from '@/services/classService';
+import { toast } from 'react-toastify';
 
 export default function MyEnrolledClassesPage() {
   const [classes, setClasses] = useState([]);
@@ -128,7 +129,18 @@ export default function MyEnrolledClassesPage() {
                 </span>
 
                 {cls.status === 'Upcoming' && (
-                  <button className="text-xs text-blue-600 underline mb-2 flex items-center gap-1">
+                  <button
+                    onClick={async () => {
+                      try {
+                        await subscribeToClassReminder(cls.id);
+                        toast.success('Reminder set');
+                      } catch (err) {
+                        console.error('Failed to subscribe to reminder', err);
+                        toast.error('Failed to set reminder');
+                      }
+                    }}
+                    className="text-xs text-blue-600 underline mb-2 flex items-center gap-1"
+                  >
                     <FaBell /> Notify Me
                   </button>
                 )}

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -154,3 +154,8 @@ export const postClassComment = async (classId, payload) => {
   const { data } = await api.post(`/users/classes/comments/${classId}`, payload);
   return data;
 };
+
+export const subscribeToClassReminder = async (classId) => {
+  const { data } = await api.post(`/users/classes/notifications/${classId}`);
+  return data;
+};


### PR DESCRIPTION
## Summary
- allow students to subscribe to class reminders from "My Enrolled Classes" page
- record reminder subscriptions and trigger reminder job via new backend route
- store subscriptions in new `class_reminder_subscriptions` table

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68985e2331448328a61311db86f7154b