### PR TITLE
Remove superadmin cart message

### DIFF
--- a/backend/src/modules/cart/cart.controller.js
+++ b/backend/src/modules/cart/cart.controller.js
@@ -2,7 +2,6 @@ const service = require("./cart.service");
 const { sendSuccess } = require("../../utils/response");
 const catchAsync = require("../../utils/catchAsync");
 const notificationService = require("../notifications/notifications.service");
-const messageService = require("../messages/messages.service");
 const userModel = require("../users/user.model");
 const { sendCartAddedEmail } = require("../../utils/email");
 
@@ -15,15 +14,6 @@ exports.addItem = catchAsync(async (req, res) => {
     type: "cart_added",
     message,
   });
-  const admins = await userModel.findAdmins();
-  const sender = admins[0];
-  if (sender) {
-    await messageService.createMessage({
-      sender_id: sender.id,
-      receiver_id: req.user.id,
-      message,
-    });
-  }
   try {
     const user = await userModel.findById(req.user.id);
     if (user?.email) await sendCartAddedEmail(user.email, item.name);


### PR DESCRIPTION
## Summary
- avoid sending admin chat message when adding items to cart
- maintain cart notifications and email alerts without superadmin name

## Testing
- `npm test` *(fails: tests/tutorialUpdateTransaction.test.js)*


------
https://chatgpt.com/codex/tasks/task_e_689cc287accc8328aa16a2428f9af007