### PR TITLE
feat: add atomic book tag updates

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -193,8 +193,7 @@ exports.updateBook = catchAsync(async (req, res) => {
       removePreviewPages: removePreviews,
     });
 
-    await service.clearBookTags(book.id);
-    book.tags = await processTags(rawTags, book.id);
+    book.tags = await service.updateBookTags(book.id, rawTags);
 
     if (
       req.user.role !== "instructor" &&

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -2,6 +2,8 @@ const db = require("../../config/database");
 const { PRICE_RANGE_MAX } = require("../../config/books");
 const fs = require("fs");
 const path = require("path");
+const tagService = require("./bookTag.service");
+const slugify = require("slugify");
 
 exports.createBook = async (data) => {
   const [row] = await db("books").insert(data).returning("*");
@@ -92,10 +94,10 @@ exports.listBooks = async (params = {}) => {
 
 exports.getBookById = (id) => db("books").where({ id }).first();
 
-exports.addBookTags = async (bookId, tagIds) => {
+exports.addBookTags = async (bookId, tagIds, trx = db) => {
   if (!tagIds.length) return;
   const rows = tagIds.map((tag_id) => ({ book_id: bookId, tag_id }));
-  await db("book_tag_map").insert(rows);
+  await trx("book_tag_map").insert(rows);
 };
 
 exports.getBookTags = (bookId) =>
@@ -104,8 +106,39 @@ exports.getBookTags = (bookId) =>
     .where("m.book_id", bookId)
     .select("t.id", "t.name", "t.slug");
 
-exports.clearBookTags = (bookId) =>
-  db("book_tag_map").where({ book_id: bookId }).del();
+exports.clearBookTags = (bookId, trx = db) =>
+  trx("book_tag_map").where({ book_id: bookId }).del();
+
+exports.updateBookTags = async (bookId, rawTags) => {
+  let tags = [];
+  if (rawTags) {
+    try {
+      tags = typeof rawTags === "string" ? JSON.parse(rawTags) : rawTags;
+      if (!Array.isArray(tags)) tags = [];
+    } catch {
+      tags = [];
+    }
+  }
+
+  const tagIds = [];
+  for (const name of tags) {
+    const existing = await tagService.findByName(name);
+    const tag =
+      existing ||
+      (await tagService.createTag({
+        name,
+        slug: slugify(name, { lower: true, strict: true }),
+      }));
+    tagIds.push(tag.id);
+  }
+
+  await db.transaction(async (trx) => {
+    await exports.clearBookTags(bookId, trx);
+    if (tagIds.length) await exports.addBookTags(bookId, tagIds, trx);
+  });
+
+  return exports.getBookTags(bookId);
+};
 
 const removeFiles = async (files = []) => {
   await Promise.all(


### PR DESCRIPTION
## Summary
- add tag service transaction helper for book tags
- update book controller to use atomic tag update

## Testing
- `cd backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68a8bd1cb1cc8328bf23f55eaa229acf