### PR TITLE
Add usage metrics and status filtering to admin coupons

### DIFF
--- a/frontend/src/pages/dashboard/admin/coupons/index.js
+++ b/frontend/src/pages/dashboard/admin/coupons/index.js
@@ -6,6 +6,8 @@ import Link from "next/link";
 
 export default function AdminCouponsPage() {
   const [coupons, setCoupons] = useState([]);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
 
   useEffect(() => {
     fetchCoupons()
@@ -15,6 +17,27 @@ export default function AdminCouponsPage() {
         toast.error("Failed to load coupons");
       });
   }, []);
+
+  const isActive = (coupon) => {
+    const now = new Date();
+    const starts = coupon.starts_at ? new Date(coupon.starts_at) : null;
+    const expires = coupon.expires_at ? new Date(coupon.expires_at) : null;
+    if (starts && now < starts) return false;
+    if (expires && now > expires) return false;
+    return true;
+  };
+
+  const filteredCoupons = coupons.filter((c) => {
+    const matchesCode = c.code
+      .toLowerCase()
+      .includes(search.toLowerCase());
+    const active = isActive(c);
+    const matchesStatus =
+      statusFilter === "all" ||
+      (statusFilter === "active" && active) ||
+      (statusFilter === "expired" && !active);
+    return matchesCode && matchesStatus;
+  });
 
   const handleDelete = async (id) => {
     if (!confirm("Delete this coupon?")) return;
@@ -32,8 +55,31 @@ export default function AdminCouponsPage() {
       <div className="p-6">
         <header className="flex justify-between mb-6">
           <h1 className="text-2xl font-bold">Coupons</h1>
-          <Link href="/dashboard/admin/coupons/new" className="bg-green-600 px-4 py-2 text-white rounded">New Coupon</Link>
+          <Link
+            href="/dashboard/admin/coupons/new"
+            className="bg-green-600 px-4 py-2 text-white rounded"
+          >
+            New Coupon
+          </Link>
         </header>
+        <div className="flex mb-4 space-x-4">
+          <input
+            type="text"
+            placeholder="Search code..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="border p-2 rounded"
+          />
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="border p-2 rounded"
+          >
+            <option value="all">All</option>
+            <option value="active">Active</option>
+            <option value="expired">Expired</option>
+          </select>
+        </div>
         <table className="min-w-full bg-white text-sm">
           <thead>
             <tr>
@@ -41,21 +87,36 @@ export default function AdminCouponsPage() {
               <th className="p-2 border">Discount %</th>
               <th className="p-2 border">Starts</th>
               <th className="p-2 border">Expires</th>
+              <th className="p-2 border">Times Used</th>
+              <th className="p-2 border">Usage Limit</th>
+              <th className="p-2 border">Status</th>
               <th className="p-2 border">Applies To</th>
               <th className="p-2 border">Actions</th>
             </tr>
           </thead>
           <tbody>
-            {coupons.map((c) => (
+            {filteredCoupons.map((c) => (
               <tr key={c.id}>
                 <td className="p-2 border">{c.code}</td>
                 <td className="p-2 border">{c.discount_percent}</td>
-                <td className="p-2 border">{c.starts_at ? new Date(c.starts_at).toLocaleDateString() : ""}</td>
-                <td className="p-2 border">{c.expires_at ? new Date(c.expires_at).toLocaleDateString() : ""}</td>
+                <td className="p-2 border">
+                  {c.starts_at ? new Date(c.starts_at).toLocaleDateString() : ""}
+                </td>
+                <td className="p-2 border">
+                  {c.expires_at ? new Date(c.expires_at).toLocaleDateString() : ""}
+                </td>
+                <td className="p-2 border">{c.times_used}</td>
+                <td className="p-2 border">{c.usage_limit ?? ""}</td>
+                <td className="p-2 border">{isActive(c) ? "Active" : "Expired"}</td>
                 <td className="p-2 border">{c.applies_to || ""}</td>
                 <td className="p-2 border space-x-2">
                   <Link href={`/dashboard/admin/coupons/edit/${c.id}`}>Edit</Link>
-                  <button onClick={() => handleDelete(c.id)} className="text-red-600">Delete</button>
+                  <button
+                    onClick={() => handleDelete(c.id)}
+                    className="text-red-600"
+                  >
+                    Delete
+                  </button>
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary
- show times used, usage limit, and active/expired status for each coupon
- allow admins to search by code and filter coupons by status

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68a170f4da288328b7a8b65d42aa3c75