### PR TITLE
Validate platform cut values

### DIFF
--- a/backend/src/modules/paymentConfig/paymentConfig.controller.js
+++ b/backend/src/modules/paymentConfig/paymentConfig.controller.js
@@ -11,6 +11,17 @@ exports.getSettings = catchAsync(async (_req, res) => {
 });
 
 exports.updateSettings = catchAsync(async (req, res) => {
+  const { platformCut } = req.body;
+  if (platformCut) {
+    for (const val of Object.values(platformCut)) {
+      if (typeof val !== "number" || isNaN(val) || val < 0 || val > 100) {
+        return res
+          .status(400)
+          .json({ error: "Platform cut values must be numbers between 0 and 100" });
+      }
+    }
+  }
+
   const settings = await service.updateSettings(req.body);
   sendSuccess(res, settings, "Settings updated");
 

--- a/backend/tests/paymentConfigRoutes.test.js
+++ b/backend/tests/paymentConfigRoutes.test.js
@@ -1,0 +1,61 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn(),
+  updateSettings: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findAdmins: jest.fn(() => [{ id: 'admin1' }]),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'admin1' }; next(); },
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const service = require('../src/modules/paymentConfig/paymentConfig.service');
+const routes = require('../src/modules/paymentConfig/paymentConfig.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payment-config', routes);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PUT /api/payment-config', () => {
+  it('updates settings with valid platformCut', async () => {
+    const payload = { platformCut: { class: 10, book: 20 } };
+    service.updateSettings.mockResolvedValue(payload);
+
+    const res = await request(app).put('/api/payment-config').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(payload);
+    expect(service.updateSettings).toHaveBeenCalledWith(payload);
+  });
+
+  it('returns 400 for out-of-range values', async () => {
+    const payload = { platformCut: { class: 101 } };
+    const res = await request(app).put('/api/payment-config').send(payload);
+    expect(res.status).toBe(400);
+    expect(service.updateSettings).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for non-numeric values', async () => {
+    const payload = { platformCut: { class: 'ten' } };
+    const res = await request(app).put('/api/payment-config').send(payload);
+    expect(res.status).toBe(400);
+    expect(service.updateSettings).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure payment platform cut values are numeric and between 0-100
- add tests for valid, out-of-range, and non-numeric platform cut inputs

## Testing
- `npm test` *(fails: Test Suites: 7 failed, 73 passed, 80 total)*
- `npm test tests/paymentConfigRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2e53289cc8328a2df58a3ba72f4c8