### PR TITLE
Add instructor class routes with ownership checks

### DIFF
--- a/backend/src/middleware/auth/verifyClassOwnership.js
+++ b/backend/src/middleware/auth/verifyClassOwnership.js
@@ -1,0 +1,29 @@
+const db = require("../../config/database");
+
+const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
+
+module.exports = async function verifyClassOwnership(req, res, next) {
+  const classId = req.params.id || req.params.classId;
+  try {
+    const cls = await db("online_classes")
+      .select("instructor_id")
+      .where({ id: classId })
+      .first();
+
+    if (!cls) return res.status(404).json({ message: "Class not found" });
+
+    const roles = req.user.roles || [req.user.role];
+    const isAdmin = roles
+      .map((r) => normalizeRole(r))
+      .some((r) => ["admin", "superadmin"].includes(r));
+
+    if (cls.instructor_id !== req.user.id && !isAdmin) {
+      return res.status(403).json({ message: "Access denied" });
+    }
+
+    next();
+  } catch (err) {
+    console.error("Failed to verify class ownership", err);
+    res.status(500).json({ message: "Failed to verify class ownership" });
+  }
+};

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -6,6 +6,7 @@ const enrollmentCtrl = require("./enrollments/classEnrollment.controller");
 const validate = require("../../middleware/validate");
 const validator = require("./class.validator");
 const upload = require("./classUploadMiddleware");
+const verifyClassOwnership = require("../../middleware/auth/verifyClassOwnership");
 const {
   verifyToken,
   isInstructorOrAdmin,
@@ -33,60 +34,54 @@ router.use("/scores", require("./scores/classScore.routes"));
 router.post(
   "/admin",
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
   upload,
   validate(validator.create),
   controller.createClass
 );
-router.get("/admin", verifyToken, isInstructorOrAdmin, controller.getAllClasses);
+router.get("/admin", verifyToken, isAdmin, controller.getAllClasses);
 router.get(
   "/admin/my",
   verifyToken,
-  isInstructorOrAdmin,
-  controller.getMyClasses
-);
-router.get(
-  "/instructor/my",
-  verifyToken,
-  isInstructor,
+  isAdmin,
   controller.getMyClasses
 );
 router.get(
   "/admin/:id",
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
   controller.getClassById
 );
 router.get(
   "/admin/:id/manage",
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
   controller.getManagementData
 );
 router.get(
   "/admin/:id/analytics",
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
   controller.getClassAnalytics
 );
 // List students enrolled in a specific class
 router.get(
   "/admin/:id/students",
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
   enrollmentCtrl.getStudentsByClass
 );
 // Fetch details for a single student's enrollment
 router.get(
   "/admin/:classId/students/:studentId",
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
   enrollmentCtrl.getStudent
 );
 router.put(
   "/admin/:id",
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
   upload,
   validate(validator.update),
   controller.updateClass
@@ -94,13 +89,13 @@ router.put(
 router.delete(
   "/admin/:id",
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
   controller.deleteClass
 );
 router.patch(
   "/admin/:id/status",
   verifyToken,
-  isInstructorOrAdmin,
+  isAdmin,
   controller.toggleClassStatus
 );
 router.patch(
@@ -115,6 +110,80 @@ router.patch(
   isAdmin,
   validate(validator.reject),
   controller.rejectClass
+);
+
+// Instructor routes
+router.post(
+  "/instructor",
+  verifyToken,
+  isInstructor,
+  upload,
+  validate(validator.create),
+  controller.createClass
+);
+router.get(
+  "/instructor/my",
+  verifyToken,
+  isInstructor,
+  controller.getMyClasses
+);
+router.get(
+  "/instructor/:id",
+  verifyToken,
+  isInstructor,
+  verifyClassOwnership,
+  controller.getClassById
+);
+router.get(
+  "/instructor/:id/manage",
+  verifyToken,
+  isInstructor,
+  verifyClassOwnership,
+  controller.getManagementData
+);
+router.get(
+  "/instructor/:id/analytics",
+  verifyToken,
+  isInstructor,
+  verifyClassOwnership,
+  controller.getClassAnalytics
+);
+router.get(
+  "/instructor/:id/students",
+  verifyToken,
+  isInstructor,
+  verifyClassOwnership,
+  enrollmentCtrl.getStudentsByClass
+);
+router.get(
+  "/instructor/:classId/students/:studentId",
+  verifyToken,
+  isInstructor,
+  verifyClassOwnership,
+  enrollmentCtrl.getStudent
+);
+router.put(
+  "/instructor/:id",
+  verifyToken,
+  isInstructor,
+  verifyClassOwnership,
+  upload,
+  validate(validator.update),
+  controller.updateClass
+);
+router.delete(
+  "/instructor/:id",
+  verifyToken,
+  isInstructor,
+  verifyClassOwnership,
+  controller.deleteClass
+);
+router.patch(
+  "/instructor/:id/status",
+  verifyToken,
+  isInstructor,
+  verifyClassOwnership,
+  controller.toggleClassStatus
 );
 
 // Tags

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -44,12 +44,12 @@ export const fetchInstructorClasses = async () => {
 };
 
 export const fetchInstructorClassById = async (id) => {
-  const { data } = await api.get(`/users/classes/admin/${id}`);
+  const { data } = await api.get(`/users/classes/instructor/${id}`);
   return data?.data ? formatClass(data.data) : null;
 };
 
 export const createInstructorClass = async (payload, onUploadProgress) => {
-  const { data } = await api.post("/users/classes/admin", payload, {
+  const { data } = await api.post("/users/classes/instructor", payload, {
     headers: { "Content-Type": "multipart/form-data" },
     ...(onUploadProgress ? { onUploadProgress } : {}),
   });
@@ -57,39 +57,29 @@ export const createInstructorClass = async (payload, onUploadProgress) => {
 };
 
 export const updateInstructorClass = async (id, payload) => {
-  const { data } = await api.put(`/users/classes/admin/${id}`, payload, {
+  const { data } = await api.put(`/users/classes/instructor/${id}`, payload, {
     headers: { "Content-Type": "multipart/form-data" },
   });
   return data?.data ? formatClass(data.data) : null;
 };
 
 export const deleteInstructorClass = async (id) => {
-  await api.delete(`/users/classes/admin/${id}`);
+  await api.delete(`/users/classes/instructor/${id}`);
   return true;
 };
 
 export const fetchInstructorClassAnalytics = async (id) => {
-  const { data } = await api.get(`/users/classes/admin/${id}/analytics`);
+  const { data } = await api.get(`/users/classes/instructor/${id}/analytics`);
   return data?.data ?? {};
 };
 
 export const toggleClassStatus = async (id) => {
-  const { data } = await api.patch(`/users/classes/admin/${id}/status`);
-  return data?.data;
-};
-
-export const approveInstructorClass = async (id) => {
-  const { data } = await api.patch(`/users/classes/admin/${id}/approve`);
-  return data?.data;
-};
-
-export const rejectInstructorClass = async (id, reason) => {
-  const { data } = await api.patch(`/users/classes/admin/${id}/reject`, { reason });
+  const { data } = await api.patch(`/users/classes/instructor/${id}/status`);
   return data?.data;
 };
 
 export const fetchClassManagementData = async (id) => {
-  const { data } = await api.get(`/users/classes/admin/${id}/manage`);
+  const { data } = await api.get(`/users/classes/instructor/${id}/manage`);
   if (!data?.data) return null;
   return {
     class: data.data.class ? formatClass(data.data.class) : null,


### PR DESCRIPTION
## Summary
- add middleware to verify instructor ownership of classes
- expose instructor-specific class routes using ownership validation
- update instructor class service to call new endpoints

## Testing
- `cd backend && npm test` *(fails: Test Suites: 7 failed, 69 passed)*
- `cd frontend && npm test` *(fails: Test Suites: 1 failed, 33 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f49c51648328be4a4780498bb6e3