### PR TITLE
feat: sync participant list with socket

### DIFF
--- a/frontend/src/components/video-call/ParticipantList.js
+++ b/frontend/src/components/video-call/ParticipantList.js
@@ -7,13 +7,41 @@ import {
   removeParticipant,
   makeCoHost,
 } from "@/services/videoCallService";
+import socket from "@/services/socketService";
 
 export default function ParticipantList({ chatId, userRole = "participant" }) {
   const [participants, setParticipants] = useState([]);
 
   useEffect(() => {
     if (!chatId) return;
+
     fetchParticipants(chatId).then((data) => setParticipants(data));
+
+    const handleParticipantUpdated = (participant) => {
+      setParticipants((prev) =>
+        prev.map((p) =>
+          p.id === participant.id ? { ...p, ...participant } : p
+        )
+      );
+    };
+
+    const handleParticipantRemoved = ({ id }) => {
+      setParticipants((prev) => prev.filter((p) => p.id !== id));
+    };
+
+    const handleUserJoined = (participant) => {
+      setParticipants((prev) => [...prev, participant]);
+    };
+
+    socket.on("participant-updated", handleParticipantUpdated);
+    socket.on("participant-removed", handleParticipantRemoved);
+    socket.on("user-joined", handleUserJoined);
+
+    return () => {
+      socket.off("participant-updated", handleParticipantUpdated);
+      socket.off("participant-removed", handleParticipantRemoved);
+      socket.off("user-joined", handleUserJoined);
+    };
   }, [chatId]);
 
   const handleMute = async (id, isMuted) => {


### PR DESCRIPTION
## Summary
- listen for participant updates and join events using shared socket in participant list
- clean up socket event listeners on unmount

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a24bc23050832881d3c154e5286f39