### PR TITLE
Load admin dashboard charts from backend

### DIFF
--- a/backend/src/modules/users/admin/admin.service.js
+++ b/backend/src/modules/users/admin/admin.service.js
@@ -39,15 +39,53 @@ exports.updateAdminProfile = async (userId, data) => {
 // ---------------------------------------------------------------------------
 
 exports.getDashboardStats = async () => {
-  const [userRow] = await db("users").count();
-  const [instructorRow] = await db("users")
-    .where({ role: "Instructor" })
-    .count();
-  const [studentRow] = await db("users")
-    .where({ role: "Student" })
-    .count();
-  const [tutorialRow] = await db("tutorials").count();
-  const [classRow] = await db("online_classes").count();
+  const [
+    userRow,
+    instructorRow,
+    studentRow,
+    tutorialRow,
+    classRow,
+    revenueRows,
+    signupRows,
+    categoryRows,
+    instructorRows,
+  ] = await Promise.all([
+    db("users").count().first(),
+    db("users").where({ role: "Instructor" }).count().first(),
+    db("users").where({ role: "Student" }).count().first(),
+    db("tutorials").count().first(),
+    db("online_classes").count().first(),
+    db("payments")
+      .where({ status: "paid" })
+      .where("created_at", ">=", db.raw("date_trunc('month', now()) - interval '5 months'"))
+      .select(
+        db.raw("TO_CHAR(date_trunc('month', created_at), 'Mon') as month")
+      )
+      .sum({ revenue: "amount" })
+      .groupByRaw("date_trunc('month', created_at)")
+      .orderByRaw("date_trunc('month', created_at)"),
+    db("users")
+      .where("created_at", ">=", db.raw("date_trunc('month', now()) - interval '5 months'"))
+      .select(
+        db.raw("TO_CHAR(date_trunc('month', created_at), 'Mon') as month")
+      )
+      .count("* as users")
+      .groupByRaw("date_trunc('month', created_at)")
+      .orderByRaw("date_trunc('month', created_at)"),
+    db("tutorials as t")
+      .leftJoin("categories as c", "t.category_id", "c.id")
+      .select(db.raw("COALESCE(c.name, 'Uncategorized') as name"))
+      .count("t.id as value")
+      .groupBy("name")
+      .orderBy("value", "desc"),
+    db("tutorials as t")
+      .leftJoin("users as u", "t.instructor_id", "u.id")
+      .select("u.full_name as instructor")
+      .count("t.id as tutorials")
+      .groupBy("u.full_name")
+      .orderBy("tutorials", "desc")
+      .limit(10),
+  ]);
 
   return {
     totalUsers: parseInt(userRow.count, 10) || 0,
@@ -55,5 +93,21 @@ exports.getDashboardStats = async () => {
     students: parseInt(studentRow.count, 10) || 0,
     tutorials: parseInt(tutorialRow.count, 10) || 0,
     classes: parseInt(classRow.count, 10) || 0,
+    monthlyRevenue: revenueRows.map((r) => ({
+      month: r.month,
+      revenue: parseFloat(r.revenue) || 0,
+    })),
+    monthlySignups: signupRows.map((r) => ({
+      month: r.month,
+      users: parseInt(r.users, 10) || 0,
+    })),
+    tutorialsByCategory: categoryRows.map((r) => ({
+      name: r.name,
+      value: parseInt(r.value, 10) || 0,
+    })),
+    instructorTutorialCount: instructorRows.map((r) => ({
+      instructor: r.instructor,
+      tutorials: parseInt(r.tutorials, 10) || 0,
+    })),
   };
 };

--- a/frontend/src/components/admin/charts/CategoryPieChart.js
+++ b/frontend/src/components/admin/charts/CategoryPieChart.js
@@ -1,18 +1,11 @@
 // components/admin/charts/CategoryPieChart.js
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 
-const data = [
-  { name: 'Development', value: 500 },
-  { name: 'Design', value: 200 },
-  { name: 'Marketing', value: 150 },
-  { name: 'Business', value: 100 },
-];
-
 const COLORS = ['#facc15', '#60a5fa', '#f87171', '#34d399'];
 
-export default function CategoryPieChart() {
+export default function CategoryPieChart({ data = [] }) {
   return (
-    <div className="bg-white p-6 rounded-xl shadow mt-8">
+    <div className="bg-white p-6 rounded-xl shadow">
       <h2 className="text-xl font-semibold mb-4">📚 Tutorials by Category</h2>
       <ResponsiveContainer width="100%" height={300}>
         <PieChart>

--- a/frontend/src/components/admin/charts/InstructorActivityChart.js
+++ b/frontend/src/components/admin/charts/InstructorActivityChart.js
@@ -1,16 +1,9 @@
 // components/admin/charts/InstructorActivityChart.js
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 
-const data = [
-  { instructor: 'John', tutorials: 8 },
-  { instructor: 'Sarah', tutorials: 6 },
-  { instructor: 'Ali', tutorials: 10 },
-  { instructor: 'Mina', tutorials: 4 },
-];
-
-export default function InstructorActivityChart() {
+export default function InstructorActivityChart({ data = [] }) {
   return (
-    <div className="bg-white p-6 rounded-xl shadow mt-8">
+    <div className="bg-white p-6 rounded-xl shadow">
       <h2 className="text-xl font-semibold mb-4">👨‍🏫 Instructor Tutorial Count</h2>
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={data}>

--- a/frontend/src/components/admin/charts/RevenueChart.js
+++ b/frontend/src/components/admin/charts/RevenueChart.js
@@ -1,18 +1,9 @@
 // components/admin/charts/RevenueChart.js
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 
-const data = [
-  { month: 'Jan', revenue: 4200 },
-  { month: 'Feb', revenue: 5320 },
-  { month: 'Mar', revenue: 6150 },
-  { month: 'Apr', revenue: 7120 },
-  { month: 'May', revenue: 8300 },
-  { month: 'Jun', revenue: 9250 },
-];
-
-export default function RevenueChart() {
+export default function RevenueChart({ data = [] }) {
   return (
-    <div className="bg-white p-6 rounded-xl shadow mt-8">
+    <div className="bg-white p-6 rounded-xl shadow">
       <h2 className="text-xl font-semibold mb-4">📈 Monthly Revenue</h2>
       <ResponsiveContainer width="100%" height={300}>
         <LineChart data={data}>

--- a/frontend/src/components/admin/charts/SignupsChart.js
+++ b/frontend/src/components/admin/charts/SignupsChart.js
@@ -1,18 +1,9 @@
 // components/admin/charts/SignupsChart.js
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 
-const data = [
-  { month: 'Jan', users: 120 },
-  { month: 'Feb', users: 180 },
-  { month: 'Mar', users: 200 },
-  { month: 'Apr', users: 230 },
-  { month: 'May', users: 310 },
-  { month: 'Jun', users: 400 },
-];
-
-export default function SignupsChart() {
+export default function SignupsChart({ data = [] }) {
   return (
-    <div className="bg-white p-6 rounded-xl shadow mt-8">
+    <div className="bg-white p-6 rounded-xl shadow">
       <h2 className="text-xl font-semibold mb-4">👥 Monthly Signups</h2>
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={data}>

--- a/frontend/src/pages/dashboard/admin/index.js
+++ b/frontend/src/pages/dashboard/admin/index.js
@@ -189,21 +189,13 @@ function AdminDashboardHome() {
       {/* Charts & Stats */}
       <section>
         <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-          <div className="bg-white rounded-xl shadow p-6">
-            <RevenueChart />
-          </div>
-          <div className="bg-white rounded-xl shadow p-6">
-            <SignupsChart />
-          </div>
+          <RevenueChart data={stats?.monthlyRevenue} />
+          <SignupsChart data={stats?.monthlySignups} />
         </div>
 
         <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 mt-6">
-          <div className="bg-white rounded-xl shadow p-6">
-            <CategoryPieChart />
-          </div>
-          <div className="bg-white rounded-xl shadow p-6">
-            <InstructorActivityChart />
-          </div>
+          <CategoryPieChart data={stats?.tutorialsByCategory} />
+          <InstructorActivityChart data={stats?.instructorTutorialCount} />
         </div>
 
         <h2 className="text-xl font-semibold text-gray-800 mb-4 mt-8">


### PR DESCRIPTION
## Summary
- Aggregate monthly revenue, signups, tutorial categories and instructor counts in admin dashboard stats
- Render admin dashboard charts with backend data

## Testing
- `npm test` (backend) *(fails: POST /api/ads/admin creates ad, PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial, PUT /api/users/tutorials/admin/:id updates tutorial with language and status, Class routes create class, Class routes create class responds even if notifications fail, Class routes create class with options, updateTutorial tag transactions commits transaction when tag update succeeds)*
- `npm test` (frontend) *(fails: bookService normalizes price and parses preview pages, bookService buildUrl preserves API base paths, bookService buildUrl prefixes relative API base paths, bookService buildUrl returns a same-origin path when API base is empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a0703bf2d083289fc2c27112f26714