### PR TITLE
fix: safeguard message event emission

### DIFF
--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -19,7 +19,6 @@ exports.createMessage = async (
       }
     } catch (err) {
       console.error("Failed to emit message-created event", err.message);
-      throw err;
     }
     return row;
   };


### PR DESCRIPTION
## Summary
- avoid throwing when socket emit fails in createMessage

## Testing
- `npm test` *(fails: tests/adsRoutes.test.js, tests/tutorialRoutes.test.js, tests/bookRoutes.test.js, tests/messageRoutes.test.js, tests/paymentCommission.test.js, tests/seoConfigRoutes.test.js, tests/blogRoutes.test.js, tests/paymentInstallments.test.js, src/modules/community/public/__tests__/public.routes.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ac0073b483288a365e5b9c3271f8