### PR TITLE
fix language update save and locale code whitespace issue

### DIFF
--- a/backend/src/modules/languages/languageIconUploadMiddleware.js
+++ b/backend/src/modules/languages/languageIconUploadMiddleware.js
@@ -1,8 +1,8 @@
-const multer = require('multer');
-const path = require('path');
-const fs = require('fs');
+const multer = require("multer");
+const path = require("path");
+const fs = require("fs");
 
-const uploadDir = path.join(__dirname, '../../../uploads/languages');
+const uploadDir = path.join(__dirname, "../../../uploads/languages");
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir, { recursive: true });
 }
@@ -16,8 +16,23 @@ const storage = multer.diskStorage({
 });
 
 const fileFilter = (_req, file, cb) => {
-  if (file.mimetype.startsWith('image/')) cb(null, true);
-  else cb(new Error('Only image files are allowed'), false);
+  if (file.mimetype.startsWith("image/")) cb(null, true);
+  else cb(new Error("Only image files are allowed"), false);
 };
 
-module.exports = multer({ storage, fileFilter, limits: { fileSize: 1024 * 1024 } });
+// Multer clears req.body when it runs on non-multipart requests. This
+// middleware applies the upload only when the request is multipart so that
+// JSON payloads for language updates are preserved.
+const upload = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: 1024 * 1024 },
+});
+
+module.exports = (req, res, next) => {
+  const contentType = req.headers["content-type"] || "";
+  if (contentType.includes("multipart/form-data")) {
+    return upload.single("icon")(req, res, next);
+  }
+  next();
+};

--- a/backend/src/modules/languages/languages.controller.js
+++ b/backend/src/modules/languages/languages.controller.js
@@ -10,6 +10,8 @@ const messageService = require("../messages/messages.service");
 
 exports.createLanguage = catchAsync(async (req, res) => {
   const data = { ...req.body };
+  if (data.name) data.name = data.name.trim();
+  if (data.code) data.code = data.code.trim();
   if (req.file) {
     data.icon_url = `/uploads/languages/${req.file.filename}`;
   }
@@ -28,6 +30,8 @@ exports.updateLanguage = catchAsync(async (req, res) => {
   if (!existing) throw new AppError("Language not found", 404);
 
   const data = { ...req.body };
+  if (data.name) data.name = data.name.trim();
+  if (data.code) data.code = data.code.trim();
   if (req.file) {
     if (existing.icon_url) {
       const oldPath = path.join(__dirname, "../../../", existing.icon_url);

--- a/backend/src/modules/languages/languages.routes.js
+++ b/backend/src/modules/languages/languages.routes.js
@@ -4,8 +4,8 @@ const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware")
 const upload = require("./languageIconUploadMiddleware");
 
 router.get("/", controller.listLanguages);
-router.post("/", verifyToken, isAdmin, upload.single("icon"), controller.createLanguage);
-router.put("/:id", verifyToken, isAdmin, upload.single("icon"), controller.updateLanguage);
+router.post("/", verifyToken, isAdmin, upload, controller.createLanguage);
+router.put("/:id", verifyToken, isAdmin, upload, controller.updateLanguage);
 router.delete("/:id", verifyToken, isAdmin, controller.deleteLanguage);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- ensure language update requests with JSON bodies aren't cleared by multer
- trim language name and code to avoid stray whitespace in URLs
- wire language routes to new conditional upload middleware

## Testing
- `npm test` *(fails: creates ad 400, tutorial routes, class routes, tutorialUpdateTransaction)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e16bb4708328b43cd1c421fe7038