### PR TITLE
fix: add missing try block to book creation

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -28,19 +28,20 @@ const removeUploadedFiles = async (files = {}) => {
 };
 
 exports.createBook = catchAsync(async (req, res) => {
-  const { tags: rawTags, ...data } = req.body;
-  data.instructor_id = req.user.id;
-  data.status = "pending";
-  if (req.files?.cover_image?.[0])
-    data.cover_image_url =
-      "/uploads/books/" + req.files.cover_image[0].filename;
-  if (req.files?.book_file?.[0])
-    data.pdf_url = "/uploads/books/" + req.files.book_file[0].filename;
-  if (req.files?.preview_pages?.length) {
-    data.preview_pages = JSON.stringify(
-      req.files.preview_pages.map((f) => "/uploads/books/" + f.filename)
-    );
-  }
+  try {
+    const { tags: rawTags, ...data } = req.body;
+    data.instructor_id = req.user.id;
+    data.status = "pending";
+    if (req.files?.cover_image?.[0])
+      data.cover_image_url =
+        "/uploads/books/" + req.files.cover_image[0].filename;
+    if (req.files?.book_file?.[0])
+      data.pdf_url = "/uploads/books/" + req.files.book_file[0].filename;
+    if (req.files?.preview_pages?.length) {
+      data.preview_pages = JSON.stringify(
+        req.files.preview_pages.map((f) => "/uploads/books/" + f.filename)
+      );
+    }
 
     const book = await service.createBook(data);
 


### PR DESCRIPTION
## Summary
- wrap book creation logic in a try/catch to ensure uploaded files are cleaned up on failure and resolve syntax error

## Testing
- `npm test` *(fails: Test Suites: 5 failed, 70 passed, 75 total)*

------
https://chatgpt.com/codex/tasks/task_e_689d81b2e94083288fde745d4517421b