### PR TITLE
Add scheduling fields to admin announcements

### DIFF
--- a/frontend/src/pages/dashboard/admin/community/announcements/index.js
+++ b/frontend/src/pages/dashboard/admin/community/announcements/index.js
@@ -10,6 +10,10 @@ import {
 export default function AdminAnnouncementsPage() {
   const [announcements, setAnnouncements] = useState([]);
   const [newMessage, setNewMessage] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [audience, setAudience] = useState("all");
+  const [pinned, setPinned] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -19,6 +23,10 @@ export default function AdminAnnouncementsPage() {
           id: a.id,
           message: a.message,
           timestamp: new Date(a.created_at).toLocaleString(),
+          startDate: a.start_date ? new Date(a.start_date).toLocaleString() : null,
+          endDate: a.end_date ? new Date(a.end_date).toLocaleString() : null,
+          audience: a.audience,
+          pinned: a.pinned,
         }));
         setAnnouncements(formatted);
       } catch (err) {
@@ -30,16 +38,37 @@ export default function AdminAnnouncementsPage() {
 
   const handlePost = async () => {
     if (!newMessage.trim()) return;
+
+    if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
+      alert("Start date must be before end date");
+      return;
+    }
+
     try {
-      const payload = { title: newMessage.trim(), message: newMessage.trim() };
+      const payload = {
+        title: newMessage.trim(),
+        message: newMessage.trim(),
+        start_date: startDate || null,
+        end_date: endDate || null,
+        audience,
+        pinned,
+      };
       const created = await createAnnouncement(payload);
       const newEntry = {
         id: created.id,
         message: created.message,
         timestamp: new Date(created.created_at).toLocaleString(),
+        startDate: created.start_date ? new Date(created.start_date).toLocaleString() : null,
+        endDate: created.end_date ? new Date(created.end_date).toLocaleString() : null,
+        audience: created.audience,
+        pinned: created.pinned,
       };
       setAnnouncements((prev) => [newEntry, ...prev]);
       setNewMessage("");
+      setStartDate("");
+      setEndDate("");
+      setAudience("all");
+      setPinned(false);
     } catch (err) {
       console.error("Failed to post announcement", err);
     }
@@ -62,14 +91,47 @@ export default function AdminAnnouncementsPage() {
         <h1 className="text-3xl font-bold mb-6">Post Announcement</h1>
 
         {/* New Announcement Form */}
-        <div className="mb-8">
+        <div className="mb-8 space-y-4">
           <textarea
             rows={3}
             value={newMessage}
             onChange={(e) => setNewMessage(e.target.value)}
             placeholder="Write something important to broadcast to all users..."
-            className="w-full border border-gray-300 rounded px-4 py-2 mb-2 resize-none"
+            className="w-full border border-gray-300 rounded px-4 py-2 resize-none"
           />
+          <div className="flex flex-wrap gap-4">
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="border border-gray-300 rounded px-3 py-2"
+              placeholder="Start date"
+            />
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="border border-gray-300 rounded px-3 py-2"
+              placeholder="End date"
+            />
+            <select
+              value={audience}
+              onChange={(e) => setAudience(e.target.value)}
+              className="border border-gray-300 rounded px-3 py-2"
+            >
+              <option value="all">All Users</option>
+              <option value="student">Students</option>
+              <option value="instructor">Instructors</option>
+            </select>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={pinned}
+                onChange={(e) => setPinned(e.target.checked)}
+              />
+              <span>Pinned</span>
+            </label>
+          </div>
           <button
             onClick={handlePost}
             className="bg-yellow-500 hover:bg-yellow-600 text-white px-6 py-2 rounded font-semibold"
@@ -87,7 +149,18 @@ export default function AdminAnnouncementsPage() {
                 className="bg-white border-l-4 border-yellow-500 p-4 rounded shadow-sm relative"
               >
                 <p className="text-gray-800">{a.message}</p>
-                <p className="text-sm text-gray-400 mt-1">{a.timestamp}</p>
+                <div className="text-sm text-gray-400 mt-1 space-y-1">
+                  <p>{a.timestamp}</p>
+                  {(a.startDate || a.endDate) && (
+                    <p>
+                      Schedule: {a.startDate || "—"} - {a.endDate || "—"}
+                    </p>
+                  )}
+                  {a.audience && <p>Audience: {a.audience}</p>}
+                  {a.pinned && (
+                    <p className="text-yellow-600 font-semibold">Pinned</p>
+                  )}
+                </div>
                 <button
                   onClick={() => handleDelete(a.id)}
                   className="absolute top-3 right-3 text-red-500 hover:text-red-700"


### PR DESCRIPTION
## Summary
- add start/end date, audience, and pinned fields to admin announcement form
- validate dates before submission and include new fields in create payload
- show schedule, audience, and pinned status in announcement list

## Testing
- `npm test` (fails: CommunityPages.test: formData.get is not a function)


------
https://chatgpt.com/codex/tasks/task_e_68a203f3d9d4832882fa7c178630328c