### PR TITLE
feat: extend book search capabilities

### DIFF
--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -1,4 +1,13 @@
 const knex = require('knex');
+const QueryBuilder = require('knex/lib/query/querybuilder');
+
+QueryBuilder.prototype.whereILike = function (column, value) {
+  return this.whereRaw(`LOWER(${column}) LIKE LOWER(?)`, [value]);
+};
+
+QueryBuilder.prototype.orWhereILike = function (column, value) {
+  return this.orWhereRaw(`LOWER(${column}) LIKE LOWER(?)`, [value]);
+};
 
 // Create an in-memory SQLite database for testing
 const mockDb = knex({
@@ -18,6 +27,8 @@ beforeAll(async () => {
     table.increments('id');
     table.string('title');
     table.string('author');
+    table.text('short_description');
+    table.text('detailed_description');
     table.integer('category_id');
     table.string('status');
     table.float('price');
@@ -27,9 +38,33 @@ beforeAll(async () => {
   });
 
   const books = [
-    { id: 1, title: 'A', instructor_id: '1', created_at: new Date('2023-01-01') },
-    { id: 2, title: 'B', instructor_id: '2', created_at: new Date('2023-01-02') },
-    { id: 3, title: 'C', instructor_id: '1', created_at: new Date('2023-01-03') },
+    {
+      id: 1,
+      title: 'A',
+      author: 'AuthorMatch',
+      short_description: 'ShortDesc1',
+      detailed_description: 'DetailedDesc1',
+      instructor_id: '1',
+      created_at: new Date('2023-01-01'),
+    },
+    {
+      id: 2,
+      title: 'B',
+      author: 'Author2',
+      short_description: 'ShortMatch',
+      detailed_description: 'DetailedDesc2',
+      instructor_id: '2',
+      created_at: new Date('2023-01-02'),
+    },
+    {
+      id: 3,
+      title: 'C',
+      author: 'Author3',
+      short_description: 'ShortDesc3',
+      detailed_description: 'DetailedMatch',
+      instructor_id: '1',
+      created_at: new Date('2023-01-03'),
+    },
   ];
   await db('books').insert(books);
 });
@@ -44,5 +79,23 @@ describe('listBooks', () => {
     expect(result.data).toHaveLength(2);
     expect(result.data.every((b) => b.instructor_id === '1')).toBe(true);
     expect(result.meta.total).toBe(2);
+  });
+
+  test('search matches author', async () => {
+    const result = await listBooks({ search: 'AuthorMatch' });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe(1);
+  });
+
+  test('search matches short_description', async () => {
+    const result = await listBooks({ search: 'ShortMatch' });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe(2);
+  });
+
+  test('search matches detailed_description', async () => {
+    const result = await listBooks({ search: 'DetailedMatch' });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe(3);
   });
 });

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -24,7 +24,10 @@ exports.listBooks = async (params = {}) => {
 
   if (search) {
     query.where(function () {
-      this.whereILike("b.title", `%${search}%`);
+      this.whereILike("b.title", `%${search}%`)
+        .orWhereILike("b.author", `%${search}%`)
+        .orWhereILike("b.short_description", `%${search}%`)
+        .orWhereILike("b.detailed_description", `%${search}%`);
     });
   }
   if (category) query.where("b.category_id", category);


### PR DESCRIPTION
## Summary
- broaden book search to include author, short and detailed descriptions
- add unit tests covering new book search fields

## Testing
- `npm test src/modules/books/__tests__/book.service.test.js`
- `npm test` *(fails: POST /api/ads/admin › creates ad, PUT /api/users/tutorials/admin/:id › returns 403 when instructor updates another instructor's tutorial, PUT /api/users/tutorials/admin/:id › updates tutorial with language and status, Class routes › create class, updateTutorial tag transactions › commits transaction when tag update succeeds, payment commission calculations › calculates commission for class payments, payment commission calculations › calculates commission for book payments, listBooks › search matches author, listBooks › search matches short_description, listBooks › search matches detailed_description, POST /api/payments/admin › creates payment with installments and enrolls, community public routes › create discussion)

------
https://chatgpt.com/codex/tasks/task_e_68a24cde7fbc83289db735fa6a1f3a67