### PR TITLE
Ensure transactional safety for tutorial tag updates

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -291,19 +291,29 @@ exports.updateTutorial = catchAsync(async (req, res) => {
     }
   }
   if (tags) {
-    await db('tutorial_tag_map').where({ tutorial_id: tutorial.id }).del();
-    const tagIds = [];
-    for (const name of tags) {
-      const existing = await tagService.findByName(name);
-      const tag =
-        existing ||
-        (await tagService.createTag({
-          name,
-          slug: slugify(name, { lower: true, strict: true }),
-        }));
-      tagIds.push(tag.id);
+    const trx = await db.transaction();
+    try {
+      await trx('tutorial_tag_map').where({ tutorial_id: tutorial.id }).del();
+      const tagIds = [];
+      for (const name of tags) {
+        const existing = await tagService.findByName(name, trx);
+        const tag =
+          existing ||
+          (await tagService.createTag(
+            {
+              name,
+              slug: slugify(name, { lower: true, strict: true }),
+            },
+            trx
+          ));
+        tagIds.push(tag.id);
+      }
+      await service.addTutorialTags(tutorial.id, tagIds, trx);
+      await trx.commit();
+    } catch (err) {
+      await trx.rollback();
+      throw err;
     }
-    await service.addTutorialTags(tutorial.id, tagIds);
     tutorial.tags = await service.getTutorialTags(tutorial.id);
   }
 

--- a/backend/tests/tutorialUpdateTransaction.test.js
+++ b/backend/tests/tutorialUpdateTransaction.test.js
@@ -1,0 +1,86 @@
+jest.mock('../src/config/database', () => {
+  const query = { where: jest.fn().mockReturnThis(), del: jest.fn().mockResolvedValue() };
+  const commitSpy = jest.fn();
+  const rollbackSpy = jest.fn();
+  const trx = Object.assign(jest.fn(() => query), {
+    commit: jest.fn(async () => { commitSpy(); }),
+    rollback: jest.fn(async () => { rollbackSpy(); }),
+  });
+  const db = Object.assign(jest.fn(() => query), {
+    transaction: jest.fn().mockResolvedValue(trx),
+    raw: jest.fn(),
+  });
+  db.__commit = commitSpy;
+  db.__rollback = rollbackSpy;
+  db.__trx = trx;
+  return db;
+});
+
+jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({
+  updateTutorial: jest.fn(),
+  addTutorialTags: jest.fn(),
+  getTutorialTags: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/tutorials/tutorialTag.service', () => ({
+  findByName: jest.fn(),
+  createTag: jest.fn(),
+}));
+
+const controller = require('../src/modules/users/tutorials/tutorial.controller');
+const service = require('../src/modules/users/tutorials/tutorial.service');
+const tagService = require('../src/modules/users/tutorials/tutorialTag.service');
+const db = require('../src/config/database');
+
+describe('updateTutorial tag transactions', () => {
+  beforeEach(() => {
+    db.transaction.mockClear();
+    db.__commit.mockClear();
+    db.__rollback.mockClear();
+    service.updateTutorial.mockReset();
+    service.addTutorialTags.mockReset();
+    service.getTutorialTags.mockReset();
+    tagService.findByName.mockReset();
+    tagService.createTag.mockReset();
+    db.transaction.mockResolvedValue(db.__trx);
+  });
+
+  const baseReq = {
+    params: { id: '1' },
+    body: { tags: ['Tag1'] },
+    files: {},
+    user: { id: 'admin', role: 'admin' },
+  };
+
+  it('commits transaction when tag update succeeds', async () => {
+    service.updateTutorial.mockResolvedValue({ id: '1' });
+    tagService.findByName.mockResolvedValue({ id: 't1' });
+    service.addTutorialTags.mockResolvedValue();
+    service.getTutorialTags.mockResolvedValue([{ id: 't1' }]);
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await controller.updateTutorial(baseReq, res, next);
+    await new Promise((resolve) => setImmediate(resolve));
+    const trx = await db.transaction.mock.results[0].value;
+    expect(db.transaction).toHaveBeenCalled();
+    expect(db.__commit).toHaveBeenCalled();
+    expect(db.__rollback).not.toHaveBeenCalled();
+    expect(service.addTutorialTags).toHaveBeenCalledWith('1', ['t1'], trx);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rolls back transaction when tag creation fails', async () => {
+    service.updateTutorial.mockResolvedValue({ id: '1' });
+    tagService.findByName.mockResolvedValue(null);
+    tagService.createTag.mockRejectedValue(new Error('fail'));
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await controller.updateTutorial(baseReq, res, next);
+    await new Promise((resolve) => setImmediate(resolve));
+    const trx = await db.transaction.mock.results[0].value;
+    expect(db.__rollback).toHaveBeenCalled();
+    expect(db.__commit).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Wrap tutorial tag map updates in an explicit transaction to commit or rollback atomically
- Add tests covering commit success and rollback on tag creation failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb8051d808328ac1e4e5bc608d987