### PR TITLE
Handle cart item data on checkout page

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -48,20 +48,28 @@ export default function CheckoutPage() {
   const parsedItems = useMemo(() => {
     if (!queryItems) return [];
     try {
-      return JSON.parse(decodeURIComponent(queryItems));
+      const raw = Array.isArray(queryItems) ? queryItems[0] : queryItems;
+      let decoded = decodeURIComponent(raw);
+      try {
+        decoded = decodeURIComponent(decoded);
+      } catch {
+        // already decoded
+      }
+      return JSON.parse(decoded);
     } catch {
       return [];
     }
   }, [queryItems]);
-  const firstItemId = parsedItems[0]?.id || cartItems[0]?.id;
-  const firstItemType = parsedItems[0]?.itemType || cartItems[0]?.item_type;
+
   useEffect(() => {
-    const id = queryItemId || cartItems[0]?.id;
-    const type = queryItemType || cartItems[0]?.item_type || 'class';
+    const source = parsedItems[0];
+    const id = queryItemId || source?.id || cartItems[0]?.id;
+    const type =
+      queryItemType || source?.itemType || cartItems[0]?.item_type || 'class';
     if (!id) return;
     setItemId(id);
     setItemType(type);
-  }, [queryItemId, queryItemType, cartItems]);
+  }, [queryItemId, queryItemType, cartItems, parsedItems]);
 
   useEffect(() => {
     if (!itemId || !itemType) return;


### PR DESCRIPTION
## Summary
- Decode checkout query parameters safely and parse them even if double-encoded
- Derive item id/type from parsed cart items so checkout renders correctly

## Testing
- `npm run lint`
- `npm test` *(fails: bookService tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b898e31548328833d31ba96b04333