### PR TITLE
Clean up empty video call rooms

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -294,6 +294,10 @@ io.on("connection", (socket) => {
       rooms[roomId] = rooms[roomId].filter((id) => id !== socket.id);
       participants[roomId] = participants[roomId].filter((p) => p.id !== socket.id);
       socket.to(roomId).emit("user-disconnected", socket.id);
+      if (!rooms[roomId].length) {
+        delete rooms[roomId];
+        delete participants[roomId];
+      }
       if (socket.participantDbId) {
         db("video_call_participants")
           .where({ id: socket.participantDbId })
@@ -443,4 +447,8 @@ async function startServer() {
   }
 }
 
-startServer();
+if (process.env.NODE_ENV !== "test") {
+  startServer();
+}
+
+module.exports = { app, server, io, rooms, participants, startServer };

--- a/backend/tests/video-calls/roomCleanup.test.js
+++ b/backend/tests/video-calls/roomCleanup.test.js
@@ -1,0 +1,58 @@
+const EventEmitter = require('events');
+
+process.env.JWT_SECRET = 'test';
+process.env.REFRESH_TOKEN_SECRET = 'test';
+
+jest.mock('../../src/config/database', () => {
+  const fn = jest.fn(() => ({
+    insert: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }),
+    where: () => ({ update: () => Promise.resolve() }),
+  }));
+  fn.migrate = { latest: () => Promise.resolve() };
+  return fn;
+});
+
+jest.mock('../../src/config/passport', () => ({
+  passport: {
+    initialize: () => (_req, _res, next) => next(),
+    authenticate: () => (_req, _res, next) => next(),
+  },
+  initStrategies: jest.fn(),
+}));
+
+jest.mock('../../src/jobs/lessonReminderJob', () => jest.fn());
+jest.mock('../../src/jobs/lessonLiveJob', () => ({ startLessonLiveJob: jest.fn() }));
+jest.mock('../../src/jobs/cartReminderJob', () => jest.fn());
+jest.mock('../../src/jobs/classReminderJob', () => jest.fn());
+jest.mock('../../src/jobs/cleanupJob', () => jest.fn());
+jest.mock('../../src/jobs/contributorStatsJob', () => jest.fn());
+
+const { io, rooms, participants } = require('../../src/server');
+
+class MockSocket extends EventEmitter {
+  constructor(id) {
+    super();
+    this.id = id;
+  }
+  join() {}
+  to() {
+    return { emit: () => {} };
+  }
+}
+
+describe('room cleanup', () => {
+  it('removes room data after last participant leaves', () => {
+    const socket = new MockSocket('s1');
+    const connectionHandler = io.listeners('connection')[0];
+    connectionHandler(socket);
+    socket.emit('join-room', { roomId: 'room1', name: 'Alice' });
+
+    expect(rooms['room1']).toEqual(['s1']);
+    expect(participants['room1']).toHaveLength(1);
+
+    socket.emit('disconnect');
+
+    expect(rooms['room1']).toBeUndefined();
+    expect(participants['room1']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Clear stored room and participant data when the last socket disconnects
- Export server internals and guard server start for easier testing
- Add regression test for video call room cleanup

## Testing
- `npm test` *(fails: adsRoutes, paymentCommission, class routes, tutorialRoutes, tutorialUpdateTransaction, public routes, paymentInstallments)*

------
https://chatgpt.com/codex/tasks/task_e_68a24bc6ba008328bf2755ab45a9e53f