### PR TITLE
feat: namespace tutorial quiz storage by id

### DIFF
--- a/frontend/src/components/tutorials/detail/TestQuiz.js
+++ b/frontend/src/components/tutorials/detail/TestQuiz.js
@@ -20,7 +20,7 @@ function shuffleArray(array) {
     return [...array].sort(() => Math.random() - 0.5);
 }
 
-const TestQuiz = ({ onComplete }) => {
+const TestQuiz = ({ onComplete, tutorialId = "default" }) => {
     const [questions, setQuestions] = useState([]);
     const [current, setCurrent] = useState(0);
     const [score, setScore] = useState(0);
@@ -28,6 +28,8 @@ const TestQuiz = ({ onComplete }) => {
     const [submitted, setSubmitted] = useState(false);
     const [showExplanation, setShowExplanation] = useState(false);
     const [attempted, setAttempted] = useState(false);
+
+    const storageKey = `quiz-passed-${tutorialId}`;
 
     // Initialize and shuffle questions
     useEffect(() => {
@@ -37,10 +39,10 @@ const TestQuiz = ({ onComplete }) => {
         }));
         setQuestions(shuffledQuestions);
 
-        if (localStorage.getItem("quiz-passed")) {
+        if (localStorage.getItem(storageKey)) {
             setAttempted(true);
         }
-    }, []);
+    }, [storageKey]);
 
     const handleSubmit = () => {
         if (!selected) return;
@@ -60,7 +62,7 @@ const TestQuiz = ({ onComplete }) => {
             setCurrent((prev) => prev + 1);
         } else {
             setSubmitted(true);
-            localStorage.setItem("quiz-passed", true);
+            localStorage.setItem(storageKey, true);
             onComplete(score + (selected === questions[current].answer ? 1 : 0));
         }
     };

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -425,6 +425,7 @@ export default function TutorialDetail() {
 
         {isEnrolled ? (
           <TestQuiz
+            tutorialId={tutorial.id}
             onComplete={(finalScore) => {
               if (finalScore >= 2) setTestPassed(true);
             }}


### PR DESCRIPTION
## Summary
- scope quiz completion key to specific tutorial using `tutorialId`
- forward tutorial id to quiz component on tutorial page

## Testing
- `npm test` (fails: bookService tests)
- `npm run lint` (fails: 69 errors, 263 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689b40841da08328a1cc7a2db968b465