### PR TITLE
Fix category loading in admin tutorial creation page

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -73,7 +73,7 @@ function CreateTutorialPage() {
       try {
         const result = await fetchAllCategories();
 
-        setCategories(result?.data || []);
+        setCategories(result || []);
 
       
       } catch (err) {


### PR DESCRIPTION
## Summary
- ensure admin tutorial creation page sets categories from API response directly

## Testing
- `npm test`
- `npm run lint` *(fails: 326 problems (67 errors, 259 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6898e2d20d3c8328a6587513e8ef00cc