### PR TITLE
Use snake_case for certificate template fields

### DIFF
--- a/frontend/src/components/admin/certificates/CertificatePreviewModal.js
+++ b/frontend/src/components/admin/certificates/CertificatePreviewModal.js
@@ -15,13 +15,22 @@ export default function CertificatePreviewModal({ template, onClose }) {
   };
 
   const {
-    borderColor = "#FACC15",
-    fontFamily = "Georgia, serif",
-    titleFont = "'Great Vibes', cursive",
+    border_color,
+    font_family,
+    title_font,
     background = "/images/paper-texture.png",
     logo = "/images/certificate/logo.png",
-    showQR = true,
+    show_qr,
+    borderColor: legacyBorderColor,
+    fontFamily: legacyFontFamily,
+    titleFont: legacyTitleFont,
+    showQR: legacyShowQR,
   } = template;
+
+  const borderColor = border_color ?? legacyBorderColor ?? "#FACC15";
+  const fontFamily = font_family ?? legacyFontFamily ?? "Georgia, serif";
+  const titleFont = title_font ?? legacyTitleFont ?? "'Great Vibes', cursive";
+  const showQR = show_qr ?? legacyShowQR ?? true;
 
   return (
     <div className="fixed inset-0 bg-gradient-to-br from-black/80 to-black/60 flex items-center justify-center z-50">

--- a/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
@@ -8,6 +8,7 @@ import {
   getTemplate,
   updateTemplate,
 } from "@/services/admin/certificateTemplateService";
+import { toSnakeCase } from "@/utils/case";
 
 export default function EditCertificateTemplate() {
   const router = useRouter();
@@ -24,7 +25,7 @@ export default function EditCertificateTemplate() {
       try {
         const existing = await getTemplate(id);
         if (existing) {
-          setForm(existing);
+          setForm(toSnakeCase(existing));
           setLogoPreview(existing.logo || "/images/certificate/logo.png");
           setBgPreview(existing.background || "/images/paper-texture.png");
         }
@@ -110,8 +111,8 @@ export default function EditCertificateTemplate() {
               <div>
                 <label className="text-sm font-medium text-gray-600">Body Font</label>
                 <select
-                  value={form.fontFamily}
-                  onChange={(e) => handleChange("fontFamily", e.target.value)}
+                value={form.font_family}
+                onChange={(e) => handleChange("font_family", e.target.value)}
                   className="select select-bordered w-full mt-1"
                 >
                   <option value="Georgia, serif">Georgia</option>
@@ -122,8 +123,8 @@ export default function EditCertificateTemplate() {
               <div>
                 <label className="text-sm font-medium text-gray-600">Title Font</label>
                 <select
-                  value={form.titleFont}
-                  onChange={(e) => handleChange("titleFont", e.target.value)}
+                value={form.title_font}
+                onChange={(e) => handleChange("title_font", e.target.value)}
                   className="select select-bordered w-full mt-1"
                 >
                   <option value="'Great Vibes', cursive">Great Vibes</option>
@@ -142,16 +143,16 @@ export default function EditCertificateTemplate() {
                 <label className="text-sm font-medium text-gray-600 block mb-1">Border Color</label>
                 <input
                   type="color"
-                  value={form.borderColor}
-                  onChange={(e) => handleChange("borderColor", e.target.value)}
+                  value={form.border_color}
+                  onChange={(e) => handleChange("border_color", e.target.value)}
                   className="w-12 h-12 border rounded-md cursor-pointer"
                 />
               </div>
               <div className="flex items-center gap-2">
                 <input
                   type="checkbox"
-                  checked={form.showQR}
-                  onChange={(e) => handleChange("showQR", e.target.checked)}
+                  checked={form.show_qr}
+                  onChange={(e) => handleChange("show_qr", e.target.checked)}
                   className="checkbox"
                 />
                 <span className="text-gray-700">Include QR Code</span>

--- a/frontend/src/pages/dashboard/admin/settings/certificates/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/create.js
@@ -11,10 +11,10 @@ export default function CreateCertificateTemplate() {
   const [form, setForm] = useState({
     name: "",
     type: "Completion",
-    borderColor: "#FACC15",
-    fontFamily: "Georgia, serif",
-    titleFont: "'Great Vibes', cursive",
-    showQR: true,
+    border_color: "#FACC15",
+    font_family: "Georgia, serif",
+    title_font: "'Great Vibes', cursive",
+    show_qr: true,
     logo: null,
     background: null,
   });
@@ -95,8 +95,8 @@ export default function CreateCertificateTemplate() {
               <div>
                 <label className="text-sm font-medium text-gray-600">Body Font</label>
                 <select
-                  value={form.fontFamily}
-                  onChange={(e) => handleChange("fontFamily", e.target.value)}
+                  value={form.font_family}
+                  onChange={(e) => handleChange("font_family", e.target.value)}
                   className="select select-bordered w-full mt-1"
                 >
                   <option value="Georgia, serif">Georgia</option>
@@ -107,8 +107,8 @@ export default function CreateCertificateTemplate() {
               <div>
                 <label className="text-sm font-medium text-gray-600">Title Font</label>
                 <select
-                  value={form.titleFont}
-                  onChange={(e) => handleChange("titleFont", e.target.value)}
+                  value={form.title_font}
+                  onChange={(e) => handleChange("title_font", e.target.value)}
                   className="select select-bordered w-full mt-1"
                 >
                   <option value="'Great Vibes', cursive">Great Vibes</option>
@@ -127,16 +127,16 @@ export default function CreateCertificateTemplate() {
                 <label className="text-sm font-medium text-gray-600 block mb-1">Border Color</label>
                 <input
                   type="color"
-                  value={form.borderColor}
-                  onChange={(e) => handleChange("borderColor", e.target.value)}
+                  value={form.border_color}
+                  onChange={(e) => handleChange("border_color", e.target.value)}
                   className="w-12 h-12 border rounded-md cursor-pointer"
                 />
               </div>
               <div className="flex items-center gap-2">
                 <input
                   type="checkbox"
-                  checked={form.showQR}
-                  onChange={(e) => handleChange("showQR", e.target.checked)}
+                  checked={form.show_qr}
+                  onChange={(e) => handleChange("show_qr", e.target.checked)}
                   className="checkbox"
                 />
                 <span className="text-gray-700">Include QR Code</span>

--- a/frontend/src/services/admin/certificateTemplateService.js
+++ b/frontend/src/services/admin/certificateTemplateService.js
@@ -1,4 +1,5 @@
 import api from "@/services/api/api";
+import { toSnakeCase } from "@/utils/case";
 
 export const getTemplates = async () => {
   const res = await api.get("/certificate-templates");
@@ -11,12 +12,18 @@ export const getTemplate = async (id) => {
 };
 
 export const saveTemplate = async (template) => {
-  const res = await api.post("/certificate-templates", template);
+  const res = await api.post(
+    "/certificate-templates",
+    toSnakeCase(template)
+  );
   return res.data?.data;
 };
 
 export const updateTemplate = async (id, data) => {
-  const res = await api.put(`/certificate-templates/${id}`, data);
+  const res = await api.put(
+    `/certificate-templates/${id}`,
+    toSnakeCase(data)
+  );
   return res.data?.data;
 };
 

--- a/frontend/src/utils/case.js
+++ b/frontend/src/utils/case.js
@@ -1,0 +1,15 @@
+export const toSnakeCase = (obj) => {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => toSnakeCase(item));
+  }
+  if (obj && typeof obj === "object" && obj.constructor === Object) {
+    return Object.keys(obj).reduce((acc, key) => {
+      const snakeKey = key
+        .replace(/([A-Z])/g, "_$1")
+        .toLowerCase();
+      acc[snakeKey] = toSnakeCase(obj[key]);
+      return acc;
+    }, {});
+  }
+  return obj;
+};


### PR DESCRIPTION
## Summary
- use snake_case for certificate template form fields
- send snake_case keys in certificateTemplateService using toSnakeCase utility
- handle both camelCase and snake_case in CertificatePreviewModal

## Testing
- `npm test`
- `npm run lint` *(fails: 92 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f061adc832895770516a41a918c