### PR TITLE
feat: internationalize tutorial creation

### DIFF
--- a/frontend/public/locales/ar/tutorials.json
+++ b/frontend/public/locales/ar/tutorials.json
@@ -40,6 +40,90 @@
     "pass_quiz_to_unlock_certificate": "اجتز الاختبار لفتح الشهادة",
     "certificate_locked": "الشهادة مقفلة",
     "free": "مجاني"
+  },
+  "create": {
+    "thumbnail_size_error": "❌ Please upload a JPG/PNG file less than 10MB.",
+    "basic": {
+      "title_label": "Tutorial Title *",
+      "title_placeholder": "Write tutorial title in any language...",
+      "short_desc_label": "Short Description *",
+      "short_desc_placeholder": "Briefly describe the tutorial content...",
+      "language_label": "Tutorial Language *",
+      "language_placeholder": "e.g., English, Arabic, French...",
+      "category_label": "Category *",
+      "select_category": "Select a Category",
+      "level_label": "Level *",
+      "select_level": "Select Level",
+      "level_beginner": "Beginner",
+      "level_intermediate": "Intermediate",
+      "level_advanced": "Advanced",
+      "lessons_label": "Number of Lessons *",
+      "lessons_placeholder": "e.g., 5",
+      "tags_label": "Tags",
+      "add_tags_placeholder": "Add tags...",
+      "add_tag": "Add",
+      "is_free": "Is it Free?",
+      "price_label": "Price (USD) *",
+      "price_placeholder": "Enter price, e.g., 19.99",
+      "next": "Next ➡️",
+      "validation": {
+        "title_required": "Title is required.",
+        "short_desc_required": "Short description is required.",
+        "category_required": "Category is required.",
+        "level_required": "Level is required.",
+        "language_required": "Tutorial language is required.",
+        "lessons_required": "Number of lessons is required.",
+        "price_required": "Valid price is required."
+      }
+    },
+    "curriculum": {
+      "heading": "📚 Curriculum",
+      "remove_chapter": "Remove Chapter",
+      "chapter_title": "Chapter Title",
+      "chapter_title_placeholder": "e.g. Introduction to React",
+      "duration_label": "Duration (e.g. 5 min)",
+      "duration_placeholder": "e.g. 10",
+      "upload_video": "Upload Chapter Video",
+      "allow_preview": "Allow Free Preview",
+      "add_chapter": "Add New Chapter",
+      "back": "⬅️ Back",
+      "next": "Next ➡️",
+      "video_upload_success": "🎬 Video uploaded successfully!",
+      "video_upload_error": "Failed to upload video"
+    },
+    "media": {
+      "upload_thumbnail": "📷 Upload Thumbnail",
+      "thumbnail_preview_alt": "Thumbnail Preview",
+      "remove_thumbnail": "Remove Thumbnail",
+      "select_image": "Select Image",
+      "upload_preview_video": "🎥 Upload Preview Video",
+      "remove_preview_video": "Remove Preview Video",
+      "select_video": "Select Video",
+      "preview_video_error": "❌ Please upload an MP4/WebM video less than 100MB.",
+      "back": "⬅️ Back",
+      "next": "➡️ Next Step"
+    },
+    "review": {
+      "heading": "✅ Review & Publish",
+      "back": "⬅️ Back",
+      "sections": {
+        "basic_info": "Basic Info",
+        "curriculum": "Curriculum",
+        "media": "Media",
+        "pricing": "Pricing"
+      },
+      "labels": {
+        "title": "Title:",
+        "short_description": "Short Description:",
+        "category": "Category:",
+        "level": "Level:",
+        "tags": "Tags:"
+      },
+      "no_chapters": "No chapters added yet.",
+      "free": "This tutorial will be FREE",
+      "price_label": "Price:",
+      "publish_tutorial": "Publish Tutorial"
+    }
   }
 }
 

--- a/frontend/public/locales/de/tutorials.json
+++ b/frontend/public/locales/de/tutorials.json
@@ -42,7 +42,88 @@
     "free": "Free"
   },
   "create": {
-    "thumbnail_size_error": "❌ Please upload a JPG/PNG file less than 10MB."
+    "thumbnail_size_error": "❌ Please upload a JPG/PNG file less than 10MB.",
+    "basic": {
+      "title_label": "Tutorial Title *",
+      "title_placeholder": "Write tutorial title in any language...",
+      "short_desc_label": "Short Description *",
+      "short_desc_placeholder": "Briefly describe the tutorial content...",
+      "language_label": "Tutorial Language *",
+      "language_placeholder": "e.g., English, Arabic, French...",
+      "category_label": "Category *",
+      "select_category": "Select a Category",
+      "level_label": "Level *",
+      "select_level": "Select Level",
+      "level_beginner": "Beginner",
+      "level_intermediate": "Intermediate",
+      "level_advanced": "Advanced",
+      "lessons_label": "Number of Lessons *",
+      "lessons_placeholder": "e.g., 5",
+      "tags_label": "Tags",
+      "add_tags_placeholder": "Add tags...",
+      "add_tag": "Add",
+      "is_free": "Is it Free?",
+      "price_label": "Price (USD) *",
+      "price_placeholder": "Enter price, e.g., 19.99",
+      "next": "Next ➡️",
+      "validation": {
+        "title_required": "Title is required.",
+        "short_desc_required": "Short description is required.",
+        "category_required": "Category is required.",
+        "level_required": "Level is required.",
+        "language_required": "Tutorial language is required.",
+        "lessons_required": "Number of lessons is required.",
+        "price_required": "Valid price is required."
+      }
+    },
+    "curriculum": {
+      "heading": "📚 Curriculum",
+      "remove_chapter": "Remove Chapter",
+      "chapter_title": "Chapter Title",
+      "chapter_title_placeholder": "e.g. Introduction to React",
+      "duration_label": "Duration (e.g. 5 min)",
+      "duration_placeholder": "e.g. 10",
+      "upload_video": "Upload Chapter Video",
+      "allow_preview": "Allow Free Preview",
+      "add_chapter": "Add New Chapter",
+      "back": "⬅️ Back",
+      "next": "Next ➡️",
+      "video_upload_success": "🎬 Video uploaded successfully!",
+      "video_upload_error": "Failed to upload video"
+    },
+    "media": {
+      "upload_thumbnail": "📷 Upload Thumbnail",
+      "thumbnail_preview_alt": "Thumbnail Preview",
+      "remove_thumbnail": "Remove Thumbnail",
+      "select_image": "Select Image",
+      "upload_preview_video": "🎥 Upload Preview Video",
+      "remove_preview_video": "Remove Preview Video",
+      "select_video": "Select Video",
+      "preview_video_error": "❌ Please upload an MP4/WebM video less than 100MB.",
+      "back": "⬅️ Back",
+      "next": "➡️ Next Step"
+    },
+    "review": {
+      "heading": "✅ Review & Publish",
+      "back": "⬅️ Back",
+      "sections": {
+        "basic_info": "Basic Info",
+        "curriculum": "Curriculum",
+        "media": "Media",
+        "pricing": "Pricing"
+      },
+      "labels": {
+        "title": "Title:",
+        "short_description": "Short Description:",
+        "category": "Category:",
+        "level": "Level:",
+        "tags": "Tags:"
+      },
+      "no_chapters": "No chapters added yet.",
+      "free": "This tutorial will be FREE",
+      "price_label": "Price:",
+      "publish_tutorial": "Publish Tutorial"
+    }
   }
 }
 

--- a/frontend/public/locales/en/tutorials.json
+++ b/frontend/public/locales/en/tutorials.json
@@ -42,7 +42,88 @@
     "free": "Free"
   },
   "create": {
-    "thumbnail_size_error": "❌ Please upload a JPG/PNG file less than 10MB."
+    "thumbnail_size_error": "❌ Please upload a JPG/PNG file less than 10MB.",
+    "basic": {
+      "title_label": "Tutorial Title *",
+      "title_placeholder": "Write tutorial title in any language...",
+      "short_desc_label": "Short Description *",
+      "short_desc_placeholder": "Briefly describe the tutorial content...",
+      "language_label": "Tutorial Language *",
+      "language_placeholder": "e.g., English, Arabic, French...",
+      "category_label": "Category *",
+      "select_category": "Select a Category",
+      "level_label": "Level *",
+      "select_level": "Select Level",
+      "level_beginner": "Beginner",
+      "level_intermediate": "Intermediate",
+      "level_advanced": "Advanced",
+      "lessons_label": "Number of Lessons *",
+      "lessons_placeholder": "e.g., 5",
+      "tags_label": "Tags",
+      "add_tags_placeholder": "Add tags...",
+      "add_tag": "Add",
+      "is_free": "Is it Free?",
+      "price_label": "Price (USD) *",
+      "price_placeholder": "Enter price, e.g., 19.99",
+      "next": "Next ➡️",
+      "validation": {
+        "title_required": "Title is required.",
+        "short_desc_required": "Short description is required.",
+        "category_required": "Category is required.",
+        "level_required": "Level is required.",
+        "language_required": "Tutorial language is required.",
+        "lessons_required": "Number of lessons is required.",
+        "price_required": "Valid price is required."
+      }
+    },
+    "curriculum": {
+      "heading": "📚 Curriculum",
+      "remove_chapter": "Remove Chapter",
+      "chapter_title": "Chapter Title",
+      "chapter_title_placeholder": "e.g. Introduction to React",
+      "duration_label": "Duration (e.g. 5 min)",
+      "duration_placeholder": "e.g. 10",
+      "upload_video": "Upload Chapter Video",
+      "allow_preview": "Allow Free Preview",
+      "add_chapter": "Add New Chapter",
+      "back": "⬅️ Back",
+      "next": "Next ➡️",
+      "video_upload_success": "🎬 Video uploaded successfully!",
+      "video_upload_error": "Failed to upload video"
+    },
+    "media": {
+      "upload_thumbnail": "📷 Upload Thumbnail",
+      "thumbnail_preview_alt": "Thumbnail Preview",
+      "remove_thumbnail": "Remove Thumbnail",
+      "select_image": "Select Image",
+      "upload_preview_video": "🎥 Upload Preview Video",
+      "remove_preview_video": "Remove Preview Video",
+      "select_video": "Select Video",
+      "preview_video_error": "❌ Please upload an MP4/WebM video less than 100MB.",
+      "back": "⬅️ Back",
+      "next": "➡️ Next Step"
+    },
+    "review": {
+      "heading": "✅ Review & Publish",
+      "back": "⬅️ Back",
+      "sections": {
+        "basic_info": "Basic Info",
+        "curriculum": "Curriculum",
+        "media": "Media",
+        "pricing": "Pricing"
+      },
+      "labels": {
+        "title": "Title:",
+        "short_description": "Short Description:",
+        "category": "Category:",
+        "level": "Level:",
+        "tags": "Tags:"
+      },
+      "no_chapters": "No chapters added yet.",
+      "free": "This tutorial will be FREE",
+      "price_label": "Price:",
+      "publish_tutorial": "Publish Tutorial"
+    }
   }
 }
 

--- a/frontend/public/locales/es/tutorials.json
+++ b/frontend/public/locales/es/tutorials.json
@@ -42,7 +42,88 @@
     "free": "Free"
   },
   "create": {
-    "thumbnail_size_error": "❌ Please upload a JPG/PNG file less than 10MB."
+    "thumbnail_size_error": "❌ Please upload a JPG/PNG file less than 10MB.",
+    "basic": {
+      "title_label": "Tutorial Title *",
+      "title_placeholder": "Write tutorial title in any language...",
+      "short_desc_label": "Short Description *",
+      "short_desc_placeholder": "Briefly describe the tutorial content...",
+      "language_label": "Tutorial Language *",
+      "language_placeholder": "e.g., English, Arabic, French...",
+      "category_label": "Category *",
+      "select_category": "Select a Category",
+      "level_label": "Level *",
+      "select_level": "Select Level",
+      "level_beginner": "Beginner",
+      "level_intermediate": "Intermediate",
+      "level_advanced": "Advanced",
+      "lessons_label": "Number of Lessons *",
+      "lessons_placeholder": "e.g., 5",
+      "tags_label": "Tags",
+      "add_tags_placeholder": "Add tags...",
+      "add_tag": "Add",
+      "is_free": "Is it Free?",
+      "price_label": "Price (USD) *",
+      "price_placeholder": "Enter price, e.g., 19.99",
+      "next": "Next ➡️",
+      "validation": {
+        "title_required": "Title is required.",
+        "short_desc_required": "Short description is required.",
+        "category_required": "Category is required.",
+        "level_required": "Level is required.",
+        "language_required": "Tutorial language is required.",
+        "lessons_required": "Number of lessons is required.",
+        "price_required": "Valid price is required."
+      }
+    },
+    "curriculum": {
+      "heading": "📚 Curriculum",
+      "remove_chapter": "Remove Chapter",
+      "chapter_title": "Chapter Title",
+      "chapter_title_placeholder": "e.g. Introduction to React",
+      "duration_label": "Duration (e.g. 5 min)",
+      "duration_placeholder": "e.g. 10",
+      "upload_video": "Upload Chapter Video",
+      "allow_preview": "Allow Free Preview",
+      "add_chapter": "Add New Chapter",
+      "back": "⬅️ Back",
+      "next": "Next ➡️",
+      "video_upload_success": "🎬 Video uploaded successfully!",
+      "video_upload_error": "Failed to upload video"
+    },
+    "media": {
+      "upload_thumbnail": "📷 Upload Thumbnail",
+      "thumbnail_preview_alt": "Thumbnail Preview",
+      "remove_thumbnail": "Remove Thumbnail",
+      "select_image": "Select Image",
+      "upload_preview_video": "🎥 Upload Preview Video",
+      "remove_preview_video": "Remove Preview Video",
+      "select_video": "Select Video",
+      "preview_video_error": "❌ Please upload an MP4/WebM video less than 100MB.",
+      "back": "⬅️ Back",
+      "next": "➡️ Next Step"
+    },
+    "review": {
+      "heading": "✅ Review & Publish",
+      "back": "⬅️ Back",
+      "sections": {
+        "basic_info": "Basic Info",
+        "curriculum": "Curriculum",
+        "media": "Media",
+        "pricing": "Pricing"
+      },
+      "labels": {
+        "title": "Title:",
+        "short_description": "Short Description:",
+        "category": "Category:",
+        "level": "Level:",
+        "tags": "Tags:"
+      },
+      "no_chapters": "No chapters added yet.",
+      "free": "This tutorial will be FREE",
+      "price_label": "Price:",
+      "publish_tutorial": "Publish Tutorial"
+    }
   }
 }
 

--- a/frontend/public/locales/fr/tutorials.json
+++ b/frontend/public/locales/fr/tutorials.json
@@ -40,6 +40,90 @@
     "pass_quiz_to_unlock_certificate": "Réussissez le quiz pour débloquer le certificat",
     "certificate_locked": "Certificat verrouillé",
     "free": "Gratuit"
+  },
+  "create": {
+    "thumbnail_size_error": "❌ Please upload a JPG/PNG file less than 10MB.",
+    "basic": {
+      "title_label": "Tutorial Title *",
+      "title_placeholder": "Write tutorial title in any language...",
+      "short_desc_label": "Short Description *",
+      "short_desc_placeholder": "Briefly describe the tutorial content...",
+      "language_label": "Tutorial Language *",
+      "language_placeholder": "e.g., English, Arabic, French...",
+      "category_label": "Category *",
+      "select_category": "Select a Category",
+      "level_label": "Level *",
+      "select_level": "Select Level",
+      "level_beginner": "Beginner",
+      "level_intermediate": "Intermediate",
+      "level_advanced": "Advanced",
+      "lessons_label": "Number of Lessons *",
+      "lessons_placeholder": "e.g., 5",
+      "tags_label": "Tags",
+      "add_tags_placeholder": "Add tags...",
+      "add_tag": "Add",
+      "is_free": "Is it Free?",
+      "price_label": "Price (USD) *",
+      "price_placeholder": "Enter price, e.g., 19.99",
+      "next": "Next ➡️",
+      "validation": {
+        "title_required": "Title is required.",
+        "short_desc_required": "Short description is required.",
+        "category_required": "Category is required.",
+        "level_required": "Level is required.",
+        "language_required": "Tutorial language is required.",
+        "lessons_required": "Number of lessons is required.",
+        "price_required": "Valid price is required."
+      }
+    },
+    "curriculum": {
+      "heading": "📚 Curriculum",
+      "remove_chapter": "Remove Chapter",
+      "chapter_title": "Chapter Title",
+      "chapter_title_placeholder": "e.g. Introduction to React",
+      "duration_label": "Duration (e.g. 5 min)",
+      "duration_placeholder": "e.g. 10",
+      "upload_video": "Upload Chapter Video",
+      "allow_preview": "Allow Free Preview",
+      "add_chapter": "Add New Chapter",
+      "back": "⬅️ Back",
+      "next": "Next ➡️",
+      "video_upload_success": "🎬 Video uploaded successfully!",
+      "video_upload_error": "Failed to upload video"
+    },
+    "media": {
+      "upload_thumbnail": "📷 Upload Thumbnail",
+      "thumbnail_preview_alt": "Thumbnail Preview",
+      "remove_thumbnail": "Remove Thumbnail",
+      "select_image": "Select Image",
+      "upload_preview_video": "🎥 Upload Preview Video",
+      "remove_preview_video": "Remove Preview Video",
+      "select_video": "Select Video",
+      "preview_video_error": "❌ Please upload an MP4/WebM video less than 100MB.",
+      "back": "⬅️ Back",
+      "next": "➡️ Next Step"
+    },
+    "review": {
+      "heading": "✅ Review & Publish",
+      "back": "⬅️ Back",
+      "sections": {
+        "basic_info": "Basic Info",
+        "curriculum": "Curriculum",
+        "media": "Media",
+        "pricing": "Pricing"
+      },
+      "labels": {
+        "title": "Title:",
+        "short_description": "Short Description:",
+        "category": "Category:",
+        "level": "Level:",
+        "tags": "Tags:"
+      },
+      "no_chapters": "No chapters added yet.",
+      "free": "This tutorial will be FREE",
+      "price_label": "Price:",
+      "publish_tutorial": "Publish Tutorial"
+    }
   }
 }
 

--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "next-i18next";
 import { fetchTutorialTags, createTutorialTag } from "@/services/instructor/tutorialTagService";
 
 export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, categories = [] }) {
+  const { t } = useTranslation("tutorials");
   const [errors, setErrors] = useState({});
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [tagInput, setTagInput] = useState("");
@@ -85,15 +87,32 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
   const validateAndContinue = () => {
     const newErrors = {};
 
-    if (!tutorialData.title) newErrors.title = "Title is required.";
-    if (!tutorialData.shortDescription) newErrors.shortDescription = "Short description is required.";
-    if (!tutorialData.category) newErrors.category = "Category is required.";
-    if (!tutorialData.level) newErrors.level = "Level is required.";
-    if (!tutorialData.language) newErrors.language = "Tutorial language is required.";
-    if (!tutorialData.lessonCount || isNaN(tutorialData.lessonCount) || tutorialData.lessonCount <= 0) {
-      newErrors.lessonCount = "Number of lessons is required.";
+    if (!tutorialData.title)
+      newErrors.title = t("create.basic.validation.title_required");
+    if (!tutorialData.shortDescription)
+      newErrors.shortDescription = t(
+        "create.basic.validation.short_desc_required"
+      );
+    if (!tutorialData.category)
+      newErrors.category = t("create.basic.validation.category_required");
+    if (!tutorialData.level)
+      newErrors.level = t("create.basic.validation.level_required");
+    if (!tutorialData.language)
+      newErrors.language = t("create.basic.validation.language_required");
+    if (
+      !tutorialData.lessonCount ||
+      isNaN(tutorialData.lessonCount) ||
+      tutorialData.lessonCount <= 0
+    ) {
+      newErrors.lessonCount = t(
+        "create.basic.validation.lessons_required"
+      );
     }
-    if (!tutorialData.isFree && (!tutorialData.price || isNaN(tutorialData.price))) newErrors.price = "Valid price is required.";
+    if (
+      !tutorialData.isFree &&
+      (!tutorialData.price || isNaN(tutorialData.price))
+    )
+      newErrors.price = t("create.basic.validation.price_required");
 
     setErrors(newErrors);
 
@@ -121,46 +140,60 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
     <div className="space-y-6">
       {/* Title */}
       <div>
-        <label className="font-semibold">Tutorial Title *</label>
+        <label className="font-semibold">
+          {t("create.basic.title_label")}
+        </label>
         <input
           type="text"
           className="w-full p-2 border rounded mt-1"
           value={tutorialData.title}
           onChange={(e) => handleChange("title", e.target.value)}
-          placeholder="Write tutorial title in any language..."
+          placeholder={t("create.basic.title_placeholder")}
         />
-        {errors.title && <p className="text-red-500 text-sm mt-1">{errors.title}</p>}
+        {errors.title && (
+          <p className="text-red-500 text-sm mt-1">{errors.title}</p>
+        )}
       </div>
 
       {/* Short Description */}
       <div>
-        <label className="font-semibold">Short Description *</label>
+        <label className="font-semibold">
+          {t("create.basic.short_desc_label")}
+        </label>
         <textarea
           rows={4}
           className="w-full p-2 border rounded mt-1"
           value={tutorialData.shortDescription}
           onChange={(e) => handleChange("shortDescription", e.target.value)}
-          placeholder="Briefly describe the tutorial content..."
+          placeholder={t("create.basic.short_desc_placeholder")}
         />
-        {errors.shortDescription && <p className="text-red-500 text-sm mt-1">{errors.shortDescription}</p>}
+        {errors.shortDescription && (
+          <p className="text-red-500 text-sm mt-1">{errors.shortDescription}</p>
+        )}
       </div>
 
       {/* Language */}
       <div>
-        <label className="font-semibold">Tutorial Language *</label>
+        <label className="font-semibold">
+          {t("create.basic.language_label")}
+        </label>
         <input
           type="text"
           className="w-full p-2 border rounded mt-1"
           value={tutorialData.language || ""}
           onChange={(e) => handleChange("language", e.target.value)}
-          placeholder="e.g., English, Arabic, French..."
+          placeholder={t("create.basic.language_placeholder")}
         />
-        {errors.language && <p className="text-red-500 text-sm mt-1">{errors.language}</p>}
+        {errors.language && (
+          <p className="text-red-500 text-sm mt-1">{errors.language}</p>
+        )}
       </div>
 
       {/* Category */}
       <div>
-        <label className="font-semibold">Category *</label>
+        <label className="font-semibold">
+          {t("create.basic.category_label")}
+        </label>
         <select
           className="w-full p-2 border rounded mt-1"
           value={tutorialData.category}
@@ -170,7 +203,9 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
             handleChange("categoryName", selected ? selected.name : "");
           }}
         >
-          <option value="">Select a Category</option>
+          <option value="">
+            {t("create.basic.select_category")}
+          </option>
           {categories.map((cat) => (
             <option key={cat.id} value={cat.id}>
               {cat.name}
@@ -184,29 +219,37 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
 
       {/* Level */}
       <div>
-        <label className="font-semibold">Level *</label>
+        <label className="font-semibold">
+          {t("create.basic.level_label")}
+        </label>
         <select
           className="w-full p-2 border rounded mt-1"
           value={tutorialData.level}
           onChange={(e) => handleChange("level", e.target.value)}
         >
-          <option value="">Select Level</option>
-          <option value="Beginner">Beginner</option>
-          <option value="Intermediate">Intermediate</option>
-          <option value="Advanced">Advanced</option>
+          <option value="">{t("create.basic.select_level")}</option>
+          <option value="Beginner">{t("create.basic.level_beginner")}</option>
+          <option value="Intermediate">
+            {t("create.basic.level_intermediate")}
+          </option>
+          <option value="Advanced">{t("create.basic.level_advanced")}</option>
         </select>
-        {errors.level && <p className="text-red-500 text-sm mt-1">{errors.level}</p>}
+        {errors.level && (
+          <p className="text-red-500 text-sm mt-1">{errors.level}</p>
+        )}
       </div>
 
       {/* Number of Lessons */}
       <div>
-        <label className="font-semibold">Number of Lessons *</label>
+        <label className="font-semibold">
+          {t("create.basic.lessons_label")}
+        </label>
         <input
           type="number"
           className="w-full p-2 border rounded mt-1"
           value={tutorialData.lessonCount || ""}
           onChange={(e) => handleChange("lessonCount", e.target.value)}
-          placeholder="e.g., 5"
+          placeholder={t("create.basic.lessons_placeholder")}
         />
         {errors.lessonCount && (
           <p className="text-red-500 text-sm mt-1">{errors.lessonCount}</p>
@@ -215,7 +258,7 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
 
       {/* Tags */}
       <div>
-        <label className="font-semibold">Tags</label>
+        <label className="font-semibold">{t("create.basic.tags_label")}</label>
         <div className="relative">
           <div className="flex flex-wrap gap-2 mb-2">
             {tutorialData.tags.map((tag) => (
@@ -240,12 +283,12 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
               value={tagInput}
               onChange={(e) => setTagInput(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter') {
+                if (e.key === "Enter") {
                   e.preventDefault();
                   addTag(tagInput);
                 }
               }}
-              placeholder="Add tags..."
+              placeholder={t("create.basic.add_tags_placeholder")}
               className="flex-1 p-2 border rounded"
             />
             <button
@@ -253,7 +296,7 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
               onClick={() => addTag(tagInput)}
               className="px-3 py-2 bg-yellow-500 text-white rounded"
             >
-              Add
+              {t("create.basic.add_tag")}
             </button>
           </div>
           {tagSuggestions.length > 0 && tagInput && (
@@ -274,7 +317,7 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
 
       {/* Is Free + Price */}
       <div className="flex items-center gap-4">
-        <label className="font-semibold">Is it Free?</label>
+        <label className="font-semibold">{t("create.basic.is_free")}</label>
         <input
           type="checkbox"
           checked={tutorialData.isFree}
@@ -285,15 +328,17 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
 
       {!tutorialData.isFree && (
         <div>
-          <label className="font-semibold">Price (USD) *</label>
+          <label className="font-semibold">{t("create.basic.price_label")}</label>
           <input
             type="number"
             className="w-full p-2 border rounded mt-1"
             value={tutorialData.price}
             onChange={(e) => handleChange("price", e.target.value)}
-            placeholder="Enter price, e.g., 19.99"
+            placeholder={t("create.basic.price_placeholder")}
           />
-          {errors.price && <p className="text-red-500 text-sm mt-1">{errors.price}</p>}
+          {errors.price && (
+            <p className="text-red-500 text-sm mt-1">{errors.price}</p>
+          )}
         </div>
       )}
 
@@ -303,7 +348,7 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
           onClick={validateAndContinue}
           className="bg-yellow-500 hover:bg-yellow-600 text-white px-8 py-3 rounded-full font-bold"
         >
-          Next ➡️
+          {t("create.basic.next")}
         </button>
       </div>
     </div>

--- a/frontend/src/components/tutorials/create/CurriculumStep.js
+++ b/frontend/src/components/tutorials/create/CurriculumStep.js
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { useTranslation } from "next-i18next";
 import { toast } from "react-hot-toast";
 import { FaPlus, FaTrash, FaPlay } from "react-icons/fa";
 import { uploadChapterVideo } from "@/services/admin/tutorialChapterService";
 
 export default function CurriculumStep({ tutorialData, setTutorialData, onNext, onBack }) {
+  const { t } = useTranslation("tutorials");
   const [uploadingIndex, setUploadingIndex] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(0);
 
@@ -53,9 +55,9 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
       const previewUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL}${serverPath}`;
       handleChange(index, "video", previewUrl);
       handleChange(index, "videoUrl", serverPath);
-      toast.success("🎬 Video uploaded successfully!");
+      toast.success(t("create.curriculum.video_upload_success"));
     } catch (err) {
-      toast.error("Failed to upload video");
+      toast.error(t("create.curriculum.video_upload_error"));
     } finally {
       setUploadingIndex(null);
       setUploadProgress(0);
@@ -65,7 +67,9 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
   return (
     <div className="space-y-8">
       {/* Heading */}
-      <h2 className="text-2xl font-bold text-gray-800">📚 Curriculum</h2>
+      <h2 className="text-2xl font-bold text-gray-800">
+        {t("create.curriculum.heading")}
+      </h2>
 
       {/* List of Chapters */}
       {tutorialData.chapters.map((chapter, index) => (
@@ -74,38 +78,46 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
           <button
             onClick={() => handleRemoveChapter(index)}
             className="absolute top-3 right-3 text-red-500 hover:text-red-700"
-            title="Remove Chapter"
+            title={t("create.curriculum.remove_chapter")}
           >
             <FaTrash />
           </button>
 
           {/* Chapter Title */}
           <div>
-            <label className="block mb-1 font-semibold text-gray-700">Chapter Title</label>
+            <label className="block mb-1 font-semibold text-gray-700">
+              {t("create.curriculum.chapter_title")}
+            </label>
             <input
               type="text"
               value={chapter.title}
               onChange={(e) => handleChange(index, "title", e.target.value)}
               className="p-2 border rounded w-full"
-              placeholder="e.g. Introduction to React"
+              placeholder={t(
+                "create.curriculum.chapter_title_placeholder"
+              )}
             />
           </div>
 
           {/* Chapter Duration */}
           <div>
-            <label className="block mb-1 font-semibold text-gray-700">Duration (e.g. 5 min)</label>
+            <label className="block mb-1 font-semibold text-gray-700">
+              {t("create.curriculum.duration_label")}
+            </label>
             <input
               type="number"
               value={chapter.duration}
               onChange={(e) => handleChange(index, "duration", e.target.value)}
               className="p-2 border rounded w-full"
-              placeholder="e.g. 10"
+              placeholder={t("create.curriculum.duration_placeholder")}
             />
           </div>
 
           {/* Chapter Video Upload */}
           <div>
-            <label className="block mb-1 font-semibold text-gray-700">Upload Chapter Video</label>
+            <label className="block mb-1 font-semibold text-gray-700">
+              {t("create.curriculum.upload_video")}
+            </label>
             {uploadingIndex === index ? (
               <div className="w-full bg-gray-300 rounded-full h-4">
                 <div
@@ -137,7 +149,9 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
               onChange={(e) => handleChange(index, "preview", e.target.checked)}
               className="form-checkbox text-yellow-500"
             />
-            <label className="text-gray-700">Allow Free Preview</label>
+            <label className="text-gray-700">
+              {t("create.curriculum.allow_preview")}
+            </label>
           </div>
         </div>
       ))}
@@ -147,7 +161,7 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
         onClick={handleAddChapter}
         className="flex items-center gap-2 px-6 py-3 bg-yellow-500 hover:bg-yellow-600 text-black font-bold rounded-full transition"
       >
-        <FaPlus /> Add New Chapter
+        <FaPlus /> {t("create.curriculum.add_chapter")}
       </button>
 
       {/* Navigation Buttons */}
@@ -156,13 +170,13 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
           onClick={onBack}
           className="px-6 py-2 bg-gray-400 hover:bg-gray-500 text-white rounded-full font-bold"
         >
-          ⬅️ Back
+          {t("create.curriculum.back")}
         </button>
         <button
           onClick={onNext}
           className="px-6 py-2 bg-green-500 hover:bg-green-600 text-white rounded-full font-bold"
         >
-          Next ➡️
+          {t("create.curriculum.next")}
         </button>
       </div>
     </div>

--- a/frontend/src/components/tutorials/create/MediaStep.js
+++ b/frontend/src/components/tutorials/create/MediaStep.js
@@ -59,7 +59,7 @@ export default function MediaStep({ tutorialData, setTutorialData, onNext, onBac
         });
       }, 100);
     } else {
-      alert("❌ Please upload an MP4/WebM video less than 100MB.");
+      alert(t("create.media.preview_video_error"));
     }
   };
 
@@ -67,10 +67,16 @@ export default function MediaStep({ tutorialData, setTutorialData, onNext, onBac
     <div className="space-y-8">
       {/* Thumbnail Upload */}
       <div className="border-2 border-dashed border-gray-300 p-6 rounded-lg text-center">
-        <h3 className="font-bold text-gray-700 mb-4">📷 Upload Thumbnail</h3>
+        <h3 className="font-bold text-gray-700 mb-4">
+          {t("create.media.upload_thumbnail")}
+        </h3>
         {thumbnailPreview ? (
           <div className="flex flex-col items-center space-y-3">
-            <img src={thumbnailPreview} alt="Thumbnail Preview" className="h-48 rounded shadow" />
+            <img
+              src={thumbnailPreview}
+              alt={t("create.media.thumbnail_preview_alt")}
+              className="h-48 rounded shadow"
+            />
             <Button
               onClick={() => {
                 setThumbnailPreview(null);
@@ -78,14 +84,17 @@ export default function MediaStep({ tutorialData, setTutorialData, onNext, onBac
               }}
               className="bg-red-500 hover:bg-red-600 text-white"
             >
-              Remove Thumbnail
+              {t("create.media.remove_thumbnail")}
             </Button>
           </div>
         ) : (
           <>
             <input type="file" accept="image/*" onChange={handleThumbnailUpload} className="hidden" id="thumbnail-upload" />
-            <label htmlFor="thumbnail-upload" className="cursor-pointer bg-yellow-400 hover:bg-yellow-500 text-black font-bold py-2 px-6 rounded">
-              Select Image
+            <label
+              htmlFor="thumbnail-upload"
+              className="cursor-pointer bg-yellow-400 hover:bg-yellow-500 text-black font-bold py-2 px-6 rounded"
+            >
+              {t("create.media.select_image")}
             </label>
           </>
         )}
@@ -93,7 +102,9 @@ export default function MediaStep({ tutorialData, setTutorialData, onNext, onBac
 
       {/* Preview Video Upload */}
       <div className="border-2 border-dashed border-gray-300 p-6 rounded-lg text-center">
-        <h3 className="font-bold text-gray-700 mb-4">🎥 Upload Preview Video</h3>
+        <h3 className="font-bold text-gray-700 mb-4">
+          {t("create.media.upload_preview_video")}
+        </h3>
         {previewVideo ? (
           <div className="flex flex-col items-center space-y-3">
             <video controls src={previewVideo} className="h-48 rounded shadow" />
@@ -110,14 +121,23 @@ export default function MediaStep({ tutorialData, setTutorialData, onNext, onBac
               }}
               className="bg-red-500 hover:bg-red-600 text-white"
             >
-              Remove Preview Video
+              {t("create.media.remove_preview_video")}
             </Button>
           </div>
         ) : (
           <>
-            <input type="file" accept="video/mp4,video/webm" onChange={handlePreviewUpload} className="hidden" id="preview-upload" />
-            <label htmlFor="preview-upload" className="cursor-pointer bg-yellow-400 hover:bg-yellow-500 text-black font-bold py-2 px-6 rounded">
-              Select Video
+            <input
+              type="file"
+              accept="video/mp4,video/webm"
+              onChange={handlePreviewUpload}
+              className="hidden"
+              id="preview-upload"
+            />
+            <label
+              htmlFor="preview-upload"
+              className="cursor-pointer bg-yellow-400 hover:bg-yellow-500 text-black font-bold py-2 px-6 rounded"
+            >
+              {t("create.media.select_video")}
             </label>
           </>
         )}
@@ -126,14 +146,14 @@ export default function MediaStep({ tutorialData, setTutorialData, onNext, onBac
       {/* Navigation Buttons */}
       <div className="flex justify-between pt-8">
         <Button onClick={onBack} className="bg-gray-400 hover:bg-gray-500 text-white">
-          ⬅️ Back
+          {t("create.media.back")}
         </Button>
         <Button
           onClick={onNext}
           disabled={!thumbnailPreview || !previewVideo}
           className="bg-green-500 hover:bg-green-600 text-white"
         >
-          ➡️ Next Step
+          {t("create.media.next")}
         </Button>
       </div>
     </div>

--- a/frontend/src/components/tutorials/create/ReviewStep.js
+++ b/frontend/src/components/tutorials/create/ReviewStep.js
@@ -1,22 +1,27 @@
-import { FaCheckCircle, FaEdit } from "react-icons/fa";
+import { FaCheckCircle } from "react-icons/fa";
+import { useTranslation } from "next-i18next";
 
 export default function ReviewStep({
   tutorialData,
   onBack,
   onPublish,
-  actionLabel = "Publish Tutorial",
+  actionLabel,
 }) {
+  const { t } = useTranslation("tutorials");
+  const publishText = actionLabel || t("create.review.publish_tutorial");
   return (
     <div className="space-y-8">
 
       {/* Review Header */}
       <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold text-gray-800">✅ Review & Publish</h2>
+        <h2 className="text-2xl font-bold text-gray-800">
+          {t("create.review.heading")}
+        </h2>
         <button
           onClick={onBack}
           className="bg-gray-300 hover:bg-gray-400 text-black px-4 py-2 rounded-full font-bold"
         >
-          ⬅️ Back
+          {t("create.review.back")}
         </button>
       </div>
 
@@ -26,24 +31,35 @@ export default function ReviewStep({
         {/* Basic Info */}
         <div className="space-y-2">
           <h3 className="text-xl font-bold text-yellow-600 flex items-center gap-2">
-            <FaCheckCircle /> Basic Info
+            <FaCheckCircle /> {t("create.review.sections.basic_info")}
           </h3>
-          <p><strong>Title:</strong> {tutorialData.title}</p>
-          <p><strong>Short Description:</strong> {tutorialData.shortDescription}</p>
           <p>
-            <strong>Category:</strong>{" "}
+            <strong>{t("create.review.labels.title")}</strong> {tutorialData.title}
+          </p>
+          <p>
+            <strong>{t("create.review.labels.short_description")}</strong>
+            {" "}
+            {tutorialData.shortDescription}
+          </p>
+          <p>
+            <strong>{t("create.review.labels.category")}</strong>{" "}
             {tutorialData.categoryName || tutorialData.category}
           </p>
-          <p><strong>Level:</strong> {tutorialData.level}</p>
+          <p>
+            <strong>{t("create.review.labels.level")}</strong> {tutorialData.level}
+          </p>
           {tutorialData.tags.length > 0 && (
-            <p><strong>Tags:</strong> {tutorialData.tags.join(", ")}</p>
+            <p>
+              <strong>{t("create.review.labels.tags")}</strong>{" "}
+              {tutorialData.tags.join(", ")}
+            </p>
           )}
         </div>
 
         {/* Curriculum */}
         <div className="space-y-2">
           <h3 className="text-xl font-bold text-yellow-600 flex items-center gap-2">
-            <FaCheckCircle /> Curriculum
+            <FaCheckCircle /> {t("create.review.sections.curriculum")}
           </h3>
           {tutorialData.chapters.length > 0 ? (
             <ul className="list-disc pl-5">
@@ -54,14 +70,14 @@ export default function ReviewStep({
               ))}
             </ul>
           ) : (
-            <p className="text-gray-500">No chapters added yet.</p>
+            <p className="text-gray-500">{t("create.review.no_chapters")}</p>
           )}
         </div>
 
         {/* Media */}
         <div className="space-y-2">
           <h3 className="text-xl font-bold text-yellow-600 flex items-center gap-2">
-            <FaCheckCircle /> Media
+            <FaCheckCircle /> {t("create.review.sections.media")}
           </h3>
           <div className="flex gap-6 items-center">
             {tutorialData.thumbnail && (
@@ -71,7 +87,7 @@ export default function ReviewStep({
                     ? URL.createObjectURL(tutorialData.thumbnail)
                     : tutorialData.thumbnail
                 }
-                alt="Thumbnail Preview"
+                alt={t("create.media.thumbnail_preview_alt")}
                 className="w-32 h-20 object-cover rounded shadow"
               />
             )}
@@ -92,13 +108,13 @@ export default function ReviewStep({
         {/* Pricing */}
         <div className="space-y-2">
           <h3 className="text-xl font-bold text-yellow-600 flex items-center gap-2">
-            <FaCheckCircle /> Pricing
+            <FaCheckCircle /> {t("create.review.sections.pricing")}
           </h3>
           {tutorialData.isFree ? (
-            <p className="text-green-600 font-semibold">This tutorial will be FREE</p>
+            <p className="text-green-600 font-semibold">{t("create.review.free")}</p>
           ) : (
             <p className="text-gray-800">
-              <strong>Price:</strong> ${tutorialData.price}
+              <strong>{t("create.review.price_label")}</strong> ${tutorialData.price}
             </p>
           )}
         </div>
@@ -111,7 +127,7 @@ export default function ReviewStep({
           onClick={onPublish}
           className="bg-yellow-500 hover:bg-yellow-600 text-black px-8 py-4 rounded-full font-bold text-xl transition-all shadow-lg"
         >
-          🚀 {actionLabel}
+          🚀 {publishText}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- wrap tutorial creation components with next-i18next translations
- add locale entries for new tutorial creation strings
- translate BasicInfoStep validation messages

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6898a2e5a970832891be289ff77a5d6d