### PR TITLE
Fix book dashboard card and admin page imports

### DIFF
--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -1,8 +1,15 @@
 import Link from "next/link";
-import Image from "next/image";
 import { useTranslation } from "next-i18next";
-import { FiEye, FiBookOpen, FiEdit, FiTrash2 } from "react-icons/fi";
+import {
+  FiEye,
+  FiBookOpen,
+  FiEdit,
+  FiTrash2,
+  FiHeart,
+  FiShoppingCart,
+} from "react-icons/fi";
 import { buildUrl } from "@/utils/url";
+import { formatCurrency } from "@/utils/currency";
 
 export default function BookCard({
   book,
@@ -49,7 +56,7 @@ export default function BookCard({
           {t(book.status)}
         </span>
       )}
-      <Image
+      <img
         src={coverUrl}
         alt={book.title}
         width={400}
@@ -59,9 +66,9 @@ export default function BookCard({
       />
       <div className="p-4">
         <h3 className="font-semibold mb-1 line-clamp-1">{book.title}</h3>
-        {book.author && (
+        {(book.uploaded_by?.name || book.author) && (
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">
-            {t("by_author", { author: book.author })}
+            {t("by_author", { author: book.uploaded_by?.name || book.author })}
           </p>
         )}
         {book.category_name && (

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -15,6 +15,8 @@ import { FiPlus, FiSearch, FiTrash2, FiChevronLeft, FiChevronRight, FiFilter, Fi
 import { Switch } from '@headlessui/react';
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { buildUrl } from "@/utils/url";
+import useNotificationStore from "@/store/notifications/notificationStore";
+import useMessageStore from "@/store/messages/messageStore";
 function AdminBooksPage() {
   const { t } = useTranslation("dashboard");
 


### PR DESCRIPTION
## Summary
- display uploader name and handle cover image with fallback in BookCard
- add missing icon and currency imports to BookCard
- import notification and message stores in admin books page to prevent runtime errors

## Testing
- `npm test` *(fails: bookService.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689f721dc65c83289729c155c838c999