### PR TITLE
refactor: clean up temporary download links

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -81,12 +81,14 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
     ]);
     const csvContent = [headers, ...rows].map(e => e.join(",")).join("\n");
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.setAttribute("download", "online_classes.csv");
     document.body.appendChild(link);
     link.click();
-    document.body.removeChild(link);
+    link.remove();
+    URL.revokeObjectURL(url);
     toast.success("Classes exported");
   };
 

--- a/frontend/src/components/video-call/RecordingManager.js
+++ b/frontend/src/components/video-call/RecordingManager.js
@@ -52,7 +52,9 @@ const useRecordingManager = () => {
     const a = document.createElement("a");
     a.href = url;
     a.download = `recording_${Date.now()}.webm`;
+    document.body.appendChild(a);
     a.click();
+    a.remove();
     URL.revokeObjectURL(url);
   };
 

--- a/frontend/src/pages/ai-tutoring/transcript.js
+++ b/frontend/src/pages/ai-tutoring/transcript.js
@@ -38,10 +38,14 @@ export default function AITranscriptPage() {
       data.history.map(item => `- [${item.date}] ${item.type}: ${item.detail}`).join("\n");
 
     const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "AI_Transcript.txt";
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   return (

--- a/frontend/src/pages/dashboard/admin/community/contributors/index.js
+++ b/frontend/src/pages/dashboard/admin/community/contributors/index.js
@@ -31,7 +31,10 @@ export default function AdminContributorsPage() {
     const a = document.createElement("a");
     a.href = url;
     a.download = "contributors.csv";
+    document.body.appendChild(a);
     a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
   };
 
   return (

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -223,10 +223,14 @@ export default function AdminGroupDetailsPage() {
     const rows = sortedMembers.map((m) => [m.name, m.role]);
     const csv = [header, ...rows].map(r => r.join(',')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.download = 'members.csv';
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   if (notFound) {

--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -149,9 +149,12 @@ export default function AdminGroupsIndex() {
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
-    link.setAttribute('href', url);
-    link.setAttribute('download', 'groups.csv');
+    link.href = url;
+    link.download = 'groups.csv';
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   const toggleSelect = (id) => {

--- a/frontend/src/pages/dashboard/instructor/payments/classes.js
+++ b/frontend/src/pages/dashboard/instructor/payments/classes.js
@@ -42,10 +42,14 @@ export default function InstructorClassEarningsPage() {
     ]);
     const csv = [headers, ...rows].map((row) => row.join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "class_earnings.csv";
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   const downloadPDF = () => {

--- a/frontend/src/pages/dashboard/instructor/payments/commissions.js
+++ b/frontend/src/pages/dashboard/instructor/payments/commissions.js
@@ -29,10 +29,14 @@ export default function InstructorCommissionPage() {
     const rows = mockSummary.breakdown.map((item) => [item.title, item.amount, item.commission]);
     const csv = [headers, ...rows].map((row) => row.join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "class_commission_breakdown.csv";
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   return (

--- a/frontend/src/pages/dashboard/instructor/payments/history.js
+++ b/frontend/src/pages/dashboard/instructor/payments/history.js
@@ -34,10 +34,14 @@ export default function InstructorPaymentsHistoryPage() {
     ]);
     const csv = [headers, ...rows].map((row) => row.join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "payment_history.csv";
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   return (

--- a/frontend/src/pages/dashboard/instructor/payments/index.js
+++ b/frontend/src/pages/dashboard/instructor/payments/index.js
@@ -38,10 +38,14 @@ export default function InstructorPaymentsPage() {
     const rows = filteredPayments.map(({ title, amount, date, status, method }) => [title, amount, date, status, method]);
     const csv = [headers, ...rows].map(row => row.join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "payments.csv";
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   return (

--- a/frontend/src/pages/dashboard/instructor/payments/tutorials.js
+++ b/frontend/src/pages/dashboard/instructor/payments/tutorials.js
@@ -41,10 +41,14 @@ export default function InstructorTutorialEarningsPage() {
     ]);
     const csv = [headers, ...rows].map((row) => row.join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "tutorial_earnings.csv";
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   const downloadPDF = () => {

--- a/frontend/src/pages/dashboard/instructor/payments/withdrawals.js
+++ b/frontend/src/pages/dashboard/instructor/payments/withdrawals.js
@@ -23,10 +23,14 @@ export default function InstructorWithdrawalsPage() {
     const rows = withdrawals.map(({ amount, method, date, status }) => [amount, method, date, status]);
     const csv = [headers, ...rows].map(row => row.join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "withdrawals.csv";
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   return (

--- a/frontend/src/pages/dashboard/instructor/students.js
+++ b/frontend/src/pages/dashboard/instructor/students.js
@@ -96,7 +96,9 @@ export default function InstructorStudentsPage() {
     const a = document.createElement("a");
     a.href = url;
     a.download = `${student.name.replace(/\s+/g, '_')}_report.txt`;
+    document.body.appendChild(a);
     a.click();
+    a.remove();
     URL.revokeObjectURL(url);
   };
 

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -125,7 +125,9 @@ export default function ViewTutorialPage() {
               const a = document.createElement("a");
               a.href = dataStr;
               a.download = `${tutorial.slug || tutorial.id}.json`;
+              document.body.appendChild(a);
               a.click();
+              a.remove();
             }}
             className="bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-2 rounded-md font-semibold flex items-center gap-2"
           >

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -419,7 +419,9 @@ export default function InstructorTutorialsPage() {
                       const a = document.createElement("a");
                       a.href = dataStr;
                       a.download = `${tutorial.slug || tutorial.id}.json`;
+                      document.body.appendChild(a);
                       a.click();
+                      a.remove();
                     }}
                     className="bg-gray-100 hover:bg-gray-200 text-gray-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
                   >

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -284,7 +284,9 @@ export default function CheckoutPage() {
     const link = document.createElement('a');
     link.href = url;
     link.download = `invoice-${invoiceNumber}.html`;
+    document.body.appendChild(link);
     link.click();
+    link.remove();
     URL.revokeObjectURL(url);
   };
 

--- a/frontend/src/pages/payments/index.js
+++ b/frontend/src/pages/payments/index.js
@@ -63,10 +63,14 @@ export default function PaymentsPage() {
       .join("\n");
 
     const blob = new Blob([csvContent], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "payments.csv";
+    document.body.appendChild(link);
     link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   };
 
   return (


### PR DESCRIPTION
## Summary
- revoke blob URLs after download and remove temporary anchors across downloads
- tidy download logic in payment exports and admin tools

## Testing
- `npm test` *(fails: TypeError: formData.get is not a function)*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68a201d414f08328b05b42288d201159