### PR TITLE
feat: post AI answer as first discussion reply

### DIFF
--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -6,7 +6,7 @@ import RichTextEditor from "@/components/RichTextEditor";
 import { FaPaperPlane, FaEdit, FaCheckCircle } from "react-icons/fa";
 import ReactMarkdown from "react-markdown";
 import { toast } from "react-toastify";
-import { createDiscussion, searchTags } from "@/services/communityService";
+import { createDiscussion, searchTags, createReply } from "@/services/communityService";
 import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
 
 // ✅ AI API URL - Update with your actual backend API endpoint
@@ -191,24 +191,34 @@ const AskQuestionPage = () => {
 
   // ✅ Accept AI Answer & Convert to Community Question
 const handleAcceptAIResponse = () => {
-  setDescription(editableResponse);
+  setDescription(title);
   setActiveTab("community");
 };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const formData = new FormData();
-      formData.append('title', title);
-      formData.append('content', description);
-      formData.append('tags', JSON.stringify(tags));
-      uploadedFiles.forEach((file) => formData.append('files', file));
-      await createDiscussion(formData);
+      let payload;
+      if (uploadedFiles.length) {
+        const formData = new FormData();
+        formData.append('title', title);
+        formData.append('content', description);
+        formData.append('tags', JSON.stringify(tags));
+        uploadedFiles.forEach((file) => formData.append('files', file));
+        payload = formData;
+      } else {
+        payload = { title, content: description, tags };
+      }
+      const discussion = await createDiscussion(payload);
+      if (editableResponse.trim()) {
+        await createReply(discussion.id, { content: editableResponse });
+      }
       toast.success("Question posted");
       setTitle("");
       setDescription("");
       setTags([]);
       setUploadedFiles([]);
+      setEditableResponse("");
     } catch (err) {
       console.error(err);
       toast.error("Failed to post question");


### PR DESCRIPTION
## Summary
- preserve the user's question text when accepting an AI answer
- post the AI-generated answer as the first reply after creating a discussion

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1a0e854f48328a0021f8e09210e14