### PR TITLE
Automatically send group invites on creation

### DIFF
--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import useAuthStore from '@/store/auth/authStore';
-import { X, Mail, Bell, MessageSquare, Smartphone, Send, Image as ImageIcon, Tag, Users } from 'lucide-react';
+import { X, Mail, Smartphone, Image as ImageIcon, Tag, Users } from 'lucide-react';
 import { toast } from 'react-toastify';
 import groupService from '@/services/groupService';
 import { fetchAllCategories } from '@/services/admin/categoryService';
@@ -149,6 +149,27 @@ export default function GroupForm() {
       const group = await groupService.createGroup(payload);
       toast.success('Group created successfully!');
 
+      if (invitedUsers.length) {
+        for (const member of invitedUsers) {
+          await sendChatMessage(member.id, {
+            text: `You are invited to join the group ${groupName}`,
+          });
+          await createNotification({
+            user_id: member.id,
+            type: 'group_invite',
+            message: `You are invited to join the group ${groupName}`,
+          });
+        }
+
+        if (inviteMethods.includes('email') || inviteMethods.includes('whatsapp')) {
+          toast.info(`Additional invite methods: ${inviteMethods.join(', ')}`);
+        }
+
+        toast.success(
+          `Invites sent to ${invitedUsers.length} member${invitedUsers.length !== 1 ? 's' : ''}.`
+        );
+      }
+
       const normalizedRole = user?.role?.toLowerCase();
       const path =
         normalizedRole === 'instructor'
@@ -163,33 +184,6 @@ export default function GroupForm() {
       toast.error(err.response?.data?.message || 'Failed to create group');
     } finally {
       setIsSubmitting(false);
-    }
-  };
-
-  const handleSendInvites = async () => {
-    try {
-      for (const user of invitedUsers) {
-        // always send message and notification
-        await sendChatMessage(user.id, {
-          text: `You are invited to join the group ${groupName}`,
-        });
-        await createNotification({
-          user_id: user.id,
-          type: 'group_invite',
-          message: `You are invited to join the group ${groupName}`,
-        });
-      }
-
-      if (inviteMethods.includes('email') || inviteMethods.includes('whatsapp')) {
-        toast.info(`Additional invite methods: ${inviteMethods.join(', ')}`);
-      }
-
-      toast.success(
-        `Invites sent to ${invitedUsers.length} member${invitedUsers.length !== 1 ? 's' : ''}.`
-      );
-    } catch (err) {
-      console.error(err);
-      toast.error('Failed to send invitations');
     }
   };
 
@@ -504,14 +498,6 @@ export default function GroupForm() {
                   </div>
                 </div>
 
-                <button
-                  type="button"
-                  onClick={handleSendInvites}
-                  className="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-lg font-medium bg-purple-600 hover:bg-purple-700 text-white"
-                >
-                  <Send size={16} />
-                  Send Invitations to {invitedUsers.length} Member{invitedUsers.length !== 1 ? 's' : ''}
-                </button>
               </div>
             </>
           )}


### PR DESCRIPTION
## Summary
- auto-send chat messages and notifications to invited users after group creation
- drop manual invite button and unused icons

## Testing
- `cd frontend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_6899ddcf119083288b53fd95ea3dbb4a