### PR TITLE
feat: add wishlist and favorite toggles

### DIFF
--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -17,6 +17,7 @@ import useAuthStore from "@/store/auth/authStore";
 import useTutorialProgress from "@/hooks/useTutorialProgress";
 import EnrollBanner from "@/components/tutorials/detail/EnrollBanner";
 import LoginPrompt from "@/components/tutorials/detail/LoginPrompt";
+import { FaBookmark, FaHeart } from "react-icons/fa";
 
 const RelatedTutorials = dynamic(() => import("@/components/tutorials/detail/RelatedTutorials"), { ssr: false });
 const CommentsSection = dynamic(() => import("@/components/tutorials/detail/CommentsSection"), { ssr: false });
@@ -29,6 +30,12 @@ import {
   fetchPublishedTutorials,
   fetchTutorialAssignments,
   enrollInTutorial,
+  addTutorialToWishlist,
+  removeTutorialFromWishlist,
+  getMyTutorialWishlist,
+  addTutorialToFavorites,
+  removeTutorialFromFavorites,
+  getMyTutorialFavorites,
 } from "@/services/tutorialService";
 import { API_BASE_URL } from "@/config/config";
 import { safeEncodeURI } from "@/utils/url";
@@ -67,9 +74,13 @@ export default function TutorialDetail() {
   const [testPassed, setTestPassed] = useState(false);
   const [assignments, setAssignments] = useState([]);
   const isLoggedIn = useAuthStore((state) => state.isAuthenticated());
+  const user = useAuthStore((state) => state.user);
+  const isStudent = user?.role?.toLowerCase() === "student";
   const [isEnrolled, setIsEnrolled] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [startTime, setStartTime] = useState(0);
+  const [inWishlist, setInWishlist] = useState(false);
+  const [inFavorites, setInFavorites] = useState(false);
 
   const { progress, saveTime, completeChapter, setIndex, startTimeFor } =
     useTutorialProgress(id);
@@ -143,6 +154,18 @@ export default function TutorialDetail() {
           (t) => String(t.id) !== String(data.id),
         );
         setRelated(others.slice(0, 3));
+        if (isLoggedIn && isStudent) {
+          try {
+            const [w, f] = await Promise.all([
+              getMyTutorialWishlist(),
+              getMyTutorialFavorites(),
+            ]);
+            setInWishlist(w.some((t) => String(t.id) === String(data.id)));
+            setInFavorites(f.some((t) => String(t.id) === String(data.id)));
+          } catch (err) {
+            console.error('Failed to load user lists', err);
+          }
+        }
       } catch (err) {
         console.error(err);
         setError(t("load_error"));
@@ -151,7 +174,7 @@ export default function TutorialDetail() {
       }
     };
     load();
-  }, [id]);
+  }, [id, isLoggedIn, isStudent]);
 
 
 
@@ -225,6 +248,54 @@ export default function TutorialDetail() {
     setIndex(currentIndex);
   };
 
+  const handleToggleWishlist = async () => {
+    if (!user) {
+      router.push('/auth/login');
+      return;
+    }
+    if (!isStudent) {
+      toast.error('Only students can save tutorials.');
+      return;
+    }
+    try {
+      if (inWishlist) {
+        await removeTutorialFromWishlist(tutorial.id);
+        setInWishlist(false);
+        toast.success('Removed from wishlist');
+      } else {
+        await addTutorialToWishlist(tutorial.id);
+        setInWishlist(true);
+        toast.success('Added to wishlist');
+      }
+    } catch (err) {
+      toast.error('Failed to update wishlist');
+    }
+  };
+
+  const handleToggleFavorite = async () => {
+    if (!user) {
+      router.push('/auth/login');
+      return;
+    }
+    if (!isStudent) {
+      toast.error('Only students can save tutorials.');
+      return;
+    }
+    try {
+      if (inFavorites) {
+        await removeTutorialFromFavorites(tutorial.id);
+        setInFavorites(false);
+        toast.success('Removed from favorites');
+      } else {
+        await addTutorialToFavorites(tutorial.id);
+        setInFavorites(true);
+        toast.success('Added to favorites');
+      }
+    } catch (err) {
+      toast.error('Failed to update favorites');
+    }
+  };
+
   return (
     <div className="bg-gray-900 text-white min-h-screen">
       <Head>
@@ -272,6 +343,21 @@ export default function TutorialDetail() {
         />
 
         <div className="flex justify-end mb-4 gap-3">
+          <button
+            onClick={handleToggleFavorite}
+            aria-label={inFavorites ? "Remove from favorites" : "Add to favorites"}
+            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600"
+          >
+            <FaHeart className={inFavorites ? "text-red-500" : "text-white"} />
+          </button>
+
+          <button
+            onClick={handleToggleWishlist}
+            aria-label={inWishlist ? "Remove from wishlist" : "Add to wishlist"}
+            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600"
+          >
+            <FaBookmark className={inWishlist ? "text-yellow-400" : "text-white"} />
+          </button>
 
           <button
             onClick={() =>


### PR DESCRIPTION
## Summary
- allow tutorial page to toggle wishlist and favorites
- load initial wishlist/favorite state and handle auth checks

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6898dcc29ba88328a291b06fb097146f