### PR TITLE
Add PayPal integration with server-side verification

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@paypal/checkout-server-sdk": "^1.0.3",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -1486,6 +1487,28 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@paypal/checkout-server-sdk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@paypal/checkout-server-sdk/-/checkout-server-sdk-1.0.3.tgz",
+      "integrity": "sha512-UEdq8akEdMz0Vs4qoQFU2gMp8PpyE/HKyMwiZuK4vIWUKl8jfd1fWKjQN5cDFm9NkFUIp5U7h++rdMOVj9WMNA==",
+      "deprecated": "Package no longer supported. The author suggests using the @paypal/paypal-server-sdk package instead: https://www.npmjs.com/package/@paypal/paypal-server-sdk. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "SEE LICENSE IN https://github.com/paypal/Checkout-NodeJS-SDK/blob/master/LICENSE",
+      "dependencies": {
+        "@paypal/paypalhttp": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@paypal/paypalhttp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@paypal/paypalhttp/-/paypalhttp-1.0.1.tgz",
+      "integrity": "sha512-DC7AHxTT7drF6dUi3YaFdPVuT15sIkpD5H2eHmdtFgxM4UanS1o1ZDfMhR9mpxd8o+X6pz2r+EZVRRq+n1cssQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@scarf/scarf": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,7 +40,8 @@
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
     "yamljs": "^0.3.0",
-    "zod": "^3.25.20"
+    "zod": "^3.25.20",
+    "@paypal/checkout-server-sdk": "^1.0.3"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/backend/src/modules/paymentMethods/paymentMethods.controller.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.controller.js
@@ -16,6 +16,7 @@ exports.createMethod = catchAsync(async (req, res) => {
     data.icon = `/uploads/payment-methods/${req.file.filename}`;
   }
   const method = await service.create(data);
+  if (method.settings) delete method.settings.client_secret;
   sendSuccess(res, method, "Method created");
 
   const admins = await userModel.findAdmins();
@@ -41,17 +42,26 @@ exports.createMethod = catchAsync(async (req, res) => {
 
 exports.getMethods = catchAsync(async (_req, res) => {
   const data = await service.getAll();
-  sendSuccess(res, data);
+  const sanitized = data.map((m) => {
+    if (m.settings) delete m.settings.client_secret;
+    return m;
+  });
+  sendSuccess(res, sanitized);
 });
 
 exports.getActiveMethods = catchAsync(async (_req, res) => {
   const data = await service.getActive();
-  sendSuccess(res, data);
+  const sanitized = data.map((m) => {
+    if (m.settings) delete m.settings.client_secret;
+    return m;
+  });
+  sendSuccess(res, sanitized);
 });
 
 exports.getMethod = catchAsync(async (req, res) => {
   const method = await service.getById(req.params.id);
   if (!method) throw new AppError("Payment method not found", 404);
+  if (method.settings) delete method.settings.client_secret;
   sendSuccess(res, method);
 });
 
@@ -69,6 +79,7 @@ exports.updateMethod = catchAsync(async (req, res) => {
   }
 
   const method = await service.update(req.params.id, data);
+  if (method.settings) delete method.settings.client_secret;
   sendSuccess(res, method, "Method updated");
 
   const admins = await userModel.findAdmins();
@@ -116,4 +127,23 @@ exports.deleteMethod = catchAsync(async (req, res) => {
       ])
     )
   );
+});
+
+exports.getPayPalClientId = catchAsync(async (_req, res) => {
+  const clientId = await service.getPayPalClientId();
+  sendSuccess(res, { clientId });
+});
+
+exports.getPayPalCredentials = catchAsync(async (_req, res) => {
+  const settings = await service.getPayPalSettings();
+  sendSuccess(res, { client_id: settings.client_id || null });
+});
+
+exports.updatePayPalCredentials = catchAsync(async (req, res) => {
+  const { client_id, client_secret } = req.body;
+  if (!client_id || !client_secret) {
+    throw new AppError("Client ID and secret are required", 400);
+  }
+  await service.updatePayPalSettings({ client_id, client_secret });
+  sendSuccess(res, { client_id }, "PayPal credentials updated");
 });

--- a/backend/src/modules/paymentMethods/paymentMethods.public.routes.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.public.routes.js
@@ -3,5 +3,6 @@ const router = express.Router();
 const controller = require("./paymentMethods.controller");
 
 router.get("/", controller.getActiveMethods);
+router.get("/paypal/client-id", controller.getPayPalClientId);
 
 module.exports = router;

--- a/backend/src/modules/paymentMethods/paymentMethods.routes.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.routes.js
@@ -8,6 +8,8 @@ router.use(verifyToken, isAdmin);
 
 router.post("/", upload.single("icon"), controller.createMethod);
 router.get("/", controller.getMethods);
+router.get("/paypal/credentials", controller.getPayPalCredentials);
+router.put("/paypal/credentials", controller.updatePayPalCredentials);
 router.get("/:id", controller.getMethod);
 router.patch("/:id", upload.single("icon"), controller.updateMethod);
 router.delete("/:id", controller.deleteMethod);

--- a/backend/src/modules/paymentMethods/paymentMethods.service.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.service.js
@@ -25,6 +25,10 @@ exports.getById = (id) => {
   return db("payment_methods_config").where({ id }).first();
 };
 
+exports.getByType = (type) => {
+  return db("payment_methods_config").where({ type }).first();
+};
+
 exports.update = async (id, data) => {
   return db.transaction(async (trx) => {
     if (data.is_default) {
@@ -42,4 +46,25 @@ exports.update = async (id, data) => {
 
 exports.delete = (id) => {
   return db("payment_methods_config").where({ id }).del();
+};
+
+exports.getPayPalSettings = async () => {
+  const row = await exports.getByType("paypal");
+  return row?.settings || {};
+};
+
+exports.updatePayPalSettings = async (settings) => {
+  const row = await exports.getByType("paypal");
+  if (!row) throw new Error("PayPal method not found");
+  const newSettings = { ...(row.settings || {}), ...settings };
+  const [updated] = await db("payment_methods_config")
+    .where({ id: row.id })
+    .update({ settings: newSettings })
+    .returning("settings");
+  return updated;
+};
+
+exports.getPayPalClientId = async () => {
+  const settings = await exports.getPayPalSettings();
+  return settings.client_id || null;
 };

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -8,6 +8,8 @@ const userModel = require("../users/user.model");
 const libraryService = require("../library/library.service");
 const enrollmentService = require("../classes/enrollments/classEnrollment.service");
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
+const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
+const paypalService = require("../../services/paypalService");
 
 exports.createPayment = catchAsync(async (req, res) => {
   const {
@@ -43,13 +45,35 @@ exports.createPayment = catchAsync(async (req, res) => {
     next_due_date = schedules[0]?.due_date || null;
   }
 
+  const method = await paymentMethodsService.getById(method_id);
+  if (!method) throw new AppError("Invalid payment method", 400);
+
+  let verifiedAmount = amount;
+  let verifiedCurrency = currency || "USD";
+  let finalStatus = status || "pending";
+  let verifiedReference = reference_id;
+
+  if (method.type === "paypal") {
+    if (!reference_id) throw new AppError("Missing PayPal order ID", 400);
+    const capture = await paypalService.captureOrder(reference_id);
+    if (capture.status !== "COMPLETED") {
+      throw new AppError("PayPal transaction not completed", 400);
+    }
+    const info =
+      capture.purchase_units?.[0]?.payments?.captures?.[0] || {};
+    verifiedAmount = parseFloat(info.amount?.value || amount);
+    verifiedCurrency = info.amount?.currency_code || verifiedCurrency;
+    verifiedReference = info.id || reference_id;
+    finalStatus = "paid";
+  }
+
   let platform_fee = 0;
-  let instructor_amount = amount;
+  let instructor_amount = verifiedAmount;
   try {
     const settings = await paymentConfigService.getSettings();
     const cut = settings?.platformCut?.[item_type] || 0;
-    platform_fee = (amount * cut) / 100;
-    instructor_amount = amount - platform_fee;
+    platform_fee = (verifiedAmount * cut) / 100;
+    instructor_amount = verifiedAmount - platform_fee;
   } catch (err) {
     console.error("Failed to load payment settings:", err);
   }
@@ -60,14 +84,14 @@ exports.createPayment = catchAsync(async (req, res) => {
     method_id,
     item_type,
     item_id,
-    amount,
-    currency: currency || "USD",
-    status: status || "pending",
-    reference_id,
+    amount: verifiedAmount,
+    currency: verifiedCurrency,
+    status: finalStatus,
+    reference_id: verifiedReference,
     receipt_url,
     platform_fee,
     instructor_amount,
-    paid_at: status === "paid" ? new Date() : null,
+    paid_at: finalStatus === "paid" ? new Date() : null,
     installments: totalInstallments,
     installment_number: 1,
     next_due_date,
@@ -79,7 +103,7 @@ exports.createPayment = catchAsync(async (req, res) => {
   try {
     const user = await userModel.findById(user_id);
     if (user?.phone) {
-      const text = `Payment of ${amount} received. Ref: ${payment.reference_id}`;
+      const text = `Payment of ${verifiedAmount} received. Ref: ${payment.reference_id}`;
       await smsService.sendSMS({ to: user.phone, text });
     }
   } catch (err) {
@@ -88,7 +112,7 @@ exports.createPayment = catchAsync(async (req, res) => {
 
   if (item_type === "book" && payment.status === "paid") {
     try {
-      await libraryService.recordPurchase(user_id, item_id, amount);
+      await libraryService.recordPurchase(user_id, item_id, verifiedAmount);
     } catch (err) {
       console.error("Failed to record book purchase:", err);
     }
@@ -96,12 +120,12 @@ exports.createPayment = catchAsync(async (req, res) => {
 
   if (item_type === "class" && payment.status === "paid") {
     try {
-      await enrollmentService.createEnrollment({
-        id: uuidv4(),
-        user_id,
-        class_id: item_id,
-        status: "enrolled",
-      });
+        await enrollmentService.createEnrollment({
+          id: uuidv4(),
+          user_id,
+          class_id: item_id,
+          status: "enrolled",
+        });
     } catch (err) {
       console.error("Failed to enroll after payment:", err);
     }

--- a/backend/src/seeds/08_payment_methods_seed.js
+++ b/backend/src/seeds/08_payment_methods_seed.js
@@ -17,6 +17,20 @@ exports.seed = async function(knex) {
       is_default: true,
       created_at: now,
       updated_at: now
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      name: 'paypal',
+      type: 'paypal',
+      icon: 'paypal',
+      active: true,
+      settings: {
+        client_id: '',
+        client_secret: ''
+      },
+      is_default: false,
+      created_at: now,
+      updated_at: now
     }
   ]);
 };

--- a/backend/src/services/paypalService.js
+++ b/backend/src/services/paypalService.js
@@ -1,0 +1,46 @@
+const paypal = require('@paypal/checkout-server-sdk');
+const paymentMethodsService = require('../modules/paymentMethods/paymentMethods.service');
+
+let client;
+
+async function getClient() {
+  if (client) return client;
+  const settings = await paymentMethodsService.getPayPalSettings();
+  if (!settings?.client_id || !settings?.client_secret) {
+    throw new Error('PayPal credentials are not configured');
+  }
+  // Default to sandbox environment; adjust as needed
+  const environment = new paypal.core.SandboxEnvironment(
+    settings.client_id,
+    settings.client_secret
+  );
+  client = new paypal.core.PayPalHttpClient(environment);
+  return client;
+}
+
+exports.createOrder = async ({ amount, currency = 'USD' }) => {
+  const request = new paypal.orders.OrdersCreateRequest();
+  request.prefer('return=representation');
+  request.requestBody({
+    intent: 'CAPTURE',
+    purchase_units: [
+      {
+        amount: {
+          currency_code: currency,
+          value: amount,
+        },
+      },
+    ],
+  });
+  const cli = await getClient();
+  const response = await cli.execute(request);
+  return response.result;
+};
+
+exports.captureOrder = async (orderId) => {
+  const request = new paypal.orders.OrdersCaptureRequest(orderId);
+  request.requestBody({});
+  const cli = await getClient();
+  const response = await cli.execute(request);
+  return response.result;
+};

--- a/backend/tests/paymentCommission.test.js
+++ b/backend/tests/paymentCommission.test.js
@@ -11,6 +11,14 @@ jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
   getSettings: jest.fn(),
 }));
 
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getById: jest.fn().mockResolvedValue({ type: 'card' }),
+}));
+
+jest.mock('../src/services/paypalService', () => ({
+  captureOrder: jest.fn(),
+}));
+
 jest.mock('../src/services/smsService', () => ({
   sendSMS: jest.fn(),
 }));

--- a/backend/tests/paymentInstallments.test.js
+++ b/backend/tests/paymentInstallments.test.js
@@ -5,6 +5,18 @@ jest.mock('../src/modules/payments/payments.service', () => ({
   create: jest.fn(),
 }));
 
+jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getById: jest.fn().mockResolvedValue({ type: 'card' }),
+}));
+
+jest.mock('../src/services/paypalService', () => ({
+  captureOrder: jest.fn(),
+}));
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (_req, _res, next) => next(),
   isAdmin: (_req, _res, next) => next(),

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { fetchPaymentMethods } from '@/services/paymentMethodService';
+import { fetchPaymentMethods, fetchPayPalClientId } from '@/services/paymentMethodService';
 import { fetchClassDetails } from '@/services/classService';
 import { validateCode } from '@/services/couponService';
 import useCartStore from '@/store/cart/cartStore';
@@ -37,6 +37,7 @@ export default function CheckoutPage() {
   const [paymentStatus, setPaymentStatus] = useState('idle');
   const [allowInstallments, setAllowInstallments] = useState(false);
   const [paypalLoaded, setPaypalLoaded] = useState(false);
+  const [paypalClientId, setPaypalClientId] = useState('');
   const removeItem = useCartStore((state) => state.removeItem);
 
 
@@ -59,6 +60,18 @@ export default function CheckoutPage() {
     };
     load();
   }, [classId]);
+
+  useEffect(() => {
+    const loadId = async () => {
+      try {
+        const id = await fetchPayPalClientId();
+        setPaypalClientId(id || '');
+      } catch (err) {
+        console.error('Failed to load PayPal client ID', err);
+      }
+    };
+    loadId();
+  }, []);
 
   const handleApplyPromo = async () => {
     try {
@@ -118,11 +131,11 @@ export default function CheckoutPage() {
   };
 
   useEffect(() => {
-    if (selectedMethod !== 'paypal' || !classInfo) return;
+    if (selectedMethod !== 'paypal' || !classInfo || !paypalClientId) return;
     const amount = (classInfo.price - discount).toString();
     if (!paypalLoaded) {
       const script = document.createElement('script');
-      script.src = `https://www.paypal.com/sdk/js?client-id=${process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID || 'test'}`;
+      script.src = `https://www.paypal.com/sdk/js?client-id=${paypalClientId}`;
       script.addEventListener('load', () => {
         setPaypalLoaded(true);
         renderPayPalButton(amount);
@@ -131,7 +144,7 @@ export default function CheckoutPage() {
     } else {
       renderPayPalButton(amount);
     }
-  }, [selectedMethod, classInfo, discount, paypalLoaded]);
+  }, [selectedMethod, classInfo, discount, paypalLoaded, paypalClientId]);
 
   const handleFileChange = (e) => setReceipt(e.target.files[0]);
   const generatePDF = () => alert('Invoice PDF downloaded (mocked)');

--- a/frontend/src/services/paymentMethodService.js
+++ b/frontend/src/services/paymentMethodService.js
@@ -4,3 +4,8 @@ export const fetchPaymentMethods = async () => {
   const { data } = await api.get("/payment-methods");
   return data?.data ?? [];
 };
+
+export const fetchPayPalClientId = async () => {
+  const { data } = await api.get("/payment-methods/paypal/client-id");
+  return data?.data?.clientId;
+};


### PR DESCRIPTION
## Summary
- store PayPal client ID/secret in payment method settings with admin endpoints
- add PayPal service and server-side verification of PayPal orders
- fetch PayPal client ID via API for checkout page

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d5de60f08328920ae05aa200a213