### PR TITLE
feat: abortable requests for book list pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -90,6 +90,7 @@ function AdminBooksPage() {
   }, [t]);
 
   const tagAbortRef = useRef(null);
+  const booksAbortRef = useRef(null);
 
   const debouncedFetchTags = useMemo(
     () =>
@@ -128,6 +129,9 @@ function AdminBooksPage() {
 
   const loadBooks = useCallback(
     async (currentPage = page) => {
+      booksAbortRef.current?.abort();
+      const controller = new AbortController();
+      booksAbortRef.current = controller;
       try {
         setLoading(true);
         const activeFilters = Object.entries(filters).reduce((acc, [key, value]) => {
@@ -149,12 +153,15 @@ function AdminBooksPage() {
           filters: activeFilters,
           sort: { sortBy },
           admin: true,
+          signal: controller.signal,
         });
         setBooks(list);
         setMeta(meta);
       } catch (err) {
-        toast.error(t("Failed to load data"));
-        console.error("Error loading:", err);
+        if (err.name !== "CanceledError" && err.name !== "AbortError") {
+          toast.error(t("Failed to load data"));
+          console.error("Error loading:", err);
+        }
       } finally {
         setLoading(false);
       }
@@ -164,6 +171,9 @@ function AdminBooksPage() {
 
   useEffect(() => {
     loadBooks();
+    return () => {
+      booksAbortRef.current?.abort();
+    };
   }, [loadBooks]);
 
   // Remember filters in localStorage

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useMemo } from "react";
+import { useEffect, useState, useRef, useMemo, useCallback } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
@@ -137,30 +137,45 @@ function InstructorBooksPage() {
       .catch(() => {});
   }, [tagInput]);
 
-  useEffect(() => {
-    const loadBooks = async () => {
+  const booksAbortRef = useRef(null);
+
+  const loadBooks = useCallback(
+    async (currentPage = page) => {
+      booksAbortRef.current?.abort();
+      const controller = new AbortController();
+      booksAbortRef.current = controller;
       try {
         setLoading(true);
         setError(null);
         const { books: list, meta } = await fetchInstructorBooks({
-          page,
+          page: currentPage,
           perPage,
           filters,
           sort: { sortBy },
+          signal: controller.signal,
         });
         setBooks(list);
         setMeta(meta);
       } catch (err) {
-        const message = t("Failed to load data");
-        toast.error(message);
-        console.error("Error loading:", err);
-        setError(message);
+        if (err.name !== "CanceledError" && err.name !== "AbortError") {
+          const message = t("Failed to load data");
+          toast.error(message);
+          console.error("Error loading:", err);
+          setError(message);
+        }
       } finally {
         setLoading(false);
       }
-    };
+    },
+    [page, perPage, filters, sortBy, t]
+  );
+
+  useEffect(() => {
     loadBooks();
-  }, [page, filters, sortBy, perPage, t]);
+    return () => {
+      booksAbortRef.current?.abort();
+    };
+  }, [loadBooks]);
 
   // Remember filters in localStorage
   useEffect(() => {

--- a/frontend/src/services/instructor/bookService.js
+++ b/frontend/src/services/instructor/bookService.js
@@ -9,6 +9,7 @@ export const fetchInstructorBooks = async ({
   filters = {},
   sort = {},
   status,
+  ...config
 } = {}) => {
   const params = {
     ...(page !== undefined && { page }),
@@ -18,13 +19,12 @@ export const fetchInstructorBooks = async ({
     ...(status ? { status } : {}),
   };
 
-  let response;
-  if (Object.keys(params).length) {
-    response = await api.get("/instructor/books", { params });
-  } else {
-    response = await api.get("/instructor/books");
-  }
-  const { data } = response;
+  const requestConfig = Object.keys(params).length
+    ? { params, ...config }
+    : { ...config };
+  const { data } = Object.keys(requestConfig).length
+    ? await api.get("/instructor/books", requestConfig)
+    : await api.get("/instructor/books");
   const list = data?.data
     ? data.data.map((book) => ({
         ...book,


### PR DESCRIPTION
## Summary
- use AbortController to cancel ongoing fetches in admin book list page
- add AbortController to instructor book list and request service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8bd2066248328b9d69869ff662ded