### PR TITLE
chore: align library key naming

### DIFF
--- a/backend/src/modules/library/library.service.js
+++ b/backend/src/modules/library/library.service.js
@@ -53,11 +53,11 @@ exports.listForStudent = async (studentId) => {
       author: row.author,
       tags: tagMap[row.id] || [],
       isFree: Number(row.price_paid) === 0,
-      price: Number(row.price_paid),
+      price_paid: Number(row.price_paid),
       purchasedAt: row.purchased_at,
-      coverUrl: row.cover_image_url,
-      pdfUrl: row.pdf_url,
-      previewUrl:
+      cover_image_url: row.cover_image_url,
+      pdf_url: row.pdf_url,
+      preview_url:
         row.allow_preview && previewPages.length ? previewPages[0] : null,
     };
   });

--- a/backend/tests/libraryRoutes.test.js
+++ b/backend/tests/libraryRoutes.test.js
@@ -31,11 +31,11 @@ describe('GET /api/library', () => {
         author: 'Author',
         tags: ['tag'],
         isFree: false,
-        price: 10,
+        price_paid: 10,
         purchasedAt: '2024-01-01T00:00:00Z',
-        coverUrl: '/cover',
-        pdfUrl: '/file.pdf',
-        previewUrl: '/preview',
+        cover_image_url: '/cover',
+        pdf_url: '/file.pdf',
+        preview_url: '/preview',
       },
     ];
     service.listForStudent.mockResolvedValue(items);

--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -26,7 +26,7 @@ function BookCard({ book }) {
       addToWishlist({
         book_id: book.id,
         title: book.title,
-        price: book.price,
+        price: book.price_paid,
         cover_url: cover,
       });
       toast.success(t("added_to_wishlist", { ns: "website" }));
@@ -58,7 +58,7 @@ function BookCard({ book }) {
             <span className="text-green-600 font-medium">{t("free")}</span>
           ) : (
             <span className="text-blue-600 font-medium">
-              {t("purchased_for", { price: book.price })}
+              {t("purchased_for", { price: book.price_paid })}
             </span>
           )}
         </div>
@@ -71,18 +71,18 @@ function BookCard({ book }) {
         )}
       </div>
       <div className="mt-4 flex gap-3 flex-wrap">
-        {book.previewUrl && (
+        {book.preview_url && (
           <a
-            href={book.previewUrl}
+            href={book.preview_url}
             target="_blank"
             className="flex items-center gap-1 text-indigo-600 hover:underline"
           >
             <FiEye className="text-lg" /> {t("preview")}
           </a>
         )}
-        {book.pdfUrl && (
+        {book.pdf_url && (
           <a
-            href={book.pdfUrl}
+            href={book.pdf_url}
             target="_blank"
             download
             className="flex items-center gap-1 text-green-600 hover:underline"


### PR DESCRIPTION
## Summary
- use snake_case for library service fields like `cover_image_url`, `pdf_url`, `preview_url`, and `price_paid`
- update library route tests for new response shape
- adjust student dashboard book listing to consume new library keys

## Testing
- `cd backend && npm test` *(fails: POST /api/ads/admin › creates ad, PUT /api/users/tutorials/admin/:id › returns 403 when instructor updates another instructor's tutorial, PUT /api/users/tutorials/admin/:id › updates tutorial with language and status, Class routes › create class, Class routes › create class responds even if notifications fail, Class routes › create class with options, updateTutorial tag transactions › commits transaction when tag update succeeds)*
- `cd frontend && npm test` *(fails: bookService tests, BookCard tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f5bd314b08328820cb916232d998e