### PR TITLE
chore: sanitize policy preview with DOMPurify

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "chart.js": "^4.4.9",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
+        "dompurify": "^3.2.6",
         "draft-js": "^0.11.7",
         "emoji-picker-react": "^4.12.0",
         "ethers": "^6.13.5",
@@ -5758,11 +5759,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
-      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "chart.js": "^4.4.9",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
+    "dompurify": "^3.2.6",
     "draft-js": "^0.11.7",
     "emoji-picker-react": "^4.12.0",
     "ethers": "^6.13.5",

--- a/frontend/src/pages/dashboard/admin/settings/policies/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/policies/index.js
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { FaSave, FaPlus } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { fetchPolicies, updatePolicies } from "@/services/admin/policiesService";
+import DOMPurify from "dompurify";
 
 // ReactQuill (lazy load to avoid SSR issues)
 const ReactQuill = dynamic(() => import("react-quill"), { ssr: false });
@@ -185,7 +186,7 @@ export default function AdminPoliciesPage() {
             <h2 className="text-xl font-bold mb-4">{policies[activeTab].title}</h2>
             <div
               className="prose dark:prose-invert max-h-[60vh] overflow-y-auto"
-              dangerouslySetInnerHTML={{ __html: policies[activeTab].content }}
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(policies[activeTab].content) }}
             />
             <button
               onClick={() => setShowPreview(false)}

--- a/frontend/src/tests/__tests__/PoliciesSanitization.test.js
+++ b/frontend/src/tests/__tests__/PoliciesSanitization.test.js
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import DOMPurify from 'dompurify';
+
+const Preview = ({ content }) => (
+  <div data-testid="preview" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }} />
+);
+
+test('sanitizes script tags and event handlers before rendering', () => {
+  const dirty = '<p>Safe</p><script>alert("x")</script><img src=x onerror="alert(1)" />';
+  const { getByTestId } = render(<Preview content={dirty} />);
+  const html = getByTestId('preview').innerHTML;
+  expect(html).toContain('<p>Safe</p>');
+  expect(html).not.toContain('<script>');
+  expect(html).not.toContain('onerror');
+});


### PR DESCRIPTION
## Summary
- install DOMPurify and sanitize policy content before preview rendering
- add test ensuring unsafe tags are removed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38a60e35883289ef2d1801cff40c2