### PR TITLE
feat: show pricing on tutorial enroll banner

### DIFF
--- a/frontend/src/components/tutorials/detail/EnrollBanner.js
+++ b/frontend/src/components/tutorials/detail/EnrollBanner.js
@@ -1,13 +1,25 @@
-const EnrollBanner = ({ onEnroll }) => (
-  <div className="bg-yellow-700/20 border border-yellow-600 text-yellow-300 p-4 rounded-lg flex items-center justify-between">
-    <p>Enroll to unlock all chapters and quizzes.</p>
-    <button
-      onClick={onEnroll}
-      className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded"
-    >
-      💳 Enroll Now
-    </button>
-  </div>
-);
+const EnrollBanner = ({ onEnroll, isPaid, price }) => {
+  const formattedPrice = isPaid
+    ? `$${Number(price).toFixed(2)}`
+    : "Free";
+
+  return (
+    <div className="bg-yellow-700/20 border border-yellow-600 text-yellow-300 p-4 rounded-lg flex items-center justify-between">
+      <p>
+        Enroll to unlock all chapters and quizzes.
+        <span className="font-semibold ml-2">{formattedPrice}</span>
+      </p>
+      <button
+        onClick={isPaid ? undefined : onEnroll}
+        disabled={isPaid}
+        className={`bg-green-500 text-white px-4 py-2 rounded ${
+          isPaid ? "opacity-50 cursor-not-allowed" : "hover:bg-green-600"
+        }`}
+      >
+        {isPaid ? "Purchase Required" : "💳 Enroll Now"}
+      </button>
+    </div>
+  );
+};
 
 export default EnrollBanner;

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -235,7 +235,13 @@ export default function TutorialDetail() {
       <div className="container mx-auto px-6 py-12 mt-16 space-y-10">
         <BackButton />
 
-        {!isEnrolled && <EnrollBanner onEnroll={enroll} />}
+        {!isEnrolled && (
+          <EnrollBanner
+            onEnroll={enroll}
+            isPaid={Number(tutorial.price) > 0}
+            price={tutorial.price}
+          />
+        )}
 
 
         {playerVideos.length > 0 ? (


### PR DESCRIPTION
## Summary
- display Free or price in tutorial enroll banner
- disable enroll button for paid tutorials without purchase
- pass pricing props from tutorial detail page

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68989eeccaec8328a5b3800b9fd510ea