### PR TITLE
Handle invalid JSON in group tags

### DIFF
--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -3,13 +3,18 @@ import { API_BASE_URL } from "@/config/config";
 
 const formatGroup = (g) => {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-  const tags = g.tags
-    ? Array.isArray(g.tags)
-      ? g.tags
-      : typeof g.tags === "string"
-        ? JSON.parse(g.tags)
-        : []
-    : [];
+  let tags = [];
+  if (g.tags) {
+    if (Array.isArray(g.tags)) {
+      tags = g.tags;
+    } else if (typeof g.tags === "string") {
+      try {
+        tags = JSON.parse(g.tags);
+      } catch {
+        tags = [];
+      }
+    }
+  }
   return {
     ...g,
     cover_image: g.cover_image ? `${base}${g.cover_image}` : g.cover_image,


### PR DESCRIPTION
## Summary
- Safely parse group tag strings with `JSON.parse` in a try/catch
- Default to an empty tag array when parsing fails

## Testing
- `npm test` (fails: TypeError: formData.get is not a function)
- `npm run lint` (fails: 92 errors, 268 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a211f026ac832896adcdd6d69d86a4