### PR TITLE
Validate message route path parameters

### DIFF
--- a/backend/src/modules/messages/messages.routes.js
+++ b/backend/src/modules/messages/messages.routes.js
@@ -15,8 +15,8 @@ const messageLimiter = rateLimit({
 router.use(verifyToken);
 
 router.get("/", controller.getMyMessages);
-router.patch("/:id/read", controller.markRead);
-router.delete("/:id", controller.deleteMessage);
+router.patch("/:id/read", validate(validator.idParam), controller.markRead);
+router.delete("/:id", validate(validator.idParam), controller.deleteMessage);
 router.post(
   "/:id/email",
   messageLimiter,
@@ -31,6 +31,7 @@ router.post(
 );
 router.post(
   "/:id/video-call",
+  validate(validator.startVideoCall),
   controller.startVideoCall
 );
 router.post(
@@ -38,6 +39,10 @@ router.post(
   validate(validator.respondVideoCall),
   controller.respondVideoCall
 );
-router.post("/call/:id/end", controller.endVideoCall);
+router.post(
+  "/call/:id/end",
+  validate(validator.endVideoCall),
+  controller.endVideoCall
+);
 
 module.exports = router;

--- a/backend/src/modules/messages/messages.validator.js
+++ b/backend/src/modules/messages/messages.validator.js
@@ -1,6 +1,15 @@
 const { z } = require("zod");
 
+const idParams = z.object({
+  id: z.coerce.number().int(),
+});
+
+exports.idParam = {
+  params: idParams,
+};
+
 exports.sendEmail = {
+  params: idParams,
   body: z.object({
     subject: z.string().trim().min(1),
     message: z.string().trim().min(1),
@@ -8,13 +17,23 @@ exports.sendEmail = {
 };
 
 exports.sendWhatsApp = {
+  params: idParams,
   body: z.object({
     message: z.string().trim().min(1),
   }),
 };
 
+exports.startVideoCall = {
+  params: idParams,
+};
+
 exports.respondVideoCall = {
+  params: idParams,
   body: z.object({
     action: z.enum(["accept", "decline"]),
   }),
+};
+
+exports.endVideoCall = {
+  params: idParams,
 };


### PR DESCRIPTION
## Summary
- add numeric ID param schema to message validators
- validate path params on message routes

## Testing
- `npm test` *(fails: Test Suites: 10 failed, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d13d664c8328a706e122fb9732d9