### PR TITLE
feat: rate-limit video call endpoints

### DIFF
--- a/backend/src/modules/messages/messages.routes.js
+++ b/backend/src/modules/messages/messages.routes.js
@@ -6,7 +6,7 @@ const validate = require("../../middleware/validate");
 const validator = require("./messages.validator");
 const rateLimit = require("express-rate-limit");
 
-// Limit email/WhatsApp notifications to prevent abuse
+// Limit messaging and call actions to prevent abuse
 const messageLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour window
   max: 20,
@@ -31,13 +31,15 @@ router.post(
 );
 router.post(
   "/:id/video-call",
+  messageLimiter,
   controller.startVideoCall
 );
 router.post(
   "/call/:id/respond",
+  messageLimiter,
   validate(validator.respondVideoCall),
   controller.respondVideoCall
 );
-router.post("/call/:id/end", controller.endVideoCall);
+router.post("/call/:id/end", messageLimiter, controller.endVideoCall);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- reuse message limiter for video-call actions to reduce abuse

## Testing
- `cd backend && npm test` *(fails: POST /api/ads/admin › creates ad, PUT /api/users/tutorials/admin/:id › returns 403 when instructor updates another instructor's tutorial, PUT /api/users/tutorials/admin/:id › updates tutorial with language and status, Class routes › create class, Class routes › create class responds even if notifications fail, Class routes › create class with options, payment commission calculations › calculates commission for class payments, payment commission calculations › calculates commission for book payments, payment commission calculations › calculates commission for tutorial payments, updateTutorial tag transactions › commits transaction when tag update succeeds, PUT /api/seo-config › updates settings, POST /api/blog › creates post, POST /api/payments/admin › creates payment with installments and enrolls, community public routes › create discussion)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d13eb4f88328803a17bed2dd79d3