### PR TITLE
Validate popup announcement dates

### DIFF
--- a/backend/src/modules/popupAnnouncements/popupAnnouncements.controller.js
+++ b/backend/src/modules/popupAnnouncements/popupAnnouncements.controller.js
@@ -25,6 +25,9 @@ exports.create = catchAsync(async (req, res) => {
     active = true,
   } = req.body || {};
   if (!title || !message) throw new AppError("Title and message required", 400);
+  if (start_date && end_date && new Date(end_date) <= new Date(start_date)) {
+    throw new AppError("end_date must be after start_date", 400);
+  }
   const payload = {
     title,
     message,
@@ -71,6 +74,10 @@ exports.create = catchAsync(async (req, res) => {
 });
 
 exports.update = catchAsync(async (req, res) => {
+  const { start_date, end_date } = req.body || {};
+  if (start_date && end_date && new Date(end_date) <= new Date(start_date)) {
+    throw new AppError("end_date must be after start_date", 400);
+  }
   const ann = await service.update(req.params.id, req.body);
   if (!ann) throw new AppError("Announcement not found", 404);
   sendSuccess(res, ann, "Announcement updated");

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
@@ -79,6 +79,11 @@ export default function CreateAnnouncementForm() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!form.title || !form.message || !form.start || !form.end) return;
+
+    if (new Date(form.end) <= new Date(form.start)) {
+      toast.error(i18n.t('dashboard:end_before_start'));
+      return;
+    }
     const payload = {
       title: form.title,
       message: form.message,


### PR DESCRIPTION
## Summary
- prevent admins from submitting popup announcements when the end date is not after the start date
- enforce start/end date order in popup announcement create and update APIs

## Testing
- `npm test` (backend) *(fails: expect 200 received 400, etc.)*
- `npm test` (frontend)
- `npm run lint` (frontend) *(fails: Component definition is missing display name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a566e7d89083288eeb1fdff7d65ccf