### PR TITLE
feat: add toasts for admin announcements

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -566,6 +566,15 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "communityAnnouncementsPage": {
+    "announcements_loaded": "Announcements loaded",
+    "loading_failed": "Failed to load announcements",
+    "announcement_saved": "Announcement posted",
+    "save_failed": "Failed to post announcement",
+    "announcement_deleted": "Announcement deleted",
+    "delete_failed": "Failed to delete announcement",
+    "confirm_delete": "Delete this announcement?"
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -542,6 +542,15 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "communityAnnouncementsPage": {
+    "announcements_loaded": "Announcements loaded",
+    "loading_failed": "Failed to load announcements",
+    "announcement_saved": "Announcement posted",
+    "save_failed": "Failed to post announcement",
+    "announcement_deleted": "Announcement deleted",
+    "delete_failed": "Failed to delete announcement",
+    "confirm_delete": "Delete this announcement?"
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -579,6 +579,15 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "communityAnnouncementsPage": {
+    "announcements_loaded": "Announcements loaded",
+    "loading_failed": "Failed to load announcements",
+    "announcement_saved": "Announcement posted",
+    "save_failed": "Failed to post announcement",
+    "announcement_deleted": "Announcement deleted",
+    "delete_failed": "Failed to delete announcement",
+    "confirm_delete": "Delete this announcement?"
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -542,6 +542,15 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "communityAnnouncementsPage": {
+    "announcements_loaded": "Announcements loaded",
+    "loading_failed": "Failed to load announcements",
+    "announcement_saved": "Announcement posted",
+    "save_failed": "Failed to post announcement",
+    "announcement_deleted": "Announcement deleted",
+    "delete_failed": "Failed to delete announcement",
+    "confirm_delete": "Delete this announcement?"
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -554,6 +554,15 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "communityAnnouncementsPage": {
+    "announcements_loaded": "Announcements loaded",
+    "loading_failed": "Failed to load announcements",
+    "announcement_saved": "Announcement posted",
+    "save_failed": "Failed to post announcement",
+    "announcement_deleted": "Announcement deleted",
+    "delete_failed": "Failed to delete announcement",
+    "confirm_delete": "Delete this announcement?"
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -579,6 +579,15 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "communityAnnouncementsPage": {
+    "announcements_loaded": "Announcements loaded",
+    "loading_failed": "Failed to load announcements",
+    "announcement_saved": "Announcement posted",
+    "save_failed": "Failed to post announcement",
+    "announcement_deleted": "Announcement deleted",
+    "delete_failed": "Failed to delete announcement",
+    "confirm_delete": "Delete this announcement?"
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -579,6 +579,15 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "communityAnnouncementsPage": {
+    "announcements_loaded": "Announcements loaded",
+    "loading_failed": "Failed to load announcements",
+    "announcement_saved": "Announcement posted",
+    "save_failed": "Failed to post announcement",
+    "announcement_deleted": "Announcement deleted",
+    "delete_failed": "Failed to delete announcement",
+    "confirm_delete": "Delete this announcement?"
+  },
   "instructorDashboardPage": {
     "title": "Instructor Dashboard",
     "total_tutorials": "Total Tutorials",

--- a/frontend/src/pages/dashboard/admin/community/announcements/index.js
+++ b/frontend/src/pages/dashboard/admin/community/announcements/index.js
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaTrash } from "react-icons/fa";
+import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
 import {
   fetchAnnouncements,
   createAnnouncement,
@@ -10,6 +12,7 @@ import {
 export default function AdminAnnouncementsPage() {
   const [announcements, setAnnouncements] = useState([]);
   const [newMessage, setNewMessage] = useState("");
+  const { t } = useTranslation("dashboard");
 
   useEffect(() => {
     const load = async () => {
@@ -21,12 +24,14 @@ export default function AdminAnnouncementsPage() {
           timestamp: new Date(a.created_at).toLocaleString(),
         }));
         setAnnouncements(formatted);
+        toast.success(t("communityAnnouncementsPage.announcements_loaded"));
       } catch (err) {
         console.error("Failed to load announcements", err);
+        toast.error(t("communityAnnouncementsPage.loading_failed"));
       }
     };
     load();
-  }, []);
+  }, [t]);
 
   const handlePost = async () => {
     if (!newMessage.trim()) return;
@@ -40,19 +45,25 @@ export default function AdminAnnouncementsPage() {
       };
       setAnnouncements((prev) => [newEntry, ...prev]);
       setNewMessage("");
+      toast.success(t("communityAnnouncementsPage.announcement_saved"));
     } catch (err) {
       console.error("Failed to post announcement", err);
+      toast.error(t("communityAnnouncementsPage.save_failed"));
     }
   };
 
   const handleDelete = async (id) => {
-    const confirmDelete = confirm("Delete this announcement?");
+    const confirmDelete = confirm(
+      t("communityAnnouncementsPage.confirm_delete")
+    );
     if (!confirmDelete) return;
     try {
       await deleteAnnouncement(id);
       setAnnouncements((prev) => prev.filter((a) => a.id !== id));
+      toast.success(t("communityAnnouncementsPage.announcement_deleted"));
     } catch (err) {
       console.error("Failed to delete announcement", err);
+      toast.error(t("communityAnnouncementsPage.delete_failed"));
     }
   };
 


### PR DESCRIPTION
## Summary
- show toast notifications for community announcement load, post, and delete actions
- localize announcement messages across supported languages

## Testing
- `npm test` *(fails: CommunityPages.test.js submitting a question triggers API call: TypeError formData.get is not a function)*
- `npm run lint` *(fails: 92 errors, 268 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a203f50d3483288efc7b0ffbf91edf