### PR TITLE
Use popup_announcements table for community admin

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -267,8 +267,8 @@
 - **Primary Key**: `id`
 - **Foreign Keys**: `user_id, discussion_id?, reply_id?`
 
-### `community_announcements`
-- **Purpose**: Admin posts shown to the community
+### `popup_announcements`
+- **Purpose**: Admin posts shown to the community in popup form
 - **Primary Key**: `id`
 - **Foreign Keys**: `author_id`
 

--- a/backend/src/migrations/20250723000000_create_popup_announcements_table.js
+++ b/backend/src/migrations/20250723000000_create_popup_announcements_table.js
@@ -4,7 +4,7 @@ exports.up = function(knex) {
     table.string('title').notNullable();
     table.text('message').notNullable();
     table.string('audience').notNullable().defaultTo('all');
-    table.jsonb('pages');
+    table.jsonb('pages').notNullable().defaultTo('[]');
     table.timestamp('start_date');
     table.timestamp('end_date');
     table.string('position').defaultTo('center');

--- a/backend/src/modules/community/admin/announcements.service.js
+++ b/backend/src/modules/community/admin/announcements.service.js
@@ -1,19 +1,19 @@
 const db = require("../../../config/database");
 
 exports.getAllAnnouncements = async () => {
-  return db("community_announcements").select("*").orderBy("created_at", "desc");
+  return db("popup_announcements").select("*").orderBy("created_at", "desc");
 };
 
 exports.createAnnouncement = async (data) => {
-  const [row] = await db("community_announcements").insert(data).returning("*");
+  const [row] = await db("popup_announcements").insert(data).returning("*");
   return row;
 };
 
 exports.updateAnnouncement = async (id, data) => {
-  const [row] = await db("community_announcements").where({ id }).update(data).returning("*");
+  const [row] = await db("popup_announcements").where({ id }).update(data).returning("*");
   return row;
 };
 
 exports.deleteAnnouncement = async (id) => {
-  return db("community_announcements").where({ id }).del();
+  return db("popup_announcements").where({ id }).del();
 };


### PR DESCRIPTION
## Summary
- Switch community announcements service to use `popup_announcements`
- Ensure popup announcements table migration sets non-null default pages array
- Update schema overview to reference popup announcements

## Testing
- `npm test` *(fails: POST /api/ads/admin creates ad; PUT /api/users/tutorials/admin/:id returns 403; Class routes create class; updateTutorial tag transactions; payment commission calculations; POST /api/payments/admin creates payment with installments; community public routes create discussion)*
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/eduSkillbridge node -e "const db=require('./src/config/database'); const m=require('./src/migrations/20250723000000_create_popup_announcements_table'); m.up(db).then(()=>db.destroy()).then(()=>console.log('done')).catch(err=>{console.error(err); db.destroy();});"`


------
https://chatgpt.com/codex/tasks/task_e_68a203f0902883288dc7ae8b4e21af74