### PR TITLE
Remove deprecated is_free book flag

### DIFF
--- a/backend/src/modules/books/book.controller.js
+++ b/backend/src/modules/books/book.controller.js
@@ -29,8 +29,7 @@ const removeUploadedFiles = async (files = {}) => {
 
 exports.createBook = catchAsync(async (req, res) => {
   try {
-    // exclude `is_free` since the database schema does not include this column
-    const { tags: rawTags, is_free: _is_free, ...data } = req.body;
+    const { tags: rawTags, ...data } = req.body;
     data.instructor_id = req.user.id;
     data.status = "pending";
     if (req.files?.cover_image?.[0])
@@ -166,13 +165,7 @@ exports.updateBook = catchAsync(async (req, res) => {
       throw new AppError("Access denied", 403);
     }
 
-  // exclude `is_free` field to align with existing database schema
-  const {
-    tags: rawTags,
-    is_free: _is_free,
-    remove_preview_pages,
-    ...data
-  } = req.body;
+  const { tags: rawTags, remove_preview_pages, ...data } = req.body;
   if (req.files?.cover_image?.[0])
     data.cover_image_url =
       "/uploads/books/" + req.files.cover_image[0].filename;

--- a/backend/src/modules/books/validation/bookValidation.js
+++ b/backend/src/modules/books/validation/bookValidation.js
@@ -19,14 +19,6 @@ exports.createBook = Joi.object({
     .falsy(0)
     .falsy('false')
     .default(false),
-  is_free: Joi.boolean()
-    .truthy('1')
-    .truthy(1)
-    .truthy('true')
-    .falsy('0')
-    .falsy(0)
-    .falsy('false')
-    .default(false),
   status: Joi.string().optional(),
   tags: Joi.alternatives(Joi.array().items(Joi.string()), Joi.string()).optional(),
 });

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1374,7 +1374,6 @@
     "bookFileRequired": "Book file is required",
     "previewPagesLabel": "Preview Pages (optional)",
     "allowPreview": "Allow Preview",
-    "isFree": "Free",
     "priceLabel": "Price",
     "priceRequired": "Price is required",
     "languageLabel": "Language",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1354,7 +1354,6 @@
     "bookFileRequired": "Book file is required",
     "previewPagesLabel": "Preview Pages (optional)",
     "allowPreview": "Allow Preview",
-    "isFree": "Free",
     "priceLabel": "Price",
     "priceRequired": "Price is required",
     "languageLabel": "Language",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1355,7 +1355,6 @@
     "previewPagesLabel": "Preview Pages (optional)",
     "clearPreviewPages": "Clear preview pages",
     "allowPreview": "Allow Preview",
-    "isFree": "Free",
     "priceLabel": "Price",
     "priceRequired": "Price is required",
     "languageLabel": "Language",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1355,7 +1355,6 @@
     "bookFileRequired": "Book file is required",
     "previewPagesLabel": "Preview Pages (optional)",
     "allowPreview": "Allow Preview",
-    "isFree": "Free",
     "priceLabel": "Price",
     "priceRequired": "Price is required",
     "languageLabel": "Language",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1354,7 +1354,6 @@
     "bookFileRequired": "Book file is required",
     "previewPagesLabel": "Preview Pages (optional)",
     "allowPreview": "Allow Preview",
-    "isFree": "Free",
     "priceLabel": "Price",
     "priceRequired": "Price is required",
     "languageLabel": "Language",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1354,7 +1354,6 @@
     "bookFileRequired": "Book file is required",
     "previewPagesLabel": "Preview Pages (optional)",
     "allowPreview": "Allow Preview",
-    "isFree": "Free",
     "priceLabel": "Price",
     "priceRequired": "Price is required",
     "languageLabel": "Language",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1356,7 +1356,6 @@
     "bookFileRequired": "Book file is required",
     "previewPagesLabel": "Preview Pages (optional)",
     "allowPreview": "Allow Preview",
-    "isFree": "Free",
     "priceLabel": "Price",
     "priceRequired": "Price is required",
     "languageLabel": "Language",

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -22,14 +22,12 @@ export default function BookForm({
   const {
     register,
     handleSubmit,
-    watch,
     formState: { errors },
     setValue,
     reset,
   } = useForm({
     defaultValues: {
       tags: [],
-      is_free: false,
       allow_preview: false,
       remove_preview_pages: false,
       ...(defaultValues || {}),
@@ -44,13 +42,11 @@ export default function BookForm({
   const [bookFileName, setBookFileName] = useState("");
   const [previewFiles, setPreviewFiles] = useState([]);
   const [uploadProgress, setUploadProgress] = useState(null);
-  const isFree = watch("is_free");
 
   useEffect(() => {
     if (defaultValues) {
       reset({
         tags: defaultValues.tags || [],
-        is_free: defaultValues.is_free ?? false,
         allow_preview: defaultValues.allow_preview ?? false,
         remove_preview_pages: false,
         ...defaultValues,
@@ -157,10 +153,9 @@ export default function BookForm({
     if (data.remove_preview_pages) {
       formData.append("remove_preview_pages", 1);
     }
-    formData.append("price", isFree ? 0 : data.price);
+    formData.append("price", data.price);
     formData.append("language", data.language);
     formData.append("license_type", data.license_type);
-    formData.append("is_free", isFree ? 1 : 0);
     formData.append("allow_preview", data.allow_preview ? 1 : 0);
     formData.append("status", data.status);
     setUploadProgress(0);
@@ -499,26 +494,6 @@ export default function BookForm({
         </div>
 
 
-      <div className="flex items-center gap-2">
-        {(() => {
-          const reg = register("is_free");
-          return (
-            <input
-              type="checkbox"
-              {...reg}
-              onChange={(e) => {
-                reg.onChange(e);
-                if (e.target.checked) setValue("price", 0);
-              }}
-              className="h-4 w-4 text-yellow-500 border-gray-300 rounded"
-            />
-          );
-        })()}
-        <label className="text-sm font-medium">
-          {t("booksCreate.isFree")}
-        </label>
-      </div>
-
       <div>
         <label className="block text-sm font-medium mb-1">
           {t("booksCreate.priceLabel")}
@@ -527,10 +502,9 @@ export default function BookForm({
           type="number"
           step="0.01"
           {...register("price", {
-            required: !isFree && t("booksCreate.priceRequired"),
+            required: t("booksCreate.priceRequired"),
           })}
-          disabled={isFree}
-          className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400 disabled:bg-gray-100"
+          className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-yellow-400"
         />
         {errors.price && (
           <p className="text-red-500 text-sm mt-1">{errors.price.message}</p>

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -51,9 +51,6 @@ function AdminEditBookPage() {
         const parsedBook = {
           ...bookData,
           tags: bookData?.tags?.map((t) => t.name || t) || [],
-          is_free:
-            bookData?.is_free === 1 ||
-            bookData?.is_free === true,
           allow_preview:
             bookData?.allow_preview === 1 ||
             bookData?.allow_preview === true,

--- a/frontend/src/pages/dashboard/admin/books/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/view/[id].js
@@ -175,7 +175,7 @@ function AdminViewBookPage() {
                   <div className="space-y-1">
                     <h3 className="text-sm font-medium text-gray-500">{t("booksView.price")}</h3>
                     <p className="text-gray-900">
-                      {book.is_free
+                      {book.price === 0
                         ? t("booksView.free")
                         : book.price != null
                         ? `$${book.price.toFixed(2)}`

--- a/frontend/src/pages/dashboard/instructor/books/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/books/[id]/edit.js
@@ -44,8 +44,6 @@ function EditBookPage() {
         const parsedBook = {
           ...bookData,
           tags: bookData?.tags?.map((t) => t.name || t) || [],
-          is_free:
-            bookData?.is_free === 1 || bookData?.is_free === true,
           allow_preview:
             bookData?.allow_preview === 1 ||
             bookData?.allow_preview === true,


### PR DESCRIPTION
## Summary
- drop is_free validation from book schemas and controllers
- stop sending is_free from book form and related pages
- clean up locale strings referencing the isFree checkbox

## Testing
- `npm test` (backend) *(fails: POST /api/books › creates a book, etc.)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a8bd0d525c832885e57eeceeb78102