### PR TITLE
Normalize support ticket priority values

### DIFF
--- a/frontend/src/components/support/PrioritySelector.js
+++ b/frontend/src/components/support/PrioritySelector.js
@@ -1,4 +1,9 @@
-const options = ['Low', 'Medium', 'High', 'Urgent'];
+const options = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'urgent', label: 'Urgent' },
+];
 
 export default function PrioritySelector({ value, onChange }) {
   return (
@@ -8,8 +13,8 @@ export default function PrioritySelector({ value, onChange }) {
       onChange={(e) => onChange(e.target.value)}
     >
       {options.map((o) => (
-        <option key={o} value={o}>
-          {o}
+        <option key={o.value} value={o.value}>
+          {o.label}
         </option>
       ))}
     </select>

--- a/frontend/src/pages/dashboard/admin/support/tickets/[id].js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/[id].js
@@ -37,9 +37,10 @@ export default function AdminTicketDetail() {
     setLoading(true);
     try {
       const data = await fetchTicketById(id);
-      setTicket(data);
+      const normalizedPriority = data.priority?.toLowerCase() || "medium";
+      setTicket({ ...data, priority: normalizedPriority });
       setStatus(data.status);
-      setPriority(data.priority || "medium");
+      setPriority(normalizedPriority);
     } catch (err) {
       console.error("Failed to fetch ticket", err);
       toast.error(t("load_failed"));
@@ -84,10 +85,11 @@ export default function AdminTicketDetail() {
   };
 
   const handlePriorityChange = async (newPriority) => {
+    const normalizedPriority = newPriority.toLowerCase();
     try {
-      await updatePriority(id, newPriority);
-      setPriority(newPriority);
-      setTicket((prev) => ({ ...prev, priority: newPriority }));
+      await updatePriority(id, normalizedPriority);
+      setPriority(normalizedPriority);
+      setTicket((prev) => ({ ...prev, priority: normalizedPriority }));
       toast.success(t("priority_updated"));
     } catch (err) {
       console.error("Failed to update priority", err);


### PR DESCRIPTION
## Summary
- use lowercase priority codes with capitalized labels
- normalize ticket priority state to lowercase when loading and updating

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57709c6ec832897b9214027cb766e