### PR TITLE
feat: add deepseek AI integration

### DIFF
--- a/backend/src/modules/ai/ai.service.js
+++ b/backend/src/modules/ai/ai.service.js
@@ -105,6 +105,34 @@ exports.answerWithAI = async (provider, question, model) => {
     }
   }
 
+  if (provider === 'deepseek') {
+    try {
+      const res = await fetch('https://api.deepseek.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${settings.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: settings.model || 'deepseek-chat',
+          messages: [{ role: 'user', content: question }],
+          max_tokens: settings.maxTokens || settings.max_tokens || 1024,
+        }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        return { answer: null, error: text };
+      }
+
+      const data = await res.json();
+      const answer = data.choices?.[0]?.message?.content?.trim();
+      return { answer, confidence: 0.9 };
+    } catch (err) {
+      return { answer: null, error: err.message };
+    }
+  }
+
   // Fallback stub for providers not yet implemented
   return {
     answer: `(${provider}) AI answer for: ${question}`,

--- a/docs/admin-third-party-integrations.md
+++ b/docs/admin-third-party-integrations.md
@@ -41,3 +41,10 @@ After storing keys on the admin page, users can select ChatGPT or Hugging Face f
    endpoint (e.g. `gpt2` or `google/flan-t5-base`).
 4. Click **Save** to store the settings.
 5. Users can now choose `huggingface` as the provider when asking AI questions.
+
+### DeepSeek Configuration
+
+1. Generate an API key in your DeepSeek account.
+2. In the admin dashboard open **Settings → Third Party** and select **DeepSeek**.
+3. Provide the API key and the desired model name (e.g. `deepseek-chat`) and optional max tokens such as `1024`.
+4. Save the settings to enable DeepSeek. Other providers can be deactivated by toggling them off.

--- a/frontend/src/pages/ai-tutoring/chat.js
+++ b/frontend/src/pages/ai-tutoring/chat.js
@@ -1,15 +1,32 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { askAI } from "@/services/aiService";
-
-const models = [
-  { key: "chatgpt", label: "ChatGPT 4" },
-  { key: "deepseek", label: "DeepSeek AI" }
-];
+import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
 
 export default function AIChatTutorPage() {
-  const [selectedModel, setSelectedModel] = useState("chatgpt");
+  const [models, setModels] = useState([]);
+  const [selectedModel, setSelectedModel] = useState("");
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const cfg = await fetchThirdPartyConfig();
+        const opts = [];
+        if (cfg.chatgpt?.apiKey && cfg.chatgpt?.active !== false)
+          opts.push({ key: "chatgpt", label: "ChatGPT" });
+        if (cfg.deepseek?.apiKey && cfg.deepseek?.active !== false)
+          opts.push({ key: "deepseek", label: "DeepSeek AI" });
+        if (cfg.huggingface?.apiKey && cfg.huggingface?.active !== false)
+          opts.push({ key: "huggingface", label: "Hugging Face" });
+        setModels(opts);
+        if (opts.length === 1) setSelectedModel(opts[0].key);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
 
   const sendMessage = async () => {
     if (!input.trim()) return;

--- a/frontend/src/pages/ai-tutoring/feedback.js
+++ b/frontend/src/pages/ai-tutoring/feedback.js
@@ -1,16 +1,33 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { askAI } from "@/services/aiService";
-
-const models = [
-  { key: "chatgpt", label: "ChatGPT 4" },
-  { key: "deepseek", label: "DeepSeek AI" }
-];
+import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
 
 export default function InstantFeedbackPage() {
-  const [selectedModel, setSelectedModel] = useState("chatgpt");
+  const [models, setModels] = useState([]);
+  const [selectedModel, setSelectedModel] = useState("");
   const [text, setText] = useState("");
   const [feedback, setFeedback] = useState(null);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const cfg = await fetchThirdPartyConfig();
+        const opts = [];
+        if (cfg.chatgpt?.apiKey && cfg.chatgpt?.active !== false)
+          opts.push({ key: "chatgpt", label: "ChatGPT" });
+        if (cfg.deepseek?.apiKey && cfg.deepseek?.active !== false)
+          opts.push({ key: "deepseek", label: "DeepSeek AI" });
+        if (cfg.huggingface?.apiKey && cfg.huggingface?.active !== false)
+          opts.push({ key: "huggingface", label: "Hugging Face" });
+        setModels(opts);
+        if (opts.length === 1) setSelectedModel(opts[0].key);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
 
   const handleSubmit = async () => {
     if (!text.trim()) return;

--- a/frontend/src/pages/ai-tutoring/lesson-planner.js
+++ b/frontend/src/pages/ai-tutoring/lesson-planner.js
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { FaArrowRight } from "react-icons/fa";
 import { askAI } from "@/services/aiService";
+import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
 
 const goals = [
   "Improve coding skills",
@@ -11,16 +12,32 @@ const goals = [
   "Explore data science"
 ];
 
-const models = [
-  { key: "chatgpt", label: "ChatGPT 4" },
-  { key: "deepseek", label: "DeepSeek AI" }
-];
-
 export default function LessonPlannerPage() {
   const [selectedGoal, setSelectedGoal] = useState("");
+  const [models, setModels] = useState([]);
   const [selectedModel, setSelectedModel] = useState("");
   const [generatedPlan, setGeneratedPlan] = useState(null);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const cfg = await fetchThirdPartyConfig();
+        const opts = [];
+        if (cfg.chatgpt?.apiKey && cfg.chatgpt?.active !== false)
+          opts.push({ key: "chatgpt", label: "ChatGPT" });
+        if (cfg.deepseek?.apiKey && cfg.deepseek?.active !== false)
+          opts.push({ key: "deepseek", label: "DeepSeek AI" });
+        if (cfg.huggingface?.apiKey && cfg.huggingface?.active !== false)
+          opts.push({ key: "huggingface", label: "Hugging Face" });
+        setModels(opts);
+        if (opts.length === 1) setSelectedModel(opts[0].key);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
 
   const handleGenerate = async () => {
     if (!selectedGoal || !selectedModel) return;

--- a/frontend/src/pages/ai-tutoring/practice.js
+++ b/frontend/src/pages/ai-tutoring/practice.js
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
 
 const sampleQuestions = [
   {
@@ -18,10 +19,6 @@ const sampleQuestions = [
   }
 ];
 
-const models = [
-  { key: "chatgpt", label: "ChatGPT 4" },
-  { key: "deepseek", label: "DeepSeek AI" }
-];
 
 const fields = [
   "Computer Science",
@@ -34,6 +31,7 @@ const fields = [
 ];
 
 export default function PracticePage() {
+  const [models, setModels] = useState([]);
   const [selectedModel, setSelectedModel] = useState("");
   const [selectedField, setSelectedField] = useState("");
   const [current, setCurrent] = useState(0);
@@ -41,6 +39,26 @@ export default function PracticePage() {
   const [showResult, setShowResult] = useState(false);
   const [score, setScore] = useState(0);
   const [quizStarted, setQuizStarted] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const cfg = await fetchThirdPartyConfig();
+        const opts = [];
+        if (cfg.chatgpt?.apiKey && cfg.chatgpt?.active !== false)
+          opts.push({ key: "chatgpt", label: "ChatGPT" });
+        if (cfg.deepseek?.apiKey && cfg.deepseek?.active !== false)
+          opts.push({ key: "deepseek", label: "DeepSeek AI" });
+        if (cfg.huggingface?.apiKey && cfg.huggingface?.active !== false)
+          opts.push({ key: "huggingface", label: "Hugging Face" });
+        setModels(opts);
+        if (opts.length === 1) setSelectedModel(opts[0].key);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
 
   const startQuiz = () => {
     if (!selectedModel || !selectedField) return;

--- a/frontend/src/pages/ai-tutoring/research.js
+++ b/frontend/src/pages/ai-tutoring/research.js
@@ -1,24 +1,40 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { askAI } from "@/services/aiService";
-
-const models = [
-  { key: "chatgpt", label: "ChatGPT 4" },
-  { key: "deepseek", label: "DeepSeek AI" }
-];
+import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
 
 const modes = [
   { key: "summary", label: "Summarize" },
   { key: "explain", label: "Explain" }
 ];
-
 export default function ResearchAssistantPage() {
-  const [selectedModel, setSelectedModel] = useState("chatgpt");
+  const [models, setModels] = useState([]);
+  const [selectedModel, setSelectedModel] = useState("");
   const [selectedMode, setSelectedMode] = useState("summary");
   const [inputText, setInputText] = useState("");
   const [output, setOutput] = useState(null);
   const [loading, setLoading] = useState(false);
   const [followUp, setFollowUp] = useState("");
   const [followUpResponse, setFollowUpResponse] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const cfg = await fetchThirdPartyConfig();
+        const opts = [];
+        if (cfg.chatgpt?.apiKey && cfg.chatgpt?.active !== false)
+          opts.push({ key: "chatgpt", label: "ChatGPT" });
+        if (cfg.deepseek?.apiKey && cfg.deepseek?.active !== false)
+          opts.push({ key: "deepseek", label: "DeepSeek AI" });
+        if (cfg.huggingface?.apiKey && cfg.huggingface?.active !== false)
+          opts.push({ key: "huggingface", label: "Hugging Face" });
+        setModels(opts);
+        if (opts.length === 1) setSelectedModel(opts[0].key);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
 
   const handleAnalyze = async () => {
     if (!inputText.trim()) return;

--- a/frontend/src/pages/ai-tutoring/transcript.js
+++ b/frontend/src/pages/ai-tutoring/transcript.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { FaDownload, FaHistory } from "react-icons/fa";
 import { askAI } from "@/services/aiService";
+import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
 
 const mockTranscript = {
   model: "ChatGPT 4",
@@ -20,8 +21,14 @@ export default function AITranscriptPage() {
   useEffect(() => {
     const load = async () => {
       try {
+        const cfg = await fetchThirdPartyConfig();
+        let provider = null;
+        if (cfg.deepseek?.apiKey && cfg.deepseek?.active !== false) provider = 'deepseek';
+        else if (cfg.chatgpt?.apiKey && cfg.chatgpt?.active !== false) provider = 'chatgpt';
+        else if (cfg.huggingface?.apiKey && cfg.huggingface?.active !== false) provider = 'huggingface';
+        if (!provider) throw new Error('No provider');
         const { answer } = await askAI(
-          "chatgpt",
+          provider,
           "Provide a sample learning transcript as JSON"
         );
         const parsed = JSON.parse(answer);

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -85,6 +85,7 @@ const AskQuestionPage = () => {
             toast.warning('ChatGPT models not configured');
           }
         }
+        if (cfg.deepseek?.apiKey && cfg.deepseek?.active !== false) opts.push('deepseek');
         if (cfg.huggingface?.apiKey && cfg.huggingface?.active !== false) opts.push('huggingface');
         setAiOptions(opts);
         if (opts.length === 0) toast.info('No AI integrations available');
@@ -319,7 +320,13 @@ const handleAcceptAIResponse = () => {
                 <option value="">Select AI Provider</option>
                 {aiOptions.map((opt) => (
                   <option key={opt} value={opt}>
-                    {opt}
+                    {opt === 'chatgpt'
+                      ? 'ChatGPT'
+                      : opt === 'huggingface'
+                      ? 'Hugging Face'
+                      : opt === 'deepseek'
+                      ? 'DeepSeek AI'
+                      : opt}
                   </option>
                 ))}
               </select>


### PR DESCRIPTION
## Summary
- add DeepSeek provider to backend AI service
- surface DeepSeek and other active AI providers on community and AI tutoring pages
- document DeepSeek setup for administrators

## Testing
- `npm test` (backend) *(fails: adsRoutes.test, tutorialRoutes.test)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a4180872c88328a33a59028610ffea