### PR TITLE
fix: ensure enrollment flag only set on explicit confirmation

### DIFF
--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -97,14 +97,12 @@ export default function TutorialDetail() {
 
     try {
       const res = await enrollInTutorial(tutorial.id);
-      const enrolledFlag = Boolean(
-        res?.is_enrolled ??
-          res?.enrolled ??
-          res?.data?.is_enrolled ??
-          res?.data?.enrolled ??
-          res?.success ??
-          true,
-      );
+      const enrolledFlag =
+        res?.is_enrolled === true ||
+        res?.enrolled === true ||
+        res?.data?.is_enrolled === true ||
+        res?.data?.enrolled === true ||
+        res?.success === true;
       setIsEnrolled(enrolledFlag);
       if (enrolledFlag) toast.success(t("enroll_success"));
       else toast.error(t("enroll_fail"));


### PR DESCRIPTION
## Summary
- prevent automatic enrollment success when API response is ambiguous

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6898f4a8a8348328ac8dce48f40d52b8