### PR TITLE
Add installation helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 SkillBridge is a full-stack learning platform powered by an Express.js backend and a Next.js frontend. Docker Compose is used to run the API, database and web application locally with minimal configuration.
 
+## Automated Installation
+
+```bash
+curl -s https://example.com/install.sh | bash
+```
+
+The script checks prerequisites, copies example env files, builds containers and seeds the database.
+
 ## Quick start
 
 1. Copy the example environment file and adjust values as needed:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/scripts/check_prereqs.sh"
+
+# Clone repository if not already inside one
+if [ ! -d "$SCRIPT_DIR/.git" ]; then
+  REPO_URL=${REPO_URL:-https://github.com/example/Skillbridge.git}
+  git clone "$REPO_URL" Skillbridge
+  cd Skillbridge
+  SCRIPT_DIR="$(pwd)"
+else
+  cd "$SCRIPT_DIR"
+fi
+
+# Copy env templates
+if [ ! -f backend/.env ]; then
+  cp backend/.env.example backend/.env
+fi
+if [ ! -f frontend/.env.local ]; then
+  cp frontend/.env.local.example frontend/.env.local
+fi
+
+# Determine docker compose command
+if command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  DOCKER_COMPOSE="docker compose"
+fi
+
+$DOCKER_COMPOSE up -d --build
+
+scripts/init_db.sh
+
+cat <<INFO
+Application is running.
+
+Frontend: http://localhost:3000
+API:      http://localhost:5002
+
+Seeded accounts:
+  SuperAdmin: support@eduskillbridge.net
+  Admin:      admin@eduskillbridge.net
+Check above output for generated passwords or set ADMIN_INITIAL_PASSWORD and SUPERADMIN_INITIAL_PASSWORD in backend/.env before running.
+INFO

--- a/scripts/check_prereqs.sh
+++ b/scripts/check_prereqs.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+# Verify Node.js
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required. Please install Node.js 18 or newer." >&2
+  exit 1
+fi
+NODE_MAJOR=$(node -v | sed -E 's/^v([0-9]+).*/\1/')
+if [ "$NODE_MAJOR" -lt 18 ]; then
+  echo "Node.js version 18 or higher is required. Current version: $(node -v)" >&2
+  exit 1
+fi
+
+# Verify Docker
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required. Please install Docker." >&2
+  exit 1
+fi
+
+# Verify Docker Compose
+if command -v docker-compose >/dev/null 2>&1; then
+  :
+elif docker compose version >/dev/null 2>&1; then
+  :
+else
+  echo "Docker Compose is required. Please install Docker Compose." >&2
+  exit 1
+fi
+
+# Verify Git
+if ! command -v git >/dev/null 2>&1; then
+  echo "Git is required. Please install Git." >&2
+  exit 1
+fi
+
+echo "All prerequisites met."

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# Determine docker compose command
+if command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  DOCKER_COMPOSE="docker compose"
+fi
+
+if [ -n "$($DOCKER_COMPOSE ps -q backend 2>/dev/null)" ]; then
+  echo "Running migrations inside backend container..."
+  $DOCKER_COMPOSE exec backend npx knex migrate:latest --knexfile knexfile.js
+  $DOCKER_COMPOSE exec backend npx knex seed:run --knexfile knexfile.js
+else
+  echo "Running migrations locally..."
+  npx knex migrate:latest --knexfile backend/knexfile.js
+  npx knex seed:run --knexfile backend/knexfile.js
+fi


### PR DESCRIPTION
## Summary
- add prerequisite checker for Node.js, Docker, Docker Compose and Git
- add database initialization script that runs locally or inside Docker
- add umbrella install script and document automated installation in README

## Testing
- `npm test` (backend) *(fails: 14 failed, 71 passed, 85 total)*
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68aa5156ca1c8328bfe0e8fe7477ffee