### PR TITLE
fix: expose media files under same-origin URLs

### DIFF
--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -1,23 +1,23 @@
 import api from "@/services/api/api";
 
-// Determine the base URL for media assets. If an absolute URL is provided
-// (e.g. "https://example.com/api"), strip any trailing API segment so media
-// files resolve correctly. For relative paths (like the default "/api" used
-// during development), keep the prefix so requests are routed through the same
-// proxy that handles API calls.
-const rawApiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+// Determine the base URL for media assets. When an absolute API URL is
+// provided (e.g. "https://example.com/api"), strip the trailing `/api` so that
+// uploaded files resolve correctly. If a relative path like "/api" is used
+// (common in local development where Next.js proxies API requests), we fall
+// back to a relative media path so files are requested from the same origin
+// without the `/api` prefix.
+const rawApiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 const API_BASE = rawApiBase.startsWith("http")
   ? rawApiBase.replace(/\/api(?:\/.*)?$/, "")
-  : rawApiBase;
+  : "";
 
 export const buildUrl = (path) => {
   if (!path) return null;
   if (/^https?:/i.test(path)) return path;
-  const base = API_BASE || (typeof window !== "undefined" ? window.location.origin : "");
   const uploadsIndex = path.indexOf("/uploads");
   const relative = uploadsIndex !== -1 ? path.substring(uploadsIndex) : path;
   const normalized = relative.startsWith("/") ? relative : `/${relative}`;
-  return `${base}${normalized}`;
+  return API_BASE ? `${API_BASE}${normalized}` : normalized;
 };
 
 const formatBook = (book) => {

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -136,8 +136,8 @@ describe("bookService", () => {
       price: 19.99,
       cover_image_url: null,
       pdf_url: null,
-      preview_url: "/api/uploads/p.pdf",
-      preview_pages: ["/api/uploads/a.png"],
+      preview_url: "/uploads/p.pdf",
+      preview_pages: ["/uploads/a.png"],
     });
   });
 
@@ -199,12 +199,12 @@ describe("bookService", () => {
     process.env.NEXT_PUBLIC_API_BASE_URL = originalBase;
   });
 
-  it("buildUrl keeps relative api prefixes by default", () => {
+  it("buildUrl returns a same-origin path when API base is relative", () => {
     const originalBase = process.env.NEXT_PUBLIC_API_BASE_URL;
     jest.isolateModules(() => {
       delete process.env.NEXT_PUBLIC_API_BASE_URL;
       const { buildUrl } = require("../../services/bookService");
-      expect(buildUrl("/uploads/test.jpg")).toBe("/api/uploads/test.jpg");
+      expect(buildUrl("/uploads/test.jpg")).toBe("/uploads/test.jpg");
     });
     process.env.NEXT_PUBLIC_API_BASE_URL = originalBase;
   });


### PR DESCRIPTION
## Summary
- build book media URLs without `/api` prefix so uploads use same-origin paths
- adjust book service tests for new media URL behavior

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689afc6786ec8328a06261ec1d691d3b