### PR TITLE
Add support ticket priority update endpoint

### DIFF
--- a/backend/src/modules/support/support.controller.js
+++ b/backend/src/modules/support/support.controller.js
@@ -213,6 +213,15 @@ exports.updateStatus = catchAsync(async (req, res) => {
   sendSuccess(res, ticket, "Status updated");
 });
 
+exports.updatePriority = catchAsync(async (req, res) => {
+  const ticket = await service.updatePriority(
+    req.params.id,
+    req.body.priority
+  );
+  if (!ticket) throw new AppError("Ticket not found", 404);
+  sendSuccess(res, ticket, "Priority updated");
+});
+
 exports.deleteTicket = catchAsync(async (req, res) => {
   const ticket = await service.getTicketById(req.params.id);
   if (!ticket) throw new AppError("Ticket not found", 404);

--- a/backend/src/modules/support/support.routes.js
+++ b/backend/src/modules/support/support.routes.js
@@ -12,6 +12,7 @@ router.delete("/tickets/:id", controller.deleteTicket);
 
 router.get("/admin/tickets", isAdmin, controller.listAllTickets);
 router.patch("/admin/tickets/:id/status", isAdmin, controller.updateStatus);
+router.patch("/admin/tickets/:id/priority", isAdmin, controller.updatePriority);
 router.get("/admin/recent-activity", isAdmin, controller.listRecentActivity);
 router.get("/admin/analytics", isAdmin, controller.getAnalytics);
 

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -111,6 +111,14 @@ exports.updateStatus = async (id, status) => {
   return row;
 };
 
+exports.updatePriority = async (id, priority) => {
+  const [row] = await db("support_tickets")
+    .where({ id })
+    .update({ priority, updated_at: db.fn.now() })
+    .returning("*");
+  return row;
+};
+
 exports.removeTicket = (id) =>
   db("support_tickets").where({ id }).del();
 

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -62,7 +62,9 @@ export const updateStatus = async (id, status) => {
 };
 
 export const updatePriority = async (id, priority) => {
-  const { data } = await api.put(`/tickets/${id}/priority`, { priority });
+  const { data } = await api.patch(`/support/admin/tickets/${id}/priority`, {
+    priority,
+  });
   return data?.data;
 };
 


### PR DESCRIPTION
## Summary
- allow admins to update support ticket priority
- expose frontend service call for updating ticket priority

## Testing
- `cd backend && npm test` (fails: tests for adsRoutes, tutorialRoutes, class routes, etc.)
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5770c46c8832896dca53e9b29a211