### PR TITLE
fix: robust item resolution on checkout page

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -67,16 +67,16 @@ export default function CheckoutPage() {
   // items before falling back to individual query params or the cart store.
   useEffect(() => {
     if (!router.isReady) return;
-    const id = queryItemId || parsedItems[0]?.id || cartItems[0]?.id;
+    const id = parsedItems[0]?.id || queryItemId || cartItems[0]?.id;
     const type =
-      queryItemType ||
       parsedItems[0]?.itemType ||
+      queryItemType ||
       cartItems[0]?.item_type ||
       'class';
     if (!id) return;
     setItemId(id);
     setItemType(type);
-  }, [router.isReady, queryItemId, queryItemType, parsedItems, cartItems]);
+  }, [router.isReady, parsedItems, queryItemId, queryItemType, cartItems]);
 
   useEffect(() => {
     if (!itemId || !itemType) return;


### PR DESCRIPTION
## Summary
- prioritize cart `items` query param when resolving checkout item
- prevent checkout crash by correctly choosing item id and type

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_689c8bb933a88328a5781e42f26230e8