### PR TITLE
feat: add default platform fee fallback

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -7,6 +7,12 @@ const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const { v4: uuidv4 } = require("uuid");
 
+const DEFAULT_PLATFORM_CUT = {
+  class: 15,
+  book: 10,
+  tutorial: 20,
+};
+
 exports.getBankPayments = catchAsync(async (req, res) => {
   const { status } = req.query;
   const data = await paymentsService.getAll(status, "bank");
@@ -30,7 +36,10 @@ exports.initiateBankPayment = catchAsync(async (req, res) => {
   let instructor_amount = amount;
   try {
     const settings = await paymentConfigService.getSettings();
-    const cut = settings?.platformCut?.[item_type] || 0;
+    const cut =
+      settings?.platformCut?.[item_type] ??
+      DEFAULT_PLATFORM_CUT[item_type] ??
+      0;
     platform_fee = (amount * cut) / 100;
     instructor_amount = amount - platform_fee;
   } catch (err) {

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -16,6 +16,12 @@ const notificationService = require("../notifications/notifications.service");
 const mailService = require("../../services/mailService");
 const couponService = require("../coupons/coupons.service");
 
+const DEFAULT_PLATFORM_CUT = {
+  class: 15,
+  book: 10,
+  tutorial: 20,
+};
+
 exports.createPayment = catchAsync(async (req, res) => {
   const {
     method_id,
@@ -104,7 +110,10 @@ exports.createPayment = catchAsync(async (req, res) => {
   let instructor_amount = verifiedAmount;
   try {
     const settings = await paymentConfigService.getSettings();
-    const cut = settings?.platformCut?.[item_type] || 0;
+    const cut =
+      settings?.platformCut?.[item_type] ??
+      DEFAULT_PLATFORM_CUT[item_type] ??
+      0;
     platform_fee = (verifiedAmount * cut) / 100;
     instructor_amount = verifiedAmount - platform_fee;
   } catch (err) {

--- a/backend/tests/bankPaymentRoutes.test.js
+++ b/backend/tests/bankPaymentRoutes.test.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/payments/payments.service', () => ({
+  create: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getByType: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'u1' }; next(); },
+  isStudent: (_req, _res, next) => next(),
+}));
+
+const paymentsService = require('../src/modules/payments/payments.service');
+const methodsService = require('../src/modules/paymentMethods/paymentMethods.service');
+const configService = require('../src/modules/paymentConfig/paymentConfig.service');
+const routes = require('../src/modules/payments/bank.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payments/bank', routes);
+
+describe('POST /api/payments/bank/initiate', () => {
+  it('falls back to default cut when config missing item type', async () => {
+    methodsService.getByType.mockResolvedValue({ id: 'm1', settings: {} });
+    configService.getSettings.mockResolvedValue({ platformCut: {} });
+    paymentsService.create.mockResolvedValue({ id: 'p1' });
+
+    const res = await request(app)
+      .post('/api/payments/bank/initiate')
+      .send({ item_type: 'tutorial', item_id: 't1', amount: 200 });
+
+    expect(res.status).toBe(200);
+    expect(paymentsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ platform_fee: 40, instructor_amount: 160 })
+    );
+  });
+});

--- a/backend/tests/paymentCommission.test.js
+++ b/backend/tests/paymentCommission.test.js
@@ -12,7 +12,7 @@ jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
 }));
 
 jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
-  getById: jest.fn().mockResolvedValue({ type: 'card' }),
+  getById: jest.fn().mockResolvedValue({ type: 'card', active: true }),
 }));
 
 jest.mock('../src/services/paypalService', () => ({
@@ -32,7 +32,7 @@ jest.mock('../src/modules/library/library.service', () => ({
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
-  verifyToken: (_req, _res, next) => next(),
+  verifyToken: (req, _res, next) => { req.user = { id: 'admin1' }; next(); },
   isAdmin: (_req, _res, next) => next(),
 }));
 
@@ -51,7 +51,7 @@ describe('payment commission calculations', () => {
 
   it('calculates commission for class payments', async () => {
     configService.getSettings.mockResolvedValue({ platformCut: { class: 10 } });
-    service.create.mockResolvedValue({ id: 'p1', reference_id: 'ref', status: 'paid' });
+    service.create.mockResolvedValue({ id: 'p1', reference_id: 'ref', status: 'pending' });
 
     const res = await request(app).post('/api/payments/admin').send({
       user_id: 'u1',
@@ -70,7 +70,7 @@ describe('payment commission calculations', () => {
 
   it('calculates commission for book payments', async () => {
     configService.getSettings.mockResolvedValue({ platformCut: { book: 20 } });
-    service.create.mockResolvedValue({ id: 'p2', reference_id: 'ref', status: 'paid' });
+    service.create.mockResolvedValue({ id: 'p2', reference_id: 'ref', status: 'pending' });
 
     const res = await request(app).post('/api/payments/admin').send({
       user_id: 'u1',
@@ -89,7 +89,7 @@ describe('payment commission calculations', () => {
 
   it('calculates commission for tutorial payments', async () => {
     configService.getSettings.mockResolvedValue({ platformCut: { tutorial: 30 } });
-    service.create.mockResolvedValue({ id: 'p3', reference_id: 'ref', status: 'paid' });
+    service.create.mockResolvedValue({ id: 'p3', reference_id: 'ref', status: 'pending' });
 
     const res = await request(app).post('/api/payments/admin').send({
       user_id: 'u1',
@@ -103,6 +103,25 @@ describe('payment commission calculations', () => {
     expect(res.status).toBe(200);
     expect(service.create).toHaveBeenCalledWith(
       expect.objectContaining({ platform_fee: 60, instructor_amount: 140 })
+    );
+  });
+
+  it('falls back to default cut when settings missing', async () => {
+    configService.getSettings.mockResolvedValue(null);
+    service.create.mockResolvedValue({ id: 'p4', reference_id: 'ref', status: 'pending' });
+
+    const res = await request(app).post('/api/payments/admin').send({
+      user_id: 'u1',
+      method_id: 'm1',
+      item_type: 'class',
+      item_id: 'i4',
+      amount: 100,
+      status: 'paid',
+    });
+
+    expect(res.status).toBe(200);
+    expect(service.create).toHaveBeenCalledWith(
+      expect.objectContaining({ platform_fee: 15, instructor_amount: 85 })
     );
   });
 });


### PR DESCRIPTION
## Summary
- define default platform cut map for payments and bank controllers
- use default percentages when payment config is missing
- test platform fee fallback for payments and bank initiation

## Testing
- `cd backend && npm test tests/paymentCommission.test.js tests/bankPaymentRoutes.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68aa5f7d84c88328a618b82ce85b21f9