### PR TITLE
Handle groups that allow auto-join

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -217,33 +217,40 @@ exports.getMyGroups = catchAsync(async (req, res) => {
 
 exports.joinGroup = catchAsync(async (req, res) => {
   const groupId = req.params.id;
-  const reqRow = await service.requestJoin(groupId, req.user.id);
-
   const group = await service.getGroupById(groupId);
-  const adminIds = await service.listAdminIds(groupId);
-  const note = `${req.user.full_name} requested to join the group "${group.name}"`;
+  if (!group) throw new AppError("Group not found", 404);
 
-  const recipients = adminIds.filter((uid) => uid !== req.user.id);
-  await Promise.all(
-    recipients.map((uid) =>
-      notificationService.createNotification({
-        user_id: uid,
-        type: "join_request",
-        message: note,
-      })
-    )
-  );
-  await Promise.all(
-    recipients.map((uid) =>
-      messageService.createMessage({
-        sender_id: req.user.id,
-        receiver_id: uid,
-        message: note,
-      })
-    )
-  );
+  if (group.requires_approval) {
+    const reqRow = await service.requestJoin(groupId, req.user.id);
 
-  sendSuccess(res, reqRow, "Request sent");
+    const adminIds = await service.listAdminIds(groupId);
+    const note = `${req.user.full_name} requested to join the group "${group.name}"`;
+
+    const recipients = adminIds.filter((uid) => uid !== req.user.id);
+    await Promise.all(
+      recipients.map((uid) =>
+        notificationService.createNotification({
+          user_id: uid,
+          type: "join_request",
+          message: note,
+        })
+      )
+    );
+    await Promise.all(
+      recipients.map((uid) =>
+        messageService.createMessage({
+          sender_id: req.user.id,
+          receiver_id: uid,
+          message: note,
+        })
+      )
+    );
+
+    sendSuccess(res, reqRow, "Request sent");
+  } else {
+    const member = await service.addMember(groupId, req.user.id, "member");
+    sendSuccess(res, member, "Joined group");
+  }
 });
 
 exports.listTags = catchAsync(async (_req, res) => {

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -102,8 +102,13 @@ exports.deleteGroup = (id) => db("groups").where({ id }).del();
 exports.addMember = async (groupId, userId, role = "admin") => {
   const [row] = await db("group_members")
     .insert({ id: uuidv4(), group_id: groupId, user_id: userId, role })
+    .onConflict(["group_id", "user_id"])
+    .ignore()
     .returning("*");
-  return row;
+  if (row) return row;
+  return db("group_members")
+    .where({ group_id: groupId, user_id: userId })
+    .first();
 };
 
 exports.requestJoin = async (groupId, userId) => {


### PR DESCRIPTION
## Summary
- Allow joinGroup controller to add members immediately when groups don't require approval
- Skip admin notifications for auto-joined members
- Update addMember service helper to ignore conflicts and return existing membership

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899ee062138832895f923a5dc067c93