### PR TITLE
Fix media path handling for book cover images

### DIFF
--- a/backend/src/migrations/20250901000000_alter_book_media_columns_to_text.js
+++ b/backend/src/migrations/20250901000000_alter_book_media_columns_to_text.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'books';
+
+exports.up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.text('cover_image_url').alter();
+    table.text('pdf_url').alter();
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.string('cover_image_url').alter();
+    table.string('pdf_url').alter();
+  });
+};

--- a/backend/src/modules/media/media.controller.js
+++ b/backend/src/modules/media/media.controller.js
@@ -3,7 +3,11 @@ const path = require('path');
 const mime = require('mime-types');
 
 exports.stream = (req, res) => {
-  const filePath = path.join(__dirname, '../../../uploads', req.params.filename);
+  const requested = req.params[0] || req.params.filename || '';
+  const safePath = path
+    .normalize(requested)
+    .replace(/^([\.]{2}[\/])+/, '');
+  const filePath = path.join(__dirname, '../../../uploads', safePath);
   fs.stat(filePath, (err, stats) => {
     if (err || !stats.isFile()) {
       return res.status(404).json({ message: 'File not found' });

--- a/backend/src/modules/media/media.routes.js
+++ b/backend/src/modules/media/media.routes.js
@@ -1,6 +1,6 @@
 const router = require('express').Router();
 const controller = require('./media.controller');
 
-router.get('/:filename', controller.stream);
+router.get('/*', controller.stream);
 
 module.exports = router;

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -13,11 +13,13 @@ const API_BASE = rawApiBase.startsWith("http")
 export const buildUrl = (path) => {
   if (!path) return null;
   if (/^https?:/i.test(path)) return path;
-  const base = API_BASE || (typeof window !== "undefined" ? window.location.origin : "");
+  const base =
+    API_BASE || (typeof window !== "undefined" ? window.location.origin : "");
   const uploadsIndex = path.indexOf("/uploads");
-  const relative = uploadsIndex !== -1 ? path.substring(uploadsIndex) : path;
+  const relative =
+    uploadsIndex !== -1 ? path.substring(uploadsIndex + 8) : path; // 8 = '/uploads'.length
   const normalized = relative.startsWith("/") ? relative : `/${relative}`;
-  return `${base}${normalized}`;
+  return `${base}/media${normalized}`;
 };
 
 const formatBook = (book) => {

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -131,14 +131,14 @@ describe("bookService", () => {
     };
     api.get.mockResolvedValueOnce({ data: { data: apiData } });
     const book = await fetchBook(3);
-    expect(book).toEqual({
-      id: 3,
-      price: 19.99,
-      cover_image_url: null,
-      pdf_url: null,
-      preview_url: "/api/uploads/p.pdf",
-      preview_pages: ["/api/uploads/a.png"],
-    });
+      expect(book).toEqual({
+        id: 3,
+        price: 19.99,
+        cover_image_url: null,
+        pdf_url: null,
+        preview_url: "/api/media/p.pdf",
+        preview_pages: ["/api/media/a.png"],
+      });
   });
 
   it("returns null when book is not found", async () => {
@@ -193,7 +193,7 @@ describe("bookService", () => {
       process.env.NEXT_PUBLIC_API_BASE_URL = "https://example.com/api/v1";
       const { buildUrl } = require("../../services/bookService");
       expect(buildUrl("/uploads/test.jpg")).toBe(
-        "https://example.com/uploads/test.jpg"
+        "https://example.com/media/test.jpg"
       );
     });
     process.env.NEXT_PUBLIC_API_BASE_URL = originalBase;
@@ -204,7 +204,7 @@ describe("bookService", () => {
     jest.isolateModules(() => {
       delete process.env.NEXT_PUBLIC_API_BASE_URL;
       const { buildUrl } = require("../../services/bookService");
-      expect(buildUrl("/uploads/test.jpg")).toBe("/api/uploads/test.jpg");
+      expect(buildUrl("/uploads/test.jpg")).toBe("/api/media/test.jpg");
     });
     process.env.NEXT_PUBLIC_API_BASE_URL = originalBase;
   });


### PR DESCRIPTION
## Summary
- allow nested media paths by sanitizing requested file and using wildcard route
- build media URLs against unified `/api/media` endpoint and widen book media columns

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689afc6786ec8328a06261ec1d691d3b