### PR TITLE
feat: migrate to reCAPTCHA v3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.3.8",
         "react-easy-crop": "^5.4.1",
-        "react-google-recaptcha": "^2.1.0",
+        "react-google-recaptcha-v3": "^1.11.0",
         "react-hook-form": "^7.56.4",
         "react-hot-toast": "^2.5.2",
         "react-i18next": "^15.4.1",
@@ -12237,19 +12237,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-async-script": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-async-script/-/react-async-script-1.2.0.tgz",
-      "integrity": "sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0",
-        "prop-types": "^15.5.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.4.1"
-      }
-    },
     "node_modules/react-beautiful-dnd": {
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
@@ -12446,17 +12433,17 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
     },
-    "node_modules/react-google-recaptcha": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-2.1.0.tgz",
-      "integrity": "sha512-K9jr7e0CWFigi8KxC3WPvNqZZ47df2RrMAta6KmRoE4RUi7Ys6NmNjytpXpg4HI/svmQJLKR+PncEPaNJ98DqQ==",
+    "node_modules/react-google-recaptcha-v3": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.11.0.tgz",
+      "integrity": "sha512-kLQqpz/77m8+trpBwzqcxNtvWZYoZ/YO6Vm2cVTHW8hs80BWUfDpC7RDwuAvpswwtSYApWfaSpIDFWAIBNIYxQ==",
       "license": "MIT",
       "dependencies": {
-        "prop-types": "^15.5.0",
-        "react-async-script": "^1.1.1"
+        "hoist-non-react-statics": "^3.3.2"
       },
       "peerDependencies": {
-        "react": ">=16.4.1"
+        "react": "^16.3 || ^17.0 || ^18.0 || ^19.0",
+        "react-dom": "^17.0 || ^18.0 || ^19.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.3.8",
     "react-easy-crop": "^5.4.1",
-    "react-google-recaptcha": "^2.1.0",
+    "react-google-recaptcha-v3": "^1.11.0",
     "react-hook-form": "^7.56.4",
     "react-hot-toast": "^2.5.2",
     "react-i18next": "^15.4.1",

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -1,7 +1,7 @@
 // ───────────────────────────────────────
 // 📁 frontend/src/pages/auth/login.js
 //  ──────────────────────────────────────
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
@@ -13,7 +13,7 @@ import useAppConfigStore from "@/store/appConfigStore";
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
 import InputField from "@/shared/components/auth/InputField";
 import SocialLogin from "@/shared/components/auth/SocialLogin";
-import ReCAPTCHA from "react-google-recaptcha";
+import { GoogleReCaptchaProvider, useGoogleReCaptcha } from "react-google-recaptcha-v3";
 import { fetchSocialLoginConfig } from "@/services/socialLoginService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
@@ -26,7 +26,7 @@ import nextI18NextConfig from '../../../next-i18next.config.js';
 // ─────────────────────
 import { loginSchema as createLoginSchema } from "@/utils/auth/validationSchemas";
 
-export default function Login() {
+function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading }) {
   const router = useRouter();
   const { t } = useTranslation("auth");
   const user = useAuthStore((state) => state.user);
@@ -35,9 +35,7 @@ export default function Login() {
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const settings = useAppConfigStore((state) => state.settings);
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
-  const [recaptchaCfg, setRecaptchaCfg] = useState(null);
-  const [cfgLoading, setCfgLoading] = useState(true);
-  const recaptchaRef = useRef(null);
+  const { executeRecaptcha } = useGoogleReCaptcha() || {};
 
   // ─────────────────────
   // 📝 Form setup
@@ -78,13 +76,6 @@ export default function Login() {
     fetchAppConfig();
   }, [fetchAppConfig]);
 
-  useEffect(() => {
-    fetchSocialLoginConfig()
-      .then(setRecaptchaCfg)
-      .catch(() => {})
-      .finally(() => setCfgLoading(false));
-  }, []);
-
   // ─────────────────────────────
   // 🔑 Handle form submission
   // ─────────────────────────────
@@ -100,9 +91,8 @@ export default function Login() {
       setCfgLoading(false);
     }
     let token;
-    if (cfg?.recaptcha?.active && recaptchaRef.current) {
-      token = await recaptchaRef.current.executeAsync();
-      recaptchaRef.current.reset();
+    if (cfg?.recaptcha?.active && executeRecaptcha) {
+      token = await executeRecaptcha("login");
     }
     const loggedInUser = await login({ ...data, recaptchaToken: token });
     toast.success(t("login_successful"));
@@ -245,15 +235,41 @@ export default function Login() {
         </p>
       </motion.div>
 
-      {recaptchaCfg?.recaptcha?.active && (
-        <ReCAPTCHA
-          sitekey={recaptchaCfg.recaptcha.siteKey}
-          size="invisible"
-          badge="bottomleft"
-          ref={recaptchaRef}
-        />
-      )}
     </div>
+  );
+}
+
+export default function Login() {
+  const [recaptchaCfg, setRecaptchaCfg] = useState(null);
+  const [cfgLoading, setCfgLoading] = useState(true);
+
+  useEffect(() => {
+    fetchSocialLoginConfig()
+      .then(setRecaptchaCfg)
+      .catch(() => {})
+      .finally(() => setCfgLoading(false));
+  }, []);
+
+  if (recaptchaCfg?.recaptcha?.active) {
+    return (
+      <GoogleReCaptchaProvider reCaptchaKey={recaptchaCfg.recaptcha.siteKey}>
+        <LoginForm
+          recaptchaCfg={recaptchaCfg}
+          cfgLoading={cfgLoading}
+          setRecaptchaCfg={setRecaptchaCfg}
+          setCfgLoading={setCfgLoading}
+        />
+      </GoogleReCaptchaProvider>
+    );
+  }
+
+  return (
+    <LoginForm
+      recaptchaCfg={recaptchaCfg}
+      cfgLoading={cfgLoading}
+      setRecaptchaCfg={setRecaptchaCfg}
+      setCfgLoading={setCfgLoading}
+    />
   );
 }
 

--- a/frontend/src/pages/auth/register.js
+++ b/frontend/src/pages/auth/register.js
@@ -1,5 +1,5 @@
 // 📁 src/pages/auth/register.js
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
@@ -17,22 +17,20 @@ import SocialRegister from "@/shared/components/auth/SocialRegister";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import { registerSchema } from "@/utils/auth/validationSchemas";
-import ReCAPTCHA from "react-google-recaptcha";
+import { GoogleReCaptchaProvider, useGoogleReCaptcha } from "react-google-recaptcha-v3";
 import { fetchSocialLoginConfig } from "@/services/socialLoginService";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 
-export default function Register() {
+function RegisterForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading }) {
   const router = useRouter();
   const { t } = useTranslation("auth");
   const { register: registerUser, user, hasHydrated } = useAuthStore();
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const settings = useAppConfigStore((state) => state.settings);
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
-  const [recaptchaCfg, setRecaptchaCfg] = useState(null);
-  const [cfgLoading, setCfgLoading] = useState(true);
-  const recaptchaRef = useRef(null);
+  const { executeRecaptcha } = useGoogleReCaptcha() || {};
 
   const {
     register,
@@ -64,13 +62,6 @@ export default function Register() {
     fetchAppConfig();
   }, [fetchAppConfig]);
 
-  useEffect(() => {
-    fetchSocialLoginConfig()
-      .then(setRecaptchaCfg)
-      .catch(() => {})
-      .finally(() => setCfgLoading(false));
-  }, []);
-
   const onSubmit = async (data) => {
     try {
       const { full_name, email, phone, password, role } = data;
@@ -81,9 +72,8 @@ export default function Register() {
         setCfgLoading(false);
       }
       let token;
-      if (cfg?.recaptcha?.active && recaptchaRef.current) {
-        token = await recaptchaRef.current.executeAsync();
-        recaptchaRef.current.reset();
+      if (cfg?.recaptcha?.active && executeRecaptcha) {
+        token = await executeRecaptcha("register");
       }
       await registerUser({
         full_name,
@@ -232,16 +222,41 @@ export default function Register() {
         </p>
       </motion.div>
 
-      {/* Avoid moving the reCAPTCHA badge when hovering the card */}
-      {recaptchaCfg?.recaptcha?.active && (
-        <ReCAPTCHA
-          sitekey={recaptchaCfg.recaptcha.siteKey}
-          size="invisible"
-          badge="bottomleft"
-          ref={recaptchaRef}
-        />
-      )}
     </div>
+  );
+}
+
+export default function Register() {
+  const [recaptchaCfg, setRecaptchaCfg] = useState(null);
+  const [cfgLoading, setCfgLoading] = useState(true);
+
+  useEffect(() => {
+    fetchSocialLoginConfig()
+      .then(setRecaptchaCfg)
+      .catch(() => {})
+      .finally(() => setCfgLoading(false));
+  }, []);
+
+  if (recaptchaCfg?.recaptcha?.active) {
+    return (
+      <GoogleReCaptchaProvider reCaptchaKey={recaptchaCfg.recaptcha.siteKey}>
+        <RegisterForm
+          recaptchaCfg={recaptchaCfg}
+          cfgLoading={cfgLoading}
+          setRecaptchaCfg={setRecaptchaCfg}
+          setCfgLoading={setCfgLoading}
+        />
+      </GoogleReCaptchaProvider>
+    );
+  }
+
+  return (
+    <RegisterForm
+      recaptchaCfg={recaptchaCfg}
+      cfgLoading={cfgLoading}
+      setRecaptchaCfg={setRecaptchaCfg}
+      setCfgLoading={setCfgLoading}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- replace react-google-recaptcha with react-google-recaptcha-v3
- execute reCAPTCHA v3 token during login and registration

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68a419ef79c88328bf9557772d53bbf0