### PR TITLE
Handle missing tutorials when toggling status

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -340,6 +340,9 @@ exports.togglePublishStatus = catchAsync(async (req, res) => {
     await assertInstructorOwnsTutorial(req.user.id, tutorialId);
   }
   const updated = await service.togglePublishStatus(tutorialId);
+  if (!updated) {
+    throw new AppError("Tutorial not found", 404);
+  }
 
   const tut = await service.getTutorialById(tutorialId);
   if (

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -149,6 +149,10 @@ exports.permanentlyDeleteTutorial = async (id) => {
 
 exports.togglePublishStatus = async (id) => {
   const tutorial = await db("tutorials").where({ id }).first();
+  if (!tutorial) {
+    return null;
+  }
+
   const newStatus = tutorial.status === "published" ? "draft" : "published";
   const updateData = { status: newStatus };
 


### PR DESCRIPTION
## Summary
- Safely handle missing tutorials in `togglePublishStatus` service
- Return 404 from controller if a tutorial isn't found before toggling status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f4abea3083289f54cba6b97d3491