### PR TITLE
Protect tutorial assignments access

### DIFF
--- a/backend/src/middleware/auth/verifyTutorialAccess.js
+++ b/backend/src/middleware/auth/verifyTutorialAccess.js
@@ -1,0 +1,34 @@
+const db = require("../../config/database");
+
+const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
+
+module.exports = async function verifyTutorialAccess(req, res, next) {
+  const { tutorialId } = req.params;
+  const userId = req.user.id;
+
+  try {
+    const tutorial = await db("tutorials")
+      .select("instructor_id")
+      .where({ id: tutorialId })
+      .first();
+
+    if (!tutorial) return res.status(404).json({ message: "Tutorial not found" });
+
+    const roles = req.user.roles || [req.user.role];
+    const norm = roles.map((r) => normalizeRole(r));
+    const isAdmin = norm.some((r) => ["admin", "superadmin"].includes(r));
+    const isInstructor = norm.includes("instructor") && tutorial.instructor_id === userId;
+
+    if (!isAdmin && !isInstructor) {
+      const enrollment = await db("tutorial_enrollments")
+        .where({ tutorial_id: tutorialId, user_id: userId })
+        .first();
+      if (!enrollment) return res.status(403).json({ message: "Access denied" });
+    }
+
+    next();
+  } catch (err) {
+    console.error("Failed to verify tutorial access", err);
+    res.status(500).json({ message: "Failed to verify tutorial access" });
+  }
+};

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
@@ -4,7 +4,8 @@ const { sendSuccess } = require('../../../../utils/response');
 const service = require('./tutorialAssignment.service');
 
 exports.getAssignmentsByTutorial = catchAsync(async (req, res) => {
-  const assignments = await service.getByTutorial(req.params.tutorialId);
+  const { tutorialId } = req.params;
+  const assignments = await service.getByTutorial(tutorialId);
   sendSuccess(res, assignments);
 });
 

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.routes.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.routes.js
@@ -1,11 +1,12 @@
 const router = require('express').Router();
 const ctrl = require('./tutorialAssignment.controller');
 const { verifyToken, isInstructorOrAdmin } = require('../../../../middleware/auth/authMiddleware');
+const verifyTutorialAccess = require('../../../../middleware/auth/verifyTutorialAccess');
 const validate = require('../../../../middleware/validate');
 const validator = require('./tutorialAssignment.validator');
 
 router.get('/admin', verifyToken, isInstructorOrAdmin, ctrl.getAllAssignments);
-router.get('/:tutorialId', ctrl.getAssignmentsByTutorial);
+router.get('/:tutorialId', verifyToken, verifyTutorialAccess, ctrl.getAssignmentsByTutorial);
 router.post(
   '/:tutorialId',
   verifyToken,


### PR DESCRIPTION
## Summary
- Restrict assignment retrieval to tutorial instructor, enrolled students, or admins via new middleware
- Simplify tutorial assignment controller to rely on middleware access check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899be8d74a0832895fb41652c42f405