### PR TITLE
Fix checkout effect dependency to prevent redundant state updates

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -45,13 +45,15 @@ export default function CheckoutPage() {
   const [allowInstallments, setAllowInstallments] = useState(false);
   const [paypalLoaded, setPaypalLoaded] = useState(false);
   const [paypalClientId, setPaypalClientId] = useState('');
+  const firstItemId = cartItems[0]?.id;
+  const firstItemType = cartItems[0]?.item_type;
   useEffect(() => {
-    const id = queryItemId || cartItems[0]?.id;
-    const type = queryItemType || cartItems[0]?.item_type || 'class';
+    const id = queryItemId || firstItemId;
+    const type = queryItemType || firstItemType || 'class';
     if (!id) return;
-    setItemId(id);
-    setItemType(type);
-  }, [queryItemId, queryItemType, cartItems]);
+    if (id !== itemId) setItemId(id);
+    if (type !== itemType) setItemType(type);
+  }, [queryItemId, queryItemType, firstItemId, firstItemType, itemId, itemType]);
 
   useEffect(() => {
     if (!itemId || !itemType) return;


### PR DESCRIPTION
## Summary
- stabilize checkout effect dependencies on cart items
- skip itemId and itemType updates when values unchanged

## Testing
- `npm test` (fails: bookService.test.js)
- `npm run lint` (fails: 69 errors, 263 warnings)
- `npm run dev` followed by `curl -s http://localhost:3000/payments/checkout`

------
https://chatgpt.com/codex/tasks/task_e_689b6824abf48328bd209abe0132ea7c