### PR TITLE
Check coupon usage limits and record redemption

### DIFF
--- a/backend/src/modules/coupons/coupons.controller.js
+++ b/backend/src/modules/coupons/coupons.controller.js
@@ -52,5 +52,11 @@ exports.validateCode = catchAsync(async (req, res) => {
   if (coupon.expires_at && new Date(coupon.expires_at) < new Date()) {
     throw new AppError("Coupon expired", 400);
   }
+  if (
+    coupon.usage_limit !== null &&
+    coupon.times_used >= coupon.usage_limit
+  ) {
+    throw new AppError("Coupon usage limit reached", 400);
+  }
   sendSuccess(res, coupon, "Coupon valid");
 });

--- a/backend/src/modules/coupons/coupons.service.js
+++ b/backend/src/modules/coupons/coupons.service.js
@@ -17,6 +17,14 @@ exports.findByCode = (code) => {
   return db("coupons").whereRaw("LOWER(code) = LOWER(?)", [code]).first();
 };
 
+exports.incrementUsage = async (id) => {
+  const [row] = await db("coupons")
+    .where({ id })
+    .increment("times_used", 1)
+    .returning("*");
+  return row;
+};
+
 exports.updateCoupon = async (id, data) => {
   const [row] = await db("coupons").where({ id }).update(data).returning("*");
   return row;

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -13,6 +13,7 @@ const paymentMethodsService = require("../paymentMethods/paymentMethods.service"
 const paypalService = require("../../services/paypalService");
 const notificationService = require("../notifications/notifications.service");
 const mailService = require("../../services/mailService");
+const couponService = require("../coupons/coupons.service");
 
 exports.createPayment = catchAsync(async (req, res) => {
   const {
@@ -27,6 +28,7 @@ exports.createPayment = catchAsync(async (req, res) => {
     allow_installments,
     installments,
     receipt_url,
+    coupon_id,
   } = req.body;
   if (!user_id || !method_id || !item_type || !item_id || !amount) {
     throw new AppError("Missing required fields", 400);
@@ -102,6 +104,14 @@ exports.createPayment = catchAsync(async (req, res) => {
   const createArgs = [createData];
   if (schedules.length) createArgs.push(schedules);
   const payment = await service.create(...createArgs);
+
+  if (coupon_id && payment.status === "paid") {
+    try {
+      await couponService.incrementUsage(coupon_id);
+    } catch (err) {
+      console.error("Failed to increment coupon usage:", err);
+    }
+  }
 
   let user;
   try {


### PR DESCRIPTION
## Summary
- Reject coupons that exceed their usage limit during validation
- Add service helper to increment coupon use
- Record coupon redemption during payment processing

## Testing
- `npm test` *(fails: adsRoutes.test.js, tutorialRoutes.test.js, class.routes.test.js, tutorialUpdateTransaction.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d6c08bc4832894f86fd3be319f79