### PR TITLE
Protect tutorial assignments access

### DIFF
--- a/backend/src/middleware/auth/verifyTutorialAccess.js
+++ b/backend/src/middleware/auth/verifyTutorialAccess.js
@@ -1,0 +1,34 @@
+const db = require("../../config/database");
+
+const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
+
+module.exports = async function verifyTutorialAccess(req, res, next) {
+  const { tutorialId } = req.params;
+  const userId = req.user.id;
+
+  try {
+    const tutorial = await db("tutorials")
+      .select("instructor_id")
+      .where({ id: tutorialId })
+      .first();
+
+    if (!tutorial) return res.status(404).json({ message: "Tutorial not found" });
+
+    const roles = req.user.roles || [req.user.role];
+    const norm = roles.map((r) => normalizeRole(r));
+    const isAdmin = norm.some((r) => ["admin", "superadmin"].includes(r));
+    const isInstructor = norm.includes("instructor") && tutorial.instructor_id === userId;
+
+    if (!isAdmin && !isInstructor) {
+      const enrollment = await db("tutorial_enrollments")
+        .where({ tutorial_id: tutorialId, user_id: userId })
+        .first();
+      if (!enrollment) return res.status(403).json({ message: "Access denied" });
+    }
+
+    next();
+  } catch (err) {
+    console.error("Failed to verify tutorial access", err);
+    res.status(500).json({ message: "Failed to verify tutorial access" });
+  }
+};

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
@@ -4,7 +4,8 @@ const { sendSuccess } = require('../../../../utils/response');
 const service = require('./tutorialAssignment.service');
 
 exports.getAssignmentsByTutorial = catchAsync(async (req, res) => {
-  const assignments = await service.getByTutorial(req.params.tutorialId);
+  const { tutorialId } = req.params;
+  const assignments = await service.getByTutorial(tutorialId);
   sendSuccess(res, assignments);
 });
 

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.routes.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.routes.js
@@ -1,11 +1,12 @@
 const router = require('express').Router();
 const ctrl = require('./tutorialAssignment.controller');
 const { verifyToken, isInstructorOrAdmin } = require('../../../../middleware/auth/authMiddleware');
+const verifyTutorialAccess = require('../../../../middleware/auth/verifyTutorialAccess');
 const validate = require('../../../../middleware/validate');
 const validator = require('./tutorialAssignment.validator');
 
 router.get('/admin', verifyToken, isInstructorOrAdmin, ctrl.getAllAssignments);
-router.get('/:tutorialId', ctrl.getAssignmentsByTutorial);
+router.get('/:tutorialId', verifyToken, verifyTutorialAccess, ctrl.getAssignmentsByTutorial);
 router.post(
   '/:tutorialId',
   verifyToken,

--- a/frontend/src/components/tutorials/StudentTutorialCard.js
+++ b/frontend/src/components/tutorials/StudentTutorialCard.js
@@ -7,53 +7,59 @@ export default function StudentTutorialCard({ tutorial }) {
     : 0;
 
   return (
-    <div className="bg-white shadow rounded-lg p-4 space-y-2 border border-gray-200">
-      <img
-        src={tutorial.thumbnail || "/default-thumbnail.jpg"}
-        alt={tutorial.title}
-        className="w-full h-40 object-cover rounded-md"
-        loading="lazy"
-      />
-      <h2 className="text-lg font-semibold flex items-center gap-2">
-        <span className="inline-block text-xs bg-yellow-100 text-yellow-700 px-2 py-0.5 rounded-full">
+    <div className="bg-white rounded-xl shadow-md overflow-hidden border border-gray-100 hover:shadow-lg transition">
+      <div className="relative">
+        <img
+          src={tutorial.thumbnail || "/default-thumbnail.jpg"}
+          alt={tutorial.title}
+          className="w-full h-44 object-cover"
+          loading="lazy"
+        />
+        <span className="absolute top-2 left-2 text-xs bg-yellow-100 text-yellow-800 px-2 py-0.5 rounded-full">
           {tutorial.category}
         </span>
-        <FaBookOpen className="text-yellow-500" /> {tutorial.title}
-      </h2>
-      <p className="text-xs text-gray-500">Instructor: {tutorial.instructor}</p>
-      <div className="w-full bg-gray-100 h-2 rounded-full relative">
-        <div className="absolute right-1 -top-4 text-xs text-gray-500">
-          {Math.round(progressPercent)}%
+      </div>
+
+      <div className="p-4 space-y-3">
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <FaBookOpen className="text-yellow-500" /> {tutorial.title}
+        </h2>
+        <p className="text-sm text-gray-500">Instructor: {tutorial.instructor}</p>
+
+        <div className="w-full bg-gray-100 h-2 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-yellow-400"
+            style={{ width: `${progressPercent}%` }}
+          />
         </div>
-        <div
-          className="h-2 bg-yellow-400 rounded-full"
-          style={{ width: `${progressPercent}%` }}
-        />
-      </div>
-      <div className="flex justify-between text-xs text-gray-500">
-        <span>
-          {tutorial.completedLessons}/{tutorial.totalLessons} lessons
-        </span>
-        {tutorial.isCompleted ? (
-          <span className="text-green-600 flex items-center gap-1">
-            <FaCheckCircle /> Completed
+
+        <div className="flex justify-between text-xs text-gray-500">
+          <span>
+            {tutorial.completedLessons}/{tutorial.totalLessons} lessons
           </span>
-        ) : (
-          <span className="text-blue-600 flex items-center gap-1">
-            <FaPlayCircle /> In Progress
-          </span>
-        )}
+          {tutorial.isCompleted ? (
+            <span className="text-green-600 flex items-center gap-1">
+              <FaCheckCircle /> Completed
+            </span>
+          ) : (
+            <span className="text-blue-600 flex items-center gap-1">
+              <FaPlayCircle /> In Progress
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center text-xs text-gray-500 gap-1">
+          <FaStar className="text-yellow-400" />
+          {tutorial.rating?.toFixed?.(1) ?? tutorial.rating}
+        </div>
+
+        <Link
+          href={`/tutorials/${tutorial.id}`}
+          className="inline-flex items-center gap-2 text-sm mt-2 text-white bg-blue-600 hover:bg-blue-700 px-3 py-1.5 rounded-md transition-colors"
+        >
+          {tutorial.isCompleted ? "Review" : "Continue"}
+        </Link>
       </div>
-      <div className="flex items-center text-xs text-gray-500 gap-1">
-        <FaStar className="text-yellow-400" />
-        {tutorial.rating?.toFixed?.(1) ?? tutorial.rating}
-      </div>
-      <Link
-        href={`/tutorials/${tutorial.id}`}
-        className="inline-flex items-center gap-2 text-sm mt-2 text-white bg-blue-600 hover:bg-blue-700 px-3 py-1.5 rounded-md transition"
-      >
-        {tutorial.isCompleted ? "Review" : "Continue"}
-      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restrict assignment retrieval to tutorial instructor, enrolled students, or admins via new middleware
- Simplify tutorial assignment controller to rely on middleware access check
- Enhance student tutorial card styling with hover effects and cleaner layout

## Testing
- `npm test` (backend)
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_6899be8d74a0832895fb41652c42f405