### PR TITLE
fix: use Next.js Image and secure external links

### DIFF
--- a/frontend/src/components/instructors/ResourceUploadSection.js
+++ b/frontend/src/components/instructors/ResourceUploadSection.js
@@ -85,7 +85,14 @@ export default function ResourceUploadSection({ classId, isLive = false }) {
             <li key={i} className="bg-gray-700 px-4 py-2 rounded flex justify-between">
               <span>{res.name}</span>
               {res.type === "link" ? (
-                <a href={res.value} target="_blank" className="text-yellow-300 hover:underline">View</a>
+                <a
+                  href={res.value}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-yellow-300 hover:underline"
+                >
+                  View
+                </a>
               ) : (
                 <span className="text-gray-400">Uploaded</span>
               )}

--- a/frontend/src/components/website/sections/Footer.js
+++ b/frontend/src/components/website/sections/Footer.js
@@ -219,6 +219,7 @@ const Footer = () => {
         whileHover={{ scale: 1.2 }}
         href={`https://wa.me/${whatsappNumber}`}
         target="_blank"
+        rel="noopener noreferrer"
         className="fixed bottom-10 left-8 bg-green-500 text-white p-4 rounded-full shadow-lg hover:bg-green-600 transition z-50"
       >
         <FaWhatsapp size={24} />

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -814,6 +814,7 @@ function InstructorBooksPage() {
                           <Link
                             href={`/books/${book.slug}`}
                             target="_blank"
+                            rel="noopener noreferrer"
                             className="p-2 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-full transition-colors"
                             title={t("View")}
                           >

--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import Image from "next/image";
 import { FiDownload, FiEye, FiHeart } from "react-icons/fi";
 import { useTranslation } from "next-i18next";
 import { toast } from "react-hot-toast";
@@ -30,9 +31,11 @@ function BookCard({ book }) {
 
   return (
     <div className="border rounded-xl shadow-sm p-4 bg-white flex flex-col justify-between h-full">
-      <img
+      <Image
         src={cover}
         alt={book.title}
+        width={400}
+        height={192}
         className="w-full h-48 object-cover rounded-lg mb-4"
       />
       <div className="flex-1">
@@ -70,6 +73,7 @@ function BookCard({ book }) {
           <a
             href={book.preview_url}
             target="_blank"
+            rel="noopener noreferrer"
             className="flex items-center gap-1 text-indigo-600 hover:underline"
           >
             <FiEye className="text-lg" /> {t("preview")}
@@ -79,6 +83,7 @@ function BookCard({ book }) {
           <a
             href={book.pdf_url}
             target="_blank"
+            rel="noopener noreferrer"
             download
             className="flex items-center gap-1 text-green-600 hover:underline"
           >


### PR DESCRIPTION
## Summary
- replace `<img>` with Next.js `<Image>` on student book dashboard
- add `rel="noopener noreferrer"` to all external links

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bd2229408328918f72d49b5b2a80