### PR TITLE
Allow UUID category IDs for books and validate cart actions

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -305,8 +305,10 @@ sendSuccess(res, book, "Book status updated");
 
 exports.updateCart = catchAsync(async (req, res) => {
   const { bookId, action } = req.body;
+  const book = await service.getBookById(bookId);
+  if (!book) throw new AppError("Book not found", 404);
+  if (book.status !== "active") throw new AppError("Book is not active", 400);
   if (action === "remove") {
-
     await service.removeFromCart(req.user.id, bookId);
     return sendSuccess(res, null, "Removed from cart");
   }

--- a/backend/src/modules/books/validation/bookValidation.js
+++ b/backend/src/modules/books/validation/bookValidation.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 
 const id = Joi.number().integer().positive();
+const uuid = Joi.string().uuid();
 
 exports.createBook = Joi.object({
   title: Joi.string().min(1).required(),
@@ -9,7 +10,7 @@ exports.createBook = Joi.object({
   price: Joi.number().min(0).required(),
   language: Joi.string().required(),
   license_type: Joi.string().required(),
-  category_id: id.required(),
+  category_id: uuid.required(),
   allow_preview: Joi.boolean()
     .truthy('1')
     .truthy(1)
@@ -37,7 +38,7 @@ exports.updateBook = Joi.object({
   price: Joi.number().min(0),
   language: Joi.string(),
   license_type: Joi.string(),
-  category_id: id,
+  category_id: uuid,
   allow_preview: Joi.boolean()
     .truthy('1')
     .truthy(1)

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -116,7 +116,7 @@ describe('POST /api/books', () => {
       price: 10,
       language: 'en',
       license_type: 'standard',
-      category_id: 1,
+      category_id: '123e4567-e89b-12d3-a456-426614174000',
       is_free: false,
       status: 'pending',
     };


### PR DESCRIPTION
## Summary
- allow UUID formatted `category_id` for book creation and updates
- ensure cart operations verify book existence and active status
- adjust book route tests for new validation

## Testing
- `npm test tests/bookRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f534ee22c8328b6e97473a3b671cb