### PR TITLE
fix: revoke media preview URLs on cleanup

### DIFF
--- a/frontend/src/components/tutorials/create/MediaStep.js
+++ b/frontend/src/components/tutorials/create/MediaStep.js
@@ -26,6 +26,14 @@ export default function MediaStep({ tutorialData, setTutorialData, onNext, onBac
     }
   }, [tutorialData.thumbnail, tutorialData.preview, thumbnailPreview, previewVideo]);
 
+  // Clean up generated object URLs when media changes or component unmounts
+  useEffect(() => {
+    return () => {
+      if (thumbnailPreview) URL.revokeObjectURL(thumbnailPreview);
+      if (previewVideo) URL.revokeObjectURL(previewVideo);
+    };
+  }, [thumbnailPreview, previewVideo]);
+
   const handleThumbnailUpload = (e) => {
     const file = e.target.files[0];
     if (


### PR DESCRIPTION
## Summary
- add cleanup effect in MediaStep to revoke object URLs when media changes or component unmounts

## Testing
- `npm run lint` *(fails: 332 problems)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb7f42420832882853e379a069ee3