### PR TITLE
Add item_type column to cart items

### DIFF
--- a/backend/src/migrations/20250903000020_add_item_type_to_cart_items.js
+++ b/backend/src/migrations/20250903000020_add_item_type_to_cart_items.js
@@ -1,0 +1,20 @@
+const TABLE_NAME = 'cart_items';
+
+exports.up = async function(knex) {
+  const exists = await knex.schema.hasColumn(TABLE_NAME, 'item_type');
+  if (!exists) {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+      table.string('item_type').notNullable().defaultTo('class');
+    });
+  }
+};
+
+exports.down = async function(knex) {
+  const exists = await knex.schema.hasColumn(TABLE_NAME, 'item_type');
+  if (exists) {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+      table.dropColumn('item_type');
+    });
+  }
+};
+


### PR DESCRIPTION
## Summary
- add migration to include `item_type` in `cart_items` table if missing

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689901a842908328b5a842e6d7619a85