### PR TITLE
feat(frontend): localize instructor schedule page

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1757,6 +1757,10 @@
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
   },
+  "schedulePage": {
+    "title": "جدول تدريسي",
+    "no_events": "لا توجد أحداث قادمة"
+  },
   "permissionsPage": {
     "title": "Permissions",
     "add_permission": "Add Permission",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1770,6 +1770,10 @@
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
   },
+  "schedulePage": {
+    "title": "Mein Unterrichtsplan",
+    "no_events": "Keine kommenden Veranstaltungen"
+  },
   "permissionsPage": {
     "title": "Permissions",
     "add_permission": "Add Permission",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1801,6 +1801,10 @@
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
   },
+  "schedulePage": {
+    "title": "My Teaching Schedule",
+    "no_events": "No upcoming events"
+  },
   "permissionsPage": {
     "title": "Permissions",
     "add_permission": "Add Permission",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1771,6 +1771,10 @@
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
   },
+  "schedulePage": {
+    "title": "Mi horario de enseñanza",
+    "no_events": "No hay eventos próximos"
+  },
   "permissionsPage": {
     "title": "Permissions",
     "add_permission": "Add Permission",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1800,6 +1800,10 @@
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
   },
+  "schedulePage": {
+    "title": "Mon emploi du temps d'enseignement",
+    "no_events": "Aucun événement à venir"
+  },
   "permissionsPage": {
     "title": "Permissions",
     "add_permission": "Add Permission",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1770,6 +1770,10 @@
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
   },
+  "schedulePage": {
+    "title": "मेरी शिक्षण समय-सारणी",
+    "no_events": "कोई आगामी कार्यक्रम नहीं"
+  },
   "permissionsPage": {
     "title": "Permissions",
     "add_permission": "Add Permission",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1772,6 +1772,10 @@
     "create_success": "Coupon created successfully",
     "create_failed": "Failed to create coupon"
   },
+  "schedulePage": {
+    "title": "我的教学日程",
+    "no_events": "没有即将发生的活动"
+  },
   "permissionsPage": {
     "title": "Permissions",
     "add_permission": "Add Permission",

--- a/frontend/src/pages/dashboard/instructor/schedule.js
+++ b/frontend/src/pages/dashboard/instructor/schedule.js
@@ -4,8 +4,12 @@ import CalendarView from "@/components/shared/CalendarView";
 import { fetchInstructorScheduleEvents } from "@/services/instructor/classService";
 import useScheduleStore from "@/store/schedule/scheduleStore";
 import { getLessonRoomLink } from "@/services/lessonService";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../next-i18next.config.js";
 
 export default function InstructorSchedule() {
+  const { t } = useTranslation(["dashboard", "common"], { keyPrefix: "schedulePage" });
   const { events, clear, addEvents, prunePastEvents } = useScheduleStore();
 
   const [loading, setLoading] = useState(false);
@@ -32,7 +36,7 @@ export default function InstructorSchedule() {
   return (
     <InstructorLayout>
       <CalendarView
-        title="My Teaching Schedule"
+        title={t("title")}
         events={events}
         onEventClick={async (info) => {
           const id = info.event.id || "";
@@ -61,11 +65,21 @@ export default function InstructorSchedule() {
         }}
       />
       {loading && (
-        <p className="text-center text-gray-500 mt-4">Loading...</p>
+        <p className="text-center text-gray-500 mt-4">
+          {t("loading", { ns: "common" })}
+        </p>
       )}
       {!loading && events.length === 0 && (
-        <p className="text-center text-gray-500 mt-4">No upcoming events</p>
+        <p className="text-center text-gray-500 mt-4">{t("no_events")}</p>
       )}
     </InstructorLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard", "common"], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- add i18n support to instructor schedule page
- provide schedule translations across all locales

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aa2d9e3af083288d1c83f910094c47