### PR TITLE
feat: add favorites page for tutorials

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/studentLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/studentLinks.js
@@ -18,7 +18,8 @@ import {
   Users2,
   Home,
   Heart,
-  Book
+  Book,
+  Star
 } from 'lucide-react';
 
 export const studentNavLinks = [
@@ -36,6 +37,7 @@ export const studentNavLinks = [
       { label: 'My Tutorials', href: '/dashboard/student/tutorials', icon: Brain },
       { label: 'My Books', href: '/dashboard/student/books', icon: Book },
       { label: 'Wishlist', href: '/dashboard/student/wishlist', icon: Heart },
+      { label: 'Favorite Tutorials', href: '/dashboard/student/tutorials/favorites', icon: Star },
       { label: 'Assignments', href: '/dashboard/student/assignments', icon: FileText },
       { label: 'Certificates', href: '/dashboard/student/certificates', icon: GraduationCap },
     ]

--- a/frontend/src/pages/dashboard/student/tutorials/favorites.js
+++ b/frontend/src/pages/dashboard/student/tutorials/favorites.js
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import StudentLayout from '@/components/layouts/StudentLayout';
+import { getMyTutorialFavorites, removeTutorialFromFavorites } from '@/services/tutorialService';
+
+export default function TutorialFavoritesPage() {
+  const [favorites, setFavorites] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const items = await getMyTutorialFavorites();
+        setFavorites(items);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
+
+  const removeFavorite = async (id) => {
+    try {
+      await removeTutorialFromFavorites(id);
+      setFavorites(favorites.filter((t) => t.id !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <StudentLayout>
+      <h1 className="text-2xl font-bold mb-6">My Favorite Tutorials</h1>
+      {favorites.length === 0 ? (
+        <p className="text-gray-500">You have no favorite tutorials.</p>
+      ) : (
+        <ul className="space-y-2">
+          {favorites.map((tutorial) => (
+            <li key={tutorial.id} className="bg-white p-3 rounded-md shadow flex justify-between items-center">
+              <span className="font-medium">{tutorial.title}</span>
+              <button
+                onClick={() => removeFavorite(tutorial.id)}
+                className="text-red-500 text-sm"
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </StudentLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- allow students to view and manage favorite tutorials
- link favorites page from dashboard sidebar

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aeebca0d483289be89bc83a52fc3a