### PR TITLE
Avoid unnecessary refresh calls for unauthenticated users

### DIFF
--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -78,6 +78,20 @@ api.interceptors.response.use(
       originalRequest?.url?.includes("/auth/register");
 
     if (error.response?.status === 401 && !originalRequest._retry && !isAuthRoute) {
+      const refreshCookie = getCookie("refreshToken");
+      const hasAuthState = !!authStore.accessToken || !!authStore.user;
+
+      if (!refreshCookie && !hasAuthState) {
+        authStore.setToken(null);
+        authStore.setUser(null);
+        if (typeof window !== "undefined") {
+          localStorage.removeItem("auth");
+          Router.push("/auth/login");
+        }
+        toast.error("Session expired. Please log in again.");
+        return Promise.reject(error);
+      }
+
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });


### PR DESCRIPTION
## Summary
- Skip refresh token requests when no refresh cookie or auth state is present
- Redirect unauthenticated users to `/auth/login` immediately on 401

## Testing
- `npm test` *(frontend: 1 failing test – bookService)*
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_689b6826448083288d4f9009980760f1