### PR TITLE
Add dashboard tutorial edit page translations

### DIFF
--- a/frontend/src/locales/ar.json
+++ b/frontend/src/locales/ar.json
@@ -142,5 +142,15 @@
       "certificate_locked": "الشهادة مقفلة",
       "free": "مجاني"
     }
+  },
+  "dashboard": {
+    "tutorialEditPage": {
+      "loading": "جارٍ تحميل الدرس...",
+      "not_found": "الدرس غير موجود",
+      "save_changes": "حفظ التغييرات",
+      "update_success": "تم تحديث الدرس بنجاح",
+      "notification_updated": "تم تحديث الإشعار",
+      "update_failed": "فشل تحديث الدرس"
+    }
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -65,5 +65,15 @@
       "certificate_locked": "Certificate locked",
       "free": "Free"
     }
+  },
+  "dashboard": {
+    "tutorialEditPage": {
+      "loading": "Loading tutorial...",
+      "not_found": "Tutorial not found",
+      "save_changes": "Save Changes",
+      "update_success": "Tutorial updated successfully",
+      "notification_updated": "Notification updated",
+      "update_failed": "Failed to update tutorial"
+    }
   }
 }

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -65,5 +65,15 @@
       "certificate_locked": "Certificat verrouillé",
       "free": "Gratuit"
     }
+  },
+  "dashboard": {
+    "tutorialEditPage": {
+      "loading": "Chargement du tutoriel...",
+      "not_found": "Tutoriel introuvable",
+      "save_changes": "Enregistrer les modifications",
+      "update_success": "Tutoriel mis à jour avec succès",
+      "notification_updated": "Notification mise à jour",
+      "update_failed": "Échec de la mise à jour du tutoriel"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add English translations for dashboard tutorial edit page
- provide matching Arabic and French translations

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6898a2e4c3588328a3eb9a2997b6bdb6