### PR TITLE
fix: import missing book price default

### DIFF
--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -15,6 +15,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../next-i18next.config.js";
 import { mapBookForCart, mapBookForWishlist } from "@/utils/bookMapping";
+import { BOOK_PRICE_RANGE_DEFAULT } from "@/utils/constants";
 
 export default function BooksPage() {
   const { t } = useTranslation(["website", "common"]);


### PR DESCRIPTION
## Summary
- import `BOOK_PRICE_RANGE_DEFAULT` in books page to avoid undefined reference during build

## Testing
- `npm test`
- `npm run lint` *(fails: 91 errors, 262 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689d7767ecc8832894934d4dbc974374