### PR TITLE
Verify enrollment before tutorial completion and streamline checks

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -36,43 +36,39 @@ exports.complete = catchAsync(async (req, res) => {
   const { tutorialId } = req.params;
   const user_id = req.user.id;
 
+  // Ensure enrollment exists
+  const enrollment = await db("tutorial_enrollments")
+    .where({ user_id, tutorial_id: tutorialId })
+    .first();
+  if (!enrollment) throw new AppError("Enrollment not found", 404);
+
   // Verify all chapters completed
-  let allChaptersCompleted = true;
-  const hasChapters = await db.schema.hasTable("tutorial_chapters");
-  const hasCompletions = await db.schema.hasTable("tutorial_chapter_completions");
+  const [{ count: totalChapters }] = await db("tutorial_chapters")
+    .where({ tutorial_id: tutorialId })
+    .count("id as count");
 
-  if (hasChapters && hasCompletions) {
-    const [{ count: totalChapters }] = await db("tutorial_chapters")
-      .where({ tutorial_id: tutorialId })
-      .count("id as count");
+  const [{ count: completedChapters }] = await db(
+    "tutorial_chapter_completions as tcc"
+  )
+    .join("tutorial_chapters as tc", "tcc.chapter_id", "tc.id")
+    .where("tc.tutorial_id", tutorialId)
+    .andWhere("tcc.user_id", user_id)
+    .count("tcc.id as count");
 
-    const [{ count: completedChapters }] = await db(
-      "tutorial_chapter_completions as tcc"
-    )
-      .join("tutorial_chapters as tc", "tcc.chapter_id", "tc.id")
-      .where("tc.tutorial_id", tutorialId)
-      .andWhere("tcc.user_id", user_id)
-      .count("tcc.id as count");
-
-    allChaptersCompleted = Number(totalChapters) === Number(completedChapters);
-  }
+  const allChaptersCompleted =
+    Number(totalChapters) === Number(completedChapters);
 
   // Verify quiz passed if any
   let quizPassed = true;
-  const hasQuizzes = await db.schema.hasTable("tutorial_quizzes");
-  const hasAttempts = await db.schema.hasTable("quiz_attempts");
+  const quiz = await db("tutorial_quizzes")
+    .where({ tutorial_id: tutorialId })
+    .first();
 
-  if (hasQuizzes && hasAttempts) {
-    const quiz = await db("tutorial_quizzes")
-      .where({ tutorial_id: tutorialId })
+  if (quiz) {
+    const attempt = await db("quiz_attempts")
+      .where({ tutorial_id: tutorialId, user_id, passed: true })
       .first();
-
-    if (quiz) {
-      const attempt = await db("quiz_attempts")
-        .where({ tutorial_id: tutorialId, user_id, passed: true })
-        .first();
-      quizPassed = Boolean(attempt);
-    }
+    quizPassed = Boolean(attempt);
   }
 
   if (!allChaptersCompleted || !quizPassed) {


### PR DESCRIPTION
## Summary
- ensure a tutorial enrollment exists before marking completion
- remove redundant schema existence checks for chapters and quizzes
- update enrollment to completed only after confirming all requirements

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68986b9e4f4c8328b3e8826323321ad6