### PR TITLE
Fix checkout crash from cart and remove duplicate button

### DIFF
--- a/frontend/src/components/books/CartItem.js
+++ b/frontend/src/components/books/CartItem.js
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { FaTrash, FaPlus, FaMinus, FaGift } from "react-icons/fa";
 import { motion } from "framer-motion";
 
@@ -9,7 +8,6 @@ export default function CartItem({
   onDecrease,
   onRemove,
 }) {
-  const itemType = item.item_type || item.type || "class";
   return (
     <motion.li
       initial={{ opacity: 0, y: -10 }}
@@ -48,15 +46,6 @@ export default function CartItem({
         </motion.button>
       </div>
       <div className="flex items-center space-x-4">
-        <Link href={`/payments/checkout?itemType=${itemType}&itemId=${item.id}`}>
-          <motion.button
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.9 }}
-            className="px-3 py-2 bg-green-500 text-black rounded-lg hover:bg-green-600"
-          >
-            Checkout
-          </motion.button>
-        </Link>
         <motion.button
           whileHover={{ scale: 1.2 }}
           whileTap={{ scale: 0.9 }}

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -66,6 +66,7 @@ export default function CheckoutPage() {
   // an `itemId` and causing it to crash. We now prioritise the parsed query
   // items before falling back to individual query params or the cart store.
   useEffect(() => {
+    if (!router.isReady) return;
     const id = queryItemId || parsedItems[0]?.id || cartItems[0]?.id;
     const type =
       queryItemType ||
@@ -75,7 +76,7 @@ export default function CheckoutPage() {
     if (!id) return;
     setItemId(id);
     setItemType(type);
-  }, [queryItemId, queryItemType, parsedItems, cartItems]);
+  }, [router.isReady, queryItemId, queryItemType, parsedItems, cartItems]);
 
   useEffect(() => {
     if (!itemId || !itemType) return;


### PR DESCRIPTION
## Summary
- ensure checkout page reads cart items from query params once router is ready to avoid crash
- drop per-item checkout button to prevent duplicates on cart page

## Testing
- `npm test` *(fails: bookService.test.js)*
- `npm run lint` *(fails: 69 errors, 263 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b9287d4848328952233ca51377d44