### PR TITLE
refactor: unify class status naming

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -70,14 +70,14 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
   );
 
   const exportCSV = () => {
-    const headers = ["Title", "Instructor", "Start Date", "End Date", "Category", "Status"];
+    const headers = ["Title", "Instructor", "Start Date", "End Date", "Category", "Publish Status"];
     const rows = classList.map(cls => [
       cls.title,
       cls.instructor,
       cls.start_date,
       cls.end_date,
       cls.category,
-      cls.status
+      cls.publishStatus
     ]);
     const csvContent = [headers, ...rows].map(e => e.join(",")).join("\n");
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
@@ -100,7 +100,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
         setClassList((prev) =>
           prev.map((c) =>
             c.id === id
-              ? { ...c, approvalStatus: "Approved", status: updated?.status }
+              ? { ...c, approvalStatus: "Approved", publishStatus: updated?.publishStatus }
               : c
           )
         );
@@ -147,21 +147,21 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
         const updated = await toggleClassStatus(id);
         setClassList((prev) =>
           prev.map((c) =>
-            c.id === id ? { ...c, status: updated.status } : c
+            c.id === id ? { ...c, publishStatus: updated.publishStatus } : c
           )
         );
         toast.success("Status updated");
-        const message = `Class "${target.title}" status changed to ${updated.status}.`;
+        const message = `Class "${target.title}" publish status changed to ${updated.publishStatus}.`;
         await createNotification({ user_id: user.id, type: "class_status_changed", message });
         await sendChatMessage(user.id, { text: message });
         if (target.instructor_id && target.instructor_id !== user.id) {
           await createNotification({
             user_id: target.instructor_id,
             type: "class_status_changed",
-            message: `Your class "${target.title}" status was changed to ${updated.status}.`,
+            message: `Your class "${target.title}" publish status was changed to ${updated.publishStatus}.`,
           });
           await sendChatMessage(target.instructor_id, {
-            text: `Your class "${target.title}" status was changed to ${updated.status}.`,
+            text: `Your class "${target.title}" publish status was changed to ${updated.publishStatus}.`,
           });
         }
         refreshNotifications?.();
@@ -322,12 +322,12 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
                   <button
                     onClick={() => handleStatusChange(cls.id, 'toggle')}
                     className={`px-3 py-1 rounded-full text-xs font-bold transition-colors ${
-                        cls.status === 'published'
+                        cls.publishStatus === 'published'
                           ? 'bg-green-100 text-green-800 hover:bg-green-200'
                           : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200'
                       }`}
                   >
-                    {cls.status === 'published' ? 'Published' : 'Draft'}
+                    {cls.publishStatus === 'published' ? 'Published' : 'Draft'}
                   </button>
                 </td>
                 <td className="px-6 py-4">

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/edit.js
@@ -42,7 +42,7 @@ function EditInstructorClass() {
     maxStudents: '',
     isFree: false,
     allowInstallments: false,
-    isApproved: false,
+    isPublished: false,
     image: '',
     imagePreview: '',
     demoVideo: null,
@@ -102,7 +102,7 @@ function EditInstructorClass() {
             maxStudents: data.max_students ?? '',
             isFree: data.price === 0,
             allowInstallments: Boolean(data.allow_installments),
-            isApproved: data.status === 'published',
+            isPublished: data.publishStatus === 'published',
             imagePreview: data.cover_image || '',
             demoPreview: data.demo_video_url || '',
           }));
@@ -181,7 +181,7 @@ function EditInstructorClass() {
       }
       if (formData.maxStudents) payload.append('max_students', formData.maxStudents);
       payload.append('allow_installments', formData.allowInstallments ? 'true' : 'false');
-      payload.append('status', formData.isApproved ? 'published' : 'draft');
+      payload.append('status', formData.isPublished ? 'published' : 'draft');
       if (formData.category) payload.append('category_id', formData.category);
       if (formData.image) payload.append('cover_image', formData.image);
       if (formData.demoVideo) payload.append('demo_video', formData.demoVideo);
@@ -338,8 +338,8 @@ function EditInstructorClass() {
                 <label className="inline-flex items-center">
                   <input
                     type="checkbox"
-                    name="isApproved"
-                    checked={formData.isApproved}
+                    name="isPublished"
+                    checked={formData.isPublished}
                     onChange={handleChange}
                     className="h-4 w-4 text-yellow-600 focus:ring-yellow-500 border-gray-300 rounded"
                   />

--- a/frontend/src/pages/dashboard/instructor/online-classes/index.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/index.js
@@ -129,12 +129,12 @@ export default function MyClasses() {
               <div className="flex gap-2 mb-4 mt-2">
                 <span
                   className={`px-3 py-1 rounded-full text-xs font-bold ${
-                    cls.status === "published"
+                    cls.publishStatus === "published"
                       ? "bg-green-100 text-green-800"
                       : "bg-yellow-100 text-yellow-800"
                   }`}
                 >
-                  {cls.status === "published" ? "Published" : "Draft"}
+                  {cls.publishStatus === "published" ? "Published" : "Draft"}
                 </span>
                 <span
                   className={`px-3 py-1 rounded-full text-xs font-bold ${

--- a/frontend/src/pages/dashboard/instructor/payments/class-breakdown.js
+++ b/frontend/src/pages/dashboard/instructor/payments/class-breakdown.js
@@ -2,9 +2,33 @@ import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { useState } from "react";
 
 const mockClassEarnings = [
-  { id: 1, title: "React Basics", status: "Live", students: 20, price: 25, total: 500 },
-  { id: 2, title: "Next.js Bootcamp", status: "Completed", students: 30, price: 30, total: 900 },
-  { id: 3, title: "Node.js Fundamentals", status: "Draft", students: 0, price: 40, total: 0 },
+  {
+    id: 1,
+    title: "React Basics",
+    publishStatus: "published",
+    scheduleStatus: "Live",
+    students: 20,
+    price: 25,
+    total: 500,
+  },
+  {
+    id: 2,
+    title: "Next.js Bootcamp",
+    publishStatus: "published",
+    scheduleStatus: "Completed",
+    students: 30,
+    price: 30,
+    total: 900,
+  },
+  {
+    id: 3,
+    title: "Node.js Fundamentals",
+    publishStatus: "draft",
+    scheduleStatus: "Upcoming",
+    students: 0,
+    price: 40,
+    total: 0,
+  },
 ];
 
 export default function InstructorClassEarningsPage() {
@@ -13,7 +37,11 @@ export default function InstructorClassEarningsPage() {
   const filtered =
     filter === "all"
       ? mockClassEarnings
-      : mockClassEarnings.filter((cls) => cls.status.toLowerCase() === filter);
+      : mockClassEarnings.filter(
+          (cls) =>
+            cls.scheduleStatus.toLowerCase() === filter ||
+            cls.publishStatus.toLowerCase() === filter
+        );
 
   return (
     <InstructorLayout>
@@ -39,7 +67,8 @@ export default function InstructorClassEarningsPage() {
             <thead>
               <tr className="bg-gray-100 text-left">
                 <th className="p-3">Class</th>
-                <th className="p-3">Status</th>
+                <th className="p-3">Schedule</th>
+                <th className="p-3">Publish</th>
                 <th className="p-3">Students</th>
                 <th className="p-3">Price</th>
                 <th className="p-3">Total</th>
@@ -49,7 +78,8 @@ export default function InstructorClassEarningsPage() {
               {filtered.map((cls) => (
                 <tr key={cls.id} className="border-b hover:bg-gray-50">
                   <td className="p-3 font-medium">{cls.title}</td>
-                  <td className="p-3">{cls.status}</td>
+                  <td className="p-3">{cls.scheduleStatus}</td>
+                  <td className="p-3">{cls.publishStatus}</td>
                   <td className="p-3">{cls.students}</td>
                   <td className="p-3">${cls.price}</td>
                   <td className="p-3 font-semibold text-green-700">${cls.total}</td>

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -2,28 +2,32 @@ import api from "@/services/api/api";
 import { toDateInput } from "@/utils/date";
 import { safeEncodeURI } from "@/utils/url";
 
-const formatClass = (cls) => ({
-  ...cls,
-  cover_image: cls.cover_image
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
-    : null,
-  demo_video_url: cls.demo_video_url
-    ? safeEncodeURI(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
-      )
-    : null,
-  instructor_image: cls.instructor_image
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`
-    : null,
-  trending: Boolean(cls.trending),
+const formatClass = (cls) => {
+  const { status, ...rest } = cls;
+  return {
+    ...rest,
+    publishStatus: status,
+    cover_image: cls.cover_image
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
+      : null,
+    demo_video_url: cls.demo_video_url
+      ? safeEncodeURI(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
+        )
+      : null,
+    instructor_image: cls.instructor_image
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`
+      : null,
+    trending: Boolean(cls.trending),
 
-  start_date: cls.start_date ? toDateInput(cls.start_date) : "",
-  end_date: cls.end_date ? toDateInput(cls.end_date) : "",
+    start_date: cls.start_date ? toDateInput(cls.start_date) : "",
+    end_date: cls.end_date ? toDateInput(cls.end_date) : "",
 
-  approvalStatus: cls.moderation_status || "Pending",
-  scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),
-  views: cls.views || 0,
-});
+    approvalStatus: cls.moderation_status || "Pending",
+    scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),
+    views: cls.views || 0,
+  };
+};
 
 const computeScheduleStatus = (start, end) => {
   const now = new Date();
@@ -84,7 +88,7 @@ export const fetchAdminClassAnalytics = async (id) => {
 
 export const toggleClassStatus = async (id) => {
   const { data } = await api.patch(`/users/classes/admin/${id}/status`);
-  return data?.data;
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const approveAdminClass = async (id) => {

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -3,7 +3,7 @@ import { extractData } from "@/services/api/helpers";
 import { API_BASE_URL } from "@/config/config";
 import { safeEncodeURI } from "@/utils/url";
 
-const formatClass = (cls) => ({
+const formatBaseClass = (cls) => ({
   ...cls,
   cover_image: cls.cover_image
     ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`
@@ -19,6 +19,14 @@ const formatClass = (cls) => ({
   instructorBio: cls.instructor_bio || cls.instructorBio,
 });
 
+const formatClass = (cls) => {
+  const { status, ...rest } = formatBaseClass(cls);
+  return {
+    ...rest,
+    publishStatus: status,
+  };
+};
+
 const computeScheduleStatus = (start, end) => {
   const now = new Date();
   const s = start ? new Date(start) : null;
@@ -30,7 +38,7 @@ const computeScheduleStatus = (start, end) => {
 };
 
 const formatEnrolledClass = (cls) => {
-  const base = formatClass(cls);
+  const base = formatBaseClass(cls);
   const { start_date, end_date, status, ...rest } = base;
   return {
     ...rest,

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -2,28 +2,32 @@ import api from "@/services/api/api";
 import { toDateInput } from "@/utils/date";
 import { safeEncodeURI } from "@/utils/url";
 
-const formatClass = (cls) => ({
-  ...cls,
-  cover_image: cls.cover_image
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
-    : null,
-  demo_video_url: cls.demo_video_url
-    ? safeEncodeURI(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
-      )
-    : null,
-  instructor_image: cls.instructor_image
-    ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`
-    : null,
-  trending: Boolean(cls.trending),
+const formatClass = (cls) => {
+  const { status, ...rest } = cls;
+  return {
+    ...rest,
+    publishStatus: status,
+    cover_image: cls.cover_image
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
+      : null,
+    demo_video_url: cls.demo_video_url
+      ? safeEncodeURI(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
+        )
+      : null,
+    instructor_image: cls.instructor_image
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`
+      : null,
+    trending: Boolean(cls.trending),
 
-  start_date: cls.start_date ? toDateInput(cls.start_date) : "",
-  end_date: cls.end_date ? toDateInput(cls.end_date) : "",
+    start_date: cls.start_date ? toDateInput(cls.start_date) : "",
+    end_date: cls.end_date ? toDateInput(cls.end_date) : "",
 
-  approvalStatus: cls.moderation_status || "Pending",
-  scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),
-  views: cls.views || 0,
-});
+    approvalStatus: cls.moderation_status || "Pending",
+    scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),
+    views: cls.views || 0,
+  };
+};
 
 const computeScheduleStatus = (start, end) => {
   const now = new Date();
@@ -75,12 +79,12 @@ export const fetchInstructorClassAnalytics = async (id) => {
 
 export const toggleClassStatus = async (id) => {
   const { data } = await api.patch(`/users/classes/admin/${id}/status`);
-  return data?.data;
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const approveInstructorClass = async (id) => {
   const { data } = await api.patch(`/users/classes/admin/${id}/approve`);
-  return data?.data;
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const rejectInstructorClass = async (id, reason) => {


### PR DESCRIPTION
## Summary
- standardize class status terminology across services
- update admin and instructor dashboards to use publishStatus
- convert instructor class editor to track publish state explicitly

## Testing
- `npm run lint` *(fails: Component definition is missing display name)*
- `npm test` *(fails: Community pages – formData.get is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f49d05ac83288030fb022a14f056