### PR TITLE
feat: add bank payment admin approval routes

### DIFF
--- a/backend/src/modules/payments/bank.admin.routes.js
+++ b/backend/src/modules/payments/bank.admin.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./bank.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.post("/:id/approve", verifyToken, isAdmin, controller.approveBankPayment);
+router.post("/:id/reject", verifyToken, isAdmin, controller.rejectBankPayment);
+
+module.exports = router;

--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -1,0 +1,70 @@
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./payments.service");
+const libraryService = require("../library/library.service");
+const enrollmentService = require("../classes/enrollments/classEnrollment.service");
+const tutorialEnrollmentService = require("../users/tutorials/enrollments/tutorialEnrollment.service");
+const { v4: uuidv4 } = require("uuid");
+
+exports.approveBankPayment = catchAsync(async (req, res) => {
+  const payment = await service.getById(req.params.id);
+  if (!payment) throw new AppError("Payment not found", 404);
+
+  const updated = await service.update(req.params.id, {
+    status: "completed",
+    paid_at: new Date(),
+  });
+
+  if (payment.item_type === "book") {
+    try {
+      await libraryService.recordPurchase(
+        payment.user_id,
+        payment.item_id,
+        payment.amount
+      );
+    } catch (err) {
+      console.error("Failed to record book purchase:", err);
+    }
+  }
+
+  if (payment.item_type === "class") {
+    try {
+      await enrollmentService.createEnrollment({
+        id: uuidv4(),
+        user_id: payment.user_id,
+        class_id: payment.item_id,
+        status: "enrolled",
+      });
+    } catch (err) {
+      console.error("Failed to enroll after payment:", err);
+    }
+  }
+
+  if (payment.item_type === "tutorial") {
+    try {
+      await tutorialEnrollmentService.createEnrollment({
+        id: uuidv4(),
+        user_id: payment.user_id,
+        tutorial_id: payment.item_id,
+        status: "enrolled",
+      });
+    } catch (err) {
+      console.error("Failed to enroll in tutorial after payment:", err);
+    }
+  }
+
+  sendSuccess(res, updated, "Bank payment approved");
+});
+
+exports.rejectBankPayment = catchAsync(async (req, res) => {
+  const payment = await service.getById(req.params.id);
+  if (!payment) throw new AppError("Payment not found", 404);
+
+  const updated = await service.update(req.params.id, {
+    status: "rejected",
+  });
+
+  sendSuccess(res, updated, "Bank payment rejected");
+});
+

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -121,6 +121,10 @@ app.use(
 );
 app.use("/api/payments/student", require("./modules/payments/student.routes"));
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
+app.use(
+  "/api/admin/payments/bank",
+  require("./modules/payments/bank.admin.routes")
+);
 app.use("/api/payments/config", require("./modules/paymentConfig/paymentConfig.routes"));
 app.use("/api/messages/config", require("./modules/messagesConfig/messagesConfig.routes"));
 app.use("/api/social-login/config", require("./modules/socialLoginConfig/socialLoginConfig.routes"));


### PR DESCRIPTION
## Summary
- add admin routes for approving or rejecting bank payments
- implement controller to update payment status and grant access
- mount bank payment admin routes on server

## Testing
- `cd backend && npm test` *(fails: POST /api/ads/admin creates ad, tutorial admin update routes, class routes create class, updateTutorial tag transactions)*

------
https://chatgpt.com/codex/tasks/task_e_68a09fe6d75c8328a3c98a26f802a97a