### PR TITLE
feat: add active/inactive book statuses

### DIFF
--- a/frontend/public/locales/ar/website.json
+++ b/frontend/public/locales/ar/website.json
@@ -162,6 +162,8 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
+  "active": "نشط",
+  "inactive": "غير نشط",
   "by_author": "by {{author}}",
   "network_error": "خطأ في الشبكة: يرجى التحقق من API_BASE_URL وخادم الخلفية.",
   "tutorials_load_error": "فشل تحميل الدروس.",

--- a/frontend/public/locales/de/website.json
+++ b/frontend/public/locales/de/website.json
@@ -162,6 +162,8 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
+  "active": "Aktiv",
+  "inactive": "Inaktiv",
   "by_author": "by {{author}}",
   "network_error": "Netzwerkfehler: Bitte API_BASE_URL und Backend-Server prüfen.",
   "tutorials_load_error": "Laden der Tutorials fehlgeschlagen.",

--- a/frontend/public/locales/en/website.json
+++ b/frontend/public/locales/en/website.json
@@ -162,6 +162,8 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
+  "active": "Active",
+  "inactive": "Inactive",
   "by_author": "by {{author}}",
   "network_error": "Network error: please check API_BASE_URL and backend server.",
   "tutorials_load_error": "Failed to load tutorials.",

--- a/frontend/public/locales/es/website.json
+++ b/frontend/public/locales/es/website.json
@@ -162,6 +162,8 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
+  "active": "Activo",
+  "inactive": "Inactivo",
   "by_author": "by {{author}}",
   "network_error": "Error de red: verifique API_BASE_URL y el servidor backend.",
   "tutorials_load_error": "No se pudieron cargar los tutoriales.",

--- a/frontend/public/locales/fr/website.json
+++ b/frontend/public/locales/fr/website.json
@@ -162,6 +162,8 @@
   "pending": "Pending",
   "approved": "Approved",
   "rejected": "Rejected",
+  "active": "Actif",
+  "inactive": "Inactif",
   "by_author": "by {{author}}",
   "network_error": "Erreur réseau : veuillez vérifier API_BASE_URL et le serveur backend.",
   "tutorials_load_error": "Échec du chargement des tutoriels.",

--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -33,6 +33,8 @@ export default function BookCard({
     pending: "bg-yellow-100 text-yellow-800",
     approved: "bg-green-100 text-green-800",
     rejected: "bg-red-100 text-red-800",
+    active: "bg-green-100 text-green-800",
+    inactive: "bg-gray-100 text-gray-800",
   };
 
   return (

--- a/frontend/src/tests/__tests__/BookCard.test.js
+++ b/frontend/src/tests/__tests__/BookCard.test.js
@@ -35,4 +35,19 @@ describe('BookCard', () => {
     render(<BookCard book={book} />);
     expect(screen.getByText('£10.00')).toBeInTheDocument();
   });
+
+  it.each([
+    ['pending', 'bg-yellow-100', 'text-yellow-800'],
+    ['approved', 'bg-green-100', 'text-green-800'],
+    ['rejected', 'bg-red-100', 'text-red-800'],
+    ['active', 'bg-green-100', 'text-green-800'],
+    ['inactive', 'bg-gray-100', 'text-gray-800'],
+  ])('renders %s badge with correct classes', (status, bg, text) => {
+    const book = { id: 1, title: 'Test Book', price: 10, status };
+    render(<BookCard book={book} />);
+    const badge = screen.getByText(status);
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass(bg);
+    expect(badge).toHaveClass(text);
+  });
 });


### PR DESCRIPTION
## Summary
- show active/inactive badges on BookCard
- localize active/inactive strings across website locales
- test BookCard status badges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ccf26843c832885a60a99b9066f8d