### PR TITLE
Enable Apple social login

### DIFF
--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -3,8 +3,8 @@ const passport = require('passport');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
 // Facebook login strategy
 const FacebookStrategy = require('passport-facebook').Strategy;
-// Apple login is disabled until production deployment
-// const AppleStrategy = require('passport-apple').Strategy;
+// Apple login strategy
+const AppleStrategy = require('passport-apple').Strategy;
 const GitHubStrategy = require('passport-github2').Strategy;
 
 const socialAuthService = require('../modules/auth/services/socialAuth.service');
@@ -112,45 +112,44 @@ async function initStrategies() {
     );
   }
 
-  // Apple login is temporarily disabled until the project is deployed
-  // const apple = providers.apple || {};
-  // if (
-  //   apple.active &&
-  //   (apple.clientId || process.env.APPLE_CLIENT_ID) &&
-  //   (apple.teamId || process.env.APPLE_TEAM_ID) &&
-  //   (apple.keyId || process.env.APPLE_KEY_ID)
-  // ) {
-  //   passport.use(
-  //     'apple',
-  //     new AppleStrategy(
-  //       {
-  //         clientID: apple.clientId || process.env.APPLE_CLIENT_ID || '',
-  //         teamID: apple.teamId || process.env.APPLE_TEAM_ID || '',
-  //         keyID: apple.keyId || process.env.APPLE_KEY_ID || '',
-  //         callbackURL: '/api/auth/apple/callback',
-  //         privateKeyString: ((apple.privateKey || process.env.APPLE_PRIVATE_KEY) || '').replace(/\\n/g, '\n'),
-  //         scope: ['name', 'email'],
-  //       },
-  //       async (_accessToken, _refreshToken, idToken, profile, done) => {
-  //         try {
-  //           const { sub, email } = idToken || {};
-  //           const fullName = profile?.name
-  //             ? `${profile.name.firstName || ''} ${profile.name.lastName || ''}`.trim()
-  //             : 'User';
-  //           const result = await socialAuthService.loginOrRegister({
-  //             provider: 'apple',
-  //             providerId: sub,
-  //             email,
-  //             fullName,
-  //           });
-  //           return done(null, result);
-  //         } catch (err) {
-  //           return done(err);
-  //         }
-  //       }
-  //     )
-  //   );
-  // }
+  const apple = providers.apple || {};
+  if (
+    apple.active &&
+    (apple.clientId || process.env.APPLE_CLIENT_ID) &&
+    (apple.teamId || process.env.APPLE_TEAM_ID) &&
+    (apple.keyId || process.env.APPLE_KEY_ID)
+  ) {
+    passport.use(
+      'apple',
+      new AppleStrategy(
+        {
+          clientID: apple.clientId || process.env.APPLE_CLIENT_ID || '',
+          teamID: apple.teamId || process.env.APPLE_TEAM_ID || '',
+          keyID: apple.keyId || process.env.APPLE_KEY_ID || '',
+          callbackURL: apple.redirectUrl || '/api/auth/apple/callback',
+          privateKeyString: ((apple.privateKey || process.env.APPLE_PRIVATE_KEY) || '').replace(/\\n/g, '\n'),
+          scope: ['name', 'email'],
+        },
+        async (_accessToken, _refreshToken, idToken, profile, done) => {
+          try {
+            const { sub, email } = idToken || {};
+            const fullName = profile?.name
+              ? `${profile.name.firstName || ''} ${profile.name.lastName || ''}`.trim()
+              : 'User';
+            const result = await socialAuthService.loginOrRegister({
+              provider: 'apple',
+              providerId: sub,
+              email,
+              fullName,
+            });
+            return done(null, result);
+          } catch (err) {
+            return done(err);
+          }
+        }
+      )
+    );
+  }
   initialized = true;
 }
 

--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -46,25 +46,25 @@ exports.facebookCallback = (req, res, next) => {
   })(req, res, next);
 };
 
-// Apple OAuth is disabled until the project is hosted
-// exports.appleAuth = passport.authenticate('apple');
+// Apple OAuth
+exports.appleAuth = passport.authenticate('apple', { scope: ['name', 'email'] });
 
-// exports.appleCallback = (req, res, next) => {
-//   passport.authenticate('apple', { session: false }, (err, result) => {
-//     if (err || !result) {
-//       return res.redirect(`${process.env.FRONTEND_URL || ''}/auth/login?error=social`);
-//     }
-//     const { accessToken, refreshToken } = result;
-//     res.cookie('refreshToken', refreshToken, {
-//       httpOnly: true,
-//       secure: process.env.NODE_ENV === 'production',
-//       sameSite: 'strict',
-//       maxAge: 7 * 24 * 60 * 60 * 1000,
-//     });
-//     const redirectUrl = `${process.env.FRONTEND_URL || ''}/auth/social-success?token=${accessToken}`;
-//     res.redirect(redirectUrl);
-//   })(req, res, next);
-// };
+exports.appleCallback = (req, res, next) => {
+  passport.authenticate('apple', { session: false }, (err, result) => {
+    if (err || !result) {
+      return res.redirect(`${frontendBase}/auth/login?error=social`);
+    }
+    const { refreshToken } = result;
+    res.cookie('refreshToken', refreshToken, refreshCookieOptions);
+    let origin = req.query.origin;
+    if (!allowedOrigins.includes(origin)) {
+      const headerOrigin = req.get('origin');
+      origin = allowedOrigins.includes(headerOrigin) ? headerOrigin : frontendBase;
+    }
+    const redirectUrl = `${origin}/auth/social-success`;
+    res.redirect(redirectUrl);
+  })(req, res, next);
+};
 
 // GitHub OAuth
 exports.githubAuth = passport.authenticate('github', { scope: ['user:email'] });

--- a/backend/src/modules/auth/routes/auth.routes.js
+++ b/backend/src/modules/auth/routes/auth.routes.js
@@ -114,9 +114,9 @@ router.get("/google/callback", socialAuthController.googleCallback);
 // Facebook login routes
 router.get("/facebook", socialAuthController.facebookAuth);
 router.get("/facebook/callback", socialAuthController.facebookCallback);
-// Apple routes are disabled until production deployment
-// router.get("/apple", socialAuthController.appleAuth);
-// router.post("/apple/callback", socialAuthController.appleCallback);
+// Apple login routes
+router.get("/apple", socialAuthController.appleAuth);
+router.post("/apple/callback", socialAuthController.appleCallback);
 
 // GitHub routes
 router.get("/github", socialAuthController.githubAuth);

--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -202,7 +202,7 @@ export default function SocialLoginSettingsPage() {
     setProviders(updated);
     const adjusted = updated.map((p) => ({
       ...p,
-      active: p.active || providerHasCredentials(p),
+      active: p.active && providerHasCredentials(p),
     }));
     const payload = {
       enabled: globalActive,
@@ -260,10 +260,10 @@ export default function SocialLoginSettingsPage() {
 
   const handleSave = async () => {
     const prevState = getCurrentState();
-    // ensure providers with credentials default to active unless explicitly disabled
+    // ensure providers are only active when toggled on and have required credentials
     const adjusted = providers.map((p) => ({
       ...p,
-      active: p.active || providerHasCredentials(p),
+      active: p.active && providerHasCredentials(p),
     }));
 
     const payload = {
@@ -303,7 +303,7 @@ export default function SocialLoginSettingsPage() {
     const prevState = getCurrentState();
     const adjusted = providers.map((p) => ({
       ...p,
-      active: p.active || providerHasCredentials(p),
+      active: p.active && providerHasCredentials(p),
     }));
     const payload = {
       enabled: globalActive,


### PR DESCRIPTION
## Summary
- Enable Apple OAuth strategy and routes in backend so Apple login works when configured
- Ensure admin social login settings only activate providers with credentials

## Testing
- ❌ `npm test` (backend) — 9 failing test suites
- ✅ `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a4ba8ece748328a2874d24a22f332a