### PR TITLE
Fix bulk status change handler in admin group management

### DIFF
--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -106,7 +106,7 @@ export default function AdminGroupsIndex() {
     }
   };
 
-  const handleBulkDelete = () => {
+  const handleBulkStatusChange = async (status) => {
     if (selectedGroups.length === 0) return;
     const confirmChange = confirm(`Change status of selected groups to ${status}?`);
     if (confirmChange) {


### PR DESCRIPTION
## Summary
- rename duplicated bulk deletion handler to `handleBulkStatusChange`
- make bulk status change handler async and accept target status

## Testing
- `npm test` *(fails: CommunityPages.test.js: TypeError formData.get is not a function)*
- `npm run lint` *(fails: 92 errors, 271 warnings)*
- `npm run build` *(fails: ReferenceError: closeConfirmModal is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a217dc57c88328b56b6634ae839594