### PR TITLE
Handle invalid promo code as 404

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -146,7 +146,7 @@ export default function CheckoutPage() {
       setError('');
     } catch (err) {
       setDiscount(0);
-      if (err?.response?.status === 400) {
+      if (err?.response?.status === 404) {
         setError('Invalid promo code');
       } else {
         setError('Failed to apply promo code. Please try again.');

--- a/frontend/src/tests/__tests__/checkoutPromo.test.js
+++ b/frontend/src/tests/__tests__/checkoutPromo.test.js
@@ -68,7 +68,7 @@ test('applies promo code successfully', async () => {
 });
 
 test('shows error for invalid promo code', async () => {
-  validateCode.mockRejectedValue({ response: { status: 400 } });
+  validateCode.mockRejectedValue({ response: { status: 404 } });
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
   fireEvent.change(screen.getByPlaceholderText('Enter promo code'), {


### PR DESCRIPTION
## Summary
- handle promo code validation failures with 404 status
- update checkout promo tests to expect 404 for invalid codes

## Testing
- `npm test -- src/tests/__tests__/checkoutPromo.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0d6bf032883288190449efd84871d