### PR TITLE
feat: add pagination to user messages

### DIFF
--- a/backend/src/modules/messages/messages.controller.js
+++ b/backend/src/modules/messages/messages.controller.js
@@ -4,7 +4,10 @@ const AppError = require("../../utils/AppError");
 const service = require("./messages.service");
 
 exports.getMyMessages = catchAsync(async (req, res) => {
-  const data = await service.getUserMessages(req.user.id);
+  let { limit, offset } = req.query;
+  if (limit !== undefined) limit = parseInt(limit, 10);
+  if (offset !== undefined) offset = parseInt(offset, 10);
+  const data = await service.getUserMessages(req.user.id, { limit, offset });
   sendSuccess(res, data);
 });
 

--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -35,7 +35,7 @@ exports.createMessage = async (
   }
 };
 
-exports.getUserMessages = async (userId) => {
+exports.getUserMessages = async (userId, { limit, offset } = {}) => {
   const retentionHours = parseInt(
     process.env.MESSAGE_RETENTION_HOURS || "24",
     10,
@@ -48,11 +48,16 @@ exports.getUserMessages = async (userId) => {
       .del();
   }
 
-  return db("messages")
+  const query = db("messages")
     .select("messages.*", "users.full_name as sender_name")
     .leftJoin("users", "messages.sender_id", "users.id")
     .where({ receiver_id: userId })
     .orderBy("sent_at", "desc");
+
+  if (limit !== undefined) query.limit(limit);
+  if (offset !== undefined) query.offset(offset);
+
+  return query;
 };
 
 exports.markAsRead = async (id, userId) => {

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -16,8 +16,11 @@ export const getGroups = async () => {
   return res.data.data || res.data;
 };
 
-export const getMessages = async () => {
-  const res = await api.get("/messages");
+export const getMessages = async ({ limit, offset } = {}) => {
+  const params = {};
+  if (limit !== undefined) params.limit = limit;
+  if (offset !== undefined) params.offset = offset;
+  const res = await api.get("/messages", { params });
   return res.data.data || res.data;
 };
 


### PR DESCRIPTION
## Summary
- support optional limit/offset for user message retrieval
- parse pagination parameters in messages controller
- allow frontend messageService to request paginated messages

## Testing
- `npm test` (backend) *(fails: 13 failing suites)*
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_68a9abff47ec832881cabad9f3bdeda7