### PR TITLE
test: ensure book filters send correct keys

### DIFF
--- a/frontend/src/tests/bookFilters.test.js
+++ b/frontend/src/tests/bookFilters.test.js
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import BooksPage from '@/pages/marketplace/books';
+
+jest.mock('../services/bookService', () => ({
+  fetchBooks: jest.fn(() => Promise.resolve({ books: [] }))
+}));
+
+// Mock sidebar to control filter changes
+jest.mock('../components/books/FilterSidebar', () => ({ onFilterChange }) => (
+  <div>
+    <button onClick={() => onFilterChange({ category: 'cat1' })}>set-category</button>
+    <button onClick={() => onFilterChange({ category: '', priceRange: 30 })}>set-price</button>
+  </div>
+));
+
+jest.mock('../components/website/sections/Navbar', () => () => <div />);
+jest.mock('../components/website/sections/Footer', () => () => <div />);
+jest.mock('../components/books/BookCard', () => () => <div />);
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}));
+
+beforeAll(() => {
+  class IO {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  global.IntersectionObserver = IO;
+});
+
+describe('BooksPage filters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends category and priceRange keys when filters applied', async () => {
+    const { fetchBooks } = require('../services/bookService');
+    fetchBooks.mockResolvedValue({ books: [] });
+
+    render(<BooksPage />);
+
+    await waitFor(() => expect(fetchBooks).toHaveBeenCalled());
+    fetchBooks.mockClear();
+
+    fireEvent.click(screen.getByText('set-category'));
+    await waitFor(() => expect(fetchBooks).toHaveBeenCalled());
+    let args = fetchBooks.mock.calls[0][0];
+    expect(args.filters).toHaveProperty('category', 'cat1');
+    expect(args.filters).toHaveProperty('priceRange');
+
+    fetchBooks.mockClear();
+
+    fireEvent.click(screen.getByText('set-price'));
+    await waitFor(() => expect(fetchBooks).toHaveBeenCalled());
+    args = fetchBooks.mock.calls[0][0];
+    expect(args.filters).toHaveProperty('priceRange', 30);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for marketplace books filters verifying `category` and `priceRange` params

## Testing
- `npm test src/tests/bookFilters.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8bd2407e48328a6fbeff8dc77d8b3