### PR TITLE
feat: enforce tutorial chapter ownership

### DIFF
--- a/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
+++ b/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
@@ -6,6 +6,22 @@ const { v4: uuidv4 } = require("uuid");
 const uploadChapterVideo = require("./uploadChapterVideo");
 const db = require("../../../../config/database");
 
+// Ensure the requesting user is the tutorial's instructor or an admin
+const assertTutorialAccess = async (req, tutorialId) => {
+  const tutorial = await db("tutorials")
+    .select("instructor_id")
+    .where({ id: tutorialId })
+    .first();
+
+  if (!tutorial) throw new AppError("Tutorial not found", 404);
+
+  const role = req.user?.role?.toLowerCase();
+  const isAdmin = ["admin", "superadmin"].includes(role);
+  if (tutorial.instructor_id !== req.user.id && !isAdmin) {
+    throw new AppError("Access denied", 403);
+  }
+};
+
 // Handle chapter video uploads
 exports.uploadVideo = (req, res) => {
   if (!req.file) {
@@ -22,6 +38,8 @@ exports.uploadVideo = (req, res) => {
 exports.createChapter = catchAsync(async (req, res) => {
   const { tutorial_id, title, order, video_url, duration, is_preview = false } = req.body;
   if (!title || !tutorial_id) throw new AppError("Tutorial ID and title are required", 400);
+
+  await assertTutorialAccess(req, tutorial_id);
 
   const chapter = await service.create({
     id: uuidv4(),
@@ -42,6 +60,8 @@ exports.updateChapter = catchAsync(async (req, res) => {
   const chapter = await service.findById(id);
   if (!chapter) throw new AppError("Chapter not found", 404);
 
+  await assertTutorialAccess(req, chapter.tutorial_id);
+
   const data = { ...req.body };
   if (data.duration) {
     data.duration = parseInt(data.duration);
@@ -55,6 +75,8 @@ exports.deleteChapter = catchAsync(async (req, res) => {
   const { id } = req.params;
   const chapter = await service.findById(id);
   if (!chapter) throw new AppError("Chapter not found", 404);
+
+  await assertTutorialAccess(req, chapter.tutorial_id);
 
   await service.delete(id);
   sendSuccess(res, null, "Chapter deleted");
@@ -93,6 +115,8 @@ exports.reorderChapters = catchAsync(async (req, res) => {
   if (!Array.isArray(orderedIds)) {
     throw new AppError("orderedIds must be an array", 400);
   }
+
+  await assertTutorialAccess(req, tutorialId);
 
   const updates = orderedIds.map((id, index) => ({ id, order: index + 1 }));
   await service.reorderChapters(tutorialId, updates);


### PR DESCRIPTION
## Summary
- restrict chapter create, update, delete, and reorder to the tutorial's instructor or admins
- centralize instructor access validation in controller helper

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68986b9e946083288e385ad83326a1c0