### PR TITLE
refactor: centralize social auth callback logic

### DIFF
--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -3,85 +3,43 @@ const { passport } = require('../../../config/passport');
 const { refreshCookieOptions } = require('../../../utils/cookie');
 const { frontendBase, allowedOrigins } = require('../../../utils/frontend');
 
+// Shared callback handler for social auth providers
+const handleCallback = (provider) => (req, res, next) => {
+  passport.authenticate(provider, { session: false }, (err, result) => {
+    if (err || !result) {
+      return res.redirect(`${frontendBase}/auth/login?error=social`);
+    }
+    const { refreshToken } = result;
+    res.cookie('refreshToken', refreshToken, refreshCookieOptions);
+    let origin = req.query.origin;
+    if (!allowedOrigins.includes(origin)) {
+      const headerOrigin = req.get('origin');
+      origin = allowedOrigins.includes(headerOrigin) ? headerOrigin : frontendBase;
+    }
+    const redirectUrl = `${origin}/auth/social-success`;
+    res.redirect(redirectUrl);
+  })(req, res, next);
+};
+
 
 // Google OAuth
 exports.googleAuth = passport.authenticate('google', {
   scope: ['profile', 'email'],
 });
 
-exports.googleCallback = (req, res, next) => {
-  passport.authenticate('google', { session: false }, (err, result) => {
-    if (err || !result) {
-      return res.redirect(`${frontendBase}/auth/login?error=social`);
-    }
-    const { refreshToken } = result;
-    res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    let origin = req.query.origin;
-    if (!allowedOrigins.includes(origin)) {
-      const headerOrigin = req.get('origin');
-      origin = allowedOrigins.includes(headerOrigin) ? headerOrigin : frontendBase;
-    }
-    const redirectUrl = `${origin}/auth/social-success`;
-    res.redirect(redirectUrl);
-  })(req, res, next);
-};
+exports.googleCallback = handleCallback('google');
 
 // Facebook OAuth
 exports.facebookAuth = passport.authenticate('facebook', { scope: ['email'] });
 
-exports.facebookCallback = (req, res, next) => {
-  passport.authenticate('facebook', { session: false }, (err, result) => {
-    if (err || !result) {
-      return res.redirect(`${frontendBase}/auth/login?error=social`);
-    }
-    const { refreshToken } = result;
-    res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    let origin = req.query.origin;
-    if (!allowedOrigins.includes(origin)) {
-      const headerOrigin = req.get('origin');
-      origin = allowedOrigins.includes(headerOrigin) ? headerOrigin : frontendBase;
-    }
-    const redirectUrl = `${origin}/auth/social-success`;
-    res.redirect(redirectUrl);
-  })(req, res, next);
-};
+exports.facebookCallback = handleCallback('facebook');
 
 // Apple OAuth
 exports.appleAuth = passport.authenticate('apple', { scope: ['name', 'email'] });
 
-exports.appleCallback = (req, res, next) => {
-  passport.authenticate('apple', { session: false }, (err, result) => {
-    if (err || !result) {
-      return res.redirect(`${frontendBase}/auth/login?error=social`);
-    }
-    const { refreshToken } = result;
-    res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    let origin = req.query.origin;
-    if (!allowedOrigins.includes(origin)) {
-      const headerOrigin = req.get('origin');
-      origin = allowedOrigins.includes(headerOrigin) ? headerOrigin : frontendBase;
-    }
-    const redirectUrl = `${origin}/auth/social-success`;
-    res.redirect(redirectUrl);
-  })(req, res, next);
-};
+exports.appleCallback = handleCallback('apple');
 
 // GitHub OAuth
 exports.githubAuth = passport.authenticate('github', { scope: ['user:email'] });
 
-exports.githubCallback = (req, res, next) => {
-  passport.authenticate('github', { session: false }, (err, result) => {
-    if (err || !result) {
-      return res.redirect(`${frontendBase}/auth/login?error=social`);
-    }
-    const { refreshToken } = result;
-    res.cookie('refreshToken', refreshToken, refreshCookieOptions);
-    let origin = req.query.origin;
-    if (!allowedOrigins.includes(origin)) {
-      const headerOrigin = req.get('origin');
-      origin = allowedOrigins.includes(headerOrigin) ? headerOrigin : frontendBase;
-    }
-    const redirectUrl = `${origin}/auth/social-success`;
-    res.redirect(redirectUrl);
-  })(req, res, next);
-};
+exports.githubCallback = handleCallback('github');


### PR DESCRIPTION
## Summary
- add shared handler for social OAuth callbacks
- use helper in google, facebook, apple, and github callbacks

## Testing
- `cd backend && npm test` *(fails: 14 failing test suites, 70 passing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa47b51dac83289d635594e6e4d6ad