### PR TITLE
feat: add cart option to tutorial card

### DIFF
--- a/frontend/src/components/tutorials/TutorialCard.js
+++ b/frontend/src/components/tutorials/TutorialCard.js
@@ -2,12 +2,28 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Star, Eye, PlayCircle } from "lucide-react";
 import Link from "next/link";
+import useCartStore from "@/store/cart/cartStore";
+import { formatCurrency } from "@/utils/currency";
 
 const DEFAULT_IMAGE =
   "https://www.classcentral.com/report/wp-content/uploads/2022/06/C-Programming-BCG-Banner.png";
 const DEFAULT_AVATAR = "https://i.pravatar.cc/40";
 
 const TutorialCard = ({ tutorial = {} }) => {
+  const addItem = useCartStore((state) => state.addItem);
+
+  const formattedPrice =
+    Number(tutorial.price) > 0 ? formatCurrency(tutorial.price) : "Free";
+
+  const handleAddToCart = async () => {
+    await addItem({
+      id: tutorial.id,
+      name: tutorial.title,
+      price: tutorial.price || 0,
+      item_type: "tutorial",
+    });
+  };
+
   return (
     <motion.div
       whileHover={{ scale: 1.03 }}
@@ -69,19 +85,29 @@ const TutorialCard = ({ tutorial = {} }) => {
           {tutorial.category || "General"} &middot; {tutorial.level || "N/A"}
         </div>
         <div className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-          {Number(tutorial.price) > 0 ? `$${tutorial.price}` : "Free"} &middot;{" "}
-          {tutorial.duration || "Unknown Duration"}
+          {formattedPrice} &middot; {tutorial.duration || "Unknown Duration"}
         </div>
 
-        {/* Explore Button */}
-        <Link href={`/tutorials/${tutorial.id || 0}`} passHref>
-          <motion.button
-            className="mt-4 w-full bg-yellow-500 hover:bg-yellow-600 text-black font-semibold py-2 px-4 rounded-full transition"
-            whileHover={{ scale: 1.03 }}
-          >
-            Explore Tutorial
-          </motion.button>
-        </Link>
+        {/* Actions */}
+        <div className="mt-4 flex gap-2">
+          <Link href={`/tutorials/${tutorial.id || 0}`} passHref>
+            <motion.button
+              className="flex-1 bg-yellow-500 hover:bg-yellow-600 text-black font-semibold py-2 px-4 rounded-full transition"
+              whileHover={{ scale: 1.03 }}
+            >
+              Explore Tutorial
+            </motion.button>
+          </Link>
+          {Number(tutorial.price) > 0 && (
+            <motion.button
+              onClick={handleAddToCart}
+              className="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-full transition"
+              whileHover={{ scale: 1.03 }}
+            >
+              Add to Cart
+            </motion.button>
+          )}
+        </div>
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- show formatted price in tutorial cards
- add "Add to Cart" action using cart store
- keep explore option for direct tutorial view

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_689909b3e4e483288b7211d4c00036f4