### PR TITLE
feat: add admin assignment permissions

### DIFF
--- a/backend/src/modules/classes/assignments/classAssignment.routes.js
+++ b/backend/src/modules/classes/assignments/classAssignment.routes.js
@@ -1,10 +1,10 @@
 const router = require("express").Router();
 const ctrl = require("./classAssignment.controller");
-const { verifyToken, isInstructorOrAdmin } = require("../../../middleware/auth/authMiddleware");
+const { verifyToken, isInstructorOrAdmin, isAdmin } = require("../../../middleware/auth/authMiddleware");
 const validate = require("../../../middleware/validate");
 const validator = require("./classAssignment.validator");
 
-router.get("/admin", verifyToken, isInstructorOrAdmin, ctrl.getAllAssignments);
+router.get("/admin", verifyToken, isAdmin, ctrl.getAllAssignments);
 router.get("/class/:classId", ctrl.getAssignmentsByClass);
 router.post(
   "/class/:classId",

--- a/backend/src/seeds/10_permissions_seed.js
+++ b/backend/src/seeds/10_permissions_seed.js
@@ -12,5 +12,11 @@ exports.seed = async function(knex) {
       description: "Create/update/delete online classes",
       created_at: new Date(),
     },
+    { code: "view_assignments", description: "View assignments", created_at: new Date() },
+    {
+      code: "manage_assignments",
+      description: "Create/update/delete assignments",
+      created_at: new Date(),
+    },
   ]);
 };

--- a/frontend/src/mocks/rolesPermissionsMock.js
+++ b/frontend/src/mocks/rolesPermissionsMock.js
@@ -26,6 +26,8 @@ export const roles = [
     "revoke_certificate",
     "view_class_analytics",
     "view_student_progress",
+    "view_assignments",
+    "manage_assignments",
   ];
   
   export const rolePermissions = {


### PR DESCRIPTION
## Summary
- restrict admin assignment listing route to admins
- seed view/manage assignment permissions and expose them in mocks

## Testing
- `npm test` (backend) *failed: 11 failing test suites*
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68a8a08f4a88832880e7e2649d44cc12