### PR TITLE
feat: improve coupon creation feedback

### DIFF
--- a/frontend/src/pages/dashboard/admin/coupons/new.js
+++ b/frontend/src/pages/dashboard/admin/coupons/new.js
@@ -23,6 +23,9 @@ const createCouponSchema = (t) =>
         .min(1, t("code_required"))
         .transform((val) => val.toUpperCase())
         .superRefine(async (val, ctx) => {
+          // Only check availability for codes with minimum valid length
+          if (val.length < 3) return;
+
           try {
             await validateCode(val);
             ctx.addIssue({
@@ -102,6 +105,7 @@ export default function NewCouponPage() {
       const message =
         err?.response?.data?.message || err?.message || t("create_failed");
       setServerError(message);
+      toast.error(message);
     }
   };
 


### PR DESCRIPTION
## Summary
- only validate coupon codes once they reach the minimum length
- show toast notifications for coupon creation failures

## Testing
- `npm test`
- `npm run lint` *(fails: 92 errors, 270 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e3bea0d48328aa18785278846c18