### PR TITLE
Fix tutorial pricing display

### DIFF
--- a/frontend/src/components/tutorials/TutorialCard.js
+++ b/frontend/src/components/tutorials/TutorialCard.js
@@ -69,7 +69,7 @@ const TutorialCard = ({ tutorial = {} }) => {
           {tutorial.category || "General"} &middot; {tutorial.level || "N/A"}
         </div>
         <div className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-          {tutorial.price ? `$${tutorial.price}` : "Free"} &middot;{" "}
+          {Number(tutorial.price) > 0 ? `$${tutorial.price}` : "Free"} &middot;{" "}
           {tutorial.duration || "Unknown Duration"}
         </div>
 

--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -305,12 +305,12 @@ const LandingTutorialsSection = () => {
               <div className="mt-2">
                 <span
                   className={`px-2 py-1 rounded-full text-sm font-semibold ${
-                    tut.is_paid && tut.price
+                    Number(tut.price) > 0
                       ? 'bg-yellow-500 text-black'
                       : 'bg-green-500 text-black'
                   }`}
                 >
-                  {tut.is_paid && tut.price ? '$' + tut.price : t('free')}
+                  {Number(tut.price) > 0 ? '$' + tut.price : t('free')}
                 </span>
               </div>
 

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -406,7 +406,7 @@ export default function TutorialDetail() {
 
         <TutorialHeader
           {...tutorial}
-          price={tutorial.is_paid && tutorial.price ? `$${tutorial.price}` : t("free")}
+          price={Number(tutorial.price) > 0 ? `$${tutorial.price}` : t("free")}
         />
         <InstructorBio
           name={tutorial.instructor}

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -115,8 +115,8 @@ const TutorialsSection = () => {
 
     const matchPrice =
       !filters.price ||
-      !tut.is_paid ||
-      (tut.price != null && Number(tut.price) <= Number(filters.price));
+      tut.price == null ||
+      Number(tut.price) <= Number(filters.price);
 
     const matchSearch =
       tut.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -295,7 +295,7 @@ const TutorialsSection = () => {
                     onClick={() => router.push(`/tutorials/${tut.id}`)}
                   >
                     {/* Premium Badge */}
-                    {tut.is_paid && (
+                    {Number(tut.price) > 0 && (
                       <div className="absolute top-3 right-3 z-10 bg-gradient-to-r from-amber-500 to-yellow-500 text-black text-xs font-bold px-2 py-1 rounded-full">
                         {t("premium_badge")}
                       </div>
@@ -386,7 +386,7 @@ const TutorialsSection = () => {
                           </span>
                         </div>
                         <div className="text-sm font-medium">
-                          {tut.is_paid && tut.price ? (
+                          {Number(tut.price) > 0 ? (
                             <span className="bg-gradient-to-r from-amber-500 to-yellow-500 text-transparent bg-clip-text">
                               ${tut.price}
                             </span>

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -17,6 +17,7 @@ const formatTutorial = (tut) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.instructor_avatar}`
     : null,
   instructorBio: tut.instructor_bio || tut.instructorBio,
+  price: tut.price != null ? Number(tut.price) : 0,
   rating: typeof tut.rating === "string" || typeof tut.rating === "number"
     ? parseFloat(tut.rating)
     : 0,


### PR DESCRIPTION
## Summary
- normalize tutorial price data to numbers
- show actual price or Free on tutorial cards and listings
- pass formatted price to tutorial details

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898e0116564832893344b2d766138e2