### PR TITLE
feat: enforce case-insensitive tutorial titles

### DIFF
--- a/backend/src/migrations/20250903000050_add_lower_title_index_to_tutorials.js
+++ b/backend/src/migrations/20250903000050_add_lower_title_index_to_tutorials.js
@@ -1,0 +1,7 @@
+exports.up = function (knex) {
+  return knex.raw('CREATE INDEX tutorials_lower_title_idx ON tutorials (LOWER(title));');
+};
+
+exports.down = function (knex) {
+  return knex.raw('DROP INDEX IF EXISTS tutorials_lower_title_idx;');
+};

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -81,7 +81,9 @@ exports.createTutorial = catchAsync(async (req, res) => {
     : [];
 
   // 🚫 Prevent duplicate titles
-  const existing = await db("tutorials").where({ title }).first();
+  const existing = await db("tutorials")
+    .whereRaw('LOWER(title) = ?', title.toLowerCase())
+    .first();
   if (existing) {
     return res.status(400).json({ message: "Tutorial title already exists" });
   }

--- a/backend/tests/tutorialCreate.test.js
+++ b/backend/tests/tutorialCreate.test.js
@@ -1,6 +1,7 @@
 jest.mock('../src/config/database', () => {
   const mockDb = jest.fn(() => ({
     where: jest.fn().mockReturnThis(),
+    whereRaw: jest.fn().mockReturnThis(),
     first: jest.fn().mockResolvedValue(null),
   }));
   mockDb.transaction = jest.fn(async (cb) => {
@@ -49,6 +50,7 @@ jest.mock('../src/utils/email', () => ({
 const controller = require('../src/modules/users/tutorials/tutorial.controller');
 const service = require('../src/modules/users/tutorials/tutorial.service');
 const userModel = require('../src/modules/users/user.model');
+const db = require('../src/config/database');
 
 
 describe('createTutorial', () => {
@@ -146,6 +148,30 @@ describe('createTutorial', () => {
     await new Promise((resolve) => setImmediate(resolve));
     const data = service.createTutorial.mock.calls[0][0];
     expect(data.is_paid).toBe(true);
+  });
+
+  it('rejects duplicate titles regardless of case', async () => {
+    const whereRaw = jest.fn().mockReturnThis();
+    const first = jest.fn().mockResolvedValue({ id: 'existing' });
+    db.mockImplementationOnce(() => ({ whereRaw, first }));
+
+    const req = {
+      body: {
+        title: 'My Unique',
+        category_id: 'cat',
+        level: 'beginner',
+      },
+      user: { id: 'inst1', role: 'instructor' },
+      files: {},
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await controller.createTutorial(req, res, jest.fn());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(whereRaw).toHaveBeenCalledWith('LOWER(title) = ?', 'my unique');
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(service.createTutorial).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure tutorial titles are checked case-insensitively before creation
- add index on lower(title) for faster lookups
- test that titles differing only by case are rejected

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb80626548328bca50e8295a0f874