### PR TITLE
Validate book existence before cart and wishlist operations

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -307,6 +307,9 @@ sendSuccess(res, book, "Book status updated");
 
 exports.updateCart = catchAsync(async (req, res) => {
   const { bookId, action } = req.body || {};
+  const book = await service.getBookById(bookId);
+  if (!book) throw new AppError('Book not found', 404);
+  if (book.status !== 'active') throw new AppError('Book is not active', 400);
   if (action === 'remove') {
     await service.removeFromCart(req.user.id, bookId);
     return sendSuccess(res, null, 'Removed from cart');
@@ -321,11 +324,17 @@ exports.checkout = catchAsync(async (req, res) => {
 });
 
 exports.addWishlist = catchAsync(async (req, res) => {
+  const book = await service.getBookById(req.body.bookId);
+  if (!book) throw new AppError('Book not found', 404);
+  if (book.status !== 'active') throw new AppError('Book is not active', 400);
   await service.addToWishlist(req.user.id, req.body.bookId);
   sendSuccess(res, null, 'Added to wishlist');
 });
 
 exports.removeWishlist = catchAsync(async (req, res) => {
+  const book = await service.getBookById(req.body.bookId);
+  if (!book) throw new AppError('Book not found', 404);
+  if (book.status !== 'active') throw new AppError('Book is not active', 400);
   await service.removeFromWishlist(req.user.id, req.body.bookId);
   sendSuccess(res, null, 'Removed from wishlist');
 });

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -210,6 +210,7 @@ describe('POST /api/books/cart', () => {
       req.user = { id: '1', role: 'student', roles: ['student'] };
       next();
     });
+    service.getBookById.mockResolvedValue({ id: '10', status: 'active' });
     const res = await request(app)
       .post('/api/books/cart')
       .send({ bookId: '10' });
@@ -222,11 +223,38 @@ describe('POST /api/books/cart', () => {
       req.user = { id: '1', role: 'student', roles: ['student'] };
       next();
     });
+    service.getBookById.mockResolvedValue({ id: '10', status: 'active' });
     const res = await request(app)
       .post('/api/books/cart')
       .send({ bookId: '10', action: 'remove' });
     expect(res.status).toBe(200);
     expect(service.removeFromCart).toHaveBeenCalledWith('1', '10');
+  });
+
+  it('returns 404 when book not found', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    service.getBookById.mockResolvedValue(null);
+    const res = await request(app)
+      .post('/api/books/cart')
+      .send({ bookId: '10' });
+    expect(res.status).toBe(404);
+    expect(service.addToCart).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when book is inactive', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    service.getBookById.mockResolvedValue({ id: '10', status: 'inactive' });
+    const res = await request(app)
+      .post('/api/books/cart')
+      .send({ bookId: '10' });
+    expect(res.status).toBe(400);
+    expect(service.addToCart).not.toHaveBeenCalled();
   });
 });
 
@@ -251,11 +279,38 @@ describe('POST /api/books/wishlist', () => {
       req.user = { id: '1', role: 'student', roles: ['student'] };
       next();
     });
+    service.getBookById.mockResolvedValue({ id: '10', status: 'active' });
     const res = await request(app)
       .post('/api/books/wishlist')
       .send({ bookId: '10' });
     expect(res.status).toBe(200);
     expect(service.addToWishlist).toHaveBeenCalledWith('1', '10');
+  });
+
+  it('returns 404 when book not found', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    service.getBookById.mockResolvedValue(null);
+    const res = await request(app)
+      .post('/api/books/wishlist')
+      .send({ bookId: '10' });
+    expect(res.status).toBe(404);
+    expect(service.addToWishlist).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when book is inactive', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    service.getBookById.mockResolvedValue({ id: '10', status: 'inactive' });
+    const res = await request(app)
+      .post('/api/books/wishlist')
+      .send({ bookId: '10' });
+    expect(res.status).toBe(400);
+    expect(service.addToWishlist).not.toHaveBeenCalled();
   });
 });
 
@@ -265,11 +320,25 @@ describe('DELETE /api/books/wishlist', () => {
       req.user = { id: '1', role: 'student', roles: ['student'] };
       next();
     });
+    service.getBookById.mockResolvedValue({ id: '10', status: 'active' });
     const res = await request(app)
       .delete('/api/books/wishlist')
       .send({ bookId: '10' });
     expect(res.status).toBe(200);
     expect(service.removeFromWishlist).toHaveBeenCalledWith('1', '10');
+  });
+
+  it('returns 404 when book not found', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: '1', role: 'student', roles: ['student'] };
+      next();
+    });
+    service.getBookById.mockResolvedValue(null);
+    const res = await request(app)
+      .delete('/api/books/wishlist')
+      .send({ bookId: '10' });
+    expect(res.status).toBe(404);
+    expect(service.removeFromWishlist).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- verify book is active before adding or removing it from cart or wishlist
- add tests for cart and wishlist routes rejecting nonexistent or inactive book IDs

## Testing
- `npm test` *(fails: updateTutorial tag transactions commits transaction when tag update succeeds)*
- `npm test -- tests/bookRoutes.test.js`
- `npm test -- tests/tutorialUpdateTransaction.test.js` *(fails: expect(db.__commit).toHaveBeenCalled())*


------
https://chatgpt.com/codex/tasks/task_e_689ccf201c28832897f5660e0dc901cf