### PR TITLE
fix: add validation to certificate template routes

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
@@ -2,12 +2,17 @@ const express = require("express");
 const router = express.Router();
 const controller = require("./certificateTemplates.controller");
 const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+const validate = require("../../middleware/validate");
+const {
+  createTemplate,
+  updateTemplate,
+} = require("./certificateTemplates.validation");
 const upload = require("./certificateTemplateUpload.middleware");
 
 router.use(verifyToken, isAdmin);
 
 router.get("/", controller.list);
-router.post("/", controller.create);
+router.post("/", validate(createTemplate), controller.create);
 router.post("/upload", upload, controller.upload);
 router.get("/:id", controller.get);
 router.put("/:id", validate(updateTemplate), controller.update);


### PR DESCRIPTION
## Summary
- import validation middleware and schemas for certificate templates
- validate create and update routes

## Testing
- `npm test` *(fails: adsRoutes, tutorialRoutes, class routes, tutorialUpdateTransaction, paymentCommission, seoConfig, blogRoutes, paymentInstallments, community public routes)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b1c18b4c8328bdbe487f59d97253