### PR TITLE
feat: enable tutorial media editing

### DIFF
--- a/frontend/src/components/tutorials/create/MediaStep.js
+++ b/frontend/src/components/tutorials/create/MediaStep.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "next-i18next";
 
@@ -7,6 +7,24 @@ export default function MediaStep({ tutorialData, setTutorialData, onNext, onBac
   const [thumbnailPreview, setThumbnailPreview] = useState(null);
   const [previewVideo, setPreviewVideo] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(0);
+
+  useEffect(() => {
+    if (tutorialData?.thumbnail && !thumbnailPreview) {
+      if (tutorialData.thumbnail instanceof File) {
+        setThumbnailPreview(URL.createObjectURL(tutorialData.thumbnail));
+      } else {
+        setThumbnailPreview(tutorialData.thumbnail);
+      }
+    }
+    if (tutorialData?.preview && !previewVideo) {
+      if (tutorialData.preview instanceof File) {
+        setPreviewVideo(URL.createObjectURL(tutorialData.preview));
+      } else {
+        setPreviewVideo(tutorialData.preview);
+      }
+      setUploadProgress(100);
+    }
+  }, [tutorialData.thumbnail, tutorialData.preview, thumbnailPreview, previewVideo]);
 
   const handleThumbnailUpload = (e) => {
     const file = e.target.files[0];

--- a/frontend/src/components/tutorials/create/ReviewStep.js
+++ b/frontend/src/components/tutorials/create/ReviewStep.js
@@ -64,16 +64,24 @@ export default function ReviewStep({
             <FaCheckCircle /> Media
           </h3>
           <div className="flex gap-6 items-center">
-            {tutorialData.thumbnail instanceof File && (
+            {tutorialData.thumbnail && (
               <img
-                src={URL.createObjectURL(tutorialData.thumbnail)}
+                src={
+                  tutorialData.thumbnail instanceof File
+                    ? URL.createObjectURL(tutorialData.thumbnail)
+                    : tutorialData.thumbnail
+                }
                 alt="Thumbnail Preview"
                 className="w-32 h-20 object-cover rounded shadow"
               />
             )}
-            {tutorialData.preview instanceof File && (
+            {tutorialData.preview && (
               <video
-                src={URL.createObjectURL(tutorialData.preview)}
+                src={
+                  tutorialData.preview instanceof File
+                    ? URL.createObjectURL(tutorialData.preview)
+                    : tutorialData.preview
+                }
                 controls
                 className="w-32 h-20 rounded shadow"
               />

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -79,7 +79,7 @@ export default function EditTutorialPage() {
   }, [tutorialData, id]);
 
   const onNext = () => setStep((prev) => prev + 1);
-  const onPrev = () => setStep((prev) => prev - 1);
+  const onBack = () => setStep((prev) => prev - 1);
 
   if (loading) return <div className="p-6">{t("dashboard:tutorialEditPage.loading")}</div>;
   if (error) return <div className="p-6 text-red-500">{error}</div>;
@@ -101,7 +101,7 @@ export default function EditTutorialPage() {
             tutorialData={tutorialData}
             setTutorialData={setTutorialData}
             onNext={onNext}
-            onPrev={onPrev}
+            onBack={onBack}
           />
         )}
         {step === 3 && (
@@ -109,13 +109,13 @@ export default function EditTutorialPage() {
             tutorialData={tutorialData}
             setTutorialData={setTutorialData}
             onNext={onNext}
-            onPrev={onPrev}
+            onBack={onBack}
           />
         )}
         {step === 4 && (
           <ReviewStep
             tutorialData={tutorialData}
-            onBack={onPrev}
+            onBack={onBack}
             actionLabel={t("dashboard:tutorialEditPage.save_changes")}
             onPublish={async () => {
               const formData = new FormData();

--- a/frontend/src/tests/__tests__/InstructorTutorialsPage.test.js
+++ b/frontend/src/tests/__tests__/InstructorTutorialsPage.test.js
@@ -43,16 +43,16 @@ describe('InstructorTutorialsPage', () => {
     submitTutorialForReview.mockRejectedValue(new Error('fail'));
 
     render(<InstructorTutorialsPage />);
-    const submitButton = await screen.findByText('Submit');
+    const submitButton = await screen.findByText('dashboard:tutorialsPage.submit');
     fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(submitTutorialForReview).toHaveBeenCalledWith(1);
     });
 
-    expect(toast.error).toHaveBeenCalledWith('Failed to submit tutorial for review');
+    expect(toast.error).toHaveBeenCalledWith('dashboard:tutorialsPage.submit_for_review_failed');
     expect(toast.success).not.toHaveBeenCalled();
     // Button remains because state wasn't updated
-    expect(screen.getByText('Submit')).toBeInTheDocument();
+    expect(screen.getByText('dashboard:tutorialsPage.submit')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- allow tutorial media step to preload and replace existing thumbnail and preview
- show existing or newly uploaded media in review step
- align tests with i18n keys for instructor tutorials page
- fix navigation handlers in tutorial edit flow

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68989c198f988328a3775db778de5bc3