### PR TITLE
Add interactive installation wizard for SSL setup

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,26 @@
 
 Follow these steps to run SkillBridge on a server or production host.
 
+## Automated Nginx and SSL setup
+
+After pointing your domain DNS records to the server, run the installation
+wizard to configure Nginx and request Let's Encrypt certificates:
+
+```bash
+./install.sh
+```
+
+The script prompts for the environment and, in production mode, the domain
+name. To run non-interactively you can provide arguments:
+
+```bash
+./install.sh production yourdomain.com
+```
+
+In either case the script updates the domain placeholders in `nginx/conf.d`
+and uses `certbot` (or `acme.sh`) to generate certificates at the paths
+referenced in `nginx/conf.d/ssl.conf`.
+
 ## Configure environment variables
 
 1. **Backend** – copy `backend/.env.example` to `backend/.env` and set:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Basic installation script.
+# Usage: ./install.sh [development|production] [domain]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MODE=${1:-}
+DOMAIN=${2:-}
+
+if [[ -z "$MODE" ]]; then
+  echo "Welcome to the SkillBridge installation wizard."
+  read -rp "Choose mode ([d]evelopment/[p]roduction) [development]: " MODE_INPUT
+  case "$MODE_INPUT" in
+    ""|d|development) MODE=development ;;
+    p|production) MODE=production ;;
+    *) echo "Invalid selection: $MODE_INPUT" >&2; exit 1 ;;
+  esac
+fi
+
+if [[ "$MODE" == "production" && -z "$DOMAIN" ]]; then
+  read -rp "Enter domain (e.g., example.com): " DOMAIN
+fi
+
+if [[ "$MODE" == "production" ]]; then
+  if [[ -z "$DOMAIN" ]]; then
+    echo "Domain is required for production" >&2
+    echo "Usage: $0 production <domain>" >&2
+    exit 1
+  fi
+  echo "Running server deployment for $DOMAIN"
+  "$SCRIPT_DIR/scripts/deploy_server.sh" "$DOMAIN"
+else
+  echo "Running in development mode; no deployment actions performed."
+fi

--- a/scripts/deploy_server.sh
+++ b/scripts/deploy_server.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script to configure nginx for a provided domain and obtain Let's Encrypt certificates.
+# Usage: ./scripts/deploy_server.sh <domain>
+
+if [[ $EUID -ne 0 ]]; then
+  echo "This script must be run as root." >&2
+  exit 1
+fi
+
+DOMAIN=${1:-}
+if [[ -z "$DOMAIN" ]]; then
+  echo "Usage: $0 <domain>" >&2
+  exit 1
+fi
+
+BARE_DOMAIN=${DOMAIN#www.}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+DEFAULT_CONF="$REPO_ROOT/nginx/conf.d/default.conf"
+SSL_CONF="$REPO_ROOT/nginx/conf.d/ssl.conf"
+
+echo "Updating Nginx config for $DOMAIN"
+# Replace domain placeholders in nginx config
+for file in "$DEFAULT_CONF" "$SSL_CONF"; do
+  if [[ -f "$file" ]]; then
+    sed -i "s/www.eduskillbridge.net/www.${BARE_DOMAIN}/g" "$file"
+    sed -i "s/eduskillbridge.net/${BARE_DOMAIN}/g" "$file"
+  fi
+done
+
+# Obtain certificates using certbot or acme.sh
+CERT_PATH="/etc/letsencrypt/live/${BARE_DOMAIN}"
+mkdir -p "$CERT_PATH"
+if command -v certbot >/dev/null 2>&1; then
+  certbot certonly --non-interactive --agree-tos --nginx -d "$BARE_DOMAIN" -d "www.$BARE_DOMAIN" -m "admin@${BARE_DOMAIN}"
+elif command -v acme.sh >/dev/null 2>&1; then
+  acme.sh --issue -d "$BARE_DOMAIN" -d "www.$BARE_DOMAIN" --webroot /var/www/html
+  acme.sh --install-cert -d "$BARE_DOMAIN" \
+    --key-file       "$CERT_PATH/privkey.pem" \
+    --fullchain-file "$CERT_PATH/fullchain.pem"
+else
+  echo "Neither certbot nor acme.sh is installed." >&2
+  exit 1
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl reload nginx
+elif command -v nginx >/dev/null 2>&1; then
+  nginx -s reload
+fi
+
+echo "Certificates installed to $CERT_PATH"


### PR DESCRIPTION
## Summary
- prompt for installation mode and domain via interactive `install.sh` wizard
- harden `deploy_server.sh` by requiring root, using repo-relative paths and reloading nginx after certificate issuance
- update deployment docs to describe the new wizard and optional arguments

## Testing
- `shellcheck install.sh scripts/deploy_server.sh`
- `cd backend && npm test` *(fails: Test Suites: 14 failed, 71 passed, 85 total)*
- `cd frontend && npm test` *(fails: Test Suites: 14 failed, 71 passed, 85 total)*

------
https://chatgpt.com/codex/tasks/task_e_68aa515915908328bade2e61ab49a29d