### PR TITLE
feat: abort tutorial data fetch on unmount

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -52,24 +52,34 @@ function AdminTutorialsPage() {
 
   // Load tutorials and categories from backend on mount
   useEffect(() => {
+    const controller = new AbortController();
+    let isMounted = true;
+
     const loadData = async () => {
       try {
         setLoading(true);
         const [tuts, cats] = await Promise.all([
-          fetchAllTutorials(),
-          fetchAllCategories(),
+          fetchAllTutorials({ signal: controller.signal }),
+          fetchAllCategories({}, { signal: controller.signal }),
         ]);
+        if (!isMounted) return;
         setTutorials(tuts);
         setCategories(cats?.data || cats || []);
       } catch (err) {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         console.error(err);
-        toast.error(t('load_error'));
+        if (isMounted) toast.error(t('load_error'));
       } finally {
-        setLoading(false);
+        if (isMounted) setLoading(false);
       }
     };
 
     loadData();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
   }, []);
 
   // Pagination

--- a/frontend/src/services/admin/categoryService.js
+++ b/frontend/src/services/admin/categoryService.js
@@ -4,8 +4,8 @@
 // ─────────────────────────────────────────────────────────
 import api from "@/services/api/api";
 
-export const fetchAllCategories = async (params = {}) => {
-  const { data } = await api.get("/users/categories", { params });
+export const fetchAllCategories = async (params = {}, config = {}) => {
+  const { data } = await api.get("/users/categories", { params, ...config });
   return data?.data;
 };
 

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -20,10 +20,11 @@ export const createTutorial = async (formData) => {
 /**
  * Fetch all tutorials for admin dashboard view.
  *
+ * @param {object} config - Optional Axios config (e.g. abort signal)
  * @returns {Promise<Array>} Array of tutorial objects
  */
-export const fetchAllTutorials = async () => {
-  const { data } = await api.get("/users/tutorials/admin");
+export const fetchAllTutorials = async (config = {}) => {
+  const { data } = await api.get("/users/tutorials/admin", config);
   const tutorials = data?.data ?? [];
   return tutorials.map((t) => ({
     id: t.id,


### PR DESCRIPTION
## Summary
- cancel admin tutorial loading requests on unmount
- allow tutorial and category services to receive abort signals

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6898e2da1d9883289fde5aa43fc888bf