### PR TITLE
refactor: use async fs for certificate upload

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplateUpload.middleware.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplateUpload.middleware.js
@@ -1,11 +1,17 @@
 const multer = require("multer");
 const path = require("path");
-const fs = require("fs");
+const fsPromises = require("fs/promises");
 
 const uploadDir = path.join(__dirname, "../../../uploads/certificateTemplates");
-if (!fs.existsSync(uploadDir)) {
-  fs.mkdirSync(uploadDir, { recursive: true });
-}
+
+(async () => {
+  try {
+    await fsPromises.mkdir(uploadDir, { recursive: true });
+  } catch (error) {
+    console.error("Error creating upload directory:", error);
+    throw error;
+  }
+})();
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, uploadDir),


### PR DESCRIPTION
## Summary
- replace sync directory creation with async `fs/promises`
- log and rethrow errors during certificate template upload setup

## Testing
- `npm test` *(fails: 9 failed, 73 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5604c9abc832898b573068055c403