### PR TITLE
Allow book creation with free and status fields

### DIFF
--- a/backend/src/modules/books/validation/bookValidation.js
+++ b/backend/src/modules/books/validation/bookValidation.js
@@ -18,6 +18,15 @@ exports.createBook = Joi.object({
     .falsy(0)
     .falsy('false')
     .default(false),
+  is_free: Joi.boolean()
+    .truthy('1')
+    .truthy(1)
+    .truthy('true')
+    .falsy('0')
+    .falsy(0)
+    .falsy('false')
+    .default(false),
+  status: Joi.string().optional(),
   tags: Joi.alternatives(Joi.array().items(Joi.string()), Joi.string()).optional(),
 });
 

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -117,6 +117,8 @@ describe('POST /api/books', () => {
       language: 'en',
       license_type: 'standard',
       category_id: 1,
+      is_free: false,
+      status: 'pending',
     };
     service.createBook.mockResolvedValue({ id: '1', ...payload });
     userModel.findAdmins.mockResolvedValue([]);


### PR DESCRIPTION
## Summary
- permit `is_free` and `status` in book creation validation
- cover book creation with status and free flags in tests

## Testing
- `npm test` *(fails: adsRoutes, class.routes, tutorialUpdateTransaction, tutorialRoutes, bookRoutes)*

------
https://chatgpt.com/codex/tasks/task_e_689f2b0c84e483288af9c6545ae0bf80