### PR TITLE
refactor: centralize tutorial form data builder

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -22,6 +22,7 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import { buildTutorialFormData } from "@/utils/tutorialForm";
 
 function EditTutorialPage() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialEditPage' });
@@ -136,45 +137,16 @@ function EditTutorialPage() {
           />
         )}
         {step === 4 && (
-          <ReviewStep
-            tutorialData={tutorialData}
-            onPrev={onPrev}
-            actionLabel="Save Changes"
-            onPublish={async () => {
-              const formData = new FormData();
-              formData.append("title", tutorialData.title);
-              formData.append("description", tutorialData.shortDescription);
-              formData.append("category_id", tutorialData.category);
-              formData.append("level", tutorialData.level);
-              formData.append("language", tutorialData.language);
-              formData.append("status", tutorialData.status);
-              formData.append("is_paid", (!tutorialData.isFree).toString());
-              if (!tutorialData.isFree) {
-                formData.append("price", tutorialData.price);
-              }
-              if (tutorialData.tags.length) {
-                formData.append("tags", JSON.stringify(tutorialData.tags));
-              }
-              if (tutorialData.chapters.length) {
-                const chapters = tutorialData.chapters.map((ch, idx) => ({
-                  title: ch.title,
-                  duration: ch.duration,
-                  video_url: ch.videoUrl,
-                  order: idx + 1,
-                  is_preview: ch.preview,
-                }));
-                formData.append("chapters", JSON.stringify(chapters));
-              }
-              if (tutorialData.thumbnail instanceof File) {
-                formData.append("thumbnail", tutorialData.thumbnail);
-              }
-              if (tutorialData.preview instanceof File) {
-                formData.append("preview", tutorialData.preview);
-              }
+            <ReviewStep
+              tutorialData={tutorialData}
+              onPrev={onPrev}
+              actionLabel="Save Changes"
+              onPublish={async () => {
+                const formData = buildTutorialFormData(tutorialData);
 
-              try {
-                await updateTutorial(id, formData);
-                toast.success(t('update_success'));
+                try {
+                  await updateTutorial(id, formData);
+                  toast.success(t('update_success'));
 
                 try {
                   await createNotification({

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -15,6 +15,7 @@ import { fetchAllCategories } from "@/services/admin/categoryService";
 import StepProgressBar from "@/components/tutorials/create/StepProgressBar";
 import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
+import { buildTutorialFormData } from "@/utils/tutorialForm";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
@@ -105,32 +106,7 @@ function CreateTutorialPage() {
       return;
     }
 
-    const formData = new FormData();
-    formData.append("title", tutorialData.title);
-    formData.append("description", tutorialData.shortDescription);
-    formData.append("category_id", tutorialData.category);
-    formData.append("level", tutorialData.level);
-    formData.append("language", tutorialData.language);
-    formData.append("status", status);
-    formData.append("is_paid", (!tutorialData.isFree).toString());
-    if (!tutorialData.isFree) {
-      formData.append("price", tutorialData.price);
-    }
-    if (tutorialData.tags.length) {
-      formData.append("tags", JSON.stringify(tutorialData.tags));
-    }
-    if (tutorialData.chapters.length) {
-      const chapters = tutorialData.chapters.map((ch, idx) => ({
-        title: ch.title,
-        duration: ch.duration,
-        video_url: ch.videoUrl,
-        order: idx + 1,
-        is_preview: ch.preview,
-      }));
-      formData.append("chapters", JSON.stringify(chapters));
-    }
-    if (tutorialData.thumbnail) formData.append("thumbnail", tutorialData.thumbnail);
-    if (tutorialData.preview) formData.append("preview", tutorialData.preview);
+    const formData = buildTutorialFormData(tutorialData, status);
 
     try {
       await createTutorial(formData);

--- a/frontend/src/tests/__tests__/tutorialForm.test.js
+++ b/frontend/src/tests/__tests__/tutorialForm.test.js
@@ -1,0 +1,78 @@
+import { buildTutorialFormData } from "@/utils/tutorialForm";
+
+describe("buildTutorialFormData", () => {
+  it("builds form data with provided status", () => {
+    const tutorialData = {
+      title: "Test Tutorial",
+      shortDescription: "Short desc",
+      category: "cat1",
+      level: "beginner",
+      language: "en",
+      isFree: false,
+      price: 100,
+      tags: ["a", "b"],
+      chapters: [
+        { title: "Ch1", duration: 10, videoUrl: "vid1", preview: true },
+        { title: "Ch2", duration: 20, videoUrl: "vid2", preview: false },
+      ],
+      thumbnail: new File([""], "thumb.jpg", { type: "image/jpeg" }),
+      preview: new File([""], "prev.mp4", { type: "video/mp4" }),
+    };
+
+    const formData = buildTutorialFormData(tutorialData, "draft");
+
+    expect(formData.get("title")).toBe("Test Tutorial");
+    expect(formData.get("description")).toBe("Short desc");
+    expect(formData.get("category_id")).toBe("cat1");
+    expect(formData.get("level")).toBe("beginner");
+    expect(formData.get("language")).toBe("en");
+    expect(formData.get("status")).toBe("draft");
+    expect(formData.get("is_paid")).toBe("true");
+    expect(formData.get("price")).toBe("100");
+    expect(JSON.parse(formData.get("tags"))).toEqual(["a", "b"]);
+    expect(JSON.parse(formData.get("chapters"))).toEqual([
+      {
+        title: "Ch1",
+        duration: 10,
+        video_url: "vid1",
+        order: 1,
+        is_preview: true,
+      },
+      {
+        title: "Ch2",
+        duration: 20,
+        video_url: "vid2",
+        order: 2,
+        is_preview: false,
+      },
+    ]);
+    expect(formData.get("thumbnail")).toBe(tutorialData.thumbnail);
+    expect(formData.get("preview")).toBe(tutorialData.preview);
+  });
+
+  it("uses tutorial status when no override and skips optional fields", () => {
+    const tutorialData = {
+      title: "Test",
+      shortDescription: "Desc",
+      category: "cat1",
+      level: "beginner",
+      language: "en",
+      isFree: true,
+      tags: [],
+      chapters: [],
+      status: "draft",
+      thumbnail: "existing-thumb.jpg",
+      preview: null,
+    };
+
+    const formData = buildTutorialFormData(tutorialData);
+
+    expect(formData.get("status")).toBe("draft");
+    expect(formData.get("is_paid")).toBe("false");
+    expect(formData.has("price")).toBe(false);
+    expect(formData.has("tags")).toBe(false);
+    expect(formData.has("chapters")).toBe(false);
+    expect(formData.has("thumbnail")).toBe(false);
+    expect(formData.has("preview")).toBe(false);
+  });
+});

--- a/frontend/src/utils/tutorialForm.js
+++ b/frontend/src/utils/tutorialForm.js
@@ -1,0 +1,33 @@
+export function buildTutorialFormData(tutorialData, status) {
+  const formData = new FormData();
+  formData.append("title", tutorialData.title);
+  formData.append("description", tutorialData.shortDescription);
+  formData.append("category_id", tutorialData.category);
+  formData.append("level", tutorialData.level);
+  formData.append("language", tutorialData.language);
+  formData.append("status", status ?? tutorialData.status);
+  formData.append("is_paid", (!tutorialData.isFree).toString());
+  if (!tutorialData.isFree) {
+    formData.append("price", tutorialData.price);
+  }
+  if (tutorialData.tags?.length) {
+    formData.append("tags", JSON.stringify(tutorialData.tags));
+  }
+  if (tutorialData.chapters?.length) {
+    const chapters = tutorialData.chapters.map((ch, idx) => ({
+      title: ch.title,
+      duration: ch.duration,
+      video_url: ch.videoUrl,
+      order: idx + 1,
+      is_preview: ch.preview,
+    }));
+    formData.append("chapters", JSON.stringify(chapters));
+  }
+  if (tutorialData.thumbnail instanceof File) {
+    formData.append("thumbnail", tutorialData.thumbnail);
+  }
+  if (tutorialData.preview instanceof File) {
+    formData.append("preview", tutorialData.preview);
+  }
+  return formData;
+}


### PR DESCRIPTION
## Summary
- add `buildTutorialFormData` helper for shared FormData logic
- refactor tutorial creation and editing pages to use helper
- test utility to ensure correct payload generation

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb7f2d96c8328b74c2d5bdd2821d4