### PR TITLE
Use discount price when adding tutorials to cart

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -428,12 +428,22 @@ const LandingTutorialsSection = () => {
                           return;
                         }
                         try {
+                          const price = tut.discountPrice ?? tut.price;
+                          if (price == null) {
+                            console.error(
+                              `Cannot add tutorial ${tut.id} to cart: missing price`,
+                            );
+                            return;
+                          }
                           await addItem({
                             id: tut.id,
                             name: tut.title,
                             item_type: 'tutorial',
-                            price: tut.price || 0,
+                            price,
                             quantity: 1,
+                            ...(tut.currency || tut.currencyCode
+                              ? { currency: tut.currency || tut.currencyCode }
+                              : {}),
                           });
                           toast.success('Added to cart');
                         } catch (err) {

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -539,11 +539,21 @@ const TutorialsSection = () => {
                             className="px-2 py-1 text-xs rounded bg-yellow-500 text-black hover:bg-yellow-400"
                             onClick={(e) => {
                               e.stopPropagation();
+                              const price = tut.discountPrice ?? tut.price;
+                              if (price == null) {
+                                console.error(
+                                  `Cannot add tutorial ${tut.id} to cart: missing price`,
+                                );
+                                return;
+                              }
                               addItem({
                                 id: tut.id,
                                 name: tut.title,
                                 item_type: "tutorial",
-                                price: tut.price || 0,
+                                price,
+                                ...(tut.currency || tut.currencyCode
+                                  ? { currency: tut.currency || tut.currencyCode }
+                                  : {}),
                               });
                             }}
                           >


### PR DESCRIPTION
## Summary
- use `tut.discountPrice ?? tut.price` for tutorial cart items
- include `currency` and guard against missing price when adding tutorials to cart

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6899abf3952c83289a66e4f655604cd4