### PR TITLE
feat: add toast notifications for coupon actions

### DIFF
--- a/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchCouponById, updateCoupon } from "@/services/admin/couponService";
 
@@ -32,16 +33,21 @@ export default function EditCouponPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await updateCoupon(id, {
-      code,
-      discount_percent: parseInt(discount, 10),
-      starts_at: startsAt || undefined,
-      expires_at: expiresAt || undefined,
-      usage_limit: usageLimit ? parseInt(usageLimit, 10) : undefined,
-      applies_to: appliesTo,
-      applies_to_id: appliesToId || undefined,
-    }).catch(() => {});
-    router.push("/dashboard/admin/coupons");
+    try {
+      await updateCoupon(id, {
+        code,
+        discount_percent: parseInt(discount, 10),
+        starts_at: startsAt || undefined,
+        expires_at: expiresAt || undefined,
+        usage_limit: usageLimit ? parseInt(usageLimit, 10) : undefined,
+        applies_to: appliesTo,
+        applies_to_id: appliesToId || undefined,
+      });
+      toast.success("Coupon updated successfully");
+      router.push("/dashboard/admin/coupons");
+    } catch (err) {
+      toast.error("Failed to update coupon");
+    }
   };
 
   return (

--- a/frontend/src/pages/dashboard/admin/coupons/index.js
+++ b/frontend/src/pages/dashboard/admin/coupons/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchCoupons, deleteCoupon } from "@/services/admin/couponService";
 import Link from "next/link";
@@ -7,13 +8,23 @@ export default function AdminCouponsPage() {
   const [coupons, setCoupons] = useState([]);
 
   useEffect(() => {
-    fetchCoupons().then(setCoupons).catch(() => setCoupons([]));
+    fetchCoupons()
+      .then(setCoupons)
+      .catch(() => {
+        setCoupons([]);
+        toast.error("Failed to load coupons");
+      });
   }, []);
 
   const handleDelete = async (id) => {
     if (!confirm("Delete this coupon?")) return;
-    await deleteCoupon(id).catch(() => {});
-    setCoupons((prev) => prev.filter((c) => c.id !== id));
+    try {
+      await deleteCoupon(id);
+      setCoupons((prev) => prev.filter((c) => c.id !== id));
+      toast.success("Coupon deleted successfully");
+    } catch (err) {
+      toast.error("Failed to delete coupon");
+    }
   };
 
   return (

--- a/frontend/src/pages/dashboard/admin/coupons/new.js
+++ b/frontend/src/pages/dashboard/admin/coupons/new.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { createCoupon } from "@/services/admin/couponService";
 import { useRouter } from "next/router";
@@ -15,16 +16,21 @@ export default function NewCouponPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await createCoupon({
-      code,
-      discount_percent: parseInt(discount, 10),
-      starts_at: startsAt || undefined,
-      expires_at: expiresAt || undefined,
-      usage_limit: usageLimit ? parseInt(usageLimit, 10) : undefined,
-      applies_to: appliesTo,
-      applies_to_id: appliesToId || undefined,
-    }).catch(() => {});
-    router.push("/dashboard/admin/coupons");
+    try {
+      await createCoupon({
+        code,
+        discount_percent: parseInt(discount, 10),
+        starts_at: startsAt || undefined,
+        expires_at: expiresAt || undefined,
+        usage_limit: usageLimit ? parseInt(usageLimit, 10) : undefined,
+        applies_to: appliesTo,
+        applies_to_id: appliesToId || undefined,
+      });
+      toast.success("Coupon created successfully");
+      router.push("/dashboard/admin/coupons");
+    } catch (err) {
+      toast.error("Failed to create coupon");
+    }
   };
 
   return (

--- a/frontend/src/pages/dashboard/instructor/coupons/edit/[id].js
+++ b/frontend/src/pages/dashboard/instructor/coupons/edit/[id].js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { toast } from "react-toastify";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { fetchCouponById, updateCoupon } from "@/services/instructor/couponService";
 
@@ -22,8 +23,13 @@ export default function InstructorCouponEdit() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await updateCoupon(id, { code, discount_percent: parseInt(discount, 10) }).catch(() => {});
-    router.push("/dashboard/instructor/coupons");
+    try {
+      await updateCoupon(id, { code, discount_percent: parseInt(discount, 10) });
+      toast.success("Coupon updated successfully");
+      router.push("/dashboard/instructor/coupons");
+    } catch (err) {
+      toast.error("Failed to update coupon");
+    }
   };
 
   return (

--- a/frontend/src/pages/dashboard/instructor/coupons/index.js
+++ b/frontend/src/pages/dashboard/instructor/coupons/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { fetchCoupons, deleteCoupon } from "@/services/instructor/couponService";
 import Link from "next/link";
@@ -7,13 +8,23 @@ export default function InstructorCouponsPage() {
   const [coupons, setCoupons] = useState([]);
 
   useEffect(() => {
-    fetchCoupons().then(setCoupons).catch(() => setCoupons([]));
+    fetchCoupons()
+      .then(setCoupons)
+      .catch(() => {
+        setCoupons([]);
+        toast.error("Failed to load coupons");
+      });
   }, []);
 
   const handleDelete = async (id) => {
     if (!confirm("Delete this coupon?")) return;
-    await deleteCoupon(id).catch(() => {});
-    setCoupons((prev) => prev.filter((c) => c.id !== id));
+    try {
+      await deleteCoupon(id);
+      setCoupons((prev) => prev.filter((c) => c.id !== id));
+      toast.success("Coupon deleted successfully");
+    } catch (err) {
+      toast.error("Failed to delete coupon");
+    }
   };
 
   return (

--- a/frontend/src/pages/dashboard/instructor/coupons/new.js
+++ b/frontend/src/pages/dashboard/instructor/coupons/new.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { toast } from "react-toastify";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { createCoupon } from "@/services/instructor/couponService";
 import { useRouter } from "next/router";
@@ -10,8 +11,13 @@ export default function InstructorCouponNew() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await createCoupon({ code, discount_percent: parseInt(discount, 10) }).catch(() => {});
-    router.push("/dashboard/instructor/coupons");
+    try {
+      await createCoupon({ code, discount_percent: parseInt(discount, 10) });
+      toast.success("Coupon created successfully");
+      router.push("/dashboard/instructor/coupons");
+    } catch (err) {
+      toast.error("Failed to create coupon");
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- show success and error toasts on admin coupon CRUD
- show success and error toasts on instructor coupon CRUD

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d6c1efb48328bcbebef8629fafc9