### PR TITLE
Verify assignment completion before issuing tutorial certificates

### DIFF
--- a/backend/src/modules/users/tutorials/certificate/__tests__/certificate.service.test.js
+++ b/backend/src/modules/users/tutorials/certificate/__tests__/certificate.service.test.js
@@ -1,0 +1,58 @@
+jest.mock("../../../../../config/database", () => jest.fn());
+const db = require("../../../../../config/database");
+const { isUserCompletedTutorial } = require("../certificate.service");
+
+describe("isUserCompletedTutorial", () => {
+  beforeEach(() => {
+    db.mockReset();
+  });
+
+  test("returns true when progress is 100 and all assignments are passed", async () => {
+    const enrollmentQuery = {
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue({ id: "enr" }),
+    };
+    const assignmentQuery = {
+      where: jest.fn().mockReturnThis(),
+      count: jest.fn().mockResolvedValue([{ count: 2 }]),
+    };
+    const submissionQuery = {
+      join: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      count: jest.fn().mockResolvedValue([{ count: 2 }]),
+    };
+    db.mockImplementation((table) => {
+      if (table === "tutorial_enrollments") return enrollmentQuery;
+      if (table === "tutorial_assignments") return assignmentQuery;
+      if (table === "assignment_submissions as s") return submissionQuery;
+    });
+
+    const res = await isUserCompletedTutorial("u1", "t1");
+    expect(res).toBe(true);
+  });
+
+  test("returns false when assignments are missing or not passed", async () => {
+    const enrollmentQuery = {
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue({ id: "enr" }),
+    };
+    const assignmentQuery = {
+      where: jest.fn().mockReturnThis(),
+      count: jest.fn().mockResolvedValue([{ count: 2 }]),
+    };
+    const submissionQuery = {
+      join: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      count: jest.fn().mockResolvedValue([{ count: 1 }]),
+    };
+    db.mockImplementation((table) => {
+      if (table === "tutorial_enrollments") return enrollmentQuery;
+      if (table === "tutorial_assignments") return assignmentQuery;
+      if (table === "assignment_submissions as s") return submissionQuery;
+    });
+
+    const res = await isUserCompletedTutorial("u1", "t1");
+    expect(res).toBe(false);
+  });
+});
+

--- a/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
+++ b/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
@@ -1,0 +1,62 @@
+const request = require("supertest");
+const express = require("express");
+
+jest.mock("../../../../../config/database", () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn(() => Promise.resolve({ id: "t1", title: "Tut" }));
+  return db;
+});
+
+jest.mock("../certificate.service", () => ({
+  isUserCompletedTutorial: jest.fn(),
+  findExisting: jest.fn(),
+  issueCertificate: jest.fn(),
+}));
+
+jest.mock("../../../../notifications/notifications.service", () => ({
+  createNotification: jest.fn(() => Promise.resolve({})),
+}));
+
+jest.mock("../../../../../middleware/auth/authMiddleware", () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: "user1" };
+    next();
+  },
+  isStudent: (_req, _res, next) => next(),
+}));
+
+const routes = require("../tutorialCertificate.routes");
+const service = require("../certificate.service");
+
+const app = express();
+app.use(express.json());
+app.use("/api/users/tutorials/certificate", routes);
+
+describe("generate certificate route", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test("returns 403 when tutorial is not fully completed", async () => {
+    service.isUserCompletedTutorial.mockResolvedValue(false);
+
+    const res = await request(app).post(
+      "/api/users/tutorials/certificate/t1/certificate/generate",
+    );
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  test("issues certificate when requirements are met", async () => {
+    service.isUserCompletedTutorial.mockResolvedValue(true);
+    service.findExisting.mockResolvedValue(null);
+    service.issueCertificate.mockResolvedValue({ id: "cert1" });
+
+    const res = await request(app).post(
+      "/api/users/tutorials/certificate/t1/certificate/generate",
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(service.issueCertificate).toHaveBeenCalled();
+  });
+});
+

--- a/backend/src/modules/users/tutorials/certificate/certificate.service.js
+++ b/backend/src/modules/users/tutorials/certificate/certificate.service.js
@@ -7,12 +7,34 @@ const generateCode = () => {
 };
 
 // Check if user completed the tutorial
+// Now also verifies that all assignments have been submitted and passed
 const isUserCompletedTutorial = async (userId, tutorialId) => {
+  // Ensure tutorial progress is 100%
   const enrollment = await db("tutorial_enrollments")
     .where({ user_id: userId, tutorial_id: tutorialId })
     .where("progress", 100)
     .first();
-  return !!enrollment;
+  if (!enrollment) return false;
+
+  // Get total assignments for the tutorial
+  const [assignmentRow] = await db("tutorial_assignments")
+    .where({ tutorial_id: tutorialId })
+    .count("id as count");
+  const totalAssignments = parseInt(assignmentRow?.count, 10) || 0;
+
+  if (totalAssignments === 0) return true;
+
+  // Count assignments submitted/passed by the user
+  const [submittedRow] = await db("assignment_submissions as s")
+    .join("tutorial_assignments as a", "s.assignment_id", "a.id")
+    .where("a.tutorial_id", tutorialId)
+    .where("s.user_id", userId)
+    .where("s.grade", ">=", 60)
+    .count("s.id as count");
+
+  const passedAssignments = parseInt(submittedRow?.count, 10) || 0;
+
+  return passedAssignments >= totalAssignments;
 };
 
 // Check if certificate already exists

--- a/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
@@ -9,9 +9,13 @@ exports.generateCertificate = catchAsync(async (req, res) => {
   const { tutorialId } = req.params;
   const userId = req.user.id;
 
-  // 1. Validate completion
+  // 1. Validate completion (including assignments)
   const completed = await service.isUserCompletedTutorial(userId, tutorialId);
-  if (!completed) throw new AppError("You must complete the tutorial to receive a certificate.", 403);
+  if (!completed)
+    throw new AppError(
+      "You must complete the tutorial and all assignments to receive a certificate.",
+      403,
+    );
 
   // 2. Avoid duplicates
   const existing = await service.findExisting(userId, tutorialId);


### PR DESCRIPTION
## Summary
- Extend tutorial certificate eligibility to ensure all tutorial assignments are submitted and passed
- Warn students to complete assignments before generating certificates
- Add service and route tests for certificate generation workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1f3f55248328906ca1a8608f0daf