### PR TITLE
Verify tutorial approval before enrollment

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -11,6 +11,8 @@ exports.enroll = catchAsync(async (req, res) => {
 
   const tutorial = await db("tutorials").where({ id: tutorialId }).first();
   if (!tutorial) throw new AppError("Tutorial not found", 404);
+  if (tutorial.moderation_status !== "Approved")
+    throw new AppError("Tutorial not approved", 400);
   if (tutorial.status !== "published")
     throw new AppError("Tutorial not published", 400);
 


### PR DESCRIPTION
## Summary
- block enrollment when tutorial hasn't been approved
- return explicit error if moderation status is not `Approved`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68986b9e768483289e251534644fc3ce