### PR TITLE
Add global toast container for notifications

### DIFF
--- a/frontend/src/components/admin/users/AddUserModal.js
+++ b/frontend/src/components/admin/users/AddUserModal.js
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
-import "react-toastify/dist/ReactToastify.css";
 
 export default function AddUserModal({ isOpen, onClose, onSubmit }) {
   const { t } = useTranslation("dashboard");

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -4,6 +4,8 @@ import useSWR from "swr";
 import nextI18NextConfig from "../../next-i18next.config.js";
 import { motion, AnimatePresence } from "framer-motion";
 import { Toaster, toast } from "react-hot-toast";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import "react-quill/dist/quill.snow.css";       // ✅ Rich text editor
 import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
 import "@/styles/globals.css";    
@@ -217,7 +219,7 @@ function MyApp({ Component, pageProps, router }) {
               />
             )}
 
-            {/* Global Toast Message Container */}
+            {/* Global Toast Message Containers */}
             <Toaster
               position="top-center"
               toastOptions={{
@@ -228,6 +230,7 @@ function MyApp({ Component, pageProps, router }) {
                 },
               }}
             />
+            <ToastContainer position="top-right" autoClose={3000} />
           </motion.div>
         </AnimatePresence>
       </>

--- a/frontend/src/pages/offers/new.js
+++ b/frontend/src/pages/offers/new.js
@@ -3,8 +3,7 @@ import { useRouter } from "next/router";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import { FaTag } from "react-icons/fa";
-import { ToastContainer, toast } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
+import { toast } from "react-toastify";
 import { createOffer } from "@/services/offerService";
 
 const availableTags = ["Urgent", "LiveClass", "Discount", "Flexible", "OneOnOne"];
@@ -46,7 +45,6 @@ const CreateOffer = () => {
   return (
     <div className="bg-gray-950 text-white min-h-screen">
       <Navbar />
-      <ToastContainer position="top-right" autoClose={3000} />
       <section className="pt-24 pb-16 px-4">
         <div className="max-w-4xl mx-auto">
           <h1 className="text-4xl font-extrabold text-yellow-400 text-center mb-6">


### PR DESCRIPTION
## Summary
- configure react-toastify globally so toast notifications render
- remove redundant local ToastContainer and CSS imports

## Testing
- `npm test` *(fails: bookService normalizes price and buildUrl)*

------
https://chatgpt.com/codex/tasks/task_e_689b892663b48328915babbe8ed1b55f