### PR TITLE
Extract addItem hook in tutorial detail page

### DIFF
--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -76,6 +76,7 @@ export default function TutorialDetail() {
   const [assignments, setAssignments] = useState([]);
   const isLoggedIn = useAuthStore((state) => state.isAuthenticated());
   const user = useAuthStore((state) => state.user);
+  const addItem = useCartStore((state) => state.addItem);
   const isStudent = user?.role?.toLowerCase() === "student";
   const [isEnrolled, setIsEnrolled] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);


### PR DESCRIPTION
## Summary
- Retrieve `addItem` action from cart store in tutorial detail page
- Use `addItem` in `handleAddToCart` to add tutorials to cart

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898f455fe24832898e555cb80071c90