### PR TITLE
feat: display tutorial price

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -299,6 +299,18 @@ const LandingTutorialsSection = () => {
                 </span>
               </div>
 
+              <div className="mt-2">
+                <span
+                  className={`px-2 py-1 rounded-full text-sm font-semibold ${
+                    tut.is_paid && tut.price
+                      ? 'bg-yellow-500 text-black'
+                      : 'bg-green-500 text-black'
+                  }`}
+                >
+                  {tut.is_paid && tut.price ? '$' + tut.price : t('free')}
+                </span>
+              </div>
+
               {/* Progress Bar */}
               <div className="mt-3">
                 <div className="h-2 bg-gray-700 rounded-full overflow-hidden">


### PR DESCRIPTION
## Summary
- show tutorial price or free label in TutorialsSection

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6898dcbf5f648328810a926ce23d4d1f