### PR TITLE
Add translations for admin permissions page

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1756,5 +1756,28 @@
     "start_before_end": "Start date must be before expiration",
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
+  },
+  "permissionsPage": {
+    "title": "Permissions",
+    "add_permission": "Add Permission",
+    "permission": "Permission",
+    "actions": "Actions",
+    "permission_name_required": "Permission name is required",
+    "permission_exists": "Permission already exists",
+    "permission_added": "Permission added",
+    "permission_add_failed": "Failed to add permission",
+    "permission_removed": "Permission removed",
+    "permission_delete_failed": "Failed to delete",
+    "no_permissions": "No permissions found",
+    "loading": "Loading...",
+    "add_new_permission": "Add New Permission",
+    "placeholder": "e.g. manage_users",
+    "cancel": "Cancel",
+    "add": "Add",
+    "confirm_deletion": "Confirm Deletion",
+    "delete_question": "Are you sure you want to delete this permission?",
+    "delete": "Delete",
+    "deletion_cancelled": "Deletion cancelled",
+    "failed_to_load_permissions": "Failed to load permissions"
   }
 }

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1769,5 +1769,28 @@
     "start_before_end": "Start date must be before expiration",
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
+  },
+  "permissionsPage": {
+    "title": "Permissions",
+    "add_permission": "Add Permission",
+    "permission": "Permission",
+    "actions": "Actions",
+    "permission_name_required": "Permission name is required",
+    "permission_exists": "Permission already exists",
+    "permission_added": "Permission added",
+    "permission_add_failed": "Failed to add permission",
+    "permission_removed": "Permission removed",
+    "permission_delete_failed": "Failed to delete",
+    "no_permissions": "No permissions found",
+    "loading": "Loading...",
+    "add_new_permission": "Add New Permission",
+    "placeholder": "e.g. manage_users",
+    "cancel": "Cancel",
+    "add": "Add",
+    "confirm_deletion": "Confirm Deletion",
+    "delete_question": "Are you sure you want to delete this permission?",
+    "delete": "Delete",
+    "deletion_cancelled": "Deletion cancelled",
+    "failed_to_load_permissions": "Failed to load permissions"
   }
 }

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1800,5 +1800,28 @@
     "start_before_end": "Start date must be before expiration",
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
+  },
+  "permissionsPage": {
+    "title": "Permissions",
+    "add_permission": "Add Permission",
+    "permission": "Permission",
+    "actions": "Actions",
+    "permission_name_required": "Permission name is required",
+    "permission_exists": "Permission already exists",
+    "permission_added": "Permission added",
+    "permission_add_failed": "Failed to add permission",
+    "permission_removed": "Permission removed",
+    "permission_delete_failed": "Failed to delete",
+    "no_permissions": "No permissions found",
+    "loading": "Loading...",
+    "add_new_permission": "Add New Permission",
+    "placeholder": "e.g. manage_users",
+    "cancel": "Cancel",
+    "add": "Add",
+    "confirm_deletion": "Confirm Deletion",
+    "delete_question": "Are you sure you want to delete this permission?",
+    "delete": "Delete",
+    "deletion_cancelled": "Deletion cancelled",
+    "failed_to_load_permissions": "Failed to load permissions"
   }
 }

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1770,5 +1770,28 @@
     "start_before_end": "Start date must be before expiration",
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
+  },
+  "permissionsPage": {
+    "title": "Permissions",
+    "add_permission": "Add Permission",
+    "permission": "Permission",
+    "actions": "Actions",
+    "permission_name_required": "Permission name is required",
+    "permission_exists": "Permission already exists",
+    "permission_added": "Permission added",
+    "permission_add_failed": "Failed to add permission",
+    "permission_removed": "Permission removed",
+    "permission_delete_failed": "Failed to delete",
+    "no_permissions": "No permissions found",
+    "loading": "Loading...",
+    "add_new_permission": "Add New Permission",
+    "placeholder": "e.g. manage_users",
+    "cancel": "Cancel",
+    "add": "Add",
+    "confirm_deletion": "Confirm Deletion",
+    "delete_question": "Are you sure you want to delete this permission?",
+    "delete": "Delete",
+    "deletion_cancelled": "Deletion cancelled",
+    "failed_to_load_permissions": "Failed to load permissions"
   }
 }

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1799,5 +1799,28 @@
     "start_before_end": "Start date must be before expiration",
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
+  },
+  "permissionsPage": {
+    "title": "Permissions",
+    "add_permission": "Add Permission",
+    "permission": "Permission",
+    "actions": "Actions",
+    "permission_name_required": "Permission name is required",
+    "permission_exists": "Permission already exists",
+    "permission_added": "Permission added",
+    "permission_add_failed": "Failed to add permission",
+    "permission_removed": "Permission removed",
+    "permission_delete_failed": "Failed to delete",
+    "no_permissions": "No permissions found",
+    "loading": "Loading...",
+    "add_new_permission": "Add New Permission",
+    "placeholder": "e.g. manage_users",
+    "cancel": "Cancel",
+    "add": "Add",
+    "confirm_deletion": "Confirm Deletion",
+    "delete_question": "Are you sure you want to delete this permission?",
+    "delete": "Delete",
+    "deletion_cancelled": "Deletion cancelled",
+    "failed_to_load_permissions": "Failed to load permissions"
   }
 }

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1769,5 +1769,28 @@
     "start_before_end": "Start date must be before expiration",
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
+  },
+  "permissionsPage": {
+    "title": "Permissions",
+    "add_permission": "Add Permission",
+    "permission": "Permission",
+    "actions": "Actions",
+    "permission_name_required": "Permission name is required",
+    "permission_exists": "Permission already exists",
+    "permission_added": "Permission added",
+    "permission_add_failed": "Failed to add permission",
+    "permission_removed": "Permission removed",
+    "permission_delete_failed": "Failed to delete",
+    "no_permissions": "No permissions found",
+    "loading": "Loading...",
+    "add_new_permission": "Add New Permission",
+    "placeholder": "e.g. manage_users",
+    "cancel": "Cancel",
+    "add": "Add",
+    "confirm_deletion": "Confirm Deletion",
+    "delete_question": "Are you sure you want to delete this permission?",
+    "delete": "Delete",
+    "deletion_cancelled": "Deletion cancelled",
+    "failed_to_load_permissions": "Failed to load permissions"
   }
 }

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1771,5 +1771,28 @@
     "start_before_end": "Start date must be before expiration",
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
+  },
+  "permissionsPage": {
+    "title": "Permissions",
+    "add_permission": "Add Permission",
+    "permission": "Permission",
+    "actions": "Actions",
+    "permission_name_required": "Permission name is required",
+    "permission_exists": "Permission already exists",
+    "permission_added": "Permission added",
+    "permission_add_failed": "Failed to add permission",
+    "permission_removed": "Permission removed",
+    "permission_delete_failed": "Failed to delete",
+    "no_permissions": "No permissions found",
+    "loading": "Loading...",
+    "add_new_permission": "Add New Permission",
+    "placeholder": "e.g. manage_users",
+    "cancel": "Cancel",
+    "add": "Add",
+    "confirm_deletion": "Confirm Deletion",
+    "delete_question": "Are you sure you want to delete this permission?",
+    "delete": "Delete",
+    "deletion_cancelled": "Deletion cancelled",
+    "failed_to_load_permissions": "Failed to load permissions"
   }
 }

--- a/frontend/src/pages/dashboard/admin/permissions/index.js
+++ b/frontend/src/pages/dashboard/admin/permissions/index.js
@@ -4,6 +4,9 @@ import withAuthProtection from "@/hooks/withAuthProtection";
 import useAuthStore from "@/store/auth/authStore";
 import { PlusCircle, Trash2 } from "lucide-react";
 import toast from "react-hot-toast";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import {
   fetchAllPermissions,
   createPermission,
@@ -11,6 +14,7 @@ import {
 } from "@/services/admin/roleService";
 
 function PermissionsPage() {
+  const { t } = useTranslation("dashboard");
   const [permissions, setPermissions] = useState([]);
   const [showAddModal, setShowAddModal] = useState(false);
   const [newPermission, setNewPermission] = useState("");
@@ -28,7 +32,7 @@ function PermissionsPage() {
         setPermissions(data);
       } catch (err) {
         console.error(err);
-        toast.error("Failed to load permissions");
+        toast.error(t("permissionsPage.failed_to_load_permissions"));
       } finally {
         setLoading(false);
       }
@@ -38,20 +42,20 @@ function PermissionsPage() {
   const handleAdd = async () => {
     if (!canManage) return;
     if (!newPermission.trim()) {
-      toast.error("Permission name is required");
+      toast.error(t("permissionsPage.permission_name_required"));
       return;
     }
     if (permissions.some((p) => p.code === newPermission)) {
-      toast.error("Permission already exists");
+      toast.error(t("permissionsPage.permission_exists"));
       return;
     }
     try {
       const created = await createPermission({ code: newPermission });
       setPermissions([...permissions, created]);
-      toast.success("Permission added");
+      toast.success(t("permissionsPage.permission_added"));
     } catch (err) {
       console.error(err);
-      toast.error("Failed to add permission");
+      toast.error(t("permissionsPage.permission_add_failed"));
     }
     setNewPermission("");
     setShowAddModal(false);
@@ -70,10 +74,10 @@ function PermissionsPage() {
       setPermissions((perms) =>
         perms.filter((p) => p.id !== permissionToDelete)
       );
-      toast.success("Permission removed");
+      toast.success(t("permissionsPage.permission_removed"));
     } catch (err) {
       console.error(err);
-      toast.error("Failed to delete");
+      toast.error(t("permissionsPage.permission_delete_failed"));
     }
     setPermissionToDelete(null);
     setShowDeleteModal(false);
@@ -82,21 +86,23 @@ function PermissionsPage() {
   const handleCancelDelete = () => {
     setShowDeleteModal(false);
     setPermissionToDelete(null);
-    toast("Deletion cancelled");
+    toast(t("permissionsPage.deletion_cancelled"));
   };
 
   return (
     <AdminLayout>
       <div className="p-6 sm:p-8">
         <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl sm:text-3xl font-bold text-gray-800">Permissions</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-800">
+            {t("permissionsPage.title")}
+          </h1>
           {canManage && (
             <button
               className="inline-flex items-center gap-2 bg-yellow-500 text-white hover:bg-yellow-600 transition px-4 py-2 rounded-lg shadow-sm"
               onClick={() => setShowAddModal(true)}
             >
               <PlusCircle className="w-5 h-5" />
-              Add Permission
+              {t("permissionsPage.add_permission")}
             </button>
           )}
         </div>
@@ -105,9 +111,13 @@ function PermissionsPage() {
           <table className="min-w-full text-sm">
             <thead className="bg-gray-100 text-gray-700 text-left">
               <tr>
-                <th className="px-6 py-3 font-semibold">Permission</th>
+                <th className="px-6 py-3 font-semibold">
+                  {t("permissionsPage.permission")}
+                </th>
                 {canManage && (
-                  <th className="px-6 py-3 text-right font-semibold">Actions</th>
+                  <th className="px-6 py-3 text-right font-semibold">
+                    {t("permissionsPage.actions")}
+                  </th>
                 )}
               </tr>
             </thead>
@@ -122,7 +132,7 @@ function PermissionsPage() {
                       <button
                         onClick={() => openDeleteModal(perm.id)}
                         className="text-red-600 hover:text-red-800 transition"
-                        title="Delete"
+                        title={t("permissionsPage.delete")}
                       >
                         <Trash2 className="w-5 h-5" />
                       </button>
@@ -136,7 +146,7 @@ function PermissionsPage() {
                     className="px-6 py-4 text-center text-gray-500"
                     colSpan={canManage ? 2 : 1}
                   >
-                    No permissions found
+                    {t("permissionsPage.no_permissions")}
                   </td>
                 </tr>
               )}
@@ -146,7 +156,7 @@ function PermissionsPage() {
                     className="px-6 py-4 text-center text-gray-500"
                     colSpan={canManage ? 2 : 1}
                   >
-                    Loading...
+                    {t("permissionsPage.loading")}
                   </td>
                 </tr>
               )}
@@ -158,11 +168,13 @@ function PermissionsPage() {
         {showAddModal && canManage && (
           <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50 px-4">
             <div className="bg-white w-full max-w-md rounded-xl p-6 shadow-xl">
-              <h3 className="text-lg font-bold mb-4 text-gray-800">Add New Permission</h3>
+              <h3 className="text-lg font-bold mb-4 text-gray-800">
+                {t("permissionsPage.add_new_permission")}
+              </h3>
               <input
                 value={newPermission}
                 onChange={(e) => setNewPermission(e.target.value)}
-                placeholder="e.g. manage_users"
+                placeholder={t("permissionsPage.placeholder")}
                 className="w-full border border-gray-300 p-2 rounded focus:ring-2 focus:ring-yellow-500 focus:outline-none mb-4"
               />
               <div className="flex justify-end gap-3">
@@ -170,13 +182,13 @@ function PermissionsPage() {
                   onClick={() => setShowAddModal(false)}
                   className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded"
                 >
-                  Cancel
+                  {t("permissionsPage.cancel")}
                 </button>
                 <button
                   onClick={handleAdd}
                   className="px-4 py-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
                 >
-                  Add
+                  {t("permissionsPage.add")}
                 </button>
               </div>
             </div>
@@ -187,22 +199,24 @@ function PermissionsPage() {
         {showDeleteModal && canManage && (
           <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50 px-4">
             <div className="bg-white w-full max-w-md rounded-xl p-6 shadow-xl">
-              <h3 className="text-lg font-bold mb-4 text-gray-800">Confirm Deletion</h3>
+              <h3 className="text-lg font-bold mb-4 text-gray-800">
+                {t("permissionsPage.confirm_deletion")}
+              </h3>
               <p className="mb-6 text-gray-700">
-                Are you sure you want to delete this permission?
+                {t("permissionsPage.delete_question")}
               </p>
               <div className="flex justify-end gap-3">
                 <button
                   onClick={handleCancelDelete}
                   className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded"
                 >
-                  Cancel
+                  {t("permissionsPage.cancel")}
                 </button>
                 <button
                   onClick={handleDelete}
                   className="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded"
                 >
-                  Delete
+                  {t("permissionsPage.delete")}
                 </button>
               </div>
             </div>
@@ -213,4 +227,18 @@ function PermissionsPage() {
   );
 }
 
-export default withAuthProtection(PermissionsPage, { permissions: ["view_permissions"] });
+export default withAuthProtection(PermissionsPage, {
+  permissions: ["view_permissions"],
+});
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(
+        locale,
+        ["dashboard"],
+        nextI18NextConfig
+      )),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- localize admin permissions page with next-i18next
- add permissions page strings to all locale files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a834decc8328b1d56ad5912058f0