### PR TITLE
feat: support audio replies

### DIFF
--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -62,11 +62,19 @@ exports.listReplies = catchAsync(async (req, res) => {
 exports.createReply = catchAsync(async (req, res) => {
   const { content } = req.body || {};
   if (!content) throw new AppError('Missing fields', 400);
+
+  const file = req.files?.file?.[0];
+  const audio = req.files?.audio?.[0];
+
   const reply = await service.createReply({
     discussion_id: req.params.id,
     user_id: req.user.id,
     content,
-    file_url: req.file ? `/uploads/community/${req.file.filename}` : null,
+    file_url: file
+      ? `/uploads/community/${file.filename}`
+      : audio
+      ? `/uploads/community/${audio.filename}`
+      : null,
   });
   sendSuccess(res, reply, 'Reply posted');
 });

--- a/backend/src/modules/community/public/replyUpload.middleware.js
+++ b/backend/src/modules/community/public/replyUpload.middleware.js
@@ -2,7 +2,16 @@ const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
 
-const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
+const allowed = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/jpg',
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/wav',
+  'audio/ogg',
+];
 const uploadDir = path.join(__dirname, '../../../../uploads/community');
 if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
 
@@ -19,4 +28,11 @@ const fileFilter = (_req, file, cb) => {
   cb(null, allowed.includes(file.mimetype));
 };
 
-module.exports = multer({ storage, fileFilter, limits: { fileSize: 5 * 1024 * 1024 } }).single('file');
+module.exports = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: 10 * 1024 * 1024 },
+}).fields([
+  { name: 'file', maxCount: 1 },
+  { name: 'audio', maxCount: 1 },
+]);

--- a/frontend/src/pages/community/question/details.js
+++ b/frontend/src/pages/community/question/details.js
@@ -24,6 +24,7 @@ const QuestionDetails = () => {
   const [replyText, setReplyText] = useState("");
   const [replies, setReplies] = useState([]);
   const [audioFile, setAudioFile] = useState(null);
+  const [audioPreview, setAudioPreview] = useState(null);
   const [file, setFile] = useState(null);
   const [filePreview, setFilePreview] = useState(null);
 
@@ -79,7 +80,15 @@ const QuestionDetails = () => {
   };
 
   // ✅ Handle Audio Upload
-  const handleAudioUpload = (e) => setAudioFile(e.target.files[0]);
+  const handleAudioUpload = (e) => {
+    const f = e.target.files[0];
+    setAudioFile(f);
+    if (f) {
+      setAudioPreview(URL.createObjectURL(f));
+    } else {
+      setAudioPreview(null);
+    }
+  };
 
   // ✅ Handle File Upload
   const handleFileUpload = (e) => {
@@ -104,6 +113,7 @@ const QuestionDetails = () => {
     const fd = new FormData();
     fd.append('content', replyText);
     if (file) fd.append('file', file);
+    if (audioFile) fd.append('audio', audioFile);
     try {
       const newReply = await createReply(router.query.id, fd);
       setReplies([...replies, newReply]);
@@ -111,6 +121,9 @@ const QuestionDetails = () => {
       setFile(null);
       if (filePreview) URL.revokeObjectURL(filePreview);
       setFilePreview(null);
+      setAudioFile(null);
+      if (audioPreview) URL.revokeObjectURL(audioPreview);
+      setAudioPreview(null);
       toast.success('Reply posted');
     } catch (err) {
       console.error(err);
@@ -121,8 +134,9 @@ const QuestionDetails = () => {
   useEffect(() => {
     return () => {
       if (filePreview) URL.revokeObjectURL(filePreview);
+      if (audioPreview) URL.revokeObjectURL(audioPreview);
     };
-  }, [filePreview]);
+  }, [filePreview, audioPreview]);
 
   return (
     <div className="bg-gray-900 min-h-screen text-white">
@@ -186,7 +200,20 @@ const QuestionDetails = () => {
               </div>
               <p className="text-gray-300 mt-2"><ReactMarkdown>{reply.content}</ReactMarkdown></p>
               {reply.file_url && (
-                <img src={reply.file_url} alt="attachment" className="mt-2 max-w-full rounded" />
+                /(mp3|wav|ogg|m4a)$/i.test(reply.file_url)
+                  ? (
+                      <audio controls className="mt-2 w-full">
+                        <source src={reply.file_url} />
+                        Your browser does not support the audio element.
+                      </audio>
+                    )
+                  : (
+                      <img
+                        src={reply.file_url}
+                        alt="attachment"
+                        className="mt-2 max-w-full rounded"
+                      />
+                    )
               )}
             </div>
           ))}
@@ -203,6 +230,14 @@ const QuestionDetails = () => {
         {/* ✅ File & Video Call */}
         <input type="file" accept="audio/*" className="mt-3 bg-gray-800 p-2 rounded-lg text-white" onChange={handleAudioUpload} />
         <input type="file" accept=".pdf,.jpg,.png" className="mt-3 bg-gray-800 p-2 rounded-lg text-white" onChange={handleFileUpload} />
+        {audioFile && audioPreview && (
+          <div className="mt-2">
+            <audio controls className="w-full">
+              <source src={audioPreview} />
+              Your browser does not support the audio element.
+            </audio>
+          </div>
+        )}
         {file && (
           <div className="mt-2">
             {file.type.startsWith('image/') ? (


### PR DESCRIPTION
## Summary
- allow uploading audio files in community replies
- handle audio attachments on backend and display them in UI

## Testing
- `npm test` (backend) *(fails: POST /api/ads/admin creates ad; PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial; PUT /api/users/tutorials/admin/:id updates tutorial with language and status; Class routes create class; Class routes create class responds even if notifications fail; Class routes create class with options; updateTutorial tag transactions commits transaction when tag update succeeds; payment commission calculations calculates commission for class payments; payment commission calculations calculates commission for book payments; POST /api/payments/admin creates payment with installments and enrolls)*
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68a197c291bc8328b169feb24f134d88