### PR TITLE
feat: allow clearing book preview pages

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -167,7 +167,12 @@ exports.updateBook = catchAsync(async (req, res) => {
     }
 
   // exclude `is_free` field to align with existing database schema
-  const { tags: rawTags, is_free: _is_free, ...data } = req.body;
+  const {
+    tags: rawTags,
+    is_free: _is_free,
+    remove_preview_pages,
+    ...data
+  } = req.body;
   if (req.files?.cover_image?.[0])
     data.cover_image_url =
       "/uploads/books/" + req.files.cover_image[0].filename;
@@ -178,8 +183,15 @@ exports.updateBook = catchAsync(async (req, res) => {
       req.files.preview_pages.map((f) => "/uploads/books/" + f.filename)
     );
   }
+  const removePreviews =
+    remove_preview_pages === "1" ||
+    remove_preview_pages === "true" ||
+    remove_preview_pages === 1 ||
+    remove_preview_pages === true;
 
-    const book = await service.updateBook(req.params.id, data);
+    const book = await service.updateBook(req.params.id, data, {
+      removePreviewPages: removePreviews,
+    });
 
     await service.clearBookTags(book.id);
     book.tags = await processTags(rawTags, book.id);

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -1,5 +1,7 @@
 const db = require("../../config/database");
 const { PRICE_RANGE_MAX } = require("../../config/books");
+const fs = require("fs");
+const path = require("path");
 
 exports.createBook = async (data) => {
   const [row] = await db("books").insert(data).returning("*");
@@ -102,7 +104,44 @@ exports.getBookTags = (bookId) =>
 exports.clearBookTags = (bookId) =>
   db("book_tag_map").where({ book_id: bookId }).del();
 
-exports.updateBook = async (id, data) => {
+const removeFiles = async (files = []) => {
+  await Promise.all(
+    files.map((f) =>
+      fs.promises
+        .unlink(
+          path.join(
+            __dirname,
+            "../../../",
+            f.startsWith("/") ? f.slice(1) : f
+          )
+        )
+        .catch(() => {})
+    )
+  );
+};
+
+exports.updateBook = async (id, data, { removePreviewPages = false } = {}) => {
+  if (removePreviewPages || data.preview_pages) {
+    const existing = await db("books")
+      .where({ id })
+      .select("preview_pages")
+      .first();
+    let prev = [];
+    if (existing?.preview_pages) {
+      if (Array.isArray(existing.preview_pages)) prev = existing.preview_pages;
+      else {
+        try {
+          prev = JSON.parse(existing.preview_pages) || [];
+        } catch {
+          prev = [];
+        }
+      }
+    }
+    await removeFiles(prev);
+    if (removePreviewPages && !data.preview_pages) {
+      data.preview_pages = null;
+    }
+  }
   const [row] = await db("books").where({ id }).update(data).returning("*");
   return row;
 };

--- a/backend/tests/bookRoutes.test.js
+++ b/backend/tests/bookRoutes.test.js
@@ -137,7 +137,11 @@ describe('PUT /api/books/:id', () => {
     service.updateBook.mockResolvedValue({ id: '1', ...payload });
     const res = await request(app).put('/api/books/1').send(payload);
     expect(res.status).toBe(200);
-    expect(service.updateBook).toHaveBeenCalledWith('1', expect.any(Object));
+    expect(service.updateBook).toHaveBeenCalledWith(
+      '1',
+      expect.any(Object),
+      { removePreviewPages: false }
+    );
     expect(notificationService.createNotification).toHaveBeenCalledWith({
       user_id: '2',
       type: 'book_updated',

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1251,6 +1251,7 @@
     "bookFileLabel": "Book File (PDF)",
     "bookFileRequired": "Book file is required",
     "previewPagesLabel": "Preview Pages (optional)",
+    "clearPreviewPages": "Clear preview pages",
     "allowPreview": "Allow Preview",
     "isFree": "Free",
     "priceLabel": "Price",

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -30,6 +30,7 @@ export default function BookForm({
       tags: [],
       is_free: false,
       allow_preview: false,
+      remove_preview_pages: false,
       ...(defaultValues || {}),
       status: defaultValues?.status ?? "pending",
     },
@@ -50,6 +51,7 @@ export default function BookForm({
         tags: defaultValues.tags || [],
         is_free: defaultValues.is_free ?? false,
         allow_preview: defaultValues.allow_preview ?? false,
+        remove_preview_pages: false,
         ...defaultValues,
         status: defaultValues.status ?? "pending",
       });
@@ -152,6 +154,9 @@ export default function BookForm({
       Array.from(data.preview_pages).forEach((file) =>
         formData.append("preview_pages", file)
       );
+    }
+    if (data.remove_preview_pages) {
+      formData.append("remove_preview_pages", 1);
     }
     formData.append("price", isFree ? 0 : data.price);
     formData.append("language", data.language);
@@ -457,6 +462,25 @@ export default function BookForm({
           <p className="text-red-500 text-sm mt-1">
             {errors.preview_pages.message}
           </p>
+        )}
+        {isEdit && defaultValues?.preview_pages?.length > 0 && (
+          <div className="flex items-center gap-2 mt-2">
+            {(() => {
+              const reg = register("remove_preview_pages");
+              return (
+                <input
+                  type="checkbox"
+                  {...reg}
+                  className="h-4 w-4 text-yellow-500 border-gray-300 rounded"
+                />
+              );
+            })()}
+            <label className="text-sm font-medium">
+              {t("booksCreate.clearPreviewPages", {
+                defaultValue: "Clear preview pages",
+              })}
+            </label>
+          </div>
         )}
       </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- allow update endpoint to accept `remove_preview_pages` flag and forward to service
- clear existing preview page files and set column to null when requested
- add frontend option to clear preview pages and send flag

## Testing
- ⚠️ `cd backend && npm test` (fails: adsRoutes.test.js etc.)
- ✅ `cd backend && npm test tests/bookRoutes.test.js`
- ✅ `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24ce163e4832897be6c95ad8ae875