### PR TITLE
Add online class permissions for admin dashboard

### DIFF
--- a/backend/src/seeds/10_permissions_seed.js
+++ b/backend/src/seeds/10_permissions_seed.js
@@ -6,5 +6,11 @@ exports.seed = async function(knex) {
     { code: "manage_roles", description: "Create/update/delete roles", created_at: new Date() },
     { code: "view_permissions", description: "Read permission definitions", created_at: new Date() },
     { code: "manage_permissions", description: "Create/update/delete permissions", created_at: new Date() },
+    { code: "view_online_classes", description: "View online classes", created_at: new Date() },
+    {
+      code: "manage_online_classes",
+      description: "Create/update/delete online classes",
+      created_at: new Date(),
+    },
   ]);
 };

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -1,6 +1,7 @@
 // pages/dashboard/admin/online-classes/[id]/analytics.js
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import { useEffect, useState } from "react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -40,7 +41,7 @@ const EMPTY_STATS = {
   registrationTrend: [],
 };
 
-export default function AnalyticsDashboard() {
+function AnalyticsDashboard() {
   const router = useRouter();
   const { id } = router.query;
   const { t, i18n } = useTranslation('dashboard');
@@ -172,6 +173,13 @@ export default function AnalyticsDashboard() {
 AnalyticsDashboard.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+const ProtectedAnalyticsDashboard = withAuthProtection(AnalyticsDashboard, {
+  permissions: ['manage_online_classes'],
+});
+ProtectedAnalyticsDashboard.getLayout = AnalyticsDashboard.getLayout;
+
+export default ProtectedAnalyticsDashboard;
 
 export async function getServerSideProps({ locale }) {
   return {

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -2,6 +2,7 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import Link from "next/link";
 import { fetchAdminClassById } from "@/services/admin/classService";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
@@ -10,7 +11,7 @@ import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
 
-export default function AdminClassDetailPage() {
+function AdminClassDetailPage() {
   const { id } = useRouter().query;
   const [details, setDetails] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -244,6 +245,13 @@ export default function AdminClassDetailPage() {
 AdminClassDetailPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+const ProtectedAdminClassDetailPage = withAuthProtection(AdminClassDetailPage, {
+  permissions: ['manage_online_classes'],
+});
+ProtectedAdminClassDetailPage.getLayout = AdminClassDetailPage.getLayout;
+
+export default ProtectedAdminClassDetailPage;
 
 export async function getServerSideProps({ locale }) {
   return {

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
@@ -125,7 +125,7 @@ ManageStudentInClassPage.getLayout = function getLayout(page) {
 
 const ProtectedManageStudentInClassPage = withAuthProtection(
   ManageStudentInClassPage,
-  ["admin", "superadmin", "instructor"]
+  { permissions: ['manage_online_classes'] }
 );
 
 ProtectedManageStudentInClassPage.getLayout = ManageStudentInClassPage.getLayout;

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
@@ -98,11 +98,9 @@ ClassStudentsPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
 
-const ProtectedClassStudentsPage = withAuthProtection(ClassStudentsPage, [
-  "admin",
-  "superadmin",
-  "instructor",
-]);
+const ProtectedClassStudentsPage = withAuthProtection(ClassStudentsPage, {
+  permissions: ['manage_online_classes'],
+});
 
 ProtectedClassStudentsPage.getLayout = ClassStudentsPage.getLayout;
 

--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -763,7 +763,9 @@ CreateOnlineClass.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
 
-const ProtectedCreateOnlineClass = withAuthProtection(CreateOnlineClass, ['admin', 'superadmin']);
+const ProtectedCreateOnlineClass = withAuthProtection(CreateOnlineClass, {
+  permissions: ['manage_online_classes'],
+});
 ProtectedCreateOnlineClass.getLayout = CreateOnlineClass.getLayout;
 export default ProtectedCreateOnlineClass;
 export { CreateOnlineClass };

--- a/frontend/src/pages/dashboard/admin/online-classes/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/edit/[id].js
@@ -16,12 +16,13 @@ import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
 import AdminLayout from '@/components/layouts/AdminLayout';
+import withAuthProtection from '@/hooks/withAuthProtection';
 import { FaArrowLeft } from 'react-icons/fa';
 import { fetchAdminClassById, updateAdminClass } from '@/services/admin/classService';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
 
-export default function EditClassPage() {
+function EditClassPage() {
   const router = useRouter();
   const { id } = router.query;
   const { t, i18n } = useTranslation('dashboard');
@@ -186,6 +187,13 @@ export default function EditClassPage() {
 EditClassPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+const ProtectedEditClassPage = withAuthProtection(EditClassPage, {
+  permissions: ['manage_online_classes'],
+});
+ProtectedEditClassPage.getLayout = EditClassPage.getLayout;
+
+export default ProtectedEditClassPage;
 
 export async function getServerSideProps({ locale }) {
   return {

--- a/frontend/src/pages/dashboard/admin/online-classes/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/index.js
@@ -57,7 +57,7 @@ AdminOnlineClassesPage.getLayout = function getLayout(page) {
 
 const ProtectedAdminOnlineClassesPage = withAuthProtection(
   AdminOnlineClassesPage,
-  ["admin", "superadmin", "instructor"]
+  { permissions: ["view_online_classes"] }
 );
 
 ProtectedAdminOnlineClassesPage.getLayout = AdminOnlineClassesPage.getLayout;


### PR DESCRIPTION
## Summary
- seed new `view_online_classes` and `manage_online_classes` permissions
- gate admin online class pages behind `withAuthProtection` using these permissions

## Testing
- `cd backend && npm test` *(fails: adsRoutes.test.js, tutorialRoutes.test.js, messageRoutes.test.js, paymentCommission.test.js, seoConfigRoutes.test.js)*
- `cd frontend && npm test` *(fails: blogRoutes.test.js, paymentInstallments.test.js, public.routes.test.js, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a876aa925c8328abe989ff378e4280