### PR TITLE
feat: control rich text editor reply

### DIFF
--- a/frontend/src/components/RichTextEditor.js
+++ b/frontend/src/components/RichTextEditor.js
@@ -1,9 +1,21 @@
-import React, { useState } from "react";
-import { Editor, EditorState, RichUtils, convertToRaw } from "draft-js";
+import React, { useState, useEffect } from "react";
+import { Editor, EditorState, RichUtils, convertToRaw, ContentState } from "draft-js";
 import "draft-js/dist/Draft.css"; // Import Draft.js styles
 
-const RichTextEditor = ({ onChange }) => {
-  const [editorState, setEditorState] = useState(() => EditorState.createEmpty());
+const RichTextEditor = ({ onChange, value }) => {
+  const [editorState, setEditorState] = useState(() =>
+    value ? EditorState.createWithContent(ContentState.createFromText(value)) : EditorState.createEmpty()
+  );
+
+  useEffect(() => {
+    if (value === undefined) return;
+    const currentText = editorState.getCurrentContent().getPlainText();
+    if (value === "" && currentText !== "") {
+      setEditorState(EditorState.createEmpty());
+    } else if (value !== "" && value !== currentText) {
+      setEditorState(EditorState.createWithContent(ContentState.createFromText(value)));
+    }
+  }, [value]);
 
   // Handle changes in the editor
   const handleEditorChange = (newState) => {

--- a/frontend/src/pages/community/question/details.js
+++ b/frontend/src/pages/community/question/details.js
@@ -195,7 +195,7 @@ const QuestionDetails = () => {
 
         {/* ✅ User Reply Section */}
         <h2 className="text-2xl font-bold text-yellow-500 mt-8">Your Reply</h2>
-        <RichTextEditor onChange={setReplyText} />
+        <RichTextEditor value={replyText} onChange={setReplyText} />
         <button onClick={handleReply} className="mt-4 px-6 py-3 bg-yellow-500 text-gray-900 font-bold rounded-lg hover:bg-yellow-600">
           Post Reply
         </button>

--- a/frontend/src/tests/__tests__/CommunityPages.test.js
+++ b/frontend/src/tests/__tests__/CommunityPages.test.js
@@ -12,8 +12,8 @@ jest.mock('../../components/community/Filters', () => () => <div />);
 jest.mock('../../components/community/Pagination', () => () => <div />);
 jest.mock('../../components/FileUploader', () => () => <div />);
 // simple textarea mock for rich text editor
-jest.mock('../../components/RichTextEditor', () => ({ onChange }) => (
-  <textarea data-testid="editor" onChange={(e) => onChange && onChange(e.target.value)} />
+jest.mock('../../components/RichTextEditor', () => ({ onChange, value }) => (
+  <textarea data-testid="editor" value={value} onChange={(e) => onChange && onChange(e.target.value)} />
 ));
 jest.mock('react-markdown', () => (props) => <div>{props.children}</div>);
 


### PR DESCRIPTION
## Summary
- make RichTextEditor accept a value prop and reset when cleared
- bind replyText state to RichTextEditor in question details page
- adjust CommunityPages test mock for new RichTextEditor API

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a197c1ae68832882b4c96b0090fa0e