### PR TITLE
Fix admin group page data loading

### DIFF
--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -195,18 +195,12 @@ const handleAcceptAIResponse = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      let payload;
-      if (uploadedFiles.length) {
-        const formData = new FormData();
-        formData.append('title', title);
-        formData.append('content', description);
-        formData.append('tags', JSON.stringify(tags));
-        uploadedFiles.forEach((file) => formData.append('files', file));
-        payload = formData;
-      } else {
-        payload = { title, content: description, tags };
-      }
-      const discussion = await createDiscussion(payload);
+      const formData = new FormData();
+      formData.append('title', title);
+      formData.append('content', description);
+      formData.append('tags', JSON.stringify(tags));
+      uploadedFiles.forEach((file) => formData.append('files', file));
+      const discussion = await createDiscussion(formData);
       if (editableResponse.trim()) {
         await createReply(discussion.id, { content: editableResponse });
       }

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -64,7 +64,9 @@ export default function AdminGroupDetailsPage() {
       try {
         const [data, list, reqs] = await Promise.all([
           groupService.getGroupById(id, { signal: controller.signal }),
-          groupService.getGroupMembers(id, { signal: controller.signal }).catch(() => []),
+          groupService
+            .getGroupMembers(id, { signal: controller.signal })
+            .catch(() => []),
           groupService
             .getJoinRequestsForGroup(id, { signal: controller.signal })
             .catch(() => []),
@@ -75,30 +77,15 @@ export default function AdminGroupDetailsPage() {
           return;
         }
         setGroup(data);
-      } catch (err) {
-        if (err?.response?.status === 404) {
-          setNotFound(true);
-        } else {
-          toast.error('Failed to load group');
-        }
-        return;
-      }
-      try {
-        const list = await groupService.getGroupMembers(id);
         setMembers(list);
         setRequests(reqs);
         setPendingCount(Array.isArray(reqs) ? reqs.length : 0);
       } catch (err) {
         if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         if (err?.response?.status === 404) {
-          if (isMounted) setNotFound(true);
+          setNotFound(true);
         } else {
-          if (isMounted) {
-            setNotFound(true);
-            setMembers([]);
-            setRequests([]);
-            setPendingCount(0);
-          }
+          toast.error('Failed to load group');
         }
       }
     };


### PR DESCRIPTION
## Summary
- load group, members, and join requests in a single call on admin group page
- send questions as FormData so API receives expected payload

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21bc9eee48328959dacdcd799a5db