### PR TITLE
Handle duplicated certificate template defaults

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.service.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.service.js
@@ -42,6 +42,9 @@ exports.duplicate = async (id) => {
   delete newTemplate.id;
   delete newTemplate.created_at;
   delete newTemplate.updated_at;
+  newTemplate.active = false;
+  newTemplate.created_at = db.fn.now();
+  newTemplate.updated_at = db.fn.now();
   newTemplate.name = `Copy of ${template.name}`;
   const [row] = await db("certificate_templates").insert(newTemplate).returning("*");
   return row;


### PR DESCRIPTION
## Summary
- Ensure duplicated certificate templates are inactive and have fresh timestamps

## Testing
- `npm test` *(fails: POST /api/ads/admin creates ad, PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5604e5cc08328918c1a3a6994235c