### PR TITLE
fix: normalize tutorial categories and rating rendering

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -28,6 +28,7 @@ export const getStars = (rating) => {
   const safeRating = Number.isFinite(rating)
     ? Math.min(Math.max(rating, 0), 5)
     : 0;
+  if (safeRating <= 0) return null;
   const full = Math.floor(safeRating);
   const half = safeRating % 1 >= 0.5;
   return (
@@ -163,7 +164,11 @@ const LandingTutorialsSection = () => {
   const filteredTutorials =
     activeTab === "All"
       ? tutorials
-      : tutorials.filter((t) => t.category === activeTab);
+      : tutorials.filter((t) => {
+          const categoryName =
+            t.category || t.categoryName || t.category_name;
+          return categoryName === activeTab;
+        });
 
   return (
     <section className="bg-gray-950 py-16 text-white px-4 sm:px-6">

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -30,6 +30,9 @@ export const formatTutorial = (tut) => ({
       ? tut.tags.split(",").map((tag) => tag.trim()).filter(Boolean)
       : [],
   trending: Boolean(tut.trending),
+  // Normalize category fields so components can filter reliably
+  category: tut.category || tut.category_name || tut.categoryName || null,
+  categoryId: tut.category_id || tut.categoryId || null,
 });
 
 export const fetchFeaturedTutorials = async () => {


### PR DESCRIPTION
## Summary
- normalize category fields in tutorial service for consistent filtering
- show no stars when rating is zero or invalid
- allow TutorialsSection to filter tutorials across multiple category field names

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899a33758a88328961ba49508d39306