### PR TITLE
Handle missing instructor names in tutorials search

### DIFF
--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -162,7 +162,7 @@ const TutorialsSection = () => {
 
     const matchSearch =
       tut.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      tut.instructor.toLowerCase().includes(searchQuery.toLowerCase());
+      (tut.instructor || "").toLowerCase().includes(searchQuery.toLowerCase());
 
     return matchCategory && matchLevel && matchPrice && matchSearch;
   });

--- a/frontend/src/tests/__tests__/TutorialsNoInstructor.test.js
+++ b/frontend/src/tests/__tests__/TutorialsNoInstructor.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TutorialsSection from '@/pages/tutorials/index';
+import useAuthStore from '@/store/auth/authStore';
+import * as tutorialService from '../../services/tutorialService';
+
+jest.mock('next/image', () => (props) => <img {...props} />);
+jest.mock('next/router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('next-i18next', () => ({ useTranslation: () => ({ t: (key) => key }) }));
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }) => <div {...props}>{children}</div>,
+    h2: ({ children, ...props }) => <h2 {...props}>{children}</h2>,
+    button: ({ children, ...props }) => <button {...props}>{children}</button>,
+  },
+}));
+jest.mock('../../components/website/sections/Navbar', () => () => <div />);
+jest.mock('../../components/website/sections/Footer', () => () => <div />);
+jest.mock('../../components/tutorials/FilterSidebar', () => () => <div />);
+
+const addItem = jest.fn();
+jest.mock('../../store/cart/cartStore', () => ({
+  __esModule: true,
+  default: (selector) => selector({ addItem }),
+}));
+
+jest.mock('../../services/tutorialService', () => ({
+  fetchPublishedTutorials: jest.fn(),
+  fetchTutorialProgress: jest.fn(),
+}));
+
+beforeAll(() => {
+  class IO {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  global.IntersectionObserver = IO;
+});
+
+beforeEach(() => {
+  useAuthStore.setState({ user: null });
+  jest.clearAllMocks();
+});
+
+test('handles tutorials without instructor in search', async () => {
+  tutorialService.fetchPublishedTutorials.mockResolvedValue([
+    { id: 1, title: 'Tutorless', category_name: '', level: '', price: null },
+  ]);
+  tutorialService.fetchTutorialProgress.mockResolvedValue(null);
+
+  render(<TutorialsSection />);
+  const input = await screen.findByPlaceholderText('search_placeholder');
+  fireEvent.change(input, { target: { value: 'Tutor' } });
+  expect(await screen.findByText('Tutorless')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- handle tutorials missing instructor names in search filtering
- add test covering tutorials without instructors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb8008db88328acb7b145232e8184