### PR TITLE
Handle groups without contact user

### DIFF
--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -77,16 +77,15 @@ exports.getGroupById = async (id) => {
     .leftJoin("users as u", "g.creator_id", "u.id")
     .leftJoin("categories as c", "g.category_id", "c.id")
     .leftJoin("group_members as gm", "g.id", "gm.group_id")
-    .leftJoin("users as contact", "g.contact_id", "contact.id")
     .where("g.id", id)
-    .groupBy("g.id", "u.full_name", "u.role", "c.name", "contact.phone")
+    .groupBy("g.id", "u.full_name", "u.role", "u.email", "u.phone", "c.name")
     .select(
       "g.*",
       db.raw("COALESCE(u.full_name, '') as creator_name"),
       db.raw("COALESCE(u.role, '') as creator_role"),
       db.raw("COALESCE(u.email, '') as contact_email"),
       db.raw("COALESCE(c.name, '') as category"),
-      db.raw("COALESCE(contact.phone, '') as contact_phone"),
+      db.raw("COALESCE(u.phone, '') as contact_phone"),
       db.raw("COUNT(DISTINCT gm.id) as members_count"),
     )
     .first();


### PR DESCRIPTION
## Summary
- prevent `/api/groups/:id` from erroring when `contact_id` is absent by removing invalid join
- expose creator's email and phone as group contact info

## Testing
- `npm test` *(fails: POST /api/ads/admin creates ad, PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial, PUT /api/users/tutorials/admin/:id updates tutorial with language and status, Class routes create class, Class routes create class responds even if notifications fail, Class routes create class with options, payment commission calculations calculates commission for class payments, payment commission calculations calculates commission for book payments, POST /api/payments/admin creates payment with installments and enrolls, community public routes create discussion, updateTutorial tag transactions commits transaction when tag update succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_68a23702d290832882a2bb400b94f683