### PR TITLE
Derive tutorial payment status from price

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -16,7 +16,7 @@ exports.enroll = catchAsync(async (req, res) => {
   if (tutorial.status !== "published")
     throw new AppError("Tutorial not published", 400);
 
-  if (tutorial.is_paid) {
+  if (Number(tutorial.price) > 0) {
     const payment = await db("payments")
       .where({ user_id, item_type: "tutorial", item_id: tutorialId })
       .first();

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -118,6 +118,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     level,
     duration: duration ?? null,
     price,
+    is_paid: Number(price) > 0,
     instructor_id,
     status,
     moderation_status: status === "published" ? "Pending" : null,

--- a/backend/tests/tutorialCreate.test.js
+++ b/backend/tests/tutorialCreate.test.js
@@ -105,5 +105,47 @@ describe('createTutorial', () => {
     const data = service.createTutorial.mock.calls[0][0];
     expect(data.instructor_id).toBe(myId);
   });
+
+  it('sets is_paid to false when price is 0', async () => {
+    service.createTutorial.mockResolvedValue({ id: 'tutFree' });
+
+    const req = {
+      body: {
+        title: 'Free Tut',
+        category_id: 'cat',
+        level: 'beginner',
+        price: 0,
+      },
+      user: { id: 'inst1', role: 'instructor' },
+      files: {},
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await controller.createTutorial(req, res, jest.fn());
+    await new Promise((resolve) => setImmediate(resolve));
+    const data = service.createTutorial.mock.calls[0][0];
+    expect(data.is_paid).toBe(false);
+  });
+
+  it('sets is_paid to true when price is greater than 0', async () => {
+    service.createTutorial.mockResolvedValue({ id: 'tutPaid' });
+
+    const req = {
+      body: {
+        title: 'Paid Tut',
+        category_id: 'cat',
+        level: 'beginner',
+        price: 10,
+      },
+      user: { id: 'inst1', role: 'instructor' },
+      files: {},
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await controller.createTutorial(req, res, jest.fn());
+    await new Promise((resolve) => setImmediate(resolve));
+    const data = service.createTutorial.mock.calls[0][0];
+    expect(data.is_paid).toBe(true);
+  });
 });
 

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -33,7 +33,7 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
             first: () =>
               Promise.resolve({
                 id: 't1',
-                is_paid: false,
+                price: 0,
                 moderation_status: 'Approved',
                 status: 'published',
               }),
@@ -59,7 +59,7 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
             first: () =>
               Promise.resolve({
                 id: 't2',
-                is_paid: true,
+                price: 100,
                 moderation_status: 'Approved',
                 status: 'published',
               }),
@@ -89,7 +89,7 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
             first: () =>
               Promise.resolve({
                 id: 't3',
-                is_paid: true,
+                price: 50,
                 moderation_status: 'Approved',
                 status: 'published',
               }),


### PR DESCRIPTION
## Summary
- Derive `is_paid` from tutorial price when creating tutorials
- Check tutorial price instead of `is_paid` when validating enrollment payment
- Add tests covering free and paid tutorials for creation and enrollment

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f457c5408328812c6d7ad3435fd4