### PR TITLE
Use AbortController for admin group data fetching

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@react-pdf/renderer": "^4.3.0",
         "@stripe/react-stripe-js": "^3.1.1",
         "@stripe/stripe-js": "^5.6.0",
+        "abort-controller": "^3.0.0",
         "axios": "^1.7.9",
         "bad-words": "^4.0.0",
         "chart.js": "^4.4.9",
@@ -3721,6 +3722,18 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
@@ -6641,6 +6654,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@react-pdf/renderer": "^4.3.0",
     "@stripe/react-stripe-js": "^3.1.1",
     "@stripe/stripe-js": "^5.6.0",
+    "abort-controller": "^3.0.0",
     "axios": "^1.7.9",
     "bad-words": "^4.0.0",
     "chart.js": "^4.4.9",

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -1,6 +1,7 @@
 // Enhanced Admin Group Details Page (Final Polished UI with All Tabs and Overview Enhancements)
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import AbortController from 'abort-controller';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import ConfirmModal from '@/components/common/ConfirmModal';
 import {
@@ -56,38 +57,47 @@ export default function AdminGroupDetailsPage() {
 
   useEffect(() => {
     if (!router.isReady || !id) return;
+    const controller = new AbortController();
+    let isMounted = true;
+
     const load = async () => {
       try {
-        const data = await groupService.getGroupById(id);
+        const [data, list, reqs] = await Promise.all([
+          groupService.getGroupById(id, { signal: controller.signal }),
+          groupService.getGroupMembers(id, { signal: controller.signal }).catch(() => []),
+          groupService
+            .getJoinRequestsForGroup(id, { signal: controller.signal })
+            .catch(() => []),
+        ]);
+        if (!isMounted) return;
         if (!data) {
           setNotFound(true);
           return;
         }
         setGroup(data);
-      } catch (err) {
-        if (err?.response?.status === 404) {
-          setNotFound(true);
-          return;
-        }
-        setNotFound(true);
-        return;
-      }
-      try {
-        const list = await groupService.getGroupMembers(id);
         setMembers(list);
-      } catch {
-        setMembers([]);
-      }
-      try {
-        const reqs = await groupService.getJoinRequestsForGroup(id);
         setRequests(reqs);
         setPendingCount(Array.isArray(reqs) ? reqs.length : 0);
-      } catch {
-        setRequests([]);
-        setPendingCount(0);
+      } catch (err) {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
+        if (err?.response?.status === 404) {
+          if (isMounted) setNotFound(true);
+        } else {
+          if (isMounted) {
+            setNotFound(true);
+            setMembers([]);
+            setRequests([]);
+            setPendingCount(0);
+          }
+        }
       }
     };
     load();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
   }, [router.isReady, id]);
 
   const filteredMembers = members.filter((m) =>

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -54,8 +54,8 @@ const groupService = {
     return Array.isArray(list) ? list.map(formatGroup) : list;
   },
 
-  getGroupById: async (id) => {
-    const { data } = await api.get(`/groups/${id}`);
+  getGroupById: async (id, opts = {}) => {
+    const { data } = await api.get(`/groups/${id}`, opts);
     return data?.data ? formatGroup(data.data) : null;
   },
 
@@ -79,8 +79,8 @@ const groupService = {
     return data?.data ? formatGroup(data.data) : null;
   },
 
-  getGroupMembers: async (groupId) => {
-    const { data } = await api.get(`/groups/${groupId}/members`);
+  getGroupMembers: async (groupId, opts = {}) => {
+    const { data } = await api.get(`/groups/${groupId}/members`, opts);
     const list = data?.data ?? [];
 
     const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
@@ -179,8 +179,8 @@ const groupService = {
     return data?.data ? formatGroup(data.data) : null;
   },
 
-  getJoinRequestsForGroup: async (groupId) => {
-    const { data } = await api.get(`/groups/${groupId}/requests`);
+  getJoinRequestsForGroup: async (groupId, opts = {}) => {
+    const { data } = await api.get(`/groups/${groupId}/requests`, opts);
     const list = data?.data ?? [];
     return Array.isArray(list)
       ? list.map((r) => ({


### PR DESCRIPTION
## Summary
- fetch group, members, and requests in parallel using an AbortController to cancel on unmount
- allow group service methods to accept AbortController signals
- add abort-controller dependency for request cancellation

## Testing
- `npm test` (fails: TypeError: formData.get is not a function)
- `npm run lint` (fails: component definition is missing display name)


------
https://chatgpt.com/codex/tasks/task_e_68a211ee3d448328bf3733b53d3ebf1f