### PR TITLE
refactor: use async write stream for logger

### DIFF
--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -8,14 +8,19 @@ const LOG_FILE = path.join(LOG_DIR, "error.log");
 if (!fs.existsSync(LOG_DIR)) {
   fs.mkdirSync(LOG_DIR);
 }
+const logStream = fs.createWriteStream(LOG_FILE, { flags: "a" });
+
+logStream.on("error", (err) => {
+  console.error("Failed to write to log file:", err);
+});
 
 function append(type, args) {
   const line = `${new Date().toISOString()} [${type}] ${args.join(" ")}\n`;
-  try {
-    fs.appendFileSync(LOG_FILE, line);
-  } catch (_) {
-    // fail silently
-  }
+  logStream.write(line, (err) => {
+    if (err) {
+      console.error("Failed to write to log file:", err);
+    }
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- switch logger to use `fs.createWriteStream` for non-blocking writes
- surface file write errors via stream and write callbacks

## Testing
- `npm test` *(fails: Test Suites: 13 failed, 70 passed, 83 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a9abe2c60c8328b30ae555d9de14a5