### PR TITLE
Clamp tutorial rating to valid range

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -16,8 +16,10 @@ import { fetchFeaturedTutorials } from "@/services/tutorialService";
 const PROGRESS_KEY = "skillbridge_tutorialProgress";
 
 
-const getStars = (rating) => {
-  const safeRating = Number.isFinite(rating) && rating > 0 ? rating : 0;
+export const getStars = (rating) => {
+  const safeRating = Number.isFinite(rating)
+    ? Math.min(Math.max(rating, 0), 5)
+    : 0;
   const full = Math.floor(safeRating);
   const half = safeRating % 1 >= 0.5;
   return (

--- a/frontend/src/tests/__tests__/TutorialsSection.test.js
+++ b/frontend/src/tests/__tests__/TutorialsSection.test.js
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import { getStars } from '@/components/website/sections/TutorialsSection';
+
+describe('getStars rating clamp', () => {
+  it('renders no stars for ratings below 0', () => {
+    const { container } = render(<>{getStars(-2)}</>);
+    expect(container.querySelectorAll('svg').length).toBe(0);
+  });
+
+  it('renders five stars for ratings above 5', () => {
+    const { container } = render(<>{getStars(6.7)}</>);
+    expect(container.querySelectorAll('svg').length).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- Clamp tutorial star rating to 0-5 range before calculating full and half stars
- Export star helper and add tests for rating clamping

## Testing
- `npm test` *(fails: InstructorTutorialsPage.test.js: Unable to find an element with the text: Submit)*

------
https://chatgpt.com/codex/tasks/task_e_68989108c64883288a2eaf3beb6da2c7