### PR TITLE
feat: add moderation review endpoint

### DIFF
--- a/backend/src/modules/moderation/moderation.controller.js
+++ b/backend/src/modules/moderation/moderation.controller.js
@@ -1,0 +1,8 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./moderation.service");
+
+exports.getFlags = catchAsync(async (_req, res) => {
+  const flags = await service.getFlaggedMessages();
+  sendSuccess(res, flags);
+});

--- a/backend/src/modules/moderation/moderation.routes.js
+++ b/backend/src/modules/moderation/moderation.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./moderation.controller");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken);
+router.get("/flags", controller.getFlags);
+
+module.exports = router;

--- a/backend/src/modules/moderation/moderation.service.js
+++ b/backend/src/modules/moderation/moderation.service.js
@@ -1,0 +1,16 @@
+const db = require("../../config/database");
+
+exports.getFlaggedMessages = async () => {
+  return db({ cm: "chat_moderation" })
+    .join({ u: "users" }, "cm.user_id", "u.id")
+    .select(
+      "cm.id",
+      db.raw("COALESCE(u.full_name, u.email, '') as user"),
+      db.raw("COALESCE(u.role, '') as role"),
+      db.raw("cm.message as content"),
+      db.raw("cm.matched_words"),
+      db.raw("cm.created_at as time"),
+      db.raw("'Flagged' as status")
+    )
+    .orderBy("cm.created_at", "desc");
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -178,6 +178,7 @@ app.use("/api/notifications", require("./modules/notifications/notifications.rou
 app.use("/api/system-errors", require("./modules/errorLogs/errorLogs.routes"));
 app.use("/api/messages", require("./modules/messages/messages.routes"));
 app.use("/api/chat", require("./modules/chat/chat.routes"));
+app.use("/api/moderation", require("./modules/moderation/moderation.routes"));
 app.use("/api/languages", require("./modules/languages/languages.routes"));
 app.use("/api/currencies", require("./modules/currencies/currencies.routes"));
 app.use("/api/blog", require("./modules/blog/blog.routes"));

--- a/backend/tests/moderationRoutes.test.js
+++ b/backend/tests/moderationRoutes.test.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+const express = require('express');
+const errorHandler = require('../src/middleware/errorHandler');
+
+jest.mock('../src/modules/moderation/moderation.service', () => ({
+  getFlaggedMessages: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'admin1' };
+    next();
+  },
+}));
+
+const service = require('../src/modules/moderation/moderation.service');
+const routes = require('../src/modules/moderation/moderation.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/moderation', routes);
+app.use(errorHandler);
+
+describe('GET /api/moderation/flags', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns flagged messages', async () => {
+    const flags = [
+      {
+        id: 1,
+        user: 'student',
+        role: 'Student',
+        content: 'bad',
+        matched_words: '["bad"]',
+        time: '2025-01-01',
+        status: 'Flagged',
+      },
+    ];
+    service.getFlaggedMessages.mockResolvedValue(flags);
+    const res = await request(app).get('/api/moderation/flags');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(flags);
+    expect(service.getFlaggedMessages).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/admin/security/MessageFlagLog.js
+++ b/frontend/src/components/admin/security/MessageFlagLog.js
@@ -1,28 +1,29 @@
 // components/admin/security/MessageFlagLog.js
-const flaggedMessages = [
-    {
-      id: 1,
-      user: "student_ayman",
-      role: "Student",
-      content: "This is stupid",
-      time: "2025-04-14 10:42",
-      status: "Flagged"
-    },
-    {
-      id: 2,
-      user: "instructor_maria",
-      role: "Instructor",
-      content: "That’s a dumb answer",
-      time: "2025-04-14 10:46",
-      status: "Pending Review"
+import { useEffect, useState } from "react";
+import { fetchFlaggedMessages } from "@/services/admin/moderationService";
+
+export default function MessageFlagLog() {
+  const [flaggedMessages, setFlaggedMessages] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchFlaggedMessages();
+        setFlaggedMessages(data);
+      } catch (err) {
+        console.error("Failed to load flagged messages", err);
+      }
     }
-  ];
-  
-  export default function MessageFlagLog() {
-    return (
-      <div className="bg-white p-6 rounded-xl shadow">
-        <h2 className="text-xl font-semibold mb-4">🚨 Flagged Messages</h2>
-        <div className="overflow-x-auto">
+    load();
+  }, []);
+
+  return (
+    <div className="bg-white p-6 rounded-xl shadow">
+      <h2 className="text-xl font-semibold mb-4">🚨 Flagged Messages</h2>
+      <div className="overflow-x-auto">
+        {flaggedMessages.length === 0 ? (
+          <p className="text-sm text-gray-600">No flagged messages.</p>
+        ) : (
           <table className="min-w-full table-auto text-sm text-left">
             <thead className="bg-gray-100 text-gray-600">
               <tr>
@@ -42,7 +43,9 @@ const flaggedMessages = [
                   <td className="px-4 py-2 text-red-600">{msg.content}</td>
                   <td className="px-4 py-2">{msg.time}</td>
                   <td className="px-4 py-2">
-                    <span className={`px-2 py-1 rounded text-xs font-semibold ${msg.status === 'Flagged' ? 'bg-red-100 text-red-600' : 'bg-yellow-100 text-yellow-600'}`}>
+                    <span
+                      className={`px-2 py-1 rounded text-xs font-semibold ${msg.status === 'Flagged' ? 'bg-red-100 text-red-600' : 'bg-yellow-100 text-yellow-600'}`}
+                    >
                       {msg.status}
                     </span>
                   </td>
@@ -54,8 +57,8 @@ const flaggedMessages = [
               ))}
             </tbody>
           </table>
-        </div>
+        )}
       </div>
-    );
-  }
-  
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose `/api/moderation/flags` for admin to review flagged chat messages
- surface flagged messages in admin dashboard using moderation service
- cover moderation endpoint with a Jest test

## Testing
- `npm test` *(fails: adsRoutes.test.js, tutorialRoutes.test.js, class.routes.test.js, bookRoutes.test.js, messageRoutes.test.js, seoConfigRoutes.test.js, socialLoginConfigService.test.js, tutorialUpdateTransaction.test.js, public.routes.test.js, paymentInstallments.test.js)*
- `npm test -- tests/moderationRoutes.test.js`
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68aa3a12c04c83288b29a56c2f7c47e7