### PR TITLE
Serve certificate uploads via API path

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
@@ -72,7 +72,13 @@ exports.duplicate = async (req, res, next) => {
 exports.upload = async (req, res, next) => {
   try {
     if (!req.file) return res.status(400).json({ message: "No file uploaded" });
-    const url = `/uploads/certificateTemplates/${req.file.filename}`;
+    // Use "/api/uploads" so the URL works behind reverse proxies (e.g., Nginx)
+    // that forward all "/api" requests to the backend. Returning a direct
+    // "/uploads" path causes the frontend to request the file from its own
+    // server instead of the backend, resulting in broken images. Prefixing the
+    // path with "/api" ensures the request is routed to the backend where the
+    // static file middleware serves uploaded certificate assets.
+    const url = `/api/uploads/certificateTemplates/${req.file.filename}`;
     sendSuccess(res, { url });
   } catch (err) {
     next(err);

--- a/backend/tests/certificateTemplateUpload.test.js
+++ b/backend/tests/certificateTemplateUpload.test.js
@@ -1,0 +1,33 @@
+const request = require("supertest");
+const express = require("express");
+
+// Mock authentication to bypass middleware protections
+jest.mock("../src/middleware/auth/authMiddleware", () => ({
+  verifyToken: jest.fn((req, _res, next) => {
+    req.user = { id: "admin", role: "admin", roles: ["admin"] };
+    next();
+  }),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+// Import routes after mocking auth middleware
+const routes = require("../src/modules/certificateTemplates/certificateTemplates.routes");
+
+const app = express();
+app.use(express.json());
+app.use("/api/certificate-templates", routes);
+
+describe("POST /api/certificate-templates/upload", () => {
+  it("returns a URL under /api/uploads", async () => {
+    const res = await request(app)
+      .post("/api/certificate-templates/upload")
+      .attach("file", Buffer.from("dummy"), {
+        filename: "test.png",
+        contentType: "image/png",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.url).toMatch(/^\/api\/uploads\/certificateTemplates\//);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Return certificate upload URLs under `/api/uploads` to ensure media is served by backend behind reverse proxies
- Add unit test validating certificate template uploads return API-based URLs

## Testing
- `npm test tests/certificateTemplateUpload.test.js`
- `npm test` *(fails: POST /api/ads/admin creates ad, PUT /api/users/tutorials/admin/:id returns 403, Class routes create class, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a4df0932d883288e466ca81e5d998d