### PR TITLE
Sanitize certificate template asset uploads

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
@@ -1,5 +1,8 @@
 const service = require("./certificateTemplates.service");
 const { sendSuccess } = require("../../utils/response");
+const path = require("path");
+
+const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp", "image/jpg"];
 
 exports.list = async (req, res, next) => {
   try {
@@ -72,13 +75,18 @@ exports.duplicate = async (req, res, next) => {
 exports.upload = async (req, res, next) => {
   try {
     if (!req.file) return res.status(400).json({ message: "No file uploaded" });
+    if (!ALLOWED_IMAGE_TYPES.includes(req.file.mimetype))
+      return res.status(400).json({ message: "Invalid file type" });
+    const sanitizedFilename = path
+      .basename(req.file.filename)
+      .replace(/[^\w.-]/g, "");
     // Use "/api/uploads" so the URL works behind reverse proxies (e.g., Nginx)
     // that forward all "/api" requests to the backend. Returning a direct
     // "/uploads" path causes the frontend to request the file from its own
     // server instead of the backend, resulting in broken images. Prefixing the
     // path with "/api" ensures the request is routed to the backend where the
     // static file middleware serves uploaded certificate assets.
-    const url = `/api/uploads/certificateTemplates/${req.file.filename}`;
+    const url = `/api/uploads/certificateTemplates/${sanitizedFilename}`;
     sendSuccess(res, { url });
   } catch (err) {
     next(err);

--- a/frontend/src/components/admin/certificates/CertificatePreviewModal.js
+++ b/frontend/src/components/admin/certificates/CertificatePreviewModal.js
@@ -1,6 +1,10 @@
 import { FaTimes } from "react-icons/fa";
 import QRCode from "react-qr-code";
 
+const isTemplateAsset = (url) =>
+  typeof url === "string" &&
+  url.startsWith("/api/uploads/certificateTemplates/");
+
 export default function CertificatePreviewModal({ template, onClose, mockData }) {
   if (!template) return null;
 
@@ -33,6 +37,12 @@ export default function CertificatePreviewModal({ template, onClose, mockData })
   const fontFamily = font_family ?? legacyFontFamily ?? "Georgia, serif";
   const titleFont = title_font ?? legacyTitleFont ?? "'Great Vibes', cursive";
   const showQR = show_qr ?? legacyShowQR ?? true;
+  const safeBackground = isTemplateAsset(background)
+    ? background
+    : "/images/paper-texture.png";
+  const safeLogo = isTemplateAsset(logo)
+    ? logo
+    : "/images/certificate/logo.png";
 
   return (
     <div className="fixed inset-0 bg-gradient-to-br from-black/80 to-black/60 flex items-center justify-center z-50">
@@ -49,7 +59,7 @@ export default function CertificatePreviewModal({ template, onClose, mockData })
         <div
           className="w-full border-[12px] rounded-xl p-10 text-center relative shadow-inner"
           style={{
-            backgroundImage: `url('${background}')`,
+            backgroundImage: `url('${safeBackground}')`,
             backgroundSize: "cover",
             backgroundRepeat: "no-repeat",
             borderColor,
@@ -58,7 +68,7 @@ export default function CertificatePreviewModal({ template, onClose, mockData })
         >
           {/* Logo */}
           <div className="flex justify-center mb-6">
-            <img src={logo} alt="Logo" className="w-32" />
+            <img src={safeLogo} alt="Logo" className="w-32" />
           </div>
 
           {/* Title */}


### PR DESCRIPTION
## Summary
- Validate and sanitize certificate template upload filenames and types on backend
- Accept certificate preview images only from `/api/uploads/certificateTemplates/`

## Testing
- `npm test` (backend) *(fails: 9 failing suites)*
- `npm test` (frontend)
- `npm run lint` (frontend) *(fails: 93 errors, 275 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a5605288fc832880cb0578e9b59637