### PR TITLE
Import wishlist and favorites services

### DIFF
--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -7,7 +7,12 @@ import { useTranslation } from "next-i18next";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import FilterSidebar from "@/components/tutorials/FilterSidebar";
-import { fetchPublishedTutorials, fetchTutorialProgress } from "@/services/tutorialService";
+import {
+  fetchPublishedTutorials,
+  fetchTutorialProgress,
+  getMyTutorialWishlist,
+  getMyTutorialFavorites,
+} from "@/services/tutorialService";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
 


### PR DESCRIPTION
## Summary
- fix undefined references by importing `getMyTutorialWishlist` and `getMyTutorialFavorites`

## Testing
- `npm run lint` *(fails: Component definition is missing display name)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cb7ff34f083288ad276d240ab69c5