### PR TITLE
Handle null roles in auth middleware

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -7,7 +7,9 @@ const tokenBlacklist = new Set();
  * ✅ Helper: Determines if a role has admin-level access
  */
 // Normalize role string for consistent comparisons
-const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
+// Guard against null/undefined or non-string values to avoid runtime errors
+const normalizeRole = (role) =>
+  typeof role === "string" ? role.toLowerCase().replace(/\s+/g, "") : "";
 
 const isAdminRole = (roles = []) => {
   const arr = Array.isArray(roles) ? roles : [roles];

--- a/backend/tests/authRoles.test.js
+++ b/backend/tests/authRoles.test.js
@@ -1,0 +1,27 @@
+const { isAdmin } = require("../src/middleware/auth/authMiddleware");
+
+describe("auth middleware role handling", () => {
+  const resFactory = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  it("denies access gracefully when roles array contains null", () => {
+    const req = { user: { roles: [null] } };
+    const res = resFactory();
+    const next = jest.fn();
+    isAdmin(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("allows access when admin role present alongside null", () => {
+    const req = { user: { roles: [null, "Admin"] } };
+    const res = resFactory();
+    const next = jest.fn();
+    isAdmin(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- avoid runtime error when role values are null or non-strings by guarding normalizeRole
- test that auth middleware gracefully rejects null roles and still honors admin role

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: bookService.test.js 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689b86a3b6dc8328bb8083524ca84bdf