### PR TITLE
fix: import missing dependencies for tutorial view

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -15,6 +15,8 @@ import {
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
 import { safeEncodeURI } from "@/utils/url";
 import ProgressChecklistModal from '@/components/tutorials/ProgressChecklistModal';
+import ConfirmModal from "@/components/common/ConfirmModal";
+import { toast } from "react-toastify";
 import { fetchInstructorTutorialById, submitTutorialForReview, deleteInstructorTutorial } from "@/services/instructor/tutorialService";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";


### PR DESCRIPTION
## Summary
- import `ConfirmModal` component and `toast` notifier on instructor tutorial view page

## Testing
- `npm test` *(fails: InstructorTutorialsPage.test.js - Unable to find an element with the text: Submit)*
- `npm run lint` *(fails: 69 errors, 260 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68988a1c28148328b4e82e57785876c5