### PR TITLE
Notify students of new tutorial assignments

### DIFF
--- a/backend/src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js
+++ b/backend/src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js
@@ -1,0 +1,143 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn(() => Promise.resolve(null));
+  db.select = jest.fn(() => db);
+  db.insert = jest.fn(() => db);
+  db.update = jest.fn(() => db);
+  return db;
+});
+
+jest.mock('../tutorialAssignment.service', () => ({
+  getByTutorial: jest.fn(),
+  getAllAssignments: jest.fn(),
+  createAssignment: jest.fn(),
+  updateAssignment: jest.fn(),
+  deleteAssignment: jest.fn(),
+}));
+const service = require('../tutorialAssignment.service');
+
+jest.mock('../../tutorial.service', () => ({
+  getTutorialById: jest.fn(() => Promise.resolve({ id: 't1', title: 'Tutorial' })),
+}));
+
+jest.mock('../../enrollments/tutorialEnrollment.service', () => ({
+  getByTutorial: jest.fn(() =>
+    Promise.resolve([
+      { id: 's1', email: 's1@test.com', phone: '111' },
+      { id: 's2', email: 's2@test.com', phone: '222' },
+    ])
+  ),
+}));
+
+jest.mock('../../../../notifications/notifications.service', () => ({
+  createNotification: jest.fn(() => Promise.resolve({})),
+}));
+
+jest.mock('../../../../../utils/email', () => ({
+  sendAssignmentEmail: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../../../../services/smsService', () => ({
+  sendSMS: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'test-user' };
+    next();
+  },
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+  isStudent: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+  isInstructor: (_req, _res, next) => next(),
+}));
+
+jest.mock('../../../../../middleware/auth/verifyTutorialAccess', () => (
+  _req,
+  _res,
+  next
+) => next());
+
+const routes = require('../../tutorial.routes');
+const emailUtil = require('../../../../../utils/email');
+const smsService = require('../../../../../services/smsService');
+const notificationService = require('../../../../notifications/notifications.service');
+
+const app = express();
+app.use(express.json());
+app.use('/api/users/tutorials', routes);
+
+describe('Tutorial assignment routes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('get assignments by tutorial', async () => {
+    const list = [{ id: '1' }];
+    service.getByTutorial.mockResolvedValue(list);
+    const res = await request(app).get('/api/users/tutorials/assignments/tut1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual(list);
+  });
+
+  test('get all assignments', async () => {
+    const list = [{ id: '1' }];
+    service.getAllAssignments.mockResolvedValue(list);
+    const res = await request(app).get('/api/users/tutorials/assignments/admin');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual(list);
+  });
+
+  test('create assignment sends messages', async () => {
+    service.createAssignment.mockResolvedValue({
+      id: '1',
+      title: 'New',
+      due_date: '2024-01-01T00:00:00.000Z',
+    });
+    const res = await request(app)
+      .post('/api/users/tutorials/assignments/t1')
+      .send({ title: 'New', due_date: '2024-01-01T00:00:00.000Z' });
+    expect(res.statusCode).toBe(200);
+    expect(service.createAssignment).toHaveBeenCalled();
+    expect(emailUtil.sendAssignmentEmail).toHaveBeenCalledTimes(2);
+    expect(smsService.sendSMS).toHaveBeenCalledTimes(2);
+    expect(notificationService.createNotification).toHaveBeenCalledTimes(2);
+  });
+
+  test('create assignment fails with invalid date', async () => {
+    const res = await request(app)
+      .post('/api/users/tutorials/assignments/t1')
+      .send({ title: 'New', due_date: 'not-a-date' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe('Validation error');
+    expect(service.createAssignment).not.toHaveBeenCalled();
+  });
+
+  test('create assignment fails with missing title', async () => {
+    const res = await request(app)
+      .post('/api/users/tutorials/assignments/t1')
+      .send({ due_date: '2024-01-01T00:00:00.000Z' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe('Validation error');
+    expect(service.createAssignment).not.toHaveBeenCalled();
+  });
+
+  test('update assignment', async () => {
+    service.updateAssignment.mockResolvedValue({ id: '1' });
+    const res = await request(app)
+      .put('/api/users/tutorials/assignments/1')
+      .send({ title: 'Edit' });
+    expect(res.statusCode).toBe(200);
+    expect(service.updateAssignment).toHaveBeenCalled();
+  });
+
+  test('delete assignment', async () => {
+    service.deleteAssignment.mockResolvedValue();
+    const res = await request(app).delete('/api/users/tutorials/assignments/1');
+    expect(res.statusCode).toBe(200);
+    expect(service.deleteAssignment).toHaveBeenCalled();
+  });
+});
+

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
@@ -1,9 +1,12 @@
 const { v4: uuidv4 } = require('uuid');
 const catchAsync = require('../../../../utils/catchAsync');
 const { sendSuccess } = require('../../../../utils/response');
-const AppError = require('../../../../utils/AppError');
-const db = require('../../../../config/database');
 const service = require('./tutorialAssignment.service');
+const tutorialService = require('../tutorial.service');
+const enrollmentService = require('../enrollments/tutorialEnrollment.service');
+const notificationService = require('../../../notifications/notifications.service');
+const smsService = require('../../../../services/smsService');
+const { sendAssignmentEmail } = require('../../../../utils/email');
 
 exports.getAssignmentsByTutorial = catchAsync(async (req, res) => {
   const { tutorialId } = req.params;
@@ -18,6 +21,40 @@ exports.createAssignment = catchAsync(async (req, res) => {
     tutorial_id: req.params.tutorialId,
   };
   const assignment = await service.createAssignment(data);
+
+  try {
+    const tutorial = await tutorialService.getTutorialById(req.params.tutorialId);
+    const students = await enrollmentService.getByTutorial(req.params.tutorialId);
+    if (tutorial && students.length) {
+      const message = `New assignment "${assignment.title}" posted for tutorial "${tutorial.title}".`;
+      await Promise.all(
+        students.map((s) =>
+          notificationService.createNotification({
+            user_id: s.id,
+            type: 'new_assignment',
+            message,
+          })
+        )
+      );
+      await Promise.all(
+        students.map(async (s) => {
+          try {
+            if (s.email) {
+              await sendAssignmentEmail(s.email, assignment.title, tutorial.title, assignment.due_date);
+            }
+            if (s.phone) {
+              await smsService.sendSMS({ to: s.phone, text: message });
+            }
+          } catch (err) {
+            console.error('Error sending assignment email/SMS:', err.message);
+          }
+        })
+      );
+    }
+  } catch (err) {
+    console.error('Error sending assignment notifications:', err.message);
+  }
+
   sendSuccess(res, assignment, 'Assignment created');
 });
 

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.service.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.service.js
@@ -24,3 +24,19 @@ exports.getByUser = async (user_id) => {
     .select("tutorials.*", "tutorial_enrollments.status", "tutorial_enrollments.enrolled_at");
 };
 
+// List all students enrolled in a tutorial
+exports.getByTutorial = async (tutorial_id) => {
+  return db("tutorial_enrollments as te")
+    .join("users as u", "te.user_id", "u.id")
+    .where("te.tutorial_id", tutorial_id)
+    .select(
+      "u.id",
+      "u.full_name",
+      "u.email",
+      "u.phone",
+      "te.status",
+      "te.enrolled_at"
+    )
+    .orderBy("te.enrolled_at");
+};
+


### PR DESCRIPTION
## Summary
- notify enrolled students when an instructor posts a tutorial assignment via in-app notification, email, and SMS
- support fetching all students enrolled in a tutorial
- add coverage for tutorial assignment notifications

## Testing
- `npm test src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689b05e7accc83288fa72f20eb90f99f