### PR TITLE
Ensure only purchasers can leave book reviews

### DIFF
--- a/backend/src/modules/bookReviews/bookReview.controller.js
+++ b/backend/src/modules/bookReviews/bookReview.controller.js
@@ -10,6 +10,7 @@ exports.listReviews = catchAsync(async (req, res) => {
 
 exports.createReview = catchAsync(async (req, res) => {
   const payload = { ...req.body, user_id: req.user?.id };
+  await service.ensurePurchased(payload.user_id, payload.book_id);
   const [review] = await service.createReview(payload);
   sendSuccess(res, review, "Review created");
 });

--- a/backend/src/modules/bookReviews/bookReview.service.js
+++ b/backend/src/modules/bookReviews/bookReview.service.js
@@ -1,4 +1,14 @@
 const model = require("./bookReview.model");
+const db = require("../../config/database");
+const AppError = require("../../utils/AppError");
+
+exports.ensurePurchased = async (studentId, bookId) => {
+  const row = await db("book_purchases")
+    .where({ student_id: studentId, book_id: bookId })
+    .first();
+  if (!row) throw new AppError("Book not purchased", 403);
+  return row;
+};
 
 exports.createReview = (data) => model.create(data);
 


### PR DESCRIPTION
## Summary
- verify book purchases exist before creating a review
- add service to enforce purchase requirement

## Testing
- `npm test` *(fails: 14 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4c4cfb6c8328a0de41a5e1a4b785