### PR TITLE
Fetch categories when loading tutorial drafts

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -42,7 +42,19 @@ export default function EditTutorialPage() {
         ...parsed,
         lessonCount: parsed.lessonCount || parsed.chapters?.length || 1,
       });
-      setLoading(false);
+
+      const loadCats = async () => {
+        try {
+          const cats = await fetchAllCategories();
+          setCategories(cats?.data || cats || []);
+        } catch (err) {
+          console.error(err);
+          setError(t("tutorials:detail.load_error"));
+        } finally {
+          setLoading(false);
+        }
+      };
+      loadCats();
       return;
     }
 


### PR DESCRIPTION
## Summary
- Fetch categories when loading an instructor tutorial from a saved draft so category options are available
- Load categories for both draft and non-draft code paths

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a2e7052883288968f0f35cb22685