### PR TITLE
refactor: unify group toasts with react-hot-toast

### DIFF
--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import useAuthStore from '@/store/auth/authStore';
 import { X, Mail, Smartphone, Image as ImageIcon, Tag, Users } from 'lucide-react';
-import { toast } from 'react-toastify';
+import toast from 'react-hot-toast';
 import groupService from '@/services/groupService';
 import { fetchAllCategories } from '@/services/admin/categoryService';
 import userService from '@/services/profile/userService';
@@ -162,7 +162,7 @@ export default function GroupForm() {
         }
 
         if (inviteMethods.includes('email') || inviteMethods.includes('whatsapp')) {
-          toast.info(`Additional invite methods: ${inviteMethods.join(', ')}`);
+          toast(`Additional invite methods: ${inviteMethods.join(', ')}`);
         }
 
         toast.success(

--- a/frontend/src/components/groups/GroupMembersList.js
+++ b/frontend/src/components/groups/GroupMembersList.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import groupService from "@/services/groupService";
-import { toast } from "react-toastify";
+import toast from "react-hot-toast";
 import { FaUserSlash, FaVolumeMute, FaUserShield, FaBan } from "react-icons/fa";
 
 export default function GroupMembersList({

--- a/frontend/src/components/groups/JoinRequestCard.js
+++ b/frontend/src/components/groups/JoinRequestCard.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import groupService from '@/services/groupService';
-import { toast } from 'react-toastify';
+import toast from 'react-hot-toast';
 
 export default function JoinRequestCard({ groupId, onCountChange }) {
   const [requests, setRequests] = useState([]);
@@ -23,7 +23,7 @@ export default function JoinRequestCard({ groupId, onCountChange }) {
         toast.success('Request approved');
       } else {
         await groupService.rejectRequest(id);
-        toast.info('Request rejected');
+        toast('Request rejected');
       }
 
       setRequests(prev => {

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -17,7 +17,7 @@ import {
   FaFolderOpen,
 } from 'react-icons/fa';
 import groupService from '@/services/groupService';
-import { toast } from 'react-toastify';
+import toast from 'react-hot-toast';
 
 // ...imports (same as before)...
 

--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -13,7 +13,7 @@ import {
   FaRegSquare
 } from 'react-icons/fa';
 import groupService from '@/services/groupService';
-import { toast } from 'react-toastify';
+import toast from 'react-hot-toast';
 
 const imagePool = [
   'https://media.npr.org/assets/img/2012/01/25/newnewearth_wide-e15c88c202099fecf4a9d6f6f0e2a19826d9a26f.jpg?s=1400&c=100&f=jpeg',


### PR DESCRIPTION
## Summary
- replace react-toastify with react-hot-toast in group-related components and admin pages
- handle informational messages using toast() and rely on global Toaster in _app

## Testing
- `npm test`
- `npm run lint` *(fails: 68 errors, 263 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6899e924e878832889490bcdbd96f6af