### PR TITLE
feat: add helper for consistent date formatting

### DIFF
--- a/frontend/src/pages/dashboard/admin/community/announcements/index.js
+++ b/frontend/src/pages/dashboard/admin/community/announcements/index.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaTrash } from "react-icons/fa";
+import { formatDateTime } from "@/utils/date";
 import {
   fetchAnnouncements,
   createAnnouncement,
@@ -18,7 +19,7 @@ export default function AdminAnnouncementsPage() {
         const formatted = (data || []).map((a) => ({
           id: a.id,
           message: a.message,
-          timestamp: new Date(a.created_at).toLocaleString(),
+          timestamp: formatDateTime(a.created_at),
         }));
         setAnnouncements(formatted);
       } catch (err) {
@@ -36,7 +37,7 @@ export default function AdminAnnouncementsPage() {
       const newEntry = {
         id: created.id,
         message: created.message,
-        timestamp: new Date(created.created_at).toLocaleString(),
+        timestamp: formatDateTime(created.created_at),
       };
       setAnnouncements((prev) => [newEntry, ...prev]);
       setNewMessage("");

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -1,4 +1,5 @@
 // utils/date.js
+import { format } from 'date-fns';
 
 export function toDateInput(value) {
   if (!value) return '';
@@ -11,4 +12,10 @@ export function toDateTimeISO(value) {
   if (!value) return '';
   const d = new Date(value);
   return Number.isNaN(d.getTime()) ? value : d.toISOString();
+}
+
+export function formatDateTime(value) {
+  if (!value) return '';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : format(d, 'yyyy-MM-dd HH:mm');
 }


### PR DESCRIPTION
## Summary
- add `formatDateTime` using `date-fns` for `yyyy-MM-dd HH:mm` output
- format announcement timestamps using shared helper

## Testing
- `npm test` *(fails: Community pages — TypeError: formData.get is not a function)*
- `npm run lint` *(fails: 92 errors, 268 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a203f5b4a08328bdc19f2ecddf783a