### PR TITLE
refactor: centralize tutorial tag parsing

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -23,6 +23,7 @@ const { v4: uuidv4 } = require("uuid");
 
 const { sendSuccess } = require("../../../utils/response");
 const slugify = require("slugify");
+const { parseTags } = require("./tutorial.helpers");
 
 // Helper to resolve uploads subdirectory based on user role
 const getRoleDir = (req) => {
@@ -131,18 +132,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
   };
 
   // Parse tags safely
-  let tags = [];
-  if (rawTags) {
-    if (typeof rawTags === "string") {
-      try {
-        tags = JSON.parse(rawTags);
-      } catch (err) {
-        return res.status(400).json({ message: "Invalid tags JSON" });
-      }
-    } else if (Array.isArray(rawTags)) {
-      tags = rawTags;
-    }
-  }
+  const tags = parseTags(rawTags);
 
   let tutorial;
   await db.transaction(async (trx) => {
@@ -278,19 +268,11 @@ exports.updateTutorial = catchAsync(async (req, res) => {
     throw new AppError("Tutorial not found", 404);
   }
 
-  let tags = null;
-  if (rawTags) {
-    if (typeof rawTags === 'string') {
-      try {
-        tags = JSON.parse(rawTags);
-      } catch (err) {
-        return res.status(400).json({ message: "Invalid tags JSON" });
-      }
-    } else if (Array.isArray(rawTags)) {
-      tags = rawTags;
-    }
+  let tags;
+  if (rawTags !== undefined) {
+    tags = parseTags(rawTags);
   }
-  if (tags) {
+  if (tags !== undefined) {
     await db('tutorial_tag_map').where({ tutorial_id: tutorial.id }).del();
     const tagIds = [];
     for (const name of tags) {

--- a/backend/src/modules/users/tutorials/tutorial.helpers.js
+++ b/backend/src/modules/users/tutorials/tutorial.helpers.js
@@ -1,0 +1,35 @@
+const AppError = require("../../../utils/AppError");
+
+/**
+ * Safely parse tags from request input.
+ * Accepts an array or a JSON string representing an array.
+ * Returns an array of tag names. Throws AppError on invalid input.
+ *
+ * @param {string|string[]|undefined|null} rawTags
+ * @returns {string[]}
+ */
+function parseTags(rawTags) {
+  if (rawTags === undefined || rawTags === null || rawTags === '') {
+    return [];
+  }
+
+  if (typeof rawTags === 'string') {
+    try {
+      const parsed = JSON.parse(rawTags);
+      if (!Array.isArray(parsed)) {
+        throw new Error('Tags JSON is not an array');
+      }
+      return parsed;
+    } catch (err) {
+      throw new AppError('Invalid tags JSON', 400);
+    }
+  }
+
+  if (Array.isArray(rawTags)) {
+    return rawTags;
+  }
+
+  throw new AppError('Invalid tags JSON', 400);
+}
+
+module.exports = { parseTags };

--- a/backend/tests/parseTags.test.js
+++ b/backend/tests/parseTags.test.js
@@ -1,0 +1,27 @@
+const { parseTags } = require('../src/modules/users/tutorials/tutorial.helpers');
+const AppError = require('../src/utils/AppError');
+
+describe('parseTags', () => {
+  test('returns array when input is array', () => {
+    const input = ['js', 'node'];
+    expect(parseTags(input)).toEqual(input);
+  });
+
+  test('parses valid JSON string', () => {
+    const input = '["js","node"]';
+    expect(parseTags(input)).toEqual(['js', 'node']);
+  });
+
+  test('returns empty array when input is undefined', () => {
+    expect(parseTags(undefined)).toEqual([]);
+  });
+
+  test('throws AppError on invalid JSON string', () => {
+    expect(() => parseTags('not json')).toThrow(AppError);
+  });
+
+  test('throws AppError when JSON is not an array', () => {
+    expect(() => parseTags('{"a":1}')).toThrow(AppError);
+    expect(() => parseTags({ a: 1 })).toThrow(AppError);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `parseTags` helper for tutorials
- use `parseTags` in `createTutorial` and `updateTutorial` to remove duplication
- test `parseTags` for valid and invalid inputs

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb801c54883289e3ee161e399b440