### PR TITLE
Persist coupon ID and send in payment requests

### DIFF
--- a/frontend/src/pages/payments/[id].js
+++ b/frontend/src/pages/payments/[id].js
@@ -5,6 +5,7 @@ import { BrowserProvider, parseEther } from "ethers";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import { validateCode } from "@/services/couponService";
+import { processPayment } from "@/services/paymentService";
 import { toast } from "react-toastify";
 
 export default function CheckoutPage() {
@@ -22,6 +23,7 @@ export default function CheckoutPage() {
 
   const [isProcessing, setIsProcessing] = useState(false);
   const [appliedDiscount, setAppliedDiscount] = useState(0);
+  const [couponId, setCouponId] = useState(null);
   const [ethStatus, setEthStatus] = useState("");
   const [account, setAccount] = useState(null);
 
@@ -39,29 +41,38 @@ export default function CheckoutPage() {
       if (coupon) {
         const discountAmount = (coursePrice * coupon.discount_percent) / 100;
         setAppliedDiscount(discountAmount);
+        setCouponId(coupon.id);
         toast.success("Coupon applied!");
       } else {
         setAppliedDiscount(0);
+        setCouponId(null);
         toast.error("Invalid coupon code");
       }
     } catch (err) {
       setAppliedDiscount(0);
+      setCouponId(null);
       toast.error("Invalid coupon code");
     }
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!formData.fullName || !formData.email) {
       toast.error("Please fill out all required fields.");
       return;
     }
 
     setIsProcessing(true);
-    setTimeout(() => {
-      setIsProcessing(false);
+    try {
+      const payload = { ...formData, coupon_id: couponId, amount: finalTotal };
+      await processPayment(payload);
       toast.success("Payment successful! Redirecting...");
       router.push("/payments/success");
-    }, 1500);
+    } catch (err) {
+      console.error(err);
+      toast.error("Payment failed.");
+    } finally {
+      setIsProcessing(false);
+    }
   };
 
   const connectWallet = async () => {

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -94,6 +94,7 @@ export default function CheckoutPage() {
   const [selectedMethod, setSelectedMethod] = useState('');
   const [promoCode, setPromoCode] = useState('');
   const [discount, setDiscount] = useState(0);
+  const [couponId, setCouponId] = useState(null);
   const [invoicePreview, setInvoicePreview] = useState(false);
   const [bankInfo, setBankInfo] = useState(null);
   const [paymentStatus, setPaymentStatus] = useState('idle');
@@ -143,9 +144,11 @@ export default function CheckoutPage() {
     try {
       const data = await validateCode(promoCode);
       setDiscount(data.discount_percent);
+      setCouponId(data.id);
       toast.success('Promo code applied');
     } catch (err) {
       setDiscount(0);
+      setCouponId(null);
       if (err?.response?.status === 404) {
         toast.error('Invalid promo code');
       } else {
@@ -182,7 +185,9 @@ export default function CheckoutPage() {
     if (selectedMethod === 'bank') {
       try {
         setPaymentStatus('processing');
-        const data = await initiateBankPayment({ itemId: itemInfo.id, itemType });
+        const payload = { itemId: itemInfo.id, itemType };
+        if (couponId) payload.coupon_id = couponId;
+        const data = await initiateBankPayment(payload);
         setBankInfo(data);
         setInvoicePreview(true);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Store coupon ID after validating promo codes on checkout pages
- Include `coupon_id` in payment payloads so the backend can track usage

## Testing
- `npm test`
- `npm run lint` *(fails: 93 errors, 266 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a170f59f3c8328aab070ac6840794b