### PR TITLE
Fix role permissions seed lookup

### DIFF
--- a/backend/src/seeds/11_role_permissions_seed.js
+++ b/backend/src/seeds/11_role_permissions_seed.js
@@ -5,16 +5,12 @@ exports.seed = async function(knex) {
   const permissions = await knex("permissions").select("id", "code");
 
   const roleId = (name) => roles.find((r) => r.name === name).id;
-  const permId = (code) => permissions.find((p) => p.code === code).id;
-
   const rows = [];
 
   permissions.forEach((p) => {
-    rows.push({ role_id: roleId("SuperAdmin"), permission_id: p.id });
-  });
-
-  ["view_roles", "view_permissions"].forEach((code) => {
-    rows.push({ role_id: roleId("Admin"), permission_id: permId(code) });
+    ["SuperAdmin", "Admin"].forEach((name) => {
+      rows.push({ role_id: roleId(name), permission_id: p.id });
+    });
   });
 
   await knex("role_permissions").insert(rows);


### PR DESCRIPTION
## Summary
- ensure SuperAdmin and Admin roles seed with all available permissions

## Testing
- `npx knex seed:run` *(fails: Unable to acquire a connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ecc0799883289227111c38b73627