### PR TITLE
feat: add book plan limits to seeds and config

### DIFF
--- a/backend/src/seeds/09_plans_seed.js
+++ b/backend/src/seeds/09_plans_seed.js
@@ -125,6 +125,20 @@ exports.seed = async function (knex) {
     },
     {
       id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.basic,
+      feature_key: 'books_purchase_limit',
+      value: '5',
+      description: 'Students can purchase up to 5 books per month'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.basic,
+      feature_key: 'books_publish_limit',
+      value: '0',
+      description: 'Instructors cannot publish books'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.regular,
       feature_key: 'ads_max_ads',
       value: '3',
@@ -174,6 +188,20 @@ exports.seed = async function (knex) {
     },
     {
       id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.regular,
+      feature_key: 'books_purchase_limit',
+      value: '20',
+      description: 'Students can purchase up to 20 books per month'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.regular,
+      feature_key: 'books_publish_limit',
+      value: '10',
+      description: 'Instructors can publish up to 10 books'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.prime,
       feature_key: 'ads_max_ads',
       value: '10',
@@ -220,6 +248,20 @@ exports.seed = async function (knex) {
       feature_key: 'groups_join_limit',
       value: 'unlimited',
       description: 'Join unlimited groups'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'books_purchase_limit',
+      value: 'unlimited',
+      description: 'Students can purchase unlimited books'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'books_publish_limit',
+      value: 'unlimited',
+      description: 'Instructors can publish unlimited books'
     }
   ]);
 };

--- a/frontend/src/config/plansConfig.js
+++ b/frontend/src/config/plansConfig.js
@@ -6,21 +6,27 @@ const plansConfig = {
       maxAdDuration: 3, // days
       placements: ["dashboard"],
       allowBranding: false,
-      showAnalytics: false
+      showAnalytics: false,
+      booksPurchaseLimit: 5,
+      booksPublishLimit: 0
     },
     regular: {
       maxAds: 3,
       maxAdDuration: 7,
       placements: ["dashboard", "homepage"],
       allowBranding: false,
-      showAnalytics: true
+      showAnalytics: true,
+      booksPurchaseLimit: 20,
+      booksPublishLimit: 10
     },
     prime: {
       maxAds: 10,
       maxAdDuration: 30,
       placements: ["dashboard", "homepage", "email", "sidebar"],
       allowBranding: true,
-      showAnalytics: true
+      showAnalytics: true,
+      booksPurchaseLimit: Infinity,
+      booksPublishLimit: Infinity
     }
   };
   


### PR DESCRIPTION
## Summary
- seed book purchase and publish limits for basic, regular, and prime plans
- expose book limits in client plan configuration

## Testing
- `npm test` (backend) *(fails: Expected 403 but received 400, etc.)*
- `npm test` (frontend) *(fails: buildUrl is not a function, formatCurrency not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689f694ae6048328a18d60d267286e75