### PR TITLE
Use contributor id as key for admin contributors

### DIFF
--- a/frontend/src/pages/dashboard/admin/community/contributors/index.js
+++ b/frontend/src/pages/dashboard/admin/community/contributors/index.js
@@ -65,8 +65,8 @@ export default function AdminContributorsPage() {
         {/* Contributor List */}
         <div className="space-y-4">
           {filtered.length > 0 ? (
-            filtered.map((user, index) => (
-              <div key={index} className="bg-white p-4 rounded shadow-sm flex items-center gap-4">
+            filtered.map((user) => (
+              <div key={user.id} className="bg-white p-4 rounded shadow-sm flex items-center gap-4">
                 <img
                   src={user.avatar || "/images/default-avatar.png"}
                   className="w-12 h-12 rounded-full border"


### PR DESCRIPTION
## Summary
- use contributor.id as key in admin contributors page instead of index

## Testing
- `npm test` (fails: TypeError in CommunityPages.test.js)
- `npm run lint` (fails: component display name errors)


------
https://chatgpt.com/codex/tasks/task_e_68a201d63b3c832882666f5763607a50