### PR TITLE
Validate instructor availability slots and add tests

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -8,6 +8,7 @@ const path = require("path");
 const instructorService = require("./instructor.service");
 const notificationService = require("../../notifications/notifications.service");
 const messageService = require("../../messages/messages.service");
+const { availabilitySlotSchema } = require("./instructor.validator");
 
 
 /**
@@ -350,13 +351,49 @@ exports.updateAvailability = async (req, res) => {
     const userId = req.user.id;
     const { availability } = req.body;
 
-    if (!Array.isArray(availability)) {
-        return res.status(400).json({ message: 'Availability must be an array' });
+    const parsed = availabilitySlotSchema.array().safeParse(availability);
+    if (!parsed.success) {
+        return res.status(400).json({ message: 'Invalid availability slots', errors: parsed.error.errors });
+    }
+
+    const slots = parsed.data;
+
+    if (slots.length > 50) {
+        return res.status(400).json({ message: 'Too many availability slots' });
+    }
+
+    const toMinutes = (t) => {
+        const [h, m] = t.split(':').map(Number);
+        return h * 60 + m;
+    };
+
+    const seenIds = new Set();
+    const byDay = {};
+
+    for (const slot of slots) {
+        if (seenIds.has(slot.id)) {
+            return res.status(400).json({ message: 'Duplicate slot id detected' });
+        }
+        seenIds.add(slot.id);
+
+        for (const day of slot.daysOfWeek) {
+            if (!byDay[day]) byDay[day] = [];
+            byDay[day].push(slot);
+        }
+    }
+
+    for (const day in byDay) {
+        const daySlots = byDay[day].sort((a, b) => toMinutes(a.startTime) - toMinutes(b.startTime));
+        for (let i = 1; i < daySlots.length; i++) {
+            if (toMinutes(daySlots[i].startTime) < toMinutes(daySlots[i - 1].endTime)) {
+                return res.status(400).json({ message: 'Overlapping availability slots detected' });
+            }
+        }
     }
 
     await db('instructor_profiles')
         .where({ user_id: userId })
-        .update({ availability: JSON.stringify(availability) });
+        .update({ availability: JSON.stringify(slots) });
 
     res.json({ message: 'Availability updated successfully' });
 };

--- a/backend/src/modules/users/instructor/instructor.validator.js
+++ b/backend/src/modules/users/instructor/instructor.validator.js
@@ -51,7 +51,32 @@ const uploadCertificateSchema = z.object({
   // The actual file is handled via multer, but this can validate accompanying fields
 });
 
+// 🔹 Availability Slot Schema
+const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+const availabilitySlotSchema = z
+  .object({
+    id: z.string().uuid(),
+    title: z.string().trim().min(1),
+    startTime: z.string().regex(timeRegex, "Invalid time format"),
+    endTime: z.string().regex(timeRegex, "Invalid time format"),
+    daysOfWeek: z.array(z.number().int().min(0).max(6)).nonempty(),
+    startRecur: z.string().optional(),
+    endRecur: z.string().optional(),
+    backgroundColor: z.string().optional(),
+    borderColor: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      const [sh, sm] = data.startTime.split(":").map(Number);
+      const [eh, em] = data.endTime.split(":").map(Number);
+      return eh * 60 + em > sh * 60 + sm;
+    },
+    { message: "endTime must be after startTime", path: ["endTime"] }
+  );
+
 module.exports = {
   updateInstructorProfileSchema,
   uploadCertificateSchema,
+  availabilitySlotSchema,
 };

--- a/backend/tests/instructorAvailabilityRoutes.test.js
+++ b/backend/tests/instructorAvailabilityRoutes.test.js
@@ -1,0 +1,86 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database');
+const db = require('../src/config/database');
+const updateMock = jest.fn().mockResolvedValue();
+db.mockImplementation(() => ({
+  where: () => ({ update: updateMock })
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'user1' }; next(); },
+  isInstructor: (_req, _res, next) => next(),
+}));
+
+const routes = require('../src/modules/users/instructor/instructor.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/users/instructor', routes);
+
+describe('PATCH /api/users/instructor/availability validation', () => {
+  beforeEach(() => {
+    updateMock.mockClear();
+  });
+
+  it('rejects slot with missing required fields', async () => {
+    const res = await request(app)
+      .patch('/api/users/instructor/availability')
+      .send({
+        availability: [
+          {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            startTime: '09:00',
+            endTime: '10:00',
+            daysOfWeek: [1],
+          },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects slot with invalid time format', async () => {
+    const res = await request(app)
+      .patch('/api/users/instructor/availability')
+      .send({
+        availability: [
+          {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            title: 'Morning',
+            startTime: '25:00',
+            endTime: '26:00',
+            daysOfWeek: [1],
+          },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects overlapping slots', async () => {
+    const res = await request(app)
+      .patch('/api/users/instructor/availability')
+      .send({
+        availability: [
+          {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            title: 'Slot1',
+            startTime: '09:00',
+            endTime: '10:00',
+            daysOfWeek: [1],
+          },
+          {
+            id: '223e4567-e89b-12d3-a456-426614174000',
+            title: 'Slot2',
+            startTime: '09:30',
+            endTime: '10:30',
+            daysOfWeek: [1],
+          },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- define zod schema for instructor availability slots
- validate and check for overlaps/duplicates when updating availability
- add tests for malformed slot payloads

## Testing
- `npm test tests/instructorAvailabilityRoutes.test.js`
- `npm test` *(fails: adsRoutes, tutorialRoutes, class.routes, tutorialUpdateTransaction, paymentCommission, paymentInstallments, community public routes)*

------
https://chatgpt.com/codex/tasks/task_e_68a24cd0332083289a53789968dc8e9e