### PR TITLE
feat: restrict participant updates to room hosts

### DIFF
--- a/backend/src/middleware/auth/verifyHostRole.js
+++ b/backend/src/middleware/auth/verifyHostRole.js
@@ -1,0 +1,22 @@
+const db = require("../../config/database");
+
+module.exports = async function verifyHostRole(req, res, next) {
+  const { roomId } = req.params;
+  try {
+    const socketId = global.userSockets?.[req.user.id];
+    if (!socketId)
+      return res.status(403).json({ message: "Not allowed" });
+    const participant = await db("video_call_participants")
+      .select("role")
+      .where({ room_id: roomId, socket_id: socketId })
+      .andWhere("left_at", null)
+      .first();
+    if (!participant || participant.role !== "host") {
+      return res.status(403).json({ message: "Not allowed" });
+    }
+    next();
+  } catch (err) {
+    console.error("Failed to verify host role", err);
+    res.status(500).json({ message: "Failed to verify host role" });
+  }
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -11,6 +11,7 @@ const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");
 const { verifyToken } = require("./middleware/auth/authMiddleware");
 const verifyEnrollment = require("./middleware/auth/verifyEnrollment");
+const verifyHostRole = require("./middleware/auth/verifyHostRole");
 const csrf = require("./middleware/csrf");
 const path = require("path");
 const startLessonReminderJob = require("./jobs/lessonReminderJob");
@@ -325,6 +326,7 @@ app.get("/api/video-calls/:roomId/participants", verifyToken, async (req, res) =
 app.patch(
   "/api/video-calls/:roomId/participants/:id",
   verifyToken,
+  verifyHostRole,
   async (req, res) => {
     const { roomId, id } = req.params;
     const { isMuted, role } = req.body || {};
@@ -365,6 +367,7 @@ app.patch(
 app.delete(
   "/api/video-calls/:roomId/participants/:id",
   verifyToken,
+  verifyHostRole,
   async (req, res) => {
     const { roomId, id } = req.params;
     try {

--- a/backend/tests/video-calls/hostRole.test.js
+++ b/backend/tests/video-calls/hostRole.test.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../src/config/database', () => {
+  return jest.fn((table) => {
+    if (table === 'video_call_participants') {
+      return {
+        select: () => ({
+          where: () => ({
+            andWhere: () => ({
+              first: () => Promise.resolve({ role: 'participant' })
+            })
+          })
+        })
+      };
+    }
+    return {};
+  });
+});
+
+const verifyHostRole = require('../../src/middleware/auth/verifyHostRole');
+
+const app = express();
+app.use(express.json());
+const attachUser = (req, _res, next) => { req.user = { id: 'user1' }; next(); };
+
+global.userSockets = { user1: 'socket1' };
+
+app.patch('/api/video-calls/:roomId/participants/:id', attachUser, verifyHostRole, (_req, res) => res.json({}));
+app.delete('/api/video-calls/:roomId/participants/:id', attachUser, verifyHostRole, (_req, res) => res.status(204).end());
+
+describe('verifyHostRole middleware', () => {
+  it('rejects non-host user for participant update', async () => {
+    const res = await request(app)
+      .patch('/api/video-calls/room1/participants/socket2')
+      .send({ isMuted: true });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects non-host user for participant removal', async () => {
+    const res = await request(app)
+      .delete('/api/video-calls/room1/participants/socket2');
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add verifyHostRole middleware to enforce host-only participant management
- protect video call participant update and delete routes with host check
- test that non-hosts receive 403 when attempting participant changes

## Testing
- `npm test tests/video-calls/authorization.test.js`
- `npm test tests/video-calls/hostRole.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a24bc5b4f88328a96e3d1a19363490