### PR TITLE
feat: add support message attachments

### DIFF
--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -183,6 +183,16 @@ exports.addMessage = catchAsync(async (req, res) => {
   sendSuccess(res, msg, "Message added");
 });
 
+exports.uploadAttachment = catchAsync(async (req, res) => {
+  const file = req.file;
+  if (!file) throw new AppError("No file uploaded", 400);
+  const attachment = await service.uploadAttachment(
+    req.params.messageId,
+    file
+  );
+  sendSuccess(res, attachment, "Attachment uploaded");
+});
+
 exports.updateStatus = catchAsync(async (req, res) => {
   const ticket = await service.updateStatus(req.params.id, req.body.status);
   if (!ticket) throw new AppError("Ticket not found", 404);

--- a/backend/src/modules/support/support.routes.js
+++ b/backend/src/modules/support/support.routes.js
@@ -1,6 +1,8 @@
 const router = require("express").Router();
 const controller = require("./support.controller");
 const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+const multer = require("multer");
+const upload = multer({ dest: "uploads/support_attachments" });
 
 router.use(verifyToken);
 
@@ -9,6 +11,11 @@ router.get("/my-tickets", controller.listMyTickets);
 router.get("/tickets/:id", controller.getTicket);
 router.post("/tickets/:id/messages", controller.addMessage);
 router.delete("/tickets/:id", controller.deleteTicket);
+router.post(
+  "/messages/:messageId/attachments",
+  upload.single("file"),
+  controller.uploadAttachment
+);
 
 router.get("/admin/tickets", isAdmin, controller.listAllTickets);
 router.patch("/admin/tickets/:id/status", isAdmin, controller.updateStatus);

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -103,6 +103,15 @@ exports.addMessage = async ({ ticket_id, sender_id, message }) => {
   return row;
 };
 
+exports.uploadAttachment = (messageId, file) =>
+  db("support_attachments")
+    .insert({
+      message_id: messageId,
+      file_url: file.path,
+      file_name: file.originalname,
+    })
+    .returning("*");
+
 exports.updateStatus = async (id, status) => {
   const [row] = await db("support_tickets")
     .where({ id })

--- a/frontend/src/components/support/TicketReplyBox.js
+++ b/frontend/src/components/support/TicketReplyBox.js
@@ -2,12 +2,15 @@ import { useState } from 'react';
 
 export default function TicketReplyBox({ onSend, loading = false, disabled = false }) {
   const [message, setMessage] = useState('');
+  const [attachment, setAttachment] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!message.trim()) return;
-    await onSend(message.trim());
+    await onSend(message.trim(), attachment);
     setMessage('');
+    setAttachment(null);
+    if (e.target?.reset) e.target.reset();
   };
 
   return (
@@ -22,6 +25,13 @@ export default function TicketReplyBox({ onSend, loading = false, disabled = fal
         placeholder="Type your response here..."
         disabled={loading || disabled}
         className="w-full min-h-[120px] border border-gray-300 rounded-lg px-4 py-3 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 disabled:bg-gray-100"
+      />
+
+      <input
+        type="file"
+        onChange={(e) => setAttachment(e.target.files[0] || null)}
+        disabled={loading || disabled}
+        className="block w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100"
       />
 
       <button

--- a/frontend/src/pages/dashboard/admin/support/tickets/[id].js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/[id].js
@@ -6,7 +6,8 @@ import {
   fetchTicketById,
   addMessage,
   updateStatus,
-  updatePriority
+  updatePriority,
+  uploadAttachment
 } from "@/services/supportService";
 import TicketDetailPanel from "@/components/support/TicketDetailPanel";
 import TicketReplyBox from "@/components/support/TicketReplyBox";
@@ -48,11 +49,12 @@ export default function AdminTicketDetail() {
     }
   };
 
-  const handleReply = async (msg) => {
+  const handleReply = async (msg, file) => {
     if (!msg.trim()) return toast.warn(t("reply_required"));
     setReplying(true);
     try {
-      await addMessage(id, msg);
+      const message = await addMessage(id, msg);
+      if (file) await uploadAttachment(message.id, file);
       await load();
       toast.success(t("reply_sent"));
     } catch (err) {

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -51,6 +51,17 @@ export const addMessage = async (id, message) => {
   return data?.data;
 };
 
+export const uploadAttachment = async (messageId, file) => {
+  const form = new FormData();
+  form.append('file', file);
+  const { data } = await api.post(
+    `/support/messages/${messageId}/attachments`,
+    form,
+    { headers: { 'Content-Type': 'multipart/form-data' } }
+  );
+  return data?.data;
+};
+
 export const deleteTicket = async (id) => {
   const { data } = await api.delete(`/support/tickets/${id}`);
   return data?.data;


### PR DESCRIPTION
## Summary
- add file upload capability to support ticket replies
- allow backend to store support message attachments

## Testing
- `npm test` (backend) *(fails: adsRoutes, tutorialRoutes, etc.)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a577108a5c8328b767b3cabc31af03