### PR TITLE
refactor: centralize role helpers

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -5,21 +5,7 @@ const {
   addToken: addTokenToStore,
   isTokenBlacklisted,
 } = require("../../services/tokenBlacklistService");
-
-/**
- * ✅ Helper: Determines if a role has admin-level access
- */
-// Normalize role string for consistent comparisons
-// Guard against null/undefined or non-string values to avoid runtime errors
-const normalizeRole = (role) =>
-  typeof role === "string" ? role.toLowerCase().replace(/\s+/g, "") : "";
-
-const isAdminRole = (roles = []) => {
-  const arr = Array.isArray(roles) ? roles : [roles];
-  return arr
-    .map((r) => normalizeRole(r))
-    .some((r) => ["admin", "superadmin"].includes(r));
-};
+const { normalizeRole, isAdminRole } = require("../../utils/role");
 
 
 /**

--- a/backend/src/middleware/auth/verifyClassOwnership.js
+++ b/backend/src/middleware/auth/verifyClassOwnership.js
@@ -1,7 +1,6 @@
 const logger = require('../../utils/logger.js');
 const db = require("../../config/database");
-
-const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
+const { isAdminRole } = require("../../utils/role");
 
 module.exports = async function verifyClassOwnership(req, res, next) {
   const classId = req.params.id || req.params.classId;
@@ -14,9 +13,7 @@ module.exports = async function verifyClassOwnership(req, res, next) {
     if (!cls) return res.status(404).json({ message: "Class not found" });
 
     const roles = req.user.roles || [req.user.role];
-    const isAdmin = roles
-      .map((r) => normalizeRole(r))
-      .some((r) => ["admin", "superadmin"].includes(r));
+    const isAdmin = isAdminRole(roles);
 
     if (cls.instructor_id !== req.user.id && !isAdmin) {
       return res.status(403).json({ message: "Access denied" });

--- a/backend/src/middleware/auth/verifyTutorialAccess.js
+++ b/backend/src/middleware/auth/verifyTutorialAccess.js
@@ -1,7 +1,6 @@
 const logger = require('../../utils/logger.js');
 const db = require("../../config/database");
-
-const normalizeRole = (role = "") => role.toLowerCase().replace(/\s+/g, "");
+const { normalizeRole, isAdminRole } = require("../../utils/role");
 
 module.exports = async function verifyTutorialAccess(req, res, next) {
   const { tutorialId } = req.params;
@@ -16,8 +15,8 @@ module.exports = async function verifyTutorialAccess(req, res, next) {
     if (!tutorial) return res.status(404).json({ message: "Tutorial not found" });
 
     const roles = req.user.roles || [req.user.role];
+    const isAdmin = isAdminRole(roles);
     const norm = roles.map((r) => normalizeRole(r));
-    const isAdmin = norm.some((r) => ["admin", "superadmin"].includes(r));
     const isInstructor = norm.includes("instructor") && tutorial.instructor_id === userId;
 
     if (!isAdmin && !isInstructor) {

--- a/backend/src/utils/role.js
+++ b/backend/src/utils/role.js
@@ -1,0 +1,14 @@
+const normalizeRole = (role) =>
+  typeof role === "string" ? role.toLowerCase().replace(/\s+/g, "") : "";
+
+const isAdminRole = (roles = []) => {
+  const arr = Array.isArray(roles) ? roles : [roles];
+  return arr
+    .map((r) => normalizeRole(r))
+    .some((r) => ["admin", "superadmin"].includes(r));
+};
+
+module.exports = {
+  normalizeRole,
+  isAdminRole,
+};


### PR DESCRIPTION
## Summary
- add `normalizeRole` and `isAdminRole` utilities
- reuse centralized role helpers across auth middleware and access checks

## Testing
- `npm test` *(fails: Expected 200 Received 400, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa47b27ad48328aff0b83cfee3cc30