### PR TITLE
refactor tutorial progress endpoints and update callers

### DIFF
--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -152,7 +152,14 @@ const LandingTutorialsSection = () => {
         return updated;
       });
       try {
-        await saveTutorialProgress(tutorialId, percent);
+        const res = await saveTutorialProgress(tutorialId, percent);
+        if (res?.progress != null && res.progress !== percent) {
+          setProgress((prev) => {
+            const updated = { ...prev, [tutorialId]: res.progress };
+            localStorage.setItem(key, JSON.stringify(updated));
+            return updated;
+          });
+        }
       } catch (err) {
         console.error('Failed to sync progress', err);
       }

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -16,29 +16,23 @@ import useAuthStore from "@/store/auth/authStore";
  * Prefers backend API data and falls back to `localStorage` if unavailable.
  * @param {Object} tut - Tutorial information containing an `id` and optional
  * chapter metadata.
- * @returns {Promise<{enrolled: boolean, progressPercent: number}>}
+ * @returns {Promise<{enrolled: boolean, status: string | null, progress: number}>}
  */
 export const loadTutorialStatus = async (tut) => {
   const userId = useAuthStore.getState().user?.id;
   let enrolled = false;
   let progressPercent = 0;
+  let status = null;
 
   try {
     const apiData = await fetchTutorialProgress(tut.id);
     if (apiData) {
       enrolled = !!apiData.enrolled;
-      if (apiData.progressPercent != null) {
-        progressPercent = Number(apiData.progressPercent);
-      } else if (apiData.progress != null) {
+      status = apiData.status ?? null;
+      if (apiData.progress != null) {
         progressPercent = Number(apiData.progress);
-      } else if (
-        apiData.completedChapters != null &&
-        apiData.totalChapters
-      ) {
-        progressPercent =
-          (apiData.completedChapters / apiData.totalChapters) * 100;
       }
-      return { enrolled, progressPercent };
+      return { enrolled, status, progress: progressPercent };
     }
   } catch (err) {
     // Ignore API errors and fall back to localStorage
@@ -64,7 +58,7 @@ export const loadTutorialStatus = async (tut) => {
     }
   }
 
-  return { enrolled, progressPercent };
+  return { enrolled, status, progress: progressPercent };
 };
 
 const TutorialsSection = () => {
@@ -331,8 +325,11 @@ const TutorialsSection = () => {
             {/* Tutorial Cards Grid */}
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
               {visibleTutorials.map((tut) => {
-                const { enrolled, progress: progressPercent = 0 } =
-                  statusMap[tut.id] || {};
+                const {
+                  enrolled,
+                  status: enrollStatus,
+                  progress: progressPercent = 0,
+                } = statusMap[tut.id] || {};
 
                 return (
                   <motion.div

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -120,11 +120,11 @@ export const getMyEnrolledTutorials = async () => {
 
 export const saveTutorialProgress = async (tutorialId, progress) => {
   try {
-    const { data } = await api.post(
-      `/users/tutorials/progress/${tutorialId}`,
+    const { data } = await api.patch(
+      `/users/tutorials/enroll/${tutorialId}/progress`,
       { progress },
     );
-    return data;
+    return data?.data ?? data;
   } catch (err) {
     // Ignore if API not supported
     if (err.response && [404, 500, 501].includes(err.response.status)) {
@@ -192,6 +192,16 @@ export const fetchTutorialAssignments = async (tutorialId) => {
 
 // Retrieve the current user's enrollment status and progress for a tutorial
 export const fetchTutorialProgress = async (tutorialId) => {
-  const { data } = await api.get(`/users/tutorials/progress/${tutorialId}`);
-  return data?.data ?? null;
+  try {
+    const { data } = await api.get(
+      `/users/tutorials/enroll/${tutorialId}/status`,
+    );
+    return data?.data ?? data ?? null;
+  } catch (err) {
+    // Ignore if API not supported
+    if (err.response && [404, 500, 501].includes(err.response.status)) {
+      return null;
+    }
+    throw err;
+  }
 };

--- a/frontend/src/store/tutorialProgressStore.js
+++ b/frontend/src/store/tutorialProgressStore.js
@@ -18,21 +18,27 @@ const useTutorialProgressStore = create((set, get) => ({
         try {
           const offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
           const progress = offline[id] || 0;
-          const data = { enrolled: false, progress };
+          const data = { enrolled: false, status: null, progress };
           set((state) => ({ status: { ...state.status, [id]: data } }));
           return data;
         } catch {}
       }
-      return { enrolled: false, progress: 0 };
+      return { enrolled: false, status: null, progress: 0 };
     }
   },
   async updateProgress(id, progress) {
     try {
-      await saveTutorialProgress(id, progress);
+      const data = await saveTutorialProgress(id, progress);
       set((state) => ({
         status: {
           ...state.status,
-          [id]: { ...(state.status[id] || {}), enrolled: true, progress },
+          [id]:
+            data || {
+              ...(state.status[id] || {}),
+              enrolled: true,
+              status: data?.status ?? state.status[id]?.status ?? null,
+              progress,
+            },
         },
       }));
       if (typeof window !== "undefined") {
@@ -60,11 +66,17 @@ const useTutorialProgressStore = create((set, get) => ({
     for (const id of ids) {
       try {
         const progress = offline[id];
-        await saveTutorialProgress(id, progress);
+        const data = await saveTutorialProgress(id, progress);
         set((state) => ({
           status: {
             ...state.status,
-            [id]: { ...(state.status[id] || {}), enrolled: true, progress },
+            [id]:
+              data || {
+                ...(state.status[id] || {}),
+                enrolled: true,
+                status: data?.status ?? state.status[id]?.status ?? null,
+                progress,
+              },
           },
         }));
         delete offline[id];

--- a/frontend/src/tests/__tests__/tutorialStatus.test.js
+++ b/frontend/src/tests/__tests__/tutorialStatus.test.js
@@ -22,19 +22,24 @@ describe('loadTutorialStatus', () => {
       JSON.stringify({ completedChapters: [1, 2] })
     );
 
-    const { enrolled, progressPercent } = await loadTutorialStatus(tut);
+    const { enrolled, progress } = await loadTutorialStatus(tut);
     expect(enrolled).toBe(true);
-    expect(progressPercent).toBeCloseTo(50);
+    expect(progress).toBeCloseTo(50);
   });
 
   it('uses API data when available', async () => {
     const tut = { id: 2 };
-    fetchTutorialProgress.mockResolvedValue({ enrolled: true, progress: 80 });
+    fetchTutorialProgress.mockResolvedValue({
+      enrolled: true,
+      status: 'in_progress',
+      progress: 80,
+    });
 
     const res = await loadTutorialStatus(tut);
     expect(fetchTutorialProgress).toHaveBeenCalledWith(2);
     expect(res.enrolled).toBe(true);
-    expect(res.progressPercent).toBe(80);
+    expect(res.status).toBe('in_progress');
+    expect(res.progress).toBe(80);
   });
 });
 


### PR DESCRIPTION
## Summary
- point tutorial progress helpers to new `/users/tutorials/enroll/:id` routes
- propagate `{enrolled,status,progress}` structure through stores and pages
- refresh tutorial status test for new API

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_6899be8a4a4083288ccdcffcabd29a5e