### PR TITLE
Refine admin group management

### DIFF
--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -67,9 +67,9 @@ export default function AdminGroupDetailsPage() {
       } catch (err) {
         if (err?.response?.status === 404) {
           setNotFound(true);
-          return;
+        } else {
+          toast.error('Failed to load group');
         }
-        setNotFound(true);
         return;
       }
       try {
@@ -143,6 +143,7 @@ export default function AdminGroupDetailsPage() {
         try {
           await groupService.manageMember(group.id, mid, 'kick');
           setMembers((prev) => prev.filter((m) => m.id !== mid));
+          setSelectedMembers((prev) => prev.filter((id) => id !== mid));
           toast.success('Member removed');
         } catch (err) {
           toast.error('Failed to remove member');
@@ -155,7 +156,7 @@ export default function AdminGroupDetailsPage() {
     if (!group) return;
     openConfirmModal({
       title: 'Confirm Promotion',
-      message: 'Promote this member to Moderator?',
+      message: 'Promote this member to Admin?',
       onConfirm: async () => {
         try {
           await groupService.manageMember(group.id, mid, 'promote');
@@ -164,7 +165,7 @@ export default function AdminGroupDetailsPage() {
               m.id === mid && m.role === 'member' ? { ...m, role: 'admin' } : m
             )
           );
-          toast.success('Member promoted');
+          toast.success('Member promoted to admin');
         } catch (err) {
           toast.error('Failed to promote member');
         }

--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -2,15 +2,13 @@ import { useEffect, useState } from 'react';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import Link from 'next/link';
 import {
-  FaSearch,
-  FaUsers,
   FaTrashAlt,
   FaEye,
   FaToggleOn,
   FaToggleOff,
   FaDownload,
   FaCheckSquare,
-  FaRegSquare
+  FaRegSquare,
 } from 'react-icons/fa';
 import groupService from '@/services/groupService';
 import toast from 'react-hot-toast';
@@ -23,7 +21,6 @@ const imagePool = [
 
 
 export default function AdminGroupsIndex() {
-  const [allGroups, setAllGroups] = useState([]);
   const [groups, setGroups] = useState([]);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -32,49 +29,36 @@ export default function AdminGroupsIndex() {
   const [selectedGroups, setSelectedGroups] = useState([]);
   const itemsPerPage = 6;
 
+  const sortGroups = (list) => {
+    const sorted = [...list];
+    switch (sortOption) {
+      case 'oldest':
+        sorted.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+        break;
+      case 'members':
+        sorted.sort((a, b) => b.membersCount - a.membersCount);
+        break;
+      default:
+        sorted.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    }
+    return sorted;
+  };
+
   useEffect(() => {
     groupService
       .getAllGroups(search, statusFilter)
-      .then(setAllGroups)
-      .catch(() => setAllGroups([]));
+      .then((data) => setGroups(sortGroups(data)))
+      .catch(() => setGroups([]));
   }, [search, statusFilter]);
 
   useEffect(() => {
-    let filtered = [...allGroups];
-
-    if (statusFilter !== 'all') {
-      filtered = filtered.filter((g) => g.status === statusFilter);
-    }
-
-    if (search.trim()) {
-      filtered = filtered.filter(
-        (g) =>
-          g.name.toLowerCase().includes(search.toLowerCase()) ||
-          g.creator.toLowerCase().includes(search.toLowerCase())
-      );
-    }
-
-    switch (sortOption) {
-      case 'oldest':
-        filtered.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
-        break;
-      case 'members':
-        filtered.sort((a, b) => b.membersCount - a.membersCount);
-        break;
-      default:
-        filtered.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-    }
-
-    setGroups(filtered);
-  }, [search, statusFilter, sortOption, allGroups]);
+    setGroups((prev) => sortGroups(prev));
+  }, [sortOption]);
 
   const toggleStatus = async (id, newStatus) => {
     try {
       await groupService.updateGroup(id, { status: newStatus });
       setGroups((prev) =>
-        prev.map((g) => (g.id === id ? { ...g, status: newStatus } : g))
-      );
-      setAllGroups((prev) =>
         prev.map((g) => (g.id === id ? { ...g, status: newStatus } : g))
       );
       toast.success(`Group status set to ${newStatus}`);
@@ -93,7 +77,6 @@ export default function AdminGroupsIndex() {
         toast.error('Failed to delete group');
       }
       setGroups((prev) => prev.filter((g) => g.id !== id));
-      setAllGroups((prev) => prev.filter((g) => g.id !== id));
       setSelectedGroups((prev) => prev.filter((gid) => gid !== id));
     }
   };
@@ -101,15 +84,12 @@ export default function AdminGroupsIndex() {
   const handleBulkDelete = async () => {
     const confirmDelete = confirm('Delete selected groups?');
     if (confirmDelete) {
-      for (const gid of selectedGroups) {
-        try {
-          await groupService.deleteGroup(gid);
-        } catch {
-          toast.error('Failed to delete some groups');
-        }
-      }
+      const results = await Promise.allSettled(
+        selectedGroups.map((gid) => groupService.deleteGroup(gid))
+      );
+      const failed = results.filter((r) => r.status === 'rejected').length;
+      if (failed) toast.error(`Failed to delete ${failed} groups`);
       setGroups((prev) => prev.filter((g) => !selectedGroups.includes(g.id)));
-      setAllGroups((prev) => prev.filter((g) => !selectedGroups.includes(g.id)));
       setSelectedGroups([]);
       toast.success('Selected groups deleted');
     }
@@ -119,25 +99,18 @@ export default function AdminGroupsIndex() {
     if (selectedGroups.length === 0) return;
     const confirmChange = confirm(`Change status of selected groups to ${status}?`);
     if (confirmChange) {
-      for (const gid of selectedGroups) {
-        try {
-          await groupService.updateGroup(gid, { status });
-        } catch {
-          toast.error('Failed to update some groups');
-        }
-      }
+      const results = await Promise.allSettled(
+        selectedGroups.map((gid) => groupService.updateGroup(gid, { status }))
+      );
+      const failed = results.filter((r) => r.status === 'rejected').length;
+      if (failed) toast.error(`Failed to update ${failed} groups`);
       setGroups((prev) =>
         prev.map((g) =>
           selectedGroups.includes(g.id) ? { ...g, status } : g
         )
       );
-      setAllGroups((prev) =>
-        prev.map((g) =>
-          selectedGroups.includes(g.id) ? { ...g, status } : g
-        )
-      );
+      setSelectedGroups([]);
       toast.success(`Status updated to ${status} for selected groups`);
-
     }
   };
 
@@ -264,7 +237,9 @@ export default function AdminGroupsIndex() {
                 {pageGroupIds.every((id) => selectedGroups.includes(id)) ? <FaCheckSquare /> : <FaRegSquare />} Select All on Page
               </button>
             </div>
-            {paginatedGroups.map((group) => (
+            {paginatedGroups.map((group, idx) => {
+              const placeholder = imagePool[(idx + (currentPage - 1) * itemsPerPage) % imagePool.length];
+              return (
               <div
                 key={group.id}
                 className={`p-4 bg-white rounded-lg shadow hover:shadow-lg border space-y-2 relative ${selectedGroups.includes(group.id) ? 'ring-2 ring-yellow-400' : ''}`}
@@ -278,7 +253,7 @@ export default function AdminGroupsIndex() {
                 </button>
 
                 <img
-                  src={group.cover_image || imagePool[0]}
+                  src={group.cover_image || placeholder}
                   alt={group.name}
                   className="w-full h-32 object-cover rounded-md mb-2"
                 />
@@ -299,7 +274,6 @@ export default function AdminGroupsIndex() {
                     {group.status}
                   </span>
                 </div>
-
                 <p className="text-xs bg-gray-800 text-white inline-block px-2 py-0.5 rounded">
                   📁 {group.category || 'N/A'}
                 </p>
@@ -372,7 +346,8 @@ export default function AdminGroupsIndex() {
                   </button>
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- streamline group fetching and client-side sorting
- parallelize bulk group updates and deletions
- improve group detail membership management and error messaging

## Testing
- `npm test` *(fails: TypeError: formData.get is not a function)*
- `npm run lint` *(fails: 92 errors, 270 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a210c3ee5c83288f8cd8d5f3054aa4