### PR TITLE
fix: center toast notifications

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -230,7 +230,8 @@ function MyApp({ Component, pageProps, router }) {
                 },
               }}
             />
-            <ToastContainer position="top-right" autoClose={3000} />
+            {/* Display React Toastify notifications centered at the top */}
+            <ToastContainer position="top-center" autoClose={3000} />
           </motion.div>
         </AnimatePresence>
       </>


### PR DESCRIPTION
## Summary
- center React Toastify notifications at top of screen

## Testing
- `npm test`
- `npm run lint` *(fails: 332 problems, 69 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c5d72e5448328b52ceaaad23c4b1e