### PR TITLE
feat: allow unlimited price filter

### DIFF
--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -55,7 +55,7 @@ const TutorialsSection = () => {
   const [filters, setFilters] = useState({
     categories: [],
     levels: [],
-    price: 100,
+    price: null,
   });
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [statusMap, setStatusMap] = useState({});
@@ -77,7 +77,7 @@ const TutorialsSection = () => {
   };
 
   const resetFilters = () => {
-    setFilters((prev) => ({ ...prev, categories: [], levels: [], price: 100 }));
+    setFilters((prev) => ({ ...prev, categories: [], levels: [], price: null }));
   };
 
   useEffect(() => {
@@ -114,7 +114,8 @@ const TutorialsSection = () => {
       !filters.levels.length || filters.levels.includes(tut.level);
 
     const matchPrice =
-      !filters.price ||
+      filters.price == null ||
+      filters.price === Infinity ||
       tut.price == null ||
       Number(tut.price) <= Number(filters.price);
 


### PR DESCRIPTION
## Summary
- initialize tutorials price filter with no cap
- treat null or Infinity price as unlimited when filtering tutorials

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6898f45b6a7c8328bbd4caea9bf38248