### PR TITLE
Expose group contact phone and guard WhatsApp action

### DIFF
--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -77,13 +77,15 @@ exports.getGroupById = async (id) => {
     .leftJoin("users as u", "g.creator_id", "u.id")
     .leftJoin("categories as c", "g.category_id", "c.id")
     .leftJoin("group_members as gm", "g.id", "gm.group_id")
+    .leftJoin("users as contact", "g.contact_id", "contact.id")
     .where("g.id", id)
-    .groupBy("g.id", "u.full_name", "u.role", "c.name")
+    .groupBy("g.id", "u.full_name", "u.role", "c.name", "contact.phone")
     .select(
       "g.*",
       db.raw("COALESCE(u.full_name, '') as creator_name"),
       db.raw("COALESCE(u.role, '') as creator_role"),
       db.raw("COALESCE(c.name, '') as category"),
+      db.raw("COALESCE(contact.phone, '') as contact_phone"),
       db.raw("COUNT(DISTINCT gm.id) as members_count"),
     )
     .first();

--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -27,6 +27,7 @@ const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
   const isOnline =
     selectedChat.isOnline ?? selectedChat.is_online ?? selectedChat.status === "online";
   const lastActive = selectedChat.lastActive || selectedChat.last_active;
+  const hasPhone = !!selectedChat.phone;
 
   const handleVideoCall = async () => {
     if (onStartVideoCall) {
@@ -106,8 +107,11 @@ const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
 
         {/* ✅ WhatsApp Button */}
         <button
-          className="px-3 py-2 bg-green-500 text-white rounded flex items-center gap-2 hover:bg-green-600 transition"
-          onClick={handleWhatsAppChat}
+          className={`px-3 py-2 text-white rounded flex items-center gap-2 transition ${
+            hasPhone ? "bg-green-500 hover:bg-green-600" : "bg-gray-600 cursor-not-allowed opacity-50"
+          }`}
+          onClick={hasPhone ? handleWhatsAppChat : undefined}
+          disabled={!hasPhone}
         >
           <FaWhatsapp /> WhatsApp
         </button>

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -37,6 +37,8 @@ const formatGroup = (g) => {
     creator: g.creator_name ?? g.creator ?? null,
     creatorRole: g.creator_role ?? g.creatorRole ?? null,
     status: g.status ?? "active",
+    contactPhone: g.contact_phone ?? g.contactPhone ?? null,
+    phone: g.phone ?? g.contact_phone ?? g.contactPhone ?? null,
     tags,
   };
 };


### PR DESCRIPTION
## Summary
- include designated contact's phone when fetching a group
- expose contactPhone in frontend service and use as fallback for chat phone
- disable WhatsApp button if no phone is available

## Testing
- `cd backend && npm test` (fails: 7 failed, 69 passed)
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22fba5798832880dfe19773dc86ab