### PR TITLE
Use joinUrl helper for tutorial asset URLs

### DIFF
--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -1,5 +1,6 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
+import { joinUrl } from "@/utils/url";
 
 export const formatTutorial = (tut) => {
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
@@ -49,11 +50,11 @@ export const formatTutorial = (tut) => {
 
   return {
     ...tut,
-    thumbnail: thumbnailPath ? `${baseUrl}${thumbnailPath}` : null,
-    preview: previewPath ? `${baseUrl}${previewPath}` : null,
+    thumbnail: thumbnailPath ? joinUrl(baseUrl, thumbnailPath) : null,
+    preview: previewPath ? joinUrl(baseUrl, previewPath) : null,
     instructor: tut.instructor_name || tut.instructor,
     instructorAvatar: tut.instructor_avatar
-      ? `${baseUrl}${tut.instructor_avatar}`
+      ? joinUrl(baseUrl, tut.instructor_avatar)
       : null,
     instructorBio: tut.instructor_bio || tut.instructorBio,
     price: rawPrice == null ? null : parseFloat(rawPrice),

--- a/frontend/src/tests/__tests__/tutorialService.test.js
+++ b/frontend/src/tests/__tests__/tutorialService.test.js
@@ -15,4 +15,40 @@ describe("formatTutorial", () => {
     expect(formatTutorial({ price: null }).price).toBeNull();
     expect(formatTutorial({}).price).toBeNull();
   });
+
+  describe("URL joining", () => {
+    const base = "https://api.example.com";
+
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_API_BASE_URL = base;
+    });
+
+    afterEach(() => {
+      delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    });
+
+    it("handles asset paths with leading slashes", () => {
+      const formatted = formatTutorial({
+        thumbnail_url: "/img.png",
+        preview_video: "/preview.mp4",
+        instructor_avatar: "/avatar.png",
+      });
+
+      expect(formatted.thumbnail).toBe(`${base}/img.png`);
+      expect(formatted.preview).toBe(`${base}/preview.mp4`);
+      expect(formatted.instructorAvatar).toBe(`${base}/avatar.png`);
+    });
+
+    it("handles asset paths without leading slashes", () => {
+      const formatted = formatTutorial({
+        thumbnail_url: "img.png",
+        preview_video: "preview.mp4",
+        instructor_avatar: "avatar.png",
+      });
+
+      expect(formatted.thumbnail).toBe(`${base}/img.png`);
+      expect(formatted.preview).toBe(`${base}/preview.mp4`);
+      expect(formatted.instructorAvatar).toBe(`${base}/avatar.png`);
+    });
+  });
 });

--- a/frontend/src/utils/url.js
+++ b/frontend/src/utils/url.js
@@ -1,3 +1,7 @@
 export function safeEncodeURI(url) {
   return encodeURI(url).replace(/#/g, '%23');
 }
+
+export function joinUrl(base, path) {
+  return new URL(path, base).href;
+}


### PR DESCRIPTION
## Summary
- add `joinUrl` helper to safely combine base and path
- use `joinUrl` for tutorial thumbnails, previews, and instructor avatars
- test URL joining with and without leading slashes

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899abfaeb388328a4e09d0cf5052570