### PR TITLE
Fix group cover images on student dashboard

### DIFF
--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -17,7 +17,16 @@ const formatGroup = (g) => {
   }
   return {
     ...g,
-    cover_image: g.cover_image ? `${base}${g.cover_image}` : g.cover_image,
+    cover_image: g.cover_image
+      ? g.cover_image.startsWith('http') || g.cover_image.startsWith('blob:')
+        ? g.cover_image
+        : `${base}${g.cover_image}`
+      : g.cover_image,
+    image: g.image
+      ? g.image.startsWith('http') || g.image.startsWith('blob:')
+        ? g.image
+        : `${base}${g.image}`
+      : g.image,
     membersCount: g.members_count ?? g.membersCount ?? 0,
     isPublic: g.visibility ? g.visibility === "public" : (g.isPublic ?? true),
     createdAt: g.created_at ?? g.createdAt,


### PR DESCRIPTION
## Summary
- ensure `groupService` returns absolute URLs for group cover images and image fallbacks

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22936c8888328ad16301a83712e01