### PR TITLE
Format tutorial price with currency display

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -13,6 +13,7 @@ import { toast } from "react-toastify";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
 import { fetchAllCategories } from "@/services/admin/categoryService";
+import { formatCurrency } from "@/utils/currency";
 
 import {
   fetchFeaturedTutorials,
@@ -310,7 +311,9 @@ const LandingTutorialsSection = () => {
                       : 'bg-green-500 text-black'
                   }`}
                 >
-                  {Number(tut.price) > 0 ? '$' + tut.price : t('free')}
+                  {Number(tut.price) > 0
+                    ? formatCurrency(tut.price, { currency: tut.currencyCode })
+                    : t('free')}
                 </span>
               </div>
 

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -8,6 +8,7 @@ import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import FilterSidebar from "@/components/tutorials/FilterSidebar";
 import { fetchPublishedTutorials } from "@/services/tutorialService";
+import { formatCurrency } from "@/utils/currency";
 
 /**
  * Retrieves enrollment status and progress percentage for a tutorial from
@@ -389,7 +390,7 @@ const TutorialsSection = () => {
                         <div className="text-sm font-medium">
                           {Number(tut.price) > 0 ? (
                             <span className="bg-gradient-to-r from-amber-500 to-yellow-500 text-transparent bg-clip-text">
-                              ${tut.price}
+                              {formatCurrency(tut.price, { currency: tut.currencyCode })}
                             </span>
                           ) : (
                             <span className="text-green-400">{t("free")}</span>

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -1,33 +1,49 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
 
-const formatTutorial = (tut) => ({
-  ...tut,
-  thumbnail:
-    tut.thumbnail_url || tut.cover_image
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${
-          tut.thumbnail_url || tut.cover_image
-        }`
+const formatTutorial = (tut) => {
+  const priceInfo =
+    tut.price && typeof tut.price === "object"
+      ? {
+          price: Number(tut.price.amount ?? 0),
+          currencyCode:
+            tut.price.currency ||
+            tut.price.currencyCode ||
+            tut.price.currency_code,
+        }
+      : {
+          price: tut.price != null ? Number(tut.price) : 0,
+          currencyCode: tut.currencyCode || tut.currency_code,
+        };
+
+  return {
+    ...tut,
+    thumbnail:
+      tut.thumbnail_url || tut.cover_image
+        ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${
+            tut.thumbnail_url || tut.cover_image
+          }`
+        : null,
+    preview: tut.preview_video
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.preview_video}`
       : null,
-  preview: tut.preview_video
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.preview_video}`
-    : null,
-  instructor: tut.instructor_name || tut.instructor,
-  instructorAvatar: tut.instructor_avatar
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.instructor_avatar}`
-    : null,
-  instructorBio: tut.instructor_bio || tut.instructorBio,
-  price: tut.price != null ? Number(tut.price) : 0,
-  rating: typeof tut.rating === "string" || typeof tut.rating === "number"
-    ? parseFloat(tut.rating)
-    : 0,
-  tags: Array.isArray(tut.tags)
-    ? tut.tags
-    : typeof tut.tags === "string"
-      ? tut.tags.split(",").map((tag) => tag.trim()).filter(Boolean)
-      : [],
-  trending: Boolean(tut.trending),
-});
+    instructor: tut.instructor_name || tut.instructor,
+    instructorAvatar: tut.instructor_avatar
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.instructor_avatar}`
+      : null,
+    instructorBio: tut.instructor_bio || tut.instructorBio,
+    ...priceInfo,
+    rating: typeof tut.rating === "string" || typeof tut.rating === "number"
+      ? parseFloat(tut.rating)
+      : 0,
+    tags: Array.isArray(tut.tags)
+      ? tut.tags
+      : typeof tut.tags === "string"
+        ? tut.tags.split(",").map((tag) => tag.trim()).filter(Boolean)
+        : [],
+    trending: Boolean(tut.trending),
+  };
+};
 
 export const fetchFeaturedTutorials = async () => {
   const res = await api.get("/users/tutorials/featured");


### PR DESCRIPTION
## Summary
- parse tutorial price objects into numeric `price` and `currencyCode`
- render formatted currency strings in tutorial listings

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689909bd324c8328a53da6ffb396b813