### PR TITLE
Improve tutorial dashboard data fetching and cleanup

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -9,7 +9,6 @@ import {
   FaEdit,
   FaEye,
   FaTrash,
-  FaRegEye,
   FaRegComments,
   FaStar,
   FaUsers,
@@ -55,18 +54,26 @@ export default function InstructorTutorialsPage() {
   };
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const load = async () => {
       try {
-        const data = await fetchInstructorTutorials();
+        const data = await fetchInstructorTutorials({ signal: controller.signal });
         setTutorials(data?.data || data || []);
       } catch (err) {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         console.error(err);
         setError(t("tutorials:list.load_error"));
       } finally {
         setLoading(false);
       }
     };
+
     load();
+
+    return () => {
+      controller.abort();
+    };
   }, []);
 
   const handleSearch = (query) => {
@@ -301,7 +308,7 @@ export default function InstructorTutorialsPage() {
                   {/* Stats */}
                   <div className="grid grid-cols-4 gap-2 mt-4 text-center">
                     <div className="p-2 bg-blue-50 rounded-lg">
-                      <FaRegEye className="mx-auto text-blue-500" />
+                      <FaEye className="mx-auto text-blue-500" />
                       <span className="text-xs mt-1">{tutorial.views}</span>
                     </div>
                     <div className="p-2 bg-green-50 rounded-lg">

--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -12,9 +12,10 @@ export default function StudentTutorialsPage() {
   const [sortBy, setSortBy] = useState("title");
 
   useEffect(() => {
+    const controller = new AbortController();
     const load = async () => {
       try {
-        const data = await fetchPublishedTutorials();
+        const data = await fetchPublishedTutorials({ signal: controller.signal });
         const enriched = data.map((tut) => {
           const saved = localStorage.getItem(`progress-tutorial-${tut.id}`);
           let progress = { completedChapters: [], completedQuiz: false };
@@ -33,14 +34,18 @@ export default function StudentTutorialsPage() {
           };
         });
         setTutorials(enriched);
-        setLoading(false);
       } catch (err) {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         console.error(err);
         setError("Failed to load tutorials");
+      } finally {
         setLoading(false);
       }
     };
     load();
+    return () => {
+      controller.abort();
+    };
   }, []);
 
   const filtered = tutorials.filter((tut) => {

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -24,8 +24,8 @@ const mapStatus = (tut) =>
     ? "Rejected"
     : "Pending";
 
-export const fetchInstructorTutorials = async () => {
-  const { data } = await api.get("/users/tutorials/admin/my");
+export const fetchInstructorTutorials = async (config = {}) => {
+  const { data } = await api.get("/users/tutorials/admin/my", config);
   const list = data?.data ?? [];
   return list.map((t) => ({
     ...formatBase(t),

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -88,8 +88,8 @@ export const fetchFeaturedTutorials = async () => {
   return Array.isArray(list) ? list.map(formatTutorial) : list;
 };
 
-export const fetchPublishedTutorials = async () => {
-  const res = await api.get("/users/tutorials");
+export const fetchPublishedTutorials = async (config = {}) => {
+  const res = await api.get("/users/tutorials", config);
   const list = extractData(res);
   return Array.isArray(list) ? list.map(formatTutorial) : list;
 };


### PR DESCRIPTION
## Summary
- allow instructor and student dashboards to cancel tutorial fetches on unmount
- enable abort signals in tutorial service helpers
- remove unused icon and reuse existing `FaEye` for view stats

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68aa22435a14832885262ab9326a5d36