### PR TITLE
Fix tutorial progress resume condition

### DIFF
--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -215,7 +215,7 @@ export default function TutorialDetail() {
 
   // Resume last position
   useEffect(() => {
-    if (progress.lastIndex && tutorial) {
+    if (progress.lastIndex !== undefined && tutorial) {
       setCurrentIndex(progress.lastIndex);
     }
   }, [progress.lastIndex, tutorial]);


### PR DESCRIPTION
## Summary
- fix tutorial progress resume condition to allow index 0

## Testing
- `npm test`
- `npm run lint` *(fails: 67 errors, 259 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898f49b501c8328b9927ef4d3b0cfba