### PR TITLE
Fix pending join request count display

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -756,7 +756,8 @@
     "sort_az": "أ-ي",
     "view_group": "عرض المجموعة",
     "back_to_my_groups": "العودة إلى مجموعاتي",
-    "pending_requests": "طلب انضمام معلق",
+    "pending_requests": "{{count}} طلب انضمام معلق",
+    "pending_requests_plural": "{{count}} طلبات انضمام معلقة",
     "join_pending": "⏳ جاري موافقة طلب الانضمام",
     "joined": "✅ أنت عضو في هذه المجموعة"
   },

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -684,7 +684,8 @@
     "sort_az": "A-Z",
     "view_group": "Gruppe anzeigen",
     "back_to_my_groups": "Zurück zu meinen Gruppen",
-    "pending_requests": "ausstehende Beitrittsanfrage",
+    "pending_requests": "{{count}} ausstehende Beitrittsanfrage",
+    "pending_requests_plural": "{{count}} ausstehende Beitrittsanfragen",
     "join_pending": "⏳ Beitrittsanfrage ausstehend",
     "joined": "✅ Du bist Mitglied dieser Gruppe"
   },

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -769,7 +769,8 @@
     "sort_az": "A-Z",
     "view_group": "View Group",
     "back_to_my_groups": "Back to My Groups",
-    "pending_requests": "pending join request{{count}}",
+    "pending_requests": "{{count}} pending join request",
+    "pending_requests_plural": "{{count}} pending join requests",
     "join_pending": "⏳ Join request pending approval",
     "joined": "✅ You are a member of this group"
   },

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -684,7 +684,8 @@
     "sort_az": "A-Z",
     "view_group": "Ver grupo",
     "back_to_my_groups": "Volver a mis grupos",
-    "pending_requests": "solicitud de unión pendiente",
+    "pending_requests": "{{count}} solicitud de unión pendiente",
+    "pending_requests_plural": "{{count}} solicitudes de unión pendientes",
     "join_pending": "⏳ Solicitud de unión pendiente",
     "joined": "✅ Eres miembro de este grupo"
   },

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -696,7 +696,8 @@
     "sort_az": "A-Z",
     "view_group": "Voir le groupe",
     "back_to_my_groups": "Retour à mes groupes",
-    "pending_requests": "demande en attente",
+    "pending_requests": "{{count}} demande en attente",
+    "pending_requests_plural": "{{count}} demandes en attente",
     "join_pending": "⏳ Demande d'adhésion en attente",
     "joined": "✅ Vous êtes membre de ce groupe"
   },

--- a/frontend/src/pages/dashboard/student/groups/[id].js
+++ b/frontend/src/pages/dashboard/student/groups/[id].js
@@ -154,7 +154,7 @@ export default function GroupDetailsPage() {
             <h1 className="text-2xl font-bold">{group.name}</h1>
             {pendingCount > 0 && (
               <div className="bg-red-100 text-red-800 px-3 py-1 rounded mt-2">
-                {pendingCount} {t('pending_requests')}
+                {t('pending_requests', { count: pendingCount })}
               </div>
             )}
             {["admin", "moderator"].includes(currentUserRole) && !editingName && (


### PR DESCRIPTION
## Summary
- interpolate join request count in group page
- add pluralized pending request translations for all locales

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899de1c0860832891b739d691d92752