### PR TITLE
feat: add database-backed RBAC

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -52,6 +52,7 @@ const verifyToken = async (req, res, next) => {
       return res.status(403).json({ message: "Account is not active" });
     }
     const roles = await userModel.getUserRoles(decoded.id);
+    const permissions = await userModel.getUserPermissions(decoded.id);
     const userRoles = roles.length ? roles : [user.role];
     const { password_hash, ...safeUser } = user;
     req.user = {
@@ -59,6 +60,7 @@ const verifyToken = async (req, res, next) => {
       ...safeUser,
       roles: userRoles,
       role: userRoles[0],
+      permissions,
     };
     next();
   } catch (err) {
@@ -119,6 +121,14 @@ const isStudent = (req, res, next) => {
   return res.status(403).json({ message: "Access denied. Students only." });
 };
 
+const hasPermission = (...perms) => (req, res, next) => {
+  const userPerms = req.user?.permissions || [];
+  if (perms.some((p) => userPerms.includes(p))) {
+    return next();
+  }
+  return res.status(403).json({ message: "Insufficient permission" });
+};
+
 /**
  * 🔐 Middleware: Allows access if user is self or has admin/superadmin role
  */
@@ -137,5 +147,6 @@ module.exports = {
   isInstructorOrAdmin,
   isStudent,
   isSelfOrAdmin,
+  hasPermission,
   addTokenToBlacklist: (token) => tokenBlacklist.add(token),
 };

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -75,6 +75,7 @@ exports.registerUser = async (data) => {
   }
 
   const roles = await userModel.getUserRoles(newUser.id);
+  const permissions = await userModel.getUserPermissions(newUser.id);
 
   const welcomeMessage =
     newUser.role && newUser.role.toLowerCase() === "instructor"
@@ -133,7 +134,7 @@ exports.registerUser = async (data) => {
     console.error("Error sending registration emails:", err.message);
   }
   const safeUser = sanitizeUserUtil(newUser);
-  return { user: { ...safeUser, roles } };
+  return { user: { ...safeUser, roles, permissions } };
 };
 
 
@@ -182,6 +183,7 @@ exports.loginUser = async ({ email, password }) => {
   user.is_online = true;
 
   const roles = await userModel.getUserRoles(user.id);
+  const permissions = await userModel.getUserPermissions(user.id);
   const tokenRoles = roles.length ? roles : [user.role];
   const accessToken = generateAccessToken({ id: user.id, role: tokenRoles[0], roles: tokenRoles });
   const refreshToken = await issueRefreshToken(user.id, tokenRoles[0]);
@@ -193,7 +195,7 @@ exports.loginUser = async ({ email, password }) => {
     message: "You have logged in successfully",
   });
   const safeUser = sanitizeUserUtil(user);
-  return { accessToken, refreshToken, csrfToken, user: { ...safeUser, roles } };
+  return { accessToken, refreshToken, csrfToken, user: { ...safeUser, roles, permissions } };
 };
 
 /**

--- a/backend/src/modules/roles/roles.routes.js
+++ b/backend/src/modules/roles/roles.routes.js
@@ -1,21 +1,21 @@
 const express = require("express");
 const router = express.Router();
 const controller = require("./roles.controller");
-const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+const { verifyToken, hasPermission } = require("../../middleware/auth/authMiddleware");
 
-router.use(verifyToken, isAdmin);
+router.use(verifyToken);
 
-router.get("/permissions", controller.getPermissions);
-router.post("/permissions", controller.createPermission);
-router.put("/permissions/:id", controller.updatePermission);
-router.delete("/permissions/:id", controller.deletePermission);
+router.get("/permissions", hasPermission("manage_permissions"), controller.getPermissions);
+router.post("/permissions", hasPermission("manage_permissions"), controller.createPermission);
+router.put("/permissions/:id", hasPermission("manage_permissions"), controller.updatePermission);
+router.delete("/permissions/:id", hasPermission("manage_permissions"), controller.deletePermission);
 
-router.post("/", controller.createRole);
-router.get("/", controller.getRoles);
-router.get("/:id", controller.getRole);
-router.put("/:id", controller.updateRole);
-router.delete("/:id", controller.deleteRole);
+router.post("/", hasPermission("manage_roles"), controller.createRole);
+router.get("/", hasPermission("manage_roles"), controller.getRoles);
+router.get("/:id", hasPermission("manage_roles"), controller.getRole);
+router.put("/:id", hasPermission("manage_roles"), controller.updateRole);
+router.delete("/:id", hasPermission("manage_roles"), controller.deleteRole);
 
-router.post("/:id/permissions", controller.assignPermissions);
+router.post("/:id/permissions", hasPermission("manage_roles"), controller.assignPermissions);
 
 module.exports = router;

--- a/backend/src/modules/users/profile.controller.js
+++ b/backend/src/modules/users/profile.controller.js
@@ -189,6 +189,7 @@ exports.getFullProfile = async (req, res) => {
     res.json({
       ...user,
       roles: req.user.roles,
+      permissions: req.user.permissions,
       ...roleData,
       social_links: socialLinks,
     });

--- a/backend/src/modules/users/user.model.js
+++ b/backend/src/modules/users/user.model.js
@@ -160,6 +160,15 @@ exports.getUserRoles = async (userId) => {
   return rows.map((r) => r.name);
 };
 
+exports.getUserPermissions = async (userId) => {
+  const rows = await db("user_roles")
+    .join("role_permissions", "user_roles.role_id", "role_permissions.role_id")
+    .join("permissions", "role_permissions.permission_id", "permissions.id")
+    .where("user_roles.user_id", userId)
+    .select("permissions.code");
+  return [...new Set(rows.map((r) => r.code))];
+};
+
 exports.setUserRoles = async (userId, roleIds) => {
   await db("user_roles").where({ user_id: userId }).del();
   if (roleIds.length) {

--- a/backend/tests/authMiddleware.test.js
+++ b/backend/tests/authMiddleware.test.js
@@ -1,0 +1,23 @@
+const { hasPermission } = require('../src/middleware/auth/authMiddleware');
+
+describe('hasPermission middleware', () => {
+  it('calls next when permission exists', () => {
+    const req = { user: { permissions: ['manage_roles'] } };
+    const res = {};
+    const next = jest.fn();
+    hasPermission('manage_roles')(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('sends 403 when permission missing', () => {
+    const req = { user: { permissions: ['other'] } };
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn();
+    const res = { status, json };
+    const next = jest.fn();
+    hasPermission('manage_roles')(req, res, next);
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/roleRoutes.test.js
+++ b/backend/tests/roleRoutes.test.js
@@ -9,7 +9,7 @@ jest.mock('../src/modules/roles/roles.service', () => ({
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (_req, _res, next) => next(),
-  isAdmin: (_req, _res, next) => next(),
+  hasPermission: () => (_req, _res, next) => next(),
 }));
 
 const service = require('../src/modules/roles/roles.service');

--- a/frontend/src/hooks/withAuthProtection.js
+++ b/frontend/src/hooks/withAuthProtection.js
@@ -4,7 +4,12 @@ import { useRouter } from "next/router";
 import useAuthStore from "@/store/auth/authStore";
 import { isTokenExpired } from "@/utils/auth/tokenUtils";
 
-export default function withAuthProtection(Component, allowedRoles = []) {
+export default function withAuthProtection(Component, rolesOrOptions = []) {
+  const { roles: allowedRoles = [], permissions: allowedPerms = [] } =
+    Array.isArray(rolesOrOptions)
+      ? { roles: rolesOrOptions }
+      : rolesOrOptions || {};
+
   return function ProtectedPage(props) {
     const { user, accessToken, logout } = useAuthStore();
     const router = useRouter();
@@ -22,15 +27,23 @@ export default function withAuthProtection(Component, allowedRoles = []) {
           logout();
           router.replace("/auth/login");
         } else if (
-          allowedRoles.length &&
-          !allowedRoles.includes(user.role?.toLowerCase())
+          (allowedRoles.length &&
+            !allowedRoles.includes(user.role?.toLowerCase())) ||
+          (allowedPerms.length &&
+            !allowedPerms.some((p) => user.permissions?.includes(p)))
         ) {
           router.replace("/error/403");
         }
       }
     }, [hydrated, user, accessToken]);
 
-    if (!hydrated || !user || (allowedRoles.length && !allowedRoles.includes(user.role?.toLowerCase()))) {
+    if (
+      !hydrated ||
+      !user ||
+      (allowedRoles.length && !allowedRoles.includes(user.role?.toLowerCase())) ||
+      (allowedPerms.length &&
+        !allowedPerms.some((p) => user.permissions?.includes(p)))
+    ) {
       return null;
     }
 

--- a/frontend/src/pages/dashboard/admin/permissions/index.js
+++ b/frontend/src/pages/dashboard/admin/permissions/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import { PlusCircle, Trash2 } from "lucide-react";
 import toast from "react-hot-toast";
 import {
@@ -8,7 +9,7 @@ import {
   deletePermission,
 } from "@/services/admin/roleService";
 
-export default function PermissionsPage() {
+function PermissionsPage() {
   const [permissions, setPermissions] = useState([]);
   const [showAddModal, setShowAddModal] = useState(false);
   const [newPermission, setNewPermission] = useState("");
@@ -145,3 +146,5 @@ export default function PermissionsPage() {
     </AdminLayout>
   );
 }
+
+export default withAuthProtection(PermissionsPage, { permissions: ["manage_permissions"] });

--- a/frontend/src/pages/dashboard/admin/roles/index.js
+++ b/frontend/src/pages/dashboard/admin/roles/index.js
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import RoleManagement from "@/components/admin/roles/RoleManagement";
+import withAuthProtection from "@/hooks/withAuthProtection";
 
-export default function RolesPage() {
+function RolesPage() {
   const [editingRules, setEditingRules] = useState(false);
   const [selectedRole, setSelectedRole] = useState(null);
 
@@ -56,3 +57,5 @@ export default function RolesPage() {
     </AdminLayout>
   );
 }
+
+export default withAuthProtection(RolesPage, { permissions: ["manage_roles"] });


### PR DESCRIPTION
## Summary
- add permission queries and middleware to enforce RBAC
- expose permissions to profile and auth flows
- secure role management UI with permission-based guard

## Testing
- `npm test` (backend - failing: Payment commission, blog routes, etc.)
- `npm test tests/authMiddleware.test.js tests/roleRoutes.test.js`
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a65f27fa908328a87d52407a9d98af