### PR TITLE
Protect video call routes with class enrollment checks

### DIFF
--- a/backend/src/middleware/auth/verifyEnrollment.js
+++ b/backend/src/middleware/auth/verifyEnrollment.js
@@ -1,0 +1,26 @@
+const db = require("../../config/database");
+
+module.exports = async function verifyEnrollment(req, res, next) {
+  const { roomId } = req.params;
+  try {
+    const cls = await db("online_classes")
+      .select("instructor_id")
+      .where({ id: roomId })
+      .first();
+    if (!cls) return res.status(404).json({ message: "Class not found" });
+    const isInstructor = cls.instructor_id === req.user.id;
+    let isStudent = false;
+    if (!isInstructor) {
+      const enrollment = await db("class_enrollments")
+        .where({ class_id: roomId, user_id: req.user.id })
+        .first();
+      if (enrollment) isStudent = true;
+    }
+    if (!isInstructor && !isStudent)
+      return res.status(403).json({ message: "Not allowed" });
+    next();
+  } catch (err) {
+    console.error("Failed to verify enrollment", err);
+    res.status(500).json({ message: "Failed to verify enrollment" });
+  }
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,6 +10,7 @@ const { Server } = require("socket.io");
 const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");
 const { verifyToken } = require("./middleware/auth/authMiddleware");
+const verifyEnrollment = require("./middleware/auth/verifyEnrollment");
 const csrf = require("./middleware/csrf");
 const path = require("path");
 const startLessonReminderJob = require("./jobs/lessonReminderJob");
@@ -288,48 +289,64 @@ io.on("connection", (socket) => {
   });
 });
 
-app.get("/api/video-calls/:roomId/participants", verifyToken, async (req, res) => {
-  try {
-    const rows = await db("video_call_participants")
-      .select("name", "role", "is_muted", "joined_at")
-      .where({ room_id: req.params.roomId })
-      .andWhere("left_at", null);
-    res.json(rows);
-  } catch (err) {
-    res.status(500).json({ message: "Failed to fetch participants" });
-  }
-});
+app.get(
+  "/api/video-calls/:roomId/participants",
+  verifyToken,
+  verifyEnrollment,
+  async (req, res) => {
+    try {
+      const rows = await db("video_call_participants")
+        .select("name", "role", "is_muted", "joined_at")
+        .where({ room_id: req.params.roomId })
+        .andWhere("left_at", null);
+      res.json(rows);
+    } catch (err) {
+      res.status(500).json({ message: "Failed to fetch participants" });
+    }
+  },
+);
 
-app.get("/api/video-calls/:roomId/messages", verifyToken, async (req, res) => {
-  try {
-    const messages = await db("video_call_messages")
-      .where({ room_id: req.params.roomId })
-      .orderBy("timestamp", "asc");
-    res.json(messages);
-  } catch (err) {
-    res.status(500).json({ message: "Failed to fetch messages" });
-  }
-});
+app.get(
+  "/api/video-calls/:roomId/messages",
+  verifyToken,
+  verifyEnrollment,
+  async (req, res) => {
+    try {
+      const messages = await db("video_call_messages")
+        .where({ room_id: req.params.roomId })
+        .orderBy("timestamp", "asc");
+      res.json(messages);
+    } catch (err) {
+      res.status(500).json({ message: "Failed to fetch messages" });
+    }
+  },
+);
 
-app.post("/api/video-calls/:roomId/messages", verifyToken, async (req, res) => {
-  const { text } = req.body || {};
-  const roomId = req.params.roomId;
-  if (!text?.trim()) return res.status(400).json({ message: "Message text required" });
-  try {
-    const [message] = await db("video_call_messages")
-      .insert({
-        room_id: roomId,
-        sender_id: req.user.id,
-        sender: req.user.full_name,
-        text: text.trim(),
-      })
-      .returning("*");
-    io.to(roomId).emit("call-message", message);
-    res.status(201).json(message);
-  } catch (err) {
-    res.status(500).json({ message: "Failed to store message" });
-  }
-});
+app.post(
+  "/api/video-calls/:roomId/messages",
+  verifyToken,
+  verifyEnrollment,
+  async (req, res) => {
+    const { text } = req.body || {};
+    const roomId = req.params.roomId;
+    if (!text?.trim())
+      return res.status(400).json({ message: "Message text required" });
+    try {
+      const [message] = await db("video_call_messages")
+        .insert({
+          room_id: roomId,
+          sender_id: req.user.id,
+          sender: req.user.full_name,
+          text: text.trim(),
+        })
+        .returning("*");
+      io.to(roomId).emit("call-message", message);
+      res.status(201).json(message);
+    } catch (err) {
+      res.status(500).json({ message: "Failed to store message" });
+    }
+  },
+);
 
 app.use(require("./middleware/errorHandler"));
 const PORT = process.env.PORT || 5002;

--- a/backend/tests/video-calls/authorization.test.js
+++ b/backend/tests/video-calls/authorization.test.js
@@ -1,0 +1,48 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../src/config/database', () => {
+  return jest.fn((table) => {
+    if (table === 'online_classes') {
+      return {
+        select: () => ({
+          where: () => ({ first: () => Promise.resolve({ instructor_id: 'instructor1' }) }),
+        }),
+      };
+    }
+    if (table === 'class_enrollments') {
+      return {
+        where: () => ({ first: () => Promise.resolve(null) }),
+      };
+    }
+    return {};
+  });
+});
+
+const verifyEnrollment = require('../../src/middleware/auth/verifyEnrollment');
+
+const app = express();
+app.use(express.json());
+const attachUser = (req, _res, next) => { req.user = { id: 'user1' }; next(); };
+app.get('/api/video-calls/:roomId/participants', attachUser, verifyEnrollment, (_req, res) => res.json([]));
+app.get('/api/video-calls/:roomId/messages', attachUser, verifyEnrollment, (_req, res) => res.json([]));
+app.post('/api/video-calls/:roomId/messages', attachUser, verifyEnrollment, (_req, res) => res.status(201).json({}));
+
+describe('video call authorization', () => {
+  it('rejects unauthorized participants fetch', async () => {
+    const res = await request(app).get('/api/video-calls/cls1/participants');
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects unauthorized messages fetch', async () => {
+    const res = await request(app).get('/api/video-calls/cls1/messages');
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects unauthorized message post', async () => {
+    const res = await request(app)
+      .post('/api/video-calls/cls1/messages')
+      .send({ text: 'hi' });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add verifyEnrollment middleware to restrict video call access to class instructor or enrolled students
- secure video call participant and message routes with enrollment verification
- test unauthorized access to video call endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68985e20519c8328be64f77f5408855f