### PR TITLE
Add installation helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 SkillBridge is a full-stack learning platform powered by an Express.js backend and a Next.js frontend. Docker Compose is used to run the API, database and web application locally with minimal configuration.
 
+## Automated Installation
+
+```bash
+curl -s https://example.com/install.sh | bash
+```
+
+The script checks prerequisites, copies example env files, builds containers and seeds the database.
+
+Alternatively, launch the backend and open [`/install`](http://localhost:5002/install) to use a simple web-based installer that checks prerequisites and runs the setup scripts after entering configuration values.
+
 ## Quick start
 
 1. Copy the example environment file and adjust values as needed:

--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -1,0 +1,24 @@
+const { execFile } = require('child_process');
+const path = require('path');
+
+exports.checkPrereqs = (req, res) => {
+  const script = path.join(__dirname, '../../../../scripts/check_prereqs.sh');
+  execFile(script, (error, stdout, stderr) => {
+    const output = stdout + stderr;
+    if (error) {
+      return res.status(500).json({ ok: false, output });
+    }
+    res.json({ ok: true, output });
+  });
+};
+
+exports.runInstall = (req, res) => {
+  const script = path.join(__dirname, '../../../../install.sh');
+  execFile(script, (error, stdout, stderr) => {
+    const output = stdout + stderr;
+    if (error) {
+      return res.status(500).json({ ok: false, output });
+    }
+    res.json({ ok: true, output });
+  });
+};

--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const controller = require('./install.controller');
+
+router.get('/prereqs', controller.checkPrereqs);
+router.post('/run', controller.runInstall);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -121,6 +121,9 @@ app.use((req, res, next) => {
   next();
 });
 
+const installerPath = path.join(__dirname, "../../install");
+app.use("/install", express.static(installerPath));
+
 // ─── Routes ───
 app.use("/api/auth", require("./modules/auth/routes/auth.routes"));
 app.use("/api/users", require("./modules/users/user.routes"));
@@ -201,6 +204,7 @@ app.use("/api/instructor/books", require("./modules/books/instructorBook.routes"
 app.use("/api/book-reviews", require("./modules/bookReviews/bookReview.routes"));
 app.use("/api/library", require("./modules/library/library.routes"));
 app.use("/api/search", require("./modules/search/search.routes"));
+app.use("/api/install", require("./modules/install/install.routes"));
 
 // Generate secure video room link for a lesson
 app.post("/api/users/classes/lessons/:lessonId/room", verifyToken, async (req, res) => {

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/scripts/check_prereqs.sh"
+
+# Clone repository if not already inside one
+if [ ! -d "$SCRIPT_DIR/.git" ]; then
+  REPO_URL=${REPO_URL:-https://github.com/example/Skillbridge.git}
+  git clone "$REPO_URL" Skillbridge
+  cd Skillbridge
+  SCRIPT_DIR="$(pwd)"
+else
+  cd "$SCRIPT_DIR"
+fi
+
+# Copy env templates
+if [ ! -f backend/.env ]; then
+  cp backend/.env.example backend/.env
+fi
+if [ ! -f frontend/.env.local ]; then
+  cp frontend/.env.local.example frontend/.env.local
+fi
+
+# Determine docker compose command
+if command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  DOCKER_COMPOSE="docker compose"
+fi
+
+$DOCKER_COMPOSE up -d --build
+
+"$SCRIPT_DIR/scripts/init_db.sh"
+
+cat <<INFO
+Application is running.
+
+Frontend: http://localhost:3000
+API:      http://localhost:5002
+
+Seeded accounts:
+  SuperAdmin: support@eduskillbridge.net
+  Admin:      admin@eduskillbridge.net
+Check above output for generated passwords or set ADMIN_INITIAL_PASSWORD and SUPERADMIN_INITIAL_PASSWORD in backend/.env before running.
+INFO

--- a/install/index.html
+++ b/install/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SkillBridge Installer</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+  <h1>SkillBridge Installation</h1>
+  <section id="step1">
+    <h2>Step 1: Prerequisite Check</h2>
+    <button id="checkBtn">Recheck</button>
+    <pre id="prereqOutput"></pre>
+  </section>
+  <section id="step2" style="display: none;">
+    <h2>Step 2: Configuration</h2>
+    <form id="configForm">
+      <label>
+        Admin Email
+        <input type="email" name="adminEmail" required />
+      </label>
+      <br />
+      <label>
+        Admin Password
+        <input type="password" name="adminPassword" required />
+      </label>
+      <br />
+      <button type="submit">Run Install</button>
+    </form>
+    <pre id="installOutput"></pre>
+  </section>
+  <script src="install.js" defer></script>
+</body>
+</html>

--- a/install/install.js
+++ b/install/install.js
@@ -1,0 +1,42 @@
+async function checkPrereqs() {
+  const output = document.getElementById('prereqOutput');
+  output.textContent = 'Checking...';
+  try {
+    const res = await fetch('/api/install/prereqs');
+    const data = await res.json();
+    output.textContent = data.output || JSON.stringify(data, null, 2);
+    if (data.ok) {
+      document.getElementById('step2').style.display = 'block';
+    } else {
+      document.getElementById('step2').style.display = 'none';
+    }
+  } catch (err) {
+    output.textContent = 'Error: ' + err.message;
+  }
+}
+
+document.getElementById('checkBtn').addEventListener('click', checkPrereqs);
+
+window.addEventListener('DOMContentLoaded', checkPrereqs);
+
+const form = document.getElementById('configForm');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const out = document.getElementById('installOutput');
+  out.textContent = 'Running install...';
+  const payload = {
+    adminEmail: form.adminEmail.value,
+    adminPassword: form.adminPassword.value,
+  };
+  try {
+    const res = await fetch('/api/install/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    out.textContent = data.output || JSON.stringify(data, null, 2);
+  } catch (err) {
+    out.textContent = 'Error: ' + err.message;
+  }
+});

--- a/scripts/check_prereqs.sh
+++ b/scripts/check_prereqs.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+# Verify Node.js
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required. Please install Node.js 18 or newer." >&2
+  exit 1
+fi
+NODE_MAJOR=$(node -v | sed -E 's/^v([0-9]+).*/\1/')
+if [ "$NODE_MAJOR" -lt 18 ]; then
+  echo "Node.js version 18 or higher is required. Current version: $(node -v)" >&2
+  exit 1
+fi
+
+# Verify Docker
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required. Please install Docker." >&2
+  exit 1
+fi
+
+# Verify Docker Compose
+if command -v docker-compose >/dev/null 2>&1; then
+  :
+elif docker compose version >/dev/null 2>&1; then
+  :
+else
+  echo "Docker Compose is required. Please install Docker Compose." >&2
+  exit 1
+fi
+
+# Verify Git
+if ! command -v git >/dev/null 2>&1; then
+  echo "Git is required. Please install Git." >&2
+  exit 1
+fi
+
+echo "All prerequisites met."

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Determine docker compose command
+if command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  DOCKER_COMPOSE="docker compose"
+fi
+
+if [ -n "$($DOCKER_COMPOSE ps -q backend 2>/dev/null)" ]; then
+  echo "Running migrations inside backend container..."
+  $DOCKER_COMPOSE exec backend npx knex migrate:latest --knexfile knexfile.js
+  $DOCKER_COMPOSE exec backend npx knex seed:run --knexfile knexfile.js
+else
+  echo "Running migrations locally..."
+  npx knex migrate:latest --knexfile backend/knexfile.js
+  npx knex seed:run --knexfile backend/knexfile.js
+fi


### PR DESCRIPTION
## Summary
- add prerequisite checker for Node.js, Docker, Docker Compose and Git
- add database initialization script that runs locally or inside Docker
- add umbrella install script and document automated installation in README
- add web-based installer page with backend API to run setup scripts
- use `execFile` for script execution and make install scripts path-safe

## Testing
- `npm test --silent --prefix backend` *(fails: 14 failed, 71 passed)*
- `npm test --silent --prefix frontend` *(fails: 14 failed, 71 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68aa5156ca1c8328bfe0e8fe7477ffee