### PR TITLE
feat: include enrollment status in tutorial details

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -249,7 +249,8 @@ exports.getMyTutorials = catchAsync(async (req, res) => {
 
 
 exports.getTutorialById = catchAsync(async (req, res) => {
-  const tutorial = await service.getTutorialById(req.params.id);
+  const userId = req.user?.id || null;
+  const tutorial = await service.getTutorialById(req.params.id, userId);
 
   if (!tutorial) {
     throw new AppError("Tutorial not found", 404);

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -20,8 +20,8 @@ exports.getAllTutorials = async () => {
     );
 };
 
-exports.getTutorialById = async (id) => {
-  return db({ t: 'tutorials' })
+exports.getTutorialById = async (id, userId = null) => {
+  const query = db({ t: 'tutorials' })
     .leftJoin('categories as c', 't.category_id', 'c.id')
     .leftJoin('users as u', 't.instructor_id', 'u.id')
     .leftJoin(
@@ -59,18 +59,38 @@ exports.getTutorialById = async (id) => {
         .as('v'),
       'v.tutorial_id',
       't.id'
-    )
-    .where('t.id', id)
-    .first(
-      't.*',
-      'c.name as category_name',
-      'c.image_url as category_image_url',
-      'u.full_name as instructor_name',
-      db.raw('COALESCE(r.avg_rating,0) as rating'),
-      db.raw('COALESCE(com.comment_count,0) as comment_count'),
-      db.raw('COALESCE(en.enrollments,0) as enrollments'),
-      db.raw('COALESCE(v.views,0) as views')
     );
+
+  if (userId) {
+    query.leftJoin('tutorial_enrollments as te', function () {
+      this.on('te.tutorial_id', 't.id').andOn('te.user_id', '=', userId);
+    });
+  }
+
+  query.where('t.id', id);
+
+  const columns = [
+    't.*',
+    'c.name as category_name',
+    'c.image_url as category_image_url',
+    'u.full_name as instructor_name',
+    db.raw('COALESCE(r.avg_rating,0) as rating'),
+    db.raw('COALESCE(com.comment_count,0) as comment_count'),
+    db.raw('COALESCE(en.enrollments,0) as enrollments'),
+    db.raw('COALESCE(v.views,0) as views'),
+  ];
+
+  if (userId) {
+    columns.push(
+      db.raw(
+        'CASE WHEN te.user_id IS NULL THEN false ELSE true END as is_enrolled'
+      )
+    );
+  } else {
+    columns.push(db.raw('false as is_enrolled'));
+  }
+
+  return query.select(columns).first();
 };
 
 exports.getTutorialsByInstructor = async (instructorId) => {

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -30,6 +30,7 @@ import {
   fetchTutorialDetails,
   fetchPublishedTutorials,
   fetchTutorialAssignments,
+  fetchTutorialProgress,
   enrollInTutorial,
   addTutorialToWishlist,
   removeTutorialFromWishlist,
@@ -163,11 +164,20 @@ export default function TutorialDetail() {
           };
         });
         setTutorial({ ...data, chapters });
-        setIsEnrolled(
-          Boolean(
-            data?.is_enrolled || data?.enrolled || data?.isEnrolled,
-          ),
+        let enrolled = Boolean(
+          data?.is_enrolled || data?.enrolled || data?.isEnrolled,
         );
+        if (!enrolled && isLoggedIn) {
+          try {
+            const status = await fetchTutorialProgress(id);
+            enrolled = Boolean(
+              status?.is_enrolled || status?.enrolled || status?.success,
+            );
+          } catch (err) {
+            console.error('Failed to fetch enrollment status', err);
+          }
+        }
+        setIsEnrolled(enrolled);
         try {
           const assignmentList = await fetchTutorialAssignments(id);
           setAssignments(assignmentList);


### PR DESCRIPTION
## Summary
- join tutorial_enrollments when fetching a tutorial to flag if the requester is enrolled
- expose enrollment status in tutorial controller response
- load enrollment status on tutorial detail page using API or progress lookup

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: bookService test expectations not met)*

------
https://chatgpt.com/codex/tasks/task_e_689b40825d40832890c7f789ec43cff2