### PR TITLE
refactor: use react-toastify in admin book creation

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { createBook } from "@/services/bookService";
 import BookForm from "@/components/books/BookForm";


### PR DESCRIPTION
## Summary
- use react-toastify for book creation toasts
- rely on global ToastContainer already rendered in _app.js

## Testing
- `npm test` *(fails: buildUrl is not a function, formatCurrency is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689f5cbbec7483288ecf83e9077f15d0