### PR TITLE
Refactor tutorial flows and cleanup test mocks

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -9,7 +9,6 @@ import {
   FaEdit,
   FaEye,
   FaTrash,
-  FaRegEye,
   FaRegComments,
   FaStar,
   FaUsers,
@@ -55,18 +54,26 @@ export default function InstructorTutorialsPage() {
   };
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const load = async () => {
       try {
-        const data = await fetchInstructorTutorials();
+        const data = await fetchInstructorTutorials({ signal: controller.signal });
         setTutorials(data?.data || data || []);
       } catch (err) {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         console.error(err);
         setError(t("tutorials:list.load_error"));
       } finally {
         setLoading(false);
       }
     };
+
     load();
+
+    return () => {
+      controller.abort();
+    };
   }, []);
 
   const handleSearch = (query) => {
@@ -301,7 +308,7 @@ export default function InstructorTutorialsPage() {
                   {/* Stats */}
                   <div className="grid grid-cols-4 gap-2 mt-4 text-center">
                     <div className="p-2 bg-blue-50 rounded-lg">
-                      <FaRegEye className="mx-auto text-blue-500" />
+                      <FaEye className="mx-auto text-blue-500" />
                       <span className="text-xs mt-1">{tutorial.views}</span>
                     </div>
                     <div className="p-2 bg-green-50 rounded-lg">

--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -12,9 +12,10 @@ export default function StudentTutorialsPage() {
   const [sortBy, setSortBy] = useState("title");
 
   useEffect(() => {
+    const controller = new AbortController();
     const load = async () => {
       try {
-        const data = await fetchPublishedTutorials();
+        const data = await fetchPublishedTutorials({ signal: controller.signal });
         const enriched = data.map((tut) => {
           const saved = localStorage.getItem(`progress-tutorial-${tut.id}`);
           let progress = { completedChapters: [], completedQuiz: false };
@@ -33,14 +34,18 @@ export default function StudentTutorialsPage() {
           };
         });
         setTutorials(enriched);
-        setLoading(false);
       } catch (err) {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         console.error(err);
         setError("Failed to load tutorials");
+      } finally {
         setLoading(false);
       }
     };
     load();
+    return () => {
+      controller.abort();
+    };
   }, []);
 
   const filtered = tutorials.filter((tut) => {

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -108,11 +108,13 @@ const TutorialsSection = () => {
   };
 
   useEffect(() => {
+    const controller = new AbortController();
     const loadTutorials = async () => {
       try {
-        const data = await fetchPublishedTutorials();
+        const data = await fetchPublishedTutorials({ signal: controller.signal });
         setTutorials(data?.data || data || []);
       } catch (err) {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         console.error(err);
         setError(t("load_error"));
       } finally {
@@ -120,6 +122,9 @@ const TutorialsSection = () => {
       }
     };
     loadTutorials();
+    return () => {
+      controller.abort();
+    };
   }, []);
 
   useEffect(() => {

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -24,8 +24,8 @@ const mapStatus = (tut) =>
     ? "Rejected"
     : "Pending";
 
-export const fetchInstructorTutorials = async () => {
-  const { data } = await api.get("/users/tutorials/admin/my");
+export const fetchInstructorTutorials = async (config = {}) => {
+  const { data } = await api.get("/users/tutorials/admin/my", config);
   const list = data?.data ?? [];
   return list.map((t) => ({
     ...formatBase(t),

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -88,8 +88,8 @@ export const fetchFeaturedTutorials = async () => {
   return Array.isArray(list) ? list.map(formatTutorial) : list;
 };
 
-export const fetchPublishedTutorials = async () => {
-  const res = await api.get("/users/tutorials");
+export const fetchPublishedTutorials = async (config = {}) => {
+  const res = await api.get("/users/tutorials", config);
   const list = extractData(res);
   return Array.isArray(list) ? list.map(formatTutorial) : list;
 };

--- a/frontend/src/tests/__tests__/InstructorTutorialsPage.test.js
+++ b/frontend/src/tests/__tests__/InstructorTutorialsPage.test.js
@@ -3,9 +3,27 @@ import InstructorTutorialsPage from '../../pages/dashboard/instructor/tutorials'
 import { fetchInstructorTutorials, submitTutorialForReview } from '../../services/instructor/tutorialService';
 import { toast } from 'react-toastify';
 
-jest.mock('../../components/layouts/InstructorLayout', () => ({ children }) => <div>{children}</div>);
-jest.mock('../../components/tutorials/ProgressChecklistModal', () => () => null);
-jest.mock('../../components/common/ConfirmModal', () => () => null);
+jest.mock('../../components/layouts/InstructorLayout', () => {
+  function MockInstructorLayout({ children }) {
+    return <div>{children}</div>;
+  }
+  MockInstructorLayout.displayName = 'InstructorLayout';
+  return MockInstructorLayout;
+});
+jest.mock('../../components/tutorials/ProgressChecklistModal', () => {
+  function MockProgressChecklistModal() {
+    return null;
+  }
+  MockProgressChecklistModal.displayName = 'ProgressChecklistModal';
+  return MockProgressChecklistModal;
+});
+jest.mock('../../components/common/ConfirmModal', () => {
+  function MockConfirmModal() {
+    return null;
+  }
+  MockConfirmModal.displayName = 'ConfirmModal';
+  return MockConfirmModal;
+});
 
 jest.mock('next/router', () => ({
   useRouter: () => ({ push: jest.fn() }),

--- a/frontend/src/tests/__tests__/JoinLiveSession.test.js
+++ b/frontend/src/tests/__tests__/JoinLiveSession.test.js
@@ -12,11 +12,25 @@ jest.mock('../../services/lessonService', () => ({
 }));
 const { getLessonRoomLink } = require('../../services/lessonService');
 
-jest.mock('../../components/shared/CalendarView', () => ({ onEventClick }) => (
-  <button onClick={() => onEventClick({ event: { id: 'lesson-1', start: new Date().toISOString(), extendedProps: {} } })}>cal</button>
-));
+jest.mock('../../components/shared/CalendarView', () => {
+  function MockCalendarView({ onEventClick }) {
+    return (
+      <button onClick={() => onEventClick({ event: { id: 'lesson-1', start: new Date().toISOString(), extendedProps: {} } })}>
+        cal
+      </button>
+    );
+  }
+  MockCalendarView.displayName = 'CalendarView';
+  return MockCalendarView;
+});
 
-jest.mock('../../components/layouts/InstructorLayout', () => ({ children }) => <div>{children}</div>);
+jest.mock('../../components/layouts/InstructorLayout', () => {
+  function MockInstructorLayout({ children }) {
+    return <div>{children}</div>;
+  }
+  MockInstructorLayout.displayName = 'InstructorLayout';
+  return MockInstructorLayout;
+});
 
 describe('Join live session link', () => {
   it('requests room link when lesson is live', async () => {

--- a/frontend/src/tests/__tests__/TutorialDetailAddToCart.test.js
+++ b/frontend/src/tests/__tests__/TutorialDetailAddToCart.test.js
@@ -5,22 +5,30 @@ import * as tutorialService from '../../services/tutorialService';
 
 const addItem = jest.fn();
 
-jest.mock('../../components/website/sections/Navbar', () => () => <div />);
-jest.mock('../../components/website/sections/Footer', () => () => <div />);
-jest.mock('../../components/shared/CustomVideoPlayer', () => () => <div />);
-jest.mock('../../components/tutorials/detail/TutorialHeader', () => () => <div />);
-jest.mock('../../components/tutorials/detail/TutorialOverview', () => () => <div />);
-jest.mock('../../components/tutorials/detail/InstructorBio', () => () => <div />);
-jest.mock('../../components/tutorials/detail/ChapterList', () => () => <div />);
-jest.mock('../../components/tutorials/detail/LoginPrompt', () => () => <div />);
-jest.mock('../../components/tutorials/detail/VideoPreviewList', () => () => <div />);
-jest.mock('../../components/tutorials/detail/TestQuiz', () => () => <div />);
-jest.mock('../../components/tutorials/detail/BackButton', () => () => <div />);
-jest.mock('../../components/tutorials/detail/ReviewsSection', () => () => <div />);
-jest.mock('../../components/tutorials/detail/CommentsSection', () => () => <div />);
-jest.mock('../../components/tutorials/detail/RelatedTutorials', () => () => <div />);
-jest.mock('../../components/classes/CourseProgress', () => () => <div />);
-jest.mock('../../components/tutorials/detail/TutorialSkeleton', () => () => <div />);
+function createMock(name) {
+  function Mock() {
+    return <div />;
+  }
+  Mock.displayName = name;
+  return Mock;
+}
+
+jest.mock('../../components/website/sections/Navbar', () => createMock('Navbar'));
+jest.mock('../../components/website/sections/Footer', () => createMock('Footer'));
+jest.mock('../../components/shared/CustomVideoPlayer', () => createMock('CustomVideoPlayer'));
+jest.mock('../../components/tutorials/detail/TutorialHeader', () => createMock('TutorialHeader'));
+jest.mock('../../components/tutorials/detail/TutorialOverview', () => createMock('TutorialOverview'));
+jest.mock('../../components/tutorials/detail/InstructorBio', () => createMock('InstructorBio'));
+jest.mock('../../components/tutorials/detail/ChapterList', () => createMock('ChapterList'));
+jest.mock('../../components/tutorials/detail/LoginPrompt', () => createMock('LoginPrompt'));
+jest.mock('../../components/tutorials/detail/VideoPreviewList', () => createMock('VideoPreviewList'));
+jest.mock('../../components/tutorials/detail/TestQuiz', () => createMock('TestQuiz'));
+jest.mock('../../components/tutorials/detail/BackButton', () => createMock('BackButton'));
+jest.mock('../../components/tutorials/detail/ReviewsSection', () => createMock('ReviewsSection'));
+jest.mock('../../components/tutorials/detail/CommentsSection', () => createMock('CommentsSection'));
+jest.mock('../../components/tutorials/detail/RelatedTutorials', () => createMock('RelatedTutorials'));
+jest.mock('../../components/classes/CourseProgress', () => createMock('CourseProgress'));
+jest.mock('../../components/tutorials/detail/TutorialSkeleton', () => createMock('TutorialSkeleton'));
 
 jest.mock('react-hot-toast', () => ({
   __esModule: true,

--- a/frontend/src/tests/__tests__/TutorialPageNoChapters.test.js
+++ b/frontend/src/tests/__tests__/TutorialPageNoChapters.test.js
@@ -3,23 +3,31 @@ import TutorialDetail from '../../pages/tutorials/[id]';
 import useAuthStore from '@/store/auth/authStore';
 import * as tutorialService from '../../services/tutorialService';
 
-jest.mock('../../components/website/sections/Navbar', () => () => <div />);
-jest.mock('../../components/website/sections/Footer', () => () => <div />);
-jest.mock('../../components/shared/CustomVideoPlayer', () => () => <div data-testid="player" />);
-jest.mock('../../components/tutorials/detail/TutorialHeader', () => () => <div />);
-jest.mock('../../components/tutorials/detail/TutorialOverview', () => () => <div />);
-jest.mock('../../components/tutorials/detail/InstructorBio', () => () => <div />);
-jest.mock('../../components/tutorials/detail/ChapterList', () => () => <div />);
-jest.mock('../../components/tutorials/detail/EnrollBanner', () => () => <div />);
-jest.mock('../../components/tutorials/detail/LoginPrompt', () => () => <div />);
-jest.mock('../../components/tutorials/detail/VideoPreviewList', () => () => <div />);
-jest.mock('../../components/tutorials/detail/TestQuiz', () => () => <div />);
-jest.mock('../../components/tutorials/detail/BackButton', () => () => <div />);
-jest.mock('../../components/tutorials/detail/ReviewsSection', () => () => <div />);
-jest.mock('../../components/tutorials/detail/CommentsSection', () => () => <div />);
-jest.mock('../../components/tutorials/detail/RelatedTutorials', () => () => <div />);
-jest.mock('../../components/classes/CourseProgress', () => () => <div />);
-jest.mock('../../components/tutorials/detail/TutorialSkeleton', () => () => <div />);
+function createMock(name, props) {
+  function MockComponent(p = props) {
+    return <div {...p} />;
+  }
+  MockComponent.displayName = name;
+  return MockComponent;
+}
+
+jest.mock('../../components/website/sections/Navbar', () => createMock('Navbar'));
+jest.mock('../../components/website/sections/Footer', () => createMock('Footer'));
+jest.mock('../../components/shared/CustomVideoPlayer', () => createMock('CustomVideoPlayer', { 'data-testid': 'player' }));
+jest.mock('../../components/tutorials/detail/TutorialHeader', () => createMock('TutorialHeader'));
+jest.mock('../../components/tutorials/detail/TutorialOverview', () => createMock('TutorialOverview'));
+jest.mock('../../components/tutorials/detail/InstructorBio', () => createMock('InstructorBio'));
+jest.mock('../../components/tutorials/detail/ChapterList', () => createMock('ChapterList'));
+jest.mock('../../components/tutorials/detail/EnrollBanner', () => createMock('EnrollBanner'));
+jest.mock('../../components/tutorials/detail/LoginPrompt', () => createMock('LoginPrompt'));
+jest.mock('../../components/tutorials/detail/VideoPreviewList', () => createMock('VideoPreviewList'));
+jest.mock('../../components/tutorials/detail/TestQuiz', () => createMock('TestQuiz'));
+jest.mock('../../components/tutorials/detail/BackButton', () => createMock('BackButton'));
+jest.mock('../../components/tutorials/detail/ReviewsSection', () => createMock('ReviewsSection'));
+jest.mock('../../components/tutorials/detail/CommentsSection', () => createMock('CommentsSection'));
+jest.mock('../../components/tutorials/detail/RelatedTutorials', () => createMock('RelatedTutorials'));
+jest.mock('../../components/classes/CourseProgress', () => createMock('CourseProgress'));
+jest.mock('../../components/tutorials/detail/TutorialSkeleton', () => createMock('TutorialSkeleton'));
 
 jest.mock('react-hot-toast', () => ({
   success: jest.fn(),

--- a/frontend/src/tests/__tests__/TutorialsNoInstructor.test.js
+++ b/frontend/src/tests/__tests__/TutorialsNoInstructor.test.js
@@ -4,19 +4,53 @@ import TutorialsSection from '@/pages/tutorials/index';
 import useAuthStore from '@/store/auth/authStore';
 import * as tutorialService from '../../services/tutorialService';
 
-jest.mock('next/image', () => (props) => <img {...props} />);
+jest.mock('next/image', () => {
+  function NextImage(props) {
+    return <img {...props} />;
+  }
+  NextImage.displayName = 'NextImage';
+  return NextImage;
+});
 jest.mock('next/router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
 jest.mock('next-i18next', () => ({ useTranslation: () => ({ t: (key) => key }) }));
-jest.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, ...props }) => <div {...props}>{children}</div>,
-    h2: ({ children, ...props }) => <h2 {...props}>{children}</h2>,
-    button: ({ children, ...props }) => <button {...props}>{children}</button>,
-  },
-}));
-jest.mock('../../components/website/sections/Navbar', () => () => <div />);
-jest.mock('../../components/website/sections/Footer', () => () => <div />);
-jest.mock('../../components/tutorials/FilterSidebar', () => () => <div />);
+jest.mock('framer-motion', () => {
+  const motion = {
+    div: function MotionDiv({ children, ...props }) {
+      return <div {...props}>{children}</div>;
+    },
+    h2: function MotionH2({ children, ...props }) {
+      return <h2 {...props}>{children}</h2>;
+    },
+    button: function MotionButton({ children, ...props }) {
+      return <button {...props}>{children}</button>;
+    },
+  };
+  motion.div.displayName = 'motion.div';
+  motion.h2.displayName = 'motion.h2';
+  motion.button.displayName = 'motion.button';
+  return { motion };
+});
+jest.mock('../../components/website/sections/Navbar', () => {
+  function MockNavbar() {
+    return <div />;
+  }
+  MockNavbar.displayName = 'Navbar';
+  return MockNavbar;
+});
+jest.mock('../../components/website/sections/Footer', () => {
+  function MockFooter() {
+    return <div />;
+  }
+  MockFooter.displayName = 'Footer';
+  return MockFooter;
+});
+jest.mock('../../components/tutorials/FilterSidebar', () => {
+  function MockFilterSidebar() {
+    return <div />;
+  }
+  MockFilterSidebar.displayName = 'FilterSidebar';
+  return MockFilterSidebar;
+});
 
 const addItem = jest.fn();
 jest.mock('../../store/cart/cartStore', () => ({

--- a/frontend/src/tests/__tests__/TutorialsSection.test.js
+++ b/frontend/src/tests/__tests__/TutorialsSection.test.js
@@ -5,17 +5,36 @@ import useTutorialListsStore from '@/store/tutorials/tutorialListsStore';
 import useAuthStore from '@/store/auth/authStore';
 import * as tutorialService from '../../services/tutorialService';
 
-jest.mock('next/image', () => (props) => <img {...props} />);
+jest.mock('next/image', () => {
+  function NextImage(props) {
+    return <img {...props} />;
+  }
+  NextImage.displayName = 'NextImage';
+  return NextImage;
+});
 jest.mock('next/router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
 jest.mock('next-i18next', () => ({ useTranslation: () => ({ t: (key) => key }) }));
-jest.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, ...props }) => <div {...props}>{children}</div>,
-    h2: ({ children, ...props }) => <h2 {...props}>{children}</h2>,
-    a: ({ children, ...props }) => <a {...props}>{children}</a>,
-    button: ({ children, ...props }) => <button {...props}>{children}</button>,
-  },
-}));
+jest.mock('framer-motion', () => {
+  const motion = {
+    div: function MotionDiv({ children, ...props }) {
+      return <div {...props}>{children}</div>;
+    },
+    h2: function MotionH2({ children, ...props }) {
+      return <h2 {...props}>{children}</h2>;
+    },
+    a: function MotionLink({ children, ...props }) {
+      return <a {...props}>{children}</a>;
+    },
+    button: function MotionButton({ children, ...props }) {
+      return <button {...props}>{children}</button>;
+    },
+  };
+  motion.div.displayName = 'motion.div';
+  motion.h2.displayName = 'motion.h2';
+  motion.a.displayName = 'motion.a';
+  motion.button.displayName = 'motion.button';
+  return { motion };
+});
 const addItem = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../store/cart/cartStore', () => ({
   __esModule: true,

--- a/frontend/src/tests/__tests__/checkoutPromo.test.js
+++ b/frontend/src/tests/__tests__/checkoutPromo.test.js
@@ -12,8 +12,20 @@ jest.mock('../../store/cart/cartStore', () => ({
   default: (selector) => selector({ items: [], removeItem: mockRemoveItem }),
 }));
 
-jest.mock('../../components/website/sections/Navbar', () => () => <div />);
-jest.mock('../../components/website/sections/Footer', () => () => <div />);
+jest.mock('../../components/website/sections/Navbar', () => {
+  function MockNavbar() {
+    return <div />;
+  }
+  MockNavbar.displayName = 'Navbar';
+  return MockNavbar;
+});
+jest.mock('../../components/website/sections/Footer', () => {
+  function MockFooter() {
+    return <div />;
+  }
+  MockFooter.displayName = 'Footer';
+  return MockFooter;
+});
 
 jest.mock('../../services/classService', () => ({
   fetchClassDetails: jest.fn(),

--- a/frontend/src/tests/bookFilters.test.js
+++ b/frontend/src/tests/bookFilters.test.js
@@ -6,16 +6,40 @@ jest.mock('../services/bookService', () => ({
 }));
 
 // Mock sidebar to control filter changes
-jest.mock('../components/books/FilterSidebar', () => ({ onFilterChange }) => (
-  <div>
-    <button onClick={() => onFilterChange({ category: 'cat1' })}>set-category</button>
-    <button onClick={() => onFilterChange({ category: '', priceRange: 30 })}>set-price</button>
-  </div>
-));
+jest.mock('../components/books/FilterSidebar', () => {
+  function MockFilterSidebar({ onFilterChange }) {
+    return (
+      <div>
+        <button onClick={() => onFilterChange({ category: 'cat1' })}>set-category</button>
+        <button onClick={() => onFilterChange({ category: '', priceRange: 30 })}>set-price</button>
+      </div>
+    );
+  }
+  MockFilterSidebar.displayName = 'FilterSidebar';
+  return MockFilterSidebar;
+});
 
-jest.mock('../components/website/sections/Navbar', () => () => <div />);
-jest.mock('../components/website/sections/Footer', () => () => <div />);
-jest.mock('../components/books/BookCard', () => () => <div />);
+jest.mock('../components/website/sections/Navbar', () => {
+  function MockNavbar() {
+    return <div />;
+  }
+  MockNavbar.displayName = 'Navbar';
+  return MockNavbar;
+});
+jest.mock('../components/website/sections/Footer', () => {
+  function MockFooter() {
+    return <div />;
+  }
+  MockFooter.displayName = 'Footer';
+  return MockFooter;
+});
+jest.mock('../components/books/BookCard', () => {
+  function MockBookCard() {
+    return <div />;
+  }
+  MockBookCard.displayName = 'BookCard';
+  return MockBookCard;
+});
 
 jest.mock('next-i18next', () => ({
   useTranslation: () => ({ t: (key) => key })

--- a/frontend/src/utils/community/moderation.js
+++ b/frontend/src/utils/community/moderation.js
@@ -7,5 +7,5 @@ export const warnUser = (userId, reason) => {
 };
 
 export const lockDiscussion = (discussionId) => {
-  console.log(`Discussion ${discussionId} locked`);
+  console.warn(`Discussion ${discussionId} locked`);
 };

--- a/frontend/tailwind.config.mjs
+++ b/frontend/tailwind.config.mjs
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+const config = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -15,3 +15,5 @@ export default {
   },
   plugins: [],
 };
+
+export default config;


### PR DESCRIPTION
## Summary
- add abortable fetch on public tutorials page
- export Tailwind config via named object
- give mocked components display names and replace stray console.log

## Testing
- `npm test`
- `npm run lint` *(fails: 49 errors, 305 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aa22435a14832885262ab9326a5d36