### PR TITLE
fix: initialize router in checkout page

### DIFF
--- a/frontend/src/pages/payments/[id].js
+++ b/frontend/src/pages/payments/[id].js
@@ -1,10 +1,12 @@
 // pages/payments/checkout.js
 import { useState } from "react";
+import { useRouter } from "next/router";
 import { BrowserProvider, parseEther } from "ethers";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 
 export default function CheckoutPage() {
+  const router = useRouter();
   const [formData, setFormData] = useState({
     fullName: "",
     email: "",


### PR DESCRIPTION
## Summary
- initialize `useRouter` in payment checkout dynamic page to fix navigation errors

## Testing
- `npm test` *(fails: bookService tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b6f5e2abc83289693945986fde2e3