### PR TITLE
fix: skip cart fetch for unauthenticated users

### DIFF
--- a/frontend/src/components/admin/users/UserCard.js
+++ b/frontend/src/components/admin/users/UserCard.js
@@ -43,7 +43,6 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
       await updateUserStatus(user.id, newStatus);
       setEnabled(!enabled);
       toast.success(`${user.name} is now ${newStatus}`);
-      alert(`${user.name} is now ${newStatus}`);
     } catch (err) {
       toast.error("Failed to update status");
       console.error("Status error:", err);
@@ -73,7 +72,6 @@ export default function UserCard({ user, onEdit, onDelete, isSelected, onSelect 
       await deleteUser(user.id);
       onDelete(user.id);
       toast.success(`${user.name} deleted`);
-      alert(`${user.name} deleted`);
     } catch (err) {
       toast.error("Failed to delete user");
       console.error("Delete error:", err);

--- a/frontend/src/components/admin/users/UserCardGrid.js
+++ b/frontend/src/components/admin/users/UserCardGrid.js
@@ -30,8 +30,6 @@ export default function UserCardGrid({
     );
   }
 
-  console.log("✅ Rendering user cards:", users.map(u => u.id));
-
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       {users.map((user, idx) => {

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -66,7 +66,7 @@ const Navbar = () => {
   const router = useRouter();
   const userRole = user?.role?.toLowerCase();
 
-  const { items: cartItems, fetchCart } = useCartStore();
+  const { items: cartItems, fetchCart, clearCart } = useCartStore();
 
   const notifications = useNotificationStore((state) => state.items);
   const fetchNotifications = useNotificationStore((state) => state.fetch);
@@ -147,8 +147,12 @@ const Navbar = () => {
   }, []);
 
   useEffect(() => {
-    fetchCart();
-  }, [user, fetchCart]);
+    if (user) {
+      fetchCart();
+    } else {
+      clearCart();
+    }
+  }, [user, fetchCart, clearCart]);
 
   useEffect(() => {
     if (user) {

--- a/frontend/src/pages/cart/index.js
+++ b/frontend/src/pages/cart/index.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import Navbar from "@/components/website/sections/Navbar";
 import useCartStore from "@/store/cart/cartStore";
+import useAuthStore from "@/store/auth/authStore";
 import { motion, AnimatePresence } from "framer-motion"; // ✅ Import animations
 import { FaTag, FaGift } from "react-icons/fa";
 import Link from "next/link";
@@ -15,6 +16,7 @@ const CartPage = () => {
     updateItem: updateCartItemAction,
     removeItem: removeCartItemAction,
   } = useCartStore();
+  const user = useAuthStore((state) => state.user);
   const loading = isLoading;
   const [discountCode, setDiscountCode] = useState(""); // ✅ State for Discount Code
   const [discountApplied, setDiscountApplied] = useState(false);
@@ -22,8 +24,8 @@ const CartPage = () => {
   const validDiscounts = { SAVE10: 10, "قسيمة10": 10, "DISCOUNT20": 20 }; // ✅ Support Arabic Discount Code
 
   useEffect(() => {
-    fetchCart();
-  }, [fetchCart]);
+    if (user) fetchCart();
+  }, [user, fetchCart]);
 
   // Update quantity
   const updateQuantity = (id, type) => {


### PR DESCRIPTION
## Summary
- only fetch cart data when a user is logged in, clearing the store on logout
- fetch cart on cart page only after confirming user is present

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689995dec4b4832892a2b7d43c774122