### PR TITLE
Localize student books library and connect wishlist

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -981,6 +981,15 @@
     "tutorials": "الدروس",
     "no_tutorials": "لا توجد دروس في القائمة."
   },
+  "booksPage": {
+    "by_author": "By {{author}}",
+    "preview": "Preview",
+    "download": "Download",
+    "free": "Free",
+    "purchased_for": "Purchased for ${{price}}",
+    "purchased_on": "Purchased on {{date}}",
+    "no_books": "No books in your library."
+  },
   "adminOffersPage": {
     "title": "Admin: Manage All Offers",
     "all_roles": "All Roles",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1227,6 +1227,15 @@
     "completion_rate": "🎯 Completion Rate",
     "enrollment_trend": "📈 Enrollment Trend"
   },
+  "booksPage": {
+    "by_author": "By {{author}}",
+    "preview": "Preview",
+    "download": "Download",
+    "free": "Free",
+    "purchased_for": "Purchased for ${{price}}",
+    "purchased_on": "Purchased on {{date}}",
+    "no_books": "No books in your library."
+  },
   "progressChecklistModal": {
     "title": "🧩 Tutorial Progress Checklist",
     "title_description": "Title & Description",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -994,6 +994,15 @@
     "tutorials": "Tutorials",
     "no_tutorials": "No tutorials in wishlist."
   },
+  "booksPage": {
+    "by_author": "By {{author}}",
+    "preview": "Preview",
+    "download": "Download",
+    "free": "Free",
+    "purchased_for": "Purchased for ${{price}}",
+    "purchased_on": "Purchased on {{date}}",
+    "no_books": "No books in your library."
+  },
   "adminOffersPage": {
     "title": "Admin: Manage All Offers",
     "all_roles": "All Roles",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1227,6 +1227,15 @@
     "completion_rate": "🎯 Completion Rate",
     "enrollment_trend": "📈 Enrollment Trend"
   },
+  "booksPage": {
+    "by_author": "By {{author}}",
+    "preview": "Preview",
+    "download": "Download",
+    "free": "Free",
+    "purchased_for": "Purchased for ${{price}}",
+    "purchased_on": "Purchased on {{date}}",
+    "no_books": "No books in your library."
+  },
   "progressChecklistModal": {
     "title": "🧩 Tutorial Progress Checklist",
     "title_description": "Title & Description",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -969,6 +969,15 @@
     "tutorials": "Tutoriels",
     "no_tutorials": "Aucun tutoriel dans la liste."
   },
+  "booksPage": {
+    "by_author": "By {{author}}",
+    "preview": "Preview",
+    "download": "Download",
+    "free": "Free",
+    "purchased_for": "Purchased for ${{price}}",
+    "purchased_on": "Purchased on {{date}}",
+    "no_books": "No books in your library."
+  },
   "adminOffersPage": {
     "title": "Admin: Manage All Offers",
     "all_roles": "All Roles",

--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -1,9 +1,37 @@
 import { useEffect } from "react";
-import { FiDownload, FiEye, FiStar, FiHeart } from "react-icons/fi";
+import { FiDownload, FiEye, FiHeart } from "react-icons/fi";
+import { useTranslation } from "next-i18next";
+import { toast } from "react-hot-toast";
+
+import { buildUrl } from "@/services/bookService";
 import useLibraryStore from "@/store/library/libraryStore";
+import useBookWishlistStore from "@/store/books/wishlistStore";
 
 function BookCard({ book }) {
-  const cover = book.coverUrl || "/images/default-book-cover.jpg";
+  const { t } = useTranslation("dashboard", { keyPrefix: "booksPage" });
+  const { wishlist, addToWishlist, removeFromWishlist } = useBookWishlistStore();
+
+  const cover =
+    book.cover_image_url ||
+    buildUrl(book.cover_image) ||
+    "/images/default-book-cover.jpg";
+
+  const isWishlisted = wishlist.some((item) => item.book_id === book.id);
+
+  const handleWishlist = () => {
+    if (isWishlisted) {
+      removeFromWishlist(book.id);
+      toast.success(t("removed_from_wishlist", { ns: "website" }));
+    } else {
+      addToWishlist({
+        book_id: book.id,
+        title: book.title,
+        price: book.price,
+        cover_url: cover,
+      });
+      toast.success(t("added_to_wishlist", { ns: "website" }));
+    }
+  };
 
   return (
     <div className="border rounded-xl shadow-sm p-4 bg-white flex flex-col justify-between h-full">
@@ -15,7 +43,9 @@ function BookCard({ book }) {
       <div className="flex-1">
         <h3 className="text-lg font-semibold mb-1 line-clamp-2">{book.title}</h3>
         <p className="text-sm text-gray-600 mb-2 line-clamp-2">{book.shortDescription}</p>
-        <p className="text-sm text-gray-500 mb-1">By {book.author}</p>
+        <p className="text-sm text-gray-500 mb-1">
+          {t("by_author", { author: book.author })}
+        </p>
         <div className="flex flex-wrap gap-2 text-xs text-gray-500 mb-3">
           {book.tags?.map((tag, idx) => (
             <span key={idx} className="bg-gray-100 px-2 py-0.5 rounded">
@@ -25,13 +55,19 @@ function BookCard({ book }) {
         </div>
         <div className="flex items-center gap-2 text-sm">
           {book.isFree ? (
-            <span className="text-green-600 font-medium">Free</span>
+            <span className="text-green-600 font-medium">{t("free")}</span>
           ) : (
-            <span className="text-blue-600 font-medium">Purchased for ${book.price}</span>
+            <span className="text-blue-600 font-medium">
+              {t("purchased_for", { price: book.price })}
+            </span>
           )}
         </div>
         {book.purchasedAt && (
-          <p className="text-xs text-gray-400 mt-1">Purchased on {new Date(book.purchasedAt).toLocaleDateString()}</p>
+          <p className="text-xs text-gray-400 mt-1">
+            {t("purchased_on", {
+              date: new Date(book.purchasedAt).toLocaleDateString(),
+            })}
+          </p>
         )}
       </div>
       <div className="mt-4 flex gap-3 flex-wrap">
@@ -41,7 +77,7 @@ function BookCard({ book }) {
             target="_blank"
             className="flex items-center gap-1 text-indigo-600 hover:underline"
           >
-            <FiEye className="text-lg" /> Preview
+            <FiEye className="text-lg" /> {t("preview")}
           </a>
         )}
         {book.pdfUrl && (
@@ -51,13 +87,16 @@ function BookCard({ book }) {
             download
             className="flex items-center gap-1 text-green-600 hover:underline"
           >
-            <FiDownload className="text-lg" /> Download
+            <FiDownload className="text-lg" /> {t("download")}
           </a>
         )}
-        <button className="text-yellow-500 hover:text-yellow-600">
-          <FiStar />
-        </button>
-        <button className="text-red-400 hover:text-red-500">
+        <button
+          className={
+            isWishlisted ? "text-red-500" : "text-red-400 hover:text-red-500"
+          }
+          onClick={handleWishlist}
+          aria-label={t("wishlist", { ns: "common" })}
+        >
           <FiHeart />
         </button>
       </div>
@@ -66,6 +105,7 @@ function BookCard({ book }) {
 }
 
 export default function BooksPage() {
+  const { t } = useTranslation("dashboard", { keyPrefix: "booksPage" });
   const { books, fetchLibrary } = useLibraryStore();
 
   useEffect(() => {
@@ -74,9 +114,11 @@ export default function BooksPage() {
 
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {books.map((book) => (
-        <BookCard key={book.id} book={book} />
-      ))}
+      {books.length === 0 ? (
+        <p className="text-gray-500">{t("no_books")}</p>
+      ) : (
+        books.map((book) => <BookCard key={book.id} book={book} />)
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use book.cover_image_url/buildUrl and localize dashboard book strings
- hook wishlist button to store and remove unused rating star
- show empty state when library has no books

## Testing
- `npm test`
- `npm run lint` *(fails: 91 errors, 264 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf3532e883289281ce144ec5157b