### PR TITLE
feat: notify discussion stakeholders on replies

### DIFF
--- a/backend/src/modules/community/public/__tests__/public.service.test.js
+++ b/backend/src/modules/community/public/__tests__/public.service.test.js
@@ -1,0 +1,84 @@
+jest.mock('../../../../config/database', () => {
+  const replyRow = {
+    id: 'r1',
+    discussion_id: 'd1',
+    user_id: 'u2',
+    content: 'hello',
+    file_url: null,
+  };
+
+  const insertReturning = jest.fn().mockResolvedValue([replyRow]);
+  const insert = jest.fn(() => ({ returning: insertReturning }));
+
+  const participantsDistinct = jest.fn().mockResolvedValue([
+    { user_id: 'owner1' },
+    { user_id: 'u3' },
+  ]);
+  const repliesWhereNot = jest.fn(() => ({ distinct: participantsDistinct }));
+  const repliesWhere = jest.fn(() => ({ whereNot: repliesWhereNot }));
+
+  let callCount = 0;
+  const mockDb = jest.fn((table) => {
+    if (table === 'community_replies') {
+      callCount += 1;
+      if (callCount === 1) {
+        return { insert };
+      }
+      return { where: repliesWhere };
+    }
+    if (table === 'users') {
+      return {
+        where: jest.fn(() => ({
+          first: jest.fn().mockResolvedValue({
+            full_name: 'User 2',
+            avatar_url: 'a.png',
+          }),
+        })),
+      };
+    }
+    if (table === 'community_discussions') {
+      return {
+        where: jest.fn(() => ({
+          first: jest.fn().mockResolvedValue({
+            user_id: 'owner1',
+            title: 'Disc Title',
+          }),
+        })),
+      };
+    }
+    return {};
+  });
+
+  mockDb.fn = { now: jest.fn() };
+  return mockDb;
+});
+
+jest.mock('../../../notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+const service = require('../public.service');
+const notificationService = require('../../../notifications/notifications.service');
+
+describe('createReply', () => {
+  it('notifies discussion owner and participants', async () => {
+    await service.createReply({
+      discussion_id: 'd1',
+      user_id: 'u2',
+      content: 'hello',
+    });
+
+    expect(notificationService.createNotification).toHaveBeenCalledTimes(2);
+    expect(notificationService.createNotification).toHaveBeenCalledWith({
+      user_id: 'owner1',
+      type: 'community',
+      message: expect.stringContaining('Disc Title'),
+    });
+    expect(notificationService.createNotification).toHaveBeenCalledWith({
+      user_id: 'u3',
+      type: 'community',
+      message: expect.stringContaining('Disc Title'),
+    });
+  });
+});
+

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -248,6 +248,34 @@ exports.createReply = async (data) => {
     .where({ id: data.user_id })
     .first('full_name', 'avatar_url');
 
+  const discussion = await db('community_discussions')
+    .where({ id: data.discussion_id })
+    .first('user_id', 'title');
+
+  if (discussion) {
+    const participants = await db('community_replies')
+      .where({ discussion_id: data.discussion_id })
+      .whereNot('user_id', data.user_id)
+      .distinct('user_id');
+
+    const recipientIds = new Set([
+      discussion.user_id,
+      ...participants.map((p) => p.user_id),
+    ]);
+
+    recipientIds.delete(data.user_id);
+
+    const message = `New reply in discussion: ${discussion.title}`;
+
+    for (const id of recipientIds) {
+      await notificationService.createNotification({
+        user_id: id,
+        type: 'community',
+        message,
+      });
+    }
+  }
+
   return {
     ...row,
     user_name: user?.full_name,


### PR DESCRIPTION
## Summary
- notify discussion owners and other participants when new replies are posted
- add unit test for reply notifications

## Testing
- `cd backend && npm test` *(fails: 6 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a197c5529883288a9aaff16da8f6f7