### PR TITLE
Add seed for social login settings

### DIFF
--- a/backend/src/seeds/08_social_login_settings_seed.js
+++ b/backend/src/seeds/08_social_login_settings_seed.js
@@ -1,0 +1,44 @@
+exports.seed = async function (knex) {
+  await knex('settings').where({ key: 'social_login_settings' }).del();
+  const now = new Date();
+  const config = {
+    enabled: false,
+    providers: {
+      google: {
+        active: false,
+        clientId: '',
+        clientSecret: '',
+        redirectUrl: '',
+        label: 'Sign in with Google',
+        icon: 'google'
+      },
+      facebook: {
+        active: false,
+        clientId: '',
+        clientSecret: '',
+        redirectUrl: '',
+        label: 'Sign in with Facebook',
+        icon: 'facebook'
+      },
+      github: {
+        active: false,
+        clientId: '',
+        clientSecret: '',
+        redirectUrl: '',
+        label: 'Sign in with GitHub',
+        icon: 'github'
+      }
+    },
+    recaptcha: {
+      active: false,
+      siteKey: '',
+      secretKey: ''
+    }
+  };
+  await knex('settings').insert({
+    key: 'social_login_settings',
+    value: JSON.stringify(config),
+    created_at: now,
+    updated_at: now
+  });
+};

--- a/docs/social-login-setup.md
+++ b/docs/social-login-setup.md
@@ -2,6 +2,14 @@
 
 This guide explains how to configure OAuth providers like Google so users can sign in to SkillBridge using their existing accounts.
 
+## Seed default settings
+
+Run this seed from the `backend` directory to create a default `social_login_settings` row with all providers disabled:
+
+```bash
+knex seed:run --specific=08_social_login_settings_seed.js
+```
+
 ## Google
 
 1. Open the **Google Cloud Console** and create OAuth 2.0 credentials.


### PR DESCRIPTION
## Summary
- add seed inserting default social login settings for Google, Facebook and GitHub
- document how to run the social login settings seed

## Testing
- `npm test` *(fails: POST /api/ads/admin creates ad; PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial; PUT /api/users/tutorials/admin/:id updates tutorial with language and status; Class routes create class tests; updateTutorial tag transactions commits transaction when tag update succeeds; payment commission calculations; POST /api/payments/admin creates payment with installments and enrolls; community public routes create discussion)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e48ee9a483289a1141905a06fd8e