### PR TITLE
fix: guard book price defaults

### DIFF
--- a/frontend/src/components/books/FilterSidebar.js
+++ b/frontend/src/components/books/FilterSidebar.js
@@ -9,11 +9,19 @@ import {
   BOOK_PRICE_RANGE_MAX,
 } from "@/utils/constants";
 
+// Gracefully handle missing build-time constants
+const DEFAULT_PRICE_RANGE =
+  typeof BOOK_PRICE_RANGE_DEFAULT !== "undefined"
+    ? BOOK_PRICE_RANGE_DEFAULT
+    : 100;
+const PRICE_RANGE_MAX =
+  typeof BOOK_PRICE_RANGE_MAX !== "undefined" ? BOOK_PRICE_RANGE_MAX : 500;
+
 const BookFilterSidebar = ({ onFilterChange, onResetFilters }) => {
   const { t } = useTranslation("website");
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState("");
-  const [priceRange, setPriceRange] = useState(BOOK_PRICE_RANGE_DEFAULT);
+  const [priceRange, setPriceRange] = useState(DEFAULT_PRICE_RANGE);
   const [error, setError] = useState(null);
 
   useEffect(() => {
@@ -37,7 +45,7 @@ const BookFilterSidebar = ({ onFilterChange, onResetFilters }) => {
 
   const resetFilters = () => {
     setSelectedCategory("");
-    setPriceRange(BOOK_PRICE_RANGE_DEFAULT);
+    setPriceRange(DEFAULT_PRICE_RANGE);
     onResetFilters();
   };
 
@@ -55,7 +63,7 @@ const BookFilterSidebar = ({ onFilterChange, onResetFilters }) => {
         <input
           type="range"
           min="0"
-          max={BOOK_PRICE_RANGE_MAX}
+          max={PRICE_RANGE_MAX}
           value={priceRange}
           onChange={(e) => {
             const value = Number(e.target.value);

--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -17,6 +17,12 @@ import nextI18NextConfig from "../../../../next-i18next.config.js";
 import { mapBookForCart, mapBookForWishlist } from "@/utils/bookMapping";
 import { BOOK_PRICE_RANGE_DEFAULT } from "@/utils/constants";
 
+// Fallback to a sane default if the constant is missing during build/runtime
+const DEFAULT_PRICE_RANGE =
+  typeof BOOK_PRICE_RANGE_DEFAULT !== "undefined"
+    ? BOOK_PRICE_RANGE_DEFAULT
+    : 100;
+
 export default function BooksPage() {
   const { t } = useTranslation(["website", "common"]);
   const [books, setBooks] = useState([]);
@@ -31,7 +37,7 @@ export default function BooksPage() {
   // We keep the shape here aligned with what `book.service.js` expects.
   const [filters, setFilters] = useState({
     category: "",
-    priceRange: BOOK_PRICE_RANGE_DEFAULT,
+    priceRange: DEFAULT_PRICE_RANGE,
     language: "",
     tags: [],
   });
@@ -74,7 +80,7 @@ export default function BooksPage() {
   const resetFilters = () => {
     setFilters({
       category: "",
-      priceRange: BOOK_PRICE_RANGE_DEFAULT,
+      priceRange: DEFAULT_PRICE_RANGE,
       language: "",
       tags: [],
     });


### PR DESCRIPTION
## Summary
- guard against missing `BOOK_PRICE_RANGE_*` constants when building
- prevent filter UI from crashing if env defaults are absent

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d7b7b3ea083289810a0236f2c6156