### PR TITLE
Fix incorrect library store import path in BooksPage

### DIFF
--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { FiDownload, FiEye, FiHeart } from "react-icons/fi";
 import { useTranslation } from "next-i18next";
 import { toast } from "react-hot-toast";
-import useLibraryStore from "@/store/library/libraryStore";
+import useLibraryStore from "@/store/libraryStore";
 import useBookWishlistStore from "@/store/books/wishlistStore";
 
 function BookCard({ book }) {


### PR DESCRIPTION
## Summary
- fix incorrect path to `libraryStore` in BooksPage

## Testing
- `npm test` (fails: bookService, BookCard tests)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f686bff3883289e527d51aec31780