### PR TITLE
chore: guard admin user service logging

### DIFF
--- a/frontend/eslint.config.local.mjs
+++ b/frontend/eslint.config.local.mjs
@@ -9,6 +9,18 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-const eslintConfig = [...compat.extends("next/core-web-vitals")];
+const noConsoleRule =
+  process.env.NODE_ENV === 'production'
+    ? ['error', { allow: ['warn', 'error'] }]
+    : ['warn', { allow: ['warn', 'error'] }];
+
+const eslintConfig = [
+  ...compat.extends('next/core-web-vitals'),
+  {
+    rules: {
+      'no-console': noConsoleRule,
+    },
+  },
+];
 
 export default eslintConfig;

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -52,6 +52,12 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  compiler: {
+    removeConsole:
+      process.env.NODE_ENV === 'production'
+        ? { exclude: ['error', 'warn'] }
+        : false,
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/services/admin/userService.js
+++ b/frontend/src/services/admin/userService.js
@@ -4,7 +4,9 @@ import api from "@/services/api/api";
 // ✅ Get all users (no token required for cookie session)
 export const fetchAllUsers = async () => {
   const res = await api.get("/users/admin/users");
-  console.log("🧪 Full API response:", res);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Full API response:", res);
+  }
   return res.data?.data ?? [];
 };
 
@@ -12,83 +14,107 @@ export const fetchAllUsers = async () => {
 // ✅ Get single user by ID
 export const fetchUserById = async (id) => {
   const res = await api.get(`/users/admin/${id}`);
-  console.log("🧪 Fetch user by ID:", res.data);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Fetch user by ID:", res.data);
+  }
   return res.data?.data;
 };
 
 // ✅ Update user status (active, pending, etc.)
 export const updateUserStatus = async (id, status) => {
   const res = await api.patch(`/users/admin/${id}/status`, { status });
-  console.log("🧪 Updated status:", res.data);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Updated status:", res.data);
+  }
   return res.data?.data;
 };
 
 // ✅ Update user role (Admin, Instructor, etc.)
 export const updateUserRole = async (id, role) => {
   const res = await api.patch(`/users/admin/${id}/role`, { role });
-  console.log("🧪 Updated role:", res.data);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Updated role:", res.data);
+  }
   return res.data?.data;
 };
 
 // ✅ Create new user
 export const createUser = async (payload) => {
   const res = await api.post("/users/admin", payload);
-  console.log("🧪 User created:", res.data);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 User created:", res.data);
+  }
   return res.data?.data;
 };
 
 // ✅ Update profile fields (name, phone, etc.)
 export const updateUserProfile = async (id, payload) => {
   const res = await api.patch(`/users/admin/${id}`, payload);
-  console.log("🧪 Profile updated:", res.data);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Profile updated:", res.data);
+  }
   return res.data?.data;
 };
 
 // ✅ Update avatar
 export const updateUserAvatar = async (id, avatar_url) => {
   const res = await api.patch(`/users/admin/${id}/avatar`, { avatar_url });
-  console.log("🧪 Avatar updated:", res.data);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Avatar updated:", res.data);
+  }
   return res.data?.data;
 };
 
 // ✅ Remove uploaded identity doc
 export const removeIdentity = async (id) => {
   await api.delete(`/users/admin/${id}/identity`);
-  console.log("🧪 Identity removed");
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Identity removed");
+  }
   return true;
 };
 
 // ✅ Restore soft-deleted user
 export const restoreUser = async (id) => {
   const res = await api.patch(`/users/admin/${id}/restore`);
-  console.log("🧪 User restored:", res.data);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 User restored:", res.data);
+  }
   return res.data?.data;
 };
 
 // ✅ Permanently delete user
 export const deleteUser = async (id) => {
   await api.delete(`/users/admin/${id}`);
-  console.log("🧪 User deleted");
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 User deleted");
+  }
   return true;
 };
 
 // ✅ Bulk update status for many users
 export const bulkUpdateStatus = async (ids, status) => {
   await api.post("/users/admin/bulk-update-status", { ids, status });
-  console.log("🧪 Bulk status update:", { ids, status });
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Bulk status update:", { ids, status });
+  }
   return true;
 };
 
 // ✅ Bulk delete users
 export const bulkDeleteUsers = async (ids) => {
   await api.post("/users/admin/bulk-delete", { ids });
-  console.log("🧪 Bulk users deleted:", ids);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Bulk users deleted:", ids);
+  }
   return true;
 };
 
 // ✅ Reset user password
 export const resetUserPassword = async (id) => {
   const res = await api.post(`/users/admin/${id}/reset-password`);
-  console.log("🧪 Password reset:", res.data);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("🧪 Password reset:", res.data);
+  }
   return res.data?.data;
 };


### PR DESCRIPTION
## Summary
- wrap admin user service console logs behind NODE_ENV check
- strip console statements from production builds via Next.js compiler
- enable eslint rule to flag console usage

## Testing
- `npm test`
- `npx eslint src/services/admin/userService.js next.config.mjs eslint.config.local.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a9abe77304832886d55c1ecfaa5479