### PR TITLE
fix: normalize status badge lookup

### DIFF
--- a/frontend/src/components/support/StatusBadge.js
+++ b/frontend/src/components/support/StatusBadge.js
@@ -1,11 +1,16 @@
-export default function StatusBadge({ status }) {
+export default function StatusBadge({ status = '' }) {
   const colors = {
-    Open: 'bg-blue-100 text-blue-700',
-    Pending: 'bg-yellow-100 text-yellow-800',
-    Resolved: 'bg-green-100 text-green-700',
-    Closed: 'bg-red-100 text-red-700',
+    open: 'bg-blue-100 text-blue-700',
+    pending: 'bg-yellow-100 text-yellow-800',
+    resolved: 'bg-green-100 text-green-700',
+    closed: 'bg-red-100 text-red-700',
   };
+
+  const normalized = status.toLowerCase();
+
   return (
-    <span className={`px-2 py-1 rounded text-xs font-medium capitalize ${colors[status] || ''}`}>{status}</span>
+    <span className={`px-2 py-1 rounded text-xs font-medium capitalize ${colors[normalized] || ''}`}>
+      {status}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary
- make StatusBadge color lookup case-insensitive

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5770924d48328a8db9647f7b7c343