### PR TITLE
fix: handle add to cart feedback

### DIFF
--- a/frontend/src/components/tutorials/TutorialCard.js
+++ b/frontend/src/components/tutorials/TutorialCard.js
@@ -4,6 +4,7 @@ import { Star, Eye, PlayCircle } from "lucide-react";
 import Link from "next/link";
 import { formatCurrency } from "@/utils/currency";
 import useCartStore from "@/store/cart/cartStore";
+import { toast } from "react-toastify";
 
 const DEFAULT_IMAGE =
   "https://www.classcentral.com/report/wp-content/uploads/2022/06/C-Programming-BCG-Banner.png";
@@ -16,12 +17,19 @@ const TutorialCard = ({ tutorial = {} }) => {
     Number(tutorial.price) > 0 ? formatCurrency(tutorial.price) : "Free";
 
   const handleAddToCart = async () => {
-    await addItem({
+    const success = await addItem({
       id: tutorial.id,
       name: tutorial.title,
       price: tutorial.price || 0,
       item_type: "tutorial",
+      quantity: 1,
+      ...(tutorial.currency ? { currency: tutorial.currency } : {}),
     });
+    if (success) {
+      toast.success("Added to cart");
+    } else {
+      toast.error("Failed to add to cart");
+    }
   };
 
   return (

--- a/frontend/src/store/cart/cartStore.js
+++ b/frontend/src/store/cart/cartStore.js
@@ -27,11 +27,14 @@ const useCartStore = create(
       addItem: async (item) => {
         set({ isLoading: true, error: null });
         try {
-          await apiAddToCart(item);
+          const res = await apiAddToCart(item);
+          if (!res) throw new Error("Failed to add item");
           const data = await getCartItems();
           set({ items: data, isLoading: false });
+          return true;
         } catch (err) {
           set({ error: err.message, isLoading: false });
+          return false;
         }
       },
 

--- a/frontend/src/tests/__tests__/TutorialCard.test.js
+++ b/frontend/src/tests/__tests__/TutorialCard.test.js
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import TutorialCard from '@/components/tutorials/TutorialCard';
+
+const addItem = jest.fn();
+jest.mock('../../store/cart/cartStore', () => ({
+  __esModule: true,
+  default: (selector) => selector({ addItem }),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+describe('TutorialCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds tutorial to cart with quantity and shows success toast', async () => {
+    addItem.mockResolvedValue(true);
+    const tutorial = { id: 1, title: 'Test Tutorial', price: 10 };
+    render(<TutorialCard tutorial={tutorial} />);
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+    await waitFor(() => expect(addItem).toHaveBeenCalled());
+    expect(addItem).toHaveBeenCalledWith({
+      id: 1,
+      name: 'Test Tutorial',
+      price: 10,
+      item_type: 'tutorial',
+      quantity: 1,
+    });
+    const { toast } = require('react-toastify');
+    expect(toast.success).toHaveBeenCalledWith('Added to cart');
+  });
+
+  it('shows error toast when addItem fails', async () => {
+    addItem.mockResolvedValue(false);
+    const tutorial = { id: 2, title: 'Another Tutorial', price: 5 };
+    render(<TutorialCard tutorial={tutorial} />);
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+    await waitFor(() => expect(addItem).toHaveBeenCalled());
+    const { toast } = require('react-toastify');
+    expect(toast.error).toHaveBeenCalledWith('Failed to add to cart');
+  });
+});


### PR DESCRIPTION
## Summary
- handle add-to-cart success and failures in tutorial cards
- return success status from cart store when adding items
- test cart feedback

## Testing
- `npm test`
- `npx jest --json --outputFile=/tmp/jest.json >/tmp/jest.log && tail -n 20 /tmp/jest.log`


------
https://chatgpt.com/codex/tasks/task_e_6899d331a2048328a30fa602d6e556b0