### PR TITLE
Fix checkout navigation and normalize media URLs

### DIFF
--- a/frontend/src/pages/cart/index.js
+++ b/frontend/src/pages/cart/index.js
@@ -145,9 +145,7 @@ const CartPage = () => {
             {/* Checkout Button */}
             <div className="mt-6 flex justify-end">
               {cartItems.length > 0 && (
-                <Link
-                  href={`/payments/checkout?itemType=${cartItems[0].item_type}&itemId=${cartItems[0].id}`}
-                >
+                <Link href="/payments/checkout">
                   <motion.button
                     whileHover={{ scale: 1.1 }}
                     whileTap={{ scale: 0.9 }}

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -45,15 +45,13 @@ export default function CheckoutPage() {
   const [allowInstallments, setAllowInstallments] = useState(false);
   const [paypalLoaded, setPaypalLoaded] = useState(false);
   const [paypalClientId, setPaypalClientId] = useState('');
-  const firstItemId = cartItems[0]?.id;
-  const firstItemType = cartItems[0]?.item_type;
   useEffect(() => {
-    const id = queryItemId || firstItemId;
-    const type = queryItemType || firstItemType || 'class';
+    const id = queryItemId || cartItems[0]?.id;
+    const type = queryItemType || cartItems[0]?.item_type || 'class';
     if (!id) return;
-    if (id !== itemId) setItemId(id);
-    if (type !== itemType) setItemType(type);
-  }, [queryItemId, queryItemType, firstItemId, firstItemType, itemId, itemType]);
+    setItemId(id);
+    setItemType(type);
+  }, [queryItemId, queryItemType, cartItems]);
 
   useEffect(() => {
     if (!itemId || !itemType) return;

--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -16,13 +16,11 @@ const RELATIVE_API_BASE = !API_BASE && rawApiBase
 export const buildUrl = (path) => {
   if (!path) return null;
   if (/^https?:/i.test(path)) return path;
-  const uploadsIndex = path.indexOf("/uploads");
-  const relative =
-    uploadsIndex !== -1 ? path.substring(uploadsIndex + 8) : path; // 8 = '/uploads'.length
-  const normalized = relative.startsWith("/") ? relative : `/${relative}`;
-  if (API_BASE) return `${API_BASE}${normalized}`;
-  if (RELATIVE_API_BASE) return `${RELATIVE_API_BASE}${normalized}`;
-  return normalized;
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  const mediaPath = normalized.replace(/^\/uploads/, "/media");
+  if (API_BASE) return `${API_BASE}${mediaPath}`;
+  if (RELATIVE_API_BASE) return `${RELATIVE_API_BASE}${mediaPath}`;
+  return mediaPath;
 };
 
 const formatBook = (book) => {

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -136,8 +136,8 @@ describe("bookService", () => {
       price: 19.99,
       cover_image_url: null,
       pdf_url: null,
-      preview_url: "/uploads/p.pdf",
-      preview_pages: ["/uploads/a.png"],
+      preview_url: "/media/p.pdf",
+      preview_pages: ["/media/a.png"],
     });
   });
 
@@ -214,7 +214,7 @@ describe("bookService", () => {
     jest.isolateModules(() => {
       delete process.env.NEXT_PUBLIC_API_BASE_URL;
       const { buildUrl } = require("../../services/bookService");
-      expect(buildUrl("/uploads/test.jpg")).toBe("/uploads/test.jpg");
+      expect(buildUrl("/uploads/test.jpg")).toBe("/media/test.jpg");
     });
     process.env.NEXT_PUBLIC_API_BASE_URL = originalBase;
   });


### PR DESCRIPTION
## Summary
- ensure cart checkout link doesn't drop items
- simplify checkout item selection to use cart state
- normalize /uploads paths to /media in book service

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_689b6f5e2abc83289693945986fde2e3