### PR TITLE
fix: resolve await usage and syntax errors

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -248,7 +248,7 @@ const LandingTutorialsSection = () => {
                 </span>
               )}
               <button
-                onClick={(e) => {
+                onClick={async (e) => {
                   e.stopPropagation();
                   if (!user) return router.push('/auth/login');
                   if (!isStudent) {
@@ -279,7 +279,7 @@ const LandingTutorialsSection = () => {
               </button>
 
               <button
-                onClick={(e) => {
+                onClick={async (e) => {
                   e.stopPropagation();
                   if (!user) return router.push('/auth/login');
                   if (!isStudent) {

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -447,7 +447,7 @@ const TutorialsSection = () => {
                       </button>
 
                       {/* Progress bar */}
-                      {enrolled && (
+                      {enrolled ? (
                         <div className="absolute bottom-0 left-0 right-0 z-20 h-1.5 bg-gray-700">
                           <div
                             className="h-full bg-gradient-to-r from-yellow-500 to-amber-500"


### PR DESCRIPTION
## Summary
- allow awaiting async tutorial favorites and wishlist actions
- fix tutorial list progress bar conditional rendering

## Testing
- `npm test` (fails: useAuthStore is not defined)
- `npm run lint` (fails: Component definition is missing display name)
- `npm run build` (fails: useTutorialProgressStore is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68998c57b970832893ed1ecd4641eca5