### PR TITLE
feat: add tutorial favorites

### DIFF
--- a/backend/src/migrations/20250725004600_create_tutorial_favorites_table.js
+++ b/backend/src/migrations/20250725004600_create_tutorial_favorites_table.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_favorites', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.unique(['user_id', 'tutorial_id']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_favorites');
+};

--- a/backend/src/modules/users/tutorials/favorites/tutorialFavorite.controller.js
+++ b/backend/src/modules/users/tutorials/favorites/tutorialFavorite.controller.js
@@ -1,0 +1,18 @@
+const catchAsync = require('../../../../utils/catchAsync');
+const { sendSuccess } = require('../../../../utils/response');
+const service = require('./tutorialFavorite.service');
+
+exports.add = catchAsync(async (req, res) => {
+  await service.add(req.user.id, req.params.tutorialId);
+  sendSuccess(res, null, 'Added to favorites');
+});
+
+exports.remove = catchAsync(async (req, res) => {
+  await service.remove(req.user.id, req.params.tutorialId);
+  sendSuccess(res, null, 'Removed from favorites');
+});
+
+exports.listMine = catchAsync(async (req, res) => {
+  const list = await service.listByUser(req.user.id);
+  sendSuccess(res, list);
+});

--- a/backend/src/modules/users/tutorials/favorites/tutorialFavorite.routes.js
+++ b/backend/src/modules/users/tutorials/favorites/tutorialFavorite.routes.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const ctrl = require('./tutorialFavorite.controller');
+const { verifyToken, isStudent } = require('../../../../middleware/auth/authMiddleware');
+
+router.get('/my', verifyToken, isStudent, ctrl.listMine);
+router.post('/:tutorialId', verifyToken, isStudent, ctrl.add);
+router.delete('/:tutorialId', verifyToken, isStudent, ctrl.remove);
+
+module.exports = router;

--- a/backend/src/modules/users/tutorials/favorites/tutorialFavorite.service.js
+++ b/backend/src/modules/users/tutorials/favorites/tutorialFavorite.service.js
@@ -1,0 +1,21 @@
+const db = require('../../../../config/database');
+const { v4: uuidv4 } = require('uuid');
+
+exports.add = async (userId, tutorialId) => {
+  const [item] = await db('tutorial_favorites')
+    .insert({ id: uuidv4(), user_id: userId, tutorial_id: tutorialId })
+    .onConflict(['user_id','tutorial_id']).ignore()
+    .returning('*');
+  return item;
+};
+
+exports.remove = async (userId, tutorialId) => {
+  return db('tutorial_favorites').where({ user_id: userId, tutorial_id: tutorialId }).del();
+};
+
+exports.listByUser = async (userId) => {
+  return db('tutorial_favorites as f')
+    .join('tutorials as t','f.tutorial_id','t.id')
+    .select('t.*','f.created_at')
+    .where('f.user_id', userId);
+};

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -77,6 +77,7 @@ router.post(
 
 router.use("/enroll", require("./enrollments/tutorialEnrollment.routes"));
 router.use("/wishlist", require("./wishlist/tutorialWishlist.routes"));
+router.use("/favorites", require("./favorites/tutorialFavorite.routes"));
 
 router.use("/certificate", require("./certificate/tutorialCertificate.routes"));
 

--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -7,6 +7,7 @@ import {
   FaStar,
   FaClock,
   FaBookmark,
+  FaHeart,
 } from "react-icons/fa";
 import { toast } from "react-toastify";
 import useCartStore from "@/store/cart/cartStore";
@@ -18,6 +19,9 @@ import {
   addTutorialToWishlist,
   removeTutorialFromWishlist,
   getMyTutorialWishlist,
+  addTutorialToFavorites,
+  removeTutorialFromFavorites,
+  getMyTutorialFavorites,
 } from "@/services/tutorialService";
 
 const PROGRESS_KEY = "skillbridge_tutorialProgress";
@@ -50,6 +54,7 @@ const LandingTutorialsSection = () => {
   const user = useAuthStore((state) => state.user);
   const isStudent = user?.role?.toLowerCase() === 'student';
   const [wishlistIds, setWishlistIds] = useState([]);
+  const [favoriteIds, setFavoriteIds] = useState([]);
 
   const [isMobile, setIsMobile] = useState(false);
 
@@ -110,15 +115,19 @@ const LandingTutorialsSection = () => {
 
   useEffect(() => {
     if (!user || !isStudent) return;
-    const loadWishlist = async () => {
+    const loadLists = async () => {
       try {
-        const w = await getMyTutorialWishlist();
+        const [w, f] = await Promise.all([
+          getMyTutorialWishlist(),
+          getMyTutorialFavorites(),
+        ]);
         setWishlistIds(w.map((t) => t.id));
+        setFavoriteIds(f.map((t) => t.id));
       } catch (err) {
-        console.error('Failed to load wishlist', err);
+        console.error('Failed to load user lists', err);
       }
     };
-    loadWishlist();
+    loadLists();
   }, [user, isStudent]);
 
   const filteredTutorials =
@@ -203,6 +212,33 @@ const LandingTutorialsSection = () => {
                   {tut.tags.includes("Top Rated") ? "🔥 Top Rated" : "🔥 Trending"}
                 </span>
               ) : null}
+              <button
+                onClick={async (e) => {
+                  e.stopPropagation();
+                  if (!user) return router.push('/auth/login');
+                  if (!isStudent) {
+                    toast.error('Only students can save tutorials.');
+                    return;
+                  }
+                  try {
+                    if (favoriteIds.includes(tut.id)) {
+                      await removeTutorialFromFavorites(tut.id);
+                      setFavoriteIds(favoriteIds.filter((i) => i !== tut.id));
+                    } else {
+                      await addTutorialToFavorites(tut.id);
+                      setFavoriteIds([...favoriteIds, tut.id]);
+                      toast.success('Added to favorites');
+                    }
+                  } catch (err) {
+                    toast.error('Failed to update favorites');
+                  }
+                }}
+                aria-label={favoriteIds.includes(tut.id) ? 'Remove from favorites' : 'Add to favorites'}
+                className="absolute top-2 right-10 bg-gray-700 rounded-full p-1 w-6 h-6 flex items-center justify-center hover:text-red-400"
+              >
+                <FaHeart className={favoriteIds.includes(tut.id) ? 'text-red-500' : 'text-white'} />
+              </button>
+
               <button
                 onClick={async (e) => {
                   e.stopPropagation();

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -62,6 +62,21 @@ export const getMyTutorialWishlist = async () => {
   return data?.data ?? [];
 };
 
+export const addTutorialToFavorites = async (id) => {
+  const { data } = await api.post(`/users/tutorials/favorites/${id}`);
+  return data;
+};
+
+export const removeTutorialFromFavorites = async (id) => {
+  const { data } = await api.delete(`/users/tutorials/favorites/${id}`);
+  return data;
+};
+
+export const getMyTutorialFavorites = async () => {
+  const { data } = await api.get('/users/tutorials/favorites/my');
+  return data?.data ?? [];
+};
+
 export const fetchTutorialReviews = async (tutorialId) => {
   const { data } = await api.get(`/users/tutorials/reviews/${tutorialId}`);
   return data?.data ?? [];


### PR DESCRIPTION
## Summary
- add `tutorial_favorites` table and backend CRUD routes
- expose favorites API in tutorialService
- allow toggling favorites separately from wishlist in tutorials section

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68989eeac7888328871c03561a3562e2