### PR TITLE
Add admin bank transfer listing and handle invalid message pagination

### DIFF
--- a/backend/src/modules/messages/messages.controller.js
+++ b/backend/src/modules/messages/messages.controller.js
@@ -6,8 +6,14 @@ const service = require("./messages.service");
 exports.getMyMessages = catchAsync(async (req, res) => {
   let { limit, offset } = req.query;
   const options = {};
-  if (limit !== undefined) options.limit = parseInt(limit, 10);
-  if (offset !== undefined) options.offset = parseInt(offset, 10);
+  if (limit !== undefined) {
+    const parsed = parseInt(limit, 10);
+    if (!Number.isNaN(parsed)) options.limit = parsed;
+  }
+  if (offset !== undefined) {
+    const parsed = parseInt(offset, 10);
+    if (!Number.isNaN(parsed)) options.offset = parsed;
+  }
   const data = Object.keys(options).length
     ? await service.getUserMessages(req.user.id, options)
     : await service.getUserMessages(req.user.id);

--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -57,8 +57,8 @@ exports.getUserMessages = async (userId, { limit, offset } = {}) => {
     .where({ receiver_id: userId })
     .orderBy("sent_at", "desc");
 
-  if (limit !== undefined) query.limit(limit);
-  if (offset !== undefined) query.offset(offset);
+  if (Number.isFinite(limit)) query.limit(limit);
+  if (Number.isFinite(offset)) query.offset(offset);
 
   return query;
 };

--- a/backend/src/modules/payments/bank.admin.routes.js
+++ b/backend/src/modules/payments/bank.admin.routes.js
@@ -2,8 +2,10 @@ const express = require("express");
 const router = express.Router();
 const controller = require("./bank.controller");
 const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+router.use(verifyToken, isAdmin);
 
-router.post("/:id/approve", verifyToken, isAdmin, controller.approveBankPayment);
-router.post("/:id/reject", verifyToken, isAdmin, controller.rejectBankPayment);
+router.get("/", controller.getBankPayments);
+router.post("/:id/approve", controller.approveBankPayment);
+router.post("/:id/reject", controller.rejectBankPayment);
 
 module.exports = router;

--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -7,6 +7,12 @@ const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const { v4: uuidv4 } = require("uuid");
 
+exports.getBankPayments = catchAsync(async (req, res) => {
+  const { status } = req.query;
+  const data = await paymentsService.getAll(status, "bank");
+  sendSuccess(res, data);
+});
+
 exports.initiateBankPayment = catchAsync(async (req, res) => {
   const { item_type, item_id, amount, currency } = req.body;
   const user_id = req.user?.id;

--- a/backend/src/modules/payments/payments.service.js
+++ b/backend/src/modules/payments/payments.service.js
@@ -20,7 +20,7 @@ exports.create = async (data, schedules = []) => {
   });
 };
 
-exports.getAll = async (status) => {
+exports.getAll = async (status, methodType) => {
   const query = db({ p: "payments" })
     .leftJoin("users as u", "p.user_id", "u.id")
     .leftJoin("payment_methods_config as m", "p.method_id", "m.id")
@@ -34,6 +34,10 @@ exports.getAll = async (status) => {
 
   if (status) {
     query.where("p.status", status);
+  }
+
+  if (methodType) {
+    query.andWhere("m.type", methodType);
   }
 
   return query;


### PR DESCRIPTION
## Summary
- add GET /admin/payments/bank route for bank transfer approvals
- support method filtering in payment service
- guard message listing from invalid limit/offset values

## Testing
- `npm test --silent` *(fails: Test Suites: 14 failed, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3f2d21f083289e78f4c03cd74e1c