### PR TITLE
Add liked flag to discussion details

### DIFF
--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -111,7 +111,14 @@ exports.getDiscussion = async (id, viewerId, ip, userAgent) => {
     .first();
   if (!row) return null;
   const tagsMap = await exports.getDiscussionTags(id);
-  return { ...row, tags: tagsMap[id] || [] };
+  let liked = false;
+  if (viewerId) {
+    const likeRow = await db('community_likes')
+      .where({ discussion_id: id, user_id: viewerId })
+      .first();
+    liked = !!likeRow;
+  }
+  return { ...row, tags: tagsMap[id] || [], liked };
 };
 
 const { v4: uuidv4 } = require('uuid');

--- a/frontend/src/pages/community/question/details.js
+++ b/frontend/src/pages/community/question/details.js
@@ -35,6 +35,7 @@ const QuestionDetails = () => {
         setQuestion(data);
         setLikes(data.likes || 0);
         setVotes(data.votes || 0);
+        setLiked(Boolean(data.liked));
         try {
           const r = await fetchReplies(router.query.id);
           setReplies(r);

--- a/frontend/src/services/communityService.js
+++ b/frontend/src/services/communityService.js
@@ -14,6 +14,7 @@ const formatDiscussion = (d) => ({
   ...d,
   user_avatar: formatUrl(d.user_avatar),
   image_url: formatUrl(d.image_url),
+  liked: Boolean(d.liked),
 });
 
 const formatReply = (r) => ({


### PR DESCRIPTION
## Summary
- expose `liked` boolean from backend discussion service
- include `liked` in community service discussion fetcher
- initialize question view's liked state from fetched discussion

## Testing
- `npm test` (backend) *(fails: Test Suites: 6 failed, 69 passed)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a197c31df883288dd9c3fa5f1d6394