### PR TITLE
Validate provider and question in AI controller

### DIFF
--- a/backend/src/modules/ai/ai.controller.js
+++ b/backend/src/modules/ai/ai.controller.js
@@ -4,6 +4,12 @@ const service = require('./ai.service');
 
 exports.answer = catchAsync(async (req, res) => {
   const { provider, question, model } = req.body || {};
+  if (!provider) {
+    return res.status(400).json({ message: 'provider is required' });
+  }
+  if (!question) {
+    return res.status(400).json({ message: 'question is required' });
+  }
   const result = await service.answerWithAI(provider, question, model);
   if (result.error) {
     return res.status(400).json({ message: result.error });


### PR DESCRIPTION
## Summary
- ensure AI question endpoint requires both provider and question
- return HTTP 400 with helpful messages when either field is missing

## Testing
- `npm test` *(fails: 7 failed, 69 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a0edfc988328a1840443ccaed42c