### PR TITLE
Remove redundant self-message after password reset

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -384,13 +384,6 @@ exports.resetPassword = async ({ email, code, new_password }) => {
     type: "security",
     message: "Your password was changed successfully",
   });
-
-
-  await messageService.createMessage({
-    sender_id: user.id,
-    receiver_id: user.id,
-    message: "Your password was changed successfully",
-  });
   return sanitizeUserUtil(user);
 };
 

--- a/backend/tests/authResetPasswordService.test.js
+++ b/backend/tests/authResetPasswordService.test.js
@@ -1,0 +1,84 @@
+jest.mock('../src/config/database', () => {
+  const passwordResetsTable = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    first: jest.fn().mockResolvedValue({ id: 1, code_hash: 'otp_hash' }),
+    update: jest.fn().mockResolvedValue(),
+  };
+
+  const usersTable = {
+    where: jest.fn().mockReturnValue({
+      update: jest.fn().mockResolvedValue(),
+    }),
+  };
+
+  const db = jest.fn((table) => {
+    if (table === 'password_resets') return passwordResetsTable;
+    if (table === 'users') return usersTable;
+    return {};
+  });
+
+  return db;
+});
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findByEmail: jest.fn(),
+}));
+
+jest.mock('../src/utils/email', () => ({
+  sendPasswordChangeEmail: jest.fn(),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/modules/auth/utils/sanitizeUser', () => jest.fn((u) => u));
+
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
+
+const authService = require('../src/modules/auth/services/auth.service');
+const userModel = require('../src/modules/users/user.model');
+const { sendPasswordChangeEmail } = require('../src/utils/email');
+const notificationService = require('../src/modules/notifications/notifications.service');
+const messageService = require('../src/modules/messages/messages.service');
+const bcrypt = require('bcrypt');
+
+describe('resetPassword service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends notification but not self message', async () => {
+    userModel.findByEmail.mockResolvedValue({
+      id: 1,
+      email: 'test@example.com',
+      password_hash: 'old_hash',
+    });
+
+    bcrypt.compare.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    bcrypt.hash.mockResolvedValue('new_hash');
+
+    await authService.resetPassword({
+      email: 'test@example.com',
+      code: '123456',
+      new_password: 'NewPass1!',
+    });
+
+    expect(sendPasswordChangeEmail).toHaveBeenCalledWith('test@example.com');
+    expect(notificationService.createNotification).toHaveBeenCalledWith({
+      user_id: 1,
+      type: 'security',
+      message: 'Your password was changed successfully',
+    });
+    expect(messageService.createMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Stop creating a message to the user from themselves when resetting password
- Add unit test ensuring password reset sends notification but no self-message

## Testing
- `npm test tests/authResetPasswordService.test.js`
- `npm test` *(fails: 14 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68aa47b79b008328b6f9f0600b417db0