### PR TITLE
feat: add certificate template duplication

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
@@ -59,6 +59,16 @@ exports.toggle = async (req, res, next) => {
   }
 };
 
+exports.duplicate = async (req, res, next) => {
+  try {
+    const template = await service.duplicate(req.params.id);
+    if (!template) return res.status(404).json({ message: "Template not found" });
+    sendSuccess(res, template, 201);
+  } catch (err) {
+    next(err);
+  }
+};
+
 exports.upload = async (req, res, next) => {
   try {
     if (!req.file) return res.status(400).json({ message: "No file uploaded" });

--- a/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
@@ -17,6 +17,7 @@ router.post("/upload", upload, controller.upload);
 router.get("/:id", controller.get);
 router.put("/:id", validate(updateTemplate), controller.update);
 router.patch("/:id/toggle", controller.toggle);
+router.post("/:id/duplicate", controller.duplicate);
 router.delete("/:id", controller.remove);
 
 module.exports = router;

--- a/frontend/src/services/admin/certificateTemplateService.js
+++ b/frontend/src/services/admin/certificateTemplateService.js
@@ -35,6 +35,10 @@ export const toggleTemplateStatus = async (id) => {
   const res = await api.patch(`/certificate-templates/${id}/toggle`);
   return res.data?.data;
 };
+export const duplicateTemplate = async (id) => {
+  const res = await api.post(`/certificate-templates/${id}/duplicate`);
+  return res.data?.data;
+};
 export const uploadTemplateFile = async (file) => {
   const formData = new FormData();
   formData.append("file", file);


### PR DESCRIPTION
## Summary
- add duplicate certificate template API route and controller handler
- allow frontend to call duplication endpoint

## Testing
- `npm test` (backend) *(fails: adsRoutes.test.js, paymentCommission.test.js, tutorialUpdateTransaction.test.js, seoConfigRoutes.test.js, blogRoutes.test.js, paymentInstallments.test.js, public.routes.test.js)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a4c6814c408328ba79e82715594bce