### PR TITLE
Use category IDs for tutorial filtering

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -165,9 +165,8 @@ const LandingTutorialsSection = () => {
     activeTab === "All"
       ? tutorials
       : tutorials.filter((t) => {
-          const categoryName =
-            t.category || t.categoryName || t.category_name;
-          return categoryName === activeTab;
+          const id = t.categoryId ?? t.category_id;
+          return id === activeTab;
         });
 
   return (
@@ -188,7 +187,10 @@ const LandingTutorialsSection = () => {
 
         {/* Category Tabs */}
         <div className="flex justify-center gap-2 sm:gap-4 mb-8 overflow-x-auto pb-2 px-2">
-          {[{ label: "All", value: "All" }, ...categories.map((c) => ({ label: c.name, value: c.name }))].map((tab) => (
+          {[
+            { label: "All", value: "All" },
+            ...categories.map((c) => ({ label: c.name, value: c.id })),
+          ].map((tab) => (
             <button
               key={tab.value}
               className={`flex-shrink-0 px-4 py-2 rounded-full border transition-colors ${

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -64,8 +64,19 @@ export const formatTutorial = (tut) => {
     tags: tagArray,
     trending: Boolean(tut.trending),
     // Normalize category fields so components can filter reliably
+    categoryId: (() => {
+      const id =
+        tut.category_id != null
+          ? tut.category_id
+          : tut.categoryId != null
+            ? tut.categoryId
+            : null;
+      return id != null ? Number(id) : null;
+    })(),
+    categoryName:
+      tut.category || tut.category_name || tut.categoryName || null,
+    // Keep legacy `category` field for backward compatibility
     category: tut.category || tut.category_name || tut.categoryName || null,
-    categoryId: tut.category_id || tut.categoryId || null,
   };
 };
 


### PR DESCRIPTION
## Summary
- Map featured tutorial categories to `{label, id}` pairs
- Normalize tutorial categories to expose both `categoryId` and `categoryName`
- Filter homepage tutorials by category ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899abe125348328b2688e5d993ea15f