### PR TITLE
fix: import Link component in cart page

### DIFF
--- a/frontend/src/pages/cart/index.js
+++ b/frontend/src/pages/cart/index.js
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from "framer-motion"; // ✅ Import animation
 import { FaTag, FaGift } from "react-icons/fa";
 import { toast } from "react-toastify";
 import CartItem from "@/components/books/CartItem";
+import Link from "next/link";
 
 const CartPage = () => {
   const {


### PR DESCRIPTION
## Summary
- import Link component to prevent runtime errors in the cart page

## Testing
- `npm test` *(fails: bookService, buildUrl)*
- `npm run lint` *(fails: react/display-name and others)*

------
https://chatgpt.com/codex/tasks/task_e_689b778ec78c832894f76641dc09a6b9