### PR TITLE
Fix blog Read More links

### DIFF
--- a/backend/src/modules/blog/blog.controller.js
+++ b/backend/src/modules/blog/blog.controller.js
@@ -35,6 +35,12 @@ exports.getPost = catchAsync(async (req, res) => {
   sendSuccess(res, post);
 });
 
+exports.getPostBySlug = catchAsync(async (req, res) => {
+  const post = await service.findBySlug(req.params.slug);
+  if (!post) throw new AppError("Post not found", 404);
+  sendSuccess(res, post);
+});
+
 exports.updatePost = catchAsync(async (req, res) => {
   const { id } = req.params;
   const existing = await service.getPostById(id);

--- a/backend/src/modules/blog/blog.routes.js
+++ b/backend/src/modules/blog/blog.routes.js
@@ -4,6 +4,7 @@ const upload = require("./blogUploadMiddleware");
 const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
 
 router.get("/", controller.getPosts);
+router.get("/slug/:slug", controller.getPostBySlug);
 router.get("/:id", controller.getPost);
 router.post("/", verifyToken, isAdmin, upload.single("image"), controller.createPost);
 router.put("/:id", verifyToken, isAdmin, upload.single("image"), controller.updatePost);

--- a/backend/tests/blogRoutes.test.js
+++ b/backend/tests/blogRoutes.test.js
@@ -32,6 +32,17 @@ describe('GET /api/blog', () => {
   });
 });
 
+describe('GET /api/blog/slug/:slug', () => {
+  it('returns post by slug', async () => {
+    const mock = { id: '1', slug: 'test' };
+    service.findBySlug.mockResolvedValue(mock);
+    const res = await request(app).get('/api/blog/slug/test');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.findBySlug).toHaveBeenCalledWith('test');
+  });
+});
+
 describe('POST /api/blog', () => {
   it('creates post', async () => {
     const payload = { title: 'Test' };

--- a/frontend/src/pages/blog/[slug].js
+++ b/frontend/src/pages/blog/[slug].js
@@ -1,0 +1,68 @@
+import PageHead from '@/components/common/PageHead';
+import Navbar from '@/components/website/sections/Navbar';
+import Footer from '@/components/website/sections/Footer';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { fetchBlogPost } from '@/services/blogService';
+
+export default function BlogPostPage() {
+  const router = useRouter();
+  const { slug } = router.query;
+  const [post, setPost] = useState(null);
+
+  useEffect(() => {
+    if (slug) {
+      fetchBlogPost(slug)
+        .then(setPost)
+        .catch((err) => console.error('Failed to load post', err));
+    }
+  }, [slug]);
+
+  return (
+    <>
+      <PageHead title={post ? post.title : 'Blog'} />
+      <div className="bg-gray-900 text-white min-h-screen">
+        <Navbar />
+        {post ? (
+          <article className="max-w-3xl mx-auto px-6 py-24">
+            <h1 className="text-4xl font-bold text-yellow-400 mb-4">{post.title}</h1>
+            {post.published_at && (
+              <p className="text-sm text-gray-400 mb-6">
+                {new Date(post.published_at).toLocaleDateString()}
+              </p>
+            )}
+            {post.image && (
+              <img
+                src={post.image}
+                alt={post.title}
+                className="w-full h-auto rounded mb-6"
+              />
+            )}
+            {post.content && (
+              <div
+                className="prose prose-invert max-w-none"
+                dangerouslySetInnerHTML={{ __html: post.content }}
+              />
+            )}
+          </article>
+        ) : (
+          <div className="flex items-center justify-center py-24">
+            <p>Loading...</p>
+          </div>
+        )}
+        <Footer />
+      </div>
+    </>
+  );
+}
+
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../../next-i18next.config.js';
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/services/blogService.js
+++ b/frontend/src/services/blogService.js
@@ -8,3 +8,16 @@ export const fetchBlogPosts = async () => {
     image: p.image_url ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${p.image_url}` : null,
   }));
 };
+
+export const fetchBlogPost = async (slug) => {
+  const { data } = await api.get(`/blog/slug/${slug}`);
+  const p = data?.data;
+  return p
+    ? {
+        ...p,
+        image: p.image_url
+          ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${p.image_url}`
+          : null,
+      }
+    : null;
+};


### PR DESCRIPTION
## Summary
- support fetching blog posts by slug in backend
- add dynamic blog post page and service on the frontend

## Testing
- `npm test` (backend) *(fails: adsRoutes, paymentCommission, class.routes, tutorialRoutes, seoConfigRoutes, blogRoutes, community public routes, paymentInstallments, tutorialUpdateTransaction)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a4254f4c588328ad1360b1dfbeccc0