### PR TITLE
feat: add priority filter for support tickets

### DIFF
--- a/backend/src/migrations/20250908000000_add_priority_to_support_tickets.js
+++ b/backend/src/migrations/20250908000000_add_priority_to_support_tickets.js
@@ -1,0 +1,19 @@
+exports.up = function (knex) {
+  return knex.schema.hasColumn('support_tickets', 'priority').then((exists) => {
+    if (!exists) {
+      return knex.schema.table('support_tickets', function (table) {
+        table.string('priority').defaultTo('medium');
+      });
+    }
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.hasColumn('support_tickets', 'priority').then((exists) => {
+    if (exists) {
+      return knex.schema.table('support_tickets', function (table) {
+        table.dropColumn('priority');
+      });
+    }
+  });
+};

--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -134,6 +134,7 @@ exports.listAllTickets = catchAsync(async (req, res) => {
     status: req.query.status,
     search: req.query.search,
     ticketNumber: req.query.ticketNumber,
+    priority: req.query.priority,
   };
   const tickets = await service.listAllTickets(filters);
   sendSuccess(res, tickets);

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -42,7 +42,7 @@ exports.listUserTickets = (user_id) => {
     .orderBy("created_at", "desc");
 };
 
-exports.listAllTickets = ({ status, search, ticketNumber } = {}) => {
+exports.listAllTickets = ({ status, search, ticketNumber, priority } = {}) => {
   const query = db("support_tickets")
     .leftJoin("users", "support_tickets.user_id", "users.id")
     .select(
@@ -67,6 +67,10 @@ exports.listAllTickets = ({ status, search, ticketNumber } = {}) => {
 
   if (ticketNumber) {
     query.whereILike("support_tickets.ticket_number", `%${ticketNumber}%`);
+  }
+
+  if (priority) {
+    query.where("support_tickets.priority", priority);
   }
 
   return query;


### PR DESCRIPTION
## Summary
- filter support tickets by optional priority
- allow controllers to read `priority` from query
- add migration to create `support_tickets.priority` when missing

## Testing
- `npm test` *(fails: POST /api/ads/admin › creates ad; PUT /api/users/tutorials/admin/:id › returns 403 when instructor updates another instructor's tutorial; PUT /api/users/tutorials/admin/:id › updates tutorial with language and status; Class routes › create class; Class routes › create class responds even if notifications fail; Class routes › create class with options; payment commission calculations › calculates commission for class payments; payment commission calculations › calculates commission for book payments; payment commission calculations › calculates commission for tutorial payments; updateTutorial tag transactions › commits transaction when tag update succeeds; PUT /api/seo-config › updates settings; POST /api/blog › creates post; POST /api/payments/admin › creates payment with installments and enrolls; community public routes › create discussion)*

------
https://chatgpt.com/codex/tasks/task_e_68a5770e2adc8328abda2db716f13623