### PR TITLE
feat: add popup announcement endpoint and component

### DIFF
--- a/backend/src/modules/popupAnnouncements/popupAnnouncements.controller.js
+++ b/backend/src/modules/popupAnnouncements/popupAnnouncements.controller.js
@@ -11,6 +11,12 @@ exports.list = catchAsync(async (_req, res) => {
   sendSuccess(res, data);
 });
 
+exports.active = catchAsync(async (req, res) => {
+  const { audience, page } = req.query;
+  const data = await service.getActive({ audience, page });
+  sendSuccess(res, data);
+});
+
 exports.create = catchAsync(async (req, res) => {
   const {
     title,

--- a/backend/src/modules/popupAnnouncements/popupAnnouncements.routes.js
+++ b/backend/src/modules/popupAnnouncements/popupAnnouncements.routes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const controller = require("./popupAnnouncements.controller");
 const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
 
+router.get("/active", controller.active);
 router.get("/", controller.list);
 router.use(verifyToken, isAdmin);
 router.post("/", controller.create);

--- a/backend/src/modules/popupAnnouncements/popupAnnouncements.service.js
+++ b/backend/src/modules/popupAnnouncements/popupAnnouncements.service.js
@@ -10,6 +10,36 @@ exports.getAll = async () => {
   }));
 };
 
+exports.getActive = async ({ audience = "guest", page }) => {
+  const now = new Date();
+  // determine allowed audiences based on viewer
+  const allowed = ["all"];
+  if (audience === "student" || audience === "instructor") {
+    allowed.push("logged-in", audience);
+  } else if (audience === "logged-in") {
+    allowed.push("logged-in");
+  }
+
+  const rows = await db("popup_announcements")
+    .select("*")
+    .where({ active: true })
+    .where(function () {
+      this.whereNull("start_date").orWhere("start_date", "<=", now);
+    })
+    .where(function () {
+      this.whereNull("end_date").orWhere("end_date", ">=", now);
+    })
+    .whereIn("audience", allowed)
+    .orderBy("created_at", "desc");
+
+  return rows
+    .map((r) => ({
+      ...r,
+      pages: Array.isArray(r.pages) ? r.pages : JSON.parse(r.pages || "[]"),
+    }))
+    .filter((r) => !page || r.pages.length === 0 || r.pages.includes(page));
+};
+
 exports.create = async (data) => {
   const [row] = await db("popup_announcements")
     .insert(data)

--- a/frontend/src/components/common/PopupAnnouncement.js
+++ b/frontend/src/components/common/PopupAnnouncement.js
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import api from "@/services/api/api";
+import useAuthStore from "@/store/auth/authStore";
+
+export default function PopupAnnouncement() {
+  const [popup, setPopup] = useState(null);
+  const user = useAuthStore((s) => s.user);
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchPopup = async () => {
+      try {
+        const role = user?.role?.toLowerCase();
+        const audience = !user
+          ? "guest"
+          : role === "student"
+          ? "student"
+          : role === "instructor"
+          ? "instructor"
+          : "logged-in";
+
+        const { data } = await api.get("/popup-announcements/active", {
+          params: { audience, page: router.pathname },
+        });
+        const [ann] = data?.data || [];
+        if (!ann) return;
+        if (ann.once_per_session && typeof window !== "undefined") {
+          if (sessionStorage.getItem(`popup_${ann.id}`)) return;
+          sessionStorage.setItem(`popup_${ann.id}`, "shown");
+        }
+        setPopup(ann);
+      } catch (err) {
+        console.error("Failed to load popup", err);
+      }
+    };
+    fetchPopup();
+  }, [user, router.pathname]);
+
+  if (!popup) return null;
+
+  const positionClass =
+    popup.position === "top"
+      ? "top-4 left-1/2 -translate-x-1/2"
+      : popup.position === "bottom"
+      ? "bottom-4 left-1/2 -translate-x-1/2"
+      : "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2";
+
+  const themeClass =
+    popup.theme === "blue"
+      ? "bg-blue-500 text-white"
+      : popup.theme === "green"
+      ? "bg-green-500 text-white"
+      : popup.theme === "red"
+      ? "bg-red-500 text-white"
+      : "bg-yellow-500 text-black";
+
+  return (
+    <div className={`fixed z-50 ${positionClass} transform`}> 
+      <div className={`p-4 rounded shadow ${themeClass}`}> 
+        {popup.title && <h3 className="font-bold mb-2">{popup.title}</h3>}
+        <div dangerouslySetInnerHTML={{ __html: popup.message }} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -24,6 +24,7 @@ import Head from "next/head";
 import { getLanguages } from "@/services/languageService";
 import SeoTags from "@/components/common/SeoTags";
 import PageLoader from "@/components/PageLoader";
+import PopupAnnouncement from "@/components/common/PopupAnnouncement";
 import { API_BASE_URL } from "@/config/config";
 
 const langFetcher = () => getLanguages();
@@ -207,6 +208,7 @@ function MyApp({ Component, pageProps, router }) {
               )}
             </Head>
             <SeoTags />
+            <PopupAnnouncement />
             {/* Render page with layout */}
             {getLayout(<Component {...pageProps} />)}
 


### PR DESCRIPTION
## Summary
- add public endpoint to fetch active popup announcements
- display active popup announcements on page load with position and theme
- mount popup announcement component globally

## Testing
- `cd backend && npm test` *(fails: Test Suites: 9 failed, 73 passed)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a566e54a808328a9101155e2fd9fc9