### PR TITLE
Validate JSON-LD in advanced SEO settings

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1413,6 +1413,7 @@
     },
     "advanced": {
       "invalidRedirect": "Redirect paths must start with /",
+      "invalidJson": "Invalid JSON format",
       "saved": "SEO settings saved!",
       "saveFailed": "Failed to save settings",
       "heading": "Advanced SEO Settings",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1413,6 +1413,7 @@
     },
     "advanced": {
       "invalidRedirect": "Redirect paths must start with /",
+      "invalidJson": "Invalid JSON format",
       "saved": "SEO settings saved!",
       "saveFailed": "Failed to save settings",
       "heading": "Advanced SEO Settings",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1414,6 +1414,7 @@
     },
     "advanced": {
       "invalidRedirect": "Redirect paths must start with /",
+      "invalidJson": "Invalid JSON format",
       "saved": "SEO settings saved!",
       "saveFailed": "Failed to save settings",
       "heading": "Advanced SEO Settings",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1413,6 +1413,7 @@
     },
     "advanced": {
       "invalidRedirect": "Redirect paths must start with /",
+      "invalidJson": "Invalid JSON format",
       "saved": "SEO settings saved!",
       "saveFailed": "Failed to save settings",
       "heading": "Advanced SEO Settings",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1413,6 +1413,7 @@
     },
     "advanced": {
       "invalidRedirect": "Redirect paths must start with /",
+      "invalidJson": "Invalid JSON format",
       "saved": "SEO settings saved!",
       "saveFailed": "Failed to save settings",
       "heading": "Advanced SEO Settings",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1413,6 +1413,7 @@
     },
     "advanced": {
       "invalidRedirect": "Redirect paths must start with /",
+      "invalidJson": "Invalid JSON format",
       "saved": "SEO settings saved!",
       "saveFailed": "Failed to save settings",
       "heading": "Advanced SEO Settings",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1413,6 +1413,7 @@
     },
     "advanced": {
       "invalidRedirect": "Redirect paths must start with /",
+      "invalidJson": "Invalid JSON format",
       "saved": "SEO settings saved!",
       "saveFailed": "Failed to save settings",
       "heading": "Advanced SEO Settings",

--- a/frontend/src/components/admin/settings/seo/AdvancedSEOSettings.js
+++ b/frontend/src/components/admin/settings/seo/AdvancedSEOSettings.js
@@ -52,6 +52,13 @@ export default function AdvancedSEOSettings({ config, update }) {
       toast.error(t("invalidRedirect"));
       return;
     }
+    try {
+      JSON.parse(jsonSchema);
+    } catch {
+      toast.error(t("invalidJson"));
+      return;
+    }
+
     const updated = { ...config, globalSEO, redirects, jsonSchema };
     update(updated);
     try {


### PR DESCRIPTION
## Summary
- validate JSON-LD before saving Advanced SEO settings
- add locale strings for invalid JSON errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a37ce458b88328bbdff11e6450e582