### PR TITLE
Refactor group invite notifications

### DIFF
--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -8,6 +8,8 @@ import { fetchAllCategories } from '@/services/admin/categoryService';
 import userService from '@/services/profile/userService';
 import { sendChatMessage } from '@/services/messageService';
 import { createNotification } from '@/services/notificationService';
+import useNotificationStore from '@/store/notifications/notificationStore';
+import useMessageStore from '@/store/messages/messageStore';
 import { API_BASE_URL } from '@/config/config';
 
 export default function GroupForm() {
@@ -30,6 +32,9 @@ export default function GroupForm() {
   const [users, setUsers] = useState([]);
   const [maxSize, setMaxSize] = useState('');
   const [timezone, setTimezone] = useState('');
+
+  const fetchNotifications = useNotificationStore((s) => s.fetch);
+  const fetchMessages = useMessageStore((s) => s.fetch);
 
   const getAvatarUrl = (user) => {
     const url =
@@ -150,24 +155,50 @@ export default function GroupForm() {
       toast.success('Group created successfully!');
 
       if (invitedUsers.length) {
-        for (const member of invitedUsers) {
-          await sendChatMessage(member.id, {
+        const invitePromises = invitedUsers.map((member) => {
+          const msg = sendChatMessage(member.id, {
             text: `You are invited to join the group ${groupName}`,
           });
-          await createNotification({
+          const notif = createNotification({
             user_id: member.id,
             type: 'group_invite',
             message: `You are invited to join the group ${groupName}`,
           });
-        }
+          return Promise.allSettled([msg, notif]).then((results) => ({
+            member,
+            results,
+          }));
+        });
+
+        const outcomes = await Promise.all(invitePromises);
+
+        let successCount = 0;
+        const failedMembers = [];
+        outcomes.forEach(({ member, results }) => {
+          const hasFailure = results.some((r) => r.status !== 'fulfilled');
+          if (hasFailure) {
+            const name =
+              member.name || member.email || member.username || `ID ${member.id}`;
+            failedMembers.push(name);
+          } else {
+            successCount += 1;
+          }
+        });
 
         if (inviteMethods.includes('email') || inviteMethods.includes('whatsapp')) {
           toast.info(`Additional invite methods: ${inviteMethods.join(', ')}`);
         }
 
-        toast.success(
-          `Invites sent to ${invitedUsers.length} member${invitedUsers.length !== 1 ? 's' : ''}.`
-        );
+        const summary = `Invites: ${successCount} succeeded${
+          failedMembers.length ? `, failed for ${failedMembers.join(', ')}` : ''
+        }`;
+        toast[failedMembers.length ? 'warn' : 'success'](summary);
+        if (failedMembers.length) {
+          console.error('Failed invites:', failedMembers);
+        }
+
+        fetchNotifications?.();
+        fetchMessages?.();
       }
 
       const normalizedRole = user?.role?.toLowerCase();


### PR DESCRIPTION
## Summary
- Send group invitation messages and notifications concurrently using `Promise.allSettled`
- Display a summary toast with success and failed invites and log failures
- Refresh notification and message stores so global indicators update immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e9257030832884e68c7712bc6f18