### PR TITLE
Use Redis session store and align session cookies

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@paypal/checkout-server-sdk": "^1.0.3",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^2.4.3",
+        "connect-redis": "^7.1.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
@@ -33,6 +34,7 @@
         "passport-github2": "^0.1.12",
         "passport-google-oauth20": "^2.0.0",
         "pg": "^8.16.3",
+        "redis": "^4.7.1",
         "sharp": "^0.34.2",
         "slugify": "^1.6.6",
         "socket.io": "^4.7.2",
@@ -1527,6 +1529,71 @@
         "node": ">=4"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
@@ -2639,6 +2706,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2801,6 +2877,18 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/connect-redis": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.1.tgz",
+      "integrity": "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
       }
     },
     "node_modules/console-control-strings": {
@@ -3831,6 +3919,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -6959,6 +7056,23 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/require-directory": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,8 +12,10 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@paypal/checkout-server-sdk": "^1.0.3",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^2.4.3",
+    "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
@@ -21,19 +23,21 @@
     "express-rate-limit": "^7.5.0",
     "express-session": "^1.17.3",
     "fluent-ffmpeg": "^2.1.3",
+    "joi": "^17.13.0",
     "json2csv": "^6.0.0-alpha.2",
     "jsonwebtoken": "^9.0.2",
+    "knex": "^3.1.0",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.2",
+    "node-fetch": "^3.3.2",
     "nodemailer": "^7.0.3",
     "passport": "^0.7.0",
     "passport-apple": "^2.0.2",
     "passport-facebook": "^3.0.0",
-    "passport-google-oauth20": "^2.0.0",
     "passport-github2": "^0.1.12",
-    "node-fetch": "^3.3.2",
+    "passport-google-oauth20": "^2.0.0",
     "pg": "^8.16.3",
-    "knex": "^3.1.0",
+    "redis": "^4.7.1",
     "sharp": "^0.34.2",
     "slugify": "^1.6.6",
     "socket.io": "^4.7.2",
@@ -41,14 +45,12 @@
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
     "yamljs": "^0.3.0",
-    "zod": "^3.25.20",
-    "joi": "^17.13.0",
-    "@paypal/checkout-server-sdk": "^1.0.3"
+    "zod": "^3.25.20"
   },
   "devDependencies": {
     "jest": "^29.7.0",
     "nodemon": "^3.1.10",
-    "supertest": "^6.3.4",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "supertest": "^6.3.4"
   }
 }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -6,6 +6,8 @@ const cors = require("cors");
 const morgan = require("morgan");
 const cookieParser = require("cookie-parser");
 const session = require("express-session");
+const RedisStore = require("connect-redis").default;
+const { createClient } = require("redis");
 const { Server } = require("socket.io");
 const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");
@@ -21,6 +23,7 @@ const startClassReminderJob = require("./jobs/classReminderJob");
 const startCleanupJob = require("./jobs/cleanupJob");
 const startContributorStatsJob = require("./jobs/contributorStatsJob");
 const { createLessonRoomLink } = require("./utils/roomLink");
+const { refreshCookieOptions } = require("./utils/cookie");
 require("dotenv").config();
 
 // Ensure required environment secrets are present
@@ -81,11 +84,21 @@ app.use(express.urlencoded({ extended: true, limit: "500mb" }));
 app.use(cookieParser());
 app.use(morgan("dev"));
 app.use(csrf);
-app.use(session({
+
+const sessionOptions = {
   secret: process.env.SESSION_SECRET || "skillbridge",
   resave: false,
   saveUninitialized: false,
-}));
+  cookie: { ...refreshCookieOptions },
+};
+
+if (process.env.REDIS_URL) {
+  const redisClient = createClient({ url: process.env.REDIS_URL });
+  redisClient.connect().catch(console.error);
+  sessionOptions.store = new RedisStore({ client: redisClient });
+}
+
+app.use(session(sessionOptions));
 
 app.use(passport.initialize());
 


### PR DESCRIPTION
## Summary
- switch express-session to use Redis-backed store when `REDIS_URL` is provided
- share refresh token cookie options with session cookies for consistent security
- add connect-redis and redis dependencies

## Testing
- `npm test` *(fails: POST /api/ads/admin › creates ad; PUT /api/users/tutorials/admin/:id › returns 403 when instructor updates another instructor's tutorial; PUT /api/users/tutorials/admin/:id › updates tutorial with language and status; Class routes › create class; Class routes › create class responds even if notifications fail; Class routes › create class with options; POST /api/books › creates a book; PUT /api/books/:id › updates a book; checkout › throws error when book already purchased; Sensitive data sanitization › registerUser does not return password_hash; Sensitive data sanitization › loginUser does not return password_hash; POST /api/blog › creates post; payment commission calculations › calculates commission for class payments; payment commission calculations › calculates commission for book payments; payment commission calculations › calculates commission for tutorial payments; community public routes › create discussion; PATCH /api/messages/:id/read › marks message as read; DELETE /api/messages/:id › deletes message; POST /api/messages/:id/email › sends email; POST /api/messages/:id/whatsapp › sends whatsapp message; POST /api/messages/room › creates room; POST /api/messages/room/:id/messages › creates message; POST /api/messages/call/:id/start › starts call; POST /api/messages/call/:id/respond › responds to call; POST /api/messages/call/:id/end › ends call; POST /api/payments/admin › creates payment with installments and enrolls; updateTutorial tag transactions › commits transaction when tag update succeeds; PUT /api/seo-config › updates settings)*

------
https://chatgpt.com/codex/tasks/task_e_68a9abd9b8908328a2c9687a849b7c50