### PR TITLE
feat: add chat moderation logging

### DIFF
--- a/backend/src/modules/chat/chat.controller.js
+++ b/backend/src/modules/chat/chat.controller.js
@@ -51,3 +51,13 @@ exports.togglePin = catchAsync(async (req, res) => {
   if (!msg) throw new AppError("Message not found", 404);
   sendSuccess(res, msg, msg.pinned ? "Pinned" : "Unpinned");
 });
+
+exports.logModerationEvent = catchAsync(async (req, res) => {
+  const { message, matchedWords } = req.body || {};
+  await service.logModerationEvent({
+    userId: req.user.id,
+    message,
+    matchedWords,
+  });
+  sendSuccess(res, null, "Moderation event logged");
+});

--- a/backend/src/modules/chat/chat.routes.js
+++ b/backend/src/modules/chat/chat.routes.js
@@ -17,6 +17,11 @@ const mapFilesToBody = (req, _res, next) => {
 router.use(verifyToken);
 
 router.get("/users", controller.searchUsers);
+router.post(
+  "/moderation",
+  validate(validator.logModerationEvent),
+  controller.logModerationEvent
+);
 router.get("/:userId", controller.getConversation);
 router.post(
   "/:userId",

--- a/backend/src/modules/chat/chat.service.js
+++ b/backend/src/modules/chat/chat.service.js
@@ -1,4 +1,6 @@
 const db = require("../../config/database");
+const notificationService = require("../notifications/notifications.service");
+const userModel = require("../users/user.model");
 
 exports.searchUsers = async (currentUserId, term) => {
   const subquery = db("messages")
@@ -85,4 +87,37 @@ exports.togglePin = async (userId, id) => {
     .update({ pinned: !msg.pinned })
     .returning("*");
   return updated;
+};
+
+exports.logModerationEvent = async ({ userId, message, matchedWords }) => {
+  const [row] = await db("chat_moderation")
+    .insert({
+      user_id: userId,
+      message,
+      matched_words: JSON.stringify(matchedWords),
+      created_at: new Date(),
+    })
+    .returning("*");
+
+  const admins = await userModel.findAdmins();
+  const note = `Flagged chat message from user ${userId}: ${matchedWords.join(", ")}`;
+  const results = await Promise.allSettled(
+    admins.map((admin) =>
+      notificationService.createNotification({
+        user_id: admin.id,
+        type: "chat_moderation",
+        message: note,
+      })
+    )
+  );
+  results.forEach((r, idx) => {
+    if (r.status === "rejected") {
+      console.error(
+        `Failed to notify admin ${admins[idx].id}:`,
+        r.reason?.message || r.reason
+      );
+    }
+  });
+
+  return row;
 };

--- a/backend/src/modules/chat/chat.validator.js
+++ b/backend/src/modules/chat/chat.validator.js
@@ -48,3 +48,10 @@ exports.sendMessage = {
       path: ["file"],
     }),
 };
+
+exports.logModerationEvent = {
+  body: z.object({
+    message: z.string().min(1),
+    matchedWords: z.array(z.string()).nonempty(),
+  }),
+};

--- a/backend/tests/chatRoutes.test.js
+++ b/backend/tests/chatRoutes.test.js
@@ -8,6 +8,7 @@ jest.mock('../src/modules/chat/chat.service', () => ({
   sendMessage: jest.fn(),
   deleteMessage: jest.fn(),
   togglePin: jest.fn(),
+  logModerationEvent: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -109,5 +110,19 @@ describe('PATCH /api/chat/messages/:id/pin', () => {
     const res = await request(app).patch('/api/chat/messages/1/pin');
     expect(res.status).toBe(200);
     expect(service.togglePin).toHaveBeenCalledWith('user1', '1');
+  });
+});
+
+describe('POST /api/chat/moderation', () => {
+  it('logs moderation event', async () => {
+    service.logModerationEvent.mockResolvedValue({});
+    const payload = { message: 'bad word here', matchedWords: ['bad'] };
+    const res = await request(app).post('/api/chat/moderation').send(payload);
+    expect(res.status).toBe(200);
+    expect(service.logModerationEvent).toHaveBeenCalledWith({
+      userId: 'user1',
+      message: 'bad word here',
+      matchedWords: ['bad'],
+    });
   });
 });

--- a/frontend/src/components/chat/ChatInput.js
+++ b/frontend/src/components/chat/ChatInput.js
@@ -1,16 +1,21 @@
 import React, { useState } from 'react';
 import { filterMessage } from './MessageFilter';
 import { toast } from 'react-toastify';
+import { logModerationEvent } from '@/services/chatService';
 
 function ChatInput() {
   const [message, setMessage] = useState('');
 
-  const handleSend = () => {
+  const handleSend = async () => {
     const { isClean, matchedWords } = filterMessage(message);
 
     if (!isClean) {
       alert(`⚠️ Inappropriate language detected: ${matchedWords.join(', ')}`);
-      // TODO: log to moderation system or send to admin
+      try {
+        await logModerationEvent({ message, matchedWords });
+      } catch (err) {
+        console.error('Failed to log moderation event', err);
+      }
       return;
     }
 

--- a/frontend/src/services/chatService.js
+++ b/frontend/src/services/chatService.js
@@ -1,14 +1,21 @@
+import api from "@/services/api/api";
+
 export const getChatList = async () => {
-    return [
-      { id: "chat1", name: "John Doe" },
-      { id: "chat2", name: "Study Group" },
-      { id: "chat3", name: "Instructor - Mr. Smith" },
-    ];
-  };
-  
-  export const getMessages = async (chatId) => {
-    return chatId === "chat1"
-      ? [{ id: 1, text: "Hello!", isMine: false }, { id: 2, text: "Hi there!", isMine: true }]
-      : [];
-  };
+  return [
+    { id: "chat1", name: "John Doe" },
+    { id: "chat2", name: "Study Group" },
+    { id: "chat3", name: "Instructor - Mr. Smith" },
+  ];
+};
+
+export const getMessages = async (chatId) => {
+  return chatId === "chat1"
+    ? [{ id: 1, text: "Hello!", isMine: false }, { id: 2, text: "Hi there!", isMine: true }]
+    : [];
+};
+
+export const logModerationEvent = async ({ message, matchedWords }) => {
+  const res = await api.post("/chat/moderation", { message, matchedWords });
+  return res.data.data || res.data;
+};
   


### PR DESCRIPTION
## Summary
- log flagged chat messages via new /chat/moderation endpoint
- notify admins when inappropriate language is detected
- add frontend support for moderation logging

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68985e1e83548328a274262aca087d79