### PR TITLE
Allow editing tutorial language and status

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -25,6 +25,7 @@ exports.create = z.object({
     category_id: z.string(), // assuming UUID
     instructor_id: z.string().uuid().optional(),
     level: z.string(),
+    language: z.string().optional(),
     status: z.enum(["draft", "published", "archived"]).optional(),
     price: z.preprocess(
       (val) => (val === '' || val === undefined ? undefined : Number(val)),

--- a/backend/tests/tutorialRoutes.test.js
+++ b/backend/tests/tutorialRoutes.test.js
@@ -75,6 +75,24 @@ describe('PUT /api/users/tutorials/admin/:id', () => {
     expect(res.status).toBe(403);
     expect(service.updateTutorial).not.toHaveBeenCalled();
   });
+
+  it('updates tutorial with language and status', async () => {
+    const payload = {
+      title: 'New',
+      category_id: 'cat',
+      level: 'beginner',
+      language: 'en',
+      status: 'published',
+    };
+    const updated = { id: '1', ...payload };
+    service.updateTutorial.mockResolvedValue(updated);
+    const res = await request(app)
+      .put('/api/users/tutorials/admin/1')
+      .send(payload);
+    expect(res.status).toBe(200);
+    expect(service.updateTutorial).toHaveBeenCalledWith('1', expect.objectContaining(payload));
+    expect(res.body.data).toEqual(updated);
+  });
 });
 
 describe('DELETE /api/users/tutorials/admin/:id', () => {

--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -70,6 +70,7 @@ function EditTutorialPage() {
           level: tutorial.level,
           language: tutorial.language || "",
           instructorId: tutorial.instructorId,
+          status: tutorial.status,
           lessonCount: mappedChapters.length,
           tags: tutorial.tags || [],
           chapters: mappedChapters,
@@ -137,6 +138,8 @@ function EditTutorialPage() {
               formData.append("description", tutorialData.shortDescription);
               formData.append("category_id", tutorialData.category);
               formData.append("level", tutorialData.level);
+              formData.append("language", tutorialData.language);
+              formData.append("status", tutorialData.status);
               formData.append("is_paid", (!tutorialData.isFree).toString());
               if (!tutorialData.isFree) {
                 formData.append("price", tutorialData.price);

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -84,6 +84,7 @@ export const fetchTutorialById = async (id) => {
     categoryName: t.category_name,
     level: t.level,
     language: t.language,
+    status: t.status,
     instructorId: t.instructor_id,
     instructorName: t.instructor_name,
     tags: t.tags || [],


### PR DESCRIPTION
## Summary
- Persist tutorial `status` when loading draft data and append `language` and `status` when saving edits
- Return tutorial `status` in admin service fetch and allow validator to accept `language`
- Cover update flow with test ensuring `language` and `status` fields are handled

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e2e034008328a6417831468d6e4a