### PR TITLE
fix: normalize tutorial price and tags

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -28,6 +28,7 @@ export const getStars = (rating) => {
   const safeRating = Number.isFinite(rating)
     ? Math.min(Math.max(rating, 0), 5)
     : 0;
+  if (safeRating <= 0) return null;
   const full = Math.floor(safeRating);
   const half = safeRating % 1 >= 0.5;
   return (
@@ -163,7 +164,11 @@ const LandingTutorialsSection = () => {
   const filteredTutorials =
     activeTab === "All"
       ? tutorials
-      : tutorials.filter((t) => t.category === activeTab);
+      : tutorials.filter((t) => {
+          const categoryName =
+            t.category || t.categoryName || t.category_name;
+          return categoryName === activeTab;
+        });
 
   return (
     <section className="bg-gray-950 py-16 text-white px-4 sm:px-6">
@@ -340,10 +345,14 @@ const LandingTutorialsSection = () => {
                   </div>
 
                   <div className="flex justify-between items-center mt-4 text-sm">
-                    <div className="flex items-center gap-1 text-yellow-400">
-                      {getStars(tut.rating)}
-                      <span className="text-gray-400 ml-1">({tut.ratingCount || 0})</span>
-                    </div>
+                    {tut.rating > 0 && (
+                      <div className="flex items-center gap-1 text-yellow-400">
+                        {getStars(tut.rating)}
+                        {tut.ratingCount > 0 && (
+                          <span className="text-gray-400 ml-1">({tut.ratingCount})</span>
+                        )}
+                      </div>
+                    )}
                     <div className="flex items-center gap-1 text-gray-400">
                       <FaClock size={12} /> {tut.duration}
                     </div>
@@ -352,14 +361,27 @@ const LandingTutorialsSection = () => {
                   <div className="mt-3 flex justify-between items-center">
                     <span
                       className={`px-3 py-1 rounded-full text-sm font-semibold ${
-                        Number(tut.price) > 0
+                        Number(tut.discountPrice ?? tut.price) > 0
                           ? 'bg-yellow-500 text-black'
                           : 'bg-green-500 text-black'
                       }`}
                     >
-                      {Number(tut.price) > 0
-                        ? formatCurrency(tut.price, { currency: tut.currencyCode })
-                        : t('free')}
+                      {Number(tut.discountPrice ?? tut.price) > 0 ? (
+                        tut.discountPrice && Number(tut.discountPrice) < Number(tut.price) ? (
+                          <>
+                            <span className="line-through mr-1">
+                              {formatCurrency(tut.price, { currency: tut.currency })}
+                            </span>
+                            <span>
+                              {formatCurrency(tut.discountPrice, { currency: tut.currency })}
+                            </span>
+                          </>
+                        ) : (
+                          formatCurrency(tut.price, { currency: tut.currency })
+                        )
+                      ) : (
+                        t('free')
+                      )}
                     </span>
                     
                     {enrolledIds.includes(tut.id) && (
@@ -411,6 +433,7 @@ const LandingTutorialsSection = () => {
                             name: tut.title,
                             item_type: 'tutorial',
                             price: tut.price || 0,
+                            quantity: 1,
                           });
                           toast.success('Added to cart');
                         } catch (err) {

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -1,36 +1,73 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
 
-export const formatTutorial = (tut) => ({
-  ...tut,
-  thumbnail:
-    tut.thumbnail_url || tut.cover_image
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${
-          tut.thumbnail_url || tut.cover_image
-        }`
-      : null,
-  preview: tut.preview_video
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.preview_video}`
-    : null,
-  instructor: tut.instructor_name || tut.instructor,
-  instructorAvatar: tut.instructor_avatar
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${tut.instructor_avatar}`
-    : null,
-  instructorBio: tut.instructor_bio || tut.instructorBio,
-  price:
-    tut.price === null || tut.price === undefined
-      ? null
-      : parseFloat(tut.price),
-  rating: typeof tut.rating === "string" || typeof tut.rating === "number"
-    ? parseFloat(tut.rating)
-    : 0,
-  tags: Array.isArray(tut.tags)
+export const formatTutorial = (tut) => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+  const thumbnailPath = tut.thumbnail_url || tut.cover_image;
+  const previewPath = tut.preview_video;
+
+  const rawPrice =
+    tut.price ??
+    tut.originalPrice ??
+    tut.original_price ??
+    tut.cost ??
+    null;
+
+  const rawDiscount = tut.discountPrice ?? tut.discount_price ?? null;
+
+  const currency =
+    tut.currency || tut.currency_code || tut.currencyCode || undefined;
+
+  const tagArray = Array.isArray(tut.tags)
     ? tut.tags
+        .map((tag) =>
+          typeof tag === "string" ? tag : tag.name || tag.slug || tag.tag_name
+        )
+        .filter(Boolean)
     : typeof tut.tags === "string"
-      ? tut.tags.split(",").map((tag) => tag.trim()).filter(Boolean)
-      : [],
-  trending: Boolean(tut.trending),
-});
+      ? tut.tags
+          .split(",")
+          .map((tag) => tag.trim())
+          .filter(Boolean)
+      : Array.isArray(tut.tag_list || tut.tagList || tut.tutorial_tags)
+        ? (tut.tag_list || tut.tagList || tut.tutorial_tags)
+            .map((tag) =>
+              typeof tag === "string" ? tag : tag.name || tag.slug || tag.tag_name
+            )
+            .filter(Boolean)
+        : [];
+
+  const rating =
+    typeof tut.rating === "string" || typeof tut.rating === "number"
+      ? parseFloat(tut.rating)
+      : 0;
+
+  const ratingCount = parseInt(
+    tut.ratingCount ?? tut.rating_count ?? tut.reviews_count ?? 0,
+    10,
+  );
+
+  return {
+    ...tut,
+    thumbnail: thumbnailPath ? `${baseUrl}${thumbnailPath}` : null,
+    preview: previewPath ? `${baseUrl}${previewPath}` : null,
+    instructor: tut.instructor_name || tut.instructor,
+    instructorAvatar: tut.instructor_avatar
+      ? `${baseUrl}${tut.instructor_avatar}`
+      : null,
+    instructorBio: tut.instructor_bio || tut.instructorBio,
+    price: rawPrice == null ? null : parseFloat(rawPrice),
+    discountPrice: rawDiscount == null ? null : parseFloat(rawDiscount),
+    currency,
+    rating,
+    ratingCount,
+    tags: tagArray,
+    trending: Boolean(tut.trending),
+    // Normalize category fields so components can filter reliably
+    category: tut.category || tut.category_name || tut.categoryName || null,
+    categoryId: tut.category_id || tut.categoryId || null,
+  };
+};
 
 export const fetchFeaturedTutorials = async () => {
   const res = await api.get("/users/tutorials/featured");


### PR DESCRIPTION
## Summary
- normalize price, currency, tag, and rating data from tutorial API
- handle discount pricing and hide zero ratings in TutorialsSection
- ensure add-to-cart sends quantity

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a33758a88328961ba49508d39306