### PR TITLE
Handle notification errors after tutorial updates

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -164,24 +164,30 @@ function EditTutorialPage() {
               try {
                 await updateTutorial(id, formData);
                 toast.success(t('update_success'));
-                await createNotification({
-                  user_id: user.id,
-                  type: "tutorial_updated",
-                  message: `Tutorial "${tutorialData.title}" was updated.`,
-                });
-                if (tutorialData.instructorId) {
+
+                try {
                   await createNotification({
-                    user_id: tutorialData.instructorId,
+                    user_id: user.id,
                     type: "tutorial_updated",
-                    message: `Your tutorial "${tutorialData.title}" was updated by admin.`,
+                    message: `Tutorial "${tutorialData.title}" was updated.`,
                   });
-                  await sendChatMessage(tutorialData.instructorId, {
-                    text: `Your tutorial "${tutorialData.title}" was updated by admin.`,
+                  if (tutorialData.instructorId) {
+                    await createNotification({
+                      user_id: tutorialData.instructorId,
+                      type: "tutorial_updated",
+                      message: `Your tutorial "${tutorialData.title}" was updated by admin.`,
+                    });
+                    await sendChatMessage(tutorialData.instructorId, {
+                      text: `Your tutorial "${tutorialData.title}" was updated by admin.`,
+                    });
+                  }
+                  await sendChatMessage(user.id, {
+                    text: `Tutorial "${tutorialData.title}" was updated.`,
                   });
+                } catch (err) {
+                  console.error(err);
+                  toast.error('Failed to send notification or message');
                 }
-                await sendChatMessage(user.id, {
-                  text: `Tutorial "${tutorialData.title}" was updated.`,
-                });
                 refreshNotifications?.();
                 refreshMessages?.();
                 localStorage.removeItem(`editTutorialDraft-${id}`);

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -150,14 +150,21 @@ export default function EditTutorialPage() {
               try {
                 await updateTutorial(id, formData);
                 toast.success(t("dashboard:tutorialEditPage.update_success"));
-                await createNotification({
-                  user_id: user.id,
-                  type: "tutorial_updated",
-                  message: t("dashboard:tutorialEditPage.notification_updated", { title: tutorialData.title }),
-                });
-                await sendChatMessage(user.id, {
-                  text: t("dashboard:tutorialEditPage.notification_updated", { title: tutorialData.title }),
-                });
+
+                try {
+                  await createNotification({
+                    user_id: user.id,
+                    type: "tutorial_updated",
+                    message: t("dashboard:tutorialEditPage.notification_updated", { title: tutorialData.title }),
+                  });
+                  await sendChatMessage(user.id, {
+                    text: t("dashboard:tutorialEditPage.notification_updated", { title: tutorialData.title }),
+                  });
+                } catch (err) {
+                  console.error(err);
+                  toast.error('Failed to send notification or message');
+                }
+
                 refreshNotifications?.();
                 refreshMessages?.();
                 localStorage.removeItem(`editTutorialDraft-${id}`);


### PR DESCRIPTION
## Summary
- wrap createNotification and sendChatMessage calls in their own try/catch when updating a tutorial
- log and toast notification errors without interrupting success flow

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a2e945788328875347fd9c66dc0a