### PR TITLE
Handle missing member names in group search

### DIFF
--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -91,7 +91,7 @@ export default function AdminGroupDetailsPage() {
   }, [router.isReady, id]);
 
   const filteredMembers = members.filter((m) =>
-    m.name.toLowerCase().includes(searchTerm.toLowerCase())
+    m.name?.toLowerCase().includes(searchTerm.toLowerCase())
   );
   const sortedMembers = [...filteredMembers].sort((a, b) => {
     if (sortKey === 'name') return a.name.localeCompare(b.name);


### PR DESCRIPTION
## Summary
- Safely handle undefined member names when filtering group members

## Testing
- `npm test` *(fails: Community pages › submitting a question triggers API call)*

------
https://chatgpt.com/codex/tasks/task_e_68a211f0e96c832888c2c7f37f2a8a1a