### PR TITLE
Confirm student payments with receipt URL

### DIFF
--- a/frontend/src/pages/dashboard/student/payments/index.js
+++ b/frontend/src/pages/dashboard/student/payments/index.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
 import { FaCreditCard, FaClock, FaCheckCircle, FaFileInvoice } from "react-icons/fa";
-import { fetchMyPayments, confirmBankPayment } from "@/services/student/paymentService";
+import { fetchMyPayments, confirmPayment, uploadReceipt } from "@/services/student/paymentService";
 
 export default function StudentPaymentsPage() {
   const [payments, setPayments] = useState([]);
@@ -38,7 +38,12 @@ export default function StudentPaymentsPage() {
     e.preventDefault();
     if (!selectedPayment) return;
     try {
-      await confirmBankPayment(selectedPayment.id, reference, receipt);
+      let receiptUrl;
+      if (receipt) {
+        const uploaded = await uploadReceipt(receipt);
+        receiptUrl = uploaded?.url;
+      }
+      await confirmPayment(selectedPayment.id, reference, receiptUrl);
       setPayments((prev) =>
         prev.map((p) =>
           p.id === selectedPayment.id

--- a/frontend/src/services/student/paymentService.js
+++ b/frontend/src/services/student/paymentService.js
@@ -19,13 +19,14 @@ export const uploadReceipt = async (file) => {
   return data?.data;
 };
 
-export const confirmBankPayment = async (paymentId, reference, file) => {
-  const formData = new FormData();
-  formData.append("payment_id", paymentId);
-  formData.append("transaction_reference", reference);
-  if (file) formData.append("receipt", file);
-  const { data } = await api.post("/payments/bank/confirm", formData, {
-    headers: { "Content-Type": "multipart/form-data" },
-  });
+export const confirmPayment = async (paymentId, reference, receiptUrl) => {
+  const payload = {
+    reference_id: reference,
+    receipt_url: receiptUrl,
+  };
+  const { data } = await api.post(
+    `/payments/student/${paymentId}/confirm`,
+    payload
+  );
   return data?.data;
 };


### PR DESCRIPTION
## Summary
- switch student bank payment confirmation to `/payments/student/{id}/confirm`
- upload receipt separately and send reference and `receipt_url` as JSON
- update student payments dashboard to use new confirmation flow

## Testing
- `npm test`
- `npm run lint` *(fails: 49 errors, 308 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6482d7288328a694fff87614645f