### PR TITLE
feat: add optional email and WhatsApp group notifications

### DIFF
--- a/backend/src/modules/groups/groupMessages.controller.js
+++ b/backend/src/modules/groups/groupMessages.controller.js
@@ -20,7 +20,7 @@ exports.getMessages = catchAsync(async (req, res) => {
 
 exports.sendMessage = catchAsync(async (req, res) => {
   const { id } = req.params;
-  const { message } = req.body || {};
+  const { message, sendEmail, sendWhatsapp } = req.body || {};
 
   const file = req.files?.file?.[0];
   const audio = req.files?.audio?.[0];
@@ -88,6 +88,52 @@ exports.sendMessage = catchAsync(async (req, res) => {
       );
     }
   });
+
+  const msgText = message
+    ? `${req.user.full_name}: ${message}`
+    : note;
+
+  if (sendEmail === "true" || sendEmail === true) {
+    const emailSubject = `New message in group "${group.name}"`;
+    const emailResults = await Promise.allSettled(
+      recipients.map((uid) =>
+        messageService.sendEmail({
+          sender_id: req.user.id,
+          receiver_id: uid,
+          subject: emailSubject,
+          message: msgText,
+        })
+      )
+    );
+    emailResults.forEach((res, idx) => {
+      if (res.status === "rejected") {
+        console.error(
+          `Failed to send email to user ${recipients[idx]}:`,
+          res.reason,
+        );
+      }
+    });
+  }
+
+  if (sendWhatsapp === "true" || sendWhatsapp === true) {
+    const waResults = await Promise.allSettled(
+      recipients.map((uid) =>
+        messageService.sendWhatsApp({
+          sender_id: req.user.id,
+          receiver_id: uid,
+          message: msgText,
+        })
+      )
+    );
+    waResults.forEach((res, idx) => {
+      if (res.status === "rejected") {
+        console.error(
+          `Failed to send WhatsApp message to user ${recipients[idx]}:`,
+          res.reason,
+        );
+      }
+    });
+  }
 
   sendSuccess(res, full, "Message sent");
 });

--- a/frontend/src/components/chat/GroupChat.js
+++ b/frontend/src/components/chat/GroupChat.js
@@ -51,6 +51,8 @@ export default function GroupChat({ group, groupId: idProp, groupName: nameProp 
         text: newMessage.text,
         file: newMessage.file,
         audio: newMessage.audio,
+        sendEmail: newMessage.sendEmail,
+        sendWhatsapp: newMessage.sendWhatsapp,
       });
 
       if (created) {

--- a/frontend/src/components/chat/MessageInput.js
+++ b/frontend/src/components/chat/MessageInput.js
@@ -16,6 +16,8 @@ const MessageInput = ({ sendMessage, replyTo, onCancelReply, onTyping }) => {
   const [audioBlob, setAudioBlob] = useState(null);
   const [recording, setRecording] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+  const [sendEmail, setSendEmail] = useState(false);
+  const [sendWhatsapp, setSendWhatsapp] = useState(false);
 
   const mediaRecorderRef = useRef(null);
   const fileInputRef = useRef(null);
@@ -30,12 +32,16 @@ const MessageInput = ({ sendMessage, replyTo, onCancelReply, onTyping }) => {
       text: message.trim(),
       file,
       audio: audioBlob,
+      sendEmail,
+      sendWhatsapp,
     };
 
     sendMessage(newMessage);
     setMessage("");
     setFile(null);
     setAudioBlob(null);
+    setSendEmail(false);
+    setSendWhatsapp(false);
     setShowEmojiPicker(false);
     onCancelReply?.();
     onTyping?.(false);
@@ -162,6 +168,25 @@ const MessageInput = ({ sendMessage, replyTo, onCancelReply, onTyping }) => {
         >
           <FaPaperPlane />
         </button>
+      </div>
+
+      <div className="flex items-center gap-3 mt-2 text-xs text-gray-300">
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={sendEmail}
+            onChange={(e) => setSendEmail(e.target.checked)}
+          />
+          Email
+        </label>
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={sendWhatsapp}
+            onChange={(e) => setSendWhatsapp(e.target.checked)}
+          />
+          WhatsApp
+        </label>
       </div>
 
       {/* File name preview */}

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -157,11 +157,16 @@ const groupService = {
     }));
   },
 
-  sendGroupMessage: async (groupId, { text, file, audio }) => {
+  sendGroupMessage: async (
+    groupId,
+    { text, file, audio, sendEmail, sendWhatsapp },
+  ) => {
     const form = new FormData();
     if (text) form.append("message", text);
     if (file) form.append("file", file);
     if (audio) form.append("audio", audio);
+    if (sendEmail) form.append("sendEmail", "true");
+    if (sendWhatsapp) form.append("sendWhatsapp", "true");
     const { data } = await api.post(`/groups/${groupId}/messages`, form, {
       headers: { "Content-Type": "multipart/form-data" },
     });


### PR DESCRIPTION
## Summary
- allow group messages to trigger email or WhatsApp notifications for members
- expose sendEmail/sendWhatsapp flags in group service and chat UI

## Testing
- `npm test --silent` (backend) *(fails: 7 failed, 69 passed)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a22fbbd2d48328b72e1751f047631b