### PR TITLE
Handle checkout per cart item

### DIFF
--- a/frontend/src/components/books/CartItem.js
+++ b/frontend/src/components/books/CartItem.js
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { FaTrash, FaPlus, FaMinus, FaGift } from "react-icons/fa";
 import { motion } from "framer-motion";
 
@@ -8,6 +9,7 @@ export default function CartItem({
   onDecrease,
   onRemove,
 }) {
+  const itemType = item.item_type || item.type || "class";
   return (
     <motion.li
       initial={{ opacity: 0, y: -10 }}
@@ -45,15 +47,25 @@ export default function CartItem({
           <FaPlus />
         </motion.button>
       </div>
-
-      <motion.button
-        whileHover={{ scale: 1.2 }}
-        whileTap={{ scale: 0.9 }}
-        onClick={onRemove}
-        className="p-2 text-red-500 hover:text-red-600"
-      >
-        <FaTrash />
-      </motion.button>
+      <div className="flex items-center space-x-4">
+        <Link href={`/payments/checkout?itemType=${itemType}&itemId=${item.id}`}>
+          <motion.button
+            whileHover={{ scale: 1.1 }}
+            whileTap={{ scale: 0.9 }}
+            className="px-3 py-2 bg-green-500 text-black rounded-lg hover:bg-green-600"
+          >
+            Checkout
+          </motion.button>
+        </Link>
+        <motion.button
+          whileHover={{ scale: 1.2 }}
+          whileTap={{ scale: 0.9 }}
+          onClick={onRemove}
+          className="p-2 text-red-500 hover:text-red-600"
+        >
+          <FaTrash />
+        </motion.button>
+      </div>
     </motion.li>
   );
 }

--- a/frontend/src/pages/cart/index.js
+++ b/frontend/src/pages/cart/index.js
@@ -4,7 +4,6 @@ import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
 import { motion, AnimatePresence } from "framer-motion"; // ✅ Import animations
 import { FaTag, FaGift } from "react-icons/fa";
-import Link from "next/link";
 import { toast } from "react-toastify";
 import CartItem from "@/components/books/CartItem";
 
@@ -142,22 +141,6 @@ const CartPage = () => {
               </div>
             </div>
 
-            {/* Checkout Button */}
-            <div className="mt-6 flex justify-end">
-              {cartItems.length > 0 && (
-                <Link
-                  href={`/payments/checkout?itemType=${cartItems[0].item_type}&itemId=${cartItems[0].id}`}
-                >
-                  <motion.button
-                    whileHover={{ scale: 1.1 }}
-                    whileTap={{ scale: 0.9 }}
-                    className="px-6 py-3 bg-green-500 text-black rounded-lg hover:bg-green-600 transition font-bold"
-                  >
-                    Proceed to Checkout
-                  </motion.button>
-                </Link>
-              )}
-            </div>
           </motion.div>
         )}
       </main>


### PR DESCRIPTION
## Summary
- Add checkout button to each cart item so users purchase specific items
- Remove single-cart checkout link that always targeted the first item

## Testing
- `npm test` (backend) ✅
- `npm test` (frontend) ❌

------
https://chatgpt.com/codex/tasks/task_e_689b6f5e2abc83289693945986fde2e3