### PR TITLE
Use react-hot-toast in BookDetails with localized cart feedback

### DIFF
--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
 import { buildUrl } from "@/services/bookService";
@@ -36,9 +36,13 @@ export default function BookDetails({ book }) {
     }
     try {
       setIsAdding(true);
-      await addItem(buildBookItem(book));
-      toast.success("Added to cart");
-      router.push("/cart");
+      const added = await addItem(buildBookItem(book));
+      if (added) {
+        toast.success(t("added_to_cart"));
+        router.push("/cart");
+      } else {
+        toast.error(t("failed_to_add_to_cart"));
+      }
     } finally {
       setIsAdding(false);
     }

--- a/frontend/src/tests/__tests__/BookDetails.test.js
+++ b/frontend/src/tests/__tests__/BookDetails.test.js
@@ -12,7 +12,7 @@ jest.mock('next/router', () => ({
   useRouter: () => ({ push: jest.fn() }),
 }));
 
-jest.mock('react-toastify', () => ({
+jest.mock('react-hot-toast', () => ({
   toast: { info: jest.fn(), error: jest.fn(), success: jest.fn() },
 }));
 


### PR DESCRIPTION
## Summary
- replace react-toastify with react-hot-toast in BookDetails
- localize cart success/failure messages and check addItem result
- adjust BookDetails tests for new toast library

## Testing
- `npm test`
- `npm run lint` *(fails: 91 errors, 264 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf304ac48328a6103e6ad4811377