### PR TITLE
Avoid recursive refresh interceptor

### DIFF
--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -73,9 +73,11 @@ api.interceptors.response.use(
       lastNetworkToast = Date.now();
     }
 
-    const isAuthRoute =
-      originalRequest?.url?.includes("/auth/login") ||
-      originalRequest?.url?.includes("/auth/register");
+    const isAuthRoute = [
+      "/auth/login",
+      "/auth/register",
+      "/auth/refresh",
+    ].some((route) => originalRequest?.url?.includes(route));
 
     if (error.response?.status === 401 && !originalRequest._retry && !isAuthRoute) {
       const refreshCookie = getCookie("refreshToken");


### PR DESCRIPTION
## Summary
- prevent response interceptor from retrying on /auth/refresh calls

## Testing
- `npm test` *(fails: bookService tests)*
- `npm run lint` *(fails: 69 errors, 263 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b79ae9dc08328862de9492f565fec