### PR TITLE
feat: add bank payment initiation

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -1,0 +1,50 @@
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const paymentsService = require("./payments.service");
+const paymentConfigService = require("../paymentConfig/paymentConfig.service");
+const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
+const { v4: uuidv4 } = require("uuid");
+
+exports.initiateBankPayment = catchAsync(async (req, res) => {
+  const { item_type, item_id, amount, currency } = req.body;
+  const user_id = req.user?.id;
+
+  if (!user_id || !item_type || !item_id || !amount) {
+    throw new AppError("Missing required fields", 400);
+  }
+
+  const bankMethod = await paymentMethodsService.getByType("bank");
+  if (!bankMethod) {
+    throw new AppError("Bank payment method not configured", 400);
+  }
+
+  let platform_fee = 0;
+  let instructor_amount = amount;
+  try {
+    const settings = await paymentConfigService.getSettings();
+    const cut = settings?.platformCut?.[item_type] || 0;
+    platform_fee = (amount * cut) / 100;
+    instructor_amount = amount - platform_fee;
+  } catch (err) {
+    console.error("Failed to load payment settings:", err);
+  }
+
+  const paymentData = {
+    id: uuidv4(),
+    user_id,
+    method_id: bankMethod.id,
+    item_type,
+    item_id,
+    amount,
+    currency: currency || "USD",
+    status: "pending_payment",
+    platform_fee,
+    instructor_amount,
+  };
+
+  const invoice = await paymentsService.create(paymentData);
+
+  sendSuccess(res, { settings: bankMethod.settings, invoice }, "Bank payment initiated");
+});
+

--- a/backend/src/modules/payments/bank.routes.js
+++ b/backend/src/modules/payments/bank.routes.js
@@ -1,0 +1,9 @@
+const router = require("express").Router();
+const controller = require("./bank.controller");
+const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isStudent);
+
+router.post("/initiate", controller.initiateBankPayment);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -120,6 +120,7 @@ app.use(
   require("./modules/paymentMethods/paymentMethods.public.routes")
 );
 app.use("/api/payments/student", require("./modules/payments/student.routes"));
+app.use("/api/payments/bank", require("./modules/payments/bank.routes"));
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
 app.use("/api/payments/config", require("./modules/paymentConfig/paymentConfig.routes"));
 app.use("/api/messages/config", require("./modules/messagesConfig/messagesConfig.routes"));


### PR DESCRIPTION
## Summary
- support bank payments by inserting pending payment records
- expose POST /api/payments/bank/initiate for students
- wire new bank route into server

## Testing
- `cd backend && npm test` *(fails: POST /api/ads/admin creates ad, tutorialRoutes, class routes, tutorialUpdateTransaction)*

------
https://chatgpt.com/codex/tasks/task_e_68a09fe2c0ac8328ad74e56f12f755b0