### PR TITLE
refactor: remove unused upload limits from admin book form

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -218,8 +218,6 @@ function AdminCreateBookPage() {
                 submitText={t("booksCreate.save")}
                 cancelText={t("common.cancel")}
                 onCancel={handleCancel}
-                maxFileSize={10 * 1024 * 1024}
-                allowedFileTypes={["image/jpeg", "image/png", "image/webp"]}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- remove `maxFileSize` and `allowedFileTypes` props from admin book creation page

## Testing
- `npm test` (fails: bookService, BookCard tests)
- `npm run lint` (fails: process terminated due to hang)

------
https://chatgpt.com/codex/tasks/task_e_689f5cbebdec8328b6722dffc4a2e9b1