### PR TITLE
Handle missing tutorial prices safely

### DIFF
--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -1,7 +1,7 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
 
-const formatTutorial = (tut) => ({
+export const formatTutorial = (tut) => ({
   ...tut,
   thumbnail:
     tut.thumbnail_url || tut.cover_image
@@ -17,7 +17,10 @@ const formatTutorial = (tut) => ({
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.instructor_avatar}`
     : null,
   instructorBio: tut.instructor_bio || tut.instructorBio,
-  price: tut.price != null ? Number(tut.price) : 0,
+  price:
+    tut.price === null || tut.price === undefined
+      ? null
+      : parseFloat(tut.price),
   rating: typeof tut.rating === "string" || typeof tut.rating === "number"
     ? parseFloat(tut.rating)
     : 0,

--- a/frontend/src/tests/__tests__/tutorialService.test.js
+++ b/frontend/src/tests/__tests__/tutorialService.test.js
@@ -1,0 +1,18 @@
+import { formatTutorial } from "../../services/tutorialService";
+
+describe("formatTutorial", () => {
+  it("parses numeric price strings", () => {
+    const formatted = formatTutorial({ price: "19.99" });
+    expect(formatted.price).toBe(19.99);
+  });
+
+  it("parses numeric price numbers", () => {
+    const formatted = formatTutorial({ price: 19.99 });
+    expect(formatted.price).toBe(19.99);
+  });
+
+  it("returns null when price is absent", () => {
+    expect(formatTutorial({ price: null }).price).toBeNull();
+    expect(formatTutorial({}).price).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- return `null` for absent tutorial prices and parse numeric values with `parseFloat`
- expose `formatTutorial` and test price parsing for numbers and strings

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689909b98c988328b1a53de498b22584