### PR TITLE
Add manual bank transfer payment method seed

### DIFF
--- a/backend/src/seeds/08_payment_methods_seed.js
+++ b/backend/src/seeds/08_payment_methods_seed.js
@@ -5,14 +5,18 @@ exports.seed = async function(knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       name: 'Bank Transfer',
-      type: 'bank',
+      type: 'manual',
       icon: null,
       active: true,
       settings: {
-        bank_name: 'Sample Bank',
-        account_number: '123456789',
+        bankName: 'Sample Bank',
+        accountHolderName: 'John Doe',
+        accountNumber: '123456789',
         iban: 'DE89370400440532013000',
-        instructions: 'Transfer to the above account and upload your receipt for verification.'
+        swiftCode: 'COBADEFFXXX',
+        branchAddress: '1234 Elm Street, City, Country',
+        extraInstructions:
+          'Transfer to the above account and upload your receipt for verification.'
       },
       is_default: true,
       created_at: now,


### PR DESCRIPTION
## Summary
- seed manual bank transfer payment method with full account settings

## Testing
- `npm test --prefix backend` *(fails: creates ad returns 400, tutorial admin route returns 400, class routes return 400, updateTutorial tag transactions fails)*
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres npx knex seed:run --specific 08_payment_methods_seed.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68a09fdbbc9483289fa3e95d7a529582