### PR TITLE
feat: add related questions endpoint and UI fallback

### DIFF
--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -54,6 +54,12 @@ exports.listTags = catchAsync(async (req, res) => {
   sendSuccess(res, tags);
 });
 
+exports.relatedQuestions = catchAsync(async (req, res) => {
+  const q = req.query.query || req.query.q || '';
+  const questions = await service.searchRelatedQuestions(q);
+  sendSuccess(res, { questions });
+});
+
 exports.listReplies = catchAsync(async (req, res) => {
   const replies = await service.listReplies(req.params.id);
   sendSuccess(res, replies);

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -218,6 +218,16 @@ exports.searchTags = async (q) => {
     .limit(10);
 };
 
+// Search discussion titles matching a query for related questions
+exports.searchRelatedQuestions = async (q) => {
+  if (!q) return [];
+  const rows = await db('community_discussions')
+    .whereILike('title', `%${q}%`)
+    .limit(5)
+    .pluck('title');
+  return rows;
+};
+
 exports.listReplies = async (discussionId) => {
   return db('community_replies as r')
     .leftJoin('users as u', 'r.user_id', 'u.id')

--- a/backend/src/modules/community/public/relatedQuestions.routes.js
+++ b/backend/src/modules/community/public/relatedQuestions.routes.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const ctrl = require('./public.controller');
+
+// Public endpoint to search related discussion questions
+router.get('/', ctrl.relatedQuestions);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -107,6 +107,7 @@ app.use("/api/bookings/student", require("./modules/bookings/student.routes"));
 app.use("/api/bookings/instructor", require("./modules/bookings/instructor.routes"));
 app.use("/api/community/admin", require("./modules/community/admin/admin.routes"));
 app.use("/api/community", require("./modules/community/public/public.routes"));
+app.use("/api/related-questions", require("./modules/community/public/relatedQuestions.routes"));
 app.use("/api/roles", require("./modules/roles/roles.routes"));
 app.use("/api/plans", require("./modules/plans/plans.routes"));
 // Register admin routes before public routes to prevent public routes from catching

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -32,6 +32,7 @@ const AskQuestionPage = () => {
   const [isProcessingAI, setIsProcessingAI] = useState(false);
   const [confidenceScore, setConfidenceScore] = useState(null);
   const [relatedQuestions, setRelatedQuestions] = useState([]);
+  const [relatedQuestionsError, setRelatedQuestionsError] = useState(false);
   const [editableResponse, setEditableResponse] = useState("");
   const [showPreview, setShowPreview] = useState(false);
   const [aiOptions, setAiOptions] = useState([]);
@@ -42,10 +43,23 @@ const AskQuestionPage = () => {
   // ✅ Fetch Related Questions Based on Title Input
   useEffect(() => {
     if (title.trim().length > 3) {
-      fetch(`/api/related-questions?query=${title}`)
-        .then(res => res.json())
-        .then(data => setRelatedQuestions(data.questions))
-        .catch(error => console.error("Error fetching related questions:", error));
+      fetch(`/api/related-questions?query=${encodeURIComponent(title)}`)
+        .then(res => {
+          if (!res.ok) throw new Error('Failed to fetch');
+          return res.json();
+        })
+        .then(data => {
+          setRelatedQuestions(data.questions || []);
+          setRelatedQuestionsError(false);
+        })
+        .catch(error => {
+          console.error("Error fetching related questions:", error);
+          setRelatedQuestions([]);
+          setRelatedQuestionsError(true);
+        });
+    } else {
+      setRelatedQuestions([]);
+      setRelatedQuestionsError(false);
     }
   }, [title]);
 
@@ -248,7 +262,12 @@ const handleAcceptAIResponse = () => {
             </div>
 
             {/* ✅ Show Related Questions */}
-            {relatedQuestions.length > 0 && (
+            {relatedQuestionsError && (
+              <div className="bg-gray-700 p-4 rounded-md mt-4">
+                <p className="text-red-400">Related questions are currently unavailable.</p>
+              </div>
+            )}
+            {!relatedQuestionsError && relatedQuestions.length > 0 && (
               <div className="bg-gray-700 p-4 rounded-md mt-4">
                 <h3 className="text-yellow-500 font-bold">🔗 Related Questions:</h3>
                 {relatedQuestions.map((q, index) => (


### PR DESCRIPTION
## Summary
- add `/api/related-questions` endpoint to query similar community discussions
- wire backend route and expose public controller/service function
- handle fetch failures with fallback message on ask question page

## Testing
- `npm test` (backend) *(fails: 6 failed, 69 passed)*
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_68a197b86f4c8328a1a8c55e53e672f8