### PR TITLE
feat: improve currency rate refresh logic

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/currency/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/index.js
@@ -22,6 +22,7 @@ import {
   updateCurrency,
   deleteCurrency as deleteCurrencyApi,
 } from "@/services/admin/currencyService";
+import { getAppConfig } from "@/services/appConfigService";
 import { FaPlus, FaStar, FaSync, FaTrash, FaToggleOn, FaToggleOff, FaEdit } from "react-icons/fa";
 
 const fetcher = () => fetchCurrencies();
@@ -145,20 +146,36 @@ function CurrencyManagerPage() {
     const currency = currencies.find((c) => c.id === id);
     if (!currency) return;
     try {
+      let base = currencies.find((c) => c.is_default)?.code;
+      if (!base) {
+        const config = await getAppConfig().catch(() => ({}));
+        base = config?.currency;
+      }
+      if (!base) throw new Error('Base currency not configured');
+
       const res = await fetch(
-        `https://api.exchangerate.host/latest?base=USD&symbols=${currency.code}`
+        `https://api.exchangerate.host/latest?base=${base}&symbols=${currency.code}`
       );
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Request failed with status ${res.status}`);
+      }
       const data = await res.json();
       const rate = data?.rates?.[currency.code];
-      if (!rate) throw new Error("Rate not found");
-      await updateCurrency(id, { exchange_rate: rate, last_updated: new Date().toISOString() });
+      if (!rate) throw new Error('Rate not found');
+
+      await updateCurrency(id, {
+        exchange_rate: rate,
+        last_updated: new Date().toISOString(),
+      });
       mutate();
       toast.success(t('rate_refreshed'));
       const message = `Currency "${currency.label}" rate refreshed.`;
-      notify("currency_rate_refreshed", message);
+      notify('currency_rate_refreshed', message);
     } catch (err) {
       console.error(err);
-      toast.error(t('failed_to_refresh'));
+      const msg = err?.message ? `${t('failed_to_refresh')}: ${err.message}` : t('failed_to_refresh');
+      toast.error(msg);
     }
   };
 


### PR DESCRIPTION
## Summary
- fetch default base currency before refreshing currency rates
- handle API errors explicitly and show translated toasts

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bc71254c83288737ea1cdca0f5d9