### PR TITLE
feat: add filters and pagination to tutorial listing

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -239,8 +239,15 @@ exports.createTutorial = catchAsync(async (req, res) => {
 
 
 exports.getAllTutorials = async (req, res) => {
-  const tutorials = await service.getAllTutorials(req.query);
-  sendSuccess(res, tutorials);
+  const { status, category, search, page = 1, limit = 10 } = req.query;
+  const result = await service.getAllTutorials({
+    status,
+    category,
+    search,
+    page,
+    limit,
+  });
+  sendSuccess(res, result.data, "Tutorials fetched", result.meta);
 };
 
 exports.getMyTutorials = catchAsync(async (req, res) => {

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -6,18 +6,61 @@ exports.createTutorial = async (data, trx = db) => {
   return tutorial;
 };
 
-exports.getAllTutorials = async () => {
-  return db("tutorials")
-    .leftJoin("categories", "tutorials.category_id", "categories.id")
-    .leftJoin("users", "tutorials.instructor_id", "users.id")
-    .whereNot("tutorials.status", "archived")
-    .orderBy("tutorials.created_at", "desc")
+exports.getAllTutorials = async (filters = {}) => {
+  const {
+    status,
+    category,
+    search,
+    page = 1,
+    limit = 10,
+  } = filters;
+
+  const offset = (page - 1) * limit;
+
+  const baseQuery = db("tutorials as t")
+    .leftJoin("categories as c", "t.category_id", "c.id")
+    .leftJoin("users as u", "t.instructor_id", "u.id")
+    .whereNot("t.status", "archived")
+    .modify((query) => {
+      if (status) query.andWhere("t.status", status);
+      if (category) query.andWhere("t.category_id", category);
+      if (search) {
+        query.andWhere(function () {
+          this.whereILike("t.title", `%${search}%`);
+        });
+      }
+    });
+
+  const countQuery = baseQuery
+    .clone()
+    .clearSelect()
+    .count("t.id as count")
+    .first();
+
+  const dataQuery = baseQuery
+    .clone()
+    .orderBy("t.created_at", "desc")
     .select(
-      "tutorials.*",
-      "categories.name as category_name",
-      "categories.image_url as category_image_url",
-      "users.full_name as instructor_name"
-    );
+      "t.*",
+      "c.name as category_name",
+      "c.image_url as category_image_url",
+      "u.full_name as instructor_name"
+    )
+    .limit(limit)
+    .offset(offset);
+
+  const [totalResult, tutorials] = await Promise.all([countQuery, dataQuery]);
+  const total = parseInt(totalResult.count, 10) || 0;
+
+  return {
+    data: tutorials,
+    meta: {
+      page: Number(page),
+      limit: Number(limit),
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  };
 };
 
 exports.getTutorialById = async (id, userId = null) => {


### PR DESCRIPTION
## Summary
- add flexible filtering and pagination to tutorial service
- forward query params and return pagination metadata in controller

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb7de7b9c8328af554f9ec7966510