### PR TITLE
Centralize tutorial wishlist and favorites

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -12,17 +12,10 @@ import {
 import { toast } from "react-toastify";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
+import useTutorialListsStore from "@/store/tutorials/tutorialListsStore";
 import { fetchAllCategories } from "@/services/admin/categoryService";
 
-import {
-  fetchFeaturedTutorials,
-  addTutorialToWishlist,
-  removeTutorialFromWishlist,
-  getMyTutorialWishlist,
-  addTutorialToFavorites,
-  removeTutorialFromFavorites,
-  getMyTutorialFavorites,
-} from "@/services/tutorialService";
+import { fetchFeaturedTutorials } from "@/services/tutorialService";
 
 const PROGRESS_KEY = "skillbridge_tutorialProgress";
 
@@ -53,8 +46,13 @@ const LandingTutorialsSection = () => {
   const addItem = useCartStore((state) => state.addItem);
   const user = useAuthStore((state) => state.user);
   const isStudent = user?.role?.toLowerCase() === 'student';
-  const [wishlistIds, setWishlistIds] = useState([]);
-  const [favoriteIds, setFavoriteIds] = useState([]);
+  const {
+    wishlistIds,
+    favoriteIds,
+    loadLists,
+    toggleWishlist,
+    toggleFavorite,
+  } = useTutorialListsStore();
 
   const [isMobile, setIsMobile] = useState(false);
 
@@ -114,21 +112,8 @@ const LandingTutorialsSection = () => {
   }, []);
 
   useEffect(() => {
-    if (!user || !isStudent) return;
-    const loadLists = async () => {
-      try {
-        const [w, f] = await Promise.all([
-          getMyTutorialWishlist(),
-          getMyTutorialFavorites(),
-        ]);
-        setWishlistIds(w.map((t) => t.id));
-        setFavoriteIds(f.map((t) => t.id));
-      } catch (err) {
-        console.error('Failed to load user lists', err);
-      }
-    };
     loadLists();
-  }, [user, isStudent]);
+  }, [user]);
 
   const filteredTutorials =
     activeTab === "All"
@@ -215,25 +200,9 @@ const LandingTutorialsSection = () => {
                 </span>
               )}
               <button
-                onClick={async (e) => {
+                onClick={(e) => {
                   e.stopPropagation();
-                  if (!user) return router.push('/auth/login');
-                  if (!isStudent) {
-                    toast.error('Only students can save tutorials.');
-                    return;
-                  }
-                  try {
-                    if (favoriteIds.includes(tut.id)) {
-                      await removeTutorialFromFavorites(tut.id);
-                      setFavoriteIds(favoriteIds.filter((i) => i !== tut.id));
-                    } else {
-                      await addTutorialToFavorites(tut.id);
-                      setFavoriteIds([...favoriteIds, tut.id]);
-                      toast.success('Added to favorites');
-                    }
-                  } catch (err) {
-                    toast.error('Failed to update favorites');
-                  }
+                  toggleFavorite(tut.id);
                 }}
                 aria-label={favoriteIds.includes(tut.id) ? 'Remove from favorites' : 'Add to favorites'}
                 className="absolute top-2 right-10 bg-gray-700 rounded-full p-1 w-6 h-6 flex items-center justify-center hover:text-red-400"
@@ -242,25 +211,9 @@ const LandingTutorialsSection = () => {
               </button>
 
               <button
-                onClick={async (e) => {
+                onClick={(e) => {
                   e.stopPropagation();
-                  if (!user) return router.push('/auth/login');
-                  if (!isStudent) {
-                    toast.error('Only students can save tutorials.');
-                    return;
-                  }
-                  try {
-                    if (wishlistIds.includes(tut.id)) {
-                      await removeTutorialFromWishlist(tut.id);
-                      setWishlistIds(wishlistIds.filter((i) => i !== tut.id));
-                    } else {
-                      await addTutorialToWishlist(tut.id);
-                      setWishlistIds([...wishlistIds, tut.id]);
-                      toast.success(t('added_to_wishlist'));
-                    }
-                  } catch (err) {
-                    toast.error('Failed to update wishlist');
-                  }
+                  toggleWishlist(tut.id);
                 }}
                 aria-label={wishlistIds.includes(tut.id) ? 'Remove from wishlist' : 'Add to wishlist'}
                 className="absolute top-2 right-2 bg-gray-700 rounded-full p-1 w-6 h-6 flex items-center justify-center hover:text-yellow-400"

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -2,12 +2,14 @@ import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { motion } from "framer-motion";
 import Image from "next/image";
-import { FaStar, FaFire, FaEye, FaArrowUp, FaSearch, FaFilter } from "react-icons/fa";
+import { FaStar, FaFire, FaEye, FaArrowUp, FaSearch, FaFilter, FaBookmark, FaHeart } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import FilterSidebar from "@/components/tutorials/FilterSidebar";
 import { fetchPublishedTutorials } from "@/services/tutorialService";
+import useTutorialListsStore from "@/store/tutorials/tutorialListsStore";
+import useAuthStore from "@/store/auth/authStore";
 
 /**
  * Retrieves enrollment status and progress percentage for a tutorial from
@@ -62,6 +64,18 @@ const TutorialsSection = () => {
   const router = useRouter();
   const loader = useRef(null);
   const { t } = useTranslation("tutorials", { keyPrefix: "list" });
+  const {
+    wishlistIds,
+    favoriteIds,
+    loadLists,
+    toggleWishlist,
+    toggleFavorite,
+  } = useTutorialListsStore();
+  const user = useAuthStore((state) => state.user);
+
+  useEffect(() => {
+    loadLists();
+  }, [user]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -305,6 +319,28 @@ const TutorialsSection = () => {
                     {/* Thumbnail */}
                     <div className="relative h-44 overflow-hidden">
                       <div className="absolute inset-0 bg-gradient-to-t from-gray-900 to-transparent z-10" />
+                      <div className="absolute top-2 right-2 z-20 flex flex-col gap-2">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleFavorite(tut.id);
+                          }}
+                          aria-label={favoriteIds.includes(tut.id) ? 'Remove from favorites' : 'Add to favorites'}
+                          className="bg-gray-700 rounded-full p-1 w-6 h-6 flex items-center justify-center hover:text-red-400"
+                        >
+                          <FaHeart className={favoriteIds.includes(tut.id) ? 'text-red-500' : 'text-white'} />
+                        </button>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleWishlist(tut.id);
+                          }}
+                          aria-label={wishlistIds.includes(tut.id) ? 'Remove from wishlist' : 'Add to wishlist'}
+                          className="bg-gray-700 rounded-full p-1 w-6 h-6 flex items-center justify-center hover:text-yellow-400"
+                        >
+                          <FaBookmark className={wishlistIds.includes(tut.id) ? 'text-yellow-400' : 'text-white'} />
+                        </button>
+                      </div>
                       {tut.preview ? (
                         <video
                           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"

--- a/frontend/src/store/tutorials/tutorialListsStore.js
+++ b/frontend/src/store/tutorials/tutorialListsStore.js
@@ -1,0 +1,98 @@
+import { create } from 'zustand';
+import Router from 'next/router';
+import { toast } from 'react-toastify';
+import useAuthStore from '@/store/auth/authStore';
+import {
+  addTutorialToWishlist,
+  removeTutorialFromWishlist,
+  getMyTutorialWishlist,
+  addTutorialToFavorites,
+  removeTutorialFromFavorites,
+  getMyTutorialFavorites,
+} from '@/services/tutorialService';
+
+const useTutorialListsStore = create((set, get) => ({
+  wishlistIds: [],
+  favoriteIds: [],
+
+  loadLists: async () => {
+    const user = useAuthStore.getState().user;
+    const isStudent = user?.role?.toLowerCase() === 'student';
+    if (!user || !isStudent) {
+      set({ wishlistIds: [], favoriteIds: [] });
+      return;
+    }
+    try {
+      const [w, f] = await Promise.all([
+        getMyTutorialWishlist(),
+        getMyTutorialFavorites(),
+      ]);
+      set({
+        wishlistIds: w.map((t) => t.id),
+        favoriteIds: f.map((t) => t.id),
+      });
+    } catch (err) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('Failed to load tutorial lists', err);
+      }
+    }
+  },
+
+  toggleWishlist: async (id) => {
+    const user = useAuthStore.getState().user;
+    const isStudent = user?.role?.toLowerCase() === 'student';
+    if (!user) {
+      Router.push('/auth/login');
+      return;
+    }
+    if (!isStudent) {
+      toast.error('Only students can save tutorials.');
+      return;
+    }
+    const { wishlistIds } = get();
+    try {
+      if (wishlistIds.includes(id)) {
+        await removeTutorialFromWishlist(id);
+        set({ wishlistIds: wishlistIds.filter((i) => i !== id) });
+        toast.success('Removed from wishlist');
+      } else {
+        await addTutorialToWishlist(id);
+        set({ wishlistIds: [...wishlistIds, id] });
+        toast.success('Added to wishlist');
+      }
+    } catch (err) {
+      const message = err?.response?.data?.message || 'Failed to update wishlist';
+      toast.error(message);
+    }
+  },
+
+  toggleFavorite: async (id) => {
+    const user = useAuthStore.getState().user;
+    const isStudent = user?.role?.toLowerCase() === 'student';
+    if (!user) {
+      Router.push('/auth/login');
+      return;
+    }
+    if (!isStudent) {
+      toast.error('Only students can save tutorials.');
+      return;
+    }
+    const { favoriteIds } = get();
+    try {
+      if (favoriteIds.includes(id)) {
+        await removeTutorialFromFavorites(id);
+        set({ favoriteIds: favoriteIds.filter((i) => i !== id) });
+        toast.success('Removed from favorites');
+      } else {
+        await addTutorialToFavorites(id);
+        set({ favoriteIds: [...favoriteIds, id] });
+        toast.success('Added to favorites');
+      }
+    } catch (err) {
+      const message = err?.response?.data?.message || 'Failed to update favorites';
+      toast.error(message);
+    }
+  },
+}));
+
+export default useTutorialListsStore;

--- a/frontend/src/tests/__tests__/tutorialListsStore.test.js
+++ b/frontend/src/tests/__tests__/tutorialListsStore.test.js
@@ -1,0 +1,48 @@
+import useTutorialListsStore from '@/store/tutorials/tutorialListsStore';
+import useAuthStore from '@/store/auth/authStore';
+import * as tutorialService from '../../services/tutorialService';
+import Router from 'next/router';
+
+jest.mock('next/router', () => ({ push: jest.fn() }));
+jest.mock('react-toastify', () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+jest.mock('../../services/tutorialService', () => ({
+  getMyTutorialWishlist: jest.fn().mockResolvedValue([]),
+  getMyTutorialFavorites: jest.fn().mockResolvedValue([]),
+  addTutorialToWishlist: jest.fn().mockResolvedValue({}),
+  removeTutorialFromWishlist: jest.fn().mockResolvedValue({}),
+  addTutorialToFavorites: jest.fn().mockResolvedValue({}),
+  removeTutorialFromFavorites: jest.fn().mockResolvedValue({}),
+}));
+
+beforeEach(() => {
+  useTutorialListsStore.setState({ wishlistIds: [], favoriteIds: [] });
+  useAuthStore.setState({ user: { id: 1, role: 'student' } });
+  jest.clearAllMocks();
+});
+
+test('toggleWishlist updates state after service calls', async () => {
+  const { toggleWishlist } = useTutorialListsStore.getState();
+  await toggleWishlist(5);
+  expect(tutorialService.addTutorialToWishlist).toHaveBeenCalledWith(5);
+  expect(useTutorialListsStore.getState().wishlistIds).toContain(5);
+  await toggleWishlist(5);
+  expect(tutorialService.removeTutorialFromWishlist).toHaveBeenCalledWith(5);
+  expect(useTutorialListsStore.getState().wishlistIds).not.toContain(5);
+});
+
+test('toggleFavorite updates state after service calls', async () => {
+  const { toggleFavorite } = useTutorialListsStore.getState();
+  await toggleFavorite(7);
+  expect(tutorialService.addTutorialToFavorites).toHaveBeenCalledWith(7);
+  expect(useTutorialListsStore.getState().favoriteIds).toContain(7);
+  await toggleFavorite(7);
+  expect(tutorialService.removeTutorialFromFavorites).toHaveBeenCalledWith(7);
+  expect(useTutorialListsStore.getState().favoriteIds).not.toContain(7);
+});
+
+test('redirects unauthenticated users to login', async () => {
+  useAuthStore.setState({ user: null });
+  const { toggleWishlist } = useTutorialListsStore.getState();
+  await toggleWishlist(1);
+  expect(Router.push).toHaveBeenCalledWith('/auth/login');
+});


### PR DESCRIPTION
## Summary
- add `tutorialListsStore` to manage tutorial wishlist and favorites with auth checks and error handling
- use shared store in landing page tutorials section and main tutorials listing
- cover wishlist/favorite add-remove flows with new unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689909bec9448328a7cd846a2a6206dc