### PR TITLE
Expose tutorial assignment counts and certificate status

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -7,6 +7,7 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const userModel = require("../user.model");
 const analyticsService = require("../../../services/analyticsService");
+const certificateService = require("./certificate/certificate.service");
 const AppError = require("../../../utils/AppError");
 const {
   sendTutorialCreatedAdminEmail,
@@ -521,6 +522,19 @@ exports.getPublicTutorialDetails = catchAsync(async (req, res) => {
       req.headers["user-agent"]
     );
     tutorial.views = await service.getTutorialViewCount(req.params.id);
+
+    if (req.user?.id) {
+      tutorial.assignment_count = await service.getAssignmentCount(
+        req.params.id
+      );
+      const cert = await certificateService.findExisting(
+        req.user.id,
+        req.params.id
+      );
+      if (cert) {
+        tutorial.certificate_id = cert.id;
+      }
+    }
   }
 
   analyticsService.logEvent(req.user?.id || null, 'view_tutorial', {

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -352,3 +352,10 @@ exports.getTutorialAnalytics = async (tutorialId) => {
     })),
   };
 };
+
+exports.getAssignmentCount = async (tutorialId) => {
+  const [row] = await db('tutorial_assignments')
+    .where({ tutorial_id: tutorialId })
+    .count();
+  return parseInt(row.count, 10) || 0;
+};

--- a/backend/tests/tutorialRoutes.test.js
+++ b/backend/tests/tutorialRoutes.test.js
@@ -5,6 +5,10 @@ jest.mock('../src/config/database', () => ({
   raw: jest.fn(() => Promise.resolve()),
 }));
 
+jest.mock('../src/services/analyticsService', () => ({
+  logEvent: jest.fn(),
+}));
+
 jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({
   getTutorialsByCategory: jest.fn(),
   getTutorialAnalytics: jest.fn(),
@@ -12,6 +16,14 @@ jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({
   updateTutorial: jest.fn(),
   permanentlyDeleteTutorial: jest.fn(),
   togglePublishStatus: jest.fn(),
+  getPublicTutorialDetails: jest.fn(),
+  getAssignmentCount: jest.fn(),
+  recordTutorialView: jest.fn(),
+  getTutorialViewCount: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/tutorials/certificate/certificate.service', () => ({
+  findExisting: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -27,6 +39,7 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
 const service = require('../src/modules/users/tutorials/tutorial.service');
 const routes = require('../src/modules/users/tutorials/tutorial.routes');
 const auth = require('../src/middleware/auth/authMiddleware');
+const certificateService = require('../src/modules/users/tutorials/certificate/certificate.service');
 
 const app = express();
 app.use(express.json());
@@ -46,6 +59,31 @@ describe('GET /api/users/tutorials/category/:categoryId', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mockTutorials);
     expect(service.getTutorialsByCategory).toHaveBeenCalledWith('123');
+  });
+});
+
+describe('GET /api/users/tutorials/:id', () => {
+  it('returns tutorial details with assignment count and certificate info', async () => {
+    service.getPublicTutorialDetails.mockResolvedValue({ id: '1', title: 'T' });
+    service.getAssignmentCount.mockResolvedValue(3);
+    certificateService.findExisting.mockResolvedValue({ id: 'cert1' });
+
+    const appWithUser = express();
+    appWithUser.use(express.json());
+    appWithUser.use((req, _res, next) => {
+      req.user = { id: 'student1' };
+      next();
+    });
+    appWithUser.use('/api/users/tutorials', routes);
+
+    const res = await request(appWithUser).get('/api/users/tutorials/1');
+
+    expect(res.status).toBe(200);
+    expect(service.getPublicTutorialDetails).toHaveBeenCalledWith('1');
+    expect(service.getAssignmentCount).toHaveBeenCalledWith('1');
+    expect(certificateService.findExisting).toHaveBeenCalledWith('student1', '1');
+    expect(res.body.data.assignment_count).toBe(3);
+    expect(res.body.data.certificate_id).toBe('cert1');
   });
 });
 


### PR DESCRIPTION
## Summary
- include certificate service to determine if a signed-in student has earned a certificate for a tutorial
- report the number of assignments associated with a tutorial
- test tutorial details endpoint for assignment count and certificate id

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_689b05e7accc83288fa72f20eb90f99f