### PR TITLE
Enable purchase flow for paid tutorials

### DIFF
--- a/frontend/src/components/tutorials/detail/EnrollBanner.js
+++ b/frontend/src/components/tutorials/detail/EnrollBanner.js
@@ -1,7 +1,47 @@
-const EnrollBanner = ({ onEnroll, isPaid, price }) => {
+import Link from "next/link";
+
+const EnrollBanner = ({
+  onEnroll,
+  isPaid,
+  price,
+  onAddToCart,
+  checkoutUrl,
+}) => {
   const formattedPrice = isPaid
     ? `$${Number(price).toFixed(2)}`
     : "Free";
+
+  let actionButton;
+  if (isPaid) {
+    if (checkoutUrl) {
+      actionButton = (
+        <Link
+          href={checkoutUrl}
+          className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+        >
+          Buy Now
+        </Link>
+      );
+    } else {
+      actionButton = (
+        <button
+          onClick={onAddToCart}
+          className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+        >
+          Add to Cart
+        </button>
+      );
+    }
+  } else {
+    actionButton = (
+      <button
+        onClick={onEnroll}
+        className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+      >
+        💳 Enroll Now
+      </button>
+    );
+  }
 
   return (
     <div className="bg-yellow-700/20 border border-yellow-600 text-yellow-300 p-4 rounded-lg flex items-center justify-between">
@@ -9,15 +49,7 @@ const EnrollBanner = ({ onEnroll, isPaid, price }) => {
         Enroll to unlock all chapters and quizzes.
         <span className="font-semibold ml-2">{formattedPrice}</span>
       </p>
-      <button
-        onClick={isPaid ? undefined : onEnroll}
-        disabled={isPaid}
-        className={`bg-green-500 text-white px-4 py-2 rounded ${
-          isPaid ? "opacity-50 cursor-not-allowed" : "hover:bg-green-600"
-        }`}
-      >
-        {isPaid ? "Purchase Required" : "💳 Enroll Now"}
-      </button>
+      {actionButton}
     </div>
   );
 };

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -14,6 +14,7 @@ import TutorialSkeleton from "@/components/tutorials/detail/TutorialSkeleton";
 import CourseProgress from "@/components/classes/CourseProgress";
 import toast from "react-hot-toast";
 import useAuthStore from "@/store/auth/authStore";
+import useCartStore from "@/store/cart/cartStore";
 import useTutorialProgress from "@/hooks/useTutorialProgress";
 import EnrollBanner from "@/components/tutorials/detail/EnrollBanner";
 import LoginPrompt from "@/components/tutorials/detail/LoginPrompt";
@@ -67,6 +68,8 @@ export default function TutorialDetail() {
   const [testPassed, setTestPassed] = useState(false);
   const [assignments, setAssignments] = useState([]);
   const isLoggedIn = useAuthStore((state) => state.isAuthenticated());
+  const user = useAuthStore((state) => state.user);
+  const addItem = useCartStore((state) => state.addItem);
   const [isEnrolled, setIsEnrolled] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [startTime, setStartTime] = useState(0);
@@ -99,6 +102,32 @@ export default function TutorialDetail() {
     } catch (err) {
       console.error("Enrollment failed", err);
       toast.error(t("enroll_fail"));
+    }
+  };
+
+  const handleAddToCart = async () => {
+    if (!tutorial) return;
+    if (!isLoggedIn) {
+      toast.error(t("login_first"));
+      router.push("/auth/login");
+      return;
+    }
+    if (user?.role?.toLowerCase() !== "student") {
+      toast.error("Only students can purchase");
+      return;
+    }
+
+    try {
+      await addItem({
+        id: tutorial.id,
+        name: tutorial.title,
+        price: tutorial.price,
+      });
+      toast.success("Added to cart");
+      router.push("/cart");
+    } catch (err) {
+      console.error("Failed to add to cart", err);
+      toast.error("Failed to add to cart");
     }
   };
 
@@ -240,6 +269,7 @@ export default function TutorialDetail() {
             onEnroll={enroll}
             isPaid={Number(tutorial.price) > 0}
             price={tutorial.price}
+            onAddToCart={handleAddToCart}
           />
         )}
 


### PR DESCRIPTION
## Summary
- Activate purchase button for paid tutorials in `EnrollBanner`
- Allow tutorial details page to add paid courses to cart

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898dcc2194c8328b6e2b5e46f6cd51b