### PR TITLE
Add progress validation for tutorial enrollment

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -140,13 +140,16 @@ exports.getStatus = catchAsync(async (req, res) => {
 // Update progress percentage for a tutorial
 exports.updateProgress = catchAsync(async (req, res) => {
   const { tutorialId } = req.params;
-  const { progress } = req.body;
+  let { progress } = req.body;
   const user_id = req.user.id;
 
   const enrollment = await db("tutorial_enrollments")
     .where({ user_id, tutorial_id: tutorialId })
     .first();
   if (!enrollment) throw new AppError("Enrollment not found", 404);
+
+  // Clamp progress to [0, 100] to ensure valid range
+  progress = Math.min(Math.max(Number(progress), 0), 100);
 
   await db("tutorial_enrollments")
     .where({ user_id, tutorial_id: tutorialId })

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.routes.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.routes.js
@@ -1,11 +1,19 @@
 const router = require("express").Router();
 const ctrl = require("./tutorialEnrollment.controller");
 const { verifyToken, isStudent } = require("../../../../middleware/auth/authMiddleware");
+const validate = require("../../../../middleware/validate");
+const validator = require("./tutorialEnrollment.validator");
 
 router.post("/:tutorialId", verifyToken, isStudent, ctrl.enroll);
 router.post("/:tutorialId/complete", verifyToken, isStudent, ctrl.complete);
 router.get("/:tutorialId/status", verifyToken, isStudent, ctrl.getStatus);
-router.patch("/:tutorialId/progress", verifyToken, isStudent, ctrl.updateProgress);
+router.patch(
+  "/:tutorialId/progress",
+  verifyToken,
+  isStudent,
+  validate(validator.updateProgress),
+  ctrl.updateProgress
+);
 router.get("/my", verifyToken, isStudent, ctrl.getMyEnrollments);
 
 module.exports = router;

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.validator.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.validator.js
@@ -1,0 +1,8 @@
+const { z } = require("zod");
+
+exports.updateProgress = {
+  body: z.object({
+    progress: z.number().min(0).max(100),
+  }),
+};
+


### PR DESCRIPTION
## Summary
- ensure tutorial progress is validated between 0 and 100
- apply validation middleware to progress update route
- clamp out-of-range progress values in controller

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899be8b604883288e1742f6c6ddc52a