### PR TITLE
Fix library store import path in student books page

### DIFF
--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { FiDownload, FiEye, FiHeart } from "react-icons/fi";
 import { useTranslation } from "next-i18next";
 import { toast } from "react-hot-toast";
-import useLibraryStore from "@/store/library/libraryStore";
+import useLibraryStore from "@/store/libraryStore";
 import useBookWishlistStore from "@/store/books/wishlistStore";
 
 function BookCard({ book }) {


### PR DESCRIPTION
## Summary
- fix incorrect import path for `useLibraryStore` in dashboard Books page

## Testing
- `npm test` *(fails: bookService.test, BookCard.test)*
- `npm run lint` *(fails: 93 errors, 263 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f686bff3883289e527d51aec31780