### PR TITLE
feat: allow configurable seed passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
 1. Copy the example environment file and adjust values as needed:
 
    ```bash
-   cp backend/.env.example backend/.env
-   # edit backend/.env and set your secrets
-   # FRONTEND_URL defaults to http://localhost:3000
-   # set it to your frontend's domain if different and omit any trailing slash
-   # When using docker-compose make sure the value does
-   # not include an extra "FRONTEND_URL=" prefix.
-   ```
+    cp backend/.env.example backend/.env
+    # edit backend/.env and set your secrets
+    # FRONTEND_URL defaults to http://localhost:3000
+    # set it to your frontend's domain if different and omit any trailing slash
+    # When using docker-compose make sure the value does
+    # not include an extra "FRONTEND_URL=" prefix.
+    # Optionally set ADMIN_INITIAL_PASSWORD and SUPERADMIN_INITIAL_PASSWORD
+    # to control the seeded admin credentials
+    ```
 
 2. Initialize the database (run migrations and seeds):
 
@@ -21,6 +23,10 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
    npx knex migrate:latest --knexfile backend/knexfile.js
    npx knex seed:run --knexfile backend/knexfile.js
    ```
+
+   If `ADMIN_INITIAL_PASSWORD` or `SUPERADMIN_INITIAL_PASSWORD` are not set in
+   `backend/.env`, the seed scripts will generate secure random passwords and
+   print them to the console.
 
 3. Build and launch the entire stack:
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,3 +39,8 @@ APPLE_CLIENT_ID=your_service_id
 APPLE_TEAM_ID=your_team_id
 APPLE_KEY_ID=your_key_id
 APPLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMII...\n-----END PRIVATE KEY-----"
+
+# Initial credentials for seeded admin accounts
+# If unset, the seeding process generates random passwords and logs them
+# ADMIN_INITIAL_PASSWORD=
+# SUPERADMIN_INITIAL_PASSWORD=

--- a/backend/src/seeds/seed_superadmin_user.js
+++ b/backend/src/seeds/seed_superadmin_user.js
@@ -1,4 +1,5 @@
 const bcrypt = require("bcrypt");
+const crypto = require("crypto");
 
 exports.seed = async function(knex) {
   // Clear existing user accounts but keep role definitions
@@ -18,7 +19,12 @@ exports.seed = async function(knex) {
   }
 
   // 🔐 Create SuperAdmin User
-  const hashedPassword = await bcrypt.hash("supersecure123", 10); // Use a stronger password in production
+  const rawPassword =
+    process.env.SUPERADMIN_INITIAL_PASSWORD || crypto.randomBytes(16).toString("hex");
+  if (!process.env.SUPERADMIN_INITIAL_PASSWORD) {
+    console.log(`🔐 Generated SuperAdmin password: ${rawPassword}`);
+  }
+  const hashedPassword = await bcrypt.hash(rawPassword, 10);
 
   const [superAdminUserId] = await knex("users")
     .insert({

--- a/backend/src/seeds/seed_z_admin_user.js
+++ b/backend/src/seeds/seed_z_admin_user.js
@@ -1,4 +1,5 @@
 const bcrypt = require("bcrypt");
+const crypto = require("crypto");
 
 exports.seed = async function(knex) {
   // Ensure the Admin role exists
@@ -14,7 +15,12 @@ exports.seed = async function(knex) {
   }
 
   // 🔐 Create Admin User
-  const hashedPassword = await bcrypt.hash("adminsecure123", 10);
+  const rawPassword =
+    process.env.ADMIN_INITIAL_PASSWORD || crypto.randomBytes(16).toString("hex");
+  if (!process.env.ADMIN_INITIAL_PASSWORD) {
+    console.log(`🔐 Generated Admin password: ${rawPassword}`);
+  }
+  const hashedPassword = await bcrypt.hash(rawPassword, 10);
 
   const [adminUserId] = await knex("users")
     .insert({

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,6 +51,14 @@ NEXT_PUBLIC_BOOK_PRICE_RANGE_DEFAULT=100
 NEXT_PUBLIC_BOOK_PRICE_RANGE_MAX=500
 ```
 
+### Initial admin passwords
+
+Set `ADMIN_INITIAL_PASSWORD` and `SUPERADMIN_INITIAL_PASSWORD` in
+`backend/.env` before running the seed scripts if you want to control the
+passwords for the seeded Admin and SuperAdmin accounts. When left unset, the
+seed process will generate secure random passwords and print them to the
+console.
+
 ### Frontend (optional)
 
 When using Docker Compose the frontend automatically points to the API on port


### PR DESCRIPTION
## Summary
- allow admin and SuperAdmin seed passwords via environment variables or secure random fallback
- document how to set initial admin passwords in docs and env example

## Testing
- `cd backend && npm test` *(fails: Test Suites: 13 failed, 70 passed)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9abe460108328b90b4112180f6d18