### PR TITLE
Enable Facebook OAuth routes

### DIFF
--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -26,25 +26,25 @@ exports.googleCallback = (req, res, next) => {
   })(req, res, next);
 };
 
-// Facebook OAuth is disabled until the project is hosted
-// exports.facebookAuth = passport.authenticate('facebook', { scope: ['email'] });
+// Facebook OAuth
+exports.facebookAuth = passport.authenticate('facebook', { scope: ['email'] });
 
-// exports.facebookCallback = (req, res, next) => {
-//   passport.authenticate('facebook', { session: false }, (err, result) => {
-//     if (err || !result) {
-//       return res.redirect(`${process.env.FRONTEND_URL || ''}/auth/login?error=social`);
-//     }
-//     const { accessToken, refreshToken } = result;
-//     res.cookie('refreshToken', refreshToken, {
-//       httpOnly: true,
-//       secure: process.env.NODE_ENV === 'production',
-//       sameSite: 'strict',
-//       maxAge: 7 * 24 * 60 * 60 * 1000,
-//     });
-//     const redirectUrl = `${process.env.FRONTEND_URL || ''}/auth/social-success?token=${accessToken}`;
-//     res.redirect(redirectUrl);
-//   })(req, res, next);
-// };
+exports.facebookCallback = (req, res, next) => {
+  passport.authenticate('facebook', { session: false }, (err, result) => {
+    if (err || !result) {
+      return res.redirect(`${frontendBase}/auth/login?error=social`);
+    }
+    const { refreshToken } = result;
+    res.cookie('refreshToken', refreshToken, refreshCookieOptions);
+    let origin = req.query.origin;
+    if (!allowedOrigins.includes(origin)) {
+      const headerOrigin = req.get('origin');
+      origin = allowedOrigins.includes(headerOrigin) ? headerOrigin : frontendBase;
+    }
+    const redirectUrl = `${origin}/auth/social-success`;
+    res.redirect(redirectUrl);
+  })(req, res, next);
+};
 
 // Apple OAuth is disabled until the project is hosted
 // exports.appleAuth = passport.authenticate('apple');

--- a/backend/src/modules/auth/routes/auth.routes.js
+++ b/backend/src/modules/auth/routes/auth.routes.js
@@ -111,9 +111,9 @@ router.post(
 // Google login routes
 router.get("/google", socialAuthController.googleAuth);
 router.get("/google/callback", socialAuthController.googleCallback);
-// Facebook routes are disabled until production deployment
-// router.get("/facebook", socialAuthController.facebookAuth);
-// router.get("/facebook/callback", socialAuthController.facebookCallback);
+// Facebook login routes
+router.get("/facebook", socialAuthController.facebookAuth);
+router.get("/facebook/callback", socialAuthController.facebookCallback);
 // Apple routes are disabled until production deployment
 // router.get("/apple", socialAuthController.appleAuth);
 // router.post("/apple/callback", socialAuthController.appleCallback);


### PR DESCRIPTION
## Summary
- Expose Facebook auth login and callback routes
- Forward Facebook auth requests to Passport like other providers

## Testing
- `npm test --prefix backend` *(fails: POST /api/ads/admin → expected 200 but got 400; and other suites)*
- `node -` *(302 redirect to Facebook OAuth)*

------
https://chatgpt.com/codex/tasks/task_e_68a31c59ae048328a93301f7811b5639