### PR TITLE
feat: add popup announcement preview modal

### DIFF
--- a/frontend/src/components/admin/settings/PopupPreviewModal.js
+++ b/frontend/src/components/admin/settings/PopupPreviewModal.js
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import DOMPurify from "isomorphic-dompurify";
+import { useTranslation } from "next-i18next";
+
+export default function PopupPreviewModal({ data, onClose }) {
+  const { t } = useTranslation('dashboard', { keyPrefix: 'popupAnnouncementsPage' });
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  if (!data) return null;
+
+  const positionClasses = {
+    center: 'items-center justify-center',
+    top: 'items-start justify-center pt-10',
+    bottom: 'items-end justify-center pb-10',
+  };
+
+  const themeClasses = {
+    yellow: 'bg-yellow-100 border-yellow-400 text-yellow-800',
+    blue: 'bg-blue-100 border-blue-400 text-blue-800',
+    green: 'bg-green-100 border-green-400 text-green-800',
+    red: 'bg-red-100 border-red-400 text-red-800',
+  };
+
+  const posClass = positionClasses[data.position] || positionClasses.center;
+  const themeClass = themeClasses[data.theme] || themeClasses.yellow;
+
+  return (
+    <div className={`fixed inset-0 bg-black bg-opacity-50 flex ${posClass} z-50`} role="dialog" aria-modal="true">
+      <div className={`relative max-w-sm w-full border-l-4 ${themeClass} p-6 rounded shadow-lg`}>
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-500 hover:text-black"
+          aria-label={t('close', { defaultValue: 'Close' })}
+        >
+          ✕
+        </button>
+        <h2 className="text-lg font-bold mb-2">{data.title}</h2>
+        <div className="prose text-sm" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(data.message) }} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
@@ -14,6 +14,7 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import { createPopupAnnouncement } from "@/services/admin/popupAnnouncementService";
 import { fetchPageList } from "@/services/admin/seoConfigService";
+import PopupPreviewModal from "@/components/admin/settings/PopupPreviewModal";
 
 const RichTextEditor = dynamic(() => import("react-quill"), { ssr: false });
 
@@ -51,6 +52,7 @@ export default function CreateAnnouncementForm() {
   });
 
   const [allPages, setAllPages] = useState([]);
+  const [showPreview, setShowPreview] = useState(false);
 
   useEffect(() => {
     const loadPages = async () => {
@@ -256,12 +258,13 @@ export default function CreateAnnouncementForm() {
           <button
             type="button"
             className="border px-6 py-2 rounded shadow text-gray-800 hover:bg-gray-100"
-            onClick={() => alert("🔍 Preview not implemented")}
+            onClick={() => setShowPreview(true)}
           >
             <FaEye className="inline mr-2" /> {t('preview')}
           </button>
         </div>
       </form>
+      {showPreview && <PopupPreviewModal data={form} onClose={() => setShowPreview(false)} />}
     </AdminLayout>
   );
 }

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/index.js
@@ -1,6 +1,7 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaPlus, FaEdit, FaTrash, FaEye, FaToggleOn, FaToggleOff } from "react-icons/fa";
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -10,10 +11,12 @@ import {
   updatePopupAnnouncement,
   deletePopupAnnouncement,
 } from "@/services/admin/popupAnnouncementService";
+import PopupPreviewModal from "@/components/admin/settings/PopupPreviewModal";
 
 export default function PopupAnnouncementsIndex() {
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'popupAnnouncementsPage' });
   const [announcements, setAnnouncements] = useState([]);
+  const [previewAnn, setPreviewAnn] = useState(null);
 
   useEffect(() => {
     const load = async () => {
@@ -34,7 +37,7 @@ export default function PopupAnnouncementsIndex() {
       }
     };
     load();
-  }, []);
+  }, [t]);
 
   const toggleStatus = async (id) => {
     const ann = announcements.find((a) => a.id === id);
@@ -68,12 +71,12 @@ export default function PopupAnnouncementsIndex() {
     <AdminLayout title={t('title')}>
       <div className="flex justify-between items-center mb-6" dir={i18n.dir()}>
         <h1 className="text-2xl font-bold text-gray-800">📢 {t('title')}</h1>
-        <a
+        <Link
           href="/dashboard/admin/settings/popup-announcement/create"
           className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded shadow flex items-center gap-2"
         >
           <FaPlus /> {t('add_new')}
-        </a>
+        </Link>
       </div>
 
       <div className="overflow-x-auto" dir={i18n.dir()}>
@@ -107,7 +110,7 @@ export default function PopupAnnouncementsIndex() {
                   </button>
                 </td>
                 <td className="p-3 text-center flex justify-center gap-3">
-                  <button title={t('preview')}>
+                  <button title={t('preview')} onClick={() => setPreviewAnn(a)}>
                     <FaEye className="text-blue-500" />
                   </button>
                   <a href={`/dashboard/admin/announcements/edit/${a.id}`}>
@@ -122,6 +125,7 @@ export default function PopupAnnouncementsIndex() {
           </tbody>
         </table>
       </div>
+      {previewAnn && <PopupPreviewModal data={previewAnn} onClose={() => setPreviewAnn(null)} />}
     </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add PopupPreviewModal component mirroring popup layout
- show announcement preview in create and index pages without clearing form data
- replace anchor with Next.js Link and tidy effect deps

## Testing
- `npm test`
- `npm run lint` *(fails: 93 errors, 275 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a566f570008328b9e5656d4cdaa8ef