### PR TITLE
feat: add missing certificate admin imports

### DIFF
--- a/backend/src/modules/users/tutorials/certificate/certificateAdmin.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/certificateAdmin.controller.js
@@ -1,3 +1,8 @@
+const db = require("../../../../config/database");
+const catchAsync = require("../../../../utils/catchAsync");
+const { sendSuccess } = require("../../../../utils/response");
+const AppError = require("../../../../utils/AppError");
+
 exports.revokeCertificate = catchAsync(async (req, res) => {
   const { id } = req.params;
   const { reason } = req.body;


### PR DESCRIPTION
## Summary
- require database, async handler, response helper, and AppError in certificate admin controller

## Testing
- `npx --yes eslint@8 --no-eslintrc --env node --parser-options=ecmaVersion:2021 --rule "no-unused-vars:error" src/modules/users/tutorials/certificate/certificateAdmin.controller.js`
- `npm test` *(fails: 9 failed, 73 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a56049cbe08328a21e54dd36ccc013