### PR TITLE
fix: guard token verification when secret missing

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -46,6 +46,11 @@ const verifyToken = async (req, res, next) => {
   }
 
   try {
+    if (!process.env.JWT_SECRET) {
+      return res
+        .status(500)
+        .json({ message: "JWT secret not configured" });
+    }
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     const user = await userModel.findById(decoded.id);
     if (!user) {


### PR DESCRIPTION
## Summary
- guard jwt verification by checking for missing JWT secret

## Testing
- `JWT_SECRET=testsecret npm test` *(fails: Test Suites: 14 failed, 70 passed, 84 total)*

------
https://chatgpt.com/codex/tasks/task_e_68aa47aed46c8328b6f047098e229ac3