### PR TITLE
Extend seeded coupon validity

### DIFF
--- a/backend/src/seeds/07_coupons_seed.js
+++ b/backend/src/seeds/07_coupons_seed.js
@@ -7,7 +7,7 @@ exports.seed = async function(knex) {
       code: 'DISCOUNT10',
       discount_percent: 10,
       starts_at: knex.fn.now(),
-      expires_at: knex.fn.now(),
+      expires_at: knex.raw("NOW() + INTERVAL '7 months'"),
       usage_limit: 100,
       applies_to: 'plan',
       applies_to_id: null,


### PR DESCRIPTION
## Summary
- set seeded coupon expiration to 7 months from creation

## Testing
- `npm test` *(fails: Test Suites: 4 failed, 71 passed, 75 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cb211f408328b136eebb121c7143