### PR TITLE
Restrict certificate template options and sync frontend selections

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.validation.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.validation.js
@@ -10,9 +10,17 @@ const boolean = Joi.boolean()
 
 exports.createTemplate = Joi.object({
   name: Joi.string().required(),
-  type: Joi.string(),
-  font_family: Joi.string(),
-  title_font: Joi.string(),
+  type: Joi.string().valid("Completion", "Achievement", "Attendance"),
+  font_family: Joi.string().valid(
+    "Georgia, serif",
+    "Times New Roman, serif",
+    "Arial, sans-serif"
+  ),
+  title_font: Joi.string().valid(
+    "'Great Vibes', cursive",
+    "'Playfair Display', serif",
+    "'Pacifico', cursive"
+  ),
   border_color: Joi.string(),
   logo: Joi.string().allow("", null),
   background: Joi.string().allow("", null),
@@ -22,9 +30,17 @@ exports.createTemplate = Joi.object({
 
 exports.updateTemplate = Joi.object({
   name: Joi.string(),
-  type: Joi.string(),
-  font_family: Joi.string(),
-  title_font: Joi.string(),
+  type: Joi.string().valid("Completion", "Achievement", "Attendance"),
+  font_family: Joi.string().valid(
+    "Georgia, serif",
+    "Times New Roman, serif",
+    "Arial, sans-serif"
+  ),
+  title_font: Joi.string().valid(
+    "'Great Vibes', cursive",
+    "'Playfair Display', serif",
+    "'Pacifico', cursive"
+  ),
   border_color: Joi.string(),
   logo: Joi.string().allow("", null),
   background: Joi.string().allow("", null),

--- a/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
@@ -11,6 +11,18 @@ import {
 } from "@/services/admin/certificateTemplateService";
 import { toSnakeCase } from "@/utils/case";
 
+const CERTIFICATE_TYPES = ["Completion", "Achievement", "Attendance"];
+const FONT_FAMILIES = [
+  { label: "Georgia", value: "Georgia, serif" },
+  { label: "Times New Roman", value: "Times New Roman, serif" },
+  { label: "Arial", value: "Arial, sans-serif" },
+];
+const TITLE_FONTS = [
+  { label: "Great Vibes", value: "'Great Vibes', cursive" },
+  { label: "Playfair Display", value: "'Playfair Display', serif" },
+  { label: "Pacifico", value: "'Pacifico', cursive" },
+];
+
 export default function EditCertificateTemplate() {
   const router = useRouter();
   const { id } = router.query;
@@ -98,15 +110,17 @@ export default function EditCertificateTemplate() {
                 onChange={(e) => handleChange("name", e.target.value)}
                 className="input input-bordered w-full"
               />
-              <select
-                value={form.type}
-                onChange={(e) => handleChange("type", e.target.value)}
-                className="select select-bordered w-full"
-              >
-                <option value="Completion">Completion</option>
-                <option value="Achievement">Achievement</option>
-                <option value="Attendance">Attendance</option>
-              </select>
+                <select
+                  value={form.type}
+                  onChange={(e) => handleChange("type", e.target.value)}
+                  className="select select-bordered w-full"
+                >
+                  {CERTIFICATE_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
             </div>
           </section>
 
@@ -116,27 +130,31 @@ export default function EditCertificateTemplate() {
             <div className="grid sm:grid-cols-2 gap-4">
               <div>
                 <label className="text-sm font-medium text-gray-600">Body Font</label>
-                <select
-                value={form.font_family}
-                onChange={(e) => handleChange("font_family", e.target.value)}
-                  className="select select-bordered w-full mt-1"
-                >
-                  <option value="Georgia, serif">Georgia</option>
-                  <option value="Times New Roman, serif">Times New Roman</option>
-                  <option value="Arial, sans-serif">Arial</option>
-                </select>
+                  <select
+                    value={form.font_family}
+                    onChange={(e) => handleChange("font_family", e.target.value)}
+                    className="select select-bordered w-full mt-1"
+                  >
+                    {FONT_FAMILIES.map((f) => (
+                      <option key={f.value} value={f.value}>
+                        {f.label}
+                      </option>
+                    ))}
+                  </select>
               </div>
               <div>
                 <label className="text-sm font-medium text-gray-600">Title Font</label>
-                <select
-                value={form.title_font}
-                onChange={(e) => handleChange("title_font", e.target.value)}
-                  className="select select-bordered w-full mt-1"
-                >
-                  <option value="'Great Vibes', cursive">Great Vibes</option>
-                  <option value="'Playfair Display', serif">Playfair Display</option>
-                  <option value="'Pacifico', cursive">Pacifico</option>
-                </select>
+                  <select
+                    value={form.title_font}
+                    onChange={(e) => handleChange("title_font", e.target.value)}
+                    className="select select-bordered w-full mt-1"
+                  >
+                    {TITLE_FONTS.map((f) => (
+                      <option key={f.value} value={f.value}>
+                        {f.label}
+                      </option>
+                    ))}
+                  </select>
               </div>
             </div>
           </section>

--- a/frontend/src/pages/dashboard/admin/settings/certificates/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/create.js
@@ -6,14 +6,26 @@ import { toast } from "react-toastify";
 import { saveTemplate, uploadTemplateFile } from "@/services/admin/certificateTemplateService";
 import { useRouter } from "next/router";
 
+const CERTIFICATE_TYPES = ["Completion", "Achievement", "Attendance"];
+const FONT_FAMILIES = [
+  { label: "Georgia", value: "Georgia, serif" },
+  { label: "Times New Roman", value: "Times New Roman, serif" },
+  { label: "Arial", value: "Arial, sans-serif" },
+];
+const TITLE_FONTS = [
+  { label: "Great Vibes", value: "'Great Vibes', cursive" },
+  { label: "Playfair Display", value: "'Playfair Display', serif" },
+  { label: "Pacifico", value: "'Pacifico', cursive" },
+];
+
 export default function CreateCertificateTemplate() {
   const router = useRouter();
   const [form, setForm] = useState({
     name: "",
-    type: "Completion",
+    type: CERTIFICATE_TYPES[0],
     border_color: "#FACC15",
-    font_family: "Georgia, serif",
-    title_font: "'Great Vibes', cursive",
+    font_family: FONT_FAMILIES[0].value,
+    title_font: TITLE_FONTS[0].value,
     show_qr: true,
     logo: null,
     background: null,
@@ -81,15 +93,17 @@ export default function CreateCertificateTemplate() {
                 onChange={(e) => handleChange("name", e.target.value)}
                 className="input input-bordered w-full"
               />
-              <select
-                value={form.type}
-                onChange={(e) => handleChange("type", e.target.value)}
-                className="select select-bordered w-full"
-              >
-                <option value="Completion">Completion</option>
-                <option value="Achievement">Achievement</option>
-                <option value="Attendance">Attendance</option>
-              </select>
+                <select
+                  value={form.type}
+                  onChange={(e) => handleChange("type", e.target.value)}
+                  className="select select-bordered w-full"
+                >
+                  {CERTIFICATE_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
             </div>
           </section>
 
@@ -99,27 +113,31 @@ export default function CreateCertificateTemplate() {
             <div className="grid sm:grid-cols-2 gap-4">
               <div>
                 <label className="text-sm font-medium text-gray-600">Body Font</label>
-                <select
-                  value={form.font_family}
-                  onChange={(e) => handleChange("font_family", e.target.value)}
-                  className="select select-bordered w-full mt-1"
-                >
-                  <option value="Georgia, serif">Georgia</option>
-                  <option value="Times New Roman, serif">Times New Roman</option>
-                  <option value="Arial, sans-serif">Arial</option>
-                </select>
+                  <select
+                    value={form.font_family}
+                    onChange={(e) => handleChange("font_family", e.target.value)}
+                    className="select select-bordered w-full mt-1"
+                  >
+                    {FONT_FAMILIES.map((f) => (
+                      <option key={f.value} value={f.value}>
+                        {f.label}
+                      </option>
+                    ))}
+                  </select>
               </div>
               <div>
                 <label className="text-sm font-medium text-gray-600">Title Font</label>
-                <select
-                  value={form.title_font}
-                  onChange={(e) => handleChange("title_font", e.target.value)}
-                  className="select select-bordered w-full mt-1"
-                >
-                  <option value="'Great Vibes', cursive">Great Vibes</option>
-                  <option value="'Playfair Display', serif">Playfair Display</option>
-                  <option value="'Pacifico', cursive">Pacifico</option>
-                </select>
+                  <select
+                    value={form.title_font}
+                    onChange={(e) => handleChange("title_font", e.target.value)}
+                    className="select select-bordered w-full mt-1"
+                  >
+                    {TITLE_FONTS.map((f) => (
+                      <option key={f.value} value={f.value}>
+                        {f.label}
+                      </option>
+                    ))}
+                  </select>
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- enforce allowed values for certificate template type, body font, and title font in backend validation
- populate admin certificate template forms from shared constants to mirror backend options

## Testing
- `npm test` (backend) *(fails: 9 failed, 73 passed)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a5604f917483289c0069669abf1c77