### PR TITLE
Add migration for community reports table

### DIFF
--- a/backend/src/migrations/20250518091714_create_community_reports_table.js
+++ b/backend/src/migrations/20250518091714_create_community_reports_table.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('community_reports', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('reporter_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.uuid('discussion_id').references('id').inTable('community_discussions').onDelete('CASCADE');
+    table.uuid('reply_id').references('id').inTable('community_replies').onDelete('CASCADE');
+    table.text('reason').notNullable();
+    table.string('status').defaultTo('pending');
+    table.timestamp('reported_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('community_reports');
+};


### PR DESCRIPTION
## Summary
- add community_reports migration for admin dashboard

## Testing
- `npm test` *(fails: adsRoutes.test.js, tutorialRoutes.test.js, class.routes.test.js, tutorialUpdateTransaction.test.js, paymentCommission.test.js, paymentInstallments.test.js, public.routes.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f985832c8328b8afa7f1607d44ef