### PR TITLE
Set preview URL fallback for books

### DIFF
--- a/frontend/src/services/bookService.js
+++ b/frontend/src/services/bookService.js
@@ -13,11 +13,16 @@ const formatBook = (book) => {
     }
   }
 
+  let previewUrl = buildUrl(book?.preview_url);
+  if (book?.allow_preview && !previewUrl && previewPages.length > 0) {
+    previewUrl = previewPages[0];
+  }
+
   const formatted = {
     ...book,
     cover_image_url: buildUrl(book?.cover_image_url || book?.cover_image),
     pdf_url: buildUrl(book?.pdf_url),
-    preview_url: buildUrl(book?.preview_url),
+    preview_url: previewUrl,
     preview_pages: previewPages,
   };
 

--- a/frontend/src/tests/__tests__/bookService.test.js
+++ b/frontend/src/tests/__tests__/bookService.test.js
@@ -141,6 +141,18 @@ describe("bookService", () => {
     });
   });
 
+  it("falls back to first preview page when preview_url is missing", async () => {
+    const apiData = {
+      id: 4,
+      allow_preview: true,
+      preview_pages: ["/uploads/a.png", "/uploads/b.png"],
+    };
+    api.get.mockResolvedValueOnce({ data: { data: apiData } });
+    const book = await fetchBook(4);
+    expect(book.preview_pages).toEqual(["/uploads/a.png", "/uploads/b.png"]);
+    expect(book.preview_url).toBe("/uploads/a.png");
+  });
+
   it("returns null when book is not found", async () => {
     const error = { response: { status: 404 } };
     api.get.mockRejectedValueOnce(error);


### PR DESCRIPTION
## Summary
- default preview_url to the first preview page when allow_preview is true
- add tests covering preview_url fallback behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4c4919b083289cf2d5ecb60db790