### PR TITLE
Link hero actions to homepage sections and polish search

### DIFF
--- a/frontend/src/components/website/sections/BooksSection.js
+++ b/frontend/src/components/website/sections/BooksSection.js
@@ -38,7 +38,7 @@ const BooksSection = () => {
   }, []);
 
   return (
-    <section className="bg-gray-950 py-16 text-white text-center">
+    <section id="books" className="bg-gray-950 py-16 text-white text-center">
       <motion.h2
         className="text-3xl sm:text-4xl font-bold text-yellow-400 mb-4"
         initial={{ opacity: 0, y: -20 }}

--- a/frontend/src/components/website/sections/CommunityEngagement.js
+++ b/frontend/src/components/website/sections/CommunityEngagement.js
@@ -57,7 +57,7 @@ const CommunityLandingPage = () => {
 
 
   return (
-    <div className="bg-gray-900 min-h-screen text-white">
+    <div id="community" className="bg-gray-900 min-h-screen text-white">
       <motion.section
         initial={{ opacity: 0, y: 50 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -172,6 +172,13 @@ const Hero = () => {
     handleSearch(selectedValue);
   };
 
+  const scrollToSection = (id) => {
+    if (typeof document !== "undefined") {
+      const el = document.getElementById(id);
+      el && el.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
   return (
     <motion.section
       initial={{ opacity: 0, y: 50 }}
@@ -406,29 +413,25 @@ const Hero = () => {
           {/* CTA Buttons */}
           <motion.div className="flex flex-wrap justify-center gap-4">
 
-            <Link href="/community">
-              <button className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition shadow-lg flex items-center gap-2">
-                <FaQuestionCircle /> {t('ask_question')}
-              </button>
-            </Link>
+            <button onClick={() => scrollToSection('community')}
+              className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition shadow-lg flex items-center gap-2">
+              <FaQuestionCircle /> {t('ask_question')}
+            </button>
 
-            <Link href="/online-classes">
-              <button className="px-6 py-3 bg-green-600 text-white rounded-lg font-semibold hover:bg-green-700 transition shadow-lg flex items-center gap-2">
-                <FaChalkboardTeacher /> {t('browse_online_classes')}
-              </button>
-            </Link>
+            <button onClick={() => scrollToSection('online-classes')}
+              className="px-6 py-3 bg-green-600 text-white rounded-lg font-semibold hover:bg-green-700 transition shadow-lg flex items-center gap-2">
+              <FaChalkboardTeacher /> {t('browse_online_classes')}
+            </button>
 
-            <Link href="/tutorials">
-              <button className="px-6 py-3 bg-purple-600 text-white rounded-lg font-semibold hover:bg-purple-700 transition shadow-lg flex items-center gap-2">
-                <FaBookOpen /> {t('explore_tutorials')}
-              </button>
-            </Link>
+            <button onClick={() => scrollToSection('tutorials')}
+              className="px-6 py-3 bg-purple-600 text-white rounded-lg font-semibold hover:bg-purple-700 transition shadow-lg flex items-center gap-2">
+              <FaBookOpen /> {t('explore_tutorials')}
+            </button>
 
-            <Link href="/marketplace/books">
-              <button className="px-6 py-3 bg-pink-600 text-white rounded-lg font-semibold hover:bg-pink-700 transition shadow-lg flex items-center gap-2">
-                <FaBook /> {t('explore_books')}
-              </button>
-            </Link>
+            <button onClick={() => scrollToSection('books')}
+              className="px-6 py-3 bg-pink-600 text-white rounded-lg font-semibold hover:bg-pink-700 transition shadow-lg flex items-center gap-2">
+              <FaBook /> {t('explore_books')}
+            </button>
           </motion.div>
         </div>
 

--- a/frontend/src/components/website/sections/OnlineClasses.js
+++ b/frontend/src/components/website/sections/OnlineClasses.js
@@ -105,7 +105,7 @@ const OnlineClasses = () => {
   };
 
   return (
-    <div className="bg-gray-900 min-h-screen text-white">
+    <div id="online-classes" className="bg-gray-900 min-h-screen text-white">
       <motion.section
         initial={{ opacity: 0, y: 50 }}
         animate={{ opacity: 1, y: 0 }}

--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -182,7 +182,7 @@ const LandingTutorialsSection = () => {
         });
 
   return (
-    <section className="bg-gray-950 py-16 text-white px-4 sm:px-6">
+    <section id="tutorials" className="bg-gray-950 py-16 text-white px-4 sm:px-6">
       <div className="max-w-7xl mx-auto">
         <motion.h2
           className="text-3xl sm:text-4xl font-bold text-center text-yellow-400 mb-4"


### PR DESCRIPTION
## Summary
- Scroll hero action buttons to community, online classes, tutorials, and books sections
- Expose section IDs for smooth scrolling
- Add helper to smoothly navigate to sections from hero

## Testing
- `npm test`
- `npm run lint` *(fails: 49 errors, existing)*
- `npx eslint src/components/website/sections/Hero.js src/components/website/sections/OnlineClasses.js src/components/website/sections/TutorialsSection.js src/components/website/sections/BooksSection.js src/components/website/sections/CommunityEngagement.js`

------
https://chatgpt.com/codex/tasks/task_e_68aa523c95a8832892e5d0d1bd177857