### PR TITLE
fix: enable Add to Cart in tutorial card

### DIFF
--- a/frontend/src/components/tutorials/TutorialCard.js
+++ b/frontend/src/components/tutorials/TutorialCard.js
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { Star, Eye, PlayCircle } from "lucide-react";
 import Link from "next/link";
 import { formatCurrency } from "@/utils/currency";
+import useCartStore from "@/store/cart/cartStore";
 
 const DEFAULT_IMAGE =
   "https://www.classcentral.com/report/wp-content/uploads/2022/06/C-Programming-BCG-Banner.png";


### PR DESCRIPTION
## Summary
- import cart store into TutorialCard so Add to Cart works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899d041ef10832899c1aa87ea93ae04