### PR TITLE
feat: show AI confidence score

### DIFF
--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -359,6 +359,9 @@ const handleAcceptAIResponse = () => {
                 <div className="prose prose-invert">
                   <ReactMarkdown>{aiResponse}</ReactMarkdown>
                 </div>
+                {confidenceScore !== null && (
+                  <p className="mt-2 text-sm text-gray-400">Confidence: {confidenceScore}</p>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- display AI confidence score alongside answer on ask question page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1a0ecd7748328839e3f23d5d0dc76