### PR TITLE
Show success toast on instructor book creation

### DIFF
--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -94,7 +94,13 @@ function CreateBookPage() {
           setUploadProgress(progress);
         }
       });
-      await Promise.all([fetchNotifications(), fetchMessages()]);
+      toast.success(t("booksCreate.success"));
+      try {
+        await Promise.all([fetchNotifications(), fetchMessages()]);
+      } catch (err) {
+        console.error("Failed to fetch notifications or messages", err);
+      }
+      handleRemoveImage();
       router.push("/dashboard/instructor/books?created=1");
     } catch (e) {
       console.error("Failed to create book", e);


### PR DESCRIPTION
## Summary
- show a success toast after creating a book
- don't fail creation when notifications/messages refresh fails
- clear image preview before redirecting

## Testing
- `npm test` (fails: 2 failed test suites)
- `npm run lint` (fails: 93 errors, 263 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689f5cbfdedc8328a14c67d3f20499d1