### PR TITLE
Fix checkout item query handling to prevent crash

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -53,15 +53,14 @@ export default function CheckoutPage() {
       return [];
     }
   }, [queryItems]);
-  const firstItemId = parsedItems[0]?.id || cartItems[0]?.id;
-  const firstItemType = parsedItems[0]?.itemType || cartItems[0]?.item_type;
   useEffect(() => {
-    const id = queryItemId || cartItems[0]?.id;
-    const type = queryItemType || cartItems[0]?.item_type || 'class';
+    const id = queryItemId || parsedItems[0]?.id || cartItems[0]?.id;
+    const type =
+      queryItemType || parsedItems[0]?.itemType || cartItems[0]?.item_type || 'class';
     if (!id) return;
     setItemId(id);
     setItemType(type);
-  }, [queryItemId, queryItemType, cartItems]);
+  }, [queryItemId, queryItemType, parsedItems, cartItems]);
 
   useEffect(() => {
     if (!itemId || !itemType) return;


### PR DESCRIPTION
## Summary
- handle `items` query parameter on checkout page to determine cart selection
- remove unused variables and fallback to cart items

## Testing
- `npm test` *(fails: bookService tests fail)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b898e31548328833d31ba96b04333