### PR TITLE
feat: make book price filter configurable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,6 +10,9 @@ SMTP_PORT=587
 SMTP_SECURE=false
 SMTP_USER=your_smtp_username
 SMTP_PASS=your_smtp_password
+# Price range filter defaults for books
+BOOK_PRICE_RANGE_DEFAULT=100
+BOOK_PRICE_RANGE_MAX=500
 # Allowed frontend origins separated by commas
 # Configure this to match your production domain and server IP.
 # List multiple domains separated by commas if needed.

--- a/backend/src/config/books.js
+++ b/backend/src/config/books.js
@@ -1,0 +1,7 @@
+const PRICE_RANGE_DEFAULT = Number(process.env.BOOK_PRICE_RANGE_DEFAULT || 100);
+const PRICE_RANGE_MAX = Number(process.env.BOOK_PRICE_RANGE_MAX || 500);
+
+module.exports = {
+  PRICE_RANGE_DEFAULT,
+  PRICE_RANGE_MAX,
+};

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -1,4 +1,5 @@
 const db = require("../../config/database");
+const { PRICE_RANGE_MAX } = require("../../config/books");
 
 exports.createBook = async (data) => {
   const [row] = await db("books").insert(data).returning("*");
@@ -28,7 +29,8 @@ exports.listBooks = async (params = {}) => {
   }
   if (category) query.where("b.category_id", category);
   if (status) query.where("b.status", status);
-  if (priceRange) query.where("b.price", "<=", priceRange);
+  if (priceRange)
+    query.where("b.price", "<=", Math.min(priceRange, PRICE_RANGE_MAX));
   if (language) query.where("b.language", language);
   if (instructorId) query.where("b.instructor_id", instructorId);
   const tagArr = Array.isArray(tags) ? tags : tags ? [tags] : [];

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,6 +35,22 @@ COOKIE_SECURE=false
 COOKIE_SAMESITE=None
 ```
 
+The book filter's price range uses configurable defaults:
+
+```
+BOOK_PRICE_RANGE_DEFAULT=100
+BOOK_PRICE_RANGE_MAX=500
+```
+
+These values are read in `backend/src/config/books.js` and mirrored on the
+frontend via `frontend/src/utils/constants.js`. When running the frontend
+outside Docker, add the `NEXT_PUBLIC_` variants to `frontend/.env.local`:
+
+```
+NEXT_PUBLIC_BOOK_PRICE_RANGE_DEFAULT=100
+NEXT_PUBLIC_BOOK_PRICE_RANGE_MAX=500
+```
+
 ### Frontend (optional)
 
 When using Docker Compose the frontend automatically points to the API on port

--- a/frontend/src/components/books/FilterSidebar.js
+++ b/frontend/src/components/books/FilterSidebar.js
@@ -4,12 +4,16 @@ import { FaTimesCircle } from "react-icons/fa";
 import { fetchBookCategories } from "@/services/bookCategoryService";
 import { toast } from "react-hot-toast";
 import { useTranslation } from "next-i18next";
+import {
+  BOOK_PRICE_RANGE_DEFAULT,
+  BOOK_PRICE_RANGE_MAX,
+} from "@/utils/constants";
 
 const BookFilterSidebar = ({ onFilterChange, onResetFilters }) => {
   const { t } = useTranslation("website");
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState("");
-  const [priceRange, setPriceRange] = useState(100);
+  const [priceRange, setPriceRange] = useState(BOOK_PRICE_RANGE_DEFAULT);
   const [error, setError] = useState(null);
 
   useEffect(() => {
@@ -33,7 +37,7 @@ const BookFilterSidebar = ({ onFilterChange, onResetFilters }) => {
 
   const resetFilters = () => {
     setSelectedCategory("");
-    setPriceRange(100);
+    setPriceRange(BOOK_PRICE_RANGE_DEFAULT);
     onResetFilters();
   };
 
@@ -51,7 +55,7 @@ const BookFilterSidebar = ({ onFilterChange, onResetFilters }) => {
         <input
           type="range"
           min="0"
-          max="500"
+          max={BOOK_PRICE_RANGE_MAX}
           value={priceRange}
           onChange={(e) => {
             const value = Number(e.target.value);

--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -14,6 +14,9 @@ import { toast } from "react-hot-toast";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../next-i18next.config.js";
+import {
+  BOOK_PRICE_RANGE_DEFAULT,
+} from "@/utils/constants";
 
 const buildBookItem = (book) => ({
   id: book.id,
@@ -55,7 +58,7 @@ export default function BooksPage() {
   // We keep the shape here aligned with what `book.service.js` expects.
   const [filters, setFilters] = useState({
     category: "",
-    priceRange: 100,
+    priceRange: BOOK_PRICE_RANGE_DEFAULT,
     language: "",
     tags: [],
   });
@@ -98,7 +101,7 @@ export default function BooksPage() {
   const resetFilters = () => {
     setFilters({
       category: "",
-      priceRange: 100,
+      priceRange: BOOK_PRICE_RANGE_DEFAULT,
       language: "",
       tags: [],
     });

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,2 +1,9 @@
 export const MAX_IMAGE_SIZE_MB = 10;
 export const MAX_IMAGE_SIZE = MAX_IMAGE_SIZE_MB * 1024 * 1024;
+
+export const BOOK_PRICE_RANGE_DEFAULT = Number(
+  process.env.NEXT_PUBLIC_BOOK_PRICE_RANGE_DEFAULT ?? 100
+);
+export const BOOK_PRICE_RANGE_MAX = Number(
+  process.env.NEXT_PUBLIC_BOOK_PRICE_RANGE_MAX ?? 500
+);


### PR DESCRIPTION
## Summary
- add env-driven constants for default and max book price filter
- use new config in book filter sidebar and marketplace page
- cap price range in books API and document new env vars

## Testing
- `cd backend && npm test` *(fails: updateTutorial tag transactions › commits transaction when tag update succeeds)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ccf1d379083289a7cd3ff88f8a11c