### PR TITLE
Add validation for tutorial tag name

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -7,6 +7,7 @@ const upload = require("./tutorialUploadMiddleware");
 const tutorialValidator = require("./tutorial.validator");
 const { isAdmin, verifyToken, isInstructorOrAdmin } = require("../../../middleware/auth/authMiddleware");
 const tagController = require("./tutorialTag.controller");
+const tagValidator = require("./tutorialTag.validator");
 
 // ✅ Admin routes
 router.post(
@@ -66,7 +67,13 @@ router.use("/reviews", require("./reviews/tutorialReview.routes"));
 router.use("/comments", require("./comments/tutorialComment.routes"));
 
 router.get("/tags", verifyToken, isInstructorOrAdmin, tagController.listTags);
-router.post("/tags", verifyToken, isInstructorOrAdmin, tagController.createTag);
+router.post(
+  "/tags",
+  verifyToken,
+  isInstructorOrAdmin,
+  validate(tagValidator.create),
+  tagController.createTag
+);
 
 router.use("/enroll", require("./enrollments/tutorialEnrollment.routes"));
 router.use("/wishlist", require("./wishlist/tutorialWishlist.routes"));

--- a/backend/src/modules/users/tutorials/tutorialTag.controller.js
+++ b/backend/src/modules/users/tutorials/tutorialTag.controller.js
@@ -14,7 +14,7 @@ exports.listTags = catchAsync(async (req, res) => {
 exports.createTag = catchAsync(async (req, res) => {
   const { name } = req.body;
   if (!name) {
-    return sendSuccess(res, null, "Name required");
+    return res.status(400).json({ message: "Name required" });
   }
   let tag = await service.findByName(name);
   if (!tag) {

--- a/backend/src/modules/users/tutorials/tutorialTag.validator.js
+++ b/backend/src/modules/users/tutorials/tutorialTag.validator.js
@@ -1,0 +1,7 @@
+const { z } = require("zod");
+
+exports.create = z.object({
+  body: z.object({
+    name: z.string().min(1),
+  }),
+});


### PR DESCRIPTION
## Summary
- Return a 400 error when tutorial tag name is missing
- Add Zod validator and middleware to require tag name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986ba09730832881236eac5d0a5b8d