### PR TITLE
Use Next.js Image in support ticket components

### DIFF
--- a/frontend/src/components/support/TicketCard.js
+++ b/frontend/src/components/support/TicketCard.js
@@ -1,5 +1,6 @@
 import StatusBadge from './StatusBadge';
 import { FiClock, FiTag } from 'react-icons/fi';
+import Image from 'next/image';
 
 export default function TicketCard({ ticket, onClick }) {
   const bgColors = {
@@ -29,9 +30,17 @@ export default function TicketCard({ ticket, onClick }) {
           {ticket.priority}
         </span>
         <span className="flex items-center gap-1">
-          <img
+          <Image
             src={ticket.user_avatar || '/images/default-avatar.png'}
-            alt="avatar"
+            alt={
+              ticket.user_name
+                ? `${ticket.user_name}'s avatar`
+                : ticket.user
+                ? `${ticket.user}'s avatar`
+                : 'User avatar'
+            }
+            width={16}
+            height={16}
             className="w-4 h-4 rounded-full object-cover"
           />
           {ticket.user_name || ticket.user || 'Unknown'}

--- a/frontend/src/components/support/TicketDetailPanel.js
+++ b/frontend/src/components/support/TicketDetailPanel.js
@@ -1,4 +1,5 @@
 import StatusBadge from './StatusBadge';
+import Image from 'next/image';
 
 const isImage = (url) =>
   url ? /\.(png|jpe?g|gif|webp|svg)$/i.test(url) : false;
@@ -8,9 +9,17 @@ export default function TicketDetailPanel({ ticket }) {
   return (
     <div className="p-4 bg-white rounded-lg shadow space-y-4">
       <div className="flex items-center gap-3">
-        <img
+        <Image
           src={ticket.user_avatar || '/images/default-avatar.png'}
-          alt="avatar"
+          alt={
+            ticket.user_name
+              ? `${ticket.user_name}'s avatar`
+              : ticket.user
+              ? `${ticket.user}'s avatar`
+              : 'User avatar'
+          }
+          width={32}
+          height={32}
           className="w-8 h-8 rounded-full object-cover"
         />
         <div>
@@ -25,9 +34,11 @@ export default function TicketDetailPanel({ ticket }) {
       <div className="space-y-3">
         {ticket.messages?.map((m) => (
           <div key={m.id} className="flex gap-3 items-start border p-2 rounded bg-gray-50">
-            <img
+            <Image
               src={m.sender_avatar || '/images/default-avatar.png'}
-              alt="avatar"
+              alt={m.sender_name ? `${m.sender_name}'s avatar` : 'User avatar'}
+              width={24}
+              height={24}
               className="w-6 h-6 rounded-full object-cover mt-1"
             />
             <div>
@@ -37,10 +48,12 @@ export default function TicketDetailPanel({ ticket }) {
                 <div className="mt-2 space-y-1">
                   {m.attachments.map((a) => (
                     isImage(a.file_url) ? (
-                      <img
+                      <Image
                         key={a.id}
                         src={a.file_url}
-                        alt={a.file_name || 'attachment'}
+                        alt={a.file_name || 'Image attachment'}
+                        width={160}
+                        height={160}
                         className="max-h-40 rounded"
                       />
                     ) : (


### PR DESCRIPTION
## Summary
- refactor support ticket components to use Next.js `Image`
- add descriptive alt text for user avatars and attachments

## Testing
- `npm test`
- `npm run lint` *(fails: 92 errors, 270 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a583ec66cc8328bdc9ddb73793d28c