### PR TITLE
feat: add tutorial progress tracking and enrollment APIs

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -109,3 +109,48 @@ exports.getMyEnrollments = catchAsync(async (req, res) => {
 
   sendSuccess(res, rows);
 });
+
+// Get enrollment status and progress for a tutorial
+exports.getStatus = catchAsync(async (req, res) => {
+  const { tutorialId } = req.params;
+  const user_id = req.user.id;
+
+  const enrollment = await db("tutorial_enrollments")
+    .where({ user_id, tutorial_id: tutorialId })
+    .first();
+
+  if (!enrollment) {
+    return sendSuccess(res, { enrolled: false, progress: 0, status: null });
+  }
+
+  const progress =
+    enrollment.progress != null
+      ? Number(enrollment.progress)
+      : enrollment.status === "completed"
+      ? 100
+      : 0;
+
+  sendSuccess(res, {
+    enrolled: true,
+    status: enrollment.status,
+    progress,
+  });
+});
+
+// Update progress percentage for a tutorial
+exports.updateProgress = catchAsync(async (req, res) => {
+  const { tutorialId } = req.params;
+  const { progress } = req.body;
+  const user_id = req.user.id;
+
+  const enrollment = await db("tutorial_enrollments")
+    .where({ user_id, tutorial_id: tutorialId })
+    .first();
+  if (!enrollment) throw new AppError("Enrollment not found", 404);
+
+  await db("tutorial_enrollments")
+    .where({ user_id, tutorial_id: tutorialId })
+    .update({ progress });
+
+  sendSuccess(res, { progress }, "Progress updated");
+});

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.routes.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.routes.js
@@ -4,6 +4,8 @@ const { verifyToken, isStudent } = require("../../../../middleware/auth/authMidd
 
 router.post("/:tutorialId", verifyToken, isStudent, ctrl.enroll);
 router.post("/:tutorialId/complete", verifyToken, isStudent, ctrl.complete);
+router.get("/:tutorialId/status", verifyToken, isStudent, ctrl.getStatus);
+router.patch("/:tutorialId/progress", verifyToken, isStudent, ctrl.updateProgress);
 router.get("/my", verifyToken, isStudent, ctrl.getMyEnrollments);
 
 module.exports = router;

--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -3,15 +3,11 @@ import Image from "next/image";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { motion } from "framer-motion";
-import {
-  FaStar,
-  FaClock,
-  FaBookmark,
-  FaHeart,
-} from "react-icons/fa";
+import { FaStar, FaClock, FaBookmark, FaHeart } from "react-icons/fa";
 import { toast } from "react-toastify";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
+import useTutorialProgressStore from "@/store/tutorialProgressStore";
 import { fetchAllCategories } from "@/services/admin/categoryService";
 
 import {
@@ -22,9 +18,8 @@ import {
   addTutorialToFavorites,
   removeTutorialFromFavorites,
   getMyTutorialFavorites,
+  enrollInTutorial,
 } from "@/services/tutorialService";
-
-const PROGRESS_KEY = "skillbridge_tutorialProgress";
 
 
 export const getStars = (rating) => {
@@ -48,7 +43,8 @@ const LandingTutorialsSection = () => {
   const [activeTab, setActiveTab] = useState("All");
   const [tutorials, setTutorials] = useState([]);
   const [categories, setCategories] = useState([]);
-  const [progress, setProgress] = useState({});
+  const { status: progress, fetchStatus, syncOffline } =
+    useTutorialProgressStore();
   const router = useRouter();
   const addItem = useCartStore((state) => state.addItem);
   const user = useAuthStore((state) => state.user);
@@ -98,11 +94,9 @@ const LandingTutorialsSection = () => {
           setCategories(categoryRes?.data || categoryRes || []);
         }
 
-        try {
-          const stored = JSON.parse(localStorage.getItem(PROGRESS_KEY) || "{}");
-          setProgress(stored);
-        } catch {
-          setProgress({});
+        if (user && isStudent) {
+          await syncOffline();
+          (tutorialRes || []).forEach((t) => fetchStatus(t.id));
         }
       }
     };
@@ -111,7 +105,7 @@ const LandingTutorialsSection = () => {
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [user, isStudent]);
 
   useEffect(() => {
     if (!user || !isStudent) return;
@@ -314,18 +308,43 @@ const LandingTutorialsSection = () => {
                 </span>
               </div>
 
-              {/* Progress Bar */}
-              <div className="mt-3">
-                <div className="h-2 bg-gray-700 rounded-full overflow-hidden">
-                  <div
-                    className="h-full bg-yellow-400"
-                    style={{ width: `${progress[tut.id] || 0}%` }}
-                  />
+              {progress[tut.id]?.enrolled ? (
+                <div className="mt-3">
+                  <div className="h-2 bg-gray-700 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-yellow-400"
+                      style={{ width: `${progress[tut.id]?.progress || 0}%` }}
+                    />
+                  </div>
+                  <div className="text-xs text-gray-400 mt-1">
+                    Watched: {progress[tut.id]?.progress || 0}%
+                  </div>
                 </div>
-                <div className="text-xs text-gray-400 mt-1">
-                  Watched: {progress[tut.id] || 0}%
+              ) : (
+                <div className="mt-3">
+                  <button
+                    aria-label="Enroll in tutorial"
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      if (!user) return router.push('/auth/login');
+                      if (!isStudent) {
+                        toast.error('Only students can enroll.');
+                        return;
+                      }
+                      try {
+                        await enrollInTutorial(tut.id);
+                        await fetchStatus(tut.id);
+                        toast.success('Enrolled');
+                      } catch (err) {
+                        toast.error('Enrollment failed');
+                      }
+                    }}
+                    className="w-full bg-yellow-500 hover:bg-yellow-400 text-black py-1 rounded"
+                  >
+                    Enroll
+                  </button>
                 </div>
-              </div>
+              )}
 
               <div className="flex gap-2 mt-4">
                 <button

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -7,15 +7,11 @@ import { useTranslation } from "next-i18next";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import FilterSidebar from "@/components/tutorials/FilterSidebar";
-import { fetchPublishedTutorials } from "@/services/tutorialService";
+import { fetchPublishedTutorials, enrollInTutorial } from "@/services/tutorialService";
+import useAuthStore from "@/store/auth/authStore";
+import useTutorialProgressStore from "@/store/tutorialProgressStore";
 
-/**
- * Retrieves enrollment status and progress percentage for a tutorial from
- * `localStorage`.
- * @param {Object} tut - Tutorial information containing an `id` and optional
- * chapter metadata.
- * @returns {{enrolled: boolean, progressPercent: number}}
- */
+// Retained for backward compatibility in tests and offline fallback
 export const loadTutorialStatus = (tut) => {
   let enrolled = false;
   let progressPercent = 0;
@@ -23,16 +19,12 @@ export const loadTutorialStatus = (tut) => {
   if (typeof window !== "undefined") {
     enrolled = !!localStorage.getItem(`enrolled-${tut.id}`);
     const saved = localStorage.getItem(`progress-tutorial-${tut.id}`);
-
     if (saved) {
       try {
         const data = JSON.parse(saved);
         const total = Array.isArray(tut.chapters)
           ? tut.chapters.length
-          : tut.totalLessons ||
-            tut.total_chapters ||
-            tut.chapter_count ||
-            0;
+          : tut.totalLessons || tut.total_chapters || tut.chapter_count || 0;
         if (total) {
           progressPercent =
             ((data.completedChapters?.length || 0) / total) * 100;
@@ -58,10 +50,13 @@ const TutorialsSection = () => {
     price: null,
   });
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const [statusMap, setStatusMap] = useState({});
   const router = useRouter();
   const loader = useRef(null);
   const { t } = useTranslation("tutorials", { keyPrefix: "list" });
+  const user = useAuthStore((s) => s.user);
+  const isStudent = user?.role?.toLowerCase() === "student";
+  const { status: statusMap, fetchStatus, syncOffline } =
+    useTutorialProgressStore();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -96,13 +91,13 @@ const TutorialsSection = () => {
   }, []);
 
   useEffect(() => {
-    if (!tutorials.length) return;
-    const cache = {};
-    tutorials.forEach((t) => {
-      cache[t.id] = loadTutorialStatus(t);
-    });
-    setStatusMap(cache);
-  }, [tutorials]);
+    if (!tutorials.length || !user || !isStudent) return;
+    const loadStatuses = async () => {
+      await syncOffline();
+      tutorials.forEach((t) => fetchStatus(t.id));
+    };
+    loadStatuses();
+  }, [tutorials, user, isStudent]);
 
   const filteredTutorials = tutorials.filter((tut) => {
     const matchCategory =
@@ -284,7 +279,8 @@ const TutorialsSection = () => {
             {/* Tutorial Cards Grid */}
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
               {visibleTutorials.map((tut) => {
-                const { enrolled, progressPercent = 0 } = statusMap[tut.id] || {};
+                const { enrolled, progress: progressPercent = 0 } =
+                  statusMap[tut.id] || {};
 
                 return (
                   <motion.div
@@ -323,14 +319,31 @@ const TutorialsSection = () => {
                         />
                       )}
                       
-                      {/* Progress bar */}
-                      {enrolled && (
+                      {/* Progress bar or Enroll button */}
+                      {enrolled ? (
                         <div className="absolute bottom-0 left-0 right-0 z-20 h-1.5 bg-gray-700">
                           <div
                             className="h-full bg-gradient-to-r from-yellow-500 to-amber-500"
                             style={{ width: `${progressPercent}%` }}
                           ></div>
                         </div>
+                      ) : (
+                        <button
+                          onClick={async (e) => {
+                            e.stopPropagation();
+                            if (!user) return router.push('/auth/login');
+                            if (!isStudent) {
+                              return;
+                            }
+                            try {
+                              await enrollInTutorial(tut.id);
+                              await fetchStatus(tut.id);
+                            } catch {}
+                          }}
+                          className="absolute bottom-3 left-3 z-20 bg-yellow-500 text-black text-xs font-bold px-2 py-1 rounded"
+                        >
+                          Enroll
+                        </button>
                       )}
                     </div>
 

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -107,3 +107,20 @@ export const fetchTutorialAssignments = async (tutorialId) => {
   const res = await api.get(`/users/tutorials/assignments/${tutorialId}`);
   return res.data?.data ?? [];
 };
+
+// Fetch enrollment status and progress for a tutorial
+export const fetchEnrollmentStatus = async (tutorialId) => {
+  const { data } = await api.get(`/users/tutorials/enroll/${tutorialId}/status`);
+  const payload = data?.data ?? data;
+  return {
+    enrolled: payload.enrolled ?? !!payload.status,
+    status: payload.status ?? null,
+    progress: payload.progress ?? 0,
+  };
+};
+
+// Update progress percentage for a tutorial
+export const updateTutorialProgress = async (tutorialId, progress) => {
+  const { data } = await api.patch(`/users/tutorials/enroll/${tutorialId}/progress`, { progress });
+  return data;
+};

--- a/frontend/src/store/tutorialProgressStore.js
+++ b/frontend/src/store/tutorialProgressStore.js
@@ -1,0 +1,79 @@
+import { create } from "zustand";
+import { fetchEnrollmentStatus, updateTutorialProgress } from "@/services/tutorialService";
+
+const OFFLINE_KEY = "skillbridge_offlineProgress";
+
+const useTutorialProgressStore = create((set, get) => ({
+  status: {}, // { [tutorialId]: { enrolled, progress, status } }
+  async fetchStatus(id) {
+    const existing = get().status[id];
+    if (existing) return existing;
+    try {
+      const data = await fetchEnrollmentStatus(id);
+      set((state) => ({ status: { ...state.status, [id]: data } }));
+      return data;
+    } catch (err) {
+      // Fallback to offline progress if available
+      if (typeof window !== "undefined") {
+        try {
+          const offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
+          const progress = offline[id] || 0;
+          const data = { enrolled: false, progress };
+          set((state) => ({ status: { ...state.status, [id]: data } }));
+          return data;
+        } catch {}
+      }
+      return { enrolled: false, progress: 0 };
+    }
+  },
+  async updateProgress(id, progress) {
+    try {
+      await updateTutorialProgress(id, progress);
+      set((state) => ({
+        status: {
+          ...state.status,
+          [id]: { ...(state.status[id] || {}), enrolled: true, progress },
+        },
+      }));
+      if (typeof window !== "undefined") {
+        const offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
+        delete offline[id];
+        localStorage.setItem(OFFLINE_KEY, JSON.stringify(offline));
+      }
+    } catch {
+      if (typeof window !== "undefined") {
+        const offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
+        offline[id] = progress;
+        localStorage.setItem(OFFLINE_KEY, JSON.stringify(offline));
+      }
+    }
+  },
+  async syncOffline() {
+    if (typeof window === "undefined") return;
+    let offline;
+    try {
+      offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
+    } catch {
+      offline = {};
+    }
+    const ids = Object.keys(offline);
+    for (const id of ids) {
+      try {
+        const progress = offline[id];
+        await updateTutorialProgress(id, progress);
+        set((state) => ({
+          status: {
+            ...state.status,
+            [id]: { ...(state.status[id] || {}), enrolled: true, progress },
+          },
+        }));
+        delete offline[id];
+      } catch {
+        // keep if failed
+      }
+    }
+    localStorage.setItem(OFFLINE_KEY, JSON.stringify(offline));
+  },
+}));
+
+export default useTutorialProgressStore;


### PR DESCRIPTION
## Summary
- add endpoints to fetch and update tutorial enrollment progress
- cache enrollment progress in zustand store and sync offline changes
- show enroll button or progress bar in tutorials list and section using API data

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689909c03d6c8328a5f20a271ef6bb98