### PR TITLE
feat: show message when no certificate templates

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/index.js
@@ -73,52 +73,66 @@ export default function CertificateTemplatesPage() {
           </Link>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {templates.map((template) => (
-            <div
-              key={template.id}
-              className="bg-white shadow rounded-xl p-4 border"
+        {templates.length === 0 ? (
+          <div className="text-center py-10">
+            <p className="text-gray-600 mb-4">
+              No certificate templates found. Create one to get started.
+            </p>
+            <Link
+              href="/dashboard/admin/settings/certificates/create"
+              className="btn btn-primary flex items-center gap-2 justify-center"
             >
-              <img
-                src={template.background || "/images/paper-texture.png"}
-                alt={template.name}
-                className="w-full h-40 object-cover rounded-md mb-4"
-              />
-              <h2 className="font-semibold text-lg">{template.name}</h2>
-              <p className="text-sm text-gray-500 mb-2">Type: {template.type}</p>
+              <FaPlus /> Create Template
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {templates.map((template) => (
+              <div
+                key={template.id}
+                className="bg-white shadow rounded-xl p-4 border"
+              >
+                <img
+                  src={template.background || "/images/paper-texture.png"}
+                  alt={template.name}
+                  className="w-full h-40 object-cover rounded-md mb-4"
+                />
+                <h2 className="font-semibold text-lg">{template.name}</h2>
+                <p className="text-sm text-gray-500 mb-2">Type: {template.type}</p>
 
-              <div className="flex items-center justify-between">
-                <button
-                  onClick={() => toggleStatus(template.id)}
-                  className={`text-sm flex items-center gap-1 ${
-                    template.active ? "text-green-600" : "text-gray-400"
-                  }`}
-                >
-                  {template.active ? <FaToggleOn /> : <FaToggleOff />}
-                  {template.active ? "Active" : "Inactive"}
-                </button>
-
-                <div className="flex gap-2 text-gray-600">
-                  <Link href={`/dashboard/admin/settings/certificates/${template.id}`}>
-                    <FaEdit title="Edit" />
-                  </Link>
-                  <button onClick={() => alert("Duplicate")}>
-                    <FaClone title="Duplicate" />
-                  </button>
-                  <button onClick={() => setPreviewTemplate(template)}>
-                    <FaEye title="Preview" />
-                  </button>
+                <div className="flex items-center justify-between">
                   <button
-                    onClick={() => handleDelete(template.id)}
-                    className="text-red-500"
+                    onClick={() => toggleStatus(template.id)}
+                    className={`text-sm flex items-center gap-1 ${
+                      template.active ? "text-green-600" : "text-gray-400"
+                    }`}
                   >
-                    <FaTrash title="Delete" />
+                    {template.active ? <FaToggleOn /> : <FaToggleOff />}
+                    {template.active ? "Active" : "Inactive"}
                   </button>
+
+                  <div className="flex gap-2 text-gray-600">
+                    <Link href={`/dashboard/admin/settings/certificates/${template.id}`}>
+                      <FaEdit title="Edit" />
+                    </Link>
+                    <button onClick={() => alert("Duplicate")}>
+                      <FaClone title="Duplicate" />
+                    </button>
+                    <button onClick={() => setPreviewTemplate(template)}>
+                      <FaEye title="Preview" />
+                    </button>
+                    <button
+                      onClick={() => handleDelete(template.id)}
+                      className="text-red-500"
+                    >
+                      <FaTrash title="Delete" />
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
         {previewTemplate && (
           <CertificatePreviewModal
             template={previewTemplate}


### PR DESCRIPTION
## Summary
- display placeholder message when there are no certificate templates
- include call-to-action to create a template

## Testing
- `npm test`
- `npm run lint` *(fails: 363 problems, 92 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f0c1e408328868010ebe4594260