### PR TITLE
feat: support multi-file uploads in community discussions

### DIFF
--- a/backend/src/modules/community/public/discussionUpload.middleware.js
+++ b/backend/src/modules/community/public/discussionUpload.middleware.js
@@ -19,4 +19,10 @@ const fileFilter = (_req, file, cb) => {
   cb(null, allowed.includes(file.mimetype));
 };
 
-module.exports = multer({ storage, fileFilter, limits: { fileSize: 5 * 1024 * 1024 } }).single('image');
+const upload = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
+
+module.exports = upload;

--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -37,7 +37,9 @@ exports.createDiscussion = catchAsync(async (req, res) => {
     title,
     content,
     tags,
-    image_url: req.file ? `/uploads/community/${req.file.filename}` : null,
+    image_url: Array.isArray(req.files) && req.files.length
+      ? `/uploads/community/${req.files[0].filename}`
+      : null,
   });
   sendSuccess(res, disc, "Discussion created");
 });

--- a/backend/src/modules/community/public/public.routes.js
+++ b/backend/src/modules/community/public/public.routes.js
@@ -6,7 +6,7 @@ const replyUpload = require("./replyUpload.middleware");
 
 router.get("/discussions", ctrl.listDiscussions);
 router.get("/discussions/:id", ctrl.getDiscussion);
-router.post("/discussions", verifyToken, upload, ctrl.createDiscussion);
+router.post("/discussions", verifyToken, upload.array('files'), ctrl.createDiscussion);
 router.get("/discussions/:id/replies", ctrl.listReplies);
 router.post("/discussions/:id/replies", verifyToken, replyUpload, ctrl.createReply);
 router.post("/discussions/:id/like", verifyToken, ctrl.likeDiscussion);

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -184,11 +184,17 @@ const handleAcceptAIResponse = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await createDiscussion({ title, content: description, tags });
+      const formData = new FormData();
+      formData.append('title', title);
+      formData.append('content', description);
+      formData.append('tags', JSON.stringify(tags));
+      uploadedFiles.forEach((file) => formData.append('files', file));
+      await createDiscussion(formData);
       toast.success("Question posted");
       setTitle("");
       setDescription("");
       setTags([]);
+      setUploadedFiles([]);
     } catch (err) {
       console.error(err);
       toast.error("Failed to post question");

--- a/frontend/src/services/communityService.js
+++ b/frontend/src/services/communityService.js
@@ -35,7 +35,10 @@ export const fetchDiscussionById = async (id) => {
 };
 
 export const createDiscussion = async (payload) => {
-  const { data } = await api.post('/community/discussions', payload);
+  const config = payload instanceof FormData
+    ? { headers: { "Content-Type": "multipart/form-data" } }
+    : {};
+  const { data } = await api.post('/community/discussions', payload, config);
   return data?.data;
 };
 


### PR DESCRIPTION
## Summary
- allow `createDiscussion` service to send `FormData` as multipart
- send attached files when posting a question
- permit multiple uploads for community discussions on the backend

## Testing
- `npm test` (backend) *(fails: Test Suites: 7 failed, 68 passed)*
- `npm test` (frontend) *(fails: Test Suites: 1 failed, 33 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a197bb6fb48328ac8276f4e2626b37