### PR TITLE
fix: handle missing payment method icons

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -211,7 +211,7 @@ export default function CheckoutPage() {
                   ${selectedMethod === method.name ? 'bg-yellow-500 text-black border-yellow-400' : 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600'}`}
               >
                 <div className="text-2xl">
-                  {iconMap[method.icon.toLowerCase()] || <FaMoneyCheckAlt />}
+                  {iconMap[method.icon?.toLowerCase()] || <FaMoneyCheckAlt />}
                 </div>
                 <div>{method.label}</div>
               </button>


### PR DESCRIPTION
## Summary
- avoid runtime errors when payment methods lack icons by using optional chaining
- show a default money check icon when no icon is provided

## Testing
- `npm test` *(fails: bookService.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689b68255e908328be38412723ed9633