### PR TITLE
Add validation for certificate templates

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
@@ -32,6 +32,7 @@ exports.create = async (req, res, next) => {
 exports.update = async (req, res, next) => {
   try {
     const template = await service.update(req.params.id, req.body);
+    if (!template) return res.status(404).json({ message: "Template not found" });
     sendSuccess(res, template);
   } catch (err) {
     next(err);
@@ -40,7 +41,8 @@ exports.update = async (req, res, next) => {
 
 exports.remove = async (req, res, next) => {
   try {
-    await service.remove(req.params.id);
+    const removed = await service.remove(req.params.id);
+    if (!removed) return res.status(404).json({ message: "Template not found" });
     sendSuccess(res, { id: req.params.id });
   } catch (err) {
     next(err);

--- a/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
@@ -2,13 +2,18 @@ const express = require("express");
 const router = express.Router();
 const controller = require("./certificateTemplates.controller");
 const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+const validate = require("../../middleware/validate");
+const {
+  createTemplate,
+  updateTemplate,
+} = require("./certificateTemplates.validation");
 
 router.use(verifyToken, isAdmin);
 
 router.get("/", controller.list);
-router.post("/", controller.create);
+router.post("/", validate(createTemplate), controller.create);
 router.get("/:id", controller.get);
-router.put("/:id", controller.update);
+router.put("/:id", validate(updateTemplate), controller.update);
 router.patch("/:id/toggle", controller.toggle);
 router.delete("/:id", controller.remove);
 

--- a/backend/src/modules/certificateTemplates/certificateTemplates.service.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.service.js
@@ -14,12 +14,17 @@ exports.create = async (data) => {
 };
 
 exports.update = async (id, data) => {
-  const [row] = await db("certificate_templates").where({ id }).update(data).returning("*");
-  return row;
+  const rows = await db("certificate_templates")
+    .where({ id })
+    .update(data)
+    .returning("*");
+  if (!rows.length) return null;
+  return rows[0];
 };
 
 exports.remove = async (id) => {
-  return db("certificate_templates").where({ id }).del();
+  const deleted = await db("certificate_templates").where({ id }).del();
+  return deleted;
 };
 
 exports.toggleStatus = async (id) => {

--- a/backend/src/modules/certificateTemplates/certificateTemplates.validation.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.validation.js
@@ -1,0 +1,35 @@
+const Joi = require("joi");
+
+const boolean = Joi.boolean()
+  .truthy("1")
+  .truthy(1)
+  .truthy("true")
+  .falsy("0")
+  .falsy(0)
+  .falsy("false");
+
+exports.createTemplate = Joi.object({
+  name: Joi.string().required(),
+  type: Joi.string(),
+  font_family: Joi.string(),
+  title_font: Joi.string(),
+  border_color: Joi.string(),
+  logo: Joi.string().allow("", null),
+  background: Joi.string().allow("", null),
+  show_qr: boolean,
+  active: boolean,
+}).options({ stripUnknown: true });
+
+exports.updateTemplate = Joi.object({
+  name: Joi.string(),
+  type: Joi.string(),
+  font_family: Joi.string(),
+  title_font: Joi.string(),
+  border_color: Joi.string(),
+  logo: Joi.string().allow("", null),
+  background: Joi.string().allow("", null),
+  show_qr: boolean,
+  active: boolean,
+})
+  .min(1)
+  .options({ stripUnknown: true });


### PR DESCRIPTION
## Summary
- add Joi validation schemas that strip unknown fields for certificate templates
- validate create and update routes with schema middleware
- return 404 when certificate template updates or deletes affect no rows

## Testing
- `cd backend && npm test` *(fails: 9 failed, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f0813088328be6c747730dbd39a