### PR TITLE
fix: harden checkout item parsing

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -24,35 +24,48 @@ const iconMap = {
   coinbase: <FaEthereum />,
 };
 
-function resolveCheckoutItem(query, cartItems) {
+export function resolveCheckoutItem(query, cartItems) {
   const { itemId, itemType, items } = query;
+
   if (itemId && itemType) {
     return { id: itemId, type: itemType };
   }
 
-  if (items) {
+  const parseItems = (value) => {
+    if (!value) return null;
+
+    const raw = Array.isArray(value) ? value[0] : value;
+    if (typeof raw !== 'string') return null;
+
+    let decoded = raw;
     try {
-      const raw = Array.isArray(items) ? items[0] : items;
-      let decoded = decodeURIComponent(raw);
-      try {
-        decoded = decodeURIComponent(decoded);
-      } catch {
-        // already decoded
-      }
+      decoded = decodeURIComponent(decoded);
+      decoded = decodeURIComponent(decoded);
+    } catch {
+      // ignore decode errors; we'll attempt to parse whatever we have
+    }
+
+    try {
       const parsed = JSON.parse(decoded);
       if (Array.isArray(parsed) && parsed.length === 1) {
-        const p = parsed[0];
+        const p = parsed[0] || {};
+        if (!p.id) return null;
         return { id: p.id, type: p.itemType || p.item_type || 'class' };
       }
-      return null;
-    } catch {
-      return null;
+    } catch (err) {
+      console.error('Failed to parse checkout items', err);
     }
-  }
+    return null;
+  };
 
-  if (cartItems.length === 1) {
+  const resolvedFromItems = parseItems(items);
+  if (resolvedFromItems) return resolvedFromItems;
+
+  if (Array.isArray(cartItems) && cartItems.length === 1) {
     const c = cartItems[0];
-    return { id: c.id, type: c.item_type || 'class' };
+    if (c && c.id) {
+      return { id: c.id, type: c.item_type || 'class' };
+    }
   }
 
   return null;
@@ -88,9 +101,14 @@ export default function CheckoutPage() {
       setCheckoutError('Please select exactly one item to checkout');
       return;
     }
-    setItemId(resolved.id);
-    setItemType(resolved.type);
-  }, [router.isReady, router.query, cartItems]);
+    setCheckoutError('');
+    if (resolved.id !== itemId) {
+      setItemId(resolved.id);
+    }
+    if (resolved.type !== itemType) {
+      setItemType(resolved.type);
+    }
+  }, [router.isReady, router.asPath, cartItems, itemId, itemType]);
 
   useEffect(() => {
     if (!itemId || !itemType) return;
@@ -106,8 +124,10 @@ export default function CheckoutPage() {
       }
       try {
         const data = await fetchPaymentMethods();
-        setMethods(data);
-        if (data.length > 0) setSelectedMethod(data[0].name);
+        setMethods(Array.isArray(data) ? data : []);
+        if (Array.isArray(data) && data.length > 0) {
+          setSelectedMethod(data[0].name);
+        }
       } catch (err) {
         console.error('Failed to load payment methods', err);
       }
@@ -155,9 +175,7 @@ export default function CheckoutPage() {
     };
     localStorage.setItem(storageKey, JSON.stringify([...enrolled, newItem]));
     try {
-      removeItem(itemInfo.id).catch((err) => {
-        console.error('Failed to remove from cart', err);
-      });
+      await Promise.resolve(removeItem(itemInfo.id));
     } catch (err) {
       console.error('Failed to remove from cart', err);
     }
@@ -218,7 +236,7 @@ export default function CheckoutPage() {
 
   if (checkoutError) return <div className="text-white text-center mt-32">{checkoutError}</div>;
   if (!itemInfo) return <div className="text-white text-center mt-32">Loading...</div>;
-  const finalPrice = Math.max(itemInfo.price - discount, 0);
+  const finalPrice = Math.max((itemInfo.price ?? 0) - discount, 0);
   const isFree = finalPrice === 0;
   const installments = 3;
   const perInstallment = finalPrice / installments;
@@ -227,7 +245,7 @@ export default function CheckoutPage() {
     d.setMonth(d.getMonth() + i);
     return { number: i + 1, date: d.toLocaleDateString(), amount: perInstallment.toFixed(2) };
   });
-  const availableMethods = methods.filter((m) => m.active);
+  const availableMethods = Array.isArray(methods) ? methods.filter((m) => m.active) : [];
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-950 to-gray-900 text-white">

--- a/frontend/src/tests/__tests__/resolveCheckoutItem.test.js
+++ b/frontend/src/tests/__tests__/resolveCheckoutItem.test.js
@@ -1,0 +1,19 @@
+import { resolveCheckoutItem } from '@/pages/payments/checkout';
+
+describe('resolveCheckoutItem', () => {
+  it('parses encoded items query parameter', () => {
+    const items = encodeURIComponent(JSON.stringify([{ id: '123', itemType: 'tutorial' }]));
+    const query = { items };
+    expect(resolveCheckoutItem(query, [])).toEqual({ id: '123', type: 'tutorial' });
+  });
+
+  it('falls back to cart items when query missing', () => {
+    const cart = [{ id: '1', item_type: 'class' }];
+    expect(resolveCheckoutItem({}, cart)).toEqual({ id: '1', type: 'class' });
+  });
+
+  it('returns null when nothing valid', () => {
+    const cart = [{ id: '1' }, { id: '2' }];
+    expect(resolveCheckoutItem({}, cart)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- export and test checkout item resolver
- avoid crashes when payment methods or cart removals are missing
- add unit tests covering checkout item resolution
- prevent checkout re-render loop when resolving items from query

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: Component definition is missing display name and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689cc34e56848328bd062dea2c4c0046