### PR TITLE
Fix payment method deletion route order

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -109,10 +109,18 @@ app.use("/api/community/admin", require("./modules/community/admin/admin.routes"
 app.use("/api/community", require("./modules/community/public/public.routes"));
 app.use("/api/roles", require("./modules/roles/roles.routes"));
 app.use("/api/plans", require("./modules/plans/plans.routes"));
-app.use("/api/payment-methods", require("./modules/paymentMethods/paymentMethods.public.routes"));
+// Register admin routes before public routes to prevent public routes from catching
+// requests intended for admin endpoints such as "/api/payment-methods/admin".
+app.use(
+  "/api/payment-methods/admin",
+  require("./modules/paymentMethods/paymentMethods.routes")
+);
+app.use(
+  "/api/payment-methods",
+  require("./modules/paymentMethods/paymentMethods.public.routes")
+);
 app.use("/api/payments/student", require("./modules/payments/student.routes"));
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
-app.use("/api/payment-methods/admin", require("./modules/paymentMethods/paymentMethods.routes"));
 app.use("/api/payments/config", require("./modules/paymentConfig/paymentConfig.routes"));
 app.use("/api/messages/config", require("./modules/messagesConfig/messagesConfig.routes"));
 app.use("/api/social-login/config", require("./modules/socialLoginConfig/socialLoginConfig.routes"));


### PR DESCRIPTION
## Summary
- Register admin payment-method routes before public routes so admin deletions aren't captured by public router.

## Testing
- `cd backend && npm test` (fails: POST /api/ads/admin creates ad etc.)

------
https://chatgpt.com/codex/tasks/task_e_68a09266e1588328b22290132099a9aa