### PR TITLE
Validate contributors limit parameter

### DIFF
--- a/backend/src/modules/community/admin/contributors.controller.js
+++ b/backend/src/modules/community/admin/contributors.controller.js
@@ -1,9 +1,20 @@
 const catchAsync = require("../../../utils/catchAsync");
+const AppError = require("../../../utils/AppError");
 const { sendSuccess } = require("../../../utils/response");
 const service = require("./contributors.service");
 
 exports.listContributors = catchAsync(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 20;
+  let { limit } = req.query;
+  if (limit === undefined) {
+    limit = 20;
+  } else {
+    limit = Number(limit);
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new AppError("Invalid limit", 400);
+    }
+    limit = Math.min(limit, 100);
+  }
+
   const contributors = await service.getTopContributors(limit);
   sendSuccess(res, contributors);
 });

--- a/backend/tests/adminCommunityRoutes.test.js
+++ b/backend/tests/adminCommunityRoutes.test.js
@@ -106,6 +106,24 @@ describe('GET /api/community/admin/contributors', () => {
     expect(res.body.data).toEqual(mock);
     expect(contributorsService.getTopContributors).toHaveBeenCalled();
   });
+
+  it('caps limit to 100', async () => {
+    contributorsService.getTopContributors.mockClear();
+    const mock = [{ name: 'Jane' }];
+    contributorsService.getTopContributors.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/community/admin/contributors?limit=500');
+    expect(res.status).toBe(200);
+    expect(contributorsService.getTopContributors).toHaveBeenCalledWith(100);
+  });
+
+  it('returns 400 for invalid limit', async () => {
+    contributorsService.getTopContributors.mockClear();
+
+    const res = await request(app).get('/api/community/admin/contributors?limit=-5');
+    expect(res.status).toBe(400);
+    expect(contributorsService.getTopContributors).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /api/community/admin/settings', () => {


### PR DESCRIPTION
## Summary
- enforce positive integer and cap at 100 for contributors limit
- return 400 error on invalid limit input
- add tests for limit validation and capping

## Testing
- `npm test` *(fails: 7 failed, 69 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a201d1857483288e16c3ee35318742