### PR TITLE
feat: track community contributor stats

### DIFF
--- a/backend/src/jobs/contributorStatsJob.js
+++ b/backend/src/jobs/contributorStatsJob.js
@@ -1,0 +1,44 @@
+const db = require("../config/database");
+
+function startContributorStatsJob() {
+  const DAY = 24 * 60 * 60 * 1000;
+  setInterval(async () => {
+    try {
+      const discussionCounts = await db('community_discussions')
+        .select('user_id')
+        .count({ cnt: '*' })
+        .groupBy('user_id');
+      const replyCounts = await db('community_replies')
+        .select('user_id')
+        .count({ cnt: '*' })
+        .groupBy('user_id');
+      const voteScores = await db('community_discussions as d')
+        .leftJoin('community_votes as v', 'd.id', 'v.discussion_id')
+        .select('d.user_id')
+        .sum({ score: 'v.vote' })
+        .groupBy('d.user_id');
+      const stats = {};
+      discussionCounts.forEach(r => {
+        stats[r.user_id] = { count: parseInt(r.cnt, 10) || 0, score: 0 };
+      });
+      replyCounts.forEach(r => {
+        stats[r.user_id] = stats[r.user_id] || { count: 0, score: 0 };
+        stats[r.user_id].count += parseInt(r.cnt, 10) || 0;
+      });
+      voteScores.forEach(r => {
+        stats[r.user_id] = stats[r.user_id] || { count: 0, score: 0 };
+        stats[r.user_id].score = parseInt(r.score, 10) || 0;
+      });
+      for (const [userId, data] of Object.entries(stats)) {
+        await db('community_contributors')
+          .insert({ user_id: userId, discussions_count: data.count, score: data.score })
+          .onConflict('user_id')
+          .merge({ discussions_count: data.count, score: data.score });
+      }
+    } catch (err) {
+      console.error('Error reconciling contributor stats:', err.message);
+    }
+  }, DAY);
+}
+
+module.exports = startContributorStatsJob;

--- a/backend/src/modules/community/contributorStats.util.js
+++ b/backend/src/modules/community/contributorStats.util.js
@@ -1,0 +1,24 @@
+const db = require("../../config/database");
+
+async function updateContributorStats(userId, scoreDelta = 0, countDelta = 0) {
+  if (!userId) return;
+  const updates = {};
+  if (countDelta !== 0) {
+    updates.discussions_count = db.raw("community_contributors.discussions_count + ?", [countDelta]);
+  }
+  if (scoreDelta !== 0) {
+    updates.score = db.raw("community_contributors.score + ?", [scoreDelta]);
+  }
+  if (!Object.keys(updates).length) return;
+  await db("community_contributors")
+    .insert({
+      user_id: userId,
+      discussions_count: Math.max(countDelta, 0),
+      score: scoreDelta,
+    })
+    .onConflict("user_id")
+    .merge(updates);
+}
+
+module.exports = { updateContributorStats };
+

--- a/backend/src/modules/community/public/__tests__/public.service.test.js
+++ b/backend/src/modules/community/public/__tests__/public.service.test.js
@@ -53,6 +53,7 @@ jest.mock('../../../../config/database', () => {
   return mockDb;
 });
 
+jest.mock('../../contributorStats.util', () => ({ updateContributorStats: jest.fn(), }));
 jest.mock('../../../notifications/notifications.service', () => ({
   createNotification: jest.fn(),
 }));

--- a/backend/src/modules/community/public/public.service.js
+++ b/backend/src/modules/community/public/public.service.js
@@ -1,4 +1,5 @@
 const db = require("../../../config/database");
+const { updateContributorStats } = require("../contributorStats.util");
 
 exports.getDiscussionTags = async (ids) => {
   const rows = await db("community_discussion_tags as m")
@@ -224,6 +225,7 @@ exports.createDiscussion = async (data) => {
   await exports.syncDiscussionTags(row.id, data.tags);
   const disc = { ...row, user_name: data.user_name, tags: data.tags };
   await notifyAllUsers(disc);
+  await updateContributorStats(data.user_id, 0, 1);
   return disc;
 };
 
@@ -315,6 +317,8 @@ exports.createReply = async (data) => {
     }
   }
 
+  await updateContributorStats(data.user_id, 0, 1);
+
   return {
     ...row,
     user_name: user?.full_name,
@@ -358,11 +362,20 @@ exports.getLikeCount = async (discussionId) => {
 
 // Votes
 exports.voteDiscussion = async (userId, discussionId, vote) => {
+  const existing = await db('community_votes')
+    .where({ user_id: userId, discussion_id: discussionId })
+    .first('vote');
   await db('community_votes')
     .insert({ id: uuidv4(), user_id: userId, discussion_id: discussionId, vote })
     .onConflict(['user_id', 'discussion_id']).merge({ vote });
   const [row] = await db('community_votes').where({ discussion_id: discussionId }).sum({ score: 'vote' });
-  return parseInt(row.score, 10) || 0;
+  const total = parseInt(row.score, 10) || 0;
+  const delta = vote - (existing ? existing.vote : 0);
+  if (delta !== 0) {
+    const disc = await db('community_discussions').where({ id: discussionId }).first('user_id');
+    if (disc) await updateContributorStats(disc.user_id, delta, 0);
+  }
+  return total;
 };
 
 exports.getVoteScore = async (discussionId) => {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -18,6 +18,7 @@ const { startLessonLiveJob } = require("./jobs/lessonLiveJob");
 const startCartReminderJob = require("./jobs/cartReminderJob");
 const startClassReminderJob = require("./jobs/classReminderJob");
 const startCleanupJob = require("./jobs/cleanupJob");
+const startContributorStatsJob = require("./jobs/contributorStatsJob");
 const { createLessonRoomLink } = require("./utils/roomLink");
 require("dotenv").config();
 
@@ -435,6 +436,7 @@ async function startServer() {
     startClassReminderJob();
     startCartReminderJob();
     startCleanupJob();
+    startContributorStatsJob();
   } catch (err) {
     console.error("❌ Failed to start server:", err.message);
     process.exit(1);


### PR DESCRIPTION
## Summary
- add utility to maintain contributor score and count
- update discussions, replies, and votes to adjust contributor stats
- schedule nightly job to reconcile contributor counts

## Testing
- `npm test` *(fails: adsRoutes.test.js, tutorialRoutes.test.js, class.routes.test.js, tutorialUpdateTransaction.test.js, paymentCommission.test.js, paymentInstallments.test.js, public.routes.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a201d4c38c8328969530a2862ab241