### PR TITLE
Prevent tutorial completion with pending assignments

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -84,9 +84,21 @@ exports.complete = catchAsync(async (req, res) => {
     quizPassed = Boolean(attempt);
   }
 
-  if (!allChaptersCompleted || !quizPassed) {
+  // Verify all assignments submitted
+  const [{ count: pendingAssignments }] = await db("tutorial_assignments")
+    .where({ tutorial_id: tutorialId })
+    .whereNotIn("id", function () {
+      this.select("assignment_id")
+        .from("assignment_submissions")
+        .where({ user_id });
+    })
+    .count("id as count");
+
+  const assignmentsCompleted = Number(pendingAssignments) === 0;
+
+  if (!allChaptersCompleted || !quizPassed || !assignmentsCompleted) {
     throw new AppError(
-      "Complete all chapters and pass the required quiz before finishing the tutorial",
+      "Complete all chapters, assignments, and pass the required quiz before finishing the tutorial",
       400
     );
   }

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -140,11 +140,52 @@ describe('POST /api/users/tutorials/enrollments/:id/complete', () => {
         };
       if (table === 'tutorial_quizzes')
         return { where: () => ({ first: () => Promise.resolve(null) }) };
+      if (table === 'tutorial_assignments')
+        return {
+          where: () => ({
+            whereNotIn: () => ({ count: () => Promise.resolve([{ count: 0 }]) }),
+          }),
+        };
     });
 
     const res = await request(app).post('/api/users/tutorials/enrollments/t1/complete');
     expect(res.status).toBe(200);
     expect(update).toHaveBeenCalledWith({ status: 'completed', progress: 100 });
+  });
+
+  it('prevents completion when assignments are unfinished', async () => {
+    db.mockImplementation((table) => {
+      if (table === 'tutorial_enrollments')
+        return {
+          where: () => ({ first: () => Promise.resolve({ id: 'e1' }) }),
+        };
+      if (table === 'tutorial_chapters')
+        return {
+          where: () => ({ count: () => Promise.resolve([{ count: 1 }]) }),
+        };
+      if (table === 'tutorial_chapter_completions as tcc')
+        return {
+          join: () => ({
+            where: () => ({
+              andWhere: () => ({ count: () => Promise.resolve([{ count: 1 }]) }),
+            }),
+          }),
+        };
+      if (table === 'tutorial_quizzes')
+        return { where: () => ({ first: () => Promise.resolve(null) }) };
+      if (table === 'tutorial_assignments')
+        return {
+          where: () => ({
+            whereNotIn: () => ({ count: () => Promise.resolve([{ count: 1 }]) }),
+          }),
+        };
+    });
+
+    const res = await request(app).post('/api/users/tutorials/enrollments/t1/complete');
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe(
+      'Complete all chapters, assignments, and pass the required quiz before finishing the tutorial'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Check for unfinished tutorial assignments before marking enrollment complete
- Test assignment enforcement in completion route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1f40524c8328abcae6e48ed06600