### PR TITLE
Display formatted timestamps for support ticket messages

### DIFF
--- a/frontend/src/components/support/TicketDetailPanel.js
+++ b/frontend/src/components/support/TicketDetailPanel.js
@@ -28,7 +28,14 @@ export default function TicketDetailPanel({ ticket }) {
               className="w-6 h-6 rounded-full object-cover mt-1"
             />
             <div>
-              <div className="text-xs font-semibold text-gray-700">{m.sender_name || 'User'}</div>
+              <div className="text-xs font-semibold text-gray-700">
+                {m.sender_name || 'User'}
+                {m.createdAt && (
+                  <span className="ml-2 text-gray-400">
+                    {new Date(m.createdAt).toLocaleString()}
+                  </span>
+                )}
+              </div>
               <p className="text-sm text-gray-600">{m.message}</p>
             </div>
           </div>

--- a/frontend/src/pages/support/tickets/[id].js
+++ b/frontend/src/pages/support/tickets/[id].js
@@ -75,7 +75,9 @@ export default function TicketDetailPage() {
             >
               <div className="flex justify-between text-sm mb-1">
                 <span className="font-semibold text-gray-900">{msg.name}</span>
-                <span className="text-gray-600">{msg.timestamp}</span>
+                <span className="text-gray-600">
+                  {msg.createdAt ? new Date(msg.createdAt).toLocaleString() : ''}
+                </span>
               </div>
               <p className="text-gray-900 whitespace-pre-line">{msg.message}</p>
             </div>

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -39,10 +39,14 @@ export const fetchTicketById = async (id) => {
   return {
     ...ticket,
     user_avatar: formatAvatar(ticket.user_avatar),
-    messages: (ticket.messages || []).map((m) => ({
-      ...m,
-      sender_avatar: formatAvatar(m.sender_avatar),
-    })),
+    messages: (ticket.messages || []).map((m) => {
+      const { created_at, sender_avatar, ...rest } = m;
+      return {
+        ...rest,
+        createdAt: created_at,
+        sender_avatar: formatAvatar(sender_avatar),
+      };
+    }),
   };
 };
 


### PR DESCRIPTION
## Summary
- Map `created_at` to `createdAt` for support ticket messages
- Show formatted message timestamps in TicketDetailPanel and ticket details page

## Testing
- `npm test`
- `npm run lint` *(fails: 92 errors, 272 warnings)*
- `npx eslint src/services/supportService.js src/components/support/TicketDetailPanel.js src/pages/support/tickets/[id].js`

------
https://chatgpt.com/codex/tasks/task_e_68a57707e2008328a3ae8cfef265c85a