### PR TITLE
feat: add socket listeners to call chat

### DIFF
--- a/frontend/src/components/video-call/ChatDuringCall.js
+++ b/frontend/src/components/video-call/ChatDuringCall.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { FaPaperPlane } from "react-icons/fa";
 import { fetchCallMessages, sendCallMessage } from "@/services/videoCallService";
+import socket from "@/services/socketService";
 
 const ChatDuringCall = ({ chatId }) => {
   const [messages, setMessages] = useState([]);
@@ -8,17 +9,29 @@ const ChatDuringCall = ({ chatId }) => {
 
   useEffect(() => {
     if (!chatId) return;
+
     fetchCallMessages(chatId)
       .then(setMessages)
       .catch(() => setMessages([]));
+
+    if (!socket.connected) socket.connect();
+
+    const handleMessage = (msg) => {
+      setMessages((prev) => [...prev, msg]);
+    };
+
+    socket.on("call-message", handleMessage);
+
+    return () => {
+      socket.off("call-message", handleMessage);
+    };
   }, [chatId]);
 
   const sendMessage = async () => {
     const text = newMessage.trim();
     if (!text) return;
     try {
-      const saved = await sendCallMessage(chatId, { sender: "You", text });
-      setMessages((prev) => [...prev, saved]);
+      await sendCallMessage(chatId, { text });
     } catch {
       // fail silently for this demo
     }


### PR DESCRIPTION
## Summary
- connect `ChatDuringCall` to socket server and listen for `call-message` events
- remove redundant `sender` field when sending a chat message
- clean up socket event listeners on unmount

## Testing
- `npm test`
- `npm run lint` *(fails: 92 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a24bc399c8832886a6ad306f58d28e