### PR TITLE
Normalize ticket createdAt field

### DIFF
--- a/frontend/src/pages/dashboard/admin/support/tickets/[id].js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/[id].js
@@ -163,7 +163,7 @@ export default function AdminTicketDetail() {
                     <FiUser className="mr-1.5" /> {ticket.customerName}
                   </span>
                   <span className="flex items-center">
-                    <FiCalendar className="mr-1.5" /> {new Date(ticket.createdAt).toLocaleString()}
+                    <FiCalendar className="mr-1.5" /> {ticket.createdAt ? new Date(ticket.createdAt).toLocaleString() : ""}
                   </span>
                   <span className="flex items-center">
                     <FiTag className="mr-1.5" />

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -26,9 +26,10 @@ export const fetchMyTickets = async () => {
 export const fetchAllTickets = async (filters = {}) => {
   const { data } = await api.get("/support/admin/tickets", { params: filters });
   const list = data?.data ?? [];
-  return list.map((t) => ({
-    ...t,
-    user_avatar: formatAvatar(t.user_avatar),
+  return list.map(({ created_at, user_avatar, ...rest }) => ({
+    ...rest,
+    createdAt: created_at,
+    user_avatar: formatAvatar(user_avatar),
   }));
 };
 
@@ -36,12 +37,15 @@ export const fetchTicketById = async (id) => {
   const { data } = await api.get(`/support/tickets/${id}`);
   const ticket = data?.data;
   if (!ticket) return null;
+  const { created_at, user_avatar, messages = [], ...rest } = ticket;
   return {
-    ...ticket,
-    user_avatar: formatAvatar(ticket.user_avatar),
-    messages: (ticket.messages || []).map((m) => ({
-      ...m,
-      sender_avatar: formatAvatar(m.sender_avatar),
+    ...rest,
+    createdAt: created_at,
+    user_avatar: formatAvatar(user_avatar),
+    messages: messages.map(({ created_at: msgCreatedAt, sender_avatar, ...msgRest }) => ({
+      ...msgRest,
+      createdAt: msgCreatedAt,
+      sender_avatar: formatAvatar(sender_avatar),
     })),
   };
 };


### PR DESCRIPTION
## Summary
- Convert `created_at` fields to camelCase `createdAt` in support ticket service
- Display formatted `createdAt` on admin ticket detail page

## Testing
- `npm test`
- `npm run lint` *(fails: 92 errors, 272 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a5770703308328913c3f93662b615e