### PR TITLE
feat: localize add-to-cart toast

### DIFF
--- a/frontend/public/locales/ar/website.json
+++ b/frontend/public/locales/ar/website.json
@@ -150,7 +150,7 @@
   "loading_books": "⏳ Loading books...",
   "failed_load_books": "❌ Failed to load books. Please try again later.",
   "added_to_wishlist": "Added to wishlist",
-  "added_to_cart": "Added to cart",
+  "added_to_cart": "تمت الإضافة إلى السلة",
   "book_not_found": "Book not found",
   "failed_load_book": "Failed to load book",
   "back_to_books": "← Back to books",

--- a/frontend/public/locales/de/website.json
+++ b/frontend/public/locales/de/website.json
@@ -150,7 +150,7 @@
   "loading_books": "⏳ Loading books...",
   "failed_load_books": "❌ Failed to load books. Please try again later.",
   "added_to_wishlist": "Added to wishlist",
-  "added_to_cart": "Added to cart",
+  "added_to_cart": "Zum Warenkorb hinzugefügt",
   "book_not_found": "Book not found",
   "failed_load_book": "Failed to load book",
   "back_to_books": "← Back to books",

--- a/frontend/public/locales/es/website.json
+++ b/frontend/public/locales/es/website.json
@@ -150,7 +150,7 @@
   "loading_books": "⏳ Loading books...",
   "failed_load_books": "❌ Failed to load books. Please try again later.",
   "added_to_wishlist": "Added to wishlist",
-  "added_to_cart": "Added to cart",
+  "added_to_cart": "Añadido al carrito",
   "book_not_found": "Book not found",
   "failed_load_book": "Failed to load book",
   "back_to_books": "← Back to books",

--- a/frontend/public/locales/fr/website.json
+++ b/frontend/public/locales/fr/website.json
@@ -150,7 +150,7 @@
   "loading_books": "⏳ Loading books...",
   "failed_load_books": "❌ Failed to load books. Please try again later.",
   "added_to_wishlist": "Added to wishlist",
-  "added_to_cart": "Added to cart",
+  "added_to_cart": "Ajouté au panier",
   "book_not_found": "Book not found",
   "failed_load_book": "Failed to load book",
   "back_to_books": "← Back to books",

--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -27,7 +27,7 @@ export default function BookDetails({ book }) {
     try {
       setIsAdding(true);
       await addItem(mapBookForCart(book));
-      toast.success("Added to cart");
+      toast.success(t("added_to_cart"));
       router.push("/cart");
     } finally {
       setIsAdding(false);


### PR DESCRIPTION
## Summary
- use i18n for the add-to-cart toast in BookDetails
- add "added_to_cart" translations for Arabic, French, German, and Spanish locales

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68a24ce594ac8328bb2e852e35a1acbc