### PR TITLE
Clean up uploaded files on book controller errors

### DIFF
--- a/backend/src/modules/books/__tests__/book.controller.test.js
+++ b/backend/src/modules/books/__tests__/book.controller.test.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+jest.mock('../book.service', () => ({
+  createBook: jest.fn(),
+  updateBook: jest.fn(),
+  getBookById: jest.fn(),
+  clearBookTags: jest.fn(),
+}));
+
+const controller = require('../book.controller');
+const service = require('../book.service');
+
+const makeFiles = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'book-test-'));
+  const files = ['cover.jpg', 'book.pdf', 'preview.jpg'].map((name) => {
+    const filePath = path.join(dir, name);
+    fs.writeFileSync(filePath, 'data');
+    return filePath;
+  });
+  return {
+    dir,
+    paths: files,
+    files: {
+      cover_image: [{ path: files[0], filename: path.basename(files[0]) }],
+      book_file: [{ path: files[1], filename: path.basename(files[1]) }],
+      preview_pages: [{ path: files[2], filename: path.basename(files[2]) }],
+    },
+  };
+};
+
+describe('book.controller file cleanup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('createBook removes uploaded files on error', async () => {
+    const { dir, paths, files } = makeFiles();
+    service.createBook.mockRejectedValue(new Error('fail'));
+    const req = { body: {}, files, user: { id: 1 } };
+    const res = {};
+    const next = jest.fn((err) => {
+      paths.forEach((p) => expect(fs.existsSync(p)).toBe(false));
+    });
+
+    await new Promise((resolve) => {
+      controller.createBook(req, res, (err) => {
+        next(err);
+        resolve();
+      });
+    });
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('updateBook removes uploaded files on error', async () => {
+    const { dir, paths, files } = makeFiles();
+    service.getBookById.mockResolvedValue({ id: 1, instructor_id: 1 });
+    service.updateBook.mockRejectedValue(new Error('fail'));
+    const req = { params: { id: 1 }, body: {}, files, user: { id: 1, role: 'instructor' } };
+    const res = {};
+    const next = jest.fn((err) => {
+      paths.forEach((p) => expect(fs.existsSync(p)).toBe(false));
+    });
+
+    await new Promise((resolve) => {
+      controller.updateBook(req, res, (err) => {
+        next(err);
+        resolve();
+      });
+    });
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -8,6 +8,7 @@ const messageService = require("../messages/messages.service");
 const mailService = require("../../services/mailService");
 const smsService = require("../../services/smsService");
 const userModel = require("../users/user.model");
+const fs = require("fs");
 
 const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
 const isAdminRole = (roles = []) => {
@@ -17,97 +18,111 @@ const isAdminRole = (roles = []) => {
     .some((r) => ["admin", "superadmin"].includes(r));
 };
 
+const removeUploadedFiles = async (files = {}) => {
+  const allFiles = Object.values(files).flat();
+  await Promise.all(
+    allFiles.map((file) =>
+      file?.path ? fs.promises.unlink(file.path).catch(() => {}) : null
+    )
+  );
+};
+
 exports.createBook = catchAsync(async (req, res) => {
-  const { tags: rawTags, ...body } = req.body || {};
-  const data = {
-    title: body.title,
-    short_description: body.short_description,
-    detailed_description: body.detailed_description,
-    price: body.price,
-    language: body.language,
-    license_type: body.license_type,
-    category_id: body.category_id,
-    instructor_id: req.user.id,
-    status: "pending",
-    allow_preview:
-      body.allow_preview === "1" ||
-      body.allow_preview === 1 ||
-      body.allow_preview === true ||
-      body.allow_preview === "true",
-  };
-  if (req.files?.cover_image?.[0])
-    data.cover_image_url =
-      "/uploads/books/" + req.files.cover_image[0].filename;
-  if (req.files?.book_file?.[0])
-    data.pdf_url = "/uploads/books/" + req.files.book_file[0].filename;
-  if (req.files?.preview_pages?.length) {
-    data.preview_pages = JSON.stringify(
-      req.files.preview_pages.map((f) => "/uploads/books/" + f.filename)
-    );
+  try {
+    const { tags: rawTags, ...body } = req.body || {};
+    const data = {
+      title: body.title,
+      short_description: body.short_description,
+      detailed_description: body.detailed_description,
+      price: body.price,
+      language: body.language,
+      license_type: body.license_type,
+      category_id: body.category_id,
+      instructor_id: req.user.id,
+      status: "pending",
+      allow_preview:
+        body.allow_preview === "1" ||
+        body.allow_preview === 1 ||
+        body.allow_preview === true ||
+        body.allow_preview === "true",
+    };
+    if (req.files?.cover_image?.[0])
+      data.cover_image_url =
+        "/uploads/books/" + req.files.cover_image[0].filename;
+    if (req.files?.book_file?.[0])
+      data.pdf_url = "/uploads/books/" + req.files.book_file[0].filename;
+    if (req.files?.preview_pages?.length) {
+      data.preview_pages = JSON.stringify(
+        req.files.preview_pages.map((f) => "/uploads/books/" + f.filename)
+      );
+    }
+
+    const book = await service.createBook(data);
+
+    book.tags = await processTags(rawTags, book.id);
+
+    const userMessage =
+      "Your book was submitted successfully and is under review.";
+    const admins = await userModel.findAdmins();
+    const adminMessage =
+      `Instructor ${req.user.full_name || "Instructor"} submitted a new book "${
+        book.title
+      }" that is awaiting your review.`;
+
+    const senderAdmin = admins[0];
+
+    await Promise.all([
+      notificationService.createNotification({
+        user_id: req.user.id,
+        type: "book_submitted",
+        message: userMessage,
+      }),
+      messageService.createMessage({
+        sender_id: senderAdmin ? senderAdmin.id : req.user.id,
+        receiver_id: req.user.id,
+        message: userMessage,
+      }),
+      req.user.email
+        ? mailService.sendMail({
+            to: req.user.email,
+            subject: "Book submitted for review",
+            html: `<p>${userMessage} We will notify you when it is published.</p>`,
+          })
+        : Promise.resolve(),
+      req.user.phone
+        ? smsService.sendSMS({ to: req.user.phone, text: userMessage })
+        : Promise.resolve(),
+      ...admins.map((admin) =>
+        Promise.all([
+          notificationService.createNotification({
+            user_id: admin.id,
+            type: "new_book",
+            message: adminMessage,
+          }),
+          messageService.createMessage({
+            sender_id: req.user.id,
+            receiver_id: admin.id,
+            message: adminMessage,
+          }),
+          admin.email
+            ? mailService.sendMail({
+                to: admin.email,
+                subject: "New book submitted",
+                html: `<p>${adminMessage}</p>`,
+              })
+            : Promise.resolve(),
+          admin.phone
+            ? smsService.sendSMS({ to: admin.phone, text: adminMessage })
+            : Promise.resolve(),
+        ])
+      ),
+    ]);
+
+    sendSuccess(res, book, "Book submitted for review");
+  } catch (error) {
+    await removeUploadedFiles(req.files);
+    throw error;
   }
-
-  const book = await service.createBook(data);
-
-  book.tags = await processTags(rawTags, book.id);
-
-  const userMessage =
-    "Your book was submitted successfully and is under review.";
-  const admins = await userModel.findAdmins();
-  const adminMessage =
-    `Instructor ${req.user.full_name || "Instructor"} submitted a new book "${
-      book.title
-    }" that is awaiting your review.`;
-
-  const senderAdmin = admins[0];
-
-  await Promise.all([
-    notificationService.createNotification({
-      user_id: req.user.id,
-      type: "book_submitted",
-      message: userMessage,
-    }),
-    messageService.createMessage({
-      sender_id: senderAdmin ? senderAdmin.id : req.user.id,
-      receiver_id: req.user.id,
-      message: userMessage,
-    }),
-    req.user.email
-      ? mailService.sendMail({
-          to: req.user.email,
-          subject: "Book submitted for review",
-          html: `<p>${userMessage} We will notify you when it is published.</p>`,
-        })
-      : Promise.resolve(),
-    req.user.phone
-      ? smsService.sendSMS({ to: req.user.phone, text: userMessage })
-      : Promise.resolve(),
-    ...admins.map((admin) =>
-      Promise.all([
-        notificationService.createNotification({
-          user_id: admin.id,
-          type: "new_book",
-          message: adminMessage,
-        }),
-        messageService.createMessage({
-          sender_id: req.user.id,
-          receiver_id: admin.id,
-          message: adminMessage,
-        }),
-        admin.email
-          ? mailService.sendMail({
-              to: admin.email,
-              subject: "New book submitted",
-              html: `<p>${adminMessage}</p>`,
-            })
-          : Promise.resolve(),
-        admin.phone
-          ? smsService.sendSMS({ to: admin.phone, text: adminMessage })
-          : Promise.resolve(),
-      ])
-    ),
-  ]);
-
-  sendSuccess(res, book, "Book submitted for review");
 });
 
 exports.listBooks = catchAsync(async (req, res) => {
@@ -154,61 +169,66 @@ exports.getBookAdmin = catchAsync(async (req, res) => {
 });
 
 exports.updateBook = catchAsync(async (req, res) => {
-  const existing = await service.getBookById(req.params.id);
-  if (!existing) throw new AppError("Book not found", 404);
-  if (
-    !isAdminRole(req.user.roles || req.user.role) &&
-    existing.instructor_id !== req.user.id
-  ) {
-    throw new AppError("Access denied", 403);
+  try {
+    const existing = await service.getBookById(req.params.id);
+    if (!existing) throw new AppError("Book not found", 404);
+    if (
+      !isAdminRole(req.user.roles || req.user.role) &&
+      existing.instructor_id !== req.user.id
+    ) {
+      throw new AppError("Access denied", 403);
+    }
+
+    const { tags: rawTags, ...body } = req.body || {};
+    const data = { ...body };
+    if (req.files?.cover_image?.[0])
+      data.cover_image_url =
+        "/uploads/books/" + req.files.cover_image[0].filename;
+    if (req.files?.book_file?.[0])
+      data.pdf_url = "/uploads/books/" + req.files.book_file[0].filename;
+    if (req.files?.preview_pages?.length) {
+      data.preview_pages = JSON.stringify(
+        req.files.preview_pages.map((f) => "/uploads/books/" + f.filename)
+      );
+    }
+    if (data.allow_preview !== undefined) {
+      data.allow_preview =
+        data.allow_preview === "1" ||
+        data.allow_preview === 1 ||
+        data.allow_preview === true ||
+        data.allow_preview === "true";
+    }
+
+    const book = await service.updateBook(req.params.id, data);
+
+    await service.clearBookTags(book.id);
+    book.tags = await processTags(rawTags, book.id);
+
+    if (
+      req.user.role !== "instructor" &&
+      existing.instructor_id &&
+      existing.instructor_id !== req.user.id
+    ) {
+      const message = `Your book "${book.title}" was updated by an admin.`;
+      await Promise.all([
+        notificationService.createNotification({
+          user_id: existing.instructor_id,
+          type: "book_updated",
+          message,
+        }),
+        messageService.createMessage({
+          sender_id: req.user.id,
+          receiver_id: existing.instructor_id,
+          message,
+        }),
+      ]);
+    }
+
+    sendSuccess(res, book, "Book updated");
+  } catch (error) {
+    await removeUploadedFiles(req.files);
+    throw error;
   }
-
-  const { tags: rawTags, ...body } = req.body || {};
-  const data = { ...body };
-  if (req.files?.cover_image?.[0])
-    data.cover_image_url =
-      "/uploads/books/" + req.files.cover_image[0].filename;
-  if (req.files?.book_file?.[0])
-    data.pdf_url = "/uploads/books/" + req.files.book_file[0].filename;
-  if (req.files?.preview_pages?.length) {
-    data.preview_pages = JSON.stringify(
-      req.files.preview_pages.map((f) => "/uploads/books/" + f.filename)
-    );
-  }
-  if (data.allow_preview !== undefined) {
-    data.allow_preview =
-      data.allow_preview === "1" ||
-      data.allow_preview === 1 ||
-      data.allow_preview === true ||
-      data.allow_preview === "true";
-  }
-
-  const book = await service.updateBook(req.params.id, data);
-
-  await service.clearBookTags(book.id);
-  book.tags = await processTags(rawTags, book.id);
-
-  if (
-    req.user.role !== "instructor" &&
-    existing.instructor_id &&
-    existing.instructor_id !== req.user.id
-  ) {
-    const message = `Your book "${book.title}" was updated by an admin.`;
-    await Promise.all([
-      notificationService.createNotification({
-        user_id: existing.instructor_id,
-        type: "book_updated",
-        message,
-      }),
-      messageService.createMessage({
-        sender_id: req.user.id,
-        receiver_id: existing.instructor_id,
-        message,
-      }),
-    ]);
-  }
-
-  sendSuccess(res, book, "Book updated");
 });
 
 exports.deleteBook = catchAsync(async (req, res) => {


### PR DESCRIPTION
## Summary
- Ensure uploaded files are removed if `createBook` or `updateBook` throws
- Add unit tests verifying file cleanup on controller errors

## Testing
- `npm test` *(fails: tests/tutorialUpdateTransaction.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf1f175883289f65615dfb73ac8a