### PR TITLE
feat(admin): add bank transfer approval tab

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -640,7 +640,8 @@
       "transactions": "Transactions",
       "methods": "Payment Methods",
       "configuration": "Configuration",
-      "payouts": "Payouts"
+      "payouts": "Payouts",
+      "bankTransfers": "Bank Transfers"
     },
     "total_revenue": "Total Revenue",
     "total_transactions": "Total Transactions",
@@ -659,6 +660,7 @@
     "refunded": "Refunded",
     "export_csv": "Export CSV",
     "transaction_id": "Transaction ID",
+    "order_id": "Order ID",
     "date": "Date",
     "user": "User",
     "type": "Type",
@@ -683,6 +685,7 @@
     "instructor_payouts": "Instructor Payouts",
     "mark_paid": "Mark as Paid",
     "reject": "Reject",
+    "approve": "Approve",
     "reopen": "Reopen",
     "payout_status_updated": "Payout status updated",
     "payout_status_failed": "Failed to update payout status",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -616,7 +616,8 @@
       "transactions": "Transactions",
       "methods": "Payment Methods",
       "configuration": "Configuration",
-      "payouts": "Payouts"
+      "payouts": "Payouts",
+      "bankTransfers": "Bank Transfers"
     },
     "total_revenue": "Total Revenue",
     "total_transactions": "Total Transactions",
@@ -635,6 +636,7 @@
     "refunded": "Refunded",
     "export_csv": "Export CSV",
     "transaction_id": "Transaction ID",
+    "order_id": "Order ID",
     "date": "Date",
     "user": "User",
     "type": "Type",
@@ -659,6 +661,7 @@
     "instructor_payouts": "Instructor Payouts",
     "mark_paid": "Mark as Paid",
     "reject": "Reject",
+    "approve": "Approve",
     "reopen": "Reopen",
     "payout_status_updated": "Payout status updated",
     "payout_status_failed": "Failed to update payout status",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -653,7 +653,8 @@
       "transactions": "Transactions",
       "methods": "Payment Methods",
       "configuration": "Configuration",
-      "payouts": "Payouts"
+      "payouts": "Payouts",
+      "bankTransfers": "Bank Transfers"
     },
     "total_revenue": "Total Revenue",
     "total_transactions": "Total Transactions",
@@ -672,6 +673,7 @@
     "refunded": "Refunded",
     "export_csv": "Export CSV",
     "transaction_id": "Transaction ID",
+    "order_id": "Order ID",
     "date": "Date",
     "user": "User",
     "type": "Type",
@@ -696,6 +698,7 @@
     "instructor_payouts": "Instructor Payouts",
     "mark_paid": "Mark as Paid",
     "reject": "Reject",
+    "approve": "Approve",
     "reopen": "Reopen",
     "payout_status_updated": "Payout status updated",
     "payout_status_failed": "Failed to update payout status",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -616,7 +616,8 @@
       "transactions": "Transactions",
       "methods": "Payment Methods",
       "configuration": "Configuration",
-      "payouts": "Payouts"
+      "payouts": "Payouts",
+      "bankTransfers": "Bank Transfers"
     },
     "total_revenue": "Total Revenue",
     "total_transactions": "Total Transactions",
@@ -635,6 +636,7 @@
     "refunded": "Refunded",
     "export_csv": "Export CSV",
     "transaction_id": "Transaction ID",
+    "order_id": "Order ID",
     "date": "Date",
     "user": "User",
     "type": "Type",
@@ -659,6 +661,7 @@
     "instructor_payouts": "Instructor Payouts",
     "mark_paid": "Mark as Paid",
     "reject": "Reject",
+    "approve": "Approve",
     "reopen": "Reopen",
     "payout_status_updated": "Payout status updated",
     "payout_status_failed": "Failed to update payout status",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -628,7 +628,8 @@
       "transactions": "Transactions",
       "methods": "Payment Methods",
       "configuration": "Configuration",
-      "payouts": "Payouts"
+      "payouts": "Payouts",
+      "bankTransfers": "Bank Transfers"
     },
     "total_revenue": "Total Revenue",
     "total_transactions": "Total Transactions",
@@ -647,6 +648,7 @@
     "refunded": "Refunded",
     "export_csv": "Export CSV",
     "transaction_id": "Transaction ID",
+    "order_id": "Order ID",
     "date": "Date",
     "user": "User",
     "type": "Type",
@@ -671,6 +673,7 @@
     "instructor_payouts": "Instructor Payouts",
     "mark_paid": "Mark as Paid",
     "reject": "Reject",
+    "approve": "Approve",
     "reopen": "Reopen",
     "payout_status_updated": "Payout status updated",
     "payout_status_failed": "Failed to update payout status",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -653,7 +653,8 @@
       "transactions": "Transactions",
       "methods": "Payment Methods",
       "configuration": "Configuration",
-      "payouts": "Payouts"
+      "payouts": "Payouts",
+      "bankTransfers": "Bank Transfers"
     },
     "total_revenue": "Total Revenue",
     "total_transactions": "Total Transactions",
@@ -672,6 +673,7 @@
     "refunded": "Refunded",
     "export_csv": "Export CSV",
     "transaction_id": "Transaction ID",
+    "order_id": "Order ID",
     "date": "Date",
     "user": "User",
     "type": "Type",
@@ -696,6 +698,7 @@
     "instructor_payouts": "Instructor Payouts",
     "mark_paid": "Mark as Paid",
     "reject": "Reject",
+    "approve": "Approve",
     "reopen": "Reopen",
     "payout_status_updated": "Payout status updated",
     "payout_status_failed": "Failed to update payout status",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -653,7 +653,8 @@
       "transactions": "Transactions",
       "methods": "Payment Methods",
       "configuration": "Configuration",
-      "payouts": "Payouts"
+      "payouts": "Payouts",
+      "bankTransfers": "Bank Transfers"
     },
     "total_revenue": "Total Revenue",
     "total_transactions": "Total Transactions",
@@ -672,6 +673,7 @@
     "refunded": "Refunded",
     "export_csv": "Export CSV",
     "transaction_id": "Transaction ID",
+    "order_id": "Order ID",
     "date": "Date",
     "user": "User",
     "type": "Type",
@@ -696,6 +698,7 @@
     "instructor_payouts": "Instructor Payouts",
     "mark_paid": "Mark as Paid",
     "reject": "Reject",
+    "approve": "Approve",
     "reopen": "Reopen",
     "payout_status_updated": "Payout status updated",
     "payout_status_failed": "Failed to update payout status",

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -14,10 +14,16 @@ import {
   FaToggleOff,
   FaPlus,
   FaStar,
+  FaUniversity,
 } from "react-icons/fa";
 import OverviewTab from './OverviewTab';
 
 import { fetchPayments } from '@/services/admin/paymentService';
+import {
+  fetchBankTransfers,
+  approveBankTransfer,
+  rejectBankTransfer,
+} from '@/services/admin/bankTransferService';
 import {
   fetchMethods,
   updateMethod,
@@ -65,6 +71,7 @@ export default function AdminPaymentsPage() {
     { key: 'methods', label: t('paymentsPage.tabs.methods'), icon: <FaMoneyCheckAlt /> },
     { key: 'configuration', label: t('paymentsPage.tabs.configuration'), icon: <FaCog /> },
     { key: 'payouts', label: t('paymentsPage.tabs.payouts'), icon: <FaWallet /> },
+    { key: 'bankTransfers', label: t('paymentsPage.tabs.bankTransfers'), icon: <FaUniversity /> },
   ];
 
   const notifyUser = async (userId, type, message) => {
@@ -84,6 +91,17 @@ export default function AdminPaymentsPage() {
   const [transactions, setTransactions] = useState([]);
   const [methods, setMethods] = useState([]);
   const notify = useAdminNotice();
+
+  const [bankTransfers, setBankTransfers] = useState([]);
+
+  const loadBankTransfers = async () => {
+    try {
+      const data = await fetchBankTransfers();
+      setBankTransfers(data);
+    } catch (err) {
+      console.error('Failed to load bank transfers', err);
+    }
+  };
 
   useEffect(() => {
     const loadData = async () => {
@@ -140,6 +158,7 @@ export default function AdminPaymentsPage() {
       }
     };
     loadData();
+    loadBankTransfers();
   }, []);
 
 
@@ -286,6 +305,28 @@ export default function AdminPaymentsPage() {
     } catch (err) {
       console.error(err);
       toast.error(t('paymentsPage.payout_status_failed'));
+    }
+  };
+
+  const handleApprove = async (id) => {
+    try {
+      await approveBankTransfer(id);
+      toast.success(t('paymentsPage.status_updated'));
+      loadBankTransfers();
+    } catch (err) {
+      console.error(err);
+      toast.error(t('update_failed'));
+    }
+  };
+
+  const handleReject = async (id) => {
+    try {
+      await rejectBankTransfer(id);
+      toast.success(t('paymentsPage.status_updated'));
+      loadBankTransfers();
+    } catch (err) {
+      console.error(err);
+      toast.error(t('update_failed'));
     }
   };
 
@@ -639,6 +680,45 @@ export default function AdminPaymentsPage() {
                 </tbody>
               </table>
             </div>
+          </div>
+        );
+
+      case "bankTransfers":
+        return (
+          <div className="overflow-x-auto bg-white shadow rounded">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-100 text-left">
+                <tr>
+                  <th className="px-4 py-2">{t('paymentsPage.user')}</th>
+                  <th className="px-4 py-2">{t('paymentsPage.order_id')}</th>
+                  <th className="px-4 py-2">{t('paymentsPage.amount')}</th>
+                  <th className="px-4 py-2">Receipt</th>
+                  <th className="px-4 py-2">{t('paymentsPage.actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {bankTransfers.map((bt) => (
+                  <tr key={bt.id} className="border-t hover:bg-gray-50">
+                    <td className="px-4 py-2">{bt.student_name || bt.student?.name || bt.user_name}</td>
+                    <td className="px-4 py-2">{bt.order_id}</td>
+                    <td className="px-4 py-2 font-semibold text-green-600">${parseFloat(bt.amount ?? 0).toFixed(2)}</td>
+                    <td className="px-4 py-2">
+                      {bt.receipt_url && (
+                        <img src={bt.receipt_url} alt="receipt" className="w-24 h-24 object-cover" />
+                      )}
+                    </td>
+                    <td className="px-4 py-2 space-x-2">
+                      <button onClick={() => handleApprove(bt.id)} className="text-green-600 hover:underline text-xs">
+                        {t('paymentsPage.approve')}
+                      </button>
+                      <button onClick={() => handleReject(bt.id)} className="text-red-600 hover:underline text-xs">
+                        {t('paymentsPage.reject')}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         );
 

--- a/frontend/src/services/admin/bankTransferService.js
+++ b/frontend/src/services/admin/bankTransferService.js
@@ -1,0 +1,19 @@
+import api from "@/services/api/api";
+
+export const fetchBankTransfers = async () => {
+  const { data } = await api.get("/admin/payments/bank", {
+    params: { status: "awaiting_approval" },
+  });
+  return data?.data ?? [];
+};
+
+export const approveBankTransfer = async (id) => {
+  const { data } = await api.post(`/admin/payments/bank/${id}/approve`);
+  return data?.data;
+};
+
+export const rejectBankTransfer = async (id) => {
+  const { data } = await api.post(`/admin/payments/bank/${id}/reject`);
+  return data?.data;
+};
+


### PR DESCRIPTION
## Summary
- add admin tab to review bank transfers
- show pending bank transfers with receipt and allow approve/reject
- add service and translations for bank transfer approvals

## Testing
- `npm run lint` *(fails: Component definition is missing display name)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a09fec1800832893db725f74014df1