### PR TITLE
feat: localize language config page

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -3,7 +3,7 @@
   "users": "Users",
   "settings": "Settings (JSON)",
   "language_manager": "Language Manager",
-  "language_config": "Language Config",
+  "language_config": "إعداد اللغة",
   "currency_manager": "Currency Manager",
   "social_logins": "Social Logins",
   "email_config": "Email Config",
@@ -1014,7 +1014,7 @@
     "Go to Website": "Go to Website",
     "Help Center": "Help Center",
     "Instructors": "Instructors",
-    "Language Config": "Language Config",
+    "Language Config": "إعداد اللغة",
     "Language Manager": "Language Manager",
     "Manage Classes": "Manage Classes",
     "Manage Tutorials": "Manage Tutorials",
@@ -1139,6 +1139,12 @@
     "no_app_prefix": "Do not include the `App` prefix.",
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
+  },
+  "languageConfigPage": {
+    "title": "إعداد اللغة",
+    "default_language": "اللغة الافتراضية",
+    "save": "حفظ",
+    "saving": "جاري الحفظ..."
   },
   "offersPage": {
     "title": "📚 My Offers Dashboard",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -994,7 +994,7 @@
     "Go to Website": "Go to Website",
     "Help Center": "Help Center",
     "Instructors": "Instructors",
-    "Language Config": "Language Config",
+    "Language Config": "Sprachkonfiguration",
     "Language Manager": "Language Manager",
     "Manage Classes": "Manage Classes",
     "Manage Tutorials": "Manage Tutorials",
@@ -1119,6 +1119,12 @@
     "no_app_prefix": "Do not include the `App` prefix.",
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
+  },
+  "languageConfigPage": {
+    "title": "Sprachkonfiguration",
+    "default_language": "Standardsprache",
+    "save": "Speichern",
+    "saving": "Speichern..."
   },
   "offersPage": {
     "title": "📚 My Offers Dashboard",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1120,6 +1120,12 @@
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
   },
+  "languageConfigPage": {
+    "title": "Language Configuration",
+    "default_language": "Default Language",
+    "save": "Save",
+    "saving": "Saving..."
+  },
   "offersPage": {
     "title": "📚 My Offers Dashboard",
     "post_new": "Post New Request",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -3,7 +3,7 @@
   "users": "Users",
   "settings": "Settings (JSON)",
   "language_manager": "Language Manager",
-  "language_config": "Language Config",
+  "language_config": "Configuración de idioma",
   "currency_manager": "Currency Manager",
   "social_logins": "Social Logins",
   "email_config": "Email Config",
@@ -994,7 +994,7 @@
     "Go to Website": "Go to Website",
     "Help Center": "Help Center",
     "Instructors": "Instructors",
-    "Language Config": "Language Config",
+    "Language Config": "Configuración de idioma",
     "Language Manager": "Language Manager",
     "Manage Classes": "Manage Classes",
     "Manage Tutorials": "Manage Tutorials",
@@ -1119,6 +1119,12 @@
     "no_app_prefix": "Do not include the `App` prefix.",
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
+  },
+  "languageConfigPage": {
+    "title": "Configuración de idioma",
+    "default_language": "Idioma predeterminado",
+    "save": "Guardar",
+    "saving": "Guardando..."
   },
   "offersPage": {
     "title": "📚 My Offers Dashboard",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -3,7 +3,7 @@
   "users": "Users",
   "settings": "Settings (JSON)",
   "language_manager": "Language Manager",
-  "language_config": "Language Config",
+  "language_config": "Configuration de la langue",
   "currency_manager": "Currency Manager",
   "social_logins": "Social Logins",
   "email_config": "Email Config",
@@ -994,7 +994,7 @@
     "Go to Website": "Go to Website",
     "Help Center": "Help Center",
     "Instructors": "Instructors",
-    "Language Config": "Language Config",
+    "Language Config": "Configuration de la langue",
     "Language Manager": "Language Manager",
     "Manage Classes": "Manage Classes",
     "Manage Tutorials": "Manage Tutorials",
@@ -1119,6 +1119,12 @@
     "no_app_prefix": "Do not include the `App` prefix.",
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
+  },
+  "languageConfigPage": {
+    "title": "Configuration de la langue",
+    "default_language": "Langue par défaut",
+    "save": "Enregistrer",
+    "saving": "Enregistrement..."
   },
   "offersPage": {
     "title": "📚 My Offers Dashboard",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -3,7 +3,7 @@
   "users": "Users",
   "settings": "Settings (JSON)",
   "language_manager": "Language Manager",
-  "language_config": "Language Config",
+  "language_config": "भाषा कॉन्फ़िगरेशन",
   "currency_manager": "Currency Manager",
   "social_logins": "Social Logins",
   "email_config": "Email Config",
@@ -994,7 +994,7 @@
     "Go to Website": "Go to Website",
     "Help Center": "Help Center",
     "Instructors": "Instructors",
-    "Language Config": "Language Config",
+    "Language Config": "भाषा कॉन्फ़िगरेशन",
     "Language Manager": "Language Manager",
     "Manage Classes": "Manage Classes",
     "Manage Tutorials": "Manage Tutorials",
@@ -1119,6 +1119,12 @@
     "no_app_prefix": "Do not include the `App` prefix.",
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
+  },
+  "languageConfigPage": {
+    "title": "भाषा कॉन्फ़िगरेशन",
+    "default_language": "डिफ़ॉल्ट भाषा",
+    "save": "सहेजें",
+    "saving": "सहेजा जा रहा है..."
   },
   "offersPage": {
     "title": "📚 My Offers Dashboard",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -3,7 +3,7 @@
   "users": "Users",
   "settings": "Settings (JSON)",
   "language_manager": "Language Manager",
-  "language_config": "Language Config",
+  "language_config": "语言配置",
   "currency_manager": "Currency Manager",
   "social_logins": "Social Logins",
   "email_config": "Email Config",
@@ -994,7 +994,7 @@
     "Go to Website": "Go to Website",
     "Help Center": "Help Center",
     "Instructors": "Instructors",
-    "Language Config": "Language Config",
+    "Language Config": "语言配置",
     "Language Manager": "Language Manager",
     "Manage Classes": "Manage Classes",
     "Manage Tutorials": "Manage Tutorials",
@@ -1119,6 +1119,12 @@
     "no_app_prefix": "Do not include the `App` prefix.",
     "firebase_hint": "Firebase Auth is used for phone number OTP during login. No toggle is required.",
     "default": "Default"
+  },
+  "languageConfigPage": {
+    "title": "语言配置",
+    "default_language": "默认语言",
+    "save": "保存",
+    "saving": "保存中..."
   },
   "offersPage": {
     "title": "📚 My Offers Dashboard",

--- a/frontend/src/pages/dashboard/admin/settings/language-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/language-config/index.js
@@ -4,8 +4,12 @@ import { fetchAppConfig, updateAppConfig } from "@/services/admin/appConfigServi
 import { getLanguages } from "@/services/languageService";
 import { FaSave } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 export default function LanguageConfigPage() {
+  const { t, i18n } = useTranslation("dashboard");
   const [config, setConfig] = useState({ defaultLanguage: "en" });
   const [languages, setLanguages] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -21,7 +25,7 @@ export default function LanguageConfigPage() {
         setLanguages(langs || []);
       } catch (err) {
         console.error("Failed to load data", err);
-        toast.error("Failed to load settings");
+        toast.error(t("settings_load_failed"));
       }
     };
     load();
@@ -32,10 +36,10 @@ export default function LanguageConfigPage() {
     try {
       const updated = await updateAppConfig(config);
       setConfig(updated);
-      toast.success("Settings saved");
+      toast.success(t("settings_saved"));
     } catch (err) {
       console.error(err);
-      toast.error("Failed to save settings");
+      toast.error(t("settings_save_failed"));
     } finally {
       setLoading(false);
     }
@@ -43,10 +47,10 @@ export default function LanguageConfigPage() {
 
   return (
     <AdminLayout>
-      <div className="p-6 max-w-xl mx-auto space-y-6">
-        <h1 className="text-2xl font-bold">Language Config</h1>
+      <div className="p-6 max-w-xl mx-auto space-y-6" dir={i18n.dir()}>
+        <h1 className="text-2xl font-bold">{t("languageConfigPage.title")}</h1>
         <div>
-          <label className="block font-semibold mb-1">Default Language</label>
+          <label className="block font-semibold mb-1">{t("languageConfigPage.default_language")}</label>
           <select
             className="w-full border p-2 rounded"
             value={config.defaultLanguage}
@@ -66,9 +70,17 @@ export default function LanguageConfigPage() {
           disabled={loading}
           className="bg-yellow-500 text-white px-4 py-2 rounded flex items-center gap-2"
         >
-          <FaSave /> {loading ? "Saving..." : "Save"}
+          <FaSave /> {loading ? t("languageConfigPage.saving") : t("languageConfigPage.save")}
         </button>
       </div>
     </AdminLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- add i18n support and server-side translations to admin language config page
- provide translations for language configuration labels across en, es, ar, fr, hi, de and zh locales

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba1d3c7c83289224f26216f31403