### PR TITLE
chore: remove unused FaClock import from tutorials page

### DIFF
--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { motion } from "framer-motion";
 import Image from "next/image";
-import { FaStar, FaClock, FaFire, FaEye, FaArrowUp, FaSearch, FaFilter } from "react-icons/fa";
+import { FaStar, FaFire, FaEye, FaArrowUp, FaSearch, FaFilter } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";


### PR DESCRIPTION
## Summary
- remove unused `FaClock` icon from tutorials index page import list

## Testing
- `npm run lint` *(fails: Component definition is missing display name, etc.)*
- `npx eslint src/pages/tutorials/index.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898f45a920883289b7c0b017cba0e14