### PR TITLE
feat: toggle certificate template status in single query

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.service.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.service.js
@@ -23,11 +23,9 @@ exports.remove = async (id) => {
 };
 
 exports.toggleStatus = async (id) => {
-  const template = await exports.getById(id);
-  if (!template) return null;
   const [row] = await db("certificate_templates")
     .where({ id })
-    .update({ active: !template.active })
+    .update({ active: db.raw("NOT active") })
     .returning("*");
-  return row;
+  return row || null;
 };


### PR DESCRIPTION
## Summary
- simplify certificate template status toggle using single SQL statement

## Testing
- `npm test` *(fails: 9 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f0b3ddc83289540979593e33a38