### PR TITLE
refactor book tables to shared hook

### DIFF
--- a/frontend/src/hooks/useBookTable.js
+++ b/frontend/src/hooks/useBookTable.js
@@ -1,0 +1,95 @@
+import { useState, useEffect } from "react";
+
+export default function useBookTable({
+  items = [],
+  perPage = 12,
+  initialFilters = {
+    search: "",
+    category: "",
+    status: "",
+    priceRange: null,
+    language: "",
+    tags: [],
+  },
+  storageKey = "booksFilters",
+} = {}) {
+  const [filters, setFilters] = useState(initialFilters);
+  const [selectedItems, setSelectedItems] = useState([]);
+  const [allSelected, setAllSelected] = useState(false);
+  const [bulkStatus, setBulkStatus] = useState("");
+  const [page, setPage] = useState(1);
+  const [meta, setMeta] = useState({ totalPages: 1, total: 0 });
+
+  useEffect(() => {
+    const saved =
+      typeof window !== "undefined" ? localStorage.getItem(storageKey) : null;
+    if (saved) {
+      try {
+        setFilters(JSON.parse(saved));
+      } catch {}
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(storageKey, JSON.stringify(filters));
+    }
+  }, [filters, storageKey]);
+
+  useEffect(() => {
+    setAllSelected(items.length > 0 && selectedItems.length === items.length);
+  }, [items, selectedItems]);
+
+  const handleSelect = (id) => {
+    setSelectedItems((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedItems([]);
+    } else {
+      setSelectedItems(items.map((b) => b.id));
+    }
+  };
+
+  const resetFilters = () => {
+    setFilters(initialFilters);
+    setPage(1);
+  };
+
+  const hasActiveFilters =
+    filters.search ||
+    filters.category ||
+    filters.status ||
+    (filters.priceRange && filters.priceRange > 0) ||
+    filters.language ||
+    (filters.tags && filters.tags.length > 0);
+
+  const totalPages = meta?.totalPages ?? 1;
+  const startIndex = items.length ? (page - 1) * perPage + 1 : 0;
+  const endIndex = items.length ? startIndex + items.length - 1 : 0;
+
+  return {
+    filters,
+    setFilters,
+    selectedItems,
+    setSelectedItems,
+    allSelected,
+    handleSelect,
+    toggleSelectAll,
+    bulkStatus,
+    setBulkStatus,
+    page,
+    setPage,
+    meta,
+    setMeta,
+    resetFilters,
+    hasActiveFilters,
+    totalPages,
+    startIndex,
+    endIndex,
+    perPage,
+  };
+}

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -18,32 +18,52 @@ import ConfirmModal from "@/components/common/ConfirmModal";
 import { buildUrl } from "@/utils/url";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import useBookTable from "@/hooks/useBookTable";
 function AdminBooksPage() {
   const { t } = useTranslation("dashboard");
 
   const [books, setBooks] = useState([]);
   const [categories, setCategories] = useState([]);
   const [languages, setLanguages] = useState([]);
-  const [filters, setFilters] = useState({
-    search: "",
-    category: "",
-    status: "",
-    priceRange: null,
-    language: "",
-    tags: []
-  });
   const [tagInput, setTagInput] = useState("");
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [selectedBooks, setSelectedBooks] = useState([]);
-  const [allSelected, setAllSelected] = useState(false);
   const [sortBy, setSortBy] = useState("newest");
-  const [page, setPage] = useState(1);
-  const [meta, setMeta] = useState({ totalPages: 1, total: 0 });
   const [showMobileFilters, setShowMobileFilters] = useState(false);
-  const perPage = 12;
 
-  const [bulkStatus, setBulkStatus] = useState("");
+  const {
+    filters,
+    setFilters,
+    selectedItems: selectedBooks,
+    setSelectedItems: setSelectedBooks,
+    allSelected,
+    handleSelect: handleSelectBook,
+    toggleSelectAll,
+    bulkStatus,
+    setBulkStatus,
+    page,
+    setPage,
+    meta,
+    setMeta,
+    resetFilters,
+    hasActiveFilters,
+    totalPages,
+    startIndex,
+    endIndex,
+    perPage,
+  } = useBookTable({
+    items: books,
+    perPage: 12,
+    storageKey: "adminBooksFilters",
+    initialFilters: {
+      search: "",
+      category: "",
+      status: "",
+      priceRange: null,
+      language: "",
+      tags: [],
+    },
+  });
 
   const [confirmModal, setConfirmModal] = useState({
     isOpen: false,
@@ -62,16 +82,6 @@ function AdminBooksPage() {
   const closeConfirmModal = () => {
     setConfirmModal((prev) => ({ ...prev, isOpen: false }));
   };
-
-  // Load filters from localStorage on mount
-  useEffect(() => {
-    const saved = typeof window !== "undefined" ? localStorage.getItem("adminBooksFilters") : null;
-    if (saved) {
-      try {
-        setFilters(JSON.parse(saved));
-      } catch {}
-    }
-  }, []);
 
   useEffect(() => {
     const loadCategories = async () => {
@@ -166,43 +176,6 @@ function AdminBooksPage() {
     loadBooks();
   }, [loadBooks]);
 
-  // Remember filters in localStorage
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      localStorage.setItem("adminBooksFilters", JSON.stringify(filters));
-    }
-  }, [filters]);
-
-  const totalPages = meta?.totalPages ?? 1;
-  const startIndex = books.length ? (page - 1) * perPage + 1 : 0;
-  const endIndex = books.length ? startIndex + books.length - 1 : 0;
-
-  const handleSelectBook = (id) => {
-    setSelectedBooks((prev) => {
-      const updated = prev.includes(id)
-        ? prev.filter((x) => x !== id)
-        : [...prev, id];
-      setAllSelected(updated.length === books.length);
-      return updated;
-    });
-  };
-
-  const toggleSelectAll = () => {
-    if (allSelected) {
-      setSelectedBooks([]);
-      setAllSelected(false);
-    } else {
-      setSelectedBooks(books.map((b) => b.id));
-      setAllSelected(true);
-    }
-  };
-
-  useEffect(() => {
-    setAllSelected(
-      books.length > 0 && selectedBooks.length === books.length
-    );
-  }, [books, selectedBooks]);
-
   const handleBulkDelete = async () => {
     openConfirmModal({
       title: t("Confirm Deletion"),
@@ -273,28 +246,6 @@ function AdminBooksPage() {
       toast.error(t("Failed to update status"));
     }
   };
-
-  const resetFilters = () => {
-    setFilters((prev) => ({
-      ...prev,
-      search: "",
-      category: "",
-      status: "",
-      priceRange: null,
-      language: "",
-      tags: []
-    }));
-    setPage(1);
-  };
-
-  const hasActiveFilters = (
-    filters.search || 
-    filters.category || 
-    filters.status || 
-    filters.priceRange > 0 || 
-    filters.language || 
-    filters.tags.length > 0
-  );
 
   return (
     <AdminLayout>

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -17,6 +17,7 @@ import { FiPlus, FiSearch, FiTrash2, FiChevronLeft, FiChevronRight, FiFilter, Fi
 // Switch removed as status is no longer a simple toggle
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { buildUrl } from "@/utils/url";
+import useBookTable from "@/hooks/useBookTable";
 
 function InstructorBooksPage() {
   const { t } = useTranslation("dashboard");
@@ -25,27 +26,46 @@ function InstructorBooksPage() {
   const [books, setBooks] = useState([]);
   const [categories, setCategories] = useState([]);
   const [languages, setLanguages] = useState([]);
-  const [filters, setFilters] = useState({
-    search: "", 
-    category: "", 
-    status: "", 
-    priceRange: 0, 
-    language: "", 
-    tags: [] 
-  });
   const [tagInput, setTagInput] = useState("");
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [selectedBooks, setSelectedBooks] = useState([]);
-  const [allSelected, setAllSelected] = useState(false);
   const [sortBy, setSortBy] = useState("newest");
-  const [page, setPage] = useState(1);
-  const [meta, setMeta] = useState({ totalPages: 1, total: 0 });
   const [showMobileFilters, setShowMobileFilters] = useState(false);
-  const perPage = 12;
 
-  const [bulkStatus, setBulkStatus] = useState("");
+  const {
+    filters,
+    setFilters,
+    selectedItems: selectedBooks,
+    setSelectedItems: setSelectedBooks,
+    allSelected,
+    handleSelect: handleSelectBook,
+    toggleSelectAll,
+    bulkStatus,
+    setBulkStatus,
+    page,
+    setPage,
+    meta,
+    setMeta,
+    resetFilters,
+    hasActiveFilters,
+    totalPages,
+    startIndex,
+    endIndex,
+    perPage,
+  } = useBookTable({
+    items: books,
+    perPage: 12,
+    storageKey: "instructorBooksFilters",
+    initialFilters: {
+      search: "",
+      category: "",
+      status: "",
+      priceRange: 0,
+      language: "",
+      tags: [],
+    },
+  });
 
   const [visibleCount, setVisibleCount] = useState(perPage);
   const loader = useRef(null);
@@ -101,16 +121,6 @@ function InstructorBooksPage() {
     }
   }, [router, t]);
 
-  // Load filters from localStorage on mount
-  useEffect(() => {
-    const saved = typeof window !== "undefined" ? localStorage.getItem("instructorBooksFilters") : null;
-    if (saved) {
-      try {
-        setFilters(JSON.parse(saved));
-      } catch {}
-    }
-  }, []);
-
   useEffect(() => {
     const loadCategories = async () => {
       try {
@@ -161,45 +171,6 @@ function InstructorBooksPage() {
     };
     loadBooks();
   }, [page, filters, sortBy, perPage, t]);
-
-  // Remember filters in localStorage
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      localStorage.setItem("instructorBooksFilters", JSON.stringify(filters));
-    }
-  }, [filters]);
-
-  const filteredBooks = books;
-  const totalPages = meta?.totalPages ?? 1;
-  const startIndex = books.length ? (page - 1) * perPage + 1 : 0;
-  const endIndex = books.length ? startIndex + books.length - 1 : 0;
-
-  const handleSelectBook = (id) => {
-    setSelectedBooks((prev) => {
-      const updated = prev.includes(id)
-        ? prev.filter((x) => x !== id)
-        : [...prev, id];
-      setAllSelected(updated.length === filteredBooks.length);
-      return updated;
-    });
-  };
-
-  const toggleSelectAll = () => {
-    if (allSelected) {
-      setSelectedBooks([]);
-      setAllSelected(false);
-    } else {
-      setSelectedBooks(filteredBooks.map((b) => b.id));
-      setAllSelected(true);
-    }
-  };
-
-  useEffect(() => {
-    setAllSelected(
-      filteredBooks.length > 0 &&
-        selectedBooks.length === filteredBooks.length
-    );
-  }, [filteredBooks, selectedBooks]);
 
   const handleBulkDelete = async () => {
     openConfirmModal({
@@ -262,28 +233,6 @@ function InstructorBooksPage() {
       toast.error(t("Failed to update status"));
     }
   };
-
-  const resetFilters = () => {
-    setFilters((prev) => ({
-      ...prev,
-      search: "",
-      category: "",
-      status: "",
-      priceRange: 0,
-      language: "",
-      tags: []
-    }));
-    setPage(1);
-  };
-
-  const hasActiveFilters = (
-    filters.search || 
-    filters.category || 
-    filters.status || 
-    filters.priceRange > 0 || 
-    filters.language || 
-    filters.tags.length > 0
-  );
 
   const visibleBooks = sortedBooks.slice(0, visibleCount);
 


### PR DESCRIPTION
## Summary
- add reusable `useBookTable` hook for filters, bulk actions, and pagination
- refactor admin and instructor book pages to use the shared hook

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint` *(fails: Component definition is missing display name, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a8bd1f8a788328a4ad3ff5b65aaa2e