### PR TITLE
refactor: centralize data extraction utility

### DIFF
--- a/frontend/src/services/api/helpers.js
+++ b/frontend/src/services/api/helpers.js
@@ -1,0 +1,3 @@
+// Normalize API responses by always returning the payload array or object.
+// Falls back to an empty array when no data is available.
+export const extractData = (res) => res?.data?.data ?? res?.data ?? [];

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -1,4 +1,5 @@
 import api from "@/services/api/api";
+import { extractData } from "@/services/api/helpers";
 import { API_BASE_URL } from "@/config/config";
 import { safeEncodeURI } from "@/utils/url";
 
@@ -42,13 +43,13 @@ const formatEnrolledClass = (cls) => {
 };
 
 export const fetchPublishedClasses = async () => {
-  const { data } = await api.get("/users/classes");
-  const list = data?.data ?? [];
+  const res = await api.get("/users/classes");
+  const list = extractData(res);
   const formatted = list.map((cls) => ({
     ...formatClass(cls),
     trending: Boolean(cls.trending),
   }));
-  return { ...data, data: formatted };
+  return { ...res.data, data: formatted };
 };
 
 export const fetchClassDetails = async (id) => {
@@ -69,8 +70,8 @@ export const markClassCompleted = async (id) => {
 
 export const fetchMyEnrolledClasses = async () => {
   try {
-    const { data } = await api.get("/users/classes/enroll/my");
-    const list = data?.data ?? [];
+    const res = await api.get("/users/classes/enroll/my");
+    const list = extractData(res);
     return list.map(formatEnrolledClass);
   } catch (err) {
     if (err.response && [401, 403].includes(err.response.status)) {
@@ -81,13 +82,13 @@ export const fetchMyEnrolledClasses = async () => {
 };
 
 export const fetchClassLessons = async (classId) => {
-  const { data } = await api.get(`/users/classes/lessons/class/${classId}`);
-  return data?.data ?? [];
+  const res = await api.get(`/users/classes/lessons/class/${classId}`);
+  return extractData(res);
 };
 
 export const fetchClassAssignments = async (classId) => {
-  const { data } = await api.get(`/users/classes/assignments/class/${classId}`);
-  return data?.data ?? [];
+  const res = await api.get(`/users/classes/assignments/class/${classId}`);
+  return extractData(res);
 };
 
 export const fetchMyClassAssignments = async () => {
@@ -127,8 +128,8 @@ export const removeClassFromWishlist = async (id) => {
 
 export const getMyClassWishlist = async () => {
   try {
-    const { data } = await api.get('/users/classes/wishlist/my');
-    return data?.data ?? [];
+    const res = await api.get('/users/classes/wishlist/my');
+    return extractData(res);
   } catch (err) {
     if (err.response && [401, 403].includes(err.response.status)) {
       return [];
@@ -149,8 +150,8 @@ export const unlikeClass = async (id) => {
 
 export const getMyLikedClasses = async () => {
   try {
-    const { data } = await api.get('/users/classes/likes/my');
-    return data?.data ?? [];
+    const res = await api.get('/users/classes/likes/my');
+    return extractData(res);
   } catch (err) {
     if (err.response && [401, 403].includes(err.response.status)) {
       return [];
@@ -160,8 +161,8 @@ export const getMyLikedClasses = async () => {
 };
 
 export const fetchClassReviews = async (classId) => {
-  const { data } = await api.get(`/users/classes/reviews/${classId}`);
-  return data?.data ?? [];
+  const res = await api.get(`/users/classes/reviews/${classId}`);
+  return extractData(res);
 };
 
 export const submitClassReview = async (classId, payload) => {
@@ -170,8 +171,8 @@ export const submitClassReview = async (classId, payload) => {
 };
 
 export const fetchClassComments = async (classId) => {
-  const { data } = await api.get(`/users/classes/comments/${classId}`);
-  return data?.data ?? [];
+  const res = await api.get(`/users/classes/comments/${classId}`);
+  return extractData(res);
 };
 
 export const postClassComment = async (classId, payload) => {

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -1,4 +1,5 @@
 import api from "@/services/api/api";
+import { extractData } from "@/services/api/helpers";
 import { API_BASE_URL } from "@/config/config";
 
 export const formatTutorial = (tut) => {
@@ -71,13 +72,13 @@ export const formatTutorial = (tut) => {
 
 export const fetchFeaturedTutorials = async () => {
   const res = await api.get("/users/tutorials/featured");
-  const list = res.data?.data ?? res.data ?? [];
+  const list = extractData(res);
   return Array.isArray(list) ? list.map(formatTutorial) : list;
 };
 
 export const fetchPublishedTutorials = async () => {
   const res = await api.get("/users/tutorials");
-  const list = res.data?.data ?? res.data ?? [];
+  const list = extractData(res);
   return Array.isArray(list) ? list.map(formatTutorial) : list;
 };
 
@@ -94,8 +95,8 @@ export const enrollInTutorial = async (tutorialId) => {
 
 export const getMyEnrolledTutorials = async () => {
   try {
-    const { data } = await api.get('/users/tutorials/enroll/my');
-    const list = data?.data ?? [];
+    const res = await api.get('/users/tutorials/enroll/my');
+    const list = extractData(res);
     return list.map(formatTutorial);
   } catch (err) {
     if (err.response && [401, 403].includes(err.response.status)) {
@@ -132,8 +133,8 @@ export const removeTutorialFromWishlist = async (id) => {
 };
 
 export const getMyTutorialWishlist = async () => {
-  const { data } = await api.get('/users/tutorials/wishlist/my');
-  return data?.data ?? [];
+  const res = await api.get('/users/tutorials/wishlist/my');
+  return extractData(res);
 };
 
 export const addTutorialToFavorites = async (id) => {
@@ -147,13 +148,13 @@ export const removeTutorialFromFavorites = async (id) => {
 };
 
 export const getMyTutorialFavorites = async () => {
-  const { data } = await api.get('/users/tutorials/favorites/my');
-  return data?.data ?? [];
+  const res = await api.get('/users/tutorials/favorites/my');
+  return extractData(res);
 };
 
 export const fetchTutorialReviews = async (tutorialId) => {
-  const { data } = await api.get(`/users/tutorials/reviews/${tutorialId}`);
-  return data?.data ?? [];
+  const res = await api.get(`/users/tutorials/reviews/${tutorialId}`);
+  return extractData(res);
 };
 
 export const submitTutorialReview = async (tutorialId, payload) => {
@@ -162,8 +163,8 @@ export const submitTutorialReview = async (tutorialId, payload) => {
 };
 
 export const fetchTutorialComments = async (tutorialId) => {
-  const { data } = await api.get(`/users/tutorials/comments/${tutorialId}`);
-  return data?.data ?? [];
+  const res = await api.get(`/users/tutorials/comments/${tutorialId}`);
+  return extractData(res);
 };
 
 export const postTutorialComment = async (tutorialId, payload) => {
@@ -174,7 +175,7 @@ export const postTutorialComment = async (tutorialId, payload) => {
 // Fetch assignments linked to a tutorial
 export const fetchTutorialAssignments = async (tutorialId) => {
   const res = await api.get(`/users/tutorials/assignments/${tutorialId}`);
-  return res.data?.data ?? [];
+  return extractData(res);
 };
 
 // Retrieve the current user's enrollment status and progress for a tutorial

--- a/frontend/src/tests/__tests__/tutorialService.test.js
+++ b/frontend/src/tests/__tests__/tutorialService.test.js
@@ -1,4 +1,5 @@
 import { formatTutorial } from "../../services/tutorialService";
+import { extractData } from "../../services/api/helpers";
 
 describe("formatTutorial", () => {
   it("parses numeric price strings", () => {
@@ -14,5 +15,19 @@ describe("formatTutorial", () => {
   it("returns null when price is absent", () => {
     expect(formatTutorial({ price: null }).price).toBeNull();
     expect(formatTutorial({}).price).toBeNull();
+  });
+});
+
+describe("extractData", () => {
+  it("prefers nested data", () => {
+    expect(extractData({ data: { data: [1, 2] } })).toEqual([1, 2]);
+  });
+
+  it("falls back to top-level data", () => {
+    expect(extractData({ data: [3] })).toEqual([3]);
+  });
+
+  it("defaults to empty array", () => {
+    expect(extractData({})).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- add `extractData` helper to normalize API responses
- use helper in tutorial and class services to remove repeated `res.data?.data` checks
- cover helper with unit tests

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899abfc93288328b8f5b22753191a03