### PR TITLE
feat: add sitewide nofollow SEO option

### DIFF
--- a/backend/src/modules/seoConfig/seoConfig.controller.js
+++ b/backend/src/modules/seoConfig/seoConfig.controller.js
@@ -11,7 +11,11 @@ exports.getSettings = catchAsync(async (_req, res) => {
 });
 
 exports.updateSettings = catchAsync(async (req, res) => {
-  const settings = await service.updateSettings(req.body);
+  const payload = { ...req.body };
+  if (payload.globalSEO) {
+    payload.globalSEO.nofollowSitewide = !!payload.globalSEO.nofollowSitewide;
+  }
+  const settings = await service.updateSettings(payload);
   sendSuccess(res, settings, "Settings updated");
 
   const admins = await userModel.findAdmins();

--- a/backend/src/modules/seoConfig/seoConfig.service.js
+++ b/backend/src/modules/seoConfig/seoConfig.service.js
@@ -2,6 +2,13 @@ const db = require("../../config/database");
 
 const SETTINGS_KEY = "seo_settings";
 
+const DEFAULT_GLOBAL_SEO = {
+  forceCanonical: true,
+  noindexSitewide: false,
+  nofollowSitewide: false,
+  autoPingSitemap: true,
+};
+
 exports.getSettings = async () => {
   const row = await db("settings").where({ key: SETTINGS_KEY }).first();
   const base = process.env.FRONTEND_URL || "http://localhost:3000";
@@ -9,6 +16,7 @@ exports.getSettings = async () => {
   try {
     const data = JSON.parse(row.value);
     if (!data.baseUrl) data.baseUrl = base;
+    data.globalSEO = { ...DEFAULT_GLOBAL_SEO, ...data.globalSEO };
     return data;
   } catch (_err) {
     return { baseUrl: base };
@@ -19,6 +27,7 @@ exports.updateSettings = async (settings) => {
   if (!settings.baseUrl) {
     settings.baseUrl = process.env.FRONTEND_URL || "http://localhost:3000";
   }
+  settings.globalSEO = { ...DEFAULT_GLOBAL_SEO, ...settings.globalSEO };
   const value = JSON.stringify(settings);
   const existing = await db("settings").where({ key: SETTINGS_KEY }).first();
   if (existing) {

--- a/backend/src/seeds/06_seo_settings_seed.js
+++ b/backend/src/seeds/06_seo_settings_seed.js
@@ -12,6 +12,7 @@ exports.seed = async function (knex) {
     globalSEO: {
       forceCanonical: true,
       noindexSitewide: false,
+      nofollowSitewide: false,
       autoPingSitemap: true,
     },
     redirects: [],

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1418,6 +1418,7 @@
       "heading": "Advanced SEO Settings",
       "forceCanonical": "Force canonical URLs",
       "noindexSitewide": "Noindex sitewide",
+      "nofollowSitewide": "Nofollow sitewide",
       "autoPingSitemap": "Auto ping sitemap",
       "redirects": "Redirect Rules",
       "from": "From",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1418,6 +1418,7 @@
       "heading": "Advanced SEO Settings",
       "forceCanonical": "Force canonical URLs",
       "noindexSitewide": "Noindex sitewide",
+      "nofollowSitewide": "Nofollow sitewide",
       "autoPingSitemap": "Auto ping sitemap",
       "redirects": "Redirect Rules",
       "from": "From",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1419,6 +1419,7 @@
       "heading": "Advanced SEO Settings",
       "forceCanonical": "Force canonical URLs",
       "noindexSitewide": "Noindex sitewide",
+      "nofollowSitewide": "Nofollow sitewide",
       "autoPingSitemap": "Auto ping sitemap",
       "redirects": "Redirect Rules",
       "from": "From",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1418,6 +1418,7 @@
       "heading": "Advanced SEO Settings",
       "forceCanonical": "Force canonical URLs",
       "noindexSitewide": "Noindex sitewide",
+      "nofollowSitewide": "Nofollow sitewide",
       "autoPingSitemap": "Auto ping sitemap",
       "redirects": "Redirect Rules",
       "from": "From",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1418,6 +1418,7 @@
       "heading": "Advanced SEO Settings",
       "forceCanonical": "Force canonical URLs",
       "noindexSitewide": "Noindex sitewide",
+      "nofollowSitewide": "Nofollow sitewide",
       "autoPingSitemap": "Auto ping sitemap",
       "redirects": "Redirect Rules",
       "from": "From",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1418,6 +1418,7 @@
       "heading": "Advanced SEO Settings",
       "forceCanonical": "Force canonical URLs",
       "noindexSitewide": "Noindex sitewide",
+      "nofollowSitewide": "Nofollow sitewide",
       "autoPingSitemap": "Auto ping sitemap",
       "redirects": "Redirect Rules",
       "from": "From",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1418,6 +1418,7 @@
       "heading": "Advanced SEO Settings",
       "forceCanonical": "Force canonical URLs",
       "noindexSitewide": "Noindex sitewide",
+      "nofollowSitewide": "Nofollow sitewide",
       "autoPingSitemap": "Auto ping sitemap",
       "redirects": "Redirect Rules",
       "from": "From",

--- a/frontend/src/components/admin/settings/seo/AdvancedSEOSettings.js
+++ b/frontend/src/components/admin/settings/seo/AdvancedSEOSettings.js
@@ -8,6 +8,7 @@ export default function AdvancedSEOSettings({ config, update }) {
   const defaultGlobal = {
     forceCanonical: true,
     noindexSitewide: false,
+    nofollowSitewide: false,
     autoPingSitemap: true,
   };
   const [globalSEO, setGlobalSEO] = useState(defaultGlobal);
@@ -66,7 +67,7 @@ export default function AdvancedSEOSettings({ config, update }) {
     <div className="space-y-6">
       <h2 className="text-xl font-semibold text-gray-800">{t("heading")}</h2>
 
-      <div className="grid md:grid-cols-3 gap-6">
+      <div className="grid md:grid-cols-4 gap-6">
         <label className="flex items-center gap-2">
           <input
             type="checkbox"
@@ -82,6 +83,14 @@ export default function AdvancedSEOSettings({ config, update }) {
             onChange={(e) => handleGlobalChange("noindexSitewide", e.target.checked)}
           />
           {t("noindexSitewide")}
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={globalSEO.nofollowSitewide}
+            onChange={(e) => handleGlobalChange("nofollowSitewide", e.target.checked)}
+          />
+          {t("nofollowSitewide")}
         </label>
         <label className="flex items-center gap-2">
           <input

--- a/frontend/src/components/common/SeoTags.js
+++ b/frontend/src/components/common/SeoTags.js
@@ -22,9 +22,21 @@ export default function SeoTags() {
   const baseUrl = settings.baseUrl || fallbackUrl;
   const canonical = meta.canonical || (settings.globalSEO?.forceCanonical ? `${baseUrl}${path}` : '');
 
-  const robots = settings.globalSEO?.noindexSitewide || meta.noindex || meta.nofollow
-    ? `${settings.globalSEO?.noindexSitewide || meta.noindex ? 'noindex' : 'index'},${meta.nofollow ? 'nofollow' : 'follow'}`
-    : null;
+  const robots =
+    settings.globalSEO?.noindexSitewide ||
+    settings.globalSEO?.nofollowSitewide ||
+    meta.noindex ||
+    meta.nofollow
+      ? `${
+          settings.globalSEO?.noindexSitewide || meta.noindex
+            ? 'noindex'
+            : 'index'
+        },${
+          settings.globalSEO?.nofollowSitewide || meta.nofollow
+            ? 'nofollow'
+            : 'follow'
+        }`
+      : null;
 
   return (
     <Head>


### PR DESCRIPTION
## Summary
- support `nofollowSitewide` in advanced SEO settings and SEO tags
- persist `nofollowSitewide` flag in backend SEO config service and controller
- include translation and seed defaults for the new flag

## Testing
- `cd backend && npm test` (fails: tests/adsRoutes.test.js, tests/tutorialRoutes.test.js, src/modules/classes/__tests__/class.routes.test.js, tests/paymentCommission.test.js, tests/tutorialUpdateTransaction.test.js, tests/seoConfigRoutes.test.js, tests/paymentInstallments.test.js, src/modules/community/public/__tests__/public.routes.test.js)
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a37ce671748328a31fa363e1584fb7