### PR TITLE
Fix certificate templates admin page syntax

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/index.js
@@ -99,70 +99,52 @@ export default function CertificateTemplatesPage() {
           </div>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {templates.map((template) => (
-              <div
-                key={template.id}
-                className="bg-white shadow rounded-xl p-4 border"
-              >
-                <img
-                  src={template.background || "/images/paper-texture.png"}
-                  alt={template.name}
-                  className="w-full h-40 object-cover rounded-md mb-4"
-                />
-                <h2 className="font-semibold text-lg">{template.name}</h2>
-                <p className="text-sm text-gray-500 mb-2">Type: {template.type}</p>
-
-              <div className="flex items-center justify-between">
-                <button
-                  onClick={() => toggleStatus(template.id)}
-                  className={`text-sm flex items-center gap-1 ${
-                    template.active ? "text-green-600" : "text-gray-400"
-                  }`}
+            {templates.map((template) => {
+              return (
+                <div
+                  key={template.id}
+                  className="bg-white shadow rounded-xl p-4 border"
                 >
-                  {template.active ? <FaToggleOn /> : <FaToggleOff />}
-                  {template.active ? "Active" : "Inactive"}
-                </button>
+                  <img
+                    src={template.background || "/images/paper-texture.png"}
+                    alt={template.name}
+                    className="w-full h-40 object-cover rounded-md mb-4"
+                  />
+                  <h2 className="font-semibold text-lg">{template.name}</h2>
+                  <p className="text-sm text-gray-500 mb-2">Type: {template.type}</p>
 
-                <div className="flex gap-2 text-gray-600">
-                  <Link href={`/dashboard/admin/settings/certificates/${template.id}`}>
-                    <FaEdit title="Edit" />
-                  </Link>
-                  <button onClick={() => handleDuplicate(template.id)}>
-                    <FaClone title="Duplicate" />
-                  </button>
-                  <button onClick={() => setPreviewTemplate(template)}>
-                    <FaEye title="Preview" />
-                  </button>
-                  <button
-                    onClick={() => toggleStatus(template.id)}
-                    className={`text-sm flex items-center gap-1 ${
-                      template.active ? "text-green-600" : "text-gray-400"
-                    }`}
-                  >
-                    {template.active ? <FaToggleOn /> : <FaToggleOff />}
-                    {template.active ? "Active" : "Inactive"}
-                  </button>
-
-                  <div className="flex gap-2 text-gray-600">
-                    <Link href={`/dashboard/admin/settings/certificates/${template.id}`}>
-                      <FaEdit title="Edit" />
-                    </Link>
-                    <button onClick={() => alert("Duplicate")}>
-                      <FaClone title="Duplicate" />
-                    </button>
-                    <button onClick={() => setPreviewTemplate(template)}>
-                      <FaEye title="Preview" />
-                    </button>
+                  <div className="flex items-center justify-between">
                     <button
-                      onClick={() => handleDelete(template.id)}
-                      className="text-red-500"
+                      onClick={() => toggleStatus(template.id)}
+                      className={`text-sm flex items-center gap-1 ${
+                        template.active ? "text-green-600" : "text-gray-400"
+                      }`}
                     >
-                      <FaTrash title="Delete" />
+                      {template.active ? <FaToggleOn /> : <FaToggleOff />}
+                      {template.active ? "Active" : "Inactive"}
                     </button>
+
+                    <div className="flex gap-2 text-gray-600">
+                      <Link href={`/dashboard/admin/settings/certificates/${template.id}`}>
+                        <FaEdit title="Edit" />
+                      </Link>
+                      <button onClick={() => handleDuplicate(template.id)}>
+                        <FaClone title="Duplicate" />
+                      </button>
+                      <button onClick={() => setPreviewTemplate(template)}>
+                        <FaEye title="Preview" />
+                      </button>
+                      <button
+                        onClick={() => handleDelete(template.id)}
+                        className="text-red-500"
+                      >
+                        <FaTrash title="Delete" />
+                      </button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
         {previewTemplate && (


### PR DESCRIPTION
## Summary
- fix certificate templates index listing layout by removing duplicate actions

## Testing
- `cd frontend && npm test`
- `cd backend && npm test` *(fails: 10 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a6a4df5c8328b371f5eae47de1a8