### PR TITLE
feat(groups): allow users to cancel join requests

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -246,6 +246,12 @@ exports.joinGroup = catchAsync(async (req, res) => {
   sendSuccess(res, reqRow, "Request sent");
 });
 
+exports.cancelJoin = catchAsync(async (req, res) => {
+  const groupId = req.params.id;
+  await service.cancelJoinRequest(groupId, req.user.id);
+  sendSuccess(res, null, "Request cancelled");
+});
+
 exports.listTags = catchAsync(async (_req, res) => {
   const data = await service.listTags();
   sendSuccess(res, data);

--- a/backend/src/modules/groups/groups.routes.js
+++ b/backend/src/modules/groups/groups.routes.js
@@ -8,6 +8,7 @@ const msgUpload = require("./groupMessageUpload.middleware");
 router.get("/tags", ctrl.listTags);
 router.get("/my", verifyToken, ctrl.getMyGroups);
 router.post("/:id/join", verifyToken, ctrl.joinGroup);
+router.delete("/:id/join", verifyToken, ctrl.cancelJoin);
 router.get("/:id/members", verifyToken, ctrl.listMembers);
 router.post("/:id/members/:memberId/manage", verifyToken, ctrl.manageMember);
 router.get("/:id/requests", verifyToken, ctrl.listJoinRequests);

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -115,6 +115,14 @@ exports.requestJoin = async (groupId, userId) => {
   return row;
 };
 
+exports.cancelJoinRequest = async (groupId, userId) => {
+  const [row] = await db("group_join_requests")
+    .where({ group_id: groupId, user_id: userId })
+    .del()
+    .returning("*");
+  return row;
+};
+
 exports.getUserGroups = async (userId) => {
   const memberQuery = db("group_members as gm")
     .join("groups as g", "gm.group_id", "g.id")


### PR DESCRIPTION
## Summary
- allow members to cancel their group join requests
- expose new DELETE route for canceling join requests
- support database removal of pending join request rows

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899ee0600908328b69becdbd760bcd5