### PR TITLE
Add submitting state to certificate template forms

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
@@ -2,7 +2,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import CertificatePreviewModal from "@/components/admin/certificates/CertificatePreviewModal";
-import { FaSave, FaEye } from "react-icons/fa";
+import { FaSave, FaEye, FaSpinner } from "react-icons/fa";
 import { toast } from "react-toastify";
 import {
   getTemplate,
@@ -17,6 +17,7 @@ export default function EditCertificateTemplate() {
   const [logoPreview, setLogoPreview] = useState(null);
   const [bgPreview, setBgPreview] = useState(null);
   const [showPreview, setShowPreview] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     if (!id) return;
@@ -62,6 +63,7 @@ export default function EditCertificateTemplate() {
       toast.error("Template name is required.");
       return;
     }
+    setIsSubmitting(true);
     try {
       await updateTemplate(id, form);
       toast.success("Template updated");
@@ -69,6 +71,8 @@ export default function EditCertificateTemplate() {
     } catch (err) {
       console.error("Failed to update template", err);
       toast.error("Failed to update template");
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -187,8 +191,17 @@ export default function EditCertificateTemplate() {
             <button
               className="btn btn-primary flex items-center gap-2"
               onClick={handleUpdate}
+              disabled={isSubmitting}
             >
-              <FaSave /> Update Template
+              {isSubmitting ? (
+                <>
+                  <FaSpinner className="animate-spin" /> Updating...
+                </>
+              ) : (
+                <>
+                  <FaSave /> Update Template
+                </>
+              )}
             </button>
           </section>
         </div>

--- a/frontend/src/pages/dashboard/admin/settings/certificates/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/create.js
@@ -1,7 +1,7 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState } from "react";
 import CertificatePreviewModal from "@/components/admin/certificates/CertificatePreviewModal";
-import { FaSave, FaEye } from "react-icons/fa";
+import { FaSave, FaEye, FaSpinner } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { saveTemplate } from "@/services/admin/certificateTemplateService";
 import { useRouter } from "next/router";
@@ -22,6 +22,7 @@ export default function CreateCertificateTemplate() {
   const [logoPreview, setLogoPreview] = useState("/images/certificate/logo.png");
   const [bgPreview, setBgPreview] = useState("/images/paper-texture.png");
   const [showPreview, setShowPreview] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleChange = (key, value) => {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -49,6 +50,7 @@ export default function CreateCertificateTemplate() {
       toast.error("Template name is required.");
       return;
     }
+    setIsSubmitting(true);
     try {
       await saveTemplate(form);
       toast.success("Template saved");
@@ -56,6 +58,8 @@ export default function CreateCertificateTemplate() {
     } catch (err) {
       console.error("Failed to save template", err);
       toast.error("Failed to save template");
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -172,8 +176,17 @@ export default function CreateCertificateTemplate() {
             <button
               className="btn bg-primary flex items-center gap-2"
               onClick={handleSubmit}
+              disabled={isSubmitting}
             >
-              <FaSave /> Save 
+              {isSubmitting ? (
+                <>
+                  <FaSpinner className="animate-spin" /> Saving...
+                </>
+              ) : (
+                <>
+                  <FaSave /> Save
+                </>
+              )}
             </button>
           </section>
         </div>


### PR DESCRIPTION
## Summary
- add isSubmitting state to certificate template creation and editing pages
- disable Save/Update buttons with spinner during submission

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a47f0a5adc8328b2d4c9bb52f4ee6e