### PR TITLE
feat: add toast notifications for admin tags page

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -195,6 +195,20 @@
     "details_update_failed": "فشل تحديث المدرب",
     "processing": "جارٍ الحفظ..."
   },
+  "tagsPage": {
+    "title": "الوسوم",
+    "manage": "إدارة الوسوم",
+    "placeholder": "اسم الوسم",
+    "add": "إضافة",
+    "update": "تحديث",
+    "delete_confirm": "حذف هذا الوسم؟",
+    "tag_created": "تم إنشاء الوسم",
+    "tag_updated": "تم تحديث الوسم",
+    "tag_deleted": "تم حذف الوسم",
+    "load_failed": "فشل تحميل الوسوم",
+    "save_failed": "فشل حفظ الوسم",
+    "delete_failed": "فشل حذف الوسم"
+  },
   "currenciesPage": {
     "title": "إدارة العملات",
     "add_currency": "إضافة عملة",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -172,6 +172,20 @@
     "details_update_failed": "Failed to update instructor",
     "processing": "Saving..."
   },
+  "tagsPage": {
+    "title": "Tags",
+    "manage": "Tags verwalten",
+    "placeholder": "Tag-Name",
+    "add": "Hinzufügen",
+    "update": "Aktualisieren",
+    "delete_confirm": "Diesen Tag löschen?",
+    "tag_created": "Tag erstellt",
+    "tag_updated": "Tag aktualisiert",
+    "tag_deleted": "Tag gelöscht",
+    "load_failed": "Tags konnten nicht geladen werden",
+    "save_failed": "Tag konnte nicht gespeichert werden",
+    "delete_failed": "Tag konnte nicht gelöscht werden"
+  },
   "currenciesPage": {
     "title": "Währungsverwaltung",
     "add_currency": "Währung hinzufügen",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -195,6 +195,20 @@
     "details_update_failed": "Failed to update instructor",
     "processing": "Saving..."
   },
+  "tagsPage": {
+    "title": "Tags",
+    "manage": "Manage Tags",
+    "placeholder": "Tag name",
+    "add": "Add",
+    "update": "Update",
+    "delete_confirm": "Delete this tag?",
+    "tag_created": "Tag created",
+    "tag_updated": "Tag updated",
+    "tag_deleted": "Tag deleted",
+    "load_failed": "Failed to load tags",
+    "save_failed": "Failed to save tag",
+    "delete_failed": "Failed to delete tag"
+  },
   "currenciesPage": {
     "title": "Currency Manager",
     "add_currency": "Add Currency",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -172,6 +172,20 @@
     "details_update_failed": "Failed to update instructor",
     "processing": "Saving..."
   },
+  "tagsPage": {
+    "title": "Etiquetas",
+    "manage": "Administrar etiquetas",
+    "placeholder": "Nombre de la etiqueta",
+    "add": "Agregar",
+    "update": "Actualizar",
+    "delete_confirm": "¿Eliminar esta etiqueta?",
+    "tag_created": "Etiqueta creada",
+    "tag_updated": "Etiqueta actualizada",
+    "tag_deleted": "Etiqueta eliminada",
+    "load_failed": "Error al cargar etiquetas",
+    "save_failed": "Error al guardar la etiqueta",
+    "delete_failed": "Error al eliminar la etiqueta"
+  },
   "currenciesPage": {
     "title": "Gestor de divisas",
     "add_currency": "Agregar divisa",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -183,6 +183,20 @@
     "details_update_failed": "Failed to update instructor",
     "processing": "Saving..."
   },
+  "tagsPage": {
+    "title": "Tags",
+    "manage": "Gérer les tags",
+    "placeholder": "Nom du tag",
+    "add": "Ajouter",
+    "update": "Mettre à jour",
+    "delete_confirm": "Supprimer ce tag ?",
+    "tag_created": "Tag créé",
+    "tag_updated": "Tag mis à jour",
+    "tag_deleted": "Tag supprimé",
+    "load_failed": "Échec du chargement des tags",
+    "save_failed": "Échec de l'enregistrement du tag",
+    "delete_failed": "Échec de la suppression du tag"
+  },
   "currenciesPage": {
     "title": "Gestion des devises",
     "add_currency": "Ajouter une devise",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -195,6 +195,20 @@
     "details_update_failed": "Failed to update instructor",
     "processing": "Saving..."
   },
+  "tagsPage": {
+    "title": "टैग",
+    "manage": "टैग प्रबंधित करें",
+    "placeholder": "टैग नाम",
+    "add": "जोड़ें",
+    "update": "अपडेट करें",
+    "delete_confirm": "क्या आप इस टैग को हटाना चाहते हैं?",
+    "tag_created": "टैग बनाया गया",
+    "tag_updated": "टैग अपडेट किया गया",
+    "tag_deleted": "टैग हटाया गया",
+    "load_failed": "टैग लोड करने में विफल",
+    "save_failed": "टैग सहेजने में विफल",
+    "delete_failed": "टैग हटाने में विफल"
+  },
   "currenciesPage": {
     "title": "Currency Manager",
     "add_currency": "Add Currency",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -195,6 +195,20 @@
     "details_update_failed": "Failed to update instructor",
     "processing": "Saving..."
   },
+  "tagsPage": {
+    "title": "标签",
+    "manage": "管理标签",
+    "placeholder": "标签名称",
+    "add": "添加",
+    "update": "更新",
+    "delete_confirm": "删除此标签？",
+    "tag_created": "标签已创建",
+    "tag_updated": "标签已更新",
+    "tag_deleted": "标签已删除",
+    "load_failed": "加载标签失败",
+    "save_failed": "保存标签失败",
+    "delete_failed": "删除标签失败"
+  },
   "currenciesPage": {
     "title": "Currency Manager",
     "add_currency": "Add Currency",

--- a/frontend/src/pages/dashboard/admin/community/tags/index.js
+++ b/frontend/src/pages/dashboard/admin/community/tags/index.js
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaEdit, FaTrash, FaPlus } from "react-icons/fa";
+import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import {
   fetchTags,
   createTag,
@@ -16,6 +20,7 @@ const slugify = (text) =>
     .replace(/ +/g, "-");
 
 export default function AdminTagsPage() {
+  const { t } = useTranslation('dashboard', { keyPrefix: 'tagsPage' });
   const [tags, setTags] = useState([]);
   const [newTag, setNewTag] = useState("");
   const [editing, setEditing] = useState(null);
@@ -26,7 +31,8 @@ export default function AdminTagsPage() {
         const data = await fetchTags();
         setTags(data || []);
       } catch (err) {
-        console.error("Failed to load tags", err);
+        const msg = err?.response?.data?.message || t('load_failed');
+        toast.error(msg);
       }
     };
     load();
@@ -41,14 +47,17 @@ export default function AdminTagsPage() {
         setTags((prev) =>
           prev.map((tag) => (tag.id === editing.id ? updated : tag))
         );
+        toast.success(t('tag_updated'));
         setEditing(null);
       } else {
         const created = await createTag(payload);
         setTags((prev) => [...prev, created]);
+        toast.success(t('tag_created'));
       }
       setNewTag("");
     } catch (err) {
-      console.error("Failed to save tag", err);
+      const msg = err?.response?.data?.message || t('save_failed');
+      toast.error(msg);
     }
   };
 
@@ -58,20 +67,22 @@ export default function AdminTagsPage() {
   };
 
   const handleDelete = async (id) => {
-    const confirmDelete = confirm("Delete this tag?");
+    const confirmDelete = confirm(t('delete_confirm'));
     if (!confirmDelete) return;
     try {
       await deleteTag(id);
       setTags((prev) => prev.filter((t) => t.id !== id));
+      toast.success(t('tag_deleted'));
     } catch (err) {
-      console.error("Failed to delete tag", err);
+      const msg = err?.response?.data?.message || t('delete_failed');
+      toast.error(msg);
     }
   };
 
   return (
-    <AdminLayout title="Manage Tags">
+    <AdminLayout title={t('manage')}>
       <div className="p-6 max-w-3xl mx-auto">
-        <h1 className="text-3xl font-bold mb-6">Tags</h1>
+        <h1 className="text-3xl font-bold mb-6">{t('title')}</h1>
 
         {/* Create/Edit */}
         <div className="flex items-center gap-3 mb-8">
@@ -79,7 +90,7 @@ export default function AdminTagsPage() {
             type="text"
             value={newTag}
             onChange={(e) => setNewTag(e.target.value)}
-            placeholder="Tag name"
+            placeholder={t('placeholder')}
             className="border border-gray-300 px-4 py-2 rounded w-full"
           />
           <button
@@ -87,7 +98,7 @@ export default function AdminTagsPage() {
             className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded flex items-center gap-2"
           >
             <FaPlus />
-            {editing ? "Update" : "Add"}
+            {editing ? t('update') : t('add')}
           </button>
         </div>
 
@@ -113,4 +124,12 @@ export default function AdminTagsPage() {
       </div>
     </AdminLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- integrate toast notifications on admin community tags page
- localize tag success and error messages
- add translation strings for all supported locales

## Testing
- `npm test` *(fails: formData.get is not a function in CommunityPages.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a201e1ae008328bfaf457b4fd90c35