### PR TITLE
chore: add logging for token refresh

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -78,7 +78,11 @@ exports.login = catchAsync(async (req, res) => {
  */
 exports.refreshToken = catchAsync(async (req, res) => {
   const token = req.cookies.refreshToken;
-  if (!token) return res.status(401).json({ message: "Missing refresh token" });
+  console.log("\uD83D\uDD04 Refresh token endpoint hit. Token present:", Boolean(token));
+  if (!token) {
+    console.warn("\u26A0\uFE0F Missing refresh token cookie");
+    return res.status(401).json({ message: "Missing refresh token" });
+  }
 
   try {
     const { decoded, refreshToken: newRefreshToken } = await authService.rotateRefreshToken(token);
@@ -87,6 +91,7 @@ exports.refreshToken = catchAsync(async (req, res) => {
       role: decoded.role,
     });
     const csrfToken = authService.generateCsrfToken();
+    console.log("\u2705 Refresh token rotated for user", decoded.id);
     res
       .cookie("refreshToken", newRefreshToken, refreshCookieOptions)
       .cookie("csrfToken", csrfToken, csrfCookieOptions)

--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -80,14 +80,14 @@ api.interceptors.response.use(
     ].some((route) => originalRequest?.url?.includes(route));
 
     if (error.response?.status === 401 && !originalRequest._retry && !isAuthRoute) {
+      console.warn("\u26A0\uFE0F Received 401 for", originalRequest?.url);
       const refreshCookie = getCookie("refreshToken");
       const hasAuthState = !!authStore.accessToken || !!authStore.user;
 
       if (!refreshCookie && !hasAuthState) {
-        authStore.setToken(null);
-        authStore.setUser(null);
+        console.warn("\u26A0\uFE0F No refresh cookie or auth state; redirecting to login");
+        authStore.logout(true);
         if (typeof window !== "undefined") {
-          localStorage.removeItem("auth");
           Router.push("/auth/login");
         }
         toast.error("Session expired. Please log in again.");
@@ -107,17 +107,20 @@ api.interceptors.response.use(
       isRefreshing = true;
 
       try {
+        console.log("\uD83D\uDD04 Attempting token refresh...");
         const { data } = await api.post("/auth/refresh", null, {
           withCredentials: true,
         });
+        console.log("\u2705 Token refresh successful");
         authStore.setToken(data.accessToken);
         processQueue(null, data.accessToken);
 
         originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
         return api(originalRequest);
       } catch (refreshErr) {
+        console.error("\u274C Refresh token request failed:", refreshErr);
         processQueue(refreshErr, null);
-        authStore.logout();
+        authStore.logout(true);
         toast.info("You have been logged out.");
         toast.error("Session expired. Please log in again.");
         if (typeof window !== "undefined") {
@@ -128,7 +131,7 @@ api.interceptors.response.use(
         isRefreshing = false;
       }
     } else if (error.response?.status === 401 && originalRequest._retry && !isAuthRoute) {
-      authStore.logout();
+      authStore.logout(true);
       toast.info("You have been logged out.");
       toast.error("Session expired. Please log in again.");
       if (typeof window !== "undefined") {

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -74,10 +74,13 @@ const useAuthStore = create(
         await authService.registerUser(data);
       },
 
-      logout: async () => {
-        try {
-          await authService.logoutUser();
-        } catch (_) {}
+      logout: async (skipRequest = false) => {
+        if (!skipRequest) {
+          try {
+            await authService.logoutUser();
+          } catch (_) {}
+        }
+
         // Stop polling intervals when logging out
         const notifStop = useNotificationStore.getState().stopPolling;
         const msgStop = useMessageStore.getState().stopPolling;


### PR DESCRIPTION
## Summary
- log refresh-token requests on the server for easier debugging
- add console warnings and logging to token interceptor on 401
- skip calling the logout API when refresh fails to avoid loops

## Testing
- `npm test` (backend) *(fails: adsRoutes, bookRoutes, tutorialRoutes, class.routes, tutorialUpdateTransaction)*
- `CI=1 npx jest --runInBand` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689dac08495883289643d0c4540e55ea