### PR TITLE
fix: remove duplicate addItem declaration

### DIFF
--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -83,12 +83,10 @@ export default function TutorialDetail() {
   const [startTime, setStartTime] = useState(0);
   const [inWishlist, setInWishlist] = useState(false);
   const [inFavorites, setInFavorites] = useState(false);
-  const addItem = useCartStore((state) => state.addItem);
 
   const { progress, saveTime, completeChapter, setIndex, startTimeFor } =
     useTutorialProgress(id);
   const { t } = useTranslation("tutorials", { keyPrefix: "detail" });
-  const addItem = useCartStore((state) => state.addItem);
 
   const enroll = async () => {
     if (!tutorial) return;


### PR DESCRIPTION
## Summary
- resolve duplicate `addItem` state in tutorial detail page

## Testing
- `npm test`
- `npm run lint` (fails: 67 errors, 259 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898fccec170832886354dde4658a108