### PR TITLE
feat: secure book downloads

### DIFF
--- a/backend/src/modules/library/library.controller.js
+++ b/backend/src/modules/library/library.controller.js
@@ -23,5 +23,12 @@ exports.downloadBook = catchAsync(async (req, res) => {
   if (!fs.existsSync(filePath)) {
     return res.status(404).json({ message: "File not found" });
   }
-  res.download(filePath, `${book.title || "book"}.pdf`);
+
+  res.setHeader("Content-Type", "application/pdf");
+  res.setHeader(
+    "Content-Disposition",
+    `attachment; filename="${(book.title || "book").replace(/"/g, '')}.pdf"`
+  );
+  const stream = fs.createReadStream(filePath);
+  stream.pipe(res);
 });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -105,8 +105,17 @@ app.use(passport.initialize());
 
 
 
-app.use("/uploads", express.static(path.join(__dirname, "../uploads")));
-app.use("/api/uploads", express.static(path.join(__dirname, "../uploads")));
+// Restrict direct PDF access from the uploads folder
+const uploadsPath = path.join(__dirname, "../uploads");
+const serveUploads = express.static(uploadsPath);
+const blockPdfMiddleware = (req, res, next) => {
+  if (req.path.toLowerCase().endsWith(".pdf")) {
+    return res.status(403).json({ message: "Direct PDF access is forbidden" });
+  }
+  return serveUploads(req, res, next);
+};
+app.use("/uploads", blockPdfMiddleware);
+app.use("/api/uploads", blockPdfMiddleware);
 app.use((req, res, next) => {
   res.setHeader("Access-Control-Allow-Private-Network", "true");
   next();

--- a/frontend/src/components/books/BookCard.js
+++ b/frontend/src/components/books/BookCard.js
@@ -11,6 +11,7 @@ import {
 } from "react-icons/fi";
 import { buildUrl } from "@/utils/url";
 import { formatCurrency } from "@/utils/currency";
+import { API_BASE_URL } from "@/config/config";
 
 export default function BookCard({
   book,
@@ -92,9 +93,9 @@ export default function BookCard({
             <FiEye />
             <span className="sr-only">{t("view")}</span>
           </Link>
-          {showReadLink && book.pdf_url && (
+          {showReadLink && book.id && (
             <a
-              href={book.pdf_url}
+              href={`${API_BASE_URL}/library/download/${book.id}`}
               target="_blank"
               rel="noopener noreferrer"
               className="p-2 rounded-full bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors"

--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -7,6 +7,7 @@ import useAuthStore from "@/store/auth/authStore";
 import { useTranslation } from "next-i18next";
 import { formatCurrency } from "@/utils/currency";
 import { mapBookForCart } from "@/utils/bookMapping";
+import { API_BASE_URL } from "@/config/config";
 
 export default function BookDetails({ book }) {
   const { t } = useTranslation(["website", "common"]);
@@ -36,11 +37,13 @@ export default function BookDetails({ book }) {
   };
 
   let actionButtons = null;
+  const downloadUrl = `${API_BASE_URL}/library/download/${book.id}`;
+
   if (book.is_paid) {
     if (book.user_has_access) {
       actionButtons = (
         <a
-          href={book.pdf_url}
+          href={downloadUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-block px-6 py-3 rounded-lg bg-green-500 text-white font-semibold hover:bg-green-600 transition-colors"
@@ -74,7 +77,7 @@ export default function BookDetails({ book }) {
   } else {
     actionButtons = (
       <a
-        href={book.pdf_url}
+        href={downloadUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="inline-block px-6 py-3 rounded-lg bg-yellow-500 text-gray-900 font-semibold hover:bg-yellow-400 transition-colors"

--- a/frontend/src/components/books/LibraryItem.js
+++ b/frontend/src/components/books/LibraryItem.js
@@ -1,4 +1,4 @@
-import { buildUrl } from "@/utils/url";
+import { API_BASE_URL } from "@/config/config";
 
 export default function LibraryItem({ item }) {
   return (
@@ -10,7 +10,7 @@ export default function LibraryItem({ item }) {
         )}
       </div>
       <a
-        href={buildUrl(item.pdfUrl)}
+        href={`${API_BASE_URL}/library/download/${item.id}`}
         className="text-blue-600 underline"
       >
         Download

--- a/frontend/src/pages/dashboard/admin/books/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/view/[id].js
@@ -18,6 +18,7 @@ import ConfirmModal from "@/components/common/ConfirmModal";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import { API_BASE_URL } from "@/config/config";
 
 function AdminViewBookPage() {
   const router = useRouter();
@@ -253,7 +254,7 @@ function AdminViewBookPage() {
                 <div className="flex flex-wrap gap-4">
                   {book.pdf_url && (
                     <a
-                      href={book.pdf_url}
+                      href={`${API_BASE_URL}/library/download/${book.id}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors duration-200"

--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -5,6 +5,7 @@ import { useTranslation } from "next-i18next";
 import { toast } from "react-hot-toast";
 import useLibraryStore from "@/store/libraryStore";
 import useBookWishlistStore from "@/store/books/wishlistStore";
+import { API_BASE_URL } from "@/config/config";
 
 function BookCard({ book }) {
   const { t } = useTranslation("dashboard", { keyPrefix: "booksPage" });
@@ -79,17 +80,16 @@ function BookCard({ book }) {
             <FiEye className="text-lg" /> {t("preview")}
           </a>
         )}
-        {book.pdf_url && (
+        {
           <a
-            href={book.pdf_url}
+            href={`${API_BASE_URL}/library/download/${book.id}`}
             target="_blank"
             rel="noopener noreferrer"
-            download
             className="flex items-center gap-1 text-green-600 hover:underline"
           >
             <FiDownload className="text-lg" /> {t("download")}
           </a>
-        )}
+        }
         <button
           className={
             isWishlisted ? "text-red-500" : "text-red-400 hover:text-red-500"


### PR DESCRIPTION
## Summary
- block direct PDF requests in uploads to prevent unauthenticated access
- stream book files through new /api/library/download/:bookId route
- update book download links across UI to use authenticated endpoint

## Testing
- `cd backend && npm test` *(fails: adsRoutes.test.js, bookRoutes.test.js, messageRoutes.test.js, tutorialRoutes.test.js, tutorialUpdateTransaction.test.js, paymentCommission.test.js, seoConfigRoutes.test.js, blogRoutes.test.js, paymentInstallments.test.js)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4c4eb19883289a57050e179bcad9