### PR TITLE
Handle malformed tutorial draft in create page

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -59,14 +59,19 @@ function CreateTutorialPage() {
   useEffect(() => {
     const savedDraft = localStorage.getItem("tutorialDraft");
     if (savedDraft) {
-      const draft = JSON.parse(savedDraft);
-      setTutorialData({
-        ...draft,
-        thumbnail: null,
-        preview: null,
-        language: draft.language || "",
-        lessonCount: draft.lessonCount || draft.chapters?.length || 1,
-      });
+      try {
+        const draft = JSON.parse(savedDraft);
+        setTutorialData({
+          ...draft,
+          thumbnail: null,
+          preview: null,
+          language: draft.language || "",
+          lessonCount: draft.lessonCount || draft.chapters?.length || 1,
+        });
+      } catch (err) {
+        console.error("Failed to parse tutorialDraft", err);
+        localStorage.removeItem("tutorialDraft");
+      }
     }
 
     const loadCategories = async () => {


### PR DESCRIPTION
## Summary
- guard tutorial draft loading with try/catch and clear invalid data

## Testing
- `npm test`
- `npm run lint` *(fails: 67 errors, 259 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898e2ecb96c832891b2d55777cf1c05