### PR TITLE
feat: add group email support

### DIFF
--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -271,6 +271,26 @@ exports.listMembers = catchAsync(async (req, res) => {
   sendSuccess(res, members);
 });
 
+exports.sendEmail = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  const group = await service.getGroupById(id);
+  if (!group) throw new AppError("Group not found", 404);
+  const members = await service.listMembers(id);
+  await Promise.all(
+    members
+      .filter((m) => m.user_id !== req.user.id)
+      .map((m) =>
+        messageService.sendEmail({
+          sender_id: req.user.id,
+          receiver_id: m.user_id,
+          subject: req.body.subject,
+          message: req.body.message,
+        })
+      )
+  );
+  sendSuccess(res, null, "Email sent");
+});
+
 exports.manageMember = catchAsync(async (req, res) => {
   const { memberId } = req.params;
   const { action } = req.body;

--- a/backend/src/modules/groups/groups.routes.js
+++ b/backend/src/modules/groups/groups.routes.js
@@ -22,6 +22,8 @@ router.delete("/messages/:id", verifyToken, msgCtrl.deleteMessage);
 router.post("/:id/typing", verifyToken, msgCtrl.updateTyping);
 router.get("/:id/typing", verifyToken, msgCtrl.getTyping);
 
+router.post("/:id/email", verifyToken, ctrl.sendEmail);
+
 
 router.post("/", verifyToken, upload, ctrl.createGroup);
 router.get("/", ctrl.listGroups);

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -58,7 +58,7 @@ exports.listGroups = async ({ search, status }) => {
       if (search) qb.whereILike("g.name", `%${search}%`);
       if (status && status !== "all") qb.andWhere("g.status", status);
     })
-    .groupBy("g.id", "u.full_name", "u.role", "c.name")
+    .groupBy("g.id", "u.full_name", "u.role", "u.email", "c.name")
     .select(
       "g.*",
       db.raw("COALESCE(u.full_name, '') as creator_name"),
@@ -78,11 +78,12 @@ exports.getGroupById = async (id) => {
     .leftJoin("categories as c", "g.category_id", "c.id")
     .leftJoin("group_members as gm", "g.id", "gm.group_id")
     .where("g.id", id)
-    .groupBy("g.id", "u.full_name", "u.role", "c.name")
+    .groupBy("g.id", "u.full_name", "u.role", "u.email", "c.name")
     .select(
       "g.*",
       db.raw("COALESCE(u.full_name, '') as creator_name"),
       db.raw("COALESCE(u.role, '') as creator_role"),
+      db.raw("COALESCE(u.email, '') as contact_email"),
       db.raw("COALESCE(c.name, '') as category"),
       db.raw("COUNT(DISTINCT gm.id) as members_count"),
     )

--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -27,6 +27,7 @@ const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
   const isOnline =
     selectedChat.isOnline ?? selectedChat.is_online ?? selectedChat.status === "online";
   const lastActive = selectedChat.lastActive || selectedChat.last_active;
+  const email = selectedChat.contact_email || selectedChat.email;
 
   const handleVideoCall = async () => {
     if (onStartVideoCall) {
@@ -52,8 +53,8 @@ const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
   };
 
   const handleSendEmail = () => {
-    if (selectedChat.email) {
-      window.location.href = `mailto:${selectedChat.email}?subject=Let's Chat&body=Hello!`;
+    if (email) {
+      window.location.href = `mailto:${email}?subject=Let's Chat&body=Hello!`;
     } else {
       alert("Email is missing!");
     }
@@ -113,12 +114,14 @@ const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
         </button>
 
         {/* ✅ Email Button */}
-        <button
-          className="px-3 py-2 bg-gray-600 text-white rounded flex items-center gap-2 hover:bg-gray-700 transition"
-          onClick={handleSendEmail}
-        >
-          <FaEnvelope /> Email
-        </button>
+        {email && (
+          <button
+            className="px-3 py-2 bg-gray-600 text-white rounded flex items-center gap-2 hover:bg-gray-700 transition"
+            onClick={handleSendEmail}
+          >
+            <FaEnvelope /> Email
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- expose group creator email via `contact_email`
- allow email broadcast to group members
- show chat email button only when address present

## Testing
- `npm test` (backend) *(fails: PUT /api/users/tutorials/admin/:id returns 400 not 403; Class routes create class expected 200 got 400; POST /api/ads/admin creates ad expected 200 got 400; payment commission tests expected 200 got 500; community public routes create discussion expected 200 got 500; tutorial update transactions commit not called)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a22fbb53e48328839451489c660cdd