### PR TITLE
Validate coupons during payment creation

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -76,6 +76,29 @@ exports.createPayment = catchAsync(async (req, res) => {
     finalStatus = "paid";
   }
 
+  if (coupon_id) {
+    const coupon = await couponService.getCouponById(coupon_id);
+    if (!coupon) throw new AppError("Invalid coupon", 400);
+    if (coupon.applies_to && coupon.applies_to !== item_type) {
+      throw new AppError("Coupon not valid for this item type", 400);
+    }
+    if (coupon.applies_to_id && coupon.applies_to_id !== item_id) {
+      throw new AppError("Coupon not valid for this item", 400);
+    }
+    if (coupon.starts_at && new Date(coupon.starts_at) > new Date()) {
+      throw new AppError("Coupon not active", 400);
+    }
+    if (coupon.expires_at && new Date(coupon.expires_at) < new Date()) {
+      throw new AppError("Coupon expired", 400);
+    }
+    if (
+      coupon.usage_limit !== null &&
+      coupon.times_used >= coupon.usage_limit
+    ) {
+      throw new AppError("Coupon usage limit reached", 400);
+    }
+  }
+
   let platform_fee = 0;
   let instructor_amount = verifiedAmount;
   try {

--- a/backend/tests/studentPaymentRoutes.test.js
+++ b/backend/tests/studentPaymentRoutes.test.js
@@ -14,6 +14,11 @@ jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
   getSettings: jest.fn(),
 }));
 
+jest.mock('../src/modules/coupons/coupons.service', () => ({
+  getCouponById: jest.fn(),
+  incrementUsage: jest.fn(),
+}));
+
 jest.mock('../src/services/smsService', () => ({
   sendSMS: jest.fn(),
 }));
@@ -30,6 +35,7 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
 const service = require('../src/modules/payments/payments.service');
 const methodService = require('../src/modules/paymentMethods/paymentMethods.service');
 const configService = require('../src/modules/paymentConfig/paymentConfig.service');
+const couponService = require('../src/modules/coupons/coupons.service');
 const routes = require('../src/modules/payments/student.routes');
 
 const app = express();
@@ -80,6 +86,23 @@ describe('POST /api/payments/student', () => {
       item_type: 'class',
       item_id: 'i1',
       amount: 100,
+    });
+
+    expect(res.status).toBe(400);
+    expect(service.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid coupon', async () => {
+    methodService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
+    configService.getSettings.mockResolvedValue({ platformCut: {} });
+    couponService.getCouponById.mockResolvedValue(null);
+
+    const res = await request(app).post('/api/payments/student').send({
+      method_id: 'm1',
+      item_type: 'class',
+      item_id: 'i1',
+      amount: 100,
+      coupon_id: 'bad',
     });
 
     expect(res.status).toBe(400);

--- a/frontend/src/pages/payments/[id].js
+++ b/frontend/src/pages/payments/[id].js
@@ -9,6 +9,7 @@ import { toast } from "react-toastify";
 
 export default function CheckoutPage() {
   const router = useRouter();
+  const { id } = router.query;
   const [formData, setFormData] = useState({
     fullName: "",
     email: "",
@@ -36,7 +37,7 @@ export default function CheckoutPage() {
 
   const applyCoupon = async () => {
     try {
-      const coupon = await validateCode(formData.coupon.trim());
+      const coupon = await validateCode(formData.coupon.trim(), "class", id);
       if (coupon) {
         const discountAmount = (coursePrice * coupon.discount_percent) / 100;
         setAppliedDiscount(discountAmount);

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -143,7 +143,7 @@ export default function CheckoutPage() {
 
   const handleApplyPromo = async () => {
     try {
-      const data = await validateCode(promoCode);
+      const data = await validateCode(promoCode, itemType, itemId);
       setDiscount(data.discount_percent);
       setCouponId(data.id);
       toast.success('Promo code applied');

--- a/frontend/src/services/admin/couponService.js
+++ b/frontend/src/services/admin/couponService.js
@@ -24,7 +24,12 @@ export const deleteCoupon = async (id) => {
   await api.delete(`/coupons/admin/${id}`);
 };
 
-export const validateCode = async (code) => {
-  const { data } = await api.get(`/coupons/code/${code}`);
+export const validateCode = async (code, itemType, itemId) => {
+  let url = `/coupons/code/${encodeURIComponent(code)}`;
+  if (itemType) {
+    url += `/${itemType}`;
+    if (itemId) url += `/${itemId}`;
+  }
+  const { data } = await api.get(url);
   return data?.data;
 };

--- a/frontend/src/services/couponService.js
+++ b/frontend/src/services/couponService.js
@@ -1,6 +1,11 @@
 import api from "@/services/api/api";
 
-export const validateCode = async (code) => {
-  const { data } = await api.get(`/coupons/code/${code}`);
+export const validateCode = async (code, itemType, itemId) => {
+  let url = `/coupons/code/${encodeURIComponent(code)}`;
+  if (itemType) {
+    url += `/${itemType}`;
+    if (itemId) url += `/${itemId}`;
+  }
+  const { data } = await api.get(url);
   return data?.data;
 };

--- a/frontend/src/services/instructor/couponService.js
+++ b/frontend/src/services/instructor/couponService.js
@@ -24,7 +24,12 @@ export const deleteCoupon = async (id) => {
   await api.delete(`/coupons/admin/${id}`);
 };
 
-export const validateCode = async (code) => {
-  const { data } = await api.get(`/coupons/code/${code}`);
+export const validateCode = async (code, itemType, itemId) => {
+  let url = `/coupons/code/${encodeURIComponent(code)}`;
+  if (itemType) {
+    url += `/${itemType}`;
+    if (itemId) url += `/${itemId}`;
+  }
+  const { data } = await api.get(url);
   return data?.data;
 };

--- a/frontend/src/tests/__tests__/checkoutPromo.test.js
+++ b/frontend/src/tests/__tests__/checkoutPromo.test.js
@@ -64,7 +64,7 @@ test('applies promo code successfully', async () => {
     target: { value: 'SAVE10' },
   });
   fireEvent.click(screen.getByText('Apply'));
-  await waitFor(() => expect(validateCode).toHaveBeenCalledWith('SAVE10'));
+  await waitFor(() => expect(validateCode).toHaveBeenCalledWith('SAVE10', 'class', '1'));
   expect(await screen.findByText('Discount Applied: -$10')).toBeInTheDocument();
   const { toast } = require('react-toastify');
   expect(toast.success).toHaveBeenCalledWith('Promo code applied');


### PR DESCRIPTION
## Summary
- Verify coupon details in payment controller before creating payments
- Allow coupon validation endpoints to receive optional item context
- Pass item type and ID when applying promo codes in checkout flows
- Test that invalid coupons are rejected when creating student payments

## Testing
- `cd backend && npm test` *(fails: tests/adsRoutes.test.js, tests/tutorialRoutes.test.js, src/modules/classes/__tests__/class.routes.test.js, tests/paymentCommission.test.js, tests/paymentInstallments.test.js, tests/tutorialUpdateTransaction.test.js)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18e9552c8832881d3137c486ee380