### PR TITLE
Use toast notifications for promo code errors

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -8,6 +8,7 @@ import { initiateBankPayment } from '@/services/paymentService';
 import useCartStore from '@/store/cart/cartStore';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
+import { toast } from 'react-toastify';
 import {
   FaCcStripe, FaPaypal, FaMoneyCheckAlt, FaUniversity,
   FaEthereum, FaFileInvoice, FaDownload, FaCheckCircle
@@ -95,7 +96,6 @@ export default function CheckoutPage() {
   const [discount, setDiscount] = useState(0);
   const [invoicePreview, setInvoicePreview] = useState(false);
   const [bankInfo, setBankInfo] = useState(null);
-  const [error, setError] = useState('');
   const [paymentStatus, setPaymentStatus] = useState('idle');
   const [allowInstallments, setAllowInstallments] = useState(false);
   const [paypalLoaded, setPaypalLoaded] = useState(false);
@@ -143,13 +143,13 @@ export default function CheckoutPage() {
     try {
       const data = await validateCode(promoCode);
       setDiscount(data.discount_percent);
-      setError('');
+      toast.success('Promo code applied');
     } catch (err) {
       setDiscount(0);
-      if (err?.response?.status === 400) {
-        setError('Invalid promo code');
+      if (err?.response?.status === 404) {
+        toast.error('Invalid promo code');
       } else {
-        setError('Failed to apply promo code. Please try again.');
+        toast.error('Failed to apply promo code. Please try again.');
       }
     }
   };
@@ -338,7 +338,6 @@ export default function CheckoutPage() {
               className="px-4 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600"
             >Apply</button>
           </div>
-          {error && <p className="text-red-400 mt-2 text-sm">{error}</p>}
         </div>
 
         {!isFree && (

--- a/frontend/src/tests/__tests__/checkoutPromo.test.js
+++ b/frontend/src/tests/__tests__/checkoutPromo.test.js
@@ -4,6 +4,8 @@ import { validateCode } from '../../services/couponService';
 import { fetchClassDetails } from '../../services/classService';
 import { fetchPaymentMethods, fetchPayPalClientId } from '../../services/paymentMethodService';
 
+jest.mock('react-toastify', () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+
 const mockRemoveItem = jest.fn();
 jest.mock('../../store/cart/cartStore', () => ({
   __esModule: true,
@@ -64,18 +66,22 @@ test('applies promo code successfully', async () => {
   fireEvent.click(screen.getByText('Apply'));
   await waitFor(() => expect(validateCode).toHaveBeenCalledWith('SAVE10'));
   expect(await screen.findByText('Discount Applied: -$10')).toBeInTheDocument();
-  expect(screen.queryByText('Invalid promo code')).toBeNull();
+  const { toast } = require('react-toastify');
+  expect(toast.success).toHaveBeenCalledWith('Promo code applied');
 });
 
 test('shows error for invalid promo code', async () => {
-  validateCode.mockRejectedValue({ response: { status: 400 } });
+  validateCode.mockRejectedValue({ response: { status: 404 } });
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
   fireEvent.change(screen.getByPlaceholderText('Enter promo code'), {
     target: { value: 'BADCODE' },
   });
   fireEvent.click(screen.getByText('Apply'));
-  expect(await screen.findByText('Invalid promo code')).toBeInTheDocument();
+  const { toast } = require('react-toastify');
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith('Invalid promo code');
+  });
 });
 
 test('handles network failure when applying promo code', async () => {
@@ -86,7 +92,8 @@ test('handles network failure when applying promo code', async () => {
     target: { value: 'SAVE10' },
   });
   fireEvent.click(screen.getByText('Apply'));
-  expect(
-    await screen.findByText('Failed to apply promo code. Please try again.')
-  ).toBeInTheDocument();
+  const { toast } = require('react-toastify');
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith('Failed to apply promo code. Please try again.');
+  });
 });


### PR DESCRIPTION
## Summary
- Handle 404 responses when validating promo codes and report through toast
- Replace inline promo-code error UI with react-toastify success/error toasts
- Adjust promo code tests to check toast notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d6be13c8832895dd25d5a94aaa53