### PR TITLE
feat: add book reviews

### DIFF
--- a/backend/src/migrations/20250906000000_create_book_reviews_table.js
+++ b/backend/src/migrations/20250906000000_create_book_reviews_table.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'book_reviews';
+
+exports.up = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, (table) => {
+    table.increments('id').primary();
+    table
+      .integer('book_id')
+      .references('id')
+      .inTable('books')
+      .onDelete('CASCADE');
+    table
+      .uuid('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.integer('rating').notNullable();
+    table.text('comment');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists(TABLE_NAME);
+};

--- a/backend/src/modules/bookReviews/bookReview.controller.js
+++ b/backend/src/modules/bookReviews/bookReview.controller.js
@@ -1,0 +1,26 @@
+const service = require("./bookReview.service");
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
+
+exports.listReviews = catchAsync(async (req, res) => {
+  const data = await service.listReviews(req.params.bookId);
+  sendSuccess(res, data);
+});
+
+exports.createReview = catchAsync(async (req, res) => {
+  const payload = { ...req.body, user_id: req.user?.id };
+  const [review] = await service.createReview(payload);
+  sendSuccess(res, review, "Review created");
+});
+
+exports.updateReview = catchAsync(async (req, res) => {
+  const review = await service.updateReview(req.params.id, req.body);
+  if (!review) throw new AppError("Review not found", 404);
+  sendSuccess(res, review, "Review updated");
+});
+
+exports.deleteReview = catchAsync(async (req, res) => {
+  await service.deleteReview(req.params.id);
+  sendSuccess(res, null, "Review deleted");
+});

--- a/backend/src/modules/bookReviews/bookReview.model.js
+++ b/backend/src/modules/bookReviews/bookReview.model.js
@@ -1,0 +1,30 @@
+const db = require("../../config/database");
+
+exports.create = (data) => {
+  return db("book_reviews").insert(data).returning("*");
+};
+
+exports.findById = (id) => {
+  return db("book_reviews").where({ id }).first();
+};
+
+exports.listByBook = (book_id) => {
+  return db("book_reviews").where({ book_id }).orderBy("created_at", "desc");
+};
+
+exports.update = (id, data) => {
+  return db("book_reviews")
+    .where({ id })
+    .update({ ...data, updated_at: db.fn.now() })
+    .returning("*");
+};
+
+exports.remove = (id) => db("book_reviews").where({ id }).del();
+
+exports.averageRating = async (book_id) => {
+  const row = await db("book_reviews")
+    .where({ book_id })
+    .avg("rating as avg")
+    .first();
+  return row?.avg ? Number(row.avg) : 0;
+};

--- a/backend/src/modules/bookReviews/bookReview.routes.js
+++ b/backend/src/modules/bookReviews/bookReview.routes.js
@@ -1,0 +1,10 @@
+const router = require('express').Router();
+const controller = require('./bookReview.controller');
+const { verifyToken } = require('../../middleware/auth/authMiddleware');
+
+router.get('/books/:bookId', controller.listReviews);
+router.post('/', verifyToken, controller.createReview);
+router.put('/:id', verifyToken, controller.updateReview);
+router.delete('/:id', verifyToken, controller.deleteReview);
+
+module.exports = router;

--- a/backend/src/modules/bookReviews/bookReview.service.js
+++ b/backend/src/modules/bookReviews/bookReview.service.js
@@ -1,0 +1,16 @@
+const model = require("./bookReview.model");
+
+exports.createReview = (data) => model.create(data);
+
+exports.listReviews = async (bookId) => {
+  const reviews = await model.listByBook(bookId);
+  const averageRating = await model.averageRating(bookId);
+  return { reviews, averageRating };
+};
+
+exports.updateReview = async (id, data) => {
+  const [row] = await model.update(id, data);
+  return row;
+};
+
+exports.deleteReview = (id) => model.remove(id);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -164,6 +164,7 @@ app.use("/api/media", require("./modules/media/media.routes"));
 app.use("/api/book-categories", require("./modules/bookCategories/bookCategories.routes"));
 app.use("/api/books", require("./modules/books/book.routes"));
 app.use("/api/instructor/books", require("./modules/books/instructorBook.routes"));
+app.use("/api/book-reviews", require("./modules/bookReviews/bookReview.routes"));
 app.use("/api/library", require("./modules/library/library.routes"));
 app.use("/api/search", require("./modules/search/search.routes"));
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -18,3 +18,14 @@ CREATE TABLE IF NOT EXISTS cart_items (
   UNIQUE (user_id, item_id)
 );
 
+-- book_reviews table
+CREATE TABLE IF NOT EXISTS book_reviews (
+  id SERIAL PRIMARY KEY,
+  book_id INTEGER REFERENCES books(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  rating INTEGER NOT NULL,
+  comment TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/frontend/src/components/books/BookReviewForm.js
+++ b/frontend/src/components/books/BookReviewForm.js
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { createReview } from "@/services/bookReviewService";
+import useAuthStore from "@/store/auth/authStore";
+import { toast } from "react-hot-toast";
+import { useTranslation } from "next-i18next";
+
+export default function BookReviewForm({ bookId, onSubmitted }) {
+  const { isAuthenticated } = useAuthStore();
+  const { t } = useTranslation(["website", "common"]);
+  const [rating, setRating] = useState(5);
+  const [comment, setComment] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!isAuthenticated()) {
+      toast.error(t("please_login_to_review"));
+      return;
+    }
+    try {
+      setLoading(true);
+      await createReview({ book_id: bookId, rating, comment });
+      setRating(5);
+      setComment("");
+      toast.success(t("review_submitted"));
+      onSubmitted?.();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-8 space-y-4">
+      <h3 className="text-lg font-semibold">{t("write_review")}</h3>
+      <div>
+        <label className="block mb-1">{t("rating")}</label>
+        <select
+          value={rating}
+          onChange={(e) => setRating(Number(e.target.value))}
+          className="text-gray-900 p-2 rounded"
+        >
+          {[1, 2, 3, 4, 5].map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">{t("comment")}</label>
+        <textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          className="w-full p-2 rounded text-gray-900"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50"
+      >
+        {t("submit")}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/books/BookReviewList.js
+++ b/frontend/src/components/books/BookReviewList.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { fetchReviews } from "@/services/bookReviewService";
+import { useTranslation } from "next-i18next";
+
+export default function BookReviewList({ bookId, version = 0 }) {
+  const { t } = useTranslation(["website", "common"]);
+  const [reviews, setReviews] = useState([]);
+  const [average, setAverage] = useState(0);
+
+  useEffect(() => {
+    if (!bookId) return;
+    let isMounted = true;
+    fetchReviews(bookId).then((data) => {
+      if (!isMounted) return;
+      setReviews(data.reviews || []);
+      setAverage(data.averageRating || 0);
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, [bookId, version]);
+
+  return (
+    <div className="mt-12">
+      <h2 className="text-xl font-semibold mb-4">
+        {t("reviews")}: {average.toFixed(1)} / 5
+      </h2>
+      <div className="space-y-4">
+        {reviews.map((r) => (
+          <div key={r.id} className="bg-gray-800 p-4 rounded">
+            <p className="text-yellow-400">⭐ {r.rating}</p>
+            {r.comment && <p className="mt-1">{r.comment}</p>}
+          </div>
+        ))}
+        {reviews.length === 0 && (
+          <p className="text-gray-400">{t("no_reviews")}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/marketplace/books/[id].js
+++ b/frontend/src/pages/marketplace/books/[id].js
@@ -4,6 +4,8 @@ import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import { fetchBook } from "@/services/bookService";
 import BookDetails from "@/components/books/BookDetails";
+import BookReviewList from "@/components/books/BookReviewList";
+import BookReviewForm from "@/components/books/BookReviewForm";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../next-i18next.config.js";
@@ -15,6 +17,7 @@ export default function BookDetailPage() {
   const [book, setBook] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [reviewVersion, setReviewVersion] = useState(0);
 
   useEffect(() => {
     if (!id) return;
@@ -74,7 +77,16 @@ export default function BookDetailPage() {
           </div>
         )}
 
-        {!loading && !error && book && <BookDetails book={book} />}
+        {!loading && !error && book && (
+          <>
+            <BookDetails book={book} />
+            <BookReviewList bookId={id} version={reviewVersion} />
+            <BookReviewForm
+              bookId={id}
+              onSubmitted={() => setReviewVersion((v) => v + 1)}
+            />
+          </>
+        )}
       </div>
       <Footer />
     </section>

--- a/frontend/src/services/bookReviewService.js
+++ b/frontend/src/services/bookReviewService.js
@@ -1,0 +1,28 @@
+import api from "@/services/api/api";
+
+export const fetchReviews = async (bookId) => {
+  const { data } = await api.get(`/book-reviews/books/${bookId}`);
+  return data?.data || { reviews: [], averageRating: 0 };
+};
+
+export const createReview = async (payload) => {
+  const { data } = await api.post("/book-reviews", payload);
+  return data?.data;
+};
+
+export const updateReview = async (id, payload) => {
+  const { data } = await api.put(`/book-reviews/${id}`, payload);
+  return data?.data;
+};
+
+export const deleteReview = async (id) => {
+  await api.delete(`/book-reviews/${id}`);
+  return true;
+};
+
+export default {
+  fetchReviews,
+  createReview,
+  updateReview,
+  deleteReview,
+};


### PR DESCRIPTION
## Summary
- add backend book review module with CRUD and average rating
- create book reviews table schema and migration
- integrate frontend service and components to display and submit reviews

## Testing
- `npm test` (backend) *(fails: Test Suites: 7 failed, 69 passed)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a24cee2a848328bb04e3126343b5ae