### PR TITLE
feat: allow larger blog uploads via env setting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,7 @@ PORT=5002
 DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge
 JWT_SECRET=your_jwt_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret
+MAX_BLOG_IMAGE_BYTES=10485760
 CLOUDINARY_API_KEY=your_key
 SMTP_HOST=smtp.mailtrap.io
 SMTP_PORT=587

--- a/backend/src/modules/blog/blogUploadMiddleware.js
+++ b/backend/src/modules/blog/blogUploadMiddleware.js
@@ -20,4 +20,8 @@ const fileFilter = (_req, file, cb) => {
   else cb(new Error("Invalid file type. Only images are allowed."), false);
 };
 
-module.exports = multer({ storage, fileFilter, limits: { fileSize: 2 * 1024 * 1024 } });
+module.exports = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: process.env.MAX_BLOG_IMAGE_BYTES || 10 * 1024 * 1024 }
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - JWT_SECRET=SkillBr1dge-!Secure.JWT-Key!
       - REFRESH_TOKEN_SECRET=SkillBr1dge-!Refresh.JWT-Key!
       - FRONTEND_URL=https://eduskillbridge.net
+      - MAX_BLOG_IMAGE_BYTES=10485760
     depends_on:
       - db
     volumes:


### PR DESCRIPTION
## Summary
- allow larger blog image uploads with configurable MAX_BLOG_IMAGE_BYTES
- document MAX_BLOG_IMAGE_BYTES in backend environment examples
- pass MAX_BLOG_IMAGE_BYTES to backend service in docker compose

## Testing
- `npm test`
- `docker-compose restart backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a422d8368c832894f9b6140c7927f9