### PR TITLE
feat: add tutorial assignments module

### DIFF
--- a/backend/src/migrations/20250903000010_create_tutorial_assignments_table.js
+++ b/backend/src/migrations/20250903000010_create_tutorial_assignments_table.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('tutorial_assignments', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('tutorial_id').notNullable().references('id').inTable('tutorials').onDelete('CASCADE');
+    table.string('title').notNullable();
+    table.text('description');
+    table.date('due_date');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('tutorial_assignments');
+};

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
@@ -1,0 +1,34 @@
+const { v4: uuidv4 } = require('uuid');
+const catchAsync = require('../../../../utils/catchAsync');
+const { sendSuccess } = require('../../../../utils/response');
+const service = require('./tutorialAssignment.service');
+
+exports.getAssignmentsByTutorial = catchAsync(async (req, res) => {
+  const assignments = await service.getByTutorial(req.params.tutorialId);
+  sendSuccess(res, assignments);
+});
+
+exports.createAssignment = catchAsync(async (req, res) => {
+  const data = {
+    ...req.body,
+    id: uuidv4(),
+    tutorial_id: req.params.tutorialId,
+  };
+  const assignment = await service.createAssignment(data);
+  sendSuccess(res, assignment, 'Assignment created');
+});
+
+exports.updateAssignment = catchAsync(async (req, res) => {
+  const assignment = await service.updateAssignment(req.params.assignmentId, req.body);
+  sendSuccess(res, assignment, 'Assignment updated');
+});
+
+exports.deleteAssignment = catchAsync(async (req, res) => {
+  await service.deleteAssignment(req.params.assignmentId);
+  sendSuccess(res, null, 'Assignment deleted');
+});
+
+exports.getAllAssignments = catchAsync(async (_req, res) => {
+  const assignments = await service.getAllAssignments();
+  sendSuccess(res, assignments);
+});

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.routes.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.routes.js
@@ -1,0 +1,19 @@
+const router = require('express').Router();
+const ctrl = require('./tutorialAssignment.controller');
+const { verifyToken, isInstructorOrAdmin } = require('../../../../middleware/auth/authMiddleware');
+const validate = require('../../../../middleware/validate');
+const validator = require('./tutorialAssignment.validator');
+
+router.get('/admin', verifyToken, isInstructorOrAdmin, ctrl.getAllAssignments);
+router.get('/:tutorialId', ctrl.getAssignmentsByTutorial);
+router.post(
+  '/:tutorialId',
+  verifyToken,
+  isInstructorOrAdmin,
+  validate(validator.create),
+  ctrl.createAssignment
+);
+router.put('/:assignmentId', verifyToken, isInstructorOrAdmin, validate(validator.update), ctrl.updateAssignment);
+router.delete('/:assignmentId', verifyToken, isInstructorOrAdmin, ctrl.deleteAssignment);
+
+module.exports = router;

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.service.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.service.js
@@ -1,0 +1,37 @@
+const db = require('../../../../config/database');
+
+exports.getByTutorial = async (tutorial_id) => {
+  return db('tutorial_assignments')
+    .where({ tutorial_id })
+    .orderBy('created_at', 'asc');
+};
+
+exports.createAssignment = async (data) => {
+  const [row] = await db('tutorial_assignments').insert(data).returning('*');
+  return row;
+};
+
+exports.updateAssignment = async (id, data) => {
+  const [row] = await db('tutorial_assignments').where({ id }).update(data).returning('*');
+  return row;
+};
+
+exports.deleteAssignment = async (id) => {
+  return db('tutorial_assignments').where({ id }).del();
+};
+
+exports.getAllAssignments = async () => {
+  return db('tutorial_assignments as a')
+    .leftJoin('tutorials as t', 'a.tutorial_id', 't.id')
+    .leftJoin('users as u', 't.instructor_id', 'u.id')
+    .select(
+      'a.id',
+      'a.title',
+      'a.description',
+      'a.due_date',
+      'a.tutorial_id',
+      't.title as tutorial_title',
+      'u.full_name as instructor'
+    )
+    .orderBy('a.created_at', 'desc');
+};

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.validator.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.validator.js
@@ -1,0 +1,17 @@
+const { z } = require('zod');
+
+exports.create = {
+  body: z.object({
+    title: z.string().min(3),
+    description: z.string().optional(),
+    due_date: z.string().datetime(),
+  }),
+};
+
+exports.update = {
+  body: z.object({
+    title: z.string().min(3).optional(),
+    description: z.string().optional(),
+    due_date: z.string().datetime().optional(),
+  }),
+};

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -78,6 +78,7 @@ router.post(
 router.use("/enroll", require("./enrollments/tutorialEnrollment.routes"));
 router.use("/wishlist", require("./wishlist/tutorialWishlist.routes"));
 router.use("/favorites", require("./favorites/tutorialFavorite.routes"));
+router.use("/assignments", require("./assignments/tutorialAssignment.routes"));
 
 router.use("/certificate", require("./certificate/tutorialCertificate.routes"));
 

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -132,8 +132,8 @@ export default function TutorialDetail() {
           ),
         );
         try {
-          const assignList = await fetchTutorialAssignments(id);
-          setAssignments(assignList);
+          const assignmentList = await fetchTutorialAssignments(id);
+          setAssignments(assignmentList);
         } catch (err) {
           console.error('Failed to load assignments', err);
         }

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -99,7 +99,6 @@ export const postTutorialComment = async (tutorialId, payload) => {
 
 // Fetch assignments linked to a tutorial
 export const fetchTutorialAssignments = async (tutorialId) => {
-  const res = await api.get(`/users/classes/assignments/class/${tutorialId}`);
-
+  const res = await api.get(`/users/tutorials/assignments/${tutorialId}`);
   return res.data?.data ?? [];
 };


### PR DESCRIPTION
## Summary
- add migration and backend module to manage tutorial assignments
- expose `/users/tutorials/assignments` routes and adjust frontend service
- load assignments in tutorial detail page

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6898d5dc3abc83288b2b9f0dba09089e