### PR TITLE
feat: translate admin coupon creation page

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1454,5 +1454,22 @@
     "price_or_free": "Price or Free",
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
+  },
+  "couponsPage": {
+    "new_coupon": "قسيمة جديدة",
+    "code_placeholder": "الكود",
+    "usage_limit_placeholder": "حد الاستخدام",
+    "target_id_placeholder": "معرّف الهدف",
+    "plan": "خطة",
+    "class": "صف",
+    "tutorial": "درس",
+    "saving": "جاري الحفظ...",
+    "save": "حفظ",
+    "code_required": "الكود مطلوب",
+    "code_exists": "الكود موجود بالفعل",
+    "code_validate_failed": "فشل التحقق من الكود",
+    "start_before_end": "يجب أن يكون تاريخ البداية قبل تاريخ الانتهاء",
+    "create_success": "تم إنشاء القسيمة بنجاح",
+    "create_failed": "فشل إنشاء القسيمة"
   }
 }

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1264,5 +1264,22 @@
     "price_or_free": "Price or Free",
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
+  },
+  "couponsPage": {
+    "new_coupon": "Neuer Gutschein",
+    "code_placeholder": "CODE",
+    "usage_limit_placeholder": "Nutzungsbeschränkung",
+    "target_id_placeholder": "Ziel-ID",
+    "plan": "Plan",
+    "class": "Klasse",
+    "tutorial": "Tutorial",
+    "saving": "Speichern...",
+    "save": "Speichern",
+    "code_required": "Code ist erforderlich",
+    "code_exists": "Code existiert bereits",
+    "code_validate_failed": "Codevalidierung fehlgeschlagen",
+    "start_before_end": "Startdatum muss vor Ablaufdatum liegen",
+    "create_success": "Gutschein erfolgreich erstellt",
+    "create_failed": "Gutschein konnte nicht erstellt werden"
   }
 }

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1467,5 +1467,22 @@
     "price_or_free": "Price or Free",
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
+  },
+  "couponsPage": {
+    "new_coupon": "New Coupon",
+    "code_placeholder": "CODE",
+    "usage_limit_placeholder": "Usage Limit",
+    "target_id_placeholder": "Target ID",
+    "plan": "Plan",
+    "class": "Class",
+    "tutorial": "Tutorial",
+    "saving": "Saving...",
+    "save": "Save",
+    "code_required": "Code is required",
+    "code_exists": "Code already exists",
+    "code_validate_failed": "Failed to validate code",
+    "start_before_end": "Start date must be before expiration",
+    "create_success": "Coupon created successfully",
+    "create_failed": "Failed to create coupon"
   }
 }

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1264,5 +1264,22 @@
     "price_or_free": "Price or Free",
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
+  },
+  "couponsPage": {
+    "new_coupon": "Nuevo cupón",
+    "code_placeholder": "CÓDIGO",
+    "usage_limit_placeholder": "Límite de uso",
+    "target_id_placeholder": "ID de destino",
+    "plan": "Plan",
+    "class": "Clase",
+    "tutorial": "Tutorial",
+    "saving": "Guardando...",
+    "save": "Guardar",
+    "code_required": "El código es obligatorio",
+    "code_exists": "El código ya existe",
+    "code_validate_failed": "No se pudo validar el código",
+    "start_before_end": "La fecha de inicio debe ser anterior a la expiración",
+    "create_success": "Cupón creado con éxito",
+    "create_failed": "Error al crear el cupón"
   }
 }

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1442,5 +1442,22 @@
     "price_or_free": "Price or Free",
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
+  },
+  "couponsPage": {
+    "new_coupon": "Nouveau coupon",
+    "code_placeholder": "CODE",
+    "usage_limit_placeholder": "Limite d'utilisation",
+    "target_id_placeholder": "ID cible",
+    "plan": "Plan",
+    "class": "Classe",
+    "tutorial": "Tutoriel",
+    "saving": "Enregistrement...",
+    "save": "Enregistrer",
+    "code_required": "Le code est requis",
+    "code_exists": "Le code existe déjà",
+    "code_validate_failed": "Échec de la validation du code",
+    "start_before_end": "La date de début doit être antérieure à l'expiration",
+    "create_success": "Coupon créé avec succès",
+    "create_failed": "Échec de la création du coupon"
   }
 }

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1467,5 +1467,22 @@
     "price_or_free": "Price or Free",
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
+  },
+  "couponsPage": {
+    "new_coupon": "नया कूपन",
+    "code_placeholder": "कोड",
+    "usage_limit_placeholder": "उपयोग सीमा",
+    "target_id_placeholder": "लक्ष्य आईडी",
+    "plan": "योजना",
+    "class": "कक्षा",
+    "tutorial": "ट्यूटोरियल",
+    "saving": "सहेजा जा रहा है...",
+    "save": "सहेजें",
+    "code_required": "कोड आवश्यक है",
+    "code_exists": "कोड पहले से मौजूद है",
+    "code_validate_failed": "कोड सत्यापित करने में विफल",
+    "start_before_end": "प्रारंभ तिथि समाप्ति से पहले होनी चाहिए",
+    "create_success": "कूपन सफलतापूर्वक बनाया गया",
+    "create_failed": "कूपन बनाने में विफल"
   }
 }

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1467,5 +1467,22 @@
     "price_or_free": "Price or Free",
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
+  },
+  "couponsPage": {
+    "new_coupon": "新优惠券",
+    "code_placeholder": "代码",
+    "usage_limit_placeholder": "使用限制",
+    "target_id_placeholder": "目标ID",
+    "plan": "计划",
+    "class": "课程",
+    "tutorial": "教程",
+    "saving": "保存中...",
+    "save": "保存",
+    "code_required": "代码为必填项",
+    "code_exists": "代码已存在",
+    "code_validate_failed": "验证代码失败",
+    "start_before_end": "开始日期必须早于结束日期",
+    "create_success": "优惠券创建成功",
+    "create_failed": "创建优惠券失败"
   }
 }

--- a/frontend/src/pages/dashboard/admin/coupons/new.js
+++ b/frontend/src/pages/dashboard/admin/coupons/new.js
@@ -4,63 +4,68 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import AdminLayout from "@/components/layouts/AdminLayout";
 import {
   createCoupon,
   validateCode,
 } from "@/services/admin/couponService";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 
-const couponSchema = z
-  .object({
-    code: z
-      .string()
-      .trim()
-      .min(1, "Code is required")
-      .transform((val) => val.toUpperCase())
-      .superRefine(async (val, ctx) => {
-        try {
-          await validateCode(val);
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: "Code already exists",
-          });
-        } catch (err) {
-          if (err?.response?.status !== 404) {
+const createCouponSchema = (t) =>
+  z
+    .object({
+      code: z
+        .string()
+        .trim()
+        .min(1, t("code_required"))
+        .transform((val) => val.toUpperCase())
+        .superRefine(async (val, ctx) => {
+          try {
+            await validateCode(val);
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              message: "Failed to validate code",
+              message: t("code_exists"),
             });
+          } catch (err) {
+            if (err?.response?.status !== 404) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: t("code_validate_failed"),
+              });
+            }
           }
+        }),
+      discount_percent: z.coerce.number().int().min(1).max(100),
+      starts_at: z.string().optional(),
+      expires_at: z.string().optional(),
+      usage_limit: z.preprocess(
+        (val) =>
+          val === "" || val === null || typeof val === "undefined"
+            ? undefined
+            : Number(val),
+        z.number().int().positive().optional()
+      ),
+      applies_to: z.enum(["plan", "class", "tutorial"]),
+      applies_to_id: z.string().optional(),
+    })
+    .refine(
+      (data) => {
+        if (data.starts_at && data.expires_at) {
+          return new Date(data.starts_at) < new Date(data.expires_at);
         }
-      }),
-    discount_percent: z.coerce.number().int().min(1).max(100),
-    starts_at: z.string().optional(),
-    expires_at: z.string().optional(),
-    usage_limit: z.preprocess(
-      (val) =>
-        val === "" || val === null || typeof val === "undefined"
-          ? undefined
-          : Number(val),
-      z.number().int().positive().optional()
-    ),
-    applies_to: z.enum(["plan", "class", "tutorial"]),
-    applies_to_id: z.string().optional(),
-  })
-  .refine(
-    (data) => {
-      if (data.starts_at && data.expires_at) {
-        return new Date(data.starts_at) < new Date(data.expires_at);
+        return true;
+      },
+      {
+        message: t("start_before_end"),
+        path: ["expires_at"],
       }
-      return true;
-    },
-    {
-      message: "Start date must be before expiration",
-      path: ["expires_at"],
-    }
-  );
+    );
 
 export default function NewCouponPage() {
+  const { t, i18n } = useTranslation("dashboard", { keyPrefix: "couponsPage" });
   const router = useRouter();
   const [serverError, setServerError] = useState(null);
 
@@ -69,7 +74,7 @@ export default function NewCouponPage() {
     handleSubmit,
     formState: { errors, isSubmitting },
   } = useForm({
-    resolver: zodResolver(couponSchema),
+    resolver: zodResolver(createCouponSchema(t)),
     defaultValues: {
       code: "",
       discount_percent: 10,
@@ -91,19 +96,19 @@ export default function NewCouponPage() {
         usage_limit: data.usage_limit ?? undefined,
         applies_to_id: data.applies_to_id || undefined,
       });
-      toast.success("Coupon created successfully");
+      toast.success(t("create_success"));
       router.push("/dashboard/admin/coupons");
     } catch (err) {
       const message =
-        err?.response?.data?.message || err?.message || "Failed to create coupon";
+        err?.response?.data?.message || err?.message || t("create_failed");
       setServerError(message);
     }
   };
 
   return (
     <AdminLayout>
-      <div className="p-6 max-w-lg">
-        <h1 className="text-2xl font-bold mb-4">New Coupon</h1>
+      <div className="p-6 max-w-lg" dir={i18n.dir()}>
+        <h1 className="text-2xl font-bold mb-4">{t("new_coupon")}</h1>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           {serverError && (
             <p className="text-red-600 text-sm">{serverError}</p>
@@ -111,7 +116,7 @@ export default function NewCouponPage() {
           <div>
             <input
               {...register("code")}
-              placeholder="CODE"
+              placeholder={t("code_placeholder")}
               className="border p-2 w-full"
             />
             {errors.code && (
@@ -158,7 +163,7 @@ export default function NewCouponPage() {
             <input
               type="number"
               {...register("usage_limit")}
-              placeholder="Usage Limit"
+              placeholder={t("usage_limit_placeholder")}
               className="border p-2 w-full"
             />
             {errors.usage_limit && (
@@ -172,15 +177,15 @@ export default function NewCouponPage() {
               {...register("applies_to")}
               className="border p-2 w-full"
             >
-              <option value="plan">Plan</option>
-              <option value="class">Class</option>
-              <option value="tutorial">Tutorial</option>
+              <option value="plan">{t("plan")}</option>
+              <option value="class">{t("class")}</option>
+              <option value="tutorial">{t("tutorial")}</option>
             </select>
           </div>
           <div>
             <input
               {...register("applies_to_id")}
-              placeholder="Target ID"
+              placeholder={t("target_id_placeholder")}
               className="border p-2 w-full"
             />
             {errors.applies_to_id && (
@@ -194,11 +199,19 @@ export default function NewCouponPage() {
             type="submit"
             disabled={isSubmitting}
           >
-            {isSubmitting ? "Saving..." : "Save"}
+            {isSubmitting ? t("saving") : t("save")}
           </button>
         </form>
       </div>
     </AdminLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }
 


### PR DESCRIPTION
## Summary
- localize admin coupon creation form with `next-i18next`
- add coupon form strings across all locale files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a177223d988328af6ba8ee2b1193e7