### PR TITLE
Validate tutorial status before wishlist addition

### DIFF
--- a/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.service.js
+++ b/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.service.js
@@ -1,7 +1,15 @@
 const db = require('../../../../config/database');
 const { v4: uuidv4 } = require('uuid');
+const AppError = require('../../../../utils/AppError');
 
 exports.add = async (userId, tutorialId) => {
+  const tutorial = await db('tutorials').where({ id: tutorialId }).first();
+  if (!tutorial) throw new AppError('Tutorial not found', 404);
+  if (tutorial.moderation_status !== 'Approved')
+    throw new AppError('Tutorial not approved', 400);
+  if (tutorial.status !== 'published')
+    throw new AppError('Tutorial not published', 400);
+
   const [item] = await db('tutorial_wishlist')
     .insert({ id: uuidv4(), user_id: userId, tutorial_id: tutorialId })
     .onConflict(['user_id','tutorial_id']).ignore()

--- a/backend/tests/tutorialWishlistService.test.js
+++ b/backend/tests/tutorialWishlistService.test.js
@@ -1,0 +1,57 @@
+const knex = require('knex');
+
+const mockDb = knex({
+  client: 'sqlite3',
+  connection: { filename: ':memory:' },
+  useNullAsDefault: true,
+});
+
+jest.mock('../src/config/database', () => mockDb);
+
+const service = require('../src/modules/users/tutorials/wishlist/tutorialWishlist.service');
+const AppError = require('../src/utils/AppError');
+
+beforeAll(async () => {
+  await mockDb.schema.createTable('tutorials', (table) => {
+    table.string('id').primary();
+    table.string('status');
+    table.string('moderation_status');
+  });
+  await mockDb.schema.createTable('tutorial_wishlist', (table) => {
+    table.string('id').primary();
+    table.string('user_id');
+    table.string('tutorial_id');
+    table.unique(['user_id','tutorial_id']);
+    table.timestamp('created_at').defaultTo(mockDb.fn.now());
+  });
+});
+
+afterAll(async () => {
+  await mockDb.schema.dropTableIfExists('tutorial_wishlist');
+  await mockDb.schema.dropTableIfExists('tutorials');
+  await mockDb.destroy();
+});
+
+beforeEach(async () => {
+  await mockDb('tutorial_wishlist').del();
+  await mockDb('tutorials').del();
+});
+
+describe('tutorialWishlist.service add', () => {
+  test('throws error if tutorial does not exist', async () => {
+    await expect(service.add('u1','t1')).rejects.toBeInstanceOf(AppError);
+  });
+
+  test('throws error if tutorial is not approved or published', async () => {
+    await mockDb('tutorials').insert({ id: 't2', status: 'draft', moderation_status: 'Pending' });
+    await expect(service.add('u1','t2')).rejects.toBeInstanceOf(AppError);
+  });
+
+  test('adds item when tutorial is approved and published', async () => {
+    await mockDb('tutorials').insert({ id: 't3', status: 'published', moderation_status: 'Approved' });
+    const item = await service.add('u1','t3');
+    expect(item).toMatchObject({ user_id: 'u1', tutorial_id: 't3' });
+    const rows = await mockDb('tutorial_wishlist');
+    expect(rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- check tutorial existence, approval, and publication before adding to wishlist
- add unit tests covering valid and invalid wishlist additions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68989eebe4ac8328903ae630fdc6f59c