### PR TITLE
Use API for tutorial progress with per-user storage fallback

### DIFF
--- a/frontend/src/hooks/useTutorialProgress.js
+++ b/frontend/src/hooks/useTutorialProgress.js
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
+import useAuthStore from "@/store/auth/authStore";
 
 export default function useTutorialProgress(tutorialId, chapters = []) {
+  const userId = useAuthStore((s) => s.user?.id);
   const [progress, setProgress] = useState({
     completedChapters: [], // will now store chapter IDs
     lastIndex: 0,
@@ -9,7 +11,8 @@ export default function useTutorialProgress(tutorialId, chapters = []) {
 
   useEffect(() => {
     if (!tutorialId) return;
-    const stored = localStorage.getItem(`progress-tutorial-${tutorialId}`);
+    const key = `progress-tutorial-${userId ? `${userId}-` : ""}${tutorialId}`;
+    const stored = localStorage.getItem(key);
     if (stored) {
       try {
         const parsed = JSON.parse(stored);
@@ -26,10 +29,7 @@ export default function useTutorialProgress(tutorialId, chapters = []) {
             .filter(Boolean);
           const migrated = { ...parsed, completedChapters: ids };
           setProgress(migrated);
-          localStorage.setItem(
-            `progress-tutorial-${tutorialId}`,
-            JSON.stringify(migrated),
-          );
+          localStorage.setItem(key, JSON.stringify(migrated));
         } else {
           setProgress(parsed);
         }
@@ -37,15 +37,15 @@ export default function useTutorialProgress(tutorialId, chapters = []) {
         // ignore parse errors
       }
     }
-  }, [tutorialId, chapters]);
+  }, [tutorialId, chapters, userId]);
 
   const persist = (data) => {
     setProgress(data);
     if (tutorialId) {
-      localStorage.setItem(
-        `progress-tutorial-${tutorialId}`,
-        JSON.stringify(data),
-      );
+      const key = `progress-tutorial-${
+        userId ? `${userId}-` : ""
+      }${tutorialId}`;
+      localStorage.setItem(key, JSON.stringify(data));
     }
   };
 

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -7,22 +7,51 @@ import { useTranslation } from "next-i18next";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import FilterSidebar from "@/components/tutorials/FilterSidebar";
-import { fetchPublishedTutorials } from "@/services/tutorialService";
+import {
+  fetchPublishedTutorials,
+  fetchTutorialProgress,
+} from "@/services/tutorialService";
+import useAuthStore from "@/store/auth/authStore";
 
 /**
- * Retrieves enrollment status and progress percentage for a tutorial from
- * `localStorage`.
+ * Retrieves enrollment status and progress percentage for a tutorial.
+ * Prefers backend API data and falls back to `localStorage` if unavailable.
  * @param {Object} tut - Tutorial information containing an `id` and optional
  * chapter metadata.
- * @returns {{enrolled: boolean, progressPercent: number}}
+ * @returns {Promise<{enrolled: boolean, progressPercent: number}>}
  */
-export const loadTutorialStatus = (tut) => {
+export const loadTutorialStatus = async (tut) => {
+  const userId = useAuthStore.getState().user?.id;
   let enrolled = false;
   let progressPercent = 0;
 
+  try {
+    const apiData = await fetchTutorialProgress(tut.id);
+    if (apiData) {
+      enrolled = !!apiData.enrolled;
+      if (apiData.progressPercent != null) {
+        progressPercent = Number(apiData.progressPercent);
+      } else if (apiData.progress != null) {
+        progressPercent = Number(apiData.progress);
+      } else if (
+        apiData.completedChapters != null &&
+        apiData.totalChapters
+      ) {
+        progressPercent =
+          (apiData.completedChapters / apiData.totalChapters) * 100;
+      }
+      return { enrolled, progressPercent };
+    }
+  } catch (err) {
+    // Ignore API errors and fall back to localStorage
+  }
+
   if (typeof window !== "undefined") {
-    enrolled = !!localStorage.getItem(`enrolled-${tut.id}`);
-    const saved = localStorage.getItem(`progress-tutorial-${tut.id}`);
+    const prefix = userId ? `${userId}-` : "";
+    enrolled = !!localStorage.getItem(`enrolled-${prefix}${tut.id}`);
+    const saved = localStorage.getItem(
+      `progress-tutorial-${prefix}${tut.id}`
+    );
 
     if (saved) {
       try {
@@ -97,11 +126,13 @@ const TutorialsSection = () => {
 
   useEffect(() => {
     if (!tutorials.length) return;
-    const cache = {};
-    tutorials.forEach((t) => {
-      cache[t.id] = loadTutorialStatus(t);
-    });
-    setStatusMap(cache);
+    const loadStatuses = async () => {
+      const entries = await Promise.all(
+        tutorials.map(async (t) => [t.id, await loadTutorialStatus(t)])
+      );
+      setStatusMap(Object.fromEntries(entries));
+    };
+    loadStatuses();
   }, [tutorials]);
 
   const filteredTutorials = tutorials.filter((tut) => {

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -107,3 +107,9 @@ export const fetchTutorialAssignments = async (tutorialId) => {
   const res = await api.get(`/users/tutorials/assignments/${tutorialId}`);
   return res.data?.data ?? [];
 };
+
+// Retrieve the current user's enrollment status and progress for a tutorial
+export const fetchTutorialProgress = async (tutorialId) => {
+  const { data } = await api.get(`/users/tutorials/progress/${tutorialId}`);
+  return data?.data ?? null;
+};

--- a/frontend/src/tests/__tests__/tutorialStatus.test.js
+++ b/frontend/src/tests/__tests__/tutorialStatus.test.js
@@ -1,20 +1,40 @@
 import { loadTutorialStatus } from '@/pages/tutorials/index';
+import useAuthStore from '@/store/auth/authStore';
+import { fetchTutorialProgress } from '../../services/tutorialService';
+
+jest.mock('../../services/tutorialService', () => ({
+  fetchTutorialProgress: jest.fn(),
+}));
 
 describe('loadTutorialStatus', () => {
   beforeEach(() => {
     localStorage.clear();
+    fetchTutorialProgress.mockReset();
+    useAuthStore.setState({ user: { id: 1 } });
   });
 
-  it('reads enrollment and progress from localStorage', () => {
+  it('falls back to localStorage when API is unavailable', async () => {
     const tut = { id: 1, chapters: Array(4) };
-    localStorage.setItem('enrolled-1', 'true');
+    fetchTutorialProgress.mockRejectedValue(new Error('fail'));
+    localStorage.setItem('enrolled-1-1', 'true');
     localStorage.setItem(
-      'progress-tutorial-1',
+      'progress-tutorial-1-1',
       JSON.stringify({ completedChapters: [1, 2] })
     );
 
-    const { enrolled, progressPercent } = loadTutorialStatus(tut);
+    const { enrolled, progressPercent } = await loadTutorialStatus(tut);
     expect(enrolled).toBe(true);
     expect(progressPercent).toBeCloseTo(50);
   });
+
+  it('uses API data when available', async () => {
+    const tut = { id: 2 };
+    fetchTutorialProgress.mockResolvedValue({ enrolled: true, progress: 80 });
+
+    const res = await loadTutorialStatus(tut);
+    expect(fetchTutorialProgress).toHaveBeenCalledWith(2);
+    expect(res.enrolled).toBe(true);
+    expect(res.progressPercent).toBe(80);
+  });
 });
+


### PR DESCRIPTION
## Summary
- fetch tutorial progress and enrollment via new `fetchTutorialProgress` service
- load tutorial progress asynchronously with per-user localStorage fallback and conditional progress bar
- persist tutorial progress per user in `useTutorialProgress`

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899099de2c083289412d935a1c19b9a