### PR TITLE
feat: add pagination to certificates

### DIFF
--- a/backend/src/modules/certificates/certificates.controller.js
+++ b/backend/src/modules/certificates/certificates.controller.js
@@ -8,7 +8,8 @@ const { sendSuccess } = require("../../utils/response");
 /**
  * List all certificates
  */
-exports.list = catchAsync(async (_req, res) => {
-  const certificates = await service.getAll();
+exports.list = catchAsync(async (req, res) => {
+  const { page = 1, limit = 10 } = req.query;
+  const certificates = await service.getAll({ page, limit });
   sendSuccess(res, certificates);
 });

--- a/backend/src/modules/certificates/certificates.service.js
+++ b/backend/src/modules/certificates/certificates.service.js
@@ -5,8 +5,11 @@ const db = require("../../config/database");
 
 /**
  * Fetch all certificates with related student and class info
+ * Supports simple pagination via `page` and `limit` parameters
  */
-exports.getAll = async () => {
+exports.getAll = async ({ page = 1, limit = 10 } = {}) => {
+  const offset = (page - 1) * limit;
+
   return db("certificates")
     .leftJoin("users", "certificates.user_id", "users.id")
     .leftJoin("online_classes", "certificates.class_id", "online_classes.id")
@@ -15,5 +18,7 @@ exports.getAll = async () => {
       "users.full_name as student_name",
       "online_classes.title as class_name"
     )
-    .orderBy("certificates.created_at", "desc");
+    .orderBy("certificates.created_at", "desc")
+    .offset(offset)
+    .limit(limit);
 };

--- a/frontend/src/pages/dashboard/admin/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/certificates/index.js
@@ -16,18 +16,22 @@ export default function AdminCertificatesPage() {
   const [certificates, setCertificates] = useState([]);
   const [search, setSearch] = useState('');
   const [filterStatus, setFilterStatus] = useState('all');
+  const [page, setPage] = useState(1);
+  const limit = 10;
+  const [hasMore, setHasMore] = useState(true);
 
   useEffect(() => {
     const load = async () => {
       try {
-        const data = await fetchAllCertificates();
+        const data = await fetchAllCertificates(page, limit);
         setCertificates(data);
+        setHasMore(data.length === limit);
       } catch (err) {
         console.error('Failed to load certificates', err);
       }
     };
     load();
-  }, []);
+  }, [page]);
 
   const filteredCertificates = certificates.filter(c => {
     const matchesSearch = c.studentName.toLowerCase().includes(search.toLowerCase()) ||
@@ -137,6 +141,25 @@ export default function AdminCertificatesPage() {
               )}
             </tbody>
           </table>
+        </div>
+
+        {/* Pagination */}
+        <div className="flex justify-between items-center mt-4">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <span>Page {page}</span>
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            disabled={!hasMore}
+            className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+          >
+            Next
+          </button>
         </div>
       </div>
     </AdminLayout>

--- a/frontend/src/services/admin/certificateService.js
+++ b/frontend/src/services/admin/certificateService.js
@@ -6,7 +6,9 @@ import api from "@/services/api/api";
 /**
  * Fetch all certificates for admin
  */
-export const fetchAllCertificates = async () => {
-  const { data } = await api.get("/certificates/admin");
+export const fetchAllCertificates = async (page = 1, limit = 10) => {
+  const { data } = await api.get("/certificates/admin", {
+    params: { page, limit },
+  });
   return data?.data ?? [];
 };


### PR DESCRIPTION
## Summary
- add page & limit support to certificates admin service and controller
- include pagination in admin certificates page and service

## Testing
- `npm test` (backend) *(fails: Test Suites: 9 failed, 73 passed, 82 total)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a56054436c8328bfb54a61e24c43b3