### PR TITLE
Restrict AI options to supported providers

### DIFF
--- a/docs/admin-third-party-integrations.md
+++ b/docs/admin-third-party-integrations.md
@@ -1,6 +1,6 @@
 # Admin Third Party Integrations
 
-SkillBridge lets administrators manage API keys and settings for various third-party services. These include multiple AI chat providers used on the community "Ask" page.
+SkillBridge lets administrators manage API keys and settings for various third-party services. These include the ChatGPT and Hugging Face AI providers used on the community "Ask" page.
 
 ## Backend
 
@@ -12,12 +12,12 @@ SkillBridge lets administrators manage API keys and settings for various third-p
 ## Frontend
 
 - Admin page: `frontend/src/pages/dashboard/admin/settings/thirdParty`
-- Integration modals under `frontend/src/components/admin/integrations` allow entering API keys for ChatGPT, DeepSeek, Claude, Gemini and Hugging Face.
+- Integration modals under `frontend/src/components/admin/integrations` allow entering API keys for ChatGPT and Hugging Face.
 - Saved settings are fetched through `frontend/src/services/admin/thirdPartyService.js`.
 - Community question page `frontend/src/pages/community/ask.js` calls `fetchThirdPartyConfig` to list available AI providers for users.
 - When no provider has an API key configured the page shows "No AI integrations available".
 
-After storing keys on the admin page, users can select a provider from a dropdown on the AI Assistance tab and submit questions powered by the chosen model.
+After storing keys on the admin page, users can select ChatGPT or Hugging Face from a dropdown on the AI Assistance tab and submit questions powered by the chosen model.
 
 ### ChatGPT Configuration
 

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -85,9 +85,6 @@ const AskQuestionPage = () => {
             toast.warning('ChatGPT models not configured');
           }
         }
-        if (cfg.deepseek?.apiKey && cfg.deepseek?.active !== false) opts.push('deepseek');
-        if (cfg.claude?.apiKey && cfg.claude?.active !== false) opts.push('claude');
-        if (cfg.gemini?.apiKey && cfg.gemini?.active !== false) opts.push('gemini');
         if (cfg.huggingface?.apiKey && cfg.huggingface?.active !== false) opts.push('huggingface');
         setAiOptions(opts);
         if (opts.length === 0) toast.info('No AI integrations available');

--- a/frontend/src/tests/__tests__/CommunityPages.test.js
+++ b/frontend/src/tests/__tests__/CommunityPages.test.js
@@ -60,12 +60,12 @@ describe('Community pages', () => {
     });
     fireEvent.click(screen.getByText(/Submit Question/i));
     await waitFor(() => {
-      expect(createDiscussion).toHaveBeenCalledWith({
-        title: 'My Question',
-        content: '',
-        tags: [],
-      });
+      expect(createDiscussion).toHaveBeenCalled();
     });
+    const formData = createDiscussion.mock.calls[0][0];
+    expect(formData.get('title')).toBe('My Question');
+    expect(formData.get('content')).toBe('');
+    expect(formData.get('tags')).toBe(JSON.stringify([]));
   });
 
   test('posting a reply displays it', async () => {


### PR DESCRIPTION
## Summary
- Only offer ChatGPT and Hugging Face as AI providers on the community Ask page
- Update admin integration docs to match supported AI providers
- Align community page test with form-data submission

## Testing
- `npm test`
- `npm run lint` *(fails: 93 errors, 268 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a0e9546083289cff955767fe5052