### PR TITLE
Handle empty tags and chapters on tutorial update

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -127,19 +127,18 @@ export default function EditTutorialPage() {
               if (!tutorialData.isFree) {
                 formData.append("price", tutorialData.price);
               }
-              if (tutorialData.tags.length) {
-                formData.append("tags", JSON.stringify(tutorialData.tags));
-              }
-              if (tutorialData.chapters.length) {
-                const chapters = tutorialData.chapters.map((ch, idx) => ({
-                  title: ch.title,
-                  duration: ch.duration,
-                  video_url: ch.videoUrl,
-                  order: idx + 1,
-                  is_preview: ch.preview,
-                }));
-                formData.append("chapters", JSON.stringify(chapters));
-              }
+              formData.append(
+                "tags",
+                JSON.stringify(tutorialData.tags || [])
+              );
+              const chapters = (tutorialData.chapters || []).map((ch, idx) => ({
+                title: ch.title,
+                duration: ch.duration,
+                video_url: ch.videoUrl,
+                order: idx + 1,
+                is_preview: ch.preview,
+              }));
+              formData.append("chapters", JSON.stringify(chapters));
               if (tutorialData.thumbnail instanceof File) {
                 formData.append("thumbnail", tutorialData.thumbnail);
               }


### PR DESCRIPTION
## Summary
- Always send `tags` and `chapters` arrays when saving an edited tutorial
- Backend parses these arrays, clearing tag mappings when empty and safely handling chapter data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a2e8937c8328afc069d9bd4f3860