### PR TITLE
Use reusable confirm modal for tag deletion

### DIFF
--- a/frontend/src/components/common/ConfirmModal.js
+++ b/frontend/src/components/common/ConfirmModal.js
@@ -21,15 +21,17 @@ export default function ConfirmModal({
     <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg p-6 w-full max-w-md shadow-lg">
         <h2 className="text-xl font-semibold mb-4 text-gray-800">
-          {title || t("Confirm Deletion")}
+          {t(title || "Confirm Deletion")}
         </h2>
-        <p className="text-gray-600 mb-6">{message}</p>
+        {message && (
+          <p className="text-gray-600 mb-6">{t(message)}</p>
+        )}
         <div className="flex justify-end gap-4">
           <Button
             onClick={onClose}
             className="bg-gray-300 text-black hover:bg-gray-400"
           >
-            {cancelText || t("Cancel")}
+            {t(cancelText || "Cancel")}
           </Button>
           <Button
             onClick={() => {
@@ -38,7 +40,7 @@ export default function ConfirmModal({
             }}
             className="bg-red-500 text-white hover:bg-red-600"
           >
-            {confirmText || t("Confirm")}
+            {t(confirmText || "Confirm")}
           </Button>
         </div>
       </div>

--- a/frontend/src/pages/dashboard/admin/community/tags/index.js
+++ b/frontend/src/pages/dashboard/admin/community/tags/index.js
@@ -7,6 +7,10 @@ import {
   updateTag,
   deleteTag,
 } from "@/services/admin/communityService";
+import ConfirmModal from "@/components/common/ConfirmModal";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 const slugify = (text) =>
   text
@@ -16,9 +20,18 @@ const slugify = (text) =>
     .replace(/ +/g, "-");
 
 export default function AdminTagsPage() {
+  const { t } = useTranslation("dashboard");
   const [tags, setTags] = useState([]);
   const [newTag, setNewTag] = useState("");
   const [editing, setEditing] = useState(null);
+  const [confirmModal, setConfirmModal] = useState({
+    isOpen: false,
+    title: "",
+    message: "",
+    confirmText: "",
+    cancelText: "",
+    onConfirm: null,
+  });
 
   useEffect(() => {
     const load = async () => {
@@ -57,15 +70,29 @@ export default function AdminTagsPage() {
     setNewTag(tag.name);
   };
 
-  const handleDelete = async (id) => {
-    const confirmDelete = confirm("Delete this tag?");
-    if (!confirmDelete) return;
-    try {
-      await deleteTag(id);
-      setTags((prev) => prev.filter((t) => t.id !== id));
-    } catch (err) {
-      console.error("Failed to delete tag", err);
-    }
+  const openConfirmModal = ({ title, message, confirmText, cancelText, onConfirm }) => {
+    setConfirmModal({ isOpen: true, title, message, confirmText, cancelText, onConfirm });
+  };
+
+  const closeConfirmModal = () => {
+    setConfirmModal((prev) => ({ ...prev, isOpen: false }));
+  };
+
+  const handleDelete = (tag) => {
+    openConfirmModal({
+      title: t("confirm_delete_title", { defaultValue: "Confirm Deletion" }),
+      message: t("Delete tag {{name}}?", { name: tag.name }),
+      confirmText: t("delete", { defaultValue: "Delete" }),
+      cancelText: t("cancel", { defaultValue: "Cancel" }),
+      onConfirm: async () => {
+        try {
+          await deleteTag(tag.id);
+          setTags((prev) => prev.filter((t) => t.id !== tag.id));
+        } catch (err) {
+          console.error("Failed to delete tag", err);
+        }
+      },
+    });
   };
 
   return (
@@ -103,14 +130,31 @@ export default function AdminTagsPage() {
                 <button onClick={() => handleEdit(tag)} title="Edit">
                   <FaEdit />
                 </button>
-                <button onClick={() => handleDelete(tag.id)} title="Delete">
+                <button onClick={() => handleDelete(tag)} title="Delete">
                   <FaTrash />
                 </button>
               </div>
             </div>
           ))}
         </div>
+        <ConfirmModal
+          isOpen={confirmModal.isOpen}
+          title={confirmModal.title}
+          message={confirmModal.message}
+          confirmText={confirmModal.confirmText}
+          cancelText={confirmModal.cancelText}
+          onClose={closeConfirmModal}
+          onConfirm={confirmModal.onConfirm}
+        />
       </div>
     </AdminLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- translate all ConfirmModal text so custom messages and buttons honor i18n
- replace `confirm()` in admin community tags page with configurable ConfirmModal
- load dashboard translations for tags page

## Testing
- `npm test` *(fails: CommunityPages.test.js: TypeError: formData.get is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a201df7bd88328bc760c1dcd7fe01e