### PR TITLE
feat: localize admin community dashboard

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -580,6 +580,38 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "adminCommunityDashboardPage": {
+    "title": "لوحة تحكم المجتمع",
+    "description": "قم بإدارة النقاشات، إدارة المساهمين، وتكوين ميزات على مستوى المجتمع.",
+    "error": "فشل تحميل إحصائيات لوحة التحكم.",
+    "retry": "إعادة المحاولة",
+    "loading": "جارٍ التحميل...",
+    "stats": {
+      "discussions": "المناقشات",
+      "pendingReports": "التقارير المعلقة",
+      "contributors": "المساهمون",
+      "repliesThisWeek": "الردود هذا الأسبوع"
+    },
+    "manageSections": "إدارة أقسام المجتمع",
+    "nav": {
+      "manageDiscussions": "إدارة المناقشات",
+      "reportedPosts": "المنشورات المبلغ عنها",
+      "manageTags": "إدارة الوسوم",
+      "topContributors": "أفضل المساهمين",
+      "postAnnouncement": "نشر إعلان",
+      "settings": "إعدادات المجتمع"
+    },
+    "topContributor": {
+      "title": "🏆 أفضل مساهم",
+      "meta": "{{contributions}} مساهمة • {{reputation}} سمعة"
+    },
+    "activity": {
+      "title": "📈 نشاط المجتمع (آخر 5 أيام)",
+      "discussions": "المناقشات",
+      "reports": "التقارير",
+      "replies": "الردود"
+    }
+  },
   "communityAnnouncementsPage": {
     "announcements_loaded": "Announcements loaded",
     "loading_failed": "Failed to load announcements",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -556,6 +556,38 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "adminCommunityDashboardPage": {
+    "title": "Community-Dashboard",
+    "description": "Moderieren Sie Diskussionen, verwalten Sie Mitwirkende und konfigurieren Sie communityweite Funktionen.",
+    "error": "Dashboard-Statistiken konnten nicht geladen werden.",
+    "retry": "Erneut versuchen",
+    "loading": "Lädt...",
+    "stats": {
+      "discussions": "Diskussionen",
+      "pendingReports": "Ausstehende Meldungen",
+      "contributors": "Mitwirkende",
+      "repliesThisWeek": "Antworten dieser Woche"
+    },
+    "manageSections": "Community-Bereiche verwalten",
+    "nav": {
+      "manageDiscussions": "Diskussionen verwalten",
+      "reportedPosts": "Gemeldete Beiträge",
+      "manageTags": "Tags verwalten",
+      "topContributors": "Top-Mitwirkende",
+      "postAnnouncement": "Ankündigung posten",
+      "settings": "Community-Einstellungen"
+    },
+    "topContributor": {
+      "title": "🏆 Top-Mitwirkender",
+      "meta": "{{contributions}} Beiträge • {{reputation}} Reputation"
+    },
+    "activity": {
+      "title": "📈 Community-Aktivität (letzte 5 Tage)",
+      "discussions": "Diskussionen",
+      "reports": "Meldungen",
+      "replies": "Antworten"
+    }
+  },
   "communityAnnouncementsPage": {
     "announcements_loaded": "Announcements loaded",
     "loading_failed": "Failed to load announcements",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -593,6 +593,38 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "adminCommunityDashboardPage": {
+    "title": "Community Dashboard",
+    "description": "Moderate discussions, manage contributors, and configure community-wide features.",
+    "error": "Failed to load dashboard stats.",
+    "retry": "Retry",
+    "loading": "Loading...",
+    "stats": {
+      "discussions": "Discussions",
+      "pendingReports": "Pending Reports",
+      "contributors": "Contributors",
+      "repliesThisWeek": "Replies This Week"
+    },
+    "manageSections": "Manage Community Sections",
+    "nav": {
+      "manageDiscussions": "Manage Discussions",
+      "reportedPosts": "Reported Posts",
+      "manageTags": "Manage Tags",
+      "topContributors": "Top Contributors",
+      "postAnnouncement": "Post Announcement",
+      "settings": "Community Settings"
+    },
+    "topContributor": {
+      "title": "🏆 Top Contributor",
+      "meta": "{{contributions}} contributions • {{reputation}} reputation"
+    },
+    "activity": {
+      "title": "📈 Community Activity (Last 5 Days)",
+      "discussions": "Discussions",
+      "reports": "Reports",
+      "replies": "Replies"
+    }
+  },
   "communityAnnouncementsPage": {
     "announcements_loaded": "Announcements loaded",
     "loading_failed": "Failed to load announcements",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -556,6 +556,38 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "adminCommunityDashboardPage": {
+    "title": "Panel de la comunidad",
+    "description": "Modera debates, gestiona colaboradores y configura funciones para toda la comunidad.",
+    "error": "No se pudieron cargar las estadísticas del panel.",
+    "retry": "Reintentar",
+    "loading": "Cargando...",
+    "stats": {
+      "discussions": "Debates",
+      "pendingReports": "Reportes pendientes",
+      "contributors": "Colaboradores",
+      "repliesThisWeek": "Respuestas esta semana"
+    },
+    "manageSections": "Gestionar secciones de la comunidad",
+    "nav": {
+      "manageDiscussions": "Gestionar debates",
+      "reportedPosts": "Publicaciones reportadas",
+      "manageTags": "Gestionar etiquetas",
+      "topContributors": "Principales colaboradores",
+      "postAnnouncement": "Publicar anuncio",
+      "settings": "Configuración de la comunidad"
+    },
+    "topContributor": {
+      "title": "🏆 Principal colaborador",
+      "meta": "{{contributions}} contribuciones • {{reputation}} reputación"
+    },
+    "activity": {
+      "title": "📈 Actividad de la comunidad (últimos 5 días)",
+      "discussions": "Debates",
+      "reports": "Reportes",
+      "replies": "Respuestas"
+    }
+  },
   "communityAnnouncementsPage": {
     "announcements_loaded": "Announcements loaded",
     "loading_failed": "Failed to load announcements",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -568,6 +568,38 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "adminCommunityDashboardPage": {
+    "title": "Tableau de bord de la communauté",
+    "description": "Modérez les discussions, gérez les contributeurs et configurez les fonctionnalités à l'échelle de la communauté.",
+    "error": "Échec du chargement des statistiques du tableau de bord.",
+    "retry": "Réessayer",
+    "loading": "Chargement...",
+    "stats": {
+      "discussions": "Discussions",
+      "pendingReports": "Signalements en attente",
+      "contributors": "Contributeurs",
+      "repliesThisWeek": "Réponses cette semaine"
+    },
+    "manageSections": "Gérer les sections de la communauté",
+    "nav": {
+      "manageDiscussions": "Gérer les discussions",
+      "reportedPosts": "Publications signalées",
+      "manageTags": "Gérer les étiquettes",
+      "topContributors": "Meilleurs contributeurs",
+      "postAnnouncement": "Publier une annonce",
+      "settings": "Paramètres de la communauté"
+    },
+    "topContributor": {
+      "title": "🏆 Meilleur contributeur",
+      "meta": "{{contributions}} contributions • {{reputation}} réputation"
+    },
+    "activity": {
+      "title": "📈 Activité de la communauté (5 derniers jours)",
+      "discussions": "Discussions",
+      "reports": "Signalements",
+      "replies": "Réponses"
+    }
+  },
   "communityAnnouncementsPage": {
     "announcements_loaded": "Announcements loaded",
     "loading_failed": "Failed to load announcements",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -593,6 +593,38 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "adminCommunityDashboardPage": {
+    "title": "समुदाय डैशबोर्ड",
+    "description": "चर्चाओं का संयम करें, योगदानकर्ताओं को प्रबंधित करें और समुदाय-व्यापी सुविधाएँ कॉन्फ़िगर करें।",
+    "error": "डैशबोर्ड आँकड़े लोड करने में विफल।",
+    "retry": "पुनः प्रयास करें",
+    "loading": "लोड हो रहा है...",
+    "stats": {
+      "discussions": "चर्चाएँ",
+      "pendingReports": "लंबित रिपोर्टें",
+      "contributors": "योगदानकर्ता",
+      "repliesThisWeek": "इस सप्ताह की प्रतिक्रियाएँ"
+    },
+    "manageSections": "समुदाय सेक्शन प्रबंधित करें",
+    "nav": {
+      "manageDiscussions": "चर्चाएँ प्रबंधित करें",
+      "reportedPosts": "रिपोर्ट की गई पोस्ट",
+      "manageTags": "टैग प्रबंधित करें",
+      "topContributors": "शीर्ष योगदानकर्ता",
+      "postAnnouncement": "घोषणा पोस्ट करें",
+      "settings": "समुदाय सेटिंग्स"
+    },
+    "topContributor": {
+      "title": "🏆 शीर्ष योगदानकर्ता",
+      "meta": "{{contributions}} योगदान • {{reputation}} प्रतिष्ठा"
+    },
+    "activity": {
+      "title": "📈 समुदाय गतिविधि (पिछले 5 दिन)",
+      "discussions": "चर्चाएँ",
+      "reports": "रिपोर्टें",
+      "replies": "प्रतिक्रियाएँ"
+    }
+  },
   "communityAnnouncementsPage": {
     "announcements_loaded": "Announcements loaded",
     "loading_failed": "Failed to load announcements",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -593,6 +593,38 @@
     "loading_failed": "Failed to load announcements",
     "delete": "Delete"
   },
+  "adminCommunityDashboardPage": {
+    "title": "社区仪表板",
+    "description": "管理讨论、管理贡献者并配置社区范围的功能。",
+    "error": "无法加载仪表板统计数据。",
+    "retry": "重试",
+    "loading": "加载中...",
+    "stats": {
+      "discussions": "讨论",
+      "pendingReports": "待处理报告",
+      "contributors": "贡献者",
+      "repliesThisWeek": "本周回复"
+    },
+    "manageSections": "管理社区部分",
+    "nav": {
+      "manageDiscussions": "管理讨论",
+      "reportedPosts": "被举报的帖子",
+      "manageTags": "管理标签",
+      "topContributors": "最佳贡献者",
+      "postAnnouncement": "发布公告",
+      "settings": "社区设置"
+    },
+    "topContributor": {
+      "title": "🏆 顶级贡献者",
+      "meta": "{{contributions}} 次贡献 • {{reputation}} 声望"
+    },
+    "activity": {
+      "title": "📈 社区活动（最近 5 天）",
+      "discussions": "讨论",
+      "reports": "报告",
+      "replies": "回复"
+    }
+  },
   "communityAnnouncementsPage": {
     "announcements_loaded": "Announcements loaded",
     "loading_failed": "Failed to load announcements",

--- a/frontend/src/pages/dashboard/admin/community/index.js
+++ b/frontend/src/pages/dashboard/admin/community/index.js
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import Link from "next/link";
+import { useTranslation } from "next-i18next";
 import {
   FaCommentDots,
   FaExclamationTriangle,
@@ -57,6 +58,7 @@ const StatCard = ({ label, value, color }) => (
 );
 
 export default function AdminCommunityDashboard({ initialStats }) {
+  const { t } = useTranslation("dashboard");
   const [stats, setStats] = useState(initialStats ? {
     totalDiscussions: initialStats.totalDiscussions,
     pendingReports: initialStats.pendingReports,
@@ -82,9 +84,9 @@ export default function AdminCommunityDashboard({ initialStats }) {
       }
     } catch (err) {
       console.error("Dashboard fetch error:", err);
-      setError("Failed to load dashboard stats.");
+      setError(t("adminCommunityDashboardPage.error"));
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     if (!stats) {
@@ -94,14 +96,14 @@ export default function AdminCommunityDashboard({ initialStats }) {
 
   if (error) {
     return (
-      <AdminLayout title="Community Dashboard">
+      <AdminLayout title={t("adminCommunityDashboardPage.title")}>
         <div className="p-6">
           <p className="text-red-500 mb-4">{error}</p>
           <button
             onClick={load}
             className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
           >
-            Retry
+            {t("adminCommunityDashboardPage.retry")}
           </button>
         </div>
       </AdminLayout>
@@ -110,45 +112,45 @@ export default function AdminCommunityDashboard({ initialStats }) {
 
   if (!stats) {
     return (
-      <AdminLayout title="Community Dashboard">
-        <div className="p-6">Loading...</div>
+      <AdminLayout title={t("adminCommunityDashboardPage.title")}>
+        <div className="p-6">{t("adminCommunityDashboardPage.loading")}</div>
       </AdminLayout>
     );
   }
 
   return (
-    <AdminLayout title="Community Dashboard">
+    <AdminLayout title={t("adminCommunityDashboardPage.title")}>
       <div className="p-6 max-w-7xl mx-auto">
         {/* Page Title */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-800 mb-2">Community Dashboard</h1>
+          <h1 className="text-3xl font-bold text-gray-800 mb-2">{t("adminCommunityDashboardPage.title")}</h1>
           <p className="text-gray-500 text-sm">
-            Moderate discussions, manage contributors, and configure community-wide features.
+            {t("adminCommunityDashboardPage.description")}
           </p>
         </div>
 
         {/* Summary Stats */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-10">
-          <StatCard label="Discussions" value={stats.totalDiscussions} color="bg-yellow-500" />
-          <StatCard label="Pending Reports" value={stats.pendingReports} color="bg-red-500" />
-          <StatCard label="Contributors" value={stats.contributors} color="bg-blue-500" />
-          <StatCard label="Replies This Week" value={stats.repliesThisWeek} color="bg-green-500" />
+          <StatCard label={t("adminCommunityDashboardPage.stats.discussions")} value={stats.totalDiscussions} color="bg-yellow-500" />
+          <StatCard label={t("adminCommunityDashboardPage.stats.pendingReports")} value={stats.pendingReports} color="bg-red-500" />
+          <StatCard label={t("adminCommunityDashboardPage.stats.contributors")} value={stats.contributors} color="bg-blue-500" />
+          <StatCard label={t("adminCommunityDashboardPage.stats.repliesThisWeek")} value={stats.repliesThisWeek} color="bg-green-500" />
         </div>
 
         {/* Navigation Cards */}
-        <h2 className="text-xl font-bold text-gray-800 mb-4">Manage Community Sections</h2>
+        <h2 className="text-xl font-bold text-gray-800 mb-4">{t("adminCommunityDashboardPage.manageSections")}</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-          <NavCard href="/dashboard/admin/community/discussions" label="Manage Discussions" icon={<FaCommentDots />} />
-          <NavCard href="/dashboard/admin/community/reports" label="Reported Posts" icon={<FaExclamationTriangle />} />
-          <NavCard href="/dashboard/admin/community/tags" label="Manage Tags" icon={<FaCogs />} />
-          <NavCard href="/dashboard/admin/community/contributors" label="Top Contributors" icon={<FaUsers />} />
-          <NavCard href="/dashboard/admin/community/announcements" label="Post Announcement" icon={<FaBullhorn />} />
-          <NavCard href="/dashboard/admin/community/settings" label="Community Settings" icon={<FaCogs />} />
+          <NavCard href="/dashboard/admin/community/discussions" label={t("adminCommunityDashboardPage.nav.manageDiscussions")} icon={<FaCommentDots />} />
+          <NavCard href="/dashboard/admin/community/reports" label={t("adminCommunityDashboardPage.nav.reportedPosts")} icon={<FaExclamationTriangle />} />
+          <NavCard href="/dashboard/admin/community/tags" label={t("adminCommunityDashboardPage.nav.manageTags")} icon={<FaCogs />} />
+          <NavCard href="/dashboard/admin/community/contributors" label={t("adminCommunityDashboardPage.nav.topContributors")} icon={<FaUsers />} />
+          <NavCard href="/dashboard/admin/community/announcements" label={t("adminCommunityDashboardPage.nav.postAnnouncement")} icon={<FaBullhorn />} />
+          <NavCard href="/dashboard/admin/community/settings" label={t("adminCommunityDashboardPage.nav.settings")} icon={<FaCogs />} />
         </div>
 
         {/* Top Contributor */}
         <div className="bg-white p-6 rounded-lg shadow border border-gray-200 mb-10">
-          <h3 className="text-lg font-semibold mb-3">🏆 Top Contributor</h3>
+          <h3 className="text-lg font-semibold mb-3">{t("adminCommunityDashboardPage.topContributor.title")}</h3>
           <div className="flex items-center gap-4">
             <img
               src={stats.topContributor.avatar || "/images/default-avatar.png"}
@@ -158,7 +160,10 @@ export default function AdminCommunityDashboard({ initialStats }) {
             <div>
               <p className="font-bold text-gray-800">{stats.topContributor.name}</p>
               <p className="text-sm text-gray-500">
-                {stats.topContributor.contributions} contributions • {stats.topContributor.reputation} reputation
+                {t("adminCommunityDashboardPage.topContributor.meta", {
+                  contributions: stats.topContributor.contributions,
+                  reputation: stats.topContributor.reputation,
+                })}
               </p>
             </div>
           </div>
@@ -166,7 +171,7 @@ export default function AdminCommunityDashboard({ initialStats }) {
 
         {/* Activity Chart */}
         <div className="bg-white p-6 rounded-lg shadow border border-gray-200">
-          <h3 className="text-lg font-semibold mb-4">📈 Community Activity (Last 5 Days)</h3>
+          <h3 className="text-lg font-semibold mb-4">{t("adminCommunityDashboardPage.activity.title")}</h3>
           <ResponsiveContainer width="100%" height={300}>
             <LineChart data={activityData} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" />
@@ -174,9 +179,9 @@ export default function AdminCommunityDashboard({ initialStats }) {
               <YAxis />
               <Tooltip />
               <Legend />
-              <Line type="monotone" dataKey="discussions" stroke="#F59E0B" name="Discussions" />
-              <Line type="monotone" dataKey="reports" stroke="#EF4444" name="Reports" />
-              <Line type="monotone" dataKey="replies" stroke="#10B981" name="Replies" />
+              <Line type="monotone" dataKey="discussions" stroke="#F59E0B" name={t("adminCommunityDashboardPage.activity.discussions")} />
+              <Line type="monotone" dataKey="reports" stroke="#EF4444" name={t("adminCommunityDashboardPage.activity.reports")} />
+              <Line type="monotone" dataKey="replies" stroke="#10B981" name={t("adminCommunityDashboardPage.activity.replies")} />
             </LineChart>
           </ResponsiveContainer>
         </div>


### PR DESCRIPTION
## Summary
- internationalize admin community dashboard strings
- add Community dashboard translations across locales

## Testing
- `npm test` *(fails: TypeError: formData.get is not a function)*
- `npm run lint` *(fails: 92 errors, 268 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a20d4c0f48832887928a54876e200f