### PR TITLE
feat: add tutorials translations

### DIFF
--- a/frontend/public/locales/ar/tutorials.json
+++ b/frontend/public/locales/ar/tutorials.json
@@ -125,5 +125,60 @@
       "publish_tutorial": "Publish Tutorial"
     }
   }
+  ,
+  "filters": {
+    "title": "عوامل التصفية",
+    "max_price": "أقصى سعر: ${{price}}",
+    "categories": "الفئات",
+    "difficulty_level": "مستوى الصعوبة",
+    "level_beginner": "مبتدئ",
+    "level_intermediate": "متوسط",
+    "level_advanced": "متقدم",
+    "reset": "إعادة تعيين عوامل التصفية"
+  },
+  "card": {
+    "instructor": "المدرب",
+    "lessons": "دروس",
+    "completed": "مكتمل",
+    "in_progress": "قيد التقدم",
+    "review": "مراجعة",
+    "continue": "متابعة",
+    "new": "جديد",
+    "untitled": "درس بدون عنوان",
+    "unknown_instructor": "غير معروف",
+    "views": "مشاهدات",
+    "general": "عام",
+    "na": "غير متوفر",
+    "unknown_duration": "مدة غير معروفة",
+    "explore": "استكشف الدرس",
+    "add_to_cart": "أضف إلى السلة",
+    "added_to_cart": "تمت الإضافة إلى السلة",
+    "failed_to_add_to_cart": "فشل في الإضافة إلى السلة"
+  },
+  "studentPage": {
+    "heading": "📚 دروسي",
+    "found": "تم العثور على {{count}}",
+    "search_label": "ابحث عن الدروس",
+    "search_placeholder": "ابحث عن الدروس...",
+    "filter_label": "تصفية الدروس",
+    "filter": {
+      "all": "الكل",
+      "completed": "مكتمل",
+      "in_progress": "قيد التقدم"
+    },
+    "sort_label": "ترتيب الدروس",
+    "sort": {
+      "title": "العنوان",
+      "rating": "التقييم",
+      "progress": "التقدم"
+    },
+    "no_match": "لا توجد دروس مطابقة لبحثك.",
+    "browse_all": "تصفح جميع الدروس"
+  },
+  "favoritesPage": {
+    "heading": "دروسي المفضلة",
+    "empty": "ليس لديك أي دروس مفضلة.",
+    "remove": "إزالة"
+  }
 }
 

--- a/frontend/public/locales/de/tutorials.json
+++ b/frontend/public/locales/de/tutorials.json
@@ -125,5 +125,60 @@
       "publish_tutorial": "Publish Tutorial"
     }
   }
+  ,
+  "filters": {
+    "title": "Filter",
+    "max_price": "Maximaler Preis: ${{price}}",
+    "categories": "Kategorien",
+    "difficulty_level": "Schwierigkeitsgrad",
+    "level_beginner": "Anfänger",
+    "level_intermediate": "Mittelstufe",
+    "level_advanced": "Fortgeschritten",
+    "reset": "Filter zurücksetzen"
+  },
+  "card": {
+    "instructor": "Kursleiter",
+    "lessons": "Lektionen",
+    "completed": "Abgeschlossen",
+    "in_progress": "In Bearbeitung",
+    "review": "Bewerten",
+    "continue": "Fortfahren",
+    "new": "NEU",
+    "untitled": "Unbenannter Kurs",
+    "unknown_instructor": "Unbekannt",
+    "views": "Aufrufe",
+    "general": "Allgemein",
+    "na": "k.A.",
+    "unknown_duration": "Unbekannte Dauer",
+    "explore": "Kurs ansehen",
+    "add_to_cart": "In den Warenkorb",
+    "added_to_cart": "Zum Warenkorb hinzugefügt",
+    "failed_to_add_to_cart": "Zum Warenkorb hinzufügen fehlgeschlagen"
+  },
+  "studentPage": {
+    "heading": "📚 Meine Tutorials",
+    "found": "{{count}} gefunden",
+    "search_label": "Tutorials suchen",
+    "search_placeholder": "Tutorials suchen...",
+    "filter_label": "Tutorials filtern",
+    "filter": {
+      "all": "Alle",
+      "completed": "Abgeschlossen",
+      "in_progress": "In Bearbeitung"
+    },
+    "sort_label": "Tutorials sortieren",
+    "sort": {
+      "title": "Titel",
+      "rating": "Bewertung",
+      "progress": "Fortschritt"
+    },
+    "no_match": "Keine Tutorials entsprechen deinen Kriterien.",
+    "browse_all": "Alle Tutorials durchsuchen"
+  },
+  "favoritesPage": {
+    "heading": "Meine Lieblingstutorials",
+    "empty": "Du hast keine Lieblingstutorials.",
+    "remove": "Entfernen"
+  }
 }
 

--- a/frontend/public/locales/en/tutorials.json
+++ b/frontend/public/locales/en/tutorials.json
@@ -125,5 +125,60 @@
       "publish_tutorial": "Publish Tutorial"
     }
   }
+  ,
+  "filters": {
+    "title": "Filters",
+    "max_price": "Max Price: ${{price}}",
+    "categories": "Categories",
+    "difficulty_level": "Difficulty Level",
+    "level_beginner": "Beginner",
+    "level_intermediate": "Intermediate",
+    "level_advanced": "Advanced",
+    "reset": "Reset Filters"
+  },
+  "card": {
+    "instructor": "Instructor",
+    "lessons": "lessons",
+    "completed": "Completed",
+    "in_progress": "In Progress",
+    "review": "Review",
+    "continue": "Continue",
+    "new": "NEW",
+    "untitled": "Untitled Tutorial",
+    "unknown_instructor": "Unknown",
+    "views": "views",
+    "general": "General",
+    "na": "N/A",
+    "unknown_duration": "Unknown Duration",
+    "explore": "Explore Tutorial",
+    "add_to_cart": "Add to Cart",
+    "added_to_cart": "Added to cart",
+    "failed_to_add_to_cart": "Failed to add to cart"
+  },
+  "studentPage": {
+    "heading": "📚 My Tutorials",
+    "found": "{{count}} found",
+    "search_label": "Search tutorials",
+    "search_placeholder": "Search tutorials...",
+    "filter_label": "Filter tutorials",
+    "filter": {
+      "all": "All",
+      "completed": "Completed",
+      "in_progress": "In Progress"
+    },
+    "sort_label": "Sort tutorials",
+    "sort": {
+      "title": "Title",
+      "rating": "Rating",
+      "progress": "Progress"
+    },
+    "no_match": "No tutorials match your criteria.",
+    "browse_all": "Browse all tutorials"
+  },
+  "favoritesPage": {
+    "heading": "My Favorite Tutorials",
+    "empty": "You have no favorite tutorials.",
+    "remove": "Remove"
+  }
 }
 

--- a/frontend/public/locales/es/tutorials.json
+++ b/frontend/public/locales/es/tutorials.json
@@ -125,5 +125,60 @@
       "publish_tutorial": "Publish Tutorial"
     }
   }
+  ,
+  "filters": {
+    "title": "Filtros",
+    "max_price": "Precio máximo: ${{price}}",
+    "categories": "Categorías",
+    "difficulty_level": "Nivel de dificultad",
+    "level_beginner": "Principiante",
+    "level_intermediate": "Intermedio",
+    "level_advanced": "Avanzado",
+    "reset": "Restablecer filtros"
+  },
+  "card": {
+    "instructor": "Instructor",
+    "lessons": "lecciones",
+    "completed": "Completado",
+    "in_progress": "En progreso",
+    "review": "Revisar",
+    "continue": "Continuar",
+    "new": "NUEVO",
+    "untitled": "Tutorial sin título",
+    "unknown_instructor": "Desconocido",
+    "views": "vistas",
+    "general": "General",
+    "na": "N/D",
+    "unknown_duration": "Duración desconocida",
+    "explore": "Explorar tutorial",
+    "add_to_cart": "Agregar al carrito",
+    "added_to_cart": "Agregado al carrito",
+    "failed_to_add_to_cart": "No se pudo agregar al carrito"
+  },
+  "studentPage": {
+    "heading": "📚 Mis tutoriales",
+    "found": "{{count}} encontrado(s)",
+    "search_label": "Buscar tutoriales",
+    "search_placeholder": "Buscar tutoriales...",
+    "filter_label": "Filtrar tutoriales",
+    "filter": {
+      "all": "Todos",
+      "completed": "Completados",
+      "in_progress": "En progreso"
+    },
+    "sort_label": "Ordenar tutoriales",
+    "sort": {
+      "title": "Título",
+      "rating": "Calificación",
+      "progress": "Progreso"
+    },
+    "no_match": "Ningún tutorial coincide con tus criterios.",
+    "browse_all": "Ver todos los tutoriales"
+  },
+  "favoritesPage": {
+    "heading": "Mis tutoriales favoritos",
+    "empty": "No tienes tutoriales favoritos.",
+    "remove": "Eliminar"
+  }
 }
 

--- a/frontend/public/locales/fr/tutorials.json
+++ b/frontend/public/locales/fr/tutorials.json
@@ -125,5 +125,60 @@
       "publish_tutorial": "Publish Tutorial"
     }
   }
+  ,
+  "filters": {
+    "title": "Filtres",
+    "max_price": "Prix max : ${{price}}",
+    "categories": "Catégories",
+    "difficulty_level": "Niveau de difficulté",
+    "level_beginner": "Débutant",
+    "level_intermediate": "Intermédiaire",
+    "level_advanced": "Avancé",
+    "reset": "Réinitialiser les filtres"
+  },
+  "card": {
+    "instructor": "Instructeur",
+    "lessons": "leçons",
+    "completed": "Terminé",
+    "in_progress": "En cours",
+    "review": "Revoir",
+    "continue": "Continuer",
+    "new": "NOUVEAU",
+    "untitled": "Tutoriel sans titre",
+    "unknown_instructor": "Inconnu",
+    "views": "vues",
+    "general": "Général",
+    "na": "N/A",
+    "unknown_duration": "Durée inconnue",
+    "explore": "Explorer le tutoriel",
+    "add_to_cart": "Ajouter au panier",
+    "added_to_cart": "Ajouté au panier",
+    "failed_to_add_to_cart": "Échec de l'ajout au panier"
+  },
+  "studentPage": {
+    "heading": "📚 Mes tutoriels",
+    "found": "{{count}} trouvés",
+    "search_label": "Rechercher des tutoriels",
+    "search_placeholder": "Rechercher des tutoriels...",
+    "filter_label": "Filtrer les tutoriels",
+    "filter": {
+      "all": "Tous",
+      "completed": "Terminés",
+      "in_progress": "En cours"
+    },
+    "sort_label": "Trier les tutoriels",
+    "sort": {
+      "title": "Titre",
+      "rating": "Évaluation",
+      "progress": "Progression"
+    },
+    "no_match": "Aucun tutoriel ne correspond à vos critères.",
+    "browse_all": "Parcourir tous les tutoriels"
+  },
+  "favoritesPage": {
+    "heading": "Mes tutoriels favoris",
+    "empty": "Vous n'avez aucun tutoriel favori.",
+    "remove": "Supprimer"
+  }
 }
 

--- a/frontend/public/locales/hi/tutorials.json
+++ b/frontend/public/locales/hi/tutorials.json
@@ -125,4 +125,59 @@
       "publish_tutorial": "ट्यूटोरियल प्रकाशित करें"
     }
   }
+  ,
+  "filters": {
+    "title": "फ़िल्टर",
+    "max_price": "अधिकतम कीमत: ${{price}}",
+    "categories": "श्रेणियाँ",
+    "difficulty_level": "कठिनाई स्तर",
+    "level_beginner": "शुरुआती",
+    "level_intermediate": "मध्यम",
+    "level_advanced": "उन्नत",
+    "reset": "फ़िल्टर रीसेट करें"
+  },
+  "card": {
+    "instructor": "प्रशिक्षक",
+    "lessons": "पाठ",
+    "completed": "पूर्ण",
+    "in_progress": "प्रगति पर",
+    "review": "समीक्षा",
+    "continue": "जारी रखें",
+    "new": "नया",
+    "untitled": "शीर्षक रहित ट्यूटोरियल",
+    "unknown_instructor": "अज्ञात",
+    "views": "दृश्य",
+    "general": "सामान्य",
+    "na": "लागू नहीं",
+    "unknown_duration": "अज्ञात अवधि",
+    "explore": "ट्यूटोरियल देखें",
+    "add_to_cart": "कार्ट में जोड़ें",
+    "added_to_cart": "कार्ट में जोड़ा गया",
+    "failed_to_add_to_cart": "कार्ट में जोड़ने में विफल"
+  },
+  "studentPage": {
+    "heading": "📚 मेरे ट्यूटोरियल",
+    "found": "{{count}} मिला",
+    "search_label": "ट्यूटोरियल खोजें",
+    "search_placeholder": "ट्यूटोरियल खोजें...",
+    "filter_label": "ट्यूटोरियल फ़िल्टर करें",
+    "filter": {
+      "all": "सभी",
+      "completed": "पूर्ण",
+      "in_progress": "प्रगति पर"
+    },
+    "sort_label": "ट्यूटोरियल क्रमित करें",
+    "sort": {
+      "title": "शीर्षक",
+      "rating": "रेटिंग",
+      "progress": "प्रगति"
+    },
+    "no_match": "आपके मानदंड से मेल खाने वाले कोई ट्यूटोरियल नहीं।",
+    "browse_all": "सभी ट्यूटोरियल ब्राउज़ करें"
+  },
+  "favoritesPage": {
+    "heading": "मेरे पसंदीदा ट्यूटोरियल",
+    "empty": "आपके पास कोई पसंदीदा ट्यूटोरियल नहीं है।",
+    "remove": "हटाएं"
+  }
 }

--- a/frontend/public/locales/zh/tutorials.json
+++ b/frontend/public/locales/zh/tutorials.json
@@ -125,5 +125,60 @@
       "publish_tutorial": "Publish Tutorial"
     }
   }
+  ,
+  "filters": {
+    "title": "筛选",
+    "max_price": "最高价格：${{price}}",
+    "categories": "分类",
+    "difficulty_level": "难度等级",
+    "level_beginner": "初级",
+    "level_intermediate": "中级",
+    "level_advanced": "高级",
+    "reset": "重置筛选"
+  },
+  "card": {
+    "instructor": "讲师",
+    "lessons": "课时",
+    "completed": "已完成",
+    "in_progress": "进行中",
+    "review": "评价",
+    "continue": "继续",
+    "new": "新",
+    "untitled": "无标题教程",
+    "unknown_instructor": "未知",
+    "views": "次观看",
+    "general": "通用",
+    "na": "N/A",
+    "unknown_duration": "时长未知",
+    "explore": "查看教程",
+    "add_to_cart": "加入购物车",
+    "added_to_cart": "已加入购物车",
+    "failed_to_add_to_cart": "加入购物车失败"
+  },
+  "studentPage": {
+    "heading": "📚 我的教程",
+    "found": "找到 {{count}} 个",
+    "search_label": "搜索教程",
+    "search_placeholder": "搜索教程...",
+    "filter_label": "筛选教程",
+    "filter": {
+      "all": "全部",
+      "completed": "已完成",
+      "in_progress": "进行中"
+    },
+    "sort_label": "排序教程",
+    "sort": {
+      "title": "标题",
+      "rating": "评分",
+      "progress": "进度"
+    },
+    "no_match": "没有符合条件的教程。",
+    "browse_all": "浏览所有教程"
+  },
+  "favoritesPage": {
+    "heading": "我的收藏教程",
+    "empty": "你没有收藏的教程。",
+    "remove": "移除"
+  }
 }
 

--- a/frontend/src/components/tutorials/FilterSidebar.js
+++ b/frontend/src/components/tutorials/FilterSidebar.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaChevronDown, FaChevronUp, FaTimesCircle } from "react-icons/fa";
+import { useTranslation } from "next-i18next";
 import { fetchCategoryTree } from "@/services/instructor/categoryService";
 
 const FilterSidebar = ({ onFilterChange, onResetFilters }) => {
@@ -8,6 +9,7 @@ const FilterSidebar = ({ onFilterChange, onResetFilters }) => {
   const [selectedLevels, setSelectedLevels] = useState([]);
   const [priceRange, setPriceRange] = useState(100);
   const [expandedCategory, setExpandedCategory] = useState(null);
+  const { t } = useTranslation("tutorials", { keyPrefix: "filters" });
 
   // Categories fetched from the API
   const [categories, setCategories] = useState({});
@@ -63,11 +65,11 @@ const FilterSidebar = ({ onFilterChange, onResetFilters }) => {
 
   return (
     <motion.div className="bg-gray-800 p-6 rounded-lg shadow-lg w-64" initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} transition={{ duration: 0.6 }}>
-      <h2 className="text-lg font-bold mb-4 text-yellow-400">Filters</h2>
+      <h2 className="text-lg font-bold mb-4 text-yellow-400">{t("title")}</h2>
 
       {/* Price Range */}
       <div className="mb-6">
-        <label className="text-gray-300">Max Price: ${priceRange}</label>
+        <label className="text-gray-300">{t("max_price", { price: priceRange })}</label>
         <input
           type="range"
           min="0"
@@ -83,7 +85,7 @@ const FilterSidebar = ({ onFilterChange, onResetFilters }) => {
 
       {/* Categories & Subcategories */}
       <div className="mb-6">
-        <h3 className="text-gray-300 font-semibold">Categories</h3>
+        <h3 className="text-gray-300 font-semibold">{t("categories")}</h3>
         {Object.keys(categories).map((category) => (
           <div key={category} className="mt-2">
             <button className="flex items-center justify-between w-full bg-gray-700 p-2 rounded hover:bg-gray-600" onClick={() => toggleCategory(category)}>
@@ -106,18 +108,26 @@ const FilterSidebar = ({ onFilterChange, onResetFilters }) => {
 
       {/* Difficulty Levels */}
       <div className="mb-6">
-        <h3 className="text-gray-300 font-semibold">Difficulty Level</h3>
+        <h3 className="text-gray-300 font-semibold">{t("difficulty_level")}</h3>
         {["Beginner", "Intermediate", "Advanced"].map((level) => (
           <label key={level} className="flex items-center space-x-2 text-gray-300 mt-2">
-            <input type="checkbox" value={level} checked={selectedLevels.includes(level)} onChange={() => handleLevelChange(level)} />
-            <span>{level}</span>
+            <input
+              type="checkbox"
+              value={level}
+              checked={selectedLevels.includes(level)}
+              onChange={() => handleLevelChange(level)}
+            />
+            <span>{t(`level_${level.toLowerCase()}`)}</span>
           </label>
         ))}
       </div>
 
       {/* Reset Button */}
-      <button className="bg-red-500 text-white px-4 py-2 rounded-lg w-full mt-4 flex items-center justify-center gap-2 hover:bg-red-600 transition" onClick={resetFilters}>
-        <FaTimesCircle /> Reset Filters
+      <button
+        className="bg-red-500 text-white px-4 py-2 rounded-lg w-full mt-4 flex items-center justify-center gap-2 hover:bg-red-600 transition"
+        onClick={resetFilters}
+      >
+        <FaTimesCircle /> {t("reset")}
       </button>
     </motion.div>
   );

--- a/frontend/src/components/tutorials/StudentTutorialCard.js
+++ b/frontend/src/components/tutorials/StudentTutorialCard.js
@@ -1,10 +1,16 @@
 import Link from "next/link";
 import { FaBookOpen, FaPlayCircle, FaCheckCircle, FaStar } from "react-icons/fa";
+import { useTranslation } from "next-i18next";
 
 export default function StudentTutorialCard({ tutorial }) {
   const progressPercent = tutorial.totalLessons
     ? (tutorial.completedLessons / tutorial.totalLessons) * 100
     : 0;
+  const { t } = useTranslation("tutorials", { keyPrefix: "card" });
+  const tr = (key, def) => {
+    const res = t(key);
+    return res === key ? def : res;
+  };
 
   return (
     <div className="bg-white rounded-xl shadow-md overflow-hidden border border-gray-100 hover:shadow-lg transition">
@@ -24,7 +30,9 @@ export default function StudentTutorialCard({ tutorial }) {
         <h2 className="text-lg font-semibold flex items-center gap-2">
           <FaBookOpen className="text-yellow-500" /> {tutorial.title}
         </h2>
-        <p className="text-sm text-gray-500">Instructor: {tutorial.instructor}</p>
+        <p className="text-sm text-gray-500">
+          {tr("instructor", "Instructor")}: {tutorial.instructor}
+        </p>
 
         <div className="w-full bg-gray-100 h-2 rounded-full overflow-hidden">
           <div
@@ -35,15 +43,15 @@ export default function StudentTutorialCard({ tutorial }) {
 
         <div className="flex justify-between text-xs text-gray-500">
           <span>
-            {tutorial.completedLessons}/{tutorial.totalLessons} lessons
+            {tutorial.completedLessons}/{tutorial.totalLessons} {tr("lessons", "lessons")}
           </span>
           {tutorial.isCompleted ? (
             <span className="text-green-600 flex items-center gap-1">
-              <FaCheckCircle /> Completed
+              <FaCheckCircle /> {tr("completed", "Completed")}
             </span>
           ) : (
             <span className="text-blue-600 flex items-center gap-1">
-              <FaPlayCircle /> In Progress
+              <FaPlayCircle /> {tr("in_progress", "In Progress")}
             </span>
           )}
         </div>
@@ -57,7 +65,7 @@ export default function StudentTutorialCard({ tutorial }) {
           href={`/tutorials/${tutorial.id}`}
           className="inline-flex items-center gap-2 text-sm mt-2 text-white bg-blue-600 hover:bg-blue-700 px-3 py-1.5 rounded-md transition-colors"
         >
-          {tutorial.isCompleted ? "Review" : "Continue"}
+          {tutorial.isCompleted ? tr("review", "Review") : tr("continue", "Continue")}
         </Link>
       </div>
     </div>

--- a/frontend/src/components/tutorials/TutorialCard.js
+++ b/frontend/src/components/tutorials/TutorialCard.js
@@ -2,6 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Star, Eye, PlayCircle } from "lucide-react";
 import Link from "next/link";
+import { useTranslation } from "next-i18next";
 import { formatCurrency } from "@/utils/currency";
 import useCartStore from "@/store/cart/cartStore";
 import { toast } from "react-toastify";
@@ -12,9 +13,16 @@ const DEFAULT_AVATAR = "https://i.pravatar.cc/40";
 
 const TutorialCard = ({ tutorial = {} }) => {
   const addItem = useCartStore((state) => state.addItem);
+  const { t } = useTranslation("tutorials");
+  const tr = (key, def, opts) => {
+    const res = t(key, opts);
+    return res === key ? def : res;
+  };
 
   const formattedPrice =
-    Number(tutorial.price) > 0 ? formatCurrency(tutorial.price) : "Free";
+    Number(tutorial.price) > 0
+      ? formatCurrency(tutorial.price)
+      : tr("list.free", "Free");
 
   const handleAddToCart = async () => {
     const success = await addItem({
@@ -26,9 +34,9 @@ const TutorialCard = ({ tutorial = {} }) => {
       ...(tutorial.currency ? { currency: tutorial.currency } : {}),
     });
     if (success) {
-      toast.success("Added to cart");
+      toast.success(tr("card.added_to_cart", "Added to cart"));
     } else {
-      toast.error("Failed to add to cart");
+      toast.error(tr("card.failed_to_add_to_cart", "Failed to add to cart"));
     }
   };
 
@@ -42,7 +50,7 @@ const TutorialCard = ({ tutorial = {} }) => {
       <div className="relative">
         <img
           src={tutorial.thumbnail || DEFAULT_IMAGE}
-          alt={tutorial.title || "Tutorial"}
+          alt={tutorial.title || tr("card.untitled", "Untitled Tutorial")}
           className="w-full h-40 object-cover"
         />
 
@@ -54,7 +62,7 @@ const TutorialCard = ({ tutorial = {} }) => {
         {/* New Badge */}
         {tutorial.isNew && (
           <span className="absolute top-2 left-2 bg-green-500 text-white text-xs px-2 py-1 rounded-full shadow-md">
-            NEW
+            {t("card.new")}
           </span>
         )}
       </div>
@@ -62,7 +70,7 @@ const TutorialCard = ({ tutorial = {} }) => {
       {/* Content */}
       <div className="p-4">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white truncate">
-          {tutorial.title || "Untitled Tutorial"}
+          {tutorial.title || t("card.untitled")}
         </h3>
 
         <div className="flex items-center gap-2 mt-1">
@@ -72,7 +80,7 @@ const TutorialCard = ({ tutorial = {} }) => {
             className="w-6 h-6 rounded-full"
           />
           <p className="text-sm text-gray-600 dark:text-gray-300 truncate">
-            {tutorial.instructor || "Unknown"}
+            {tutorial.instructor || tr("card.unknown_instructor", "Unknown")}
           </p>
         </div>
 
@@ -84,13 +92,13 @@ const TutorialCard = ({ tutorial = {} }) => {
           </div>
           <div className="flex items-center gap-1">
             <Eye className="w-4 h-4" />
-            {tutorial.views || 0} views
+            {tutorial.views || 0} {tr("card.views", "views")}
           </div>
         </div>
 
         {/* Category, Level, Price, Duration */}
         <div className="mt-3 text-xs text-gray-400 uppercase tracking-wider">
-          {tutorial.category || "General"} &middot; {tutorial.level || "N/A"}
+          {tutorial.category || tr("card.general", "General")} &middot; {tutorial.level || tr("card.na", "N/A")}
         </div>
         <div className="mt-1 text-sm text-gray-600 dark:text-gray-300">
           {(() => {
@@ -101,7 +109,7 @@ const TutorialCard = ({ tutorial = {} }) => {
               tutorial.discountPrice ?? tutorial.discount_price;
 
             if (Number(originalPrice) <= 0) {
-              return "Free";
+              return tr("list.free", "Free");
             }
 
             if (discountPrice && Number(discountPrice) < Number(originalPrice)) {
@@ -116,7 +124,7 @@ const TutorialCard = ({ tutorial = {} }) => {
             }
 
             return formatCurrency(originalPrice, { currency });
-          })()} &middot; {tutorial.duration || "Unknown Duration"}
+          })()} &middot; {tutorial.duration || tr("card.unknown_duration", "Unknown Duration")}
         </div>
 
         {/* Actions */}
@@ -126,7 +134,7 @@ const TutorialCard = ({ tutorial = {} }) => {
               className="flex-1 bg-yellow-500 hover:bg-yellow-600 text-black font-semibold py-2 px-4 rounded-full transition"
               whileHover={{ scale: 1.03 }}
             >
-              Explore Tutorial
+              {tr("card.explore", "Explore Tutorial")}
             </motion.button>
           </Link>
           {Number(tutorial.price) > 0 && (
@@ -135,7 +143,7 @@ const TutorialCard = ({ tutorial = {} }) => {
               className="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-full transition"
               whileHover={{ scale: 1.03 }}
             >
-              Add to Cart
+              {tr("card.add_to_cart", "Add to Cart")}
             </motion.button>
           )}
         </div>

--- a/frontend/src/pages/dashboard/student/tutorials/favorites.js
+++ b/frontend/src/pages/dashboard/student/tutorials/favorites.js
@@ -1,9 +1,17 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import StudentLayout from '@/components/layouts/StudentLayout';
 import { getMyTutorialFavorites, removeTutorialFromFavorites } from '@/services/tutorialService';
+import nextI18NextConfig from '../../../../../next-i18next.config.js';
 
 export default function TutorialFavoritesPage() {
   const [favorites, setFavorites] = useState([]);
+  const { t } = useTranslation('tutorials');
+  const tr = (key, def) => {
+    const res = t(key);
+    return res === key ? def : res;
+  };
 
   useEffect(() => {
     const load = async () => {
@@ -28,9 +36,9 @@ export default function TutorialFavoritesPage() {
 
   return (
     <StudentLayout>
-      <h1 className="text-2xl font-bold mb-6">My Favorite Tutorials</h1>
+      <h1 className="text-2xl font-bold mb-6">{tr('favoritesPage.heading', 'My Favorite Tutorials')}</h1>
       {favorites.length === 0 ? (
-        <p className="text-gray-500">You have no favorite tutorials.</p>
+        <p className="text-gray-500">{tr('favoritesPage.empty', 'You have no favorite tutorials.')}</p>
       ) : (
         <ul className="space-y-2">
           {favorites.map((tutorial) => (
@@ -40,7 +48,7 @@ export default function TutorialFavoritesPage() {
                 onClick={() => removeFavorite(tutorial.id)}
                 className="text-red-500 text-sm"
               >
-                Remove
+                {tr('favoritesPage.remove', 'Remove')}
               </button>
             </li>
           ))}
@@ -48,4 +56,12 @@ export default function TutorialFavoritesPage() {
       )}
     </StudentLayout>
   );
+}
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['tutorials'], nextI18NextConfig)),
+    },
+  };
 }

--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -1,7 +1,10 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import { fetchPublishedTutorials } from "@/services/tutorialService";
 import StudentTutorialCard from "@/components/tutorials/StudentTutorialCard";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 
 export default function StudentTutorialsPage() {
   const [search, setSearch] = useState("");
@@ -10,6 +13,11 @@ export default function StudentTutorialsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [sortBy, setSortBy] = useState("title");
+  const { t } = useTranslation("tutorials");
+  const tr = (key, def, opts) => {
+    const res = t(key, opts);
+    return res === key ? def : res;
+  };
 
   useEffect(() => {
     const controller = new AbortController();
@@ -37,7 +45,7 @@ export default function StudentTutorialsPage() {
       } catch (err) {
         if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         console.error(err);
-        setError("Failed to load tutorials");
+        setError(tr("list.load_error", "Failed to load tutorials"));
       } finally {
         setLoading(false);
       }
@@ -105,23 +113,23 @@ export default function StudentTutorialsPage() {
       <div className="p-6 space-y-6 text-gray-800">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-bold">📚 My Tutorials</h1>
-            <span className="text-sm text-gray-500">({sorted.length} found)</span>
+            <h1 className="text-2xl font-bold">{tr("studentPage.heading", "📚 My Tutorials")}</h1>
+            <span className="text-sm text-gray-500">({tr("studentPage.found", `${sorted.length} found`, { count: sorted.length })})</span>
           </div>
           <div className="flex gap-2 items-center">
             <label htmlFor="student-tutorial-search" className="sr-only">
-              Search tutorials
+              {tr("studentPage.search_label", "Search tutorials")}
             </label>
             <input
               id="student-tutorial-search"
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search tutorials..."
+              placeholder={tr("studentPage.search_placeholder", "Search tutorials...")}
               className="px-3 py-2 border border-gray-300 rounded-md text-sm w-full md:w-64"
             />
             <label htmlFor="student-tutorial-filter" className="sr-only">
-              Filter tutorials
+              {tr("studentPage.filter_label", "Filter tutorials")}
             </label>
             <select
               id="student-tutorial-filter"
@@ -129,12 +137,12 @@ export default function StudentTutorialsPage() {
               onChange={(e) => setFilter(e.target.value)}
               className="border border-gray-300 px-2 py-2 rounded-md text-sm"
             >
-              <option value="all">All</option>
-              <option value="completed">Completed</option>
-              <option value="in-progress">In Progress</option>
+              <option value="all">{tr("studentPage.filter.all", "All")}</option>
+              <option value="completed">{tr("studentPage.filter.completed", "Completed")}</option>
+              <option value="in-progress">{tr("studentPage.filter.in_progress", "In Progress")}</option>
             </select>
             <label htmlFor="student-tutorial-sort" className="sr-only">
-              Sort tutorials
+              {tr("studentPage.sort_label", "Sort tutorials")}
             </label>
             <select
               id="student-tutorial-sort"
@@ -142,9 +150,9 @@ export default function StudentTutorialsPage() {
               onChange={(e) => setSortBy(e.target.value)}
               className="border border-gray-300 px-2 py-2 rounded-md text-sm"
             >
-              <option value="title">Title</option>
-              <option value="rating">Rating</option>
-              <option value="progress">Progress</option>
+              <option value="title">{tr("studentPage.sort.title", "Title")}</option>
+              <option value="rating">{tr("studentPage.sort.rating", "Rating")}</option>
+              <option value="progress">{tr("studentPage.sort.progress", "Progress")}</option>
             </select>
           </div>
         </div>
@@ -157,11 +165,19 @@ export default function StudentTutorialsPage() {
 
         {sorted.length === 0 && (
           <div className="text-center text-gray-500">
-            <p>No tutorials match your criteria.</p>
-            <a href="/dashboard/student/tutorials" className="text-blue-600 hover:underline text-sm mt-2 inline-block">Browse all tutorials</a>
+            <p>{tr("studentPage.no_match", "No tutorials match your criteria.")}</p>
+            <a href="/dashboard/student/tutorials" className="text-blue-600 hover:underline text-sm mt-2 inline-block">{tr("studentPage.browse_all", "Browse all tutorials")}</a>
           </div>
         )}
       </div>
     </StudentLayout>
   );
+}
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["tutorials"], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- localize tutorials filter sidebar and cards
- add translations for student tutorials and favorites pages
- supply translation entries for multiple locales

## Testing
- `npm test`
- `npm run lint` *(fails: 49 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3999f29c8328981deae00a8a67e4