### PR TITLE
Fix role permissions seed lookup

### DIFF
--- a/backend/src/seeds/11_role_permissions_seed.js
+++ b/backend/src/seeds/11_role_permissions_seed.js
@@ -10,7 +10,7 @@ exports.seed = async function(knex) {
   const rows = [];
 
   permissions.forEach((p) => {
-    rows.push({ role_id: roleId("SuperAdmin"), permission_id: p.id });
+    rows.push({ role_id: roleId("SuperAdmin"), permission_id: permId(p.code) });
   });
 
   ["view_roles", "view_permissions"].forEach((code) => {


### PR DESCRIPTION
## Summary
- ensure SuperAdmin role seeds permissions by code lookup

## Testing
- `npx knex seed:run` *(fails: Unable to acquire a connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ecc0799883289227111c38b73627