### PR TITLE
feat: add translations for admin blog settings

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1651,6 +1651,25 @@
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
   },
+  "blogManagerPage": {
+    "title": "إدارة مقالات المدونة",
+    "post_title_placeholder": "عنوان المقال",
+    "upload_image": "رفع صورة",
+    "excerpt_placeholder": "مقتطف",
+    "add_post": "إضافة مقال",
+    "save": "حفظ",
+    "cancel": "إلغاء",
+    "edit": "تعديل",
+    "delete": "حذف",
+    "confirm_delete": "حذف هذا المقال؟",
+    "load_failed": "فشل تحميل المقالات",
+    "create_success": "تم إنشاء المقال",
+    "create_failed": "فشل إنشاء المقال",
+    "delete_success": "تم حذف المقال",
+    "delete_failed": "فشل حذف المقال",
+    "update_success": "تم تحديث المقال",
+    "update_failed": "فشل تحديث المقال"
+  },
   "couponsPage": {
     "new_coupon": "New Coupon",
     "code_placeholder": "CODE",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1694,6 +1694,25 @@
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
   },
+  "blogManagerPage": {
+    "title": "Blogbeiträge verwalten",
+    "post_title_placeholder": "Beitragstitel",
+    "upload_image": "Bild hochladen",
+    "excerpt_placeholder": "Auszug",
+    "add_post": "Beitrag hinzufügen",
+    "save": "Speichern",
+    "cancel": "Abbrechen",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "confirm_delete": "Diesen Beitrag löschen?",
+    "load_failed": "Beiträge konnten nicht geladen werden",
+    "create_success": "Beitrag erstellt",
+    "create_failed": "Beitrag konnte nicht erstellt werden",
+    "delete_success": "Beitrag gelöscht",
+    "delete_failed": "Beitrag konnte nicht gelöscht werden",
+    "update_success": "Beitrag aktualisiert",
+    "update_failed": "Beitrag konnte nicht aktualisiert werden"
+  },
   "couponsPage": {
     "new_coupon": "New Coupon",
     "code_placeholder": "CODE",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1695,6 +1695,25 @@
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
   },
+  "blogManagerPage": {
+    "title": "Manage Blog Posts",
+    "post_title_placeholder": "Post Title",
+    "upload_image": "Upload Image",
+    "excerpt_placeholder": "Excerpt",
+    "add_post": "Add Post",
+    "save": "Save",
+    "cancel": "Cancel",
+    "edit": "Edit",
+    "delete": "Delete",
+    "confirm_delete": "Delete this post?",
+    "load_failed": "Failed to load posts",
+    "create_success": "Post created",
+    "create_failed": "Failed to create post",
+    "delete_success": "Post deleted",
+    "delete_failed": "Failed to delete post",
+    "update_success": "Post updated",
+    "update_failed": "Failed to update post"
+  },
   "couponsPage": {
     "new_coupon": "New Coupon",
     "code_placeholder": "CODE",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1694,6 +1694,25 @@
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
   },
+  "blogManagerPage": {
+    "title": "Gestionar publicaciones del blog",
+    "post_title_placeholder": "Título de la publicación",
+    "upload_image": "Subir imagen",
+    "excerpt_placeholder": "Extracto",
+    "add_post": "Agregar publicación",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "confirm_delete": "¿Eliminar esta publicación?",
+    "load_failed": "Error al cargar las publicaciones",
+    "create_success": "Publicación creada",
+    "create_failed": "Error al crear la publicación",
+    "delete_success": "Publicación eliminada",
+    "delete_failed": "Error al eliminar la publicación",
+    "update_success": "Publicación actualizada",
+    "update_failed": "Error al actualizar la publicación"
+  },
   "couponsPage": {
     "new_coupon": "New Coupon",
     "code_placeholder": "CODE",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1694,6 +1694,25 @@
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
   },
+  "blogManagerPage": {
+    "title": "Gérer les articles du blog",
+    "post_title_placeholder": "Titre de l'article",
+    "upload_image": "Télécharger l'image",
+    "excerpt_placeholder": "Extrait",
+    "add_post": "Ajouter un article",
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "confirm_delete": "Supprimer cet article ?",
+    "load_failed": "Échec du chargement des articles",
+    "create_success": "Article créé",
+    "create_failed": "Échec de la création de l'article",
+    "delete_success": "Article supprimé",
+    "delete_failed": "Échec de la suppression de l'article",
+    "update_success": "Article mis à jour",
+    "update_failed": "Échec de la mise à jour de l'article"
+  },
   "couponsPage": {
     "new_coupon": "New Coupon",
     "code_placeholder": "CODE",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1694,6 +1694,25 @@
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
   },
+  "blogManagerPage": {
+    "title": "ब्लॉग पोस्ट प्रबंधित करें",
+    "post_title_placeholder": "पोस्ट शीर्षक",
+    "upload_image": "छवि अपलोड करें",
+    "excerpt_placeholder": "सारांश",
+    "add_post": "पोस्ट जोड़ें",
+    "save": "सहेजें",
+    "cancel": "रद्द करें",
+    "edit": "संपादित करें",
+    "delete": "हटाएँ",
+    "confirm_delete": "क्या इस पोस्ट को हटाना है?",
+    "load_failed": "पोस्ट लोड करने में विफल",
+    "create_success": "पोस्ट बनाई गई",
+    "create_failed": "पोस्ट बनाने में विफल",
+    "delete_success": "पोस्ट हटाई गई",
+    "delete_failed": "पोस्ट हटाने में विफल",
+    "update_success": "पोस्ट अपडेट की गई",
+    "update_failed": "पोस्ट अपडेट करने में विफल"
+  },
   "couponsPage": {
     "new_coupon": "New Coupon",
     "code_placeholder": "CODE",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1694,6 +1694,25 @@
     "quiz": "Quiz/Test",
     "pending_approved": "Pending/Approved"
   },
+  "blogManagerPage": {
+    "title": "管理博客文章",
+    "post_title_placeholder": "文章标题",
+    "upload_image": "上传图片",
+    "excerpt_placeholder": "摘要",
+    "add_post": "添加文章",
+    "save": "保存",
+    "cancel": "取消",
+    "edit": "编辑",
+    "delete": "删除",
+    "confirm_delete": "删除此文章？",
+    "load_failed": "加载文章失败",
+    "create_success": "文章已创建",
+    "create_failed": "创建文章失败",
+    "delete_success": "文章已删除",
+    "delete_failed": "删除文章失败",
+    "update_success": "文章已更新",
+    "update_failed": "更新文章失败"
+  },
   "couponsPage": {
     "new_coupon": "New Coupon",
     "code_placeholder": "CODE",

--- a/frontend/src/pages/dashboard/admin/settings/blog/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/blog/index.js
@@ -8,9 +8,13 @@ import {
   deletePost,
 } from "@/services/admin/blogService";
 import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 export default function AdminBlogManager() {
   const [posts, setPosts] = useState([]);
+  const { t } = useTranslation("dashboard", { keyPrefix: "blogManagerPage" });
 
   const [newPost, setNewPost] = useState({
     title: "",
@@ -31,8 +35,8 @@ export default function AdminBlogManager() {
       const list = await fetchPosts();
       setPosts(list);
     } catch (err) {
-      console.error('Failed to load posts', err);
-      toast.error('Failed to load posts');
+      console.error("Failed to load posts", err);
+      toast.error(t("load_failed"));
     }
   };
 
@@ -47,22 +51,22 @@ export default function AdminBlogManager() {
       const saved = await createPost(form);
       setPosts((prev) => [...prev, saved]);
       resetForm();
-      toast.success("Post created");
+      toast.success(t("create_success"));
     } catch (err) {
       console.error(err);
-      toast.error(err?.response?.data?.message || "Failed to create post");
+      toast.error(err?.response?.data?.message || t("create_failed"));
     }
   };
 
   const handleDelete = async (id) => {
-    if (!confirm("Delete this post?")) return;
+    if (!confirm(t("confirm_delete"))) return;
     try {
       await deletePost(id);
       setPosts((prev) => prev.filter((post) => post.id !== id));
-      toast.success("Post deleted");
+      toast.success(t("delete_success"));
     } catch (err) {
       console.error(err);
-      toast.error("Failed to delete post");
+      toast.error(t("delete_failed"));
     }
   };
 
@@ -88,10 +92,10 @@ export default function AdminBlogManager() {
       const updated = await updatePost(editId, form);
       setPosts((prev) => prev.map((p) => (p.id === editId ? updated : p)));
       resetForm();
-      toast.success("Post updated");
+      toast.success(t("update_success"));
     } catch (err) {
       console.error(err);
-      toast.error("Failed to update post");
+      toast.error(t("update_failed"));
     }
   };
 
@@ -113,12 +117,12 @@ export default function AdminBlogManager() {
   return (
     <AdminLayout>
       <div className="p-6 max-w-5xl mx-auto">
-        <h1 className="text-2xl font-bold mb-6">Manage Blog Posts</h1>
+        <h1 className="text-2xl font-bold mb-6">{t("title")}</h1>
 
         <div className="bg-white shadow rounded p-4 mb-8 space-y-4">
           <input
             type="text"
-            placeholder="Post Title"
+            placeholder={t("post_title_placeholder")}
             className="w-full border p-2 rounded"
             value={newPost.title}
             onChange={(e) => setNewPost({ ...newPost, title: e.target.value })}
@@ -126,7 +130,7 @@ export default function AdminBlogManager() {
 
           {/* Image upload with preview */}
           <div className="space-y-2">
-            <label className="block font-medium">Upload Image</label>
+            <label className="block font-medium">{t("upload_image")}</label>
             <input
               type="file"
               accept="image/*"
@@ -147,7 +151,7 @@ export default function AdminBlogManager() {
           </div>
 
           <textarea
-            placeholder="Excerpt"
+            placeholder={t("excerpt_placeholder")}
             className="w-full border p-2 rounded"
             value={newPost.excerpt}
             onChange={(e) => setNewPost({ ...newPost, excerpt: e.target.value })}
@@ -163,15 +167,15 @@ export default function AdminBlogManager() {
             {editId ? (
               <>
                 <button onClick={handleSave} className="bg-green-600 text-white px-4 py-2 rounded flex items-center gap-2">
-                  <FaSave /> Save
+                  <FaSave /> {t("save")}
                 </button>
                 <button onClick={handleCancel} className="bg-gray-500 text-white px-4 py-2 rounded flex items-center gap-2">
-                  <FaTimes /> Cancel
+                  <FaTimes /> {t("cancel")}
                 </button>
               </>
             ) : (
               <button onClick={handleAdd} className="bg-indigo-600 text-white px-4 py-2 rounded flex items-center gap-2">
-                <FaPlus /> Add Post
+                <FaPlus /> {t("add_post")}
               </button>
             )}
           </div>
@@ -195,10 +199,10 @@ export default function AdminBlogManager() {
                 <p className="text-gray-700 text-sm mb-4">{post.excerpt}</p>
                 <div className="flex gap-2">
                   <button onClick={() => handleEdit(post.id)} className="bg-yellow-500 text-white px-3 py-1 rounded flex items-center gap-1">
-                    <FaEdit /> Edit
+                    <FaEdit /> {t("edit")}
                   </button>
                   <button onClick={() => handleDelete(post.id)} className="bg-red-600 text-white px-3 py-1 rounded flex items-center gap-1">
-                    <FaTrash /> Delete
+                    <FaTrash /> {t("delete")}
                   </button>
                 </div>
               </div>
@@ -208,4 +212,12 @@ export default function AdminBlogManager() {
       </div>
     </AdminLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- localize admin blog manager page with i18n support
- provide blog management strings for all locales

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c714e300832891df52e0dc8ccdd8