### PR TITLE
feat: add stop message listener

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -16,7 +16,11 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import useCallStore from "@/store/call/callStore";
 import CallOverlay from "@/components/video-call/CallOverlay";
-import { listenCalls, listenMessages } from "@/services/messageService";
+import {
+  listenCalls,
+  listenMessages,
+  stopListenMessages,
+} from "@/services/messageService";
 import useSEOConfigStore from "@/store/seoConfigStore";
 import * as authService from "@/services/auth/authService";
 import { getFullProfile } from "@/services/profile/profileService";
@@ -131,14 +135,18 @@ function MyApp({ Component, pageProps, router }) {
   }, [seoLoaded, fetchSEO]);
 
   useEffect(() => {
-    if (user) {
-      fetchNotifs();
-      startNotifPolling();
-      fetchMsgs();
-      startMsgPolling();
-      listenCalls();
-      listenMessages();
-    }
+    if (!user) return;
+
+    fetchNotifs();
+    startNotifPolling();
+    fetchMsgs();
+    startMsgPolling();
+    listenCalls();
+    listenMessages();
+
+    return () => {
+      stopListenMessages();
+    };
   }, [user, fetchNotifs, startNotifPolling, fetchMsgs, startMsgPolling]);
 
   useEffect(() => {

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -99,12 +99,20 @@ export const togglePinMessage = async (id) => {
 export const listenCalls = () => useCallStore.getState().listen();
 
 let msgListener = false;
+const msgHandler = () => {
+  useMessageStore.getState().fetch(true);
+};
+
 export const listenMessages = () => {
   if (msgListener) return;
-  socket.on("message-created", () => {
-    useMessageStore.getState().fetch(true);
-  });
+  socket.on("message-created", msgHandler);
   msgListener = true;
+};
+
+export const stopListenMessages = () => {
+  if (!msgListener) return;
+  socket.off("message-created", msgHandler);
+  msgListener = false;
 };
 
 // Helpers to read call status from the store


### PR DESCRIPTION
## Summary
- add stopListenMessages to remove socket listener
- clean up message listener during app teardown

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d1452ab083288ef85bbecd746919