### PR TITLE
Translate enrollment messages and labels

### DIFF
--- a/frontend/public/locales/ar/website.json
+++ b/frontend/public/locales/ar/website.json
@@ -165,5 +165,18 @@
   "by_author": "by {{author}}",
   "network_error": "خطأ في الشبكة: يرجى التحقق من API_BASE_URL وخادم الخلفية.",
   "tutorials_load_error": "فشل تحميل الدروس.",
-  "categories_load_error": "فشل تحميل الفئات."
+  "categories_load_error": "فشل تحميل الفئات.",
+  "enrolled": "مسجل",
+  "progress": "التقدم",
+  "only_students_save_tutorials": "يمكن للطلاب فقط حفظ الدروس.",
+  "removed_from_favorites": "تمت الإزالة من المفضلة",
+  "added_to_favorites": "تمت الإضافة إلى المفضلة",
+  "failed_to_update_favorites": "فشل تحديث المفضلة",
+  "removed_from_wishlist": "تمت الإزالة من قائمة الرغبات",
+  "failed_to_update_wishlist": "فشل تحديث قائمة الرغبات",
+  "login_or_register_to_enroll": "يرجى تسجيل الدخول أو التسجيل للالتحاق.",
+  "only_students_enroll": "يمكن للطلاب فقط الالتحاق بالفصول.",
+  "already_enrolled_class": "أنت مسجل بالفعل في هذه الحصة",
+  "failed_to_add_to_cart": "فشل الإضافة إلى السلة",
+  "failed_to_enroll": "فشل التسجيل"
  }

--- a/frontend/public/locales/de/website.json
+++ b/frontend/public/locales/de/website.json
@@ -165,5 +165,18 @@
   "by_author": "by {{author}}",
   "network_error": "Netzwerkfehler: Bitte API_BASE_URL und Backend-Server prüfen.",
   "tutorials_load_error": "Laden der Tutorials fehlgeschlagen.",
-  "categories_load_error": "Laden der Kategorien fehlgeschlagen."
+  "categories_load_error": "Laden der Kategorien fehlgeschlagen.",
+  "enrolled": "Eingeschrieben",
+  "progress": "Fortschritt",
+  "only_students_save_tutorials": "Nur Schüler können Tutorials speichern.",
+  "removed_from_favorites": "Aus Favoriten entfernt",
+  "added_to_favorites": "Zu Favoriten hinzugefügt",
+  "failed_to_update_favorites": "Favoriten konnten nicht aktualisiert werden",
+  "removed_from_wishlist": "Von der Wunschliste entfernt",
+  "failed_to_update_wishlist": "Wunschliste konnte nicht aktualisiert werden",
+  "login_or_register_to_enroll": "Bitte einloggen oder registrieren, um sich einzuschreiben.",
+  "only_students_enroll": "Nur Studenten können sich für Kurse einschreiben.",
+  "already_enrolled_class": "Du bist bereits in diesem Kurs eingeschrieben",
+  "failed_to_add_to_cart": "Zum Warenkorb hinzufügen fehlgeschlagen",
+  "failed_to_enroll": "Einschreibung fehlgeschlagen"
  }

--- a/frontend/public/locales/en/website.json
+++ b/frontend/public/locales/en/website.json
@@ -165,6 +165,18 @@
   "by_author": "by {{author}}",
   "network_error": "Network error: please check API_BASE_URL and backend server.",
   "tutorials_load_error": "Failed to load tutorials.",
-  "categories_load_error": "Failed to load categories."
-
+  "categories_load_error": "Failed to load categories.",
+  "enrolled": "Enrolled",
+  "progress": "Progress",
+  "only_students_save_tutorials": "Only students can save tutorials.",
+  "removed_from_favorites": "Removed from favorites",
+  "added_to_favorites": "Added to favorites",
+  "failed_to_update_favorites": "Failed to update favorites",
+  "removed_from_wishlist": "Removed from wishlist",
+  "failed_to_update_wishlist": "Failed to update wishlist",
+  "login_or_register_to_enroll": "Please log in or register to enroll.",
+  "only_students_enroll": "Only students can enroll in classes.",
+  "already_enrolled_class": "You are already enrolled in this class",
+  "failed_to_add_to_cart": "Failed to add to cart",
+  "failed_to_enroll": "Failed to enroll"
 }

--- a/frontend/public/locales/es/website.json
+++ b/frontend/public/locales/es/website.json
@@ -165,5 +165,18 @@
   "by_author": "by {{author}}",
   "network_error": "Error de red: verifique API_BASE_URL y el servidor backend.",
   "tutorials_load_error": "No se pudieron cargar los tutoriales.",
-  "categories_load_error": "No se pudieron cargar las categorías."
+  "categories_load_error": "No se pudieron cargar las categorías.",
+  "enrolled": "Inscrito",
+  "progress": "Progreso",
+  "only_students_save_tutorials": "Solo los estudiantes pueden guardar tutoriales.",
+  "removed_from_favorites": "Eliminado de favoritos",
+  "added_to_favorites": "Agregado a favoritos",
+  "failed_to_update_favorites": "Error al actualizar favoritos",
+  "removed_from_wishlist": "Eliminado de la lista de deseos",
+  "failed_to_update_wishlist": "Error al actualizar la lista de deseos",
+  "login_or_register_to_enroll": "Por favor, inicia sesión o regístrate para inscribirte.",
+  "only_students_enroll": "Solo los estudiantes pueden inscribirse en clases.",
+  "already_enrolled_class": "Ya estás inscrito en esta clase",
+  "failed_to_add_to_cart": "Error al agregar al carrito",
+  "failed_to_enroll": "Error al inscribirse"
  }

--- a/frontend/public/locales/fr/website.json
+++ b/frontend/public/locales/fr/website.json
@@ -165,5 +165,18 @@
   "by_author": "by {{author}}",
   "network_error": "Erreur réseau : veuillez vérifier API_BASE_URL et le serveur backend.",
   "tutorials_load_error": "Échec du chargement des tutoriels.",
-  "categories_load_error": "Échec du chargement des catégories."
+  "categories_load_error": "Échec du chargement des catégories.",
+  "enrolled": "Inscrit",
+  "progress": "Progression",
+  "only_students_save_tutorials": "Seuls les étudiants peuvent enregistrer des tutoriels.",
+  "removed_from_favorites": "Supprimé des favoris",
+  "added_to_favorites": "Ajouté aux favoris",
+  "failed_to_update_favorites": "Échec de la mise à jour des favoris",
+  "removed_from_wishlist": "Retiré de la liste de souhaits",
+  "failed_to_update_wishlist": "Échec de la mise à jour de la liste de souhaits",
+  "login_or_register_to_enroll": "Veuillez vous connecter ou vous inscrire pour vous inscrire.",
+  "only_students_enroll": "Seuls les étudiants peuvent s'inscrire aux cours.",
+  "already_enrolled_class": "Vous êtes déjà inscrit à cette classe",
+  "failed_to_add_to_cart": "Échec de l'ajout au panier",
+  "failed_to_enroll": "Échec de l'inscription"
  }

--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -79,8 +79,8 @@ const LandingTutorialsSection = () => {
           const err = tutorialRes.error;
           const msg =
             err.code === "ERR_NETWORK"
-              ? "Network error: please check API_BASE_URL and backend server."
-              : "Failed to load tutorials";
+              ? t('network_error')
+              : t('tutorials_load_error');
           toast.error(msg);
         } else {
           setTutorials(tutorialRes || []);
@@ -90,10 +90,10 @@ const LandingTutorialsSection = () => {
           const err = categoryRes.error;
           const msg =
             err.code === "ERR_NETWORK"
-              ? "Network error: please check API_BASE_URL and backend server."
-              : "Failed to load categories";
+              ? t('network_error')
+              : t('categories_load_error');
           toast.error(msg);
-          console.error("Failed to load categories", err);
+          console.error(t('categories_load_error'), err);
         } else {
           setCategories(categoryRes?.data || categoryRes || []);
         }
@@ -256,7 +256,7 @@ const LandingTutorialsSection = () => {
                         e.stopPropagation();
                         if (!user) return router.push('/auth/login');
                         if (!isStudent) {
-                          toast.error('Only students can save tutorials.');
+                          toast.error(t('only_students_save_tutorials'));
                           return;
                         }
                         try {
@@ -264,15 +264,15 @@ const LandingTutorialsSection = () => {
                             await removeTutorialFromFavorites(tut.id);
                             const updated = await getMyTutorialFavorites();
                             setFavoriteIds(updated.map((t) => t.id));
-                            toast.success('Removed from favorites');
+                            toast.success(t('removed_from_favorites'));
                           } else {
                             await addTutorialToFavorites(tut.id);
                             const updated = await getMyTutorialFavorites();
                             setFavoriteIds(updated.map((t) => t.id));
-                            toast.success('Added to favorites');
+                            toast.success(t('added_to_favorites'));
                           }
                         } catch (err) {
-                          const message = err?.response?.data?.message || 'Failed to update favorites';
+                          const message = err?.response?.data?.message || t('failed_to_update_favorites');
                           toast.error(message);
                         }
                       }}
@@ -287,7 +287,7 @@ const LandingTutorialsSection = () => {
                         e.stopPropagation();
                         if (!user) return router.push('/auth/login');
                         if (!isStudent) {
-                          toast.error('Only students can save tutorials.');
+                          toast.error(t('only_students_save_tutorials'));
                           return;
                         }
                         try {
@@ -295,7 +295,7 @@ const LandingTutorialsSection = () => {
                             await removeTutorialFromWishlist(tut.id);
                             const updated = await getMyTutorialWishlist();
                             setWishlistIds(updated.map((t) => t.id));
-                            toast.success('Removed from wishlist');
+                            toast.success(t('removed_from_wishlist'));
                           } else {
                             await addTutorialToWishlist(tut.id);
                             const updated = await getMyTutorialWishlist();
@@ -303,7 +303,7 @@ const LandingTutorialsSection = () => {
                             toast.success(t('added_to_wishlist'));
                           }
                         } catch (err) {
-                          const message = err?.response?.data?.message || 'Failed to update wishlist';
+                          const message = err?.response?.data?.message || t('failed_to_update_wishlist');
                           toast.error(message);
                         }
                       }}
@@ -386,7 +386,7 @@ const LandingTutorialsSection = () => {
                     
                     {enrolledIds.includes(tut.id) && (
                       <span className="text-xs text-green-400 font-medium">
-                        Enrolled
+                        {t('enrolled')}
                       </span>
                     )}
                   </div>
@@ -401,7 +401,7 @@ const LandingTutorialsSection = () => {
                         />
                       </div>
                       <div className="text-xs text-gray-400 mt-1 flex justify-between">
-                        <span>Progress</span>
+                        <span>{t('progress')}</span>
                         <span>{progress[tut.id] || 0}%</span>
                       </div>
                     </div>

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -17,6 +17,7 @@ import {
 import useCartStore from '@/store/cart/cartStore';
 import useAuthStore from '@/store/auth/authStore';
 import { toast } from 'react-toastify';
+import { useTranslation } from 'next-i18next';
 import ClassReviews from '@/components/online-classes/detail/ClassReviews';
 import ClassComments from '@/components/online-classes/detail/ClassComments';
 
@@ -47,6 +48,7 @@ const StatusBadge = ({ status }) => {
 export default function ClassDetailsPage() {
   const router = useRouter();
   const { id } = router.query;
+  const { t } = useTranslation(['website', 'tutorials']);
   const [classInfo, setClassInfo] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -62,12 +64,12 @@ export default function ClassDetailsPage() {
   const isStudent = user?.role?.toLowerCase() === 'student';
 
   const handleGuestRedirect = () => {
-    toast.info('Please log in or register to enroll.');
+    toast.info(t('login_or_register_to_enroll'));
     router.push('/auth/login');
   };
 
   const handleRoleBlocked = () => {
-    toast.error('Only students can enroll in classes.');
+    toast.error(t('only_students_enroll'));
   };
 
   const handleAddToCart = async () => {
@@ -80,17 +82,17 @@ export default function ClassDetailsPage() {
       return;
     }
     if (isEnrolled) {
-      toast.info('You are already enrolled in this class');
+      toast.info(t('already_enrolled_class'));
       return;
     }
 
     try {
       await addItem({ id: classInfo.id, name: classInfo.title, price: classInfo.price });
-      toast.success('Added to cart');
+      toast.success(t('added_to_cart'));
       router.push('/cart');
     } catch (err) {
       console.error('Failed to add to cart', err);
-      toast.error('Failed to add to cart');
+      toast.error(t('failed_to_add_to_cart'));
     }
   };
 
@@ -104,18 +106,18 @@ export default function ClassDetailsPage() {
       return;
     }
     if (isEnrolled) {
-      toast.info('You are already enrolled in this class');
+      toast.info(t('already_enrolled_class'));
       return;
     }
 
     if (classInfo.price === 0) {
       try {
         await enrollInClass(classInfo.id);
-        toast.success('Enrolled successfully');
+        toast.success(t('tutorials:enroll_success'));
         router.push(`/payments/success?classId=${classInfo.id}`);
       } catch (err) {
         console.error('Failed to enroll', err);
-        toast.error('Failed to enroll');
+        toast.error(t('failed_to_enroll'));
       }
     } else {
       router.push(`/payments/checkout?classId=${classInfo.id}`);
@@ -136,15 +138,15 @@ export default function ClassDetailsPage() {
       if (inWishlist) {
         await removeClassFromWishlist(classInfo.id);
         setInWishlist(false);
-        toast.success('Removed from wishlist');
+        toast.success(t('removed_from_wishlist'));
       } else {
         await addClassToWishlist(classInfo.id);
         setInWishlist(true);
-        toast.success('Added to wishlist');
+        toast.success(t('added_to_wishlist'));
       }
     } catch (err) {
       console.error('Wishlist update failed', err);
-      toast.error('Failed to update wishlist');
+      toast.error(t('failed_to_update_wishlist'));
     }
   };
 


### PR DESCRIPTION
## Summary
- localize enrollment-related toasts and status labels
- add translation keys for enrollment and progress across locales

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_6899abf94d8c83288262150501473cf1