### PR TITLE
feat: add configurable storage for receipt uploads

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -7,3 +7,5 @@ The `/api/system-errors` route reads the latest lines from `logs/error.log` and 
 ### Bank transfer receipts
 
 Students can upload proof of manual transfers via `POST /api/payments/student/receipts` using a multipart form field named `receipt`. The uploaded file URL can then be referenced by admins when recording payments. Each payment may optionally store this URL in the new `receipt_url` column.
+
+Receipt storage is configurable via environment variables. Set `RECEIPT_STORAGE=s3` to upload files to the S3 bucket defined by `AWS_S3_BUCKET` (using private ACL). Otherwise receipts are written to the `PAYMENT_RECEIPT_DIR` directory, which defaults to `secure/payment-receipts` and is not served publicly. The upload endpoint returns a `receipt_url` that should be stored with the payment record.

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.2",
+    "multer-s3": "^3.0.1",
     "nodemailer": "^7.0.3",
     "passport": "^0.7.0",
     "passport-apple": "^2.0.2",
@@ -43,6 +44,7 @@
     "yamljs": "^0.3.0",
     "zod": "^3.25.20",
     "joi": "^17.13.0",
+    "@aws-sdk/client-s3": "^3.614.0",
     "@paypal/checkout-server-sdk": "^1.0.3"
   },
   "devDependencies": {

--- a/backend/src/modules/payments/paymentReceiptUpload.middleware.js
+++ b/backend/src/modules/payments/paymentReceiptUpload.middleware.js
@@ -2,17 +2,56 @@ const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
 
-const uploadDir = path.join(__dirname, '../../../uploads/payment-receipts');
-if (!fs.existsSync(uploadDir)) {
-  fs.mkdirSync(uploadDir, { recursive: true });
-}
+/**
+ * Storage driver for payment receipt uploads.
+ *
+ * When `RECEIPT_STORAGE` is set to `s3`, files are uploaded to the
+ * configured S3 bucket using private ACL. Otherwise files are written to a
+ * local directory that is **not** exposed via the public `/uploads` route.
+ */
 
-const storage = multer.diskStorage({
-  destination: (_req, _file, cb) => cb(null, uploadDir),
-  filename: (_req, file, cb) => {
-    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
-    cb(null, unique + path.extname(file.originalname));
-  },
-});
+let storage;
+
+if (process.env.RECEIPT_STORAGE === 's3') {
+  // Lazily require these heavy dependencies only when S3 is enabled.
+  const multerS3 = require('multer-s3');
+  const { S3Client } = require('@aws-sdk/client-s3');
+
+  const s3 = new S3Client({
+    region: process.env.AWS_REGION,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    },
+  });
+
+  storage = multerS3({
+    s3,
+    bucket: process.env.AWS_S3_BUCKET,
+    acl: 'private',
+    contentType: multerS3.AUTO_CONTENT_TYPE,
+    key: (_req, file, cb) => {
+      const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+      cb(null, `payment-receipts/${unique}${path.extname(file.originalname)}`);
+    },
+  });
+} else {
+  // Default to local storage in a secure directory outside the public uploads folder
+  const uploadDir =
+    process.env.PAYMENT_RECEIPT_DIR ||
+    path.join(__dirname, '../../../secure/payment-receipts');
+
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+
+  storage = multer.diskStorage({
+    destination: (_req, _file, cb) => cb(null, uploadDir),
+    filename: (_req, file, cb) => {
+      const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+      cb(null, unique + path.extname(file.originalname));
+    },
+  });
+}
 
 module.exports = multer({ storage });

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -11,6 +11,7 @@ const tutorialEnrollmentService = require("../users/tutorials/enrollments/tutori
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const paypalService = require("../../services/paypalService");
+const path = require("path");
 
 exports.createPayment = catchAsync(async (req, res) => {
   const {
@@ -150,8 +151,17 @@ exports.createPayment = catchAsync(async (req, res) => {
 
 exports.uploadReceipt = catchAsync(async (req, res) => {
   if (!req.file) throw new AppError("No file uploaded", 400);
-  const url = `/uploads/payment-receipts/${req.file.filename}`;
-  sendSuccess(res, { url }, "Receipt uploaded");
+
+  let receiptUrl;
+  if (process.env.RECEIPT_STORAGE === 's3') {
+    // `multer-s3` exposes the uploaded file's location
+    receiptUrl = req.file.location;
+  } else {
+    // Store a path relative to the secure receipt directory
+    receiptUrl = path.posix.join('payment-receipts', req.file.filename);
+  }
+
+  sendSuccess(res, { receipt_url: receiptUrl }, "Receipt uploaded");
 });
 
 exports.getPayments = catchAsync(async (_req, res) => {


### PR DESCRIPTION
## Summary
- allow payment receipt uploads to use S3 or secure local directory
- return receipt_url from upload endpoint and document receipt storage
- add dependencies for optional S3 support

## Testing
- `npm test` *(fails: adsRoutes.test.js, tutorialRoutes.test.js, class.routes.test.js, tutorialUpdateTransaction.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a09feeea3483288f4e53c978050a7a