### PR TITLE
Use crypto.randomInt for OTP generation

### DIFF
--- a/backend/src/modules/auth/utils/otp.js
+++ b/backend/src/modules/auth/utils/otp.js
@@ -5,12 +5,13 @@
  * @param {number} length - Length of OTP (default: 6)
  * @returns {string} - A zero-padded numeric OTP (e.g. "045321")
  */
+const crypto = require("crypto");
 const { OTP_LENGTH } = require("../constants");
 
 exports.generateOtp = (length = OTP_LENGTH) => {
   const min = Math.pow(10, length - 1);
   const max = Math.pow(10, length) - 1;
-  return Math.floor(Math.random() * (max - min + 1)) + min + "";
+  return crypto.randomInt(min, max + 1).toString().padStart(length, "0");
 };
 
 /**


### PR DESCRIPTION
## Summary
- Improve OTP generator to use cryptographically strong `crypto.randomInt`
- Ensure generated OTP is returned as a zero-padded string

## Testing
- `npm test` *(fails: 14 failed, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa47a83c048328a3bbf56817e63b83