### PR TITLE
Fix cart store invocation in tutorial detail page

### DIFF
--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -86,6 +86,7 @@ export default function TutorialDetail() {
   const { progress, saveTime, completeChapter, setIndex, startTimeFor } =
     useTutorialProgress(id);
   const { t } = useTranslation("tutorials", { keyPrefix: "detail" });
+  const addItem = useCartStore((state) => state.addItem);
 
   const enroll = async () => {
     if (!tutorial) return;


### PR DESCRIPTION
## Summary
- Retrieve `addItem` from `useCartStore` before using it in the tutorial detail page

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, 326 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6898f4a790bc832889f45eab18aa11c5