### PR TITLE
Add bank payment routes with validation and sanitization

### DIFF
--- a/backend/src/modules/payments/bank.admin.routes.js
+++ b/backend/src/modules/payments/bank.admin.routes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./bank.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+// Protect all admin bank routes
+router.use(verifyToken, isAdmin);
+
+// Admin can confirm a bank payment
+router.post("/confirm", controller.confirmBankPayment);
+
+module.exports = router;

--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -1,0 +1,91 @@
+const { v4: uuidv4 } = require("uuid");
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const db = require("../../config/database");
+
+// Basic recursive sanitization for user input
+const sanitize = (value) => {
+  if (typeof value === "string") {
+    return value.replace(/[^\w\s@.-]/g, "").trim();
+  }
+  return value;
+};
+
+const sanitizeObject = (obj = {}) => {
+  const cleaned = {};
+  for (const key in obj) {
+    const val = obj[key];
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      cleaned[key] = sanitizeObject(val);
+    } else if (Array.isArray(val)) {
+      cleaned[key] = val.map((v) => sanitize(v));
+    } else {
+      cleaned[key] = sanitize(val);
+    }
+  }
+  return cleaned;
+};
+
+exports.initiateBankPayment = catchAsync(async (req, res) => {
+  const body = sanitizeObject(req.body);
+  const orderId = body.orderId || body.order_id;
+  if (!orderId) throw new AppError("Order ID is required", 400);
+
+  const order = await db("orders").where({ id: orderId }).first();
+  if (!order) throw new AppError("Order not found", 404);
+  if (order.user_id !== req.user.id) {
+    throw new AppError("You do not own this order", 403);
+  }
+
+  const method = await db("payment_methods_config")
+    .where({ type: "bank", active: true })
+    .first();
+  if (!method) throw new AppError("Bank payments are not enabled", 400);
+
+  const paymentData = {
+    id: uuidv4(),
+    user_id: req.user.id,
+    method_id: method.id,
+    item_type: "order",
+    item_id: order.id,
+    amount: order.total_amount || order.amount || 0,
+    currency: order.currency || "USD",
+    status: "pending",
+    reference_id: order.id,
+  };
+
+  const [payment] = await db("payments").insert(paymentData).returning("*");
+  sendSuccess(res, payment, "Bank payment initiated");
+});
+
+exports.confirmBankPayment = catchAsync(async (req, res) => {
+  const body = sanitizeObject(req.body);
+  const paymentId = body.paymentId || body.payment_id;
+  const orderId = body.orderId || body.order_id;
+  if (!paymentId || !orderId) {
+    throw new AppError("Payment ID and Order ID are required", 400);
+  }
+
+  const payment = await db("payments").where({ id: paymentId }).first();
+  if (!payment) throw new AppError("Payment not found", 404);
+
+  const order = await db("orders").where({ id: orderId }).first();
+  if (!order) throw new AppError("Order not found", 404);
+
+  if (payment.user_id !== order.user_id) {
+    throw new AppError("Payment does not belong to this user", 403);
+  }
+  const paymentOrderId = payment.item_id || payment.reference_id;
+  if (paymentOrderId !== order.id) {
+    throw new AppError("Payment is not associated with the provided order", 400);
+  }
+
+  const [updated] = await db("payments")
+    .where({ id: paymentId })
+    .update({ status: "paid", paid_at: new Date() })
+    .returning("*");
+
+  sendSuccess(res, updated, "Bank payment confirmed");
+});
+

--- a/backend/src/modules/payments/bank.routes.js
+++ b/backend/src/modules/payments/bank.routes.js
@@ -1,0 +1,11 @@
+const router = require("express").Router();
+const controller = require("./bank.controller");
+const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware");
+
+// Student must be authenticated
+router.use(verifyToken, isStudent);
+
+// Initiate a bank payment for an order
+router.post("/initiate", controller.initiateBankPayment);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -120,6 +120,8 @@ app.use(
   require("./modules/paymentMethods/paymentMethods.public.routes")
 );
 app.use("/api/payments/student", require("./modules/payments/student.routes"));
+app.use("/api/payments/bank", require("./modules/payments/bank.routes"));
+app.use("/api/payments/admin/bank", require("./modules/payments/bank.admin.routes"));
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
 app.use("/api/payments/config", require("./modules/paymentConfig/paymentConfig.routes"));
 app.use("/api/messages/config", require("./modules/messagesConfig/messagesConfig.routes"));


### PR DESCRIPTION
## Summary
- add dedicated controller for bank payments with recursive sanitization
- protect bank admin routes using `verifyToken` and `isAdmin`
- register bank payment endpoints for students and admins

## Testing
- `npm test` *(fails: Test Suites: 4 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a09ff270148328b7cedc88157f9a47