### PR TITLE
fix: use discounted price when adding tutorial to cart

### DIFF
--- a/frontend/src/components/tutorials/TutorialCard.js
+++ b/frontend/src/components/tutorials/TutorialCard.js
@@ -25,10 +25,19 @@ const TutorialCard = ({ tutorial = {} }) => {
       : tr("list.free", "Free");
 
   const handleAddToCart = async () => {
+    const price = tutorial.discountPrice ?? tutorial.price;
+    if (price == null) {
+      console.error(
+        `Cannot add tutorial ${tutorial.id} to cart: missing price`,
+      );
+      toast.error(tr("card.failed_to_add_to_cart", "Failed to add to cart"));
+      return;
+    }
+
     const success = await addItem({
       id: tutorial.id,
       name: tutorial.title,
-      price: tutorial.price || 0,
+      price: price || 0,
       item_type: "tutorial",
       quantity: 1,
       ...(tutorial.currency ? { currency: tutorial.currency } : {}),

--- a/frontend/src/tests/__tests__/TutorialCard.test.js
+++ b/frontend/src/tests/__tests__/TutorialCard.test.js
@@ -33,6 +33,26 @@ describe('TutorialCard', () => {
     expect(toast.success).toHaveBeenCalledWith('Added to cart');
   });
 
+  it('uses discount price when available', async () => {
+    addItem.mockResolvedValue(true);
+    const tutorial = {
+      id: 3,
+      title: 'Discount Tutorial',
+      price: 20,
+      discountPrice: 15,
+    };
+    render(<TutorialCard tutorial={tutorial} />);
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+    await waitFor(() => expect(addItem).toHaveBeenCalled());
+    expect(addItem).toHaveBeenCalledWith({
+      id: 3,
+      name: 'Discount Tutorial',
+      price: 15,
+      item_type: 'tutorial',
+      quantity: 1,
+    });
+  });
+
   it('shows error toast when addItem fails', async () => {
     addItem.mockResolvedValue(false);
     const tutorial = { id: 2, title: 'Another Tutorial', price: 5 };


### PR DESCRIPTION
## Summary
- ensure TutorialCard adds tutorials to cart using discountPrice when available
- cover discount pricing in TutorialCard tests

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa58c37aa883289e9ecbb0b041c33c