### PR TITLE
Handle missing user during tutorial notification

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -25,6 +25,11 @@ function CreateTutorialPage() {
   const refreshNotifications = useNotificationStore((s) => s.fetch);
   const refreshMessages = useMessageStore((s) => s.fetch);
   const notify = async (type, message) => {
+    if (!user?.id) {
+      toast.warn('Notification skipped: missing user data.');
+      return;
+    }
+
     try {
       await createNotification({ user_id: user.id, type, message });
       await sendChatMessage(user.id, { text: message });


### PR DESCRIPTION
## Summary
- Guard notification send if user data is unavailable
- Warn with toast when user is missing so notifications are skipped

## Testing
- `CI=true npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6898e2eff70c8328ad0959c6383c04d8