### PR TITLE
feat: add admin assignment & category permissions

### DIFF
--- a/backend/src/modules/classes/assignments/classAssignment.routes.js
+++ b/backend/src/modules/classes/assignments/classAssignment.routes.js
@@ -1,10 +1,10 @@
 const router = require("express").Router();
 const ctrl = require("./classAssignment.controller");
-const { verifyToken, isInstructorOrAdmin } = require("../../../middleware/auth/authMiddleware");
+const { verifyToken, isInstructorOrAdmin, isAdmin } = require("../../../middleware/auth/authMiddleware");
 const validate = require("../../../middleware/validate");
 const validator = require("./classAssignment.validator");
 
-router.get("/admin", verifyToken, isInstructorOrAdmin, ctrl.getAllAssignments);
+router.get("/admin", verifyToken, isAdmin, ctrl.getAllAssignments);
 router.get("/class/:classId", ctrl.getAssignmentsByClass);
 router.post(
   "/class/:classId",

--- a/backend/src/seeds/10_permissions_seed.js
+++ b/backend/src/seeds/10_permissions_seed.js
@@ -12,5 +12,17 @@ exports.seed = async function(knex) {
       description: "Create/update/delete online classes",
       created_at: new Date(),
     },
+    { code: "view_assignments", description: "View assignments", created_at: new Date() },
+    {
+      code: "manage_assignments",
+      description: "Create/update/delete assignments",
+      created_at: new Date(),
+    },
+    { code: "view_categories", description: "View categories", created_at: new Date() },
+    {
+      code: "manage_categories",
+      description: "Create/update/delete categories",
+      created_at: new Date(),
+    },
   ]);
 };

--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -4,7 +4,7 @@ import useAuthStore from '@/store/auth/authStore';
 import { X, Mail, Smartphone, Image as ImageIcon, Tag, Users } from 'lucide-react';
 import toast from 'react-hot-toast';
 import groupService from '@/services/groupService';
-import { fetchAllCategories } from '@/services/admin/categoryService';
+import { fetchAllCategories } from '@/services/instructor/categoryService';
 import userService from '@/services/profile/userService';
 import { sendChatMessage } from '@/services/messageService';
 import { createNotification } from '@/services/notificationService';

--- a/frontend/src/components/tutorials/FilterSidebar.js
+++ b/frontend/src/components/tutorials/FilterSidebar.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaChevronDown, FaChevronUp, FaTimesCircle } from "react-icons/fa";
-import { fetchCategoryTree } from "@/services/admin/categoryService";
+import { fetchCategoryTree } from "@/services/instructor/categoryService";
 
 const FilterSidebar = ({ onFilterChange, onResetFilters }) => {
   const [selectedCategories, setSelectedCategories] = useState([]);

--- a/frontend/src/components/website/sections/StudyCategories.js
+++ b/frontend/src/components/website/sections/StudyCategories.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "next-i18next";
 import { motion, AnimatePresence } from "framer-motion";
 import { FaChevronDown, FaFilter } from "react-icons/fa";
-import { fetchCategoryTree } from "@/services/admin/categoryService";
+import { fetchCategoryTree } from "@/services/instructor/categoryService";
 import { API_BASE_URL } from "@/config/config";
 
 const renderTree = (nodes, level = 1) => {

--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -7,7 +7,7 @@ import { FaStar, FaClock, FaBookmark, FaHeart } from "react-icons/fa";
 import { toast } from "react-toastify";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
-import { fetchAllCategories } from "@/services/admin/categoryService";
+import { fetchAllCategories } from "@/services/instructor/categoryService";
 import { formatCurrency } from "@/utils/currency";
 import {
   fetchFeaturedTutorials,

--- a/frontend/src/mocks/rolesPermissionsMock.js
+++ b/frontend/src/mocks/rolesPermissionsMock.js
@@ -26,6 +26,10 @@ export const roles = [
     "revoke_certificate",
     "view_class_analytics",
     "view_student_progress",
+    "view_assignments",
+    "manage_assignments",
+    "view_categories",
+    "manage_categories",
   ];
   
   export const rolePermissions = {

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
-import { fetchAllCategories } from "@/services/admin/categoryService";
+import { fetchAllCategories } from "@/services/instructor/categoryService";
 import { createTutorial } from "@/services/admin/tutorialService";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";

--- a/frontend/src/services/admin/categoryService.js
+++ b/frontend/src/services/admin/categoryService.js
@@ -5,17 +5,17 @@
 import api from "@/services/api/api";
 
 export const fetchAllCategories = async (params = {}, config = {}) => {
-  const { data } = await api.get("/users/categories", { params, ...config });
+  const { data } = await api.get("/users/admin/categories", { params, ...config });
   return data?.data;
 };
 
 export const fetchCategoryTree = async () => {
-  const { data } = await api.get("/users/categories/tree");
+  const { data } = await api.get("/users/admin/categories/tree");
   return data?.data ?? [];
 };
 
 export const fetchCategoryById = async (id) => {
-  const { data } = await api.get(`/users/categories/${id}`);
+  const { data } = await api.get(`/users/admin/categories/${id}`);
   return data?.data;
 };
 

--- a/frontend/src/tests/__tests__/TutorialsSection.test.js
+++ b/frontend/src/tests/__tests__/TutorialsSection.test.js
@@ -32,7 +32,7 @@ jest.mock('../../services/tutorialService', () => ({
   addTutorialToFavorites: jest.fn().mockResolvedValue({}),
   removeTutorialFromFavorites: jest.fn().mockResolvedValue({}),
 }));
-jest.mock('../../services/admin/categoryService', () => ({
+jest.mock('../../services/instructor/categoryService', () => ({
   fetchAllCategories: jest.fn().mockResolvedValue([]),
 }));
 


### PR DESCRIPTION
## Summary
- restrict admin assignment listing route to admins
- seed view/manage assignment and category permissions and expose them in mocks
- secure admin category listing and adjust components to use public category API where appropriate

## Testing
- `npm test` (backend) *failed: 11 failed test suites*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a8a08f4a88832880e7e2649d44cc12