### PR TITLE
Refactor admin tutorials page into modular components

### DIFF
--- a/frontend/src/components/dashboard/admin/tutorials/BulkActions.js
+++ b/frontend/src/components/dashboard/admin/tutorials/BulkActions.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { FaCheck, FaTrash, FaTimes } from "react-icons/fa";
+import { Button } from "@/components/ui/button";
+
+function BulkActions({
+  count,
+  onBulkApprove,
+  onBulkDelete,
+  onClearSelected,
+}) {
+  if (count === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-3 items-center p-4 bg-white rounded-xl shadow-md border border-yellow-100 transition-all animate-fade-in">
+      <span className="font-semibold text-gray-700">
+        {count} {count === 1 ? "tutorial" : "tutorials"} selected
+      </span>
+
+      <Button
+        onClick={onBulkApprove}
+        className="bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white px-4 py-2 rounded-lg flex items-center shadow"
+      >
+        <FaCheck className="mr-2" /> Approve Selected
+      </Button>
+
+      <Button
+        onClick={onBulkDelete}
+        className="bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white px-4 py-2 rounded-lg flex items-center shadow"
+      >
+        <FaTrash className="mr-2" /> Delete Selected
+      </Button>
+
+      <Button
+        onClick={onClearSelected}
+        className="bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-2 rounded-lg flex items-center border border-gray-300"
+      >
+        <FaTimes className="mr-2" /> Clear Selection
+      </Button>
+    </div>
+  );
+}
+
+export default BulkActions;

--- a/frontend/src/components/dashboard/admin/tutorials/Filters.js
+++ b/frontend/src/components/dashboard/admin/tutorials/Filters.js
@@ -1,0 +1,97 @@
+import React from "react";
+import { FaSearch } from "react-icons/fa";
+import { Button } from "@/components/ui/button";
+
+function Filters({
+  searchQuery,
+  setSearchQuery,
+  filterCategory,
+  setFilterCategory,
+  filterStatus,
+  setFilterStatus,
+  filterApproval,
+  setFilterApproval,
+  categories,
+  setCurrentPage,
+}) {
+  return (
+    <div className="bg-white p-5 rounded-xl shadow-md border border-gray-100">
+      <h2 className="text-lg font-semibold text-gray-800 mb-4">Filters</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400">
+            <FaSearch />
+          </div>
+          <input
+            type="text"
+            placeholder="Search by title or instructor..."
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              setCurrentPage(1);
+            }}
+            className="pl-10 p-2.5 w-full border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
+          />
+        </div>
+
+        <select
+          value={filterCategory}
+          onChange={(e) => {
+            setFilterCategory(e.target.value);
+            setCurrentPage(1);
+          }}
+          className="p-2.5 border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
+        >
+          <option value="All">All Categories</option>
+          {categories.map((cat) => (
+            <option key={cat.id} value={cat.name}>
+              {cat.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={filterStatus}
+          onChange={(e) => {
+            setFilterStatus(e.target.value);
+            setCurrentPage(1);
+          }}
+          className="p-2.5 border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
+        >
+          <option value="All">All Status</option>
+          <option value="Published">Published</option>
+          <option value="Draft">Draft</option>
+        </select>
+
+        <select
+          value={filterApproval}
+          onChange={(e) => {
+            setFilterApproval(e.target.value);
+            setCurrentPage(1);
+          }}
+          className="p-2.5 border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
+        >
+          <option value="All">All Approval</option>
+          <option value="Approved">Approved</option>
+          <option value="Pending">Pending</option>
+          <option value="Rejected">Rejected</option>
+        </select>
+
+        <Button
+          onClick={() => {
+            setSearchQuery("");
+            setFilterCategory("All");
+            setFilterStatus("All");
+            setFilterApproval("All");
+            setCurrentPage(1);
+          }}
+          className="bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-2.5 rounded-lg border border-gray-300"
+        >
+          Clear Filters
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default Filters;

--- a/frontend/src/components/dashboard/admin/tutorials/PaginationControls.js
+++ b/frontend/src/components/dashboard/admin/tutorials/PaginationControls.js
@@ -1,0 +1,87 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+
+function PaginationControls({
+  currentPage,
+  totalPages,
+  goToPage,
+  startIndex,
+  endIndex,
+  totalResults,
+}) {
+  const renderPageNumbers = () => {
+    const pages = [];
+    const maxPagesToShow = 5;
+    let startPage;
+    let endPage;
+
+    if (totalPages <= maxPagesToShow) {
+      startPage = 1;
+      endPage = totalPages;
+    } else {
+      const maxPagesBeforeCurrent = Math.floor(maxPagesToShow / 2);
+      const maxPagesAfterCurrent = Math.ceil(maxPagesToShow / 2) - 1;
+
+      if (currentPage <= maxPagesBeforeCurrent) {
+        startPage = 1;
+        endPage = maxPagesToShow;
+      } else if (currentPage + maxPagesAfterCurrent >= totalPages) {
+        startPage = totalPages - maxPagesToShow + 1;
+        endPage = totalPages;
+      } else {
+        startPage = currentPage - maxPagesBeforeCurrent;
+        endPage = currentPage + maxPagesAfterCurrent;
+      }
+    }
+
+    for (let i = startPage; i <= endPage; i++) {
+      pages.push(
+        <button
+          key={i}
+          onClick={() => goToPage(i)}
+          className={`px-3 py-1 rounded-md ${
+            currentPage === i
+              ? "bg-yellow-500 text-white"
+              : "bg-white text-gray-700 hover:bg-gray-100"
+          }`}
+        >
+          {i}
+        </button>
+      );
+    }
+
+    return pages;
+  };
+
+  return (
+    <div className="px-6 py-4 border-t border-gray-100 flex flex-col sm:flex-row items-center justify-between">
+      <div className="text-sm text-gray-700 mb-4 sm:mb-0">
+        Showing <span className="font-medium">{startIndex + 1}</span> to{' '}
+        <span className="font-medium">{endIndex}</span> of{' '}
+        <span className="font-medium">{totalResults}</span> results
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Button
+          onClick={() => goToPage(currentPage - 1)}
+          disabled={currentPage === 1}
+          className="px-3 py-1.5 rounded-md bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          Previous
+        </Button>
+
+        <div className="flex space-x-1">{renderPageNumbers()}</div>
+
+        <Button
+          onClick={() => goToPage(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          className="px-3 py-1.5 rounded-md bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default PaginationControls;

--- a/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
+++ b/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
@@ -1,0 +1,195 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { FaSpinner, FaSearch, FaEdit, FaTrash } from "react-icons/fa";
+
+function TutorialsTable({
+  paginatedTutorials,
+  loading,
+  selectedTutorials,
+  toggleSelectAll,
+  toggleSelectOne,
+  togglePublishStatus,
+  handleApproval,
+  openRejectModal,
+  openDeleteModal,
+  setSearchQuery,
+  setFilterCategory,
+  setFilterStatus,
+  setFilterApproval,
+  setCurrentPage,
+  onEdit,
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full">
+          <thead className="bg-gray-50 border-b">
+            <tr>
+              <th className="py-4 px-4 text-left w-12">
+                <input
+                  type="checkbox"
+                  checked={
+                    paginatedTutorials.length > 0 &&
+                    paginatedTutorials.every((tut) => selectedTutorials.includes(tut.id))
+                  }
+                  onChange={(e) => toggleSelectAll(e.target.checked)}
+                  className="h-4 w-4 rounded text-yellow-500 focus:ring-yellow-400"
+                />
+              </th>
+              <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Thumbnail</th>
+              <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Title</th>
+              <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Instructor</th>
+              <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Category</th>
+              <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Status</th>
+              <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Approval</th>
+              <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Actions</th>
+            </tr>
+          </thead>
+
+          <tbody className="divide-y divide-gray-100">
+            {loading ? (
+              <tr>
+                <td colSpan="8" className="py-12 text-center">
+                  <div className="flex justify-center">
+                    <FaSpinner className="animate-spin text-yellow-500 text-3xl" />
+                  </div>
+                  <p className="mt-2 text-gray-600">Loading tutorials...</p>
+                </td>
+              </tr>
+            ) : paginatedTutorials.length === 0 ? (
+              <tr>
+                <td colSpan="8" className="py-12 text-center">
+                  <div className="flex flex-col items-center justify-center">
+                    <div className="bg-gray-200 border-2 border-dashed rounded-xl w-16 h-16 flex items-center justify-center text-gray-400 mb-4">
+                      <FaSearch className="text-2xl" />
+                    </div>
+                    <h3 className="text-lg font-medium text-gray-900">No tutorials found</h3>
+                    <p className="mt-1 text-gray-500 max-w-md">
+                      Try adjusting your search or filter to find what you're looking for.
+                    </p>
+                    <Button
+                      onClick={() => {
+                        setSearchQuery("");
+                        setFilterCategory("All");
+                        setFilterStatus("All");
+                        setFilterApproval("All");
+                        setCurrentPage(1);
+                      }}
+                      className="mt-4 bg-gray-100 hover:bg-gray-200 text-gray-800"
+                    >
+                      Reset Filters
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ) : (
+              paginatedTutorials.map((tutorial) => (
+                <tr key={tutorial.id} className="hover:bg-gray-50 transition-colors">
+                  <td className="py-4 px-4">
+                    <input
+                      type="checkbox"
+                      checked={selectedTutorials.includes(tutorial.id)}
+                      onChange={() => toggleSelectOne(tutorial.id)}
+                      className="h-4 w-4 rounded text-yellow-500 focus:ring-yellow-400"
+                    />
+                  </td>
+                  <td className="py-3 px-4">
+                    <img
+                      src={tutorial.thumbnail || "/default-thumbnail.jpg"}
+                      alt={tutorial.title}
+                      className="h-14 w-24 object-cover rounded-lg border"
+                      onError={(e) => {
+                        e.target.onerror = null;
+                        e.target.src = "/default-thumbnail.jpg";
+                      }}
+                    />
+                  </td>
+                  <td className="py-3 px-4">
+                    <div className="font-medium text-gray-900">{tutorial.title}</div>
+                    <div className="text-sm text-gray-500">
+                      {new Date(tutorial.createdAt).toLocaleDateString()}
+                    </div>
+                  </td>
+                  <td className="py-3 px-4">
+                    <div className="text-gray-900">{tutorial.instructor}</div>
+                  </td>
+                  <td className="py-3 px-4">
+                    <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                      {tutorial.category}
+                    </span>
+                  </td>
+                  <td className="py-3 px-4">
+                    <Button
+                      onClick={() => togglePublishStatus(tutorial.id)}
+                      className={`px-3 py-1 rounded-full text-xs font-bold transition-colors ${
+                        tutorial.status === "Published"
+                          ? "bg-green-100 text-green-800 hover:bg-green-200"
+                          : "bg-yellow-100 text-yellow-800 hover:bg-yellow-200"
+                      }`}
+                    >
+                      {tutorial.status}
+                    </Button>
+                  </td>
+                  <td className="py-3 px-4">
+                    {tutorial.approvalStatus === "Pending" ? (
+                      <div className="flex gap-2">
+                        <Button
+                          onClick={() => handleApproval(tutorial.id)}
+                          className="bg-green-100 hover:bg-green-200 text-green-700 text-xs px-3 py-1 rounded-full"
+                        >
+                          Approve
+                        </Button>
+                        <Button
+                          onClick={() => openRejectModal(tutorial.id)}
+                          className="bg-red-100 hover:bg-red-200 text-red-700 text-xs px-3 py-1 rounded-full"
+                        >
+                          Reject
+                        </Button>
+                      </div>
+                    ) : (
+                      <Button
+                        disabled
+                        className={`px-3 py-1 rounded-full text-xs font-bold cursor-default ${
+                          tutorial.approvalStatus === "Approved"
+                            ? "bg-green-100 text-green-800"
+                            : tutorial.approvalStatus === "Rejected"
+                            ? "bg-red-100 text-red-800"
+                            : "bg-yellow-100 text-yellow-800"
+                        }`}
+                      >
+                        {tutorial.approvalStatus}
+                      </Button>
+                    )}
+                    {tutorial.approvalStatus === "Rejected" && tutorial.rejectionReason && (
+                      <div className="text-xs text-red-600 mt-1 max-w-xs truncate" title={tutorial.rejectionReason}>
+                        {tutorial.rejectionReason}
+                      </div>
+                    )}
+                  </td>
+                  <td className="py-3 px-4">
+                    <div className="flex gap-2">
+                      <Button
+                        onClick={() => onEdit(tutorial.id)}
+                        className="bg-blue-100 hover:bg-blue-200 text-blue-700 p-2 rounded-lg"
+                        title="Edit"
+                      >
+                        <FaEdit className="text-sm" />
+                      </Button>
+                      <Button
+                        onClick={() => openDeleteModal(tutorial.id)}
+                        className="bg-red-100 hover:bg-red-200 text-red-700 p-2 rounded-lg"
+                        title="Delete"
+                      >
+                        <FaTrash className="text-sm" />
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+  );
+}
+
+export default TutorialsTable;

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -2,7 +2,11 @@ import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import { Button } from "@/components/ui/button";
-import { FaEdit, FaTrash, FaPlus, FaSearch, FaCheck, FaTimes, FaSpinner } from "react-icons/fa";
+import { FaPlus } from "react-icons/fa";
+import Filters from "@/components/dashboard/admin/tutorials/Filters";
+import TutorialsTable from "@/components/dashboard/admin/tutorials/TutorialsTable";
+import BulkActions from "@/components/dashboard/admin/tutorials/BulkActions";
+import PaginationControls from "@/components/dashboard/admin/tutorials/PaginationControls";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -314,50 +318,6 @@ function AdminTutorialsPage() {
     }
   };
 
-  // Render page numbers
-  const renderPageNumbers = () => {
-    const pages = [];
-    const maxPagesToShow = 5;
-    let startPage, endPage;
-
-    if (totalPages <= maxPagesToShow) {
-      startPage = 1;
-      endPage = totalPages;
-    } else {
-      const maxPagesBeforeCurrent = Math.floor(maxPagesToShow / 2);
-      const maxPagesAfterCurrent = Math.ceil(maxPagesToShow / 2) - 1;
-      
-      if (currentPage <= maxPagesBeforeCurrent) {
-        startPage = 1;
-        endPage = maxPagesToShow;
-      } else if (currentPage + maxPagesAfterCurrent >= totalPages) {
-        startPage = totalPages - maxPagesToShow + 1;
-        endPage = totalPages;
-      } else {
-        startPage = currentPage - maxPagesBeforeCurrent;
-        endPage = currentPage + maxPagesAfterCurrent;
-      }
-    }
-
-    for (let i = startPage; i <= endPage; i++) {
-      pages.push(
-        <button
-          key={i}
-          onClick={() => goToPage(i)}
-          className={`px-3 py-1 rounded-md ${
-            currentPage === i
-              ? "bg-yellow-500 text-white"
-              : "bg-white text-gray-700 hover:bg-gray-100"
-          }`}
-        >
-          {i}
-        </button>
-      );
-    }
-
-    return pages;
-  };
-
   return (
     <AdminLayout>
       <div className="p-6 bg-gray-50 min-h-screen space-y-6">
@@ -377,112 +337,26 @@ function AdminTutorialsPage() {
         </div>
 
         {/* Bulk Actions */}
-        {selectedTutorials.length > 0 && (
-          <div className="flex flex-wrap gap-3 items-center p-4 bg-white rounded-xl shadow-md border border-yellow-100 transition-all animate-fade-in">
-            <span className="font-semibold text-gray-700">
-              {selectedTutorials.length} {selectedTutorials.length === 1 ? "tutorial" : "tutorials"} selected
-            </span>
-
-            <Button
-              onClick={handleBulkApprove}
-              className="bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white px-4 py-2 rounded-lg flex items-center shadow"
-            >
-              <FaCheck className="mr-2" /> Approve Selected
-            </Button>
-
-            <Button
-              onClick={handleBulkDelete}
-              className="bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white px-4 py-2 rounded-lg flex items-center shadow"
-            >
-              <FaTrash className="mr-2" /> Delete Selected
-            </Button>
-
-            <Button
-              onClick={clearSelected}
-              className="bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-2 rounded-lg flex items-center border border-gray-300"
-            >
-              <FaTimes className="mr-2" /> Clear Selection
-            </Button>
-          </div>
-        )}
+        <BulkActions
+          count={selectedTutorials.length}
+          onBulkApprove={handleBulkApprove}
+          onBulkDelete={handleBulkDelete}
+          onClearSelected={clearSelected}
+        />
 
         {/* Filters Card */}
-        <div className="bg-white p-5 rounded-xl shadow-md border border-gray-100">
-          <h2 className="text-lg font-semibold text-gray-800 mb-4">Filters</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-            <div className="relative">
-              <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400">
-                <FaSearch />
-              </div>
-              <input
-                type="text"
-                placeholder="Search by title or instructor..."
-                value={searchQuery}
-                onChange={(e) => {
-                  setSearchQuery(e.target.value);
-                  setCurrentPage(1);
-                }}
-                className="pl-10 p-2.5 w-full border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
-              />
-            </div>
-            
-            <select
-              value={filterCategory}
-              onChange={(e) => {
-                setFilterCategory(e.target.value);
-                setCurrentPage(1);
-              }}
-              className="p-2.5 border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
-            >
-              <option value="All">All Categories</option>
-              {categories.map((cat) => (
-                <option key={cat.id} value={cat.name}>
-                  {cat.name}
-                </option>
-              ))}
-            </select>
-            
-            <select
-              value={filterStatus}
-              onChange={(e) => {
-                setFilterStatus(e.target.value);
-                setCurrentPage(1);
-              }}
-              className="p-2.5 border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
-            >
-              <option value="All">All Status</option>
-              <option value="Published">Published</option>
-              <option value="Draft">Draft</option>
-            </select>
-            
-            <select
-              value={filterApproval}
-              onChange={(e) => {
-                setFilterApproval(e.target.value);
-                setCurrentPage(1);
-              }}
-              className="p-2.5 border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
-            >
-              <option value="All">All Approval</option>
-              <option value="Approved">Approved</option>
-              <option value="Pending">Pending</option>
-              <option value="Rejected">Rejected</option>
-            </select>
-            
-            <Button
-              onClick={() => {
-                setSearchQuery("");
-                setFilterCategory("All");
-                setFilterStatus("All");
-                setFilterApproval("All");
-                setCurrentPage(1);
-              }}
-              className="bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-2.5 rounded-lg border border-gray-300"
-            >
-              Clear Filters
-            </Button>
-          </div>
-        </div>
+        <Filters
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          filterCategory={filterCategory}
+          setFilterCategory={setFilterCategory}
+          filterStatus={filterStatus}
+          setFilterStatus={setFilterStatus}
+          filterApproval={filterApproval}
+          setFilterApproval={setFilterApproval}
+          categories={categories}
+          setCurrentPage={setCurrentPage}
+        />
 
         {/* Stats Summary */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
@@ -506,207 +380,33 @@ function AdminTutorialsPage() {
 
         {/* TABLE */}
         <div className="bg-white rounded-xl shadow-md overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="min-w-full">
-              <thead className="bg-gray-50 border-b">
-                <tr>
-                  <th className="py-4 px-4 text-left w-12">
-                    <input
-                      type="checkbox"
-                      checked={paginatedTutorials.length > 0 && paginatedTutorials.every((tut) => selectedTutorials.includes(tut.id))}
-                      onChange={(e) => toggleSelectAll(e.target.checked)}
-                      className="h-4 w-4 rounded text-yellow-500 focus:ring-yellow-400"
-                    />
-                  </th>
-                  <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Thumbnail</th>
-                  <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Title</th>
-                  <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Instructor</th>
-                  <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Category</th>
-                  <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Status</th>
-                  <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Approval</th>
-                  <th className="py-3 px-4 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">Actions</th>
-                </tr>
-              </thead>
+          <TutorialsTable
+            paginatedTutorials={paginatedTutorials}
+            loading={loading}
+            selectedTutorials={selectedTutorials}
+            toggleSelectAll={toggleSelectAll}
+            toggleSelectOne={toggleSelectOne}
+            togglePublishStatus={togglePublishStatus}
+            handleApproval={handleApproval}
+            openRejectModal={openRejectModal}
+            openDeleteModal={openDeleteModal}
+            setSearchQuery={setSearchQuery}
+            setFilterCategory={setFilterCategory}
+            setFilterStatus={setFilterStatus}
+            setFilterApproval={setFilterApproval}
+            setCurrentPage={setCurrentPage}
+            onEdit={(id) => router.push(`/dashboard/admin/tutorials/${id}/edit`)}
+          />
 
-              <tbody className="divide-y divide-gray-100">
-                {loading ? (
-                  <tr>
-                    <td colSpan="8" className="py-12 text-center">
-                      <div className="flex justify-center">
-                        <FaSpinner className="animate-spin text-yellow-500 text-3xl" />
-                      </div>
-                      <p className="mt-2 text-gray-600">Loading tutorials...</p>
-                    </td>
-                  </tr>
-                ) : paginatedTutorials.length === 0 ? (
-                  <tr>
-                    <td colSpan="8" className="py-12 text-center">
-                      <div className="flex flex-col items-center justify-center">
-                        <div className="bg-gray-200 border-2 border-dashed rounded-xl w-16 h-16 flex items-center justify-center text-gray-400 mb-4">
-                          <FaSearch className="text-2xl" />
-                        </div>
-                        <h3 className="text-lg font-medium text-gray-900">No tutorials found</h3>
-                        <p className="mt-1 text-gray-500 max-w-md">
-                          Try adjusting your search or filter to find what you're looking for.
-                        </p>
-                        <Button
-                          onClick={() => {
-                            setSearchQuery("");
-                            setFilterCategory("All");
-                            setFilterStatus("All");
-                            setFilterApproval("All");
-                            setCurrentPage(1);
-                          }}
-                          className="mt-4 bg-gray-100 hover:bg-gray-200 text-gray-800"
-                        >
-                          Reset Filters
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                ) : (
-                  paginatedTutorials.map((tutorial) => (
-                    <tr 
-                      key={tutorial.id} 
-                      className="hover:bg-gray-50 transition-colors"
-                    >
-                      <td className="py-4 px-4">
-                        <input
-                          type="checkbox"
-                          checked={selectedTutorials.includes(tutorial.id)}
-                          onChange={() => toggleSelectOne(tutorial.id)}
-                          className="h-4 w-4 rounded text-yellow-500 focus:ring-yellow-400"
-                        />
-                      </td>
-                      <td className="py-3 px-4">
-                        <img
-                          src={tutorial.thumbnail || "/default-thumbnail.jpg"}
-                          alt={tutorial.title}
-                          className="h-14 w-24 object-cover rounded-lg border"
-                          onError={(e) => {
-                            e.target.onerror = null;
-                            e.target.src = "/default-thumbnail.jpg";
-                          }}
-                        />
-                      </td>
-                      <td className="py-3 px-4">
-                        <div className="font-medium text-gray-900">{tutorial.title}</div>
-                        <div className="text-sm text-gray-500">
-                          {new Date(tutorial.createdAt).toLocaleDateString()}
-                        </div>
-                      </td>
-                      <td className="py-3 px-4">
-                        <div className="text-gray-900">{tutorial.instructor}</div>
-                      </td>
-                      <td className="py-3 px-4">
-                        <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                          {tutorial.category}
-                        </span>
-                      </td>
-                      <td className="py-3 px-4">
-                        <Button
-                          onClick={() => togglePublishStatus(tutorial.id)}
-                          className={`px-3 py-1 rounded-full text-xs font-bold transition-colors ${
-                            tutorial.status === "Published"
-                              ? "bg-green-100 text-green-800 hover:bg-green-200"
-                              : "bg-yellow-100 text-yellow-800 hover:bg-yellow-200"
-                          }`}
-                        >
-                          {tutorial.status}
-                        </Button>
-                      </td>
-                      <td className="py-3 px-4">
-                        {tutorial.approvalStatus === "Pending" ? (
-                          <div className="flex gap-2">
-                            <Button
-                              onClick={() => handleApproval(tutorial.id)}
-                              className="bg-green-100 hover:bg-green-200 text-green-700 text-xs px-3 py-1 rounded-full"
-                            >
-                              Approve
-                            </Button>
-                            <Button
-                              onClick={() => openRejectModal(tutorial.id)}
-                              className="bg-red-100 hover:bg-red-200 text-red-700 text-xs px-3 py-1 rounded-full"
-                            >
-                              Reject
-                            </Button>
-                          </div>
-                        ) : (
-                          <Button
-                            disabled
-                            className={`px-3 py-1 rounded-full text-xs font-bold cursor-default ${
-                              tutorial.approvalStatus === "Approved"
-                                ? "bg-green-100 text-green-800"
-                                : tutorial.approvalStatus === "Rejected"
-                                  ? "bg-red-100 text-red-800"
-                                  : "bg-yellow-100 text-yellow-800"
-                            }`}
-                          >
-                            {tutorial.approvalStatus}
-                          </Button>
-                        )}
-                        {tutorial.approvalStatus === "Rejected" && tutorial.rejectionReason && (
-                          <div className="text-xs text-red-600 mt-1 max-w-xs truncate" title={tutorial.rejectionReason}>
-                            {tutorial.rejectionReason}
-                          </div>
-                        )}
-                      </td>
-                      <td className="py-3 px-4">
-                        <div className="flex gap-2">
-                          <Button
-                            onClick={() => router.push(`/dashboard/admin/tutorials/${tutorial.id}/edit`)}
-                            className="bg-blue-100 hover:bg-blue-200 text-blue-700 p-2 rounded-lg"
-                            title="Edit"
-                          >
-                            <FaEdit className="text-sm" />
-                          </Button>
-                          <Button
-                            onClick={() => openDeleteModal(tutorial.id)}
-                            className="bg-red-100 hover:bg-red-200 text-red-700 p-2 rounded-lg"
-                            title="Delete"
-                          >
-                            <FaTrash className="text-sm" />
-                          </Button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-
-          {/* Pagination */}
           {filteredTutorials.length > 0 && !loading && (
-            <div className="px-6 py-4 border-t border-gray-100 flex flex-col sm:flex-row items-center justify-between">
-              <div className="text-sm text-gray-700 mb-4 sm:mb-0">
-                Showing <span className="font-medium">{startIndex + 1}</span> to{" "}
-                <span className="font-medium">{Math.min(endIndex, filteredTutorials.length)}</span> of{" "}
-                <span className="font-medium">{filteredTutorials.length}</span> results
-              </div>
-              
-              <div className="flex items-center space-x-2">
-                <Button
-                  onClick={() => goToPage(currentPage - 1)}
-                  disabled={currentPage === 1}
-                  className="px-3 py-1.5 rounded-md bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-                >
-                  Previous
-                </Button>
-                
-                <div className="flex space-x-1">
-                  {renderPageNumbers()}
-                </div>
-                
-                <Button
-                  onClick={() => goToPage(currentPage + 1)}
-                  disabled={currentPage === totalPages}
-                  className="px-3 py-1.5 rounded-md bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
+            <PaginationControls
+              currentPage={currentPage}
+              totalPages={totalPages}
+              goToPage={goToPage}
+              startIndex={startIndex}
+              endIndex={Math.min(endIndex, filteredTutorials.length)}
+              totalResults={filteredTutorials.length}
+            />
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- Extract bulk actions, filters, table, and pagination controls into dedicated components for the admin tutorials page
- Update admin tutorials page to import and compose new components for clearer structure

## Testing
- `npm run lint` *(fails: 67 errors, 259 warnings)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e2d65910832880cc286a3790e447