### PR TITLE
Handle notification failures in class creation

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -19,12 +19,12 @@ jest.mock('../class.service', () => ({
 }));
 const service = require('../class.service');
 jest.mock('../../notifications/notifications.service', () => ({
-  createNotification: jest.fn(),
+  createNotification: jest.fn(() => Promise.resolve()),
 }));
 
 const notifications = require('../../notifications/notifications.service');
 jest.mock('../../messages/messages.service', () => ({
-  createMessage: jest.fn(),
+  createMessage: jest.fn(() => Promise.resolve()),
 }));
 const messages = require('../../messages/messages.service');
 jest.mock('../../users/user.model', () => ({
@@ -73,6 +73,18 @@ describe('Class routes', () => {
     );
     expect(notifications.createNotification).toHaveBeenCalledTimes(2);
     expect(messages.createMessage).toHaveBeenCalledTimes(2);
+  });
+
+  test('create class responds even if notifications fail', async () => {
+    const data = { id: '3', instructor_id: '2', title: 'Fail Class', status: 'published' };
+    service.createClass.mockResolvedValue(data);
+    notifications.createNotification
+      .mockResolvedValueOnce() // instructor notification
+      .mockRejectedValueOnce(new Error('notify error')); // admin notification
+
+    const res = await request(app).post('/classes/admin').send(data);
+    expect(res.statusCode).toBe(200);
+    expect(notifications.createNotification).toHaveBeenCalledTimes(2);
   });
 
   test('create class with options', async () => {

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -56,12 +56,16 @@ exports.createClass = catchAsync(async (req, res) => {
     await service.addClassTags(cls.id, tagIds);
     cls.tags = await service.getClassTags(cls.id);
   }
-  await notificationService.createNotification({
-    user_id: cls.instructor_id,
-    type: "class_created",
-    message:
-      "Your class was created successfully and is now pending review. We'll notify you once it's published.",
-  });
+  notificationService
+    .createNotification({
+      user_id: cls.instructor_id,
+      type: "class_created",
+      message:
+        "Your class was created successfully and is now pending review. We'll notify you once it's published.",
+    })
+    .catch((err) =>
+      console.error("Failed to notify instructor of new class:", err.message)
+    );
 
   const admins = await userModel.findAdmins();
   const instructor = await userModel.findById(cls.instructor_id);
@@ -69,14 +73,12 @@ exports.createClass = catchAsync(async (req, res) => {
   const adminMessage = `Instructor ${instructor.full_name} submitted a new class "${cls.title}"${
     cls.start_date ? ` starting ${new Date(cls.start_date).toLocaleDateString("en-US", { dateStyle: "long" })}` : ""
   } that is awaiting your review.`;
-  await Promise.all(
-    admins.map((admin) =>
-      notificationService.createNotification({
-        user_id: admin.id,
-        type: "new_class",
-        message: adminMessage,
-      })
-    )
+  const adminNotificationPromises = admins.map((admin) =>
+    notificationService.createNotification({
+      user_id: admin.id,
+      type: "new_class",
+      message: adminMessage,
+    })
   );
 
   const instructorMessage =
@@ -84,23 +86,54 @@ exports.createClass = catchAsync(async (req, res) => {
 
   const sender = admins[0];
   if (sender) {
-    await messageService.createMessage({
-      sender_id: sender.id,
-      receiver_id: cls.instructor_id,
-      message: instructorMessage,
-    });
-  }
-  await Promise.all(
-    admins.map((admin) =>
-      messageService.createMessage({
-        sender_id: instructor.id,
-        receiver_id: admin.id,
-        message: adminMessage,
+    messageService
+      .createMessage({
+        sender_id: sender.id,
+        receiver_id: cls.instructor_id,
+        message: instructorMessage,
       })
-    )
+      .catch((err) =>
+        console.error(
+          "Failed to send instructor class message:",
+          err.message
+        )
+      );
+  }
+
+  const adminMessagePromises = admins.map((admin) =>
+    messageService.createMessage({
+      sender_id: instructor.id,
+      receiver_id: admin.id,
+      message: adminMessage,
+    })
   );
 
   sendSuccess(res, cls, "Class created");
+
+  Promise.allSettled(adminNotificationPromises).then((results) => {
+    results.forEach((result, idx) => {
+      if (result.status === "rejected") {
+        console.error(
+          "Failed to notify admin",
+          admins[idx].id,
+          result.reason?.message || result.reason
+        );
+      }
+    });
+  });
+
+  Promise.allSettled(adminMessagePromises).then((results) => {
+    results.forEach((result, idx) => {
+      if (result.status === "rejected") {
+        console.error(
+          "Failed to send admin message",
+          admins[idx].id,
+          result.reason?.message || result.reason
+        );
+      }
+    });
+  });
+
 });
 
 exports.getAllClasses = catchAsync(async (_req, res) => {


### PR DESCRIPTION
## Summary
- Avoid blocking class creation by sending notifications/messages in the background
- Log individual failures from admin notifications and messages using `Promise.allSettled`
- Add tests to ensure class creation succeeds even when notifications fail

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1f42e35883289a91a4e59217856b