### PR TITLE
feat: add bank payment confirmation

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -1,0 +1,22 @@
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const paymentsService = require("./payments.service");
+
+exports.confirmBankPayment = catchAsync(async (req, res) => {
+  const { paymentId, transactionReference } = req.body;
+  if (!paymentId || !transactionReference) {
+    throw new AppError("Missing required fields", 400);
+  }
+  if (!req.file) {
+    throw new AppError("Receipt file is required", 400);
+  }
+  const receipt_url = `/uploads/payment-receipts/${req.file.filename}`;
+  const payment = await paymentsService.update(paymentId, {
+    status: "awaiting_approval",
+    receipt_url,
+    reference_id: transactionReference,
+  });
+  if (!payment) throw new AppError("Payment not found", 404);
+  sendSuccess(res, payment, "Bank payment confirmation submitted");
+});

--- a/backend/src/modules/payments/bank.routes.js
+++ b/backend/src/modules/payments/bank.routes.js
@@ -1,0 +1,10 @@
+const router = require("express").Router();
+const controller = require("./bank.controller");
+const upload = require("./paymentReceiptUpload.middleware");
+const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isStudent);
+
+router.post("/confirm", upload.single("receiptFile"), controller.confirmBankPayment);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -120,6 +120,7 @@ app.use(
   require("./modules/paymentMethods/paymentMethods.public.routes")
 );
 app.use("/api/payments/student", require("./modules/payments/student.routes"));
+app.use("/api/payments/bank", require("./modules/payments/bank.routes"));
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
 app.use("/api/payments/config", require("./modules/paymentConfig/paymentConfig.routes"));
 app.use("/api/messages/config", require("./modules/messagesConfig/messagesConfig.routes"));


### PR DESCRIPTION
## Summary
- add confirmBankPayment controller to handle bank receipt uploads and mark payments awaiting approval
- wire up bank payment confirmation route with receipt upload middleware
- expose bank routes in server

## Testing
- `npm test` (fails: tests/tutorialRoutes.test.js, tests/adsRoutes.test.js, src/modules/classes/__tests__/class.routes.test.js, tests/tutorialUpdateTransaction.test.js)


------
https://chatgpt.com/codex/tasks/task_e_68a09fe7907883288d8693e51227d18a