### PR TITLE
feat: debounce tag fetch

### DIFF
--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -13,21 +13,26 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
       setTagSuggestions([]);
       return;
     }
-    let ignore = false;
-    fetchTutorialTags(tagInput)
-      .then((tags) => {
-        if (!ignore) {
+
+    const controller = new AbortController();
+    const handler = setTimeout(() => {
+      fetchTutorialTags(tagInput, controller.signal)
+        .then((tags) => {
           const filtered = tags.filter(
             (t) => !tutorialData.tags.includes(t.name)
           );
           setTagSuggestions(filtered);
-        }
-      })
-      .catch(() => {
-        if (!ignore) setTagSuggestions([]);
-      });
+        })
+        .catch((err) => {
+          if (err.code !== "ERR_CANCELED" && err.name !== "CanceledError") {
+            setTagSuggestions([]);
+          }
+        });
+    }, 300);
+
     return () => {
-      ignore = true;
+      clearTimeout(handler);
+      controller.abort();
     };
   }, [tagInput, tutorialData.tags]);
 

--- a/frontend/src/services/instructor/tutorialTagService.js
+++ b/frontend/src/services/instructor/tutorialTagService.js
@@ -1,8 +1,9 @@
 import api from "@/services/api/api";
 
-export const fetchTutorialTags = async (search) => {
+export const fetchTutorialTags = async (search, signal) => {
   const { data } = await api.get("/users/tutorials/tags", {
     params: search ? { search } : {},
+    signal,
   });
   return data?.data ?? [];
 };


### PR DESCRIPTION
## Summary
- debounce tag suggestions lookup to prevent excessive requests
- allow tutorial tag fetches to be cancelled on input changes

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_689cb7f78ca883288f493ce463c00241