### PR TITLE
Persist instructor availability status across refresh

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -26,6 +26,7 @@ exports.getProfile = async (req, res) => {
       "id", "full_name", "email", "phone",
       "gender", "date_of_birth", "avatar_url",
       "is_email_verified", "is_phone_verified",
+      "is_online",
       "profile_complete", "created_at", "updated_at"
     );
 

--- a/backend/src/modules/users/profile.controller.js
+++ b/backend/src/modules/users/profile.controller.js
@@ -147,6 +147,7 @@ exports.getFullProfile = async (req, res) => {
         'avatar_url',
         'is_email_verified',
         'is_phone_verified',
+        'is_online',
         'profile_complete',
         'created_at',
         'updated_at'

--- a/frontend/src/pages/dashboard/instructor/availability.js
+++ b/frontend/src/pages/dashboard/instructor/availability.js
@@ -1,5 +1,6 @@
 // pages/dashboard/instructor/availability.js
 import { useEffect, useState, Fragment } from 'react';
+import { useTranslation } from 'next-i18next';
 import { v4 as uuidv4 } from 'uuid';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
@@ -27,6 +28,8 @@ export default function InstructorAvailabilityPage() {
   const [available, setAvailable] = useState(user?.is_online ?? false);
   const [warningModal, setWarningModal] = useState({ open: false, message: '' });
   const [confirmModal, setConfirmModal] = useState({ open: false, message: '', onConfirm: null });
+
+  const { t } = useTranslation(['dashboard', 'common']);
 
   useEffect(() => {
     setAvailable(user?.is_online ?? false);
@@ -113,7 +116,7 @@ export default function InstructorAvailabilityPage() {
   return (
     <InstructorLayout>
       <section className="py-10 px-4">
-        <h1 className="text-2xl font-bold mb-6">Set Your Availability</h1>
+        <h1 className="text-2xl font-bold mb-6">{t('availability')}</h1>
         <div className="mb-6">
           <button
             onClick={async () => {
@@ -123,9 +126,9 @@ export default function InstructorAvailabilityPage() {
                 const updated = res?.is_online ?? newStatus;
                 setAvailable(updated);
                 setUser({ ...user, is_online: updated });
-                toast.success(updated ? 'You are now available' : 'You are now unavailable');
+                toast.success(updated ? t('available_now') : t('unavailable_now'));
               } catch (err) {
-                toast.error('Failed to update availability');
+                toast.error(t('availability_update_failed'));
               }
             }}
             className={`px-4 py-2 rounded-md text-sm font-medium ${available ? 'bg-green-600 text-white' : 'bg-gray-200 text-gray-700'}`}


### PR DESCRIPTION
## Summary
- include `is_online` in instructor profile responses
- surface existing translations on the instructor availability page

## Testing
- `npm test` (frontend)
- `npm test` (backend, failed: tests/adsRoutes.test.js, tests/bookRoutes.test.js, tests/tutorialRoutes.test.js, tests/messageRoutes.test.js, tests/seoConfigRoutes.test.js, tests/blogRoutes.test.js, tests/paymentInstallments.test.js, tests/video-calls/roomCleanup.test.js, src/modules/community/public/__tests__/public.routes.test.js, tests/socialLoginConfigService.test.js)


------
https://chatgpt.com/codex/tasks/task_e_68aa273099848328a544d87dbd03f5c1