### PR TITLE
Use item price and pdfUrl in library item

### DIFF
--- a/frontend/src/components/books/LibraryItem.js
+++ b/frontend/src/components/books/LibraryItem.js
@@ -1,14 +1,16 @@
+import { buildUrl } from "@/utils/url";
+
 export default function LibraryItem({ item }) {
   return (
     <div className="flex items-center justify-between border-b py-2">
       <div>
         <h4 className="font-medium">{item.title}</h4>
-        {item.price_paid && (
-          <p className="text-sm text-gray-600">{`$${item.price_paid}`}</p>
+        {item.price && (
+          <p className="text-sm text-gray-600">{`$${item.price}`}</p>
         )}
       </div>
       <a
-        href={`/api/library/download/${item.id}`}
+        href={buildUrl(item.pdfUrl)}
         className="text-blue-600 underline"
       >
         Download


### PR DESCRIPTION
## Summary
- reference `item.price` instead of `price_paid`
- use `buildUrl(item.pdfUrl)` for download link

## Testing
- `npm test` *(fails: 2 failed, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689f5bce76548328a0d94453f0a5f17d