### PR TITLE
chore: remove unused fs import

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -1,6 +1,5 @@
 // 📁 src/modules/users/tutorials/tutorial.controller.js
 const path = require("path");
-const fs = require("fs");
 const db = require("../../../config/database"); // ✅ Required for slug check
 const service = require("./tutorial.service");
 const chapterService = require("./chapters/tutorialChapter.service");


### PR DESCRIPTION
## Summary
- remove unused `fs` import from tutorial controller

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f4ad47508328b2299c1bb14885c7