### PR TITLE
feat: prevent duplicate book purchases

### DIFF
--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -20,7 +20,7 @@ const mockDb = knex({
 jest.mock('../../../config/database', () => mockDb);
 
 const db = require('../../../config/database');
-const { listBooks } = require('../book.service');
+const { listBooks, checkout } = require('../book.service');
 
 beforeAll(async () => {
   await db.schema.createTable('books', (table) => {
@@ -37,6 +37,20 @@ beforeAll(async () => {
     table.timestamp('created_at');
   });
 
+  await db.schema.createTable('book_cart', (table) => {
+    table.uuid('student_id');
+    table.integer('book_id');
+    table.integer('quantity').defaultTo(1);
+  });
+
+  await db.schema.createTable('book_purchases', (table) => {
+    table.increments('id');
+    table.uuid('student_id');
+    table.integer('book_id');
+    table.decimal('price_paid').notNullable().defaultTo(0);
+    table.timestamp('purchased_at');
+  });
+
   const books = [
     {
       id: 1,
@@ -46,6 +60,7 @@ beforeAll(async () => {
       detailed_description: 'DetailedDesc1',
       instructor_id: '1',
       created_at: new Date('2023-01-01'),
+      price: 10,
     },
     {
       id: 2,
@@ -55,6 +70,7 @@ beforeAll(async () => {
       detailed_description: 'DetailedDesc2',
       instructor_id: '2',
       created_at: new Date('2023-01-02'),
+      price: 15,
     },
     {
       id: 3,
@@ -64,6 +80,7 @@ beforeAll(async () => {
       detailed_description: 'DetailedMatch',
       instructor_id: '1',
       created_at: new Date('2023-01-03'),
+      price: 20,
     },
   ];
   await db('books').insert(books);
@@ -97,5 +114,41 @@ describe('listBooks', () => {
     const result = await listBooks({ search: 'DetailedMatch' });
     expect(result.data).toHaveLength(1);
     expect(result.data[0].id).toBe(3);
+  });
+});
+
+describe('checkout', () => {
+  const studentId = 'student1';
+
+  beforeEach(async () => {
+    await db('book_cart').del();
+    await db('book_purchases').del();
+  });
+
+  test('throws error when book already purchased', async () => {
+    await db('book_cart').insert({ student_id: studentId, book_id: 1 });
+    await db('book_purchases').insert({
+      student_id: studentId,
+      book_id: 1,
+      price_paid: 10,
+    });
+
+    await expect(checkout(studentId)).rejects.toThrow('Book already purchased');
+
+    const purchases = await db('book_purchases').where({ student_id: studentId });
+    expect(purchases).toHaveLength(1);
+  });
+
+  test('completes checkout when no duplicates', async () => {
+    await db('book_cart').insert({ student_id: studentId, book_id: 2 });
+    const purchases = await checkout(studentId);
+    expect(purchases).toHaveLength(1);
+    const inDb = await db('book_purchases').where({
+      student_id: studentId,
+      book_id: 2,
+    });
+    expect(inDb).toHaveLength(1);
+    const cart = await db('book_cart').where({ student_id: studentId });
+    expect(cart).toHaveLength(0);
   });
 });

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -2,6 +2,7 @@ const db = require("../../config/database");
 const { PRICE_RANGE_MAX } = require("../../config/books");
 const fs = require("fs");
 const path = require("path");
+const AppError = require("../../utils/AppError");
 
 exports.createBook = async (data) => {
   const [row] = await db("books").insert(data).returning("*");
@@ -207,8 +208,20 @@ exports.checkout = async (studentId) => {
       .where({ student_id: studentId })
       .select('book_id');
     if (!items.length) return [];
+
+    const bookIds = items.map((i) => i.book_id);
+
+    const existing = await trx('book_purchases')
+      .where({ student_id: studentId })
+      .whereIn('book_id', bookIds)
+      .select('book_id');
+    if (existing.length) {
+      const ids = existing.map((e) => e.book_id).join(', ');
+      throw new AppError(`Book already purchased: ${ids}`, 409);
+    }
+
     const books = await trx('books')
-      .whereIn('id', items.map((i) => i.book_id))
+      .whereIn('id', bookIds)
       .select('id', 'price');
     const rows = books.map((b) => ({
       student_id: studentId,


### PR DESCRIPTION
## Summary
- ensure checkout rejects books already bought by a student
- add tests covering duplicate book purchase checks

## Testing
- `npm test` *(fails: POST /api/ads/admin › creates ad, PUT /api/users/tutorials/admin/:id › returns 403 when instructor updates another instructor's tutorial, PUT /api/users/tutorials/admin/:id › updates tutorial with language and status, PATCH /api/messages/:id/read › marks message as read, DELETE /api/messages/:id › deletes message, POST /api/messages/:id/email › sends email, POST /api/messages/:id/whatsapp › sends whatsapp message, POST /api/messages/:id/video-call › starts video call, POST /api/messages/call/:id/respond › responds to call, payment commission calculations › calculates commission for class payments, payment commission calculations › calculates commission for book payments, payment commission calculations › calculates commission for tutorial payments, updateTutorial tag transactions › commits transaction when tag update succeeds, PUT /api/seo-config › updates settings, POST /api/blog › creates post, POST /api/payments/admin › creates payment with installments and enrolls, community public routes › create discussion)*
- `npx jest src/modules/books/__tests__/book.service.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8bd1d676083289e49896d014c0da3