### PR TITLE
Add chat moderation table migration

### DIFF
--- a/backend/src/migrations/20250909000000_create_chat_moderation_table.js
+++ b/backend/src/migrations/20250909000000_create_chat_moderation_table.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'chat_moderation';
+
+exports.up = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, (table) => {
+    table.increments('id').primary();
+    table
+      .uuid('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.text('message').notNullable();
+    table.jsonb('matched_words').notNullable().defaultTo('[]');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists(TABLE_NAME);
+};


### PR DESCRIPTION
## Summary
- create `chat_moderation` table migration

## Testing
- `npm test` *(fails: Test Suites: 14 failed, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa468f31fc832881cf97c8a35f0fbb