### PR TITLE
Use toast in AskQuestionModal validation

### DIFF
--- a/frontend/src/components/community/AskQuestionModal.js
+++ b/frontend/src/components/community/AskQuestionModal.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { FaTimes, FaPlus, FaRobot } from "react-icons/fa";
+import { toast } from "react-toastify";
 import UserFilter from "./UserFilter";
 
 const AskQuestionModal = ({ onClose, onSubmit }) => {
@@ -11,7 +12,7 @@ const AskQuestionModal = ({ onClose, onSubmit }) => {
 
   // Handle Question Submission
   const handleSubmit = () => {
-    if (!title || !description) return alert("Please enter question details!");
+    if (!title || !description) return toast.error("Please enter question details!");
 
     onSubmit({
       title,


### PR DESCRIPTION
## Summary
- import `toast` from `react-toastify` in `AskQuestionModal`
- display a toast error when question details are missing

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a197be5f8c8328be1c9e6d6f7de608