### PR TITLE
Link online class add-to-cart with checkout

### DIFF
--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -89,7 +89,7 @@ export default function ClassDetailsPage() {
     try {
       await addItem({ id: classInfo.id, name: classInfo.title, price: classInfo.price });
       toast.success(t('added_to_cart'));
-      router.push('/cart');
+      router.push(`/payments/checkout?itemId=${classInfo.id}&itemType=class`);
     } catch (err) {
       console.error('Failed to add to cart', err);
       toast.error(t('failed_to_add_to_cart'));
@@ -120,7 +120,7 @@ export default function ClassDetailsPage() {
         toast.error(t('failed_to_enroll'));
       }
     } else {
-      router.push(`/payments/checkout?classId=${classInfo.id}`);
+      router.push(`/payments/checkout?itemId=${classInfo.id}&itemType=class`);
     }
   };
 


### PR DESCRIPTION
## Summary
- Redirect online class add-to-cart flow directly to checkout with the selected class
- Use itemId and itemType query parameters when proceeding to checkout from class page

## Testing
- `npm test`
- `npm run lint` *(fails: 49 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4d40cb64832888ec777a5fff902a