### PR TITLE
feat: connect certificate templates to backend

### DIFF
--- a/backend/src/migrations/20250712161276_add_active_to_certificate_templates.js
+++ b/backend/src/migrations/20250712161276_add_active_to_certificate_templates.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('certificate_templates', function(table) {
+    table.boolean('active').defaultTo(true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('certificate_templates', function(table) {
+    table.dropColumn('active');
+  });
+};

--- a/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
@@ -1,0 +1,58 @@
+const service = require("./certificateTemplates.service");
+const { sendSuccess } = require("../../utils/response");
+
+exports.list = async (req, res, next) => {
+  try {
+    const templates = await service.getAll();
+    sendSuccess(res, templates);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.get = async (req, res, next) => {
+  try {
+    const template = await service.getById(req.params.id);
+    if (!template) return res.status(404).json({ message: "Template not found" });
+    sendSuccess(res, template);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.create = async (req, res, next) => {
+  try {
+    const template = await service.create(req.body);
+    sendSuccess(res, template, 201);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.update = async (req, res, next) => {
+  try {
+    const template = await service.update(req.params.id, req.body);
+    sendSuccess(res, template);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.remove = async (req, res, next) => {
+  try {
+    await service.remove(req.params.id);
+    sendSuccess(res, { id: req.params.id });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.toggle = async (req, res, next) => {
+  try {
+    const template = await service.toggleStatus(req.params.id);
+    if (!template) return res.status(404).json({ message: "Template not found" });
+    sendSuccess(res, template);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./certificateTemplates.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.get("/", controller.list);
+router.post("/", controller.create);
+router.get("/:id", controller.get);
+router.put("/:id", controller.update);
+router.patch("/:id/toggle", controller.toggle);
+router.delete("/:id", controller.remove);
+
+module.exports = router;

--- a/backend/src/modules/certificateTemplates/certificateTemplates.service.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.service.js
@@ -1,0 +1,33 @@
+const db = require("../../config/database");
+
+exports.getAll = async () => {
+  return db("certificate_templates").select("*").orderBy("created_at", "desc");
+};
+
+exports.getById = async (id) => {
+  return db("certificate_templates").where({ id }).first();
+};
+
+exports.create = async (data) => {
+  const [row] = await db("certificate_templates").insert(data).returning("*");
+  return row;
+};
+
+exports.update = async (id, data) => {
+  const [row] = await db("certificate_templates").where({ id }).update(data).returning("*");
+  return row;
+};
+
+exports.remove = async (id) => {
+  return db("certificate_templates").where({ id }).del();
+};
+
+exports.toggleStatus = async (id) => {
+  const template = await exports.getById(id);
+  if (!template) return null;
+  const [row] = await db("certificate_templates")
+    .where({ id })
+    .update({ active: !template.active })
+    .returning("*");
+  return row;
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -104,6 +104,7 @@ app.use("/api/users", require("./modules/users/user.routes"));
 app.use("/api/verify", require("./modules/verify/verify.routes"));
 app.use("/api/certificates", require("./modules/users/tutorials/certificate/certificatePublic.routes"));
 app.use("/api/certificates/admin", require("./modules/certificates/certificates.routes"));
+app.use("/api/certificate-templates", require("./modules/certificateTemplates/certificateTemplates.routes"));
 app.use("/api/bookings/admin", require("./modules/bookings/bookings.routes"));
 app.use("/api/bookings/student", require("./modules/bookings/student.routes"));
 app.use("/api/bookings/instructor", require("./modules/bookings/instructor.routes"));

--- a/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
@@ -20,12 +20,20 @@ export default function EditCertificateTemplate() {
 
   useEffect(() => {
     if (!id) return;
-    const existing = getTemplate(id);
-    if (existing) {
-      setForm(existing);
-      setLogoPreview(existing.logo || "/images/certificate/logo.png");
-      setBgPreview(existing.background || "/images/paper-texture.png");
-    }
+    const load = async () => {
+      try {
+        const existing = await getTemplate(id);
+        if (existing) {
+          setForm(existing);
+          setLogoPreview(existing.logo || "/images/certificate/logo.png");
+          setBgPreview(existing.background || "/images/paper-texture.png");
+        }
+      } catch (err) {
+        console.error("Failed to load template", err);
+        toast.error("Failed to load template");
+      }
+    };
+    load();
   }, [id]);
 
   const handleChange = (key, value) => {
@@ -49,15 +57,19 @@ export default function EditCertificateTemplate() {
     reader.readAsDataURL(file);
   };
 
-  const handleUpdate = () => {
+  const handleUpdate = async () => {
     if (!form.name.trim()) {
       toast.error("Template name is required.");
       return;
     }
-
-    updateTemplate(id, form);
-    toast.success("Template updated");
-    router.push("/dashboard/admin/settings/certificates");
+    try {
+      await updateTemplate(id, form);
+      toast.success("Template updated");
+      router.push("/dashboard/admin/settings/certificates");
+    } catch (err) {
+      console.error("Failed to update template", err);
+      toast.error("Failed to update template");
+    }
   };
 
   if (!form) return <div className="p-8 text-gray-600">Loading template...</div>;

--- a/frontend/src/pages/dashboard/admin/settings/certificates/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/create.js
@@ -44,15 +44,19 @@ export default function CreateCertificateTemplate() {
     reader.readAsDataURL(file);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!form.name.trim()) {
       toast.error("Template name is required.");
       return;
     }
-
-    saveTemplate(form);
-    toast.success("Template saved");
-    router.push("/dashboard/admin/settings/certificates");
+    try {
+      await saveTemplate(form);
+      toast.success("Template saved");
+      router.push("/dashboard/admin/settings/certificates");
+    } catch (err) {
+      console.error("Failed to save template", err);
+      toast.error("Failed to save template");
+    }
   };
 
   return (

--- a/frontend/src/pages/dashboard/admin/settings/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/index.js
@@ -17,26 +17,46 @@ import {
   deleteTemplate,
   toggleTemplateStatus,
 } from "@/services/admin/certificateTemplateService";
+import { toast } from "react-toastify";
 
 export default function CertificateTemplatesPage() {
   const [templates, setTemplates] = useState([]);
   const [previewTemplate, setPreviewTemplate] = useState(null);
 
   useEffect(() => {
-    setTemplates(getTemplates());
+    refresh();
   }, []);
 
-  const refresh = () => setTemplates(getTemplates());
-
-  const toggleStatus = (id) => {
-    toggleTemplateStatus(id);
-    refresh();
+  const refresh = async () => {
+    try {
+      const data = await getTemplates();
+      setTemplates(data);
+    } catch (err) {
+      console.error("Failed to load templates", err);
+      toast.error("Failed to load templates");
+    }
   };
 
-  const handleDelete = (id) => {
-    if (confirm("Delete this template?")) {
-      deleteTemplate(id);
-      refresh();
+  const toggleStatus = async (id) => {
+    try {
+      await toggleTemplateStatus(id);
+      toast.success("Status updated");
+      await refresh();
+    } catch (err) {
+      console.error("Failed to update status", err);
+      toast.error("Failed to update status");
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm("Delete this template?")) return;
+    try {
+      await deleteTemplate(id);
+      toast.success("Template deleted");
+      await refresh();
+    } catch (err) {
+      console.error("Failed to delete template", err);
+      toast.error("Failed to delete template");
     }
   };
 

--- a/frontend/src/services/admin/certificateTemplateService.js
+++ b/frontend/src/services/admin/certificateTemplateService.js
@@ -1,56 +1,30 @@
-export const STORAGE_KEY = "sb-certificate-templates";
+import api from "@/services/api/api";
 
-const read = () => {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch (err) {
-    console.error("Failed to parse templates", err);
-    return [];
-  }
+export const getTemplates = async () => {
+  const res = await api.get("/certificate-templates");
+  return res.data?.data || [];
 };
 
-const write = (templates) => {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+export const getTemplate = async (id) => {
+  const res = await api.get(`/certificate-templates/${id}`);
+  return res.data?.data || null;
 };
 
-export const getTemplates = () => read();
-
-export const getTemplate = (id) => read().find((t) => t.id === id);
-
-export const saveTemplate = (template) => {
-  const templates = read();
-  const newTemplate = { ...template, id: template.id || Date.now().toString(), active: true };
-  templates.push(newTemplate);
-  write(templates);
-  return newTemplate;
+export const saveTemplate = async (template) => {
+  const res = await api.post("/certificate-templates", template);
+  return res.data?.data;
 };
 
-export const updateTemplate = (id, data) => {
-  const templates = read();
-  const idx = templates.findIndex((t) => t.id === id);
-  if (idx !== -1) {
-    templates[idx] = { ...templates[idx], ...data };
-    write(templates);
-    return templates[idx];
-  }
-  return null;
+export const updateTemplate = async (id, data) => {
+  const res = await api.put(`/certificate-templates/${id}`, data);
+  return res.data?.data;
 };
 
-export const deleteTemplate = (id) => {
-  const filtered = read().filter((t) => t.id !== id);
-  write(filtered);
+export const deleteTemplate = async (id) => {
+  await api.delete(`/certificate-templates/${id}`);
 };
 
-export const toggleTemplateStatus = (id) => {
-  const templates = read();
-  const idx = templates.findIndex((t) => t.id === id);
-  if (idx !== -1) {
-    templates[idx].active = !templates[idx].active;
-    write(templates);
-    return templates[idx];
-  }
-  return null;
+export const toggleTemplateStatus = async (id) => {
+  const res = await api.patch(`/certificate-templates/${id}/toggle`);
+  return res.data?.data;
 };


### PR DESCRIPTION
## Summary
- add certificate template CRUD endpoints with active toggle
- wire admin certificate template pages to backend API with toasts

## Testing
- `npm test` (backend) *(fails: expect 200 received 400/500 etc.)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a43694a2548328ab42ebe25973e6c7