### PR TITLE
Fetch instructor list from backend on student dashboard

### DIFF
--- a/frontend/src/pages/dashboard/student/instructors/index.js
+++ b/frontend/src/pages/dashboard/student/instructors/index.js
@@ -1,41 +1,19 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import InstructorCard from "@/components/student/instructors/InstructorCard";
 import InstructorFilters from "@/components/student/instructors/InstructorFilters";
 import BookingRequestModal from "@/components/student/instructors/BookingRequestModal";
 import ChatRedirectModal from "@/components/student/instructors/ChatRedirectModal";
+import { fetchPublicInstructors } from "@/services/public/instructorService";
 
-const instructors = [
-  {
-    id: 1,
-    name: "Dr. John Doe",
-    expertise: "Data Science",
-    experience: "10+ Years",
-    rating: 4.9,
-    avatar: "https://www.iwcf.org/wp-content/uploads/2018/12/Instructor-top-of-page-image-new.jpg",
-    tags: ["Beginner Friendly", "Python"],
-    availableNow: true,
-    verified: true,
-  },
-  {
-    id: 2,
-    name: "Jane Smith",
-    expertise: "Web Development",
-    experience: "8 Years",
-    rating: 4.7,
-    avatar: "https://media.istockphoto.com/id/1468138682/photo/happy-elementary-teacher-in-front-of-his-students-in-the-classroom.jpg",
-    tags: ["JavaScript", "React"],
-    availableNow: false,
-    verified: false,
-  },
-];
-
-const categories = ["All", "Data Science", "Web Development"];
 const sortOptions = ["Highest Rated", "Most Experienced"];
 
 export default function StudentInstructorsAll() {
   const router = useRouter();
+  const [instructors, setInstructors] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("All");
   const [searchQuery, setSearchQuery] = useState("");
   const [favorites, setFavorites] = useState([]);
@@ -50,6 +28,34 @@ export default function StudentInstructorsAll() {
     setFavorites(stored);
   }, []);
 
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchPublicInstructors();
+        const mapped = data.map((i) => ({
+          id: i.id,
+          name: i.full_name,
+          expertise: Array.isArray(i.expertise)
+            ? i.expertise.join(", ")
+            : i.expertise,
+          tags: Array.isArray(i.expertise) ? i.expertise : [],
+          experience: i.experience || "",
+          rating: i.rating || 0,
+          avatar: i.avatar_url,
+          availableNow: i.is_online,
+          verified: false,
+        }));
+        setInstructors(mapped);
+      } catch (err) {
+        console.error("Failed to load instructors", err);
+        setError("Failed to load instructors.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
   const toggleFavorite = (id) => {
     const updated = favorites.includes(id)
       ? favorites.filter((fid) => fid !== id)
@@ -57,12 +63,16 @@ export default function StudentInstructorsAll() {
     setFavorites(updated);
     localStorage.setItem("favorites", JSON.stringify(updated));
   };
+  const categories = useMemo(
+    () => ["All", ...new Set(instructors.flatMap((i) => i.tags))],
+    [instructors]
+  );
 
   const filtered = instructors
     .filter(
       (i) =>
         (!onlyAvailable || i.availableNow) &&
-        (selectedCategory === "All" || i.expertise === selectedCategory) &&
+        (selectedCategory === "All" || i.tags.includes(selectedCategory)) &&
         i.name.toLowerCase().includes(searchQuery.toLowerCase())
     )
     .sort((a, b) => {
@@ -92,18 +102,23 @@ export default function StudentInstructorsAll() {
           setOnlyAvailable={setOnlyAvailable}
         />
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filtered.map((i) => (
-            <InstructorCard
-              key={i.id}
-              instructor={i}
-              isFavorite={favorites.includes(i.id)}
-              onToggleFavorite={() => toggleFavorite(i.id)}
-              onBook={() => setBookingInstructor(i)}
-              onChat={() => setChatInstructorId(i.id)}
-            />
-          ))}
-        </div>
+        {error && <p className="text-red-500 mb-4">{error}</p>}
+        {loading ? (
+          <p>Loading instructors...</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filtered.map((i) => (
+              <InstructorCard
+                key={i.id}
+                instructor={i}
+                isFavorite={favorites.includes(i.id)}
+                onToggleFavorite={() => toggleFavorite(i.id)}
+                onBook={() => setBookingInstructor(i)}
+                onChat={() => setChatInstructorId(i.id)}
+              />
+            ))}
+          </div>
+        )}
 
         {/* Booking Confirmation Modal */}
         {bookingInstructor && (


### PR DESCRIPTION
## Summary
- load instructors from backend API instead of hardcoded mock data
- derive filter categories dynamically and add loading/error states

## Testing
- `CI=1 npm test`
- `npm run lint` *(fails: Component definition is missing display name in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68aa264914848328af66a4aaa0436b3b