### PR TITLE
fix: deduplicate translation hooks in tutorial pages

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/analytics.js
@@ -20,7 +20,6 @@ export default function TutorialAnalyticsPage() {
   const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const { id } = router.query;
   const [stats, setStats] = useState(null);
-  const { t } = useTranslation(["dashboard", "tutorials"]);
 
   useEffect(() => {
     if (!id) return;

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -23,8 +23,6 @@ export default function EditTutorialPage() {
   const router = useRouter();
   const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const { id } = router.query;
-  const { t } = useTranslation(["dashboard", "tutorials"]);
-
   const [step, setStep] = useState(1);
   const [tutorialData, setTutorialData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -34,7 +32,6 @@ export default function EditTutorialPage() {
   const user = useAuthStore((state) => state.user);
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
-  const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialEditPage' });
 
   useEffect(() => {
     if (!id) return;

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -24,7 +24,6 @@ export default function ViewTutorialPage() {
   const router = useRouter();
   const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const { id } = router.query;
-  const { t } = useTranslation(["dashboard", "tutorials"]);
   const [tutorial, setTutorial] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -8,7 +8,6 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
-import { useTranslation } from "next-i18next";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
@@ -43,7 +42,6 @@ export default function CreateTutorialPage() {
   const user = useAuthStore((state) => state.user);
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
-  const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialCreatePage' });
 
   useEffect(() => {
     const savedDraft = localStorage.getItem("tutorialDraft");


### PR DESCRIPTION
## Summary
- remove duplicate `useTranslation` imports and declarations in instructor tutorial pages
- ensure pages use a single `t` function for translations

## Testing
- `npm test` *(fails: Unable to find an element with the text: Submit...)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68986517114483288a5eb2c47581c699