### PR TITLE
refactor: centralize cookie parsing

### DIFF
--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -1,14 +1,6 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
-
-// Helper to read the CSRF token from cookies
-const getCsrfToken = () => {
-  if (typeof document === "undefined") return null;
-  const match = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("csrfToken="));
-  return match ? match.split("=")[1] : null;
-};
+import { getCsrfToken } from "@/services/api/csrf";
 
 export const createAd = async (payload) => {
   const headers = {};

--- a/frontend/src/services/api/csrf.js
+++ b/frontend/src/services/api/csrf.js
@@ -1,7 +1,3 @@
-export const getCsrfToken = () => {
-  if (typeof document === 'undefined') return null;
-  const value = `; ${document.cookie}`;
-  const parts = value.split('; csrfToken=');
-  if (parts.length === 2) return parts.pop().split(';').shift();
-  return null;
-};
+import { getCookie } from "@/utils/cookies";
+
+export const getCsrfToken = () => getCookie("csrfToken");

--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -7,15 +7,7 @@ import api from "./api";
 import { toast } from "react-toastify";
 import Router from "next/router";
 import useAuthStore from "@/store/auth/authStore";
-
-// Helper to read a cookie value in the browser
-const getCookie = (name) => {
-  if (typeof document === "undefined") return null;
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop().split(";").shift();
-  return null;
-};
+import { getCookie } from "@/utils/cookies";
 
 let isRefreshing = false;
 let failedQueue = [];

--- a/frontend/src/utils/cookies.js
+++ b/frontend/src/utils/cookies.js
@@ -1,0 +1,12 @@
+export const getCookie = (name) => {
+  if (typeof document === 'undefined') return null;
+  const cookies = document.cookie ? document.cookie.split('; ') : [];
+  for (let i = 0; i < cookies.length; i++) {
+    const [rawKey, ...rawVal] = cookies[i].split('=');
+    const key = decodeURIComponent(rawKey);
+    if (key === name) {
+      return decodeURIComponent(rawVal.join('='));
+    }
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- add shared cookie helper that properly decodes values
- use shared cookie utilities in token interceptor, CSRF helper, and admin ad service

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` (fails: 367 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a9abe625ac83289a5e0a4a840ce0a0