### PR TITLE
Optimize tag processing with transaction

### DIFF
--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -92,14 +92,14 @@ exports.listBooks = async (params = {}) => {
 
 exports.getBookById = (id) => db("books").where({ id }).first();
 
-exports.addBookTags = async (bookId, tagIds) => {
+exports.addBookTags = async (bookId, tagIds, trx = db) => {
   if (!tagIds.length) return;
   const rows = tagIds.map((tag_id) => ({ book_id: bookId, tag_id }));
-  await db("book_tag_map").insert(rows);
+  await trx("book_tag_map").insert(rows);
 };
 
-exports.getBookTags = (bookId) =>
-  db("book_tag_map as m")
+exports.getBookTags = (bookId, trx = db) =>
+  trx("book_tag_map as m")
     .join("tags as t", "m.tag_id", "t.id")
     .where("m.book_id", bookId)
     .select("t.id", "t.name", "t.slug");

--- a/backend/src/modules/books/book.utils.js
+++ b/backend/src/modules/books/book.utils.js
@@ -1,6 +1,7 @@
 const service = require("./book.service");
 const tagService = require("./bookTag.service");
 const slugify = require("slugify");
+const db = require("../../config/database");
 
 exports.processTags = async (rawTags, bookId) => {
   let tags = [];
@@ -13,17 +14,23 @@ exports.processTags = async (rawTags, bookId) => {
     }
   }
   if (!tags.length) return [];
-  const tagIds = [];
-  for (const name of tags) {
-    const existing = await tagService.findByName(name);
-    const tag =
-      existing ||
-      (await tagService.createTag({
+
+  return await db.transaction(async (trx) => {
+    const existing = await tagService.findByNames(tags, trx);
+    const existingMap = new Map(
+      existing.map((t) => [t.name.toLowerCase(), t])
+    );
+    const newTagData = tags
+      .filter((name) => !existingMap.has(name.toLowerCase()))
+      .map((name) => ({
         name,
         slug: slugify(name, { lower: true, strict: true }),
       }));
-    tagIds.push(tag.id);
-  }
-  await service.addBookTags(bookId, tagIds);
-  return await service.getBookTags(bookId);
+    const newTags = newTagData.length
+      ? await tagService.createTags(newTagData, trx)
+      : [];
+    const tagIds = [...existing, ...newTags].map((t) => t.id);
+    await service.addBookTags(bookId, tagIds, trx);
+    return await service.getBookTags(bookId, trx);
+  });
 };

--- a/backend/src/modules/books/bookTag.service.js
+++ b/backend/src/modules/books/bookTag.service.js
@@ -1,17 +1,26 @@
 const db = require("../../config/database");
 
-exports.getAllTags = () => db("tags").select("*").orderBy("created_at", "desc");
+exports.getAllTags = (trx = db) =>
+  trx("tags").select("*").orderBy("created_at", "desc");
 
-exports.findByName = (name) =>
-  db("tags").whereRaw("LOWER(name) = ?", [name.toLowerCase()]).first();
+exports.findByName = (name, trx = db) =>
+  trx("tags").whereRaw("LOWER(name) = ?", [name.toLowerCase()]).first();
 
-exports.createTag = async (data) => {
-  const [row] = await db("tags").insert(data).returning("*");
+exports.findByNames = (names, trx = db) =>
+  trx("tags").whereIn(trx.raw("LOWER(name)"), names.map((n) => n.toLowerCase()));
+
+exports.createTag = async (data, trx = db) => {
+  const [row] = await trx("tags").insert(data).returning("*");
   return row;
 };
 
-exports.searchTags = (search, limit = 10) =>
-  db("tags")
+exports.createTags = async (rows, trx = db) => {
+  if (!rows.length) return [];
+  return await trx("tags").insert(rows).returning("*");
+};
+
+exports.searchTags = (search, limit = 10, trx = db) =>
+  trx("tags")
     .modify((q) => {
       if (search) q.whereILike("name", `%${search}%`);
     })


### PR DESCRIPTION
## Summary
- Fetch book tags in bulk and insert missing tags in a single transaction
- Support bulk tag lookup and creation in tag service
- Allow book-tag mapping functions to participate in database transactions

## Testing
- `npm test src/modules/books`
- `npm test` *(fails: 11 test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bd1af5f08328a86fe0e1267a4a86