### PR TITLE
Validate sitemap paths in sitemap manager

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1362,6 +1362,8 @@
     },
     "sitemap": {
       "invalidPriority": "Priority must be between 0 and 1",
+      "invalidPath": "Paths must start with / and contain no spaces",
+      "duplicatePath": "Duplicate paths detected",
       "saved": "Sitemap saved",
       "saveFailed": "Failed to save",
       "heading": "Sitemap Manager",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1362,6 +1362,8 @@
     },
     "sitemap": {
       "invalidPriority": "Priority must be between 0 and 1",
+      "invalidPath": "Paths must start with / and contain no spaces",
+      "duplicatePath": "Duplicate paths detected",
       "saved": "Sitemap saved",
       "saveFailed": "Failed to save",
       "heading": "Sitemap Manager",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1363,6 +1363,8 @@
     },
     "sitemap": {
       "invalidPriority": "Priority must be between 0 and 1",
+      "invalidPath": "Paths must start with / and contain no spaces",
+      "duplicatePath": "Duplicate paths detected",
       "saved": "Sitemap saved",
       "saveFailed": "Failed to save",
       "heading": "Sitemap Manager",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1362,6 +1362,8 @@
     },
     "sitemap": {
       "invalidPriority": "Priority must be between 0 and 1",
+      "invalidPath": "Paths must start with / and contain no spaces",
+      "duplicatePath": "Duplicate paths detected",
       "saved": "Sitemap saved",
       "saveFailed": "Failed to save",
       "heading": "Sitemap Manager",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1362,6 +1362,8 @@
     },
     "sitemap": {
       "invalidPriority": "Priority must be between 0 and 1",
+      "invalidPath": "Paths must start with / and contain no spaces",
+      "duplicatePath": "Duplicate paths detected",
       "saved": "Sitemap saved",
       "saveFailed": "Failed to save",
       "heading": "Sitemap Manager",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1362,6 +1362,8 @@
     },
     "sitemap": {
       "invalidPriority": "Priority must be between 0 and 1",
+      "invalidPath": "Paths must start with / and contain no spaces",
+      "duplicatePath": "Duplicate paths detected",
       "saved": "Sitemap saved",
       "saveFailed": "Failed to save",
       "heading": "Sitemap Manager",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1362,6 +1362,8 @@
     },
     "sitemap": {
       "invalidPriority": "Priority must be between 0 and 1",
+      "invalidPath": "Paths must start with / and contain no spaces",
+      "duplicatePath": "Duplicate paths detected",
       "saved": "Sitemap saved",
       "saveFailed": "Failed to save",
       "heading": "Sitemap Manager",

--- a/frontend/src/components/admin/settings/seo/SitemapManager.js
+++ b/frontend/src/components/admin/settings/seo/SitemapManager.js
@@ -35,7 +35,22 @@ export default function SitemapManager({ config, update, availablePages }) {
       toast.error(t("invalidPriority"));
       return;
     }
-    const updated = { ...config, sitemap: pages };
+
+    // Ensure paths are unique
+    const unique = Array.from(new Map(pages.map((p) => [p.path, p])).values());
+    if (unique.length !== pages.length) {
+      setPages(unique);
+      toast.error(t("duplicatePath"));
+      return;
+    }
+
+    // Validate paths
+    if (unique.some((p) => !p.path.startsWith("/") || p.path.includes(" "))) {
+      toast.error(t("invalidPath"));
+      return;
+    }
+
+    const updated = { ...config, sitemap: unique };
     update(updated);
     try {
       await updateSEOConfig(updated);


### PR DESCRIPTION
## Summary
- validate sitemap paths to ensure leading slash, no spaces, and no duplicates
- surface validation errors and stop save when invalid
- add translations for new validation errors

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a37ce45f2c8328ad7515a5b517bfea