### PR TITLE
refactor: use Next.js Image component for books

### DIFF
--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
 import {
@@ -56,7 +57,7 @@ export default function BookCard({
           {t(book.status)}
         </span>
       )}
-      <img
+      <Image
         src={coverUrl}
         alt={book.title}
         width={400}

--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
+import Image from "next/image";
 import { toast } from "react-hot-toast";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
@@ -86,9 +87,11 @@ export default function BookDetails({ book }) {
   return (
     <div className="flex flex-col md:flex-row gap-8 bg-gray-800/60 p-6 rounded-xl shadow-lg">
       {book.cover_image_url && (
-        <img
+        <Image
           src={book.cover_image_url}
           alt={book.title}
+          width={400}
+          height={600}
           className="w-full md:w-1/3 rounded-lg object-cover"
         />
       )}


### PR DESCRIPTION
## Summary
- use `next/image` in `BookCard` and `BookDetails`
- retain styling with explicit width/height and alt text

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a24ceb0bb08328a50f5c7a0e32ee2f