### PR TITLE
refactor: use cover image upload hook

### DIFF
--- a/frontend/src/pages/dashboard/instructor/books/create.js
+++ b/frontend/src/pages/dashboard/instructor/books/create.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
@@ -13,7 +13,8 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import { FiArrowLeft, FiX } from "react-icons/fi";
 import Head from "next/head";
-import { MAX_IMAGE_SIZE, MAX_IMAGE_SIZE_MB } from "@/utils/constants";
+import useCoverImageUpload from "@/hooks/useCoverImageUpload";
+import { MAX_IMAGE_SIZE_MB } from "@/utils/constants";
 
 function CreateBookPage() {
   const router = useRouter();
@@ -21,10 +22,14 @@ function CreateBookPage() {
   const [categories, setCategories] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [coverPreview, setCoverPreview] = useState(null);
-  const [fileError, setFileError] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(null);
-  const fileInputRef = useRef(null);
+  const {
+    coverPreview,
+    fileError,
+    fileInputRef,
+    handleFileChange,
+    handleRemoveImage,
+  } = useCoverImageUpload(t);
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const fetchMessages = useMessageStore((state) => state.fetch);
 
@@ -45,41 +50,6 @@ function CreateBookPage() {
 
     loadCategories();
   }, [t]);
-
-  const handleFileChange = useCallback(
-    (e) => {
-      const file = e.target.files[0];
-      if (!file) return;
-
-      const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
-      if (!allowedTypes.includes(file.type)) {
-        setFileError(t("validation.invalidFileType"));
-        return;
-      }
-
-      if (file.size > MAX_IMAGE_SIZE) {
-        setFileError(
-          t("validation.fileTooLarge", { size: `${MAX_IMAGE_SIZE_MB}MB` })
-        );
-        return;
-      }
-
-      setFileError(null);
-
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setCoverPreview(reader.result);
-      };
-      reader.readAsDataURL(file);
-    },
-    [t]
-  );
-
-  const handleRemoveImage = useCallback(() => {
-    setCoverPreview(null);
-    setFileError(null);
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  }, []);
 
   const handleSubmit = async (formData, setProgress) => {
     if (fileInputRef.current?.files?.[0]) {


### PR DESCRIPTION
## Summary
- use `useCoverImageUpload` in instructor book creation

## Testing
- `npm test` (fails: bookService.test.js, BookCard.test.js)
- `npm run lint` (fails: 93 errors, 263 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689f5cbf9334832894b1acb9c821e362