### PR TITLE
Use user ID or IP for message rate limiting

### DIFF
--- a/backend/src/modules/messages/messages.routes.js
+++ b/backend/src/modules/messages/messages.routes.js
@@ -10,6 +10,7 @@ const rateLimit = require("express-rate-limit");
 const messageLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour window
   max: 20,
+  keyGenerator: (req) => req.user?.id || req.ip,
 });
 
 router.use(verifyToken);


### PR DESCRIPTION
## Summary
- ensure message rate limiting differentiates users by `req.user.id` with IP fallback

## Testing
- `npm test` *(fails: Expected 200, Received 400, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9abfd336c8328a54d1b7b9540996e