### PR TITLE
Use contributor ID for stable admin listings

### DIFF
--- a/backend/src/modules/community/admin/contributors.service.js
+++ b/backend/src/modules/community/admin/contributors.service.js
@@ -4,6 +4,7 @@ exports.getTopContributors = async (limit = 20) => {
   return db("community_contributors")
     .join("users", "community_contributors.user_id", "users.id")
     .select(
+      "community_contributors.user_id as id",
       "users.full_name as name",
       "users.avatar_url as avatar",
       "community_contributors.discussions_count as contributions",

--- a/backend/tests/adminCommunityRoutes.test.js
+++ b/backend/tests/adminCommunityRoutes.test.js
@@ -98,7 +98,7 @@ describe('GET /api/community/admin/stats', () => {
 
 describe('GET /api/community/admin/contributors', () => {
   it('returns contributors', async () => {
-    const mock = [{ name: 'Jane' }];
+    const mock = [{ id: '1', name: 'Jane' }];
     contributorsService.getTopContributors.mockResolvedValue(mock);
 
     const res = await request(app).get('/api/community/admin/contributors');

--- a/frontend/src/pages/dashboard/admin/community/contributors/index.js
+++ b/frontend/src/pages/dashboard/admin/community/contributors/index.js
@@ -65,8 +65,8 @@ export default function AdminContributorsPage() {
         {/* Contributor List */}
         <div className="space-y-4">
           {filtered.length > 0 ? (
-            filtered.map((user, index) => (
-              <div key={index} className="bg-white p-4 rounded shadow-sm flex items-center gap-4">
+            filtered.map((user) => (
+              <div key={user.id} className="bg-white p-4 rounded shadow-sm flex items-center gap-4">
                 <img
                   src={user.avatar || "/images/default-avatar.png"}
                   className="w-12 h-12 rounded-full border"


### PR DESCRIPTION
## Summary
- expose contributor IDs in admin contributor service
- use `user.id` as React key in `AdminContributorsPage`

## Testing
- `cd backend && npm test` *(fails: 7 failed, 69 passed)*
- `cd frontend && npm test` *(fails: 1 failed, 33 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a201d29eec832890a308613217eca5