### PR TITLE
Ensure books carry item type when added to cart

### DIFF
--- a/frontend/src/tests/__tests__/bookMapping.test.js
+++ b/frontend/src/tests/__tests__/bookMapping.test.js
@@ -19,6 +19,7 @@ describe('bookMapping utilities', () => {
       category_name: 'Category',
       rating: 4.5,
       price: 9.99,
+      item_type: 'book',
       cover_url: '/cover.jpg',
     });
   });

--- a/frontend/src/utils/bookMapping.js
+++ b/frontend/src/utils/bookMapping.js
@@ -7,6 +7,7 @@ export const mapBookForCart = (book) => ({
   category_name: book.category_name,
   rating: book.rating,
   price: book.price,
+  item_type: "book",
   cover_url:
     book.cover_image_url ||
     buildUrl(book.cover_image) ||


### PR DESCRIPTION
## Summary
- include `item_type: "book"` in book-to-cart mapping so cart service recognizes book items
- adjust book mapping test for new item_type field

## Testing
- `cd backend && npm test 2>&1 | tail -n 20`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa58ce154083289ab4d025383d809b