### PR TITLE
feat(frontend): add currency-aware enroll banner

### DIFF
--- a/frontend/src/components/tutorials/detail/EnrollBanner.js
+++ b/frontend/src/components/tutorials/detail/EnrollBanner.js
@@ -6,9 +6,13 @@ const EnrollBanner = ({
   price,
   onAddToCart,
   checkoutUrl,
+  currency = "USD",
 }) => {
   const formattedPrice = isPaid
-    ? `$${Number(price).toFixed(2)}`
+    ? new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency,
+      }).format(Number(price))
     : "Free";
 
   let actionButton;

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -389,6 +389,7 @@ export default function TutorialDetail() {
             isPaid={Number(tutorial.price) > 0}
             price={tutorial.price}
             onAddToCart={handleAddToCart}
+            currency={tutorial.currency}
           />
         )}
 


### PR DESCRIPTION
## Summary
- extend EnrollBanner with a currency prop and format price via `Intl.NumberFormat`
- pass tutorial currency to EnrollBanner on tutorial detail page

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb7e9c6408328a88f939cfce512e3