### PR TITLE
Protect tutorial assignments access

### DIFF
--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
@@ -1,10 +1,35 @@
 const { v4: uuidv4 } = require('uuid');
 const catchAsync = require('../../../../utils/catchAsync');
 const { sendSuccess } = require('../../../../utils/response');
+const AppError = require('../../../../utils/AppError');
+const db = require('../../../../config/database');
 const service = require('./tutorialAssignment.service');
 
 exports.getAssignmentsByTutorial = catchAsync(async (req, res) => {
-  const assignments = await service.getByTutorial(req.params.tutorialId);
+  const { tutorialId } = req.params;
+  const userId = req.user.id;
+
+  // Fetch tutorial to confirm ownership/instructor
+  const tutorial = await db('tutorials')
+    .select('instructor_id')
+    .where({ id: tutorialId })
+    .first();
+
+  if (!tutorial) throw new AppError('Tutorial not found', 404);
+
+  const roles = req.user.roles || [req.user.role];
+  const normalized = roles.map((r) => r.toLowerCase().replace(/\s+/g, ''));
+  const isAdmin = normalized.some((r) => ['admin', 'superadmin'].includes(r));
+  const isInstructor = normalized.includes('instructor') && tutorial.instructor_id === userId;
+
+  if (!isAdmin && !isInstructor) {
+    const enrolled = await db('tutorial_enrollments')
+      .where({ tutorial_id: tutorialId, user_id: userId })
+      .first();
+    if (!enrolled) throw new AppError('Access denied', 403);
+  }
+
+  const assignments = await service.getByTutorial(tutorialId);
   sendSuccess(res, assignments);
 });
 

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.routes.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.routes.js
@@ -5,7 +5,7 @@ const validate = require('../../../../middleware/validate');
 const validator = require('./tutorialAssignment.validator');
 
 router.get('/admin', verifyToken, isInstructorOrAdmin, ctrl.getAllAssignments);
-router.get('/:tutorialId', ctrl.getAssignmentsByTutorial);
+router.get('/:tutorialId', verifyToken, ctrl.getAssignmentsByTutorial);
 router.post(
   '/:tutorialId',
   verifyToken,


### PR DESCRIPTION
## Summary
- Require authentication for fetching tutorial assignments
- Allow only tutorial instructor, admins, or enrolled students to view assignments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899be8d74a0832895fb41652c42f405