### PR TITLE
Ensure admin tutorial pagination stays within bounds

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -90,6 +90,12 @@ function AdminTutorialsPage() {
     });
 
   const totalPages = Math.ceil(filteredTutorials.length / tutorialsPerPage);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(Math.min(currentPage, totalPages) || 1);
+    }
+  }, [currentPage, totalPages]);
   const startIndex = (currentPage - 1) * tutorialsPerPage;
   const endIndex = startIndex + tutorialsPerPage;
   const paginatedTutorials = filteredTutorials.slice(startIndex, endIndex);


### PR DESCRIPTION
## Summary
- clamp admin tutorials currentPage when filters shrink total pages

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898e2e4361883288a961cd82daa9ff1