### PR TITLE
Use Next.js Image for tutorial thumbnails

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import Image from "next/image";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { motion } from "framer-motion";
@@ -142,11 +143,14 @@ const LandingTutorialsSection = () => {
                   className="w-full h-full object-cover group-hover:brightness-75"
                 />
               ) : (
-                <img
+                <Image
                   src={tut.thumbnail || "/images/logo.png"}
                   alt={tut.title}
-                  loading="lazy"
-                  className="w-full h-full object-cover group-hover:brightness-75"
+                  fill
+                  className="object-cover group-hover:brightness-75"
+                  placeholder="blur"
+                  blurDataURL="/images/logo.png"
+                  sizes="100vw"
                 />
               )}
               {tut.tags.includes("Top Rated") || tut.trending ? (


### PR DESCRIPTION
## Summary
- replace img with optimized `next/image` in TutorialsSection

## Testing
- `npm test` *(fails: 1 failed, 23 passed, 24 total)*
- `npm run lint` *(fails: 69 errors, 259 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898910f457883289b899b51d331a487