### PR TITLE
Display uploaded payment method icons in checkout grid

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -319,7 +319,15 @@ export default function CheckoutPage() {
                   ${selectedMethod === method.type ? 'bg-yellow-500 text-black border-yellow-400' : 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600'}`}
                 >
                   <div className="text-2xl">
-                    {iconMap[(method.icon || method.type)?.toLowerCase()] || <FaMoneyCheckAlt />}
+                    {method.icon ? (
+                      <img
+                        src={method.icon}
+                        alt={method.name}
+                        className="w-8 h-8 object-contain"
+                      />
+                    ) : (
+                      iconMap[method.type?.toLowerCase()] || <FaMoneyCheckAlt />
+                    )}
                   </div>
                   <div>{method.name}</div>
                 </button>


### PR DESCRIPTION
## Summary
- show uploaded icons in payment method selection grid when provided
- fall back to existing icon map when no custom icon is available

## Testing
- `npm test`
- `npm run lint` *(fails: 360 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a17b2d560883289b14fa84ddc43a9b