### PR TITLE
Handle validation error arrays on book forms

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -79,8 +79,15 @@ function AdminCreateBookPage() {
       console.error("Failed to create book", err);
       let errorMessage = t("booksCreate.error");
       if (err.response) {
-        if (err.response.data?.errors) {
-          errorMessage = Object.values(err.response.data.errors).join(", ");
+        const respErrors = err.response.data?.errors;
+        if (respErrors) {
+          if (Array.isArray(respErrors)) {
+            errorMessage = respErrors
+              .map((e) => e?.message || e)
+              .join(", ");
+          } else {
+            errorMessage = Object.values(respErrors).join(", ");
+          }
         } else if (err.response.data?.message) {
           errorMessage = err.response.data.message;
         }

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -95,8 +95,15 @@ function AdminEditBookPage() {
         defaultValue: "Failed to update book",
       });
       if (err.response) {
-        if (err.response.data?.errors) {
-          errorMessage = Object.values(err.response.data.errors).join(", ");
+        const respErrors = err.response.data?.errors;
+        if (respErrors) {
+          if (Array.isArray(respErrors)) {
+            errorMessage = respErrors
+              .map((e) => e?.message || e)
+              .join(", ");
+          } else {
+            errorMessage = Object.values(respErrors).join(", ");
+          }
         } else if (err.response.data?.message) {
           errorMessage = err.response.data.message;
         }

--- a/frontend/src/pages/dashboard/instructor/books/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/books/[id]/edit.js
@@ -117,8 +117,15 @@ function EditBookPage() {
       console.error("Failed to update book", e);
       let errorMessage = t("booksEdit.error");
       if (e.response) {
-        if (e.response.data?.errors) {
-          errorMessage = Object.values(e.response.data.errors).join(", ");
+        const respErrors = e.response.data?.errors;
+        if (respErrors) {
+          if (Array.isArray(respErrors)) {
+            errorMessage = respErrors
+              .map((err) => err?.message || err)
+              .join(", ");
+          } else {
+            errorMessage = Object.values(respErrors).join(", ");
+          }
         } else if (e.response.data?.message) {
           errorMessage = e.response.data.message;
         }

--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -100,8 +100,15 @@ function CreateBookPage() {
       console.error("Failed to create book", e);
       let errorMessage = t("booksCreate.error");
       if (e.response) {
-        if (e.response.data?.errors) {
-          errorMessage = Object.values(e.response.data.errors).join(", ");
+        const respErrors = e.response.data?.errors;
+        if (respErrors) {
+          if (Array.isArray(respErrors)) {
+            errorMessage = respErrors
+              .map((err) => err?.message || err)
+              .join(", ");
+          } else {
+            errorMessage = Object.values(respErrors).join(", ");
+          }
         } else if (e.response.data?.message) {
           errorMessage = e.response.data.message;
         }


### PR DESCRIPTION
## Summary
- Fix book form pages to parse validation error arrays instead of showing [object Object]

## Testing
- `cd frontend && npm test` (fails: bookService.test.js, instructorBookService.test.js, BookCard.test.js)
- `cd backend && npm test` (fails: adsRoutes.test.js, bookRoutes.test.js, tutorialRoutes.test.js, class.routes.test.js, tutorialUpdateTransaction.test.js)


------
https://chatgpt.com/codex/tasks/task_e_689f365a527c832892c93a07def4e4f2