### PR TITLE
refactor: remove hook-based translations from notification store

### DIFF
--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { toast } from "react-toastify";
 import React from "react";
 import LinkText from "@/components/shared/LinkText";
-import { useTranslation } from "next-i18next";
+import i18next from "i18next";
 import {
   getNotifications,
   markNotificationAsRead,
@@ -17,7 +17,6 @@ const useNotificationStore = create((set, get) => ({
   poller: null,
 
   fetch: async (showAlert = false) => {
-    const { t } = useTranslation("common");
     set({ loading: true });
     try {
       const data = await getNotifications();
@@ -32,7 +31,7 @@ const useNotificationStore = create((set, get) => ({
           const note = filtered.find((n) => !n.read);
           toast.info(<LinkText text={note.message} />);
         } else {
-          toast.info(t("you_have_new_notifications", { count: diff }));
+          toast.info(i18next.t("you_have_new_notifications", { count: diff }));
         }
       }
       set({ items: filtered, loading: false });
@@ -42,7 +41,6 @@ const useNotificationStore = create((set, get) => ({
   },
 
   markRead: async (id) => {
-    const { t } = useTranslation("common");
     const idStr = String(id);
     const prevItems = get().items;
     const tempReadAt = new Date().toISOString();
@@ -81,7 +79,7 @@ const useNotificationStore = create((set, get) => ({
     } catch (err) {
       // Revert on failure
       set({ items: prevItems });
-      toast.error(t("failed_to_mark_notification_as_read"));
+      toast.error(i18next.t("failed_to_mark_notification_as_read"));
       return false;
     }
   },


### PR DESCRIPTION
## Summary
- replace `useTranslation` hook with `i18next` in notification store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68989ee81bc88328aba71dc877d96a3a