### PR TITLE
Validate book status updates

### DIFF
--- a/backend/src/modules/books/book.routes.js
+++ b/backend/src/modules/books/book.routes.js
@@ -33,7 +33,13 @@ router.put(
   validate({ body: validation.updateBook }),
   controller.updateBook
 );
-router.patch("/:id/status", verifyToken, isInstructorOrAdmin, controller.updateBookStatus);
+router.patch(
+  "/:id/status",
+  verifyToken,
+  isInstructorOrAdmin,
+  validate({ body: validation.updateBookStatus }),
+  controller.updateBookStatus
+);
 router.post(
   "/cart",
   verifyToken,

--- a/backend/src/modules/books/validation/bookValidation.js
+++ b/backend/src/modules/books/validation/bookValidation.js
@@ -49,6 +49,12 @@ exports.updateBook = Joi.object({
   tags: Joi.alternatives(Joi.array().items(Joi.string()), Joi.string()),
 });
 
+exports.updateBookStatus = Joi.object({
+  status: Joi.string()
+    .valid('pending', 'approved', 'rejected', 'active', 'inactive')
+    .required(),
+});
+
 exports.cartAction = Joi.object({
   bookId: id.required(),
   action: Joi.string().valid('add', 'remove').default('add'),


### PR DESCRIPTION
## Summary
- add Joi schema to restrict book status values
- enforce status validation on `/:id/status` route

## Testing
- `npm test --prefix backend` *(fails: adsRoutes, tutorialRoutes, class.routes, tutorialUpdateTransaction)*

------
https://chatgpt.com/codex/tasks/task_e_689f5bd074a083289a166460b75ad597