### PR TITLE
Seed community discussions

### DIFF
--- a/backend/src/seeds/seed_z_community_discussions.js
+++ b/backend/src/seeds/seed_z_community_discussions.js
@@ -1,0 +1,55 @@
+exports.seed = async function(knex) {
+  await knex('community_replies').del();
+  await knex('community_discussions').del();
+
+  const users = await knex('users').select('id').limit(2);
+  if (!users.length) return;
+
+  const [user1, user2 = users[0]] = users;
+  const now = knex.fn.now();
+
+  const [discussion1] = await knex('community_discussions')
+    .insert({
+      id: knex.raw('uuid_generate_v4()'),
+      user_id: user1.id || user1,
+      title: 'How to get started with SkillBridge?',
+      content: 'I am new to SkillBridge. Can someone guide me through the basics?',
+      tags: JSON.stringify(['getting-started']),
+      created_at: now,
+      updated_at: now
+    })
+    .returning('id');
+
+  const [discussion2] = await knex('community_discussions')
+    .insert({
+      id: knex.raw('uuid_generate_v4()'),
+      user_id: (user2.id || user2),
+      title: 'Best resources for learning JavaScript?',
+      content: 'What are the best tutorials or courses for learning JavaScript?',
+      tags: JSON.stringify(['javascript', 'resources']),
+      created_at: now,
+      updated_at: now
+    })
+    .returning('id');
+
+  await knex('community_replies').insert([
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      discussion_id: discussion1.id || discussion1,
+      user_id: user2.id || user2,
+      content: 'You can start by exploring the official docs and SkillBridge tutorials.',
+      is_answer: true,
+      created_at: now,
+      updated_at: now
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      discussion_id: discussion2.id || discussion2,
+      user_id: user1.id || user1,
+      content: 'I recommend checking out the MDN web docs and online courses.',
+      is_answer: false,
+      created_at: now,
+      updated_at: now
+    }
+  ]);
+};


### PR DESCRIPTION
## Summary
- seed community discussions and replies using existing user ids

## Testing
- `npm test` *(fails: POST /api/ads/admin creates ad, PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial, PUT /api/users/tutorials/admin/:id updates tutorial with language and status, Class routes create class, Class routes create class responds even if notifications fail, Class routes create class with options, updateTutorial tag transactions commits transaction when tag update succeeds, payment commission calculations calculates commission for class payments, payment commission calculations calculates commission for book payments, POST /api/payments/admin creates payment with installments and enrolls, community public routes create discussion)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bbdfd0888328aa43f2b85cad14f7