### PR TITLE
fix: add debounce import to admin books

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef, useMemo, useCallback } from "react";
+import { debounce } from "lodash";
 import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import BookCardSkeleton from "@/components/books/BookCardSkeleton";


### PR DESCRIPTION
## Summary
- import lodash debounce to support tag suggestion search on admin book list

## Testing
- `cd backend && npm test` *(fails: POST /api/ads/admin creates ad, etc.)*
- `cd frontend && npm test` *(fails: bookService tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f75e0b5908328bdca4e8fa0f4b7d2