### PR TITLE
Use date-only assignment due dates

### DIFF
--- a/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
+++ b/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
@@ -81,10 +81,10 @@ describe('Class assignment routes', () => {
   });
 
   test('create assignment sends messages', async () => {
-    service.createAssignment.mockResolvedValue({ id: '1', title: 'New', due_date: '2024-01-01T00:00:00.000Z' });
+    service.createAssignment.mockResolvedValue({ id: '1', title: 'New', due_date: '2024-01-01' });
     const res = await request(app)
       .post('/classes/assignments/class/abc')
-      .send({ title: 'New', due_date: '2024-01-01T00:00:00.000Z' });
+      .send({ title: 'New', due_date: '2024-01-01' });
     expect(res.statusCode).toBe(200);
     expect(service.createAssignment).toHaveBeenCalled();
     expect(emailUtil.sendAssignmentEmail).toHaveBeenCalledTimes(2);
@@ -103,7 +103,7 @@ describe('Class assignment routes', () => {
   test('create assignment fails with missing title', async () => {
     const res = await request(app)
       .post('/classes/assignments/class/abc')
-      .send({ due_date: '2024-01-01T00:00:00.000Z' });
+      .send({ due_date: '2024-01-01' });
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toBe('Validation error');
     expect(service.createAssignment).not.toHaveBeenCalled();

--- a/backend/src/modules/classes/assignments/classAssignment.validator.js
+++ b/backend/src/modules/classes/assignments/classAssignment.validator.js
@@ -4,7 +4,7 @@ exports.create = {
   body: z.object({
     title: z.string().min(3),
     description: z.string().optional(),
-    due_date: z.string().datetime(),
+    due_date: z.string().date(),
   }),
 };
 
@@ -12,6 +12,6 @@ exports.update = {
   body: z.object({
     title: z.string().min(3).optional(),
     description: z.string().optional(),
-    due_date: z.string().datetime().optional(),
+    due_date: z.string().date().optional(),
   }),
 };

--- a/backend/src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js
+++ b/backend/src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js
@@ -94,11 +94,11 @@ describe('Tutorial assignment routes', () => {
     service.createAssignment.mockResolvedValue({
       id: '1',
       title: 'New',
-      due_date: '2024-01-01T00:00:00.000Z',
+      due_date: '2024-01-01',
     });
     const res = await request(app)
       .post('/api/users/tutorials/assignments/t1')
-      .send({ title: 'New', due_date: '2024-01-01T00:00:00.000Z' });
+      .send({ title: 'New', due_date: '2024-01-01' });
     expect(res.statusCode).toBe(200);
     expect(service.createAssignment).toHaveBeenCalled();
     expect(emailUtil.sendAssignmentEmail).toHaveBeenCalledTimes(2);
@@ -118,7 +118,7 @@ describe('Tutorial assignment routes', () => {
   test('create assignment fails with missing title', async () => {
     const res = await request(app)
       .post('/api/users/tutorials/assignments/t1')
-      .send({ due_date: '2024-01-01T00:00:00.000Z' });
+      .send({ due_date: '2024-01-01' });
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toBe('Validation error');
     expect(service.createAssignment).not.toHaveBeenCalled();

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.validator.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.validator.js
@@ -4,7 +4,7 @@ exports.create = {
   body: z.object({
     title: z.string().min(3),
     description: z.string().optional(),
-    due_date: z.string().datetime(),
+    due_date: z.string().date(),
   }),
 };
 
@@ -12,6 +12,6 @@ exports.update = {
   body: z.object({
     title: z.string().min(3).optional(),
     description: z.string().optional(),
-    due_date: z.string().datetime().optional(),
+    due_date: z.string().date().optional(),
   }),
 };

--- a/frontend/src/pages/dashboard/admin/assignments/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/edit/[id].js
@@ -61,7 +61,7 @@ export default function EditAssignmentPage() {
             ></textarea>
 
             <input
-              type="datetime-local"
+              type="date"
               value={assignment.dueDate}
               onChange={(e) => setAssignment({ ...assignment, dueDate: e.target.value })}
               className="w-full p-3 bg-white border rounded"

--- a/frontend/src/pages/dashboard/instructor/assignments/create.js
+++ b/frontend/src/pages/dashboard/instructor/assignments/create.js
@@ -220,7 +220,7 @@ export default function CreateAssignmentPage() {
 
           {/* Due Date */}
           <input
-            type="datetime-local"
+            type="date"
             value={dueDate}
             onChange={(e) => setDueDate(e.target.value)}
             className="w-full p-3 bg-gray-100 rounded-md"


### PR DESCRIPTION
## Summary
- validate assignment due dates with `z.string().date()`
- send date strings in assignment route tests
- switch instructor and admin assignment forms to use `<input type="date">`

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b1f4212c883288c5502b3c8e5e8ec