### PR TITLE
Ensure tutorial completion sets progress to 100

### DIFF
--- a/backend/src/modules/users/tutorials/certificate/certificate.service.js
+++ b/backend/src/modules/users/tutorials/certificate/certificate.service.js
@@ -9,7 +9,8 @@ const generateCode = () => {
 // Check if user completed the tutorial
 const isUserCompletedTutorial = async (userId, tutorialId) => {
   const enrollment = await db("tutorial_enrollments")
-    .where({ user_id: userId, tutorial_id: tutorialId, status: "completed" })
+    .where({ user_id: userId, tutorial_id: tutorialId })
+    .where("progress", 100)
     .first();
   return !!enrollment;
 };

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -93,7 +93,7 @@ exports.complete = catchAsync(async (req, res) => {
 
   await db("tutorial_enrollments")
     .where({ user_id, tutorial_id: tutorialId })
-    .update({ status: "completed" });
+    .update({ status: "completed", progress: 100 });
 
   sendSuccess(res, null, "Marked as completed");
 });

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -316,7 +316,8 @@ exports.getTutorialAnalytics = async (tutorialId) => {
     .where({ tutorial_id: tutorialId })
     .count();
   const [completedRow] = await db('tutorial_enrollments')
-    .where({ tutorial_id: tutorialId, status: 'completed' })
+    .where({ tutorial_id: tutorialId })
+    .where('progress', 100)
     .count();
   const [commentRow] = await db('tutorial_comments')
     .where({ tutorial_id: tutorialId })

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -113,3 +113,38 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
   });
 });
 
+describe('POST /api/users/tutorials/enrollments/:id/complete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('marks tutorial as completed and sets progress to 100', async () => {
+    const update = jest.fn(() => Promise.resolve());
+
+    db.mockImplementation((table) => {
+      if (table === 'tutorial_enrollments')
+        return {
+          where: () => ({ first: () => Promise.resolve({ id: 'e1' }), update }),
+        };
+      if (table === 'tutorial_chapters')
+        return {
+          where: () => ({ count: () => Promise.resolve([{ count: 1 }]) }),
+        };
+      if (table === 'tutorial_chapter_completions as tcc')
+        return {
+          join: () => ({
+            where: () => ({
+              andWhere: () => ({ count: () => Promise.resolve([{ count: 1 }]) }),
+            }),
+          }),
+        };
+      if (table === 'tutorial_quizzes')
+        return { where: () => ({ first: () => Promise.resolve(null) }) };
+    });
+
+    const res = await request(app).post('/api/users/tutorials/enrollments/t1/complete');
+    expect(res.status).toBe(200);
+    expect(update).toHaveBeenCalledWith({ status: 'completed', progress: 100 });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Update tutorial completion handler to mark progress as 100%
- Base certificate issuance and analytics on the 100% progress value
- Test completion endpoint to verify progress updates

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899be8c1ac88328badb7be5665a794c