### PR TITLE
feat: add admin class rule management UI

### DIFF
--- a/frontend/src/components/admin/online-classes/rules/RuleList.js
+++ b/frontend/src/components/admin/online-classes/rules/RuleList.js
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { FaEdit, FaPlus, FaTrash } from "react-icons/fa";
+import RuleModal from "./RuleModal";
+import { Button } from "@/components/ui/button";
+
+export default function RuleList({ rules = [], onAdd, onUpdate, onDelete, canManage = false }) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingRule, setEditingRule] = useState(null);
+
+  const openNew = () => {
+    setEditingRule(null);
+    setModalOpen(true);
+  };
+
+  const openEdit = (rule) => {
+    setEditingRule(rule);
+    setModalOpen(true);
+  };
+
+  return (
+    <div className="space-y-4">
+      {canManage && (
+        <Button
+          onClick={openNew}
+          className="bg-blue-600 text-white hover:bg-blue-700 flex items-center gap-2"
+        >
+          <FaPlus />
+          Add Rule
+        </Button>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Title</th>
+              <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Description</th>
+              {canManage && <th className="px-4 py-2 text-right text-sm font-medium text-gray-700">Actions</th>}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {rules.map((rule) => (
+              <tr key={rule.id}>
+                <td className="px-4 py-2">{rule.title}</td>
+                <td className="px-4 py-2">{rule.description}</td>
+                {canManage && (
+                  <td className="px-4 py-2 text-right space-x-2">
+                    <button
+                      onClick={() => openEdit(rule)}
+                      className="text-blue-600 hover:text-blue-800"
+                    >
+                      <FaEdit />
+                    </button>
+                    <button
+                      onClick={() => onDelete?.(rule.id)}
+                      className="text-red-600 hover:text-red-800"
+                    >
+                      <FaTrash />
+                    </button>
+                  </td>
+                )}
+              </tr>
+            ))}
+            {rules.length === 0 && (
+              <tr>
+                <td
+                  className="px-4 py-4 text-center text-gray-500"
+                  colSpan={canManage ? 3 : 2}
+                >
+                  No rules found
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      {modalOpen && (
+        <RuleModal
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+          initialData={editingRule}
+          onSave={(data) => {
+            if (editingRule) {
+              onUpdate?.(editingRule.id, data);
+            } else {
+              onAdd?.(data);
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/online-classes/rules/RuleModal.js
+++ b/frontend/src/components/admin/online-classes/rules/RuleModal.js
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import Modal from "@/components/common/Modal";
+import { Button } from "@/components/ui/button";
+
+export default function RuleModal({ isOpen, onClose, initialData, onSave }) {
+  const [form, setForm] = useState({ title: "", description: "" });
+
+  useEffect(() => {
+    if (initialData) {
+      setForm({ title: initialData.title || "", description: initialData.description || "" });
+    } else {
+      setForm({ title: "", description: "" });
+    }
+  }, [initialData]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSave?.(form);
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={initialData ? "Edit Rule" : "Add Rule"}
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Title</label>
+          <input
+            type="text"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Description</label>
+          <textarea
+            value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            rows={3}
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            onClick={onClose}
+            className="bg-gray-300 text-black hover:bg-gray-400"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            className="bg-blue-600 text-white hover:bg-blue-700"
+          >
+            {initialData ? "Update" : "Create"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
@@ -1,0 +1,94 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import RuleList from "@/components/admin/online-classes/rules/RuleList";
+import useAuthStore from "@/store/auth/authStore";
+import {
+  fetchClassRules,
+  createClassRule,
+  updateClassRule,
+  deleteClassRule,
+} from "@/services/admin/classRuleService";
+
+export default function ClassRulesPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { t, i18n } = useTranslation('dashboard');
+  const user = useAuthStore((state) => state.user);
+  const [rules, setRules] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const canManage = user?.permissions?.includes('ADD_ONLINE_CLASS_RULE');
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    fetchClassRules(id)
+      .then((data) => setRules(data))
+      .catch((err) => {
+        console.error('Failed to load rules', err);
+        setRules([]);
+      })
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  const handleAdd = async (payload) => {
+    try {
+      const created = await createClassRule(id, payload);
+      if (created) setRules((prev) => [...prev, created]);
+    } catch (err) {
+      console.error('Failed to create rule', err);
+    }
+  };
+
+  const handleUpdate = async (ruleId, payload) => {
+    try {
+      const updated = await updateClassRule(id, ruleId, payload);
+      if (updated) setRules((prev) => prev.map((r) => (r.id === ruleId ? updated : r)));
+    } catch (err) {
+      console.error('Failed to update rule', err);
+    }
+  };
+
+  const handleDelete = async (ruleId) => {
+    try {
+      await deleteClassRule(id, ruleId);
+      setRules((prev) => prev.filter((r) => r.id !== ruleId));
+    } catch (err) {
+      console.error('Failed to delete rule', err);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6" dir={i18n.dir()}>
+      <h1 className="text-2xl font-bold text-gray-800">{t('classRulesPage.title', 'Class Rules')}</h1>
+      {loading ? (
+        <p className="text-sm text-gray-500">{t('loading')}</p>
+      ) : (
+        <RuleList
+          rules={rules}
+          onAdd={handleAdd}
+          onUpdate={handleUpdate}
+          onDelete={handleDelete}
+          canManage={canManage}
+        />
+      )}
+    </div>
+  );
+}
+
+ClassRulesPage.getLayout = function getLayout(page) {
+  return <AdminLayout>{page}</AdminLayout>;
+};
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+    },
+  };
+}
+

--- a/frontend/src/services/admin/classRuleService.js
+++ b/frontend/src/services/admin/classRuleService.js
@@ -1,0 +1,22 @@
+import api from "@/services/api/api";
+
+export const fetchClassRules = async (classId) => {
+  const { data } = await api.get(`/users/classes/admin/${classId}/rules`);
+  return data?.data ?? [];
+};
+
+export const createClassRule = async (classId, payload) => {
+  const { data } = await api.post(`/users/classes/admin/${classId}/rules`, payload);
+  return data?.data ?? null;
+};
+
+export const updateClassRule = async (classId, ruleId, payload) => {
+  const { data } = await api.put(`/users/classes/admin/${classId}/rules/${ruleId}`, payload);
+  return data?.data ?? null;
+};
+
+export const deleteClassRule = async (classId, ruleId) => {
+  await api.delete(`/users/classes/admin/${classId}/rules/${ruleId}`);
+  return true;
+};
+


### PR DESCRIPTION
## Summary
- add class rule CRUD service and admin page
- build rule list and modal components for online classes
- gate rule controls behind ADD_ONLINE_CLASS_RULE permission

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a65508c7488328849d08dfcb6ba4b7