### PR TITLE
Add support message attachments

### DIFF
--- a/backend/src/migrations/20250908000010_create_support_attachments_table.js
+++ b/backend/src/migrations/20250908000010_create_support_attachments_table.js
@@ -1,0 +1,18 @@
+exports.up = function (knex) {
+  return knex.schema.createTable("support_attachments", function (table) {
+    table.increments("id");
+    table
+      .uuid("message_id")
+      .references("id")
+      .inTable("support_messages")
+      .onDelete("CASCADE");
+    table.string("file_url");
+    table.string("file_name");
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists("support_attachments");
+};
+

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -93,7 +93,25 @@ exports.getTicketById = async (id) => {
     )
     .where({ ticket_id: id })
     .orderBy("support_messages.created_at", "asc");
-  return { ...ticket, messages };
+
+  // Fetch attachments for all messages in a single query
+  const ids = messages.map((m) => m.id);
+  let attachmentsByMessage = {};
+  if (ids.length) {
+    const rows = await db("support_attachments").whereIn("message_id", ids);
+    attachmentsByMessage = rows.reduce((acc, att) => {
+      acc[att.message_id] = acc[att.message_id] || [];
+      acc[att.message_id].push(att);
+      return acc;
+    }, {});
+  }
+
+  const messagesWithAttachments = messages.map((m) => ({
+    ...m,
+    attachments: attachmentsByMessage[m.id] || [],
+  }));
+
+  return { ...ticket, messages: messagesWithAttachments };
 };
 
 exports.addMessage = async ({ ticket_id, sender_id, message }) => {
@@ -102,6 +120,31 @@ exports.addMessage = async ({ ticket_id, sender_id, message }) => {
     .returning("*");
   return row;
 };
+
+// ─────────────────────
+// 📎 Attachments helpers
+// ─────────────────────
+
+/**
+ * Store an attachment linked to a support message
+ * @param {Object} params
+ * @param {string} params.message_id - Related support message ID
+ * @param {string} params.file_url - Stored file path or URL
+ * @param {string} [params.file_name] - Original filename
+ */
+exports.addAttachment = async ({ message_id, file_url, file_name }) => {
+  const [row] = await db("support_attachments")
+    .insert({ message_id, file_url, file_name })
+    .returning("*");
+  return row;
+};
+
+/**
+ * Retrieve all attachments for a given message
+ * @param {string} message_id
+ */
+exports.getAttachmentsByMessage = (message_id) =>
+  db("support_attachments").where({ message_id });
 
 exports.updateStatus = async (id, status) => {
   const [row] = await db("support_tickets")

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -29,3 +29,12 @@ CREATE TABLE IF NOT EXISTS book_reviews (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- support_attachments table
+CREATE TABLE IF NOT EXISTS support_attachments (
+  id SERIAL PRIMARY KEY,
+  message_id UUID REFERENCES support_messages(id) ON DELETE CASCADE,
+  file_url VARCHAR,
+  file_name VARCHAR,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/frontend/src/components/support/TicketDetailPanel.js
+++ b/frontend/src/components/support/TicketDetailPanel.js
@@ -1,5 +1,8 @@
 import StatusBadge from './StatusBadge';
 
+const isImage = (url) =>
+  url ? /\.(png|jpe?g|gif|webp|svg)$/i.test(url) : false;
+
 export default function TicketDetailPanel({ ticket }) {
   if (!ticket) return <div className="p-4">Select a ticket</div>;
   return (
@@ -29,7 +32,31 @@ export default function TicketDetailPanel({ ticket }) {
             />
             <div>
               <div className="text-xs font-semibold text-gray-700">{m.sender_name || 'User'}</div>
-              <p className="text-sm text-gray-600">{m.message}</p>
+              <p className="text-sm text-gray-600 whitespace-pre-line">{m.message}</p>
+              {m.attachments?.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  {m.attachments.map((a) => (
+                    isImage(a.file_url) ? (
+                      <img
+                        key={a.id}
+                        src={a.file_url}
+                        alt={a.file_name || 'attachment'}
+                        className="max-h-40 rounded"
+                      />
+                    ) : (
+                      <a
+                        key={a.id}
+                        href={a.file_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 underline text-sm block"
+                      >
+                        {a.file_name || a.file_url.split('/').pop()}
+                      </a>
+                    )
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         ))}

--- a/frontend/src/pages/support/tickets/[id].js
+++ b/frontend/src/pages/support/tickets/[id].js
@@ -11,6 +11,9 @@ import { fetchTicketById, addMessage } from "@/services/supportService";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 
+const isImage = (url) =>
+  url ? /\.(png|jpe?g|gif|webp|svg)$/i.test(url) : false;
+
 export default function TicketDetailPage() {
   const { t } = useTranslation('dashboard');
   const router = useRouter();
@@ -74,10 +77,34 @@ export default function TicketDetailPage() {
               className={`p-4 rounded-lg ${msg.sender === "user" ? "bg-gray-100" : "bg-gray-200"}`}
             >
               <div className="flex justify-between text-sm mb-1">
-                <span className="font-semibold text-gray-900">{msg.name}</span>
-                <span className="text-gray-600">{msg.timestamp}</span>
+                <span className="font-semibold text-gray-900">{msg.name || msg.sender_name}</span>
+                <span className="text-gray-600">{msg.timestamp || msg.created_at}</span>
               </div>
               <p className="text-gray-900 whitespace-pre-line">{msg.message}</p>
+              {msg.attachments?.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  {msg.attachments.map((a) =>
+                    isImage(a.file_url) ? (
+                      <img
+                        key={a.id}
+                        src={a.file_url}
+                        alt={a.file_name || 'attachment'}
+                        className="max-h-40 rounded"
+                      />
+                    ) : (
+                      <a
+                        key={a.id}
+                        href={a.file_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 underline text-sm block"
+                      >
+                        {a.file_name || a.file_url.split('/').pop()}
+                      </a>
+                    )
+                  )}
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -1,7 +1,8 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
 
-const formatAvatar = (url) => {
+// Normalize any URL returned from the API (avatars, attachments, etc.)
+const formatUrl = (url) => {
   if (!url) return null;
   if (url.startsWith("http") || url.startsWith("blob:") || url.startsWith("data:"))
     return url;
@@ -28,7 +29,7 @@ export const fetchAllTickets = async (filters = {}) => {
   const list = data?.data ?? [];
   return list.map((t) => ({
     ...t,
-    user_avatar: formatAvatar(t.user_avatar),
+    user_avatar: formatUrl(t.user_avatar),
   }));
 };
 
@@ -38,10 +39,14 @@ export const fetchTicketById = async (id) => {
   if (!ticket) return null;
   return {
     ...ticket,
-    user_avatar: formatAvatar(ticket.user_avatar),
+    user_avatar: formatUrl(ticket.user_avatar),
     messages: (ticket.messages || []).map((m) => ({
       ...m,
-      sender_avatar: formatAvatar(m.sender_avatar),
+      sender_avatar: formatUrl(m.sender_avatar),
+      attachments: (m.attachments || []).map((a) => ({
+        ...a,
+        file_url: formatUrl(a.file_url),
+      })),
     })),
   };
 };


### PR DESCRIPTION
## Summary
- allow support messages to include attachments and expose them when fetching tickets
- provide migration and schema for support_attachments table
- surface attachments in frontend ticket views with preview or download links

## Testing
- `npm test` (backend) *(fails: adsRoutes, tutorialRoutes, class routes, paymentCommission, tutorialUpdateTransaction, seoConfigRoutes, blogRoutes, paymentInstallments, community public routes)*
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68a577062c8c83289fbd36b07917f3e6