### PR TITLE
Reset selections on tutorial filter changes

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -50,6 +50,10 @@ function AdminTutorialsPage() {
   const [tutorialToReject, setTutorialToReject] = useState(null);
   const [selectedTutorials, setSelectedTutorials] = useState([]);
 
+  useEffect(() => {
+    setSelectedTutorials([]);
+  }, [searchQuery, filterCategory, filterStatus, filterApproval]);
+
   // Load tutorials and categories from backend on mount
   useEffect(() => {
     const loadData = async () => {


### PR DESCRIPTION
## Summary
- Reset selected tutorials whenever search or filter criteria change

## Testing
- `npm test`
- `npm run lint` *(fails: 326 problems, 67 errors, 259 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898e2eb13b88328b922f4389cb5bf59