### PR TITLE
feat: count community replies

### DIFF
--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -43,6 +43,15 @@ exports.listDiscussions = async () => {
       "t.discussion_id",
       "d.id"
     )
+    .leftJoin(
+      db("community_replies")
+        .select("discussion_id")
+        .count({ replies: "id" })
+        .groupBy("discussion_id")
+        .as("r"),
+      "r.discussion_id",
+      "d.id"
+    )
     .select(
       "d.id",
       "d.title",
@@ -55,7 +64,8 @@ exports.listDiscussions = async () => {
       "u.avatar_url as user_avatar",
       db.raw("COALESCE(v.views,0) as views"),
       db.raw("COALESCE(l.likes,0) as likes"),
-      db.raw("COALESCE(t.votes,0) as votes")
+      db.raw("COALESCE(t.votes,0) as votes"),
+      db.raw("COALESCE(r.replies,0) as replies")
     )
     .orderBy("d.created_at", "desc");
   const tagsMap = await exports.getDiscussionTags(rows.map((r) => r.id));

--- a/frontend/src/components/community/QuestionCard.js
+++ b/frontend/src/components/community/QuestionCard.js
@@ -7,8 +7,8 @@ const QuestionCard = ({ question }) => {
   const tags = Array.isArray(question.tags)
     ? question.tags
     : [];
-  const answersCount = Array.isArray(question.answers)
-    ? question.answers.length
+  const answersCount = typeof question.replies === "number"
+    ? question.replies
     : 0;
 
   const description = question.description || question.content || "";

--- a/frontend/src/services/communityService.js
+++ b/frontend/src/services/communityService.js
@@ -14,6 +14,7 @@ const formatDiscussion = (d) => ({
   ...d,
   user_avatar: formatUrl(d.user_avatar),
   image_url: formatUrl(d.image_url),
+  replies: d.replies ?? 0,
 });
 
 const formatReply = (r) => ({


### PR DESCRIPTION
## Summary
- include reply counts when listing community discussions
- expose replies count to frontend consumers
- show reply count on community question cards

## Testing
- `cd backend && npm test` *(fails: POST /api/ads/admin creates ad; PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial; PUT /api/users/tutorials/admin/:id updates tutorial with language and status; Class routes create class tests; updateTutorial tag transactions commits transaction when tag update succeeds; payment commission calculations; payment installments)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a197b425bc8328b613db8d8b8dc9ba