### PR TITLE
feat: add certificate admin route

### DIFF
--- a/backend/src/modules/users/tutorials/certificate/certificateAdmin.routes.js
+++ b/backend/src/modules/users/tutorials/certificate/certificateAdmin.routes.js
@@ -1,1 +1,7 @@
+const router = require("express").Router();
+const ctrl = require("./certificateAdmin.controller");
+const { verifyToken, isAdmin } = require("../../../../middleware/auth/authMiddleware");
+
 router.patch("/:id/revoke", verifyToken, isAdmin, ctrl.revokeCertificate);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -102,8 +102,14 @@ app.use((req, res, next) => {
 app.use("/api/auth", require("./modules/auth/routes/auth.routes"));
 app.use("/api/users", require("./modules/users/user.routes"));
 app.use("/api/verify", require("./modules/verify/verify.routes"));
-app.use("/api/certificates", require("./modules/users/tutorials/certificate/certificatePublic.routes"));
-app.use("/api/certificates/admin", require("./modules/certificates/certificates.routes"));
+app.use(
+  "/api/certificates",
+  require("./modules/users/tutorials/certificate/certificatePublic.routes")
+);
+app.use(
+  "/api/certificates/admin",
+  require("./modules/users/tutorials/certificate/certificateAdmin.routes")
+);
 app.use("/api/certificate-templates", require("./modules/certificateTemplates/certificateTemplates.routes"));
 app.use("/api/bookings/admin", require("./modules/bookings/bookings.routes"));
 app.use("/api/bookings/student", require("./modules/bookings/student.routes"));


### PR DESCRIPTION
## Summary
- add express router for admin certificate actions
- wire admin certificate routes into server

## Testing
- `cd backend && npm test` *(fails: Test Suites: 10 failed, 72 passed, 82 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a5604b42ec832891f0b17d671dfa93