### PR TITLE
Align platform cut config with backend item types

### DIFF
--- a/backend/tests/paymentCommission.test.js
+++ b/backend/tests/paymentCommission.test.js
@@ -86,4 +86,23 @@ describe('payment commission calculations', () => {
       expect.objectContaining({ platform_fee: 10, instructor_amount: 40 })
     );
   });
+
+  it('calculates commission for tutorial payments', async () => {
+    configService.getSettings.mockResolvedValue({ platformCut: { tutorial: 30 } });
+    service.create.mockResolvedValue({ id: 'p3', reference_id: 'ref', status: 'paid' });
+
+    const res = await request(app).post('/api/payments/admin').send({
+      user_id: 'u1',
+      method_id: 'm1',
+      item_type: 'tutorial',
+      item_id: 'i3',
+      amount: 200,
+      status: 'paid',
+    });
+
+    expect(res.status).toBe(200);
+    expect(service.create).toHaveBeenCalledWith(
+      expect.objectContaining({ platform_fee: 60, instructor_amount: 140 })
+    );
+  });
 });

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -882,7 +882,12 @@
     "rejected": "Rejected",
     "revenue_label": "Revenue ($)",
     "method_name_placeholder": "e.g. Stripe",
-    "configure": "Configure"
+    "configure": "Configure",
+    "item_types": {
+      "class": "Class",
+      "book": "Book",
+      "tutorial": "Tutorial"
+    }
   },
   "tutorialsPage": {
     "title": "Manage Tutorials",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -882,7 +882,12 @@
     "rejected": "Rejected",
     "revenue_label": "Revenue ($)",
     "method_name_placeholder": "e.g. Stripe",
-    "configure": "Configure"
+    "configure": "Configure",
+    "item_types": {
+      "class": "Kurs",
+      "book": "Buch",
+      "tutorial": "Tutorial"
+    }
   },
   "tutorialsPage": {
     "title": "Manage Tutorials",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -882,7 +882,12 @@
     "rejected": "Rejected",
     "revenue_label": "Revenue ($)",
     "method_name_placeholder": "e.g. Stripe",
-    "configure": "Configure"
+    "configure": "Configure",
+    "item_types": {
+      "class": "Class",
+      "book": "Book",
+      "tutorial": "Tutorial"
+    }
   },
   "tutorialsPage": {
     "title": "Manage Tutorials",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -882,7 +882,12 @@
     "rejected": "Rejected",
     "revenue_label": "Revenue ($)",
     "method_name_placeholder": "e.g. Stripe",
-    "configure": "Configure"
+    "configure": "Configure",
+    "item_types": {
+      "class": "Clase",
+      "book": "Libro",
+      "tutorial": "Tutorial"
+    }
   },
   "tutorialsPage": {
     "title": "Manage Tutorials",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -882,7 +882,12 @@
     "rejected": "Rejected",
     "revenue_label": "Revenue ($)",
     "method_name_placeholder": "e.g. Stripe",
-    "configure": "Configure"
+    "configure": "Configure",
+    "item_types": {
+      "class": "Classe",
+      "book": "Livre",
+      "tutorial": "Tutoriel"
+    }
   },
   "tutorialsPage": {
     "title": "Manage Tutorials",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -882,7 +882,12 @@
     "rejected": "Rejected",
     "revenue_label": "Revenue ($)",
     "method_name_placeholder": "e.g. Stripe",
-    "configure": "Configure"
+    "configure": "Configure",
+    "item_types": {
+      "class": "Class",
+      "book": "Book",
+      "tutorial": "Tutorial"
+    }
   },
   "tutorialsPage": {
     "title": "Manage Tutorials",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -882,7 +882,12 @@
     "rejected": "Rejected",
     "revenue_label": "Revenue ($)",
     "method_name_placeholder": "e.g. Stripe",
-    "configure": "Configure"
+    "configure": "Configure",
+    "item_types": {
+      "class": "Class",
+      "book": "Book",
+      "tutorial": "Tutorial"
+    }
   },
   "tutorialsPage": {
     "title": "Manage Tutorials",

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -43,10 +43,9 @@ import useAdminNotice from '@/hooks/useAdminNotice';
 const defaultConfig = {
   currency: "USD",
   platformCut: {
-    subscriptions: 10,
-    classSales: 15,
-    adPayments: 20,
-    bookings: 5,
+    class: 15,
+    book: 10,
+    tutorial: 20,
   },
   invoice: {
     logoUrl: "",
@@ -533,7 +532,9 @@ export default function AdminPaymentsPage() {
               <div className="grid grid-cols-2 gap-4">
                 {Object.entries(form.platformCut).map(([key, val]) => (
                   <div key={key}>
-                    <label className="block text-sm capitalize mb-1">{key}</label>
+                    <label className="block text-sm capitalize mb-1">
+                      {t(`paymentsPage.item_types.${key}`, key)}
+                    </label>
                     <input
                       type="number"
                       name={`platformCut.${key}`}


### PR DESCRIPTION
## Summary
- Update admin payment settings to use backend item type keys (`class`, `book`, `tutorial`)
- Translate item type labels for payment commission form
- Add commission test coverage for tutorials

## Testing
- `npm test` (backend) *(fails: 7 failed, 72 passed)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a2e53147dc83288cc8ef4927ca86e5