### PR TITLE
feat: show toast on book form fetch errors

### DIFF
--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -5,6 +5,7 @@ import { fetchBookTags, createBookTag } from "@/services/bookTagService";
 import { getLanguages } from "@/services/languageService";
 import debounce from "lodash/debounce";
 import { MAX_IMAGE_SIZE, MAX_IMAGE_SIZE_MB } from "@/utils/constants";
+import { toast } from "react-hot-toast";
 
 export default function BookForm({
   onSubmit,
@@ -63,7 +64,7 @@ export default function BookForm({
         const langs = await getLanguages();
         setLanguages(langs);
       } catch (e) {
-        console.error("Failed to load languages", e);
+        toast.error("Failed to load languages");
       }
     };
     load();
@@ -90,7 +91,7 @@ export default function BookForm({
           setTagSuggestions(data);
         } catch (err) {
           if (err.name !== "CanceledError" && err.name !== "AbortError") {
-            console.error("Failed to fetch tags", err);
+            toast.error("Failed to fetch tags");
           }
         }
       }, 300),
@@ -127,9 +128,7 @@ export default function BookForm({
           .then((newTag) =>
             setTagSuggestions((prev) => [...prev, newTag])
           )
-          .catch((err) =>
-            console.error("Failed to create tag", err)
-          );
+          .catch(() => toast.error("Failed to create tag"));
       }
     }
     setTagInput("");

--- a/frontend/src/tests/__tests__/bookForm.test.js
+++ b/frontend/src/tests/__tests__/bookForm.test.js
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import BookForm from '@/components/books/BookForm';
+
+jest.mock('../../services/languageService', () => ({
+  getLanguages: jest.fn(),
+}));
+
+jest.mock('../../services/bookTagService', () => ({
+  fetchBookTags: jest.fn(),
+  createBookTag: jest.fn(),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { error: jest.fn() },
+}));
+
+describe('BookForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows error toast when language fetch fails', async () => {
+    const { getLanguages } = require('../../services/languageService');
+    getLanguages.mockRejectedValue(new Error('fail'));
+
+    render(<BookForm onSubmit={jest.fn()} categories={[]} />);
+
+    const { toast } = require('react-hot-toast');
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to load languages'));
+  });
+
+  it('shows error toast when tag fetch fails', async () => {
+    const { getLanguages } = require('../../services/languageService');
+    getLanguages.mockResolvedValue([]);
+    const { fetchBookTags } = require('../../services/bookTagService');
+    fetchBookTags.mockRejectedValue(new Error('fail'));
+
+    render(<BookForm onSubmit={jest.fn()} categories={[]} />);
+
+    const input = screen.getByPlaceholderText('booksCreate.addTagsPlaceholder');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await waitFor(() => expect(fetchBookTags).toHaveBeenCalled());
+    const { toast } = require('react-hot-toast');
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to fetch tags'));
+  });
+});


### PR DESCRIPTION
## Summary
- show toast notifications instead of console errors when book form language or tag fetch fails
- test that book form displays errors when language or tag lookups fail

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a24cec88a8832886427706ece0df10