### PR TITLE
feat: add certificate template storage

### DIFF
--- a/frontend/src/components/admin/certificates/CertificatePreviewModal.js
+++ b/frontend/src/components/admin/certificates/CertificatePreviewModal.js
@@ -14,6 +14,15 @@ export default function CertificatePreviewModal({ template, onClose }) {
     grade: "97%",
   };
 
+  const {
+    borderColor = "#FACC15",
+    fontFamily = "Georgia, serif",
+    titleFont = "'Great Vibes', cursive",
+    background = "/images/paper-texture.png",
+    logo = "/images/certificate/logo.png",
+    showQR = true,
+  } = template;
+
   return (
     <div className="fixed inset-0 bg-gradient-to-br from-black/80 to-black/60 flex items-center justify-center z-50">
       <div className="relative w-full max-w-5xl max-h-[90vh] bg-white rounded-2xl shadow-2xl p-6 overflow-auto border border-gray-200">
@@ -29,22 +38,22 @@ export default function CertificatePreviewModal({ template, onClose }) {
         <div
           className="w-full border-[12px] rounded-xl p-10 text-center relative shadow-inner"
           style={{
-            backgroundImage: "url('/images/paper-texture.png')",
+            backgroundImage: `url('${background}')`,
             backgroundSize: "cover",
             backgroundRepeat: "no-repeat",
-            borderColor: "#FACC15",
-            fontFamily: "Georgia, serif",
+            borderColor,
+            fontFamily,
           }}
         >
           {/* Logo */}
           <div className="flex justify-center mb-6">
-            <img src="/images/certificate/logo.png" alt="Logo" className="w-32" />
+            <img src={logo} alt="Logo" className="w-32" />
           </div>
 
           {/* Title */}
           <h1
             className="text-5xl font-bold text-yellow-600 mb-6"
-            style={{ fontFamily: "'Great Vibes', cursive" }}
+            style={{ fontFamily: titleFont }}
           >
             Certificate of {template.type || "Completion"}
           </h1>
@@ -84,15 +93,17 @@ export default function CertificatePreviewModal({ template, onClose }) {
             </div>
 
             {/* QR Code */}
-            <div className="text-center">
-              <div className="bg-white border border-gray-200 p-2 rounded-md inline-block shadow-sm">
-                <QRCode
-                  value={`https://yourplatform.com/certificate/verify/${mockData.id}`}
-                  size={80}
-                />
+            {showQR && (
+              <div className="text-center">
+                <div className="bg-white border border-gray-200 p-2 rounded-md inline-block shadow-sm">
+                  <QRCode
+                    value={`https://yourplatform.com/certificate/verify/${mockData.id}`}
+                    size={80}
+                  />
+                </div>
+                <p className="text-[10px] text-gray-500 mt-1">Scan to Verify</p>
               </div>
-              <p className="text-[10px] text-gray-500 mt-1">Scan to Verify</p>
-            </div>
+            )}
 
             {/* Platform Signature */}
             <div className="text-center">

--- a/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
@@ -4,6 +4,10 @@ import { useEffect, useState } from "react";
 import CertificatePreviewModal from "@/components/admin/certificates/CertificatePreviewModal";
 import { FaSave, FaEye } from "react-icons/fa";
 import { toast } from "react-toastify";
+import {
+  getTemplate,
+  updateTemplate,
+} from "@/services/admin/certificateTemplateService";
 
 export default function EditCertificateTemplate() {
   const router = useRouter();
@@ -14,24 +18,14 @@ export default function EditCertificateTemplate() {
   const [bgPreview, setBgPreview] = useState(null);
   const [showPreview, setShowPreview] = useState(false);
 
-  // ✅ Mock fetch by ID
   useEffect(() => {
     if (!id) return;
-    // Simulate fetch from API
-    const existing = {
-      id,
-      name: "React Bootcamp",
-      type: "Completion",
-      borderColor: "#FACC15",
-      fontFamily: "Georgia, serif",
-      titleFont: "'Great Vibes', cursive",
-      showQR: true,
-      logo: null,
-      background: null,
-    };
-    setForm(existing);
-    setLogoPreview("/images/certificate/logo.png");
-    setBgPreview("/images/paper-texture.png");
+    const existing = getTemplate(id);
+    if (existing) {
+      setForm(existing);
+      setLogoPreview(existing.logo || "/images/certificate/logo.png");
+      setBgPreview(existing.background || "/images/paper-texture.png");
+    }
   }, [id]);
 
   const handleChange = (key, value) => {
@@ -41,14 +35,18 @@ export default function EditCertificateTemplate() {
   const handleImageUpload = (e, type) => {
     const file = e.target.files[0];
     if (!file) return;
-    const url = URL.createObjectURL(file);
-    if (type === "logo") {
-      setLogoPreview(url);
-      handleChange("logo", file);
-    } else {
-      setBgPreview(url);
-      handleChange("background", file);
-    }
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const url = ev.target.result;
+      if (type === "logo") {
+        setLogoPreview(url);
+        handleChange("logo", url);
+      } else {
+        setBgPreview(url);
+        handleChange("background", url);
+      }
+    };
+    reader.readAsDataURL(file);
   };
 
   const handleUpdate = () => {
@@ -57,8 +55,9 @@ export default function EditCertificateTemplate() {
       return;
     }
 
-    toast.success("Template updated (mock)");
-    console.log("Updated Template:", form);
+    updateTemplate(id, form);
+    toast.success("Template updated");
+    router.push("/dashboard/admin/settings/certificates");
   };
 
   if (!form) return <div className="p-8 text-gray-600">Loading template...</div>;

--- a/frontend/src/pages/dashboard/admin/settings/certificates/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/create.js
@@ -3,8 +3,11 @@ import { useState } from "react";
 import CertificatePreviewModal from "@/components/admin/certificates/CertificatePreviewModal";
 import { FaSave, FaEye } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { saveTemplate } from "@/services/admin/certificateTemplateService";
+import { useRouter } from "next/router";
 
 export default function CreateCertificateTemplate() {
+  const router = useRouter();
   const [form, setForm] = useState({
     name: "",
     type: "Completion",
@@ -27,14 +30,18 @@ export default function CreateCertificateTemplate() {
   const handleImageUpload = (e, type) => {
     const file = e.target.files[0];
     if (!file) return;
-    const url = URL.createObjectURL(file);
-    if (type === "logo") {
-      setLogoPreview(url);
-      handleChange("logo", file);
-    } else {
-      setBgPreview(url);
-      handleChange("background", file);
-    }
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const url = ev.target.result;
+      if (type === "logo") {
+        setLogoPreview(url);
+        handleChange("logo", url);
+      } else {
+        setBgPreview(url);
+        handleChange("background", url);
+      }
+    };
+    reader.readAsDataURL(file);
   };
 
   const handleSubmit = () => {
@@ -43,8 +50,9 @@ export default function CreateCertificateTemplate() {
       return;
     }
 
-    toast.success("Template saved (mock)");
-    console.log("Submitting", form);
+    saveTemplate(form);
+    toast.success("Template saved");
+    router.push("/dashboard/admin/settings/certificates");
   };
 
   return (

--- a/frontend/src/pages/dashboard/admin/settings/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/index.js
@@ -1,113 +1,111 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
-    FaPlus,
-    FaEdit,
-    FaTrash,
-    FaClone,
-    FaEye,
-    FaToggleOn,
-    FaToggleOff,
+  FaPlus,
+  FaEdit,
+  FaTrash,
+  FaClone,
+  FaEye,
+  FaToggleOn,
+  FaToggleOff,
 } from "react-icons/fa";
 
-// Make sure this import path matches your project structure
 import CertificatePreviewModal from "@/components/admin/certificates/CertificatePreviewModal";
-
-const mockTemplates = [
-    {
-        id: 1,
-        name: "Course Completion",
-        type: "Completion",
-        thumbnail: "/certificates/template1.png",
-        active: true,
-    },
-    {
-        id: 2,
-        name: "Achievement Award",
-        type: "Achievement",
-        thumbnail: "/certificates/template2.png",
-        active: false,
-    },
-];
+import {
+  getTemplates,
+  deleteTemplate,
+  toggleTemplateStatus,
+} from "@/services/admin/certificateTemplateService";
 
 export default function CertificateTemplatesPage() {
-    const [templates, setTemplates] = useState(mockTemplates);
-    const [previewTemplate, setPreviewTemplate] = useState(null);
+  const [templates, setTemplates] = useState([]);
+  const [previewTemplate, setPreviewTemplate] = useState(null);
 
-    const toggleStatus = (id) => {
-        setTemplates((prev) =>
-            prev.map((t) => (t.id === id ? { ...t, active: !t.active } : t))
-        );
-    };
+  useEffect(() => {
+    setTemplates(getTemplates());
+  }, []);
 
-    return (
-        <AdminLayout>
-            <div className="p-6">
-                <div className="flex justify-between items-center mb-6">
-                    <h1 className="text-2xl font-bold text-gray-800">Certificate Templates</h1>
-                    <Link
-                        href="/dashboard/admin/settings/certificates/create"
-                        className="btn btn-primary flex items-center gap-2"
-                    >
-                        <FaPlus /> Add New Template
-                    </Link>
+  const refresh = () => setTemplates(getTemplates());
+
+  const toggleStatus = (id) => {
+    toggleTemplateStatus(id);
+    refresh();
+  };
+
+  const handleDelete = (id) => {
+    if (confirm("Delete this template?")) {
+      deleteTemplate(id);
+      refresh();
+    }
+  };
+
+  return (
+    <AdminLayout>
+      <div className="p-6">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold text-gray-800">Certificate Templates</h1>
+          <Link
+            href="/dashboard/admin/settings/certificates/create"
+            className="btn btn-primary flex items-center gap-2"
+          >
+            <FaPlus /> Add New Template
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {templates.map((template) => (
+            <div
+              key={template.id}
+              className="bg-white shadow rounded-xl p-4 border"
+            >
+              <img
+                src={template.background || "/images/paper-texture.png"}
+                alt={template.name}
+                className="w-full h-40 object-cover rounded-md mb-4"
+              />
+              <h2 className="font-semibold text-lg">{template.name}</h2>
+              <p className="text-sm text-gray-500 mb-2">Type: {template.type}</p>
+
+              <div className="flex items-center justify-between">
+                <button
+                  onClick={() => toggleStatus(template.id)}
+                  className={`text-sm flex items-center gap-1 ${
+                    template.active ? "text-green-600" : "text-gray-400"
+                  }`}
+                >
+                  {template.active ? <FaToggleOn /> : <FaToggleOff />}
+                  {template.active ? "Active" : "Inactive"}
+                </button>
+
+                <div className="flex gap-2 text-gray-600">
+                  <Link href={`/dashboard/admin/settings/certificates/${template.id}`}>
+                    <FaEdit title="Edit" />
+                  </Link>
+                  <button onClick={() => alert("Duplicate")}>
+                    <FaClone title="Duplicate" />
+                  </button>
+                  <button onClick={() => setPreviewTemplate(template)}>
+                    <FaEye title="Preview" />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(template.id)}
+                    className="text-red-500"
+                  >
+                    <FaTrash title="Delete" />
+                  </button>
                 </div>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                    {templates.map((template) => (
-                        <div
-                            key={template.id}
-                            className="bg-white shadow rounded-xl p-4 border"
-                        >
-                            <img
-                                src={template.thumbnail}
-                                alt={template.name}
-                                className="w-full h-40 object-cover rounded-md mb-4"
-                            />
-                            <h2 className="font-semibold text-lg">{template.name}</h2>
-                            <p className="text-sm text-gray-500 mb-2">Type: {template.type}</p>
-
-                            <div className="flex items-center justify-between">
-                                <button
-                                    onClick={() => toggleStatus(template.id)}
-                                    className={`text-sm flex items-center gap-1 ${template.active ? "text-green-600" : "text-gray-400"
-                                        }`}
-                                >
-                                    {template.active ? <FaToggleOn /> : <FaToggleOff />}
-                                    {template.active ? "Active" : "Inactive"}
-                                </button>
-
-                                <div className="flex gap-2 text-gray-600">
-                                    <Link
-                                        href={`/dashboard/admin/settings/certificates/${template.id}`}
-                                    >
-                                        <FaEdit title="Edit" />
-                                    </Link>
-                                    <button onClick={() => alert("Duplicate")}>
-                                        <FaClone title="Duplicate" />
-                                    </button>
-                                    <button onClick={() => setPreviewTemplate(template)}>
-                                        <FaEye title="Preview" />
-                                    </button>
-                                    <button
-                                        onClick={() => alert("Delete")}
-                                        className="text-red-500"
-                                    >
-                                        <FaTrash title="Delete" />
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-                {previewTemplate && (
-                    <CertificatePreviewModal
-                        template={previewTemplate}
-                        onClose={() => setPreviewTemplate(null)}
-                    />
-                )}
+              </div>
             </div>
-        </AdminLayout>
-    );
+          ))}
+        </div>
+        {previewTemplate && (
+          <CertificatePreviewModal
+            template={previewTemplate}
+            onClose={() => setPreviewTemplate(null)}
+          />
+        )}
+      </div>
+    </AdminLayout>
+  );
 }

--- a/frontend/src/services/admin/certificateTemplateService.js
+++ b/frontend/src/services/admin/certificateTemplateService.js
@@ -1,0 +1,56 @@
+export const STORAGE_KEY = "sb-certificate-templates";
+
+const read = () => {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch (err) {
+    console.error("Failed to parse templates", err);
+    return [];
+  }
+};
+
+const write = (templates) => {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+};
+
+export const getTemplates = () => read();
+
+export const getTemplate = (id) => read().find((t) => t.id === id);
+
+export const saveTemplate = (template) => {
+  const templates = read();
+  const newTemplate = { ...template, id: template.id || Date.now().toString(), active: true };
+  templates.push(newTemplate);
+  write(templates);
+  return newTemplate;
+};
+
+export const updateTemplate = (id, data) => {
+  const templates = read();
+  const idx = templates.findIndex((t) => t.id === id);
+  if (idx !== -1) {
+    templates[idx] = { ...templates[idx], ...data };
+    write(templates);
+    return templates[idx];
+  }
+  return null;
+};
+
+export const deleteTemplate = (id) => {
+  const filtered = read().filter((t) => t.id !== id);
+  write(filtered);
+};
+
+export const toggleTemplateStatus = (id) => {
+  const templates = read();
+  const idx = templates.findIndex((t) => t.id === id);
+  if (idx !== -1) {
+    templates[idx].active = !templates[idx].active;
+    write(templates);
+    return templates[idx];
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- persist admin certificate templates in local storage
- enable create and edit pages to save templates with previews
- render certificate preview using template styles

## Testing
- `npm run lint` (fails: Component definition is missing display name)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a42f05ee40832885175d209361ab7a