### PR TITLE
Handle missing groups gracefully

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -143,6 +143,9 @@ exports.listGroups = catchAsync(async (req, res) => {
 
 exports.getGroup = catchAsync(async (req, res) => {
   const group = await service.getGroupById(req.params.id);
+  if (!group) {
+    throw new AppError("Group not found", 404);
+  }
   sendSuccess(res, group);
 });
 

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -26,7 +26,8 @@ import toast from 'react-hot-toast';
 export default function AdminGroupDetailsPage() {
   const router = useRouter();
   const { id } = router.query;
-  const [group, setGroup] = useState(null);
+  const [group, setGroup] = useState();
+  const [notFound, setNotFound] = useState(false);
   const [activeTab, setActiveTab] = useState('overview');
   const [members, setMembers] = useState([]);
   const [requests, setRequests] = useState([]);
@@ -57,9 +58,18 @@ export default function AdminGroupDetailsPage() {
     const load = async () => {
       try {
         const data = await groupService.getGroupById(id);
+        if (!data) {
+          setNotFound(true);
+          return;
+        }
         setGroup(data);
-      } catch {
-        setGroup(null);
+      } catch (err) {
+        if (err?.response?.status === 404) {
+          setNotFound(true);
+          return;
+        }
+        setNotFound(true);
+        return;
       }
       try {
         const list = await groupService.getGroupMembers(id);
@@ -217,6 +227,10 @@ export default function AdminGroupDetailsPage() {
     link.download = 'members.csv';
     link.click();
   };
+
+  if (notFound) {
+    return <AdminLayout><div className="p-6">Group not found</div></AdminLayout>;
+  }
 
   if (!group) {
     return <AdminLayout><div className="p-6">Loading group...</div></AdminLayout>;


### PR DESCRIPTION
## Summary
- Return a 404 error when a group lookup fails on the backend
- Show a "Group not found" message on the admin group page when backend returns 404 or null

## Testing
- `cd backend && npm test` *(fails: 7 failed, 69 passed)*
- `cd frontend && npm test` *(fails: 1 failed, 33 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c6ecbd7883289fe18405f4e9159c