### PR TITLE
Fix messages retrieval and expose license status endpoint

### DIFF
--- a/backend/src/modules/license/license.controller.js
+++ b/backend/src/modules/license/license.controller.js
@@ -88,3 +88,16 @@ exports.listLogs = async (_req, res, next) => {
     next(err);
   }
 };
+
+/**
+ * GET /api/license/status
+ * Return current license status and suspicious count.
+ */
+exports.getStatus = async (_req, res, next) => {
+  try {
+    const status = await service.getStatus();
+    res.json({ success: true, data: status });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/backend/src/modules/license/license.routes.js
+++ b/backend/src/modules/license/license.routes.js
@@ -9,5 +9,6 @@ router.post('/activate', validate(validator.activate), controller.activateLicens
 router.post('/validate', validate(validator.validate), controller.validateLicense);
 router.post('/deactivate', validate(validator.deactivate), controller.deactivateLicense);
 router.get('/logs', verifyToken, isAdmin, controller.listLogs);
+router.get('/status', verifyToken, isAdmin, controller.getStatus);
 
 module.exports = router;

--- a/backend/src/modules/license/license.service.js
+++ b/backend/src/modules/license/license.service.js
@@ -39,3 +39,15 @@ exports.listLogs = () =>
       'lic.purchase_code'
     )
     .orderBy('l.timestamp', 'desc');
+
+exports.getStatus = async () => {
+  const license = await db('licenses').first();
+  if (!license) return null;
+  const [{ count }] = await db('suspicious_logs')
+    .where({ license_id: license.id })
+    .count('id as count');
+  return {
+    ...license,
+    unauthorized_count: Number(count) || 0,
+  };
+};

--- a/backend/src/modules/messages/messages.controller.js
+++ b/backend/src/modules/messages/messages.controller.js
@@ -5,9 +5,12 @@ const service = require("./messages.service");
 
 exports.getMyMessages = catchAsync(async (req, res) => {
   let { limit, offset } = req.query;
-  if (limit !== undefined) limit = parseInt(limit, 10);
-  if (offset !== undefined) offset = parseInt(offset, 10);
-  const data = await service.getUserMessages(req.user.id, { limit, offset });
+  const options = {};
+  if (limit !== undefined) options.limit = parseInt(limit, 10);
+  if (offset !== undefined) options.offset = parseInt(offset, 10);
+  const data = Object.keys(options).length
+    ? await service.getUserMessages(req.user.id, options)
+    : await service.getUserMessages(req.user.id);
   sendSuccess(res, data);
 });
 

--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -42,7 +42,7 @@ exports.createMessage = async (
   }
 };
 
-exports.getUserMessages = async (userId) => {
+exports.getUserMessages = async (userId, { limit, offset } = {}) => {
   if (MESSAGE_RETENTION_MS > 0) {
     const threshold = new Date(Date.now() - MESSAGE_RETENTION_MS);
     await db("messages")


### PR DESCRIPTION
## Summary
- fix undefined pagination handling in messages service
- add admin license status endpoint with unauthorized count

## Testing
- `npm test` *(fails: 14 failed, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3f534a2083288272da0a9608875c