### PR TITLE
Add currency translations and i18n strings

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -259,6 +259,12 @@
     "processing": "Saving...",
     "currency_saved": "Currency saved!",
     "currency_updated": "Currency updated!",
+    "enter_new_exchange_rate": "أدخل سعر صرف جديد",
+    "invalid_rate": "سعر غير صالح",
+    "currency_name_placeholder": "مثال: دولار أمريكي",
+    "currency_code_placeholder": "مثال: USD",
+    "invalid_image_type": "يُسمح بملفات الصور فقط.",
+    "max_logo_size": "الحد الأقصى لحجم الشعار 2 ميجابايت.",
     "failed_to_save": "Failed to save currency.",
     "showing": "Showing {{from}}–{{to}} of {{total}} currencies"
   },

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -259,6 +259,12 @@
     "processing": "Saving...",
     "currency_saved": "Currency saved!",
     "currency_updated": "Currency updated!",
+    "enter_new_exchange_rate": "Neuen Wechselkurs eingeben",
+    "invalid_rate": "Ungültiger Kurs",
+    "currency_name_placeholder": "z. B. US-Dollar",
+    "currency_code_placeholder": "z. B. USD",
+    "invalid_image_type": "Es sind nur Bilddateien erlaubt.",
+    "max_logo_size": "Maximale Logogröße 2 MB.",
     "failed_to_save": "Failed to save currency.",
     "showing": "Showing {{from}}–{{to}} of {{total}} currencies"
   },

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -259,6 +259,12 @@
     "processing": "Saving...",
     "currency_saved": "Currency saved!",
     "currency_updated": "Currency updated!",
+    "enter_new_exchange_rate": "Enter new exchange rate",
+    "invalid_rate": "Invalid rate",
+    "currency_name_placeholder": "e.g. US Dollar",
+    "currency_code_placeholder": "e.g. USD",
+    "invalid_image_type": "Only image files are allowed.",
+    "max_logo_size": "Max file size is 2MB.",
     "failed_to_save": "Failed to save currency.",
     "showing": "Showing {{from}}–{{to}} of {{total}} currencies"
   },

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -259,6 +259,12 @@
     "processing": "Saving...",
     "currency_saved": "Currency saved!",
     "currency_updated": "Currency updated!",
+    "enter_new_exchange_rate": "Introduce un nuevo tipo de cambio",
+    "invalid_rate": "Tipo de cambio no válido",
+    "currency_name_placeholder": "p. ej. Dólar estadounidense",
+    "currency_code_placeholder": "p. ej. USD",
+    "invalid_image_type": "Solo se permiten archivos de imagen.",
+    "max_logo_size": "Tamaño máximo del logo 2 MB.",
     "failed_to_save": "Failed to save currency.",
     "showing": "Showing {{from}}–{{to}} of {{total}} currencies"
   },

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -259,6 +259,12 @@
     "processing": "Saving...",
     "currency_saved": "Currency saved!",
     "currency_updated": "Currency updated!",
+    "enter_new_exchange_rate": "Entrer un nouveau taux de change",
+    "invalid_rate": "Taux invalide",
+    "currency_name_placeholder": "ex. Dollar américain",
+    "currency_code_placeholder": "ex. USD",
+    "invalid_image_type": "Seuls les fichiers image sont autorisés.",
+    "max_logo_size": "Taille maximale du logo 2 Mo.",
     "failed_to_save": "Failed to save currency.",
     "showing": "Showing {{from}}–{{to}} of {{total}} currencies"
   },

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -259,6 +259,12 @@
     "processing": "Saving...",
     "currency_saved": "Currency saved!",
     "currency_updated": "Currency updated!",
+    "enter_new_exchange_rate": "नया विनिमय दर दर्ज करें",
+    "invalid_rate": "अमान्य दर",
+    "currency_name_placeholder": "उदा. अमेरिकी डॉलर",
+    "currency_code_placeholder": "उदा. USD",
+    "invalid_image_type": "केवल इमेज फ़ाइलें अनुमत हैं.",
+    "max_logo_size": "अधिकतम लोगो आकार 2MB है.",
     "failed_to_save": "Failed to save currency.",
     "showing": "Showing {{from}}–{{to}} of {{total}} currencies"
   },

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -259,6 +259,12 @@
     "processing": "Saving...",
     "currency_saved": "Currency saved!",
     "currency_updated": "Currency updated!",
+    "enter_new_exchange_rate": "输入新的汇率",
+    "invalid_rate": "无效的汇率",
+    "currency_name_placeholder": "例如：美元",
+    "currency_code_placeholder": "例如：USD",
+    "invalid_image_type": "只允许图片文件。",
+    "max_logo_size": "徽标最大大小为2MB。",
     "failed_to_save": "Failed to save currency.",
     "showing": "Showing {{from}}–{{to}} of {{total}} currencies"
   },

--- a/frontend/src/pages/dashboard/admin/settings/currency/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/create.js
@@ -125,7 +125,7 @@ function CreateCurrencyPage() {
               name="label"
               value={form.label}
               onChange={handleChange}
-              placeholder="e.g. US Dollar"
+              placeholder={t('currency_name_placeholder')}
               required
               className="w-full border p-2 rounded"
             />
@@ -138,7 +138,7 @@ function CreateCurrencyPage() {
               name="code"
               value={form.code}
               onChange={handleChange}
-              placeholder="e.g. USD"
+              placeholder={t('currency_code_placeholder')}
               required
               className="w-full border p-2 rounded uppercase"
             />
@@ -203,11 +203,11 @@ function CreateCurrencyPage() {
               const file = e.target.files[0];
               if (!file) return;
               if (!file.type.startsWith("image/")) {
-                alert("Only image files are allowed.");
+                alert(t('invalid_image_type'));
                 return;
               }
               if (file.size > 2 * 1024 * 1024) {
-                alert("Max file size is 2MB.");
+                alert(t('max_logo_size'));
                 return;
               }
               const reader = new FileReader();

--- a/frontend/src/pages/dashboard/admin/settings/currency/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/edit/[id].js
@@ -220,11 +220,11 @@ function EditCurrencyPage() {
               const file = e.target.files[0];
               if (!file) return;
               if (!file.type.startsWith("image/")) {
-                alert("Only image files are allowed.");
+                alert(t('invalid_image_type'));
                 return;
               }
               if (file.size > 2 * 1024 * 1024) {
-                alert("Max file size is 2MB.");
+                alert(t('max_logo_size'));
                 return;
               }
               const reader = new FileReader();

--- a/frontend/src/pages/dashboard/admin/settings/currency/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/index.js
@@ -98,7 +98,7 @@ function CurrencyManagerPage() {
     try {
       await updateCurrency(id, { is_active: !currency.is_active });
       mutate();
-      const status = currency.is_active ? "Inactive" : "Active";
+      const status = currency.is_active ? t('inactive') : t('active');
       toast.success(t('status_updated'));
       const message = `Currency "${currency.label}" status changed to ${status}.`;
       notify("currency_status_changed", message);
@@ -165,10 +165,10 @@ function CurrencyManagerPage() {
   const changeRate = async (id) => {
     const currency = currencies.find((c) => c.id === id);
     if (!currency) return;
-    const input = prompt("Enter new exchange rate", currency.exchange_rate);
+    const input = prompt(t('enter_new_exchange_rate'), currency.exchange_rate);
     if (!input) return;
     const value = parseFloat(input);
-    if (isNaN(value) || value <= 0) return alert("Invalid rate");
+    if (isNaN(value) || value <= 0) return alert(t('invalid_rate'));
     try {
       await updateCurrency(id, { exchange_rate: value });
       mutate();


### PR DESCRIPTION
## Summary
- add currency form and validation strings to translations for all locales
- replace hard-coded currency manager text with `t()` lookups

## Testing
- `npm test`
- `npm run lint` *(fails: 92 errors, 272 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bc72e6008328988a79ca0927ca9b