### PR TITLE
Fix undefined twitter image variable

### DIFF
--- a/frontend/src/components/common/SeoTags.js
+++ b/frontend/src/components/common/SeoTags.js
@@ -19,6 +19,7 @@ export default function SeoTags() {
   const meta = settings.metaTags?.[path] || {};
   const og = settings.openGraph?.[path] || {};
   const twitter = settings.twitter?.[path] || {};
+  const twitterImage = twitter.image || og.image;
 
   const fallbackUrl = process.env.NEXT_PUBLIC_SITE_URL || (typeof window !== 'undefined' ? window.location.origin : '');
   const baseUrl = settings.baseUrl || fallbackUrl;


### PR DESCRIPTION
## Summary
- compute twitter image from Twitter or Open Graph config in SEO tags

## Testing
- `npm test`
- `npm run lint` *(fails: 92 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a382ebc99c8328bdc881d3691d7901