### PR TITLE
refactor: remove alerts from user card

### DIFF
--- a/frontend/src/components/admin/users/UserCard.js
+++ b/frontend/src/components/admin/users/UserCard.js
@@ -43,7 +43,6 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
       await updateUserStatus(user.id, newStatus);
       setEnabled(!enabled);
       toast.success(`${user.name} is now ${newStatus}`);
-      alert(`${user.name} is now ${newStatus}`);
     } catch (err) {
       toast.error("Failed to update status");
       console.error("Status error:", err);
@@ -73,7 +72,6 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
       await deleteUser(user.id);
       onDelete(user.id);
       toast.success(`${user.name} deleted`);
-      alert(`${user.name} deleted`);
     } catch (err) {
       toast.error("Failed to delete user");
       console.error("Delete error:", err);

--- a/frontend/src/components/admin/users/UserCardGrid.js
+++ b/frontend/src/components/admin/users/UserCardGrid.js
@@ -30,8 +30,6 @@ export default function UserCardGrid({
     );
   }
 
-  console.log("✅ Rendering user cards:", users.map(u => u.id));
-
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       {users.map((user, idx) => {


### PR DESCRIPTION
## Summary
- clean up user card grid by dropping debug console output
- rely on toast notifications instead of blocking alerts in user card actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689995dec4b4832892a2b7d43c774122