### PR TITLE
Add class rules module with permission checks

### DIFF
--- a/backend/src/middleware/auth/verifyPermission.js
+++ b/backend/src/middleware/auth/verifyPermission.js
@@ -1,0 +1,32 @@
+const db = require("../../config/database");
+
+module.exports = function verifyPermission(code) {
+  return async (req, res, next) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+
+      const roleIds = await db("user_roles")
+        .where({ user_id: req.user.id })
+        .pluck("role_id");
+
+      if (!roleIds.length) {
+        return res.status(403).json({ message: "Insufficient permissions" });
+      }
+
+      const perms = await db("role_permissions")
+        .join("permissions", "role_permissions.permission_id", "permissions.id")
+        .whereIn("role_permissions.role_id", roleIds)
+        .pluck("permissions.code");
+
+      if (!perms.includes(code)) {
+        return res.status(403).json({ message: "Insufficient permissions" });
+      }
+
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+};

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -30,6 +30,7 @@ router.use("/reviews", require("./reviews/classReview.routes"));
 router.use("/comments", require("./comments/classComment.routes"));
 // Final scoring and certificates
 router.use("/scores", require("./scores/classScore.routes"));
+router.use("/admin/:id/rules", require("./rules/classRule.routes"));
 
 router.post(
   "/admin",

--- a/backend/src/modules/classes/rules/classRule.controller.js
+++ b/backend/src/modules/classes/rules/classRule.controller.js
@@ -1,0 +1,27 @@
+const catchAsync = require("../../../utils/catchAsync");
+const { sendSuccess } = require("../../../utils/response");
+const service = require("./classRule.service");
+
+exports.createRule = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  const { text } = req.body;
+  const rule = await service.createRule({ class_id: id, text });
+  sendSuccess(res, rule, "Rule created");
+});
+
+exports.getRules = catchAsync(async (req, res) => {
+  const rules = await service.getRules(req.params.id);
+  sendSuccess(res, rules);
+});
+
+exports.updateRule = catchAsync(async (req, res) => {
+  const { ruleId } = req.params;
+  const rule = await service.updateRule(ruleId, req.body.text);
+  sendSuccess(res, rule, "Rule updated");
+});
+
+exports.deleteRule = catchAsync(async (req, res) => {
+  const { ruleId } = req.params;
+  await service.deleteRule(ruleId);
+  sendSuccess(res, null, "Rule deleted");
+});

--- a/backend/src/modules/classes/rules/classRule.model.js
+++ b/backend/src/modules/classes/rules/classRule.model.js
@@ -1,0 +1,27 @@
+const db = require("../../../config/database");
+
+exports.create = async ({ class_id, text }) => {
+  const [row] = await db("class_rules")
+    .insert({ class_id, text })
+    .returning("*");
+  return row;
+};
+
+exports.findByClass = (class_id) => {
+  return db("class_rules")
+    .where({ class_id })
+    .select("*")
+    .orderBy("created_at", "asc");
+};
+
+exports.update = async (id, data) => {
+  const [row] = await db("class_rules")
+    .where({ id })
+    .update(data)
+    .returning("*");
+  return row;
+};
+
+exports.remove = (id) => {
+  return db("class_rules").where({ id }).del();
+};

--- a/backend/src/modules/classes/rules/classRule.routes.js
+++ b/backend/src/modules/classes/rules/classRule.routes.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router({ mergeParams: true });
+const controller = require("./classRule.controller");
+const { verifyToken } = require("../../../middleware/auth/authMiddleware");
+const verifyPermission = require("../../../middleware/auth/verifyPermission");
+
+router.use(verifyToken, verifyPermission("ADD_ONLINE_CLASS_RULE"));
+
+router.post("/", controller.createRule);
+router.get("/", controller.getRules);
+router.put("/:ruleId", controller.updateRule);
+router.delete("/:ruleId", controller.deleteRule);
+
+module.exports = router;

--- a/backend/src/modules/classes/rules/classRule.service.js
+++ b/backend/src/modules/classes/rules/classRule.service.js
@@ -1,0 +1,6 @@
+const model = require("./classRule.model");
+
+exports.createRule = ({ class_id, text }) => model.create({ class_id, text });
+exports.getRules = (class_id) => model.findByClass(class_id);
+exports.updateRule = (id, text) => model.update(id, { text });
+exports.deleteRule = (id) => model.remove(id);


### PR DESCRIPTION
## Summary
- add middleware to verify permissions based on user roles
- introduce class rules module with model, service, controller, and routes
- wire class rules routes under `/api/users/classes/admin/:id/rules`

## Testing
- `npm test` *(fails: POST /api/ads/admin creates ad; PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial; PATCH /api/messages/:id/read marks message as read; Class routes create class responds even if notifications fail; Class routes create class with options; updateTutorial tag transactions commits transaction when tag update succeeds; payment commission calculations; PUT /api/seo-config updates settings; POST /api/blog creates post; POST /api/payments/admin creates payment with installments and enrolls; community public routes create discussion)*

------
https://chatgpt.com/codex/tasks/task_e_68a65507c05083289b030d8e33a88d15