### PR TITLE
feat: localize contact settings

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1197,6 +1197,21 @@
     "save": "حفظ",
     "saving": "جاري الحفظ..."
   },
+  "contactPage": {
+    "title": "إعدادات صفحة الاتصال",
+    "public_email": "البريد الإلكتروني العام",
+    "phone_number": "رقم الهاتف",
+    "address_line": "سطر العنوان",
+    "city": "المدينة",
+    "country": "الدولة",
+    "form_recipient_email": "البريد الإلكتروني لمستلم النموذج",
+    "google_maps_embed_url": "رابط تضمين خرائط جوجل",
+    "save_settings": "حفظ الإعدادات",
+    "saving": "جارٍ الحفظ...",
+    "load_failed": "فشل في تحميل الإعدادات",
+    "save_success": "تم حفظ إعدادات الاتصال!",
+    "save_failed": "فشل في حفظ الإعدادات"
+  },
   "offersPage": {
     "title": "📚 My Offers Dashboard",
     "post_new": "Post New Request",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1177,6 +1177,21 @@
     "save": "Speichern",
     "saving": "Speichern..."
   },
+  "contactPage": {
+    "title": "Einstellungen der Kontaktseite",
+    "public_email": "Öffentliche E-Mail",
+    "phone_number": "Telefonnummer",
+    "address_line": "Adresszeile",
+    "city": "Stadt",
+    "country": "Land",
+    "form_recipient_email": "E-Mail des Formular-Empfängers",
+    "google_maps_embed_url": "Google Maps Einbettungs-URL",
+    "save_settings": "Einstellungen speichern",
+    "saving": "Speichern...",
+    "load_failed": "Einstellungen konnten nicht geladen werden",
+    "save_success": "Kontakteinstellungen gespeichert!",
+    "save_failed": "Einstellungen konnten nicht gespeichert werden"
+  },
   "offersPage": {
     "title": "📚 My Offers Dashboard",
     "post_new": "Post New Request",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1177,6 +1177,21 @@
     "save": "Save",
     "saving": "Saving..."
   },
+  "contactPage": {
+    "title": "Contact Page Settings",
+    "public_email": "Public Email",
+    "phone_number": "Phone Number",
+    "address_line": "Address Line",
+    "city": "City",
+    "country": "Country",
+    "form_recipient_email": "Form Recipient Email",
+    "google_maps_embed_url": "Google Maps Embed URL",
+    "save_settings": "Save Settings",
+    "saving": "Saving...",
+    "load_failed": "Failed to load settings",
+    "save_success": "Contact settings saved!",
+    "save_failed": "Failed to save settings"
+  },
   "offersPage": {
     "title": "📚 My Offers Dashboard",
     "post_new": "Post New Request",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1177,6 +1177,21 @@
     "save": "Guardar",
     "saving": "Guardando..."
   },
+  "contactPage": {
+    "title": "Configuración de la página de contacto",
+    "public_email": "Correo electrónico público",
+    "phone_number": "Número de teléfono",
+    "address_line": "Dirección",
+    "city": "Ciudad",
+    "country": "País",
+    "form_recipient_email": "Correo del destinatario del formulario",
+    "google_maps_embed_url": "URL de inserción de Google Maps",
+    "save_settings": "Guardar configuración",
+    "saving": "Guardando...",
+    "load_failed": "No se pudo cargar la configuración",
+    "save_success": "¡Configuración de contacto guardada!",
+    "save_failed": "No se pudo guardar la configuración"
+  },
   "offersPage": {
     "title": "📚 My Offers Dashboard",
     "post_new": "Post New Request",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1177,6 +1177,21 @@
     "save": "Enregistrer",
     "saving": "Enregistrement..."
   },
+  "contactPage": {
+    "title": "Paramètres de la page de contact",
+    "public_email": "E-mail public",
+    "phone_number": "Numéro de téléphone",
+    "address_line": "Adresse",
+    "city": "Ville",
+    "country": "Pays",
+    "form_recipient_email": "E-mail du destinataire du formulaire",
+    "google_maps_embed_url": "URL d'intégration Google Maps",
+    "save_settings": "Enregistrer les paramètres",
+    "saving": "Enregistrement...",
+    "load_failed": "Échec du chargement des paramètres",
+    "save_success": "Paramètres de contact enregistrés !",
+    "save_failed": "Échec de l'enregistrement des paramètres"
+  },
   "offersPage": {
     "title": "📚 My Offers Dashboard",
     "post_new": "Post New Request",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1177,6 +1177,21 @@
     "save": "सहेजें",
     "saving": "सहेजा जा रहा है..."
   },
+  "contactPage": {
+    "title": "संपर्क पृष्ठ सेटिंग्स",
+    "public_email": "सार्वजनिक ईमेल",
+    "phone_number": "फ़ोन नंबर",
+    "address_line": "पता पंक्ति",
+    "city": "शहर",
+    "country": "देश",
+    "form_recipient_email": "फ़ॉर्म प्राप्तकर्ता का ईमेल",
+    "google_maps_embed_url": "गूगल मानचित्र एम्बेड URL",
+    "save_settings": "सेटिंग्स सहेजें",
+    "saving": "सहेजा जा रहा है...",
+    "load_failed": "सेटिंग्स लोड करने में विफल",
+    "save_success": "संपर्क सेटिंग्स सहेजी गई!",
+    "save_failed": "सेटिंग्स सहेजने में विफल"
+  },
   "offersPage": {
     "title": "📚 My Offers Dashboard",
     "post_new": "Post New Request",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1177,6 +1177,21 @@
     "save": "保存",
     "saving": "保存中..."
   },
+  "contactPage": {
+    "title": "联系页面设置",
+    "public_email": "公开邮箱",
+    "phone_number": "电话号码",
+    "address_line": "地址行",
+    "city": "城市",
+    "country": "国家",
+    "form_recipient_email": "表单接收邮箱",
+    "google_maps_embed_url": "Google 地图嵌入链接",
+    "save_settings": "保存设置",
+    "saving": "正在保存...",
+    "load_failed": "加载设置失败",
+    "save_success": "联系设置已保存！",
+    "save_failed": "保存设置失败"
+  },
   "offersPage": {
     "title": "📚 My Offers Dashboard",
     "post_new": "Post New Request",

--- a/frontend/src/pages/dashboard/admin/settings/contact/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/contact/index.js
@@ -4,137 +4,148 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSave } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { fetchContactConfig, updateContactConfig } from "@/services/admin/contactConfigService";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 
 const initialConfig = {
-    "email": "support@skillbridge.com",
-    "phone": "+1 555-1234",
-    "addressLine": "123 Remote Learning Ave",
-    "city": "EdTech City",
-    "country": "USA",
-    "formRecipient": "support@skillbridge.com",
-    "mapEmbedUrl": "https://maps.google.com/embed?pb=..."
+  email: "support@skillbridge.com",
+  phone: "+1 555-1234",
+  addressLine: "123 Remote Learning Ave",
+  city: "EdTech City",
+  country: "USA",
+  formRecipient: "support@skillbridge.com",
+  mapEmbedUrl: "https://maps.google.com/embed?pb=...",
 };
 
-
 export default function AdminContactSettings() {
-    const [config, setConfig] = useState(initialConfig);
-    const [loading, setLoading] = useState(false);
+  const { t } = useTranslation('dashboard', { keyPrefix: 'contactPage' });
+  const [config, setConfig] = useState(initialConfig);
+  const [loading, setLoading] = useState(false);
 
-    useEffect(() => {
-        const load = async () => {
-            setLoading(true);
-            try {
-                const data = await fetchContactConfig();
-                if (data) setConfig({ ...initialConfig, ...data });
-            } catch (err) {
-                toast.error("Failed to load settings");
-            } finally {
-                setLoading(false);
-            }
-        };
-        load();
-    }, []);
-
-    const handleChange = (field, value) => {
-        setConfig((prev) => ({ ...prev, [field]: value }));
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchContactConfig();
+        if (data) setConfig({ ...initialConfig, ...data });
+      } catch (err) {
+        toast.error(t('load_failed'));
+      } finally {
+        setLoading(false);
+      }
     };
+    load();
+  }, [t]);
 
-    const handleSave = async () => {
-        setLoading(true);
-        try {
-            await updateContactConfig(config);
-            toast.success("Contact settings saved!");
-        } catch (err) {
-            toast.error("Failed to save settings");
-        } finally {
-            setLoading(false);
-        }
-    };
+  const handleChange = (field, value) => {
+    setConfig((prev) => ({ ...prev, [field]: value }));
+  };
 
-    return (
-        <AdminLayout>
-            <div className="max-w-4xl mx-auto px-4 py-8">
-                <h1 className="text-3xl font-extrabold text-gray-800 mb-8">📬 Contact Page Settings</h1>
+  const handleSave = async () => {
+    setLoading(true);
+    try {
+      await updateContactConfig(config);
+      toast.success(t('save_success'));
+    } catch (err) {
+      toast.error(t('save_failed'));
+    } finally {
+      setLoading(false);
+    }
+  };
 
-                <div className="bg-white rounded-xl shadow-md p-6 space-y-6 border border-gray-200">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-                        <div>
-                            <label className="block text-sm font-semibold text-gray-700 mb-1">Public Email</label>
-                            <input
-                                type="email"
-                                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
-                                value={config.email}
-                                onChange={(e) => handleChange("email", e.target.value)}
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-sm font-semibold text-gray-700 mb-1">Phone Number</label>
-                            <input
-                                type="text"
-                                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
-                                value={config.phone}
-                                onChange={(e) => handleChange("phone", e.target.value)}
-                            />
-                        </div>
-                        <div className="sm:col-span-2">
-                            <label className="block text-sm font-semibold text-gray-700 mb-1">Address Line</label>
-                            <input
-                                type="text"
-                                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
-                                value={config.addressLine}
-                                onChange={(e) => handleChange("addressLine", e.target.value)}
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-sm font-semibold text-gray-700 mb-1">City</label>
-                            <input
-                                type="text"
-                                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
-                                value={config.city}
-                                onChange={(e) => handleChange("city", e.target.value)}
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-sm font-semibold text-gray-700 mb-1">Country</label>
-                            <input
-                                type="text"
-                                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
-                                value={config.country}
-                                onChange={(e) => handleChange("country", e.target.value)}
-                            />
-                        </div>
-                        <div className="sm:col-span-2">
-                            <label className="block text-sm font-semibold text-gray-700 mb-1">Form Recipient Email</label>
-                            <input
-                                type="email"
-                                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
-                                value={config.formRecipient}
-                                onChange={(e) => handleChange("formRecipient", e.target.value)}
-                            />
-                        </div>
-                        <div className="sm:col-span-2">
-                            <label className="block text-sm font-semibold text-gray-700 mb-1">Google Maps Embed URL</label>
-                            <input
-                                type="text"
-                                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
-                                value={config.mapEmbedUrl}
-                                onChange={(e) => handleChange("mapEmbedUrl", e.target.value)}
-                            />
-                        </div>
-                    </div>
+  return (
+    <AdminLayout title={t('title')}>
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <h1 className="text-3xl font-extrabold text-gray-800 mb-8">📬 {t('title')}</h1>
 
-                    <div className="text-right">
-                        <button
-                            onClick={handleSave}
-                            disabled={loading}
-                            className={`inline-flex items-center gap-2 px-6 py-2 rounded-lg shadow transition ${loading ? "bg-gray-300 cursor-not-allowed" : "bg-yellow-600 text-white hover:bg-yellow-700"}`}
-                        >
-                            <FaSave /> {loading ? "Saving..." : "Save Settings"}
-                        </button>
-                    </div>
-                </div>
+        <div className="bg-white rounded-xl shadow-md p-6 space-y-6 border border-gray-200">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">{t('public_email')}</label>
+              <input
+                type="email"
+                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
+                value={config.email}
+                onChange={(e) => handleChange('email', e.target.value)}
+              />
             </div>
-        </AdminLayout>
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">{t('phone_number')}</label>
+              <input
+                type="text"
+                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
+                value={config.phone}
+                onChange={(e) => handleChange('phone', e.target.value)}
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-sm font-semibold text-gray-700 mb-1">{t('address_line')}</label>
+              <input
+                type="text"
+                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
+                value={config.addressLine}
+                onChange={(e) => handleChange('addressLine', e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">{t('city')}</label>
+              <input
+                type="text"
+                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
+                value={config.city}
+                onChange={(e) => handleChange('city', e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">{t('country')}</label>
+              <input
+                type="text"
+                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
+                value={config.country}
+                onChange={(e) => handleChange('country', e.target.value)}
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-sm font-semibold text-gray-700 mb-1">{t('form_recipient_email')}</label>
+              <input
+                type="email"
+                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
+                value={config.formRecipient}
+                onChange={(e) => handleChange('formRecipient', e.target.value)}
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-sm font-semibold text-gray-700 mb-1">{t('google_maps_embed_url')}</label>
+              <input
+                type="text"
+                className="w-full border rounded-lg p-2 focus:ring focus:ring-yellow-200"
+                value={config.mapEmbedUrl}
+                onChange={(e) => handleChange('mapEmbedUrl', e.target.value)}
+              />
+            </div>
+          </div>
 
-    );
+          <div className="text-right">
+            <button
+              onClick={handleSave}
+              disabled={loading}
+              className={`inline-flex items-center gap-2 px-6 py-2 rounded-lg shadow transition ${loading ? 'bg-gray-300 cursor-not-allowed' : 'bg-yellow-600 text-white hover:bg-yellow-700'}`}
+            >
+              <FaSave /> {loading ? t('saving') : t('save_settings')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </AdminLayout>
+  );
 }
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+    },
+  };
+}
+


### PR DESCRIPTION
## Summary
- integrate i18n on admin contact settings page
- add contact settings translations across supported locales

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4c6f7527c83288b5ccce6cd18dcba