### PR TITLE
Use i18n keys for tutorial error toasts

### DIFF
--- a/frontend/public/locales/ar/website.json
+++ b/frontend/public/locales/ar/website.json
@@ -162,5 +162,8 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
-  "by_author": "by {{author}}"
+  "by_author": "by {{author}}",
+  "network_error": "خطأ في الشبكة: يرجى التحقق من API_BASE_URL وخادم الخلفية.",
+  "tutorials_load_error": "فشل تحميل الدروس.",
+  "categories_load_error": "فشل تحميل الفئات."
  }

--- a/frontend/public/locales/de/website.json
+++ b/frontend/public/locales/de/website.json
@@ -162,5 +162,8 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
-  "by_author": "by {{author}}"
+  "by_author": "by {{author}}",
+  "network_error": "Netzwerkfehler: Bitte API_BASE_URL und Backend-Server prüfen.",
+  "tutorials_load_error": "Laden der Tutorials fehlgeschlagen.",
+  "categories_load_error": "Laden der Kategorien fehlgeschlagen."
  }

--- a/frontend/public/locales/en/website.json
+++ b/frontend/public/locales/en/website.json
@@ -162,6 +162,9 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
-  "by_author": "by {{author}}"
+  "by_author": "by {{author}}",
+  "network_error": "Network error: please check API_BASE_URL and backend server.",
+  "tutorials_load_error": "Failed to load tutorials.",
+  "categories_load_error": "Failed to load categories."
 
 }

--- a/frontend/public/locales/es/website.json
+++ b/frontend/public/locales/es/website.json
@@ -162,5 +162,8 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
-  "by_author": "by {{author}}"
+  "by_author": "by {{author}}",
+  "network_error": "Error de red: verifique API_BASE_URL y el servidor backend.",
+  "tutorials_load_error": "No se pudieron cargar los tutoriales.",
+  "categories_load_error": "No se pudieron cargar las categorías."
  }

--- a/frontend/public/locales/fr/website.json
+++ b/frontend/public/locales/fr/website.json
@@ -162,5 +162,8 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
-  "by_author": "by {{author}}"
+  "by_author": "by {{author}}",
+  "network_error": "Erreur réseau : veuillez vérifier API_BASE_URL et le serveur backend.",
+  "tutorials_load_error": "Échec du chargement des tutoriels.",
+  "categories_load_error": "Échec du chargement des catégories."
  }

--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -54,8 +54,8 @@ const LandingTutorialsSection = () => {
       } catch (err) {
         const msg =
           err.code === "ERR_NETWORK"
-            ? "Network error: please check API_BASE_URL and backend server."
-            : "Failed to load tutorials";
+            ? t('network_error')
+            : t('tutorials_load_error');
         toast.error(msg);
       }
       try {
@@ -64,10 +64,10 @@ const LandingTutorialsSection = () => {
       } catch (err) {
         const msg =
           err.code === "ERR_NETWORK"
-            ? "Network error: please check API_BASE_URL and backend server."
-            : "Failed to load categories";
+            ? t('network_error')
+            : t('categories_load_error');
         toast.error(msg);
-        console.error("Failed to load categories", err);
+        console.error(t('categories_load_error'), err);
       }
       try {
         const stored = JSON.parse(localStorage.getItem(PROGRESS_KEY) || "{}");


### PR DESCRIPTION
## Summary
- replace hard-coded toast error strings with i18n keys in TutorialsSection
- add network and load error translations for tutorials and categories across locale files

## Testing
- `npm test` *(fails: Unable to find an element with the text: Submit)*
- `npm run lint` *(fails: 69 errors, 261 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689891043ef483289f9928b5a3cc4540