### PR TITLE
Remove duplicate delete route in student bookings routes

### DIFF
--- a/backend/src/modules/bookings/student.routes.js
+++ b/backend/src/modules/bookings/student.routes.js
@@ -18,6 +18,4 @@ router.patch(
 );
 router.delete("/:id", controller.deleteStudentBooking);
 
-router.delete("/:id", controller.deleteStudentBooking);
-
 module.exports = router;


### PR DESCRIPTION
## Summary
- remove duplicate delete route in student bookings router

## Testing
- `npm test` (fails: Test Suites: 7 failed, 69 passed, 76 total)

------
https://chatgpt.com/codex/tasks/task_e_68a2478443648328b4c4342b0536ecd3