### PR TITLE
feat: validate coupon by item

### DIFF
--- a/backend/src/modules/coupons/coupons.controller.js
+++ b/backend/src/modules/coupons/coupons.controller.js
@@ -43,9 +43,15 @@ exports.deleteCoupon = catchAsync(async (req, res) => {
 });
 
 exports.validateCode = catchAsync(async (req, res) => {
-  const { code } = req.params;
+  const { code, item_type, item_id } = req.params;
   const coupon = await service.findByCode(code);
   if (!coupon) throw new AppError("Invalid coupon", 404);
+  if (coupon.applies_to && coupon.applies_to !== item_type) {
+    throw new AppError("Coupon not valid for this item type", 400);
+  }
+  if (coupon.applies_to_id && coupon.applies_to_id !== item_id) {
+    throw new AppError("Coupon not valid for this item", 400);
+  }
   if (coupon.starts_at && new Date(coupon.starts_at) > new Date()) {
     throw new AppError("Coupon not active", 400);
   }

--- a/backend/src/modules/coupons/coupons.routes.js
+++ b/backend/src/modules/coupons/coupons.routes.js
@@ -11,6 +11,7 @@ router.get("/admin/:id", verifyToken, isInstructorOrAdmin, controller.getCoupon)
 router.put("/admin/:id", verifyToken, isInstructorOrAdmin, validate(validator.update), controller.updateCoupon);
 router.delete("/admin/:id", verifyToken, isInstructorOrAdmin, controller.deleteCoupon);
 
-router.get("/code/:code", controller.validateCode);
+// Accept optional item type and id parameters for validation
+router.get("/code/:code/:item_type?/:item_id?", controller.validateCode);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow coupon validation endpoint to accept optional item type and id
- ensure coupons only apply to matching item type and item id

## Testing
- `cd backend && npm test` *(fails: adsRoutes.test.js, tutorialRoutes.test.js, class.routes.test.js, tutorialUpdateTransaction.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a170f65b8c83289161f321e116a90a