### PR TITLE
Add student payment creation endpoint and tests

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -17,7 +17,6 @@ const couponService = require("../coupons/coupons.service");
 
 exports.createPayment = catchAsync(async (req, res) => {
   const {
-    user_id,
     method_id,
     item_type,
     item_id,
@@ -30,7 +29,10 @@ exports.createPayment = catchAsync(async (req, res) => {
     receipt_url,
     coupon_id,
   } = req.body;
-  if (!user_id || !method_id || !item_type || !item_id || !amount) {
+
+  const user_id = req.user.id;
+
+  if (!method_id || !item_type || !item_id || !amount) {
     throw new AppError("Missing required fields", 400);
   }
 
@@ -51,7 +53,9 @@ exports.createPayment = catchAsync(async (req, res) => {
   }
 
   const method = await paymentMethodsService.getById(method_id);
-  if (!method) throw new AppError("Invalid payment method", 400);
+  if (!method || !method.active) {
+    throw new AppError("Invalid payment method", 400);
+  }
 
   let verifiedAmount = amount;
   let verifiedCurrency = currency || "USD";

--- a/backend/src/modules/payments/student.routes.js
+++ b/backend/src/modules/payments/student.routes.js
@@ -6,6 +6,7 @@ const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware
 router.use(verifyToken, isStudent);
 
 router.get("/", controller.getMyPayments);
+router.post("/", controller.createPayment);
 router.post("/receipts", upload.single("receipt"), controller.uploadReceipt);
 router.post("/:id/confirm", controller.confirmPayment);
 

--- a/backend/tests/studentPaymentRoutes.test.js
+++ b/backend/tests/studentPaymentRoutes.test.js
@@ -3,6 +3,23 @@ const express = require('express');
 
 jest.mock('../src/modules/payments/payments.service', () => ({
   getByUser: jest.fn(),
+  create: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getById: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findById: jest.fn().mockResolvedValue({}),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -11,6 +28,8 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
 }));
 
 const service = require('../src/modules/payments/payments.service');
+const methodService = require('../src/modules/paymentMethods/paymentMethods.service');
+const configService = require('../src/modules/paymentConfig/paymentConfig.service');
 const routes = require('../src/modules/payments/student.routes');
 
 const app = express();
@@ -26,5 +45,44 @@ describe('GET /api/payments/student', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
     expect(service.getByUser).toHaveBeenCalledWith('user1');
+  });
+});
+
+describe('POST /api/payments/student', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a payment using authenticated user id', async () => {
+    methodService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
+    configService.getSettings.mockResolvedValue({ platformCut: {} });
+    service.create.mockResolvedValue({ id: 'p1', reference_id: 'ref', status: 'pending' });
+
+    const res = await request(app).post('/api/payments/student').send({
+      user_id: 'other',
+      method_id: 'm1',
+      item_type: 'class',
+      item_id: 'i1',
+      amount: 100,
+    });
+
+    expect(res.status).toBe(200);
+    const call = service.create.mock.calls[0][0];
+    expect(call.user_id).toBe('user1');
+  });
+
+  it('rejects inactive payment methods', async () => {
+    methodService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: false });
+    configService.getSettings.mockResolvedValue({ platformCut: {} });
+
+    const res = await request(app).post('/api/payments/student').send({
+      method_id: 'm1',
+      item_type: 'class',
+      item_id: 'i1',
+      amount: 100,
+    });
+
+    expect(res.status).toBe(400);
+    expect(service.create).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- allow students to create payments via new POST endpoint
- derive user ID from auth context and enforce active payment methods
- add tests for student payment creation and method validation

## Testing
- `npm test` *(fails: adsRoutes.test.js, tutorialRoutes.test.js, class.routes.test.js, tutorialUpdateTransaction.test.js, paymentCommission.test.js, paymentInstallments.test.js)*
- `npm test tests/studentPaymentRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a17b2be3388328b3d6ab7d3fbb05c0