### PR TITLE
feat: debounce group search

### DIFF
--- a/frontend/src/hooks/useDebounce.js
+++ b/frontend/src/hooks/useDebounce.js
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+export default function useDebounce(value, delay = 300) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+

--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import useDebounce from '@/hooks/useDebounce';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import Link from 'next/link';
 import {
@@ -26,6 +27,7 @@ export default function AdminGroupsIndex() {
   const [allGroups, setAllGroups] = useState([]);
   const [groups, setGroups] = useState([]);
   const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 500);
   const [statusFilter, setStatusFilter] = useState('all');
   const [sortOption, setSortOption] = useState('newest');
   const [currentPage, setCurrentPage] = useState(1);
@@ -34,10 +36,10 @@ export default function AdminGroupsIndex() {
 
   useEffect(() => {
     groupService
-      .getAllGroups(search, statusFilter)
+      .getAllGroups(debouncedSearch, statusFilter)
       .then(setAllGroups)
       .catch(() => setAllGroups([]));
-  }, [search, statusFilter]);
+  }, [debouncedSearch, statusFilter]);
 
   useEffect(() => {
     let filtered = [...allGroups];
@@ -46,11 +48,11 @@ export default function AdminGroupsIndex() {
       filtered = filtered.filter((g) => g.status === statusFilter);
     }
 
-    if (search.trim()) {
+    if (debouncedSearch.trim()) {
       filtered = filtered.filter(
         (g) =>
-          g.name.toLowerCase().includes(search.toLowerCase()) ||
-          g.creator.toLowerCase().includes(search.toLowerCase())
+          g.name.toLowerCase().includes(debouncedSearch.toLowerCase()) ||
+          g.creator.toLowerCase().includes(debouncedSearch.toLowerCase())
       );
     }
 
@@ -66,7 +68,7 @@ export default function AdminGroupsIndex() {
     }
 
     setGroups(filtered);
-  }, [search, statusFilter, sortOption, allGroups]);
+  }, [debouncedSearch, statusFilter, sortOption, allGroups]);
 
   const toggleStatus = async (id, newStatus) => {
     try {


### PR DESCRIPTION
## Summary
- add reusable `useDebounce` hook
- debounce admin group search before fetching and filtering

## Testing
- `npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a211f28d948328b9c73fdf935195d4