### PR TITLE
Use snake_case and amount in bank payment payload

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -185,7 +185,11 @@ export default function CheckoutPage() {
     if (selectedMethod === 'bank') {
       try {
         setPaymentStatus('processing');
-        const payload = { itemId: itemInfo.id, itemType };
+        const payload = {
+          item_id: itemInfo.id,
+          item_type: itemType,
+          amount: Math.max((itemInfo.price ?? 0) - discount, 0),
+        };
         if (couponId) payload.coupon_id = couponId;
         const data = await initiateBankPayment(payload);
         setBankInfo(data);


### PR DESCRIPTION
## Summary
- send bank payment payload using `item_id`, `item_type`, `amount`
- keep optional fields like `coupon_id` in snake_case

## Testing
- `npm test`
- `npm run lint` *(fails: 93 errors, 266 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a17b2b2d188328b4eff6b2abecb5f1