### PR TITLE
feat: block replies to locked discussions

### DIFF
--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -62,6 +62,11 @@ exports.listReplies = catchAsync(async (req, res) => {
 exports.createReply = catchAsync(async (req, res) => {
   const { content } = req.body || {};
   if (!content) throw new AppError('Missing fields', 400);
+  const status = await service.getDiscussionStatus(req.params.id);
+  if (!status) throw new AppError('Discussion not found', 404);
+  if (status.locked || status.resolved) {
+    throw new AppError('Posting is not allowed', 403);
+  }
   const reply = await service.createReply({
     discussion_id: req.params.id,
     user_id: req.user.id,

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -114,6 +114,12 @@ exports.getDiscussion = async (id, viewerId, ip, userAgent) => {
   return { ...row, tags: tagsMap[id] || [] };
 };
 
+exports.getDiscussionStatus = async (id) => {
+  return db("community_discussions")
+    .where({ id })
+    .first("locked", "resolved");
+};
+
 const { v4: uuidv4 } = require('uuid');
 const notificationService = require('../../notifications/notifications.service');
 const messageService = require('../../messages/messages.service');


### PR DESCRIPTION
## Summary
- prevent creating replies when discussions are locked or resolved
- add service helper to fetch discussion status

## Testing
- `cd backend && npm test` *(fails: POST /api/ads/admin creates ad, PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial, PUT /api/users/tutorials/admin/:id updates tutorial with language and status, payment commission calculations, updateTutorial tag transactions, class routes create class, paymentInstallments)*

------
https://chatgpt.com/codex/tasks/task_e_68a197c47320832897bd472071661dc6