### PR TITLE
Validate payment receipt uploads

### DIFF
--- a/backend/src/modules/payments/paymentReceiptUpload.middleware.js
+++ b/backend/src/modules/payments/paymentReceiptUpload.middleware.js
@@ -15,4 +15,16 @@ const storage = multer.diskStorage({
   },
 });
 
-module.exports = multer({ storage });
+const fileFilter = (_req, file, cb) => {
+  if (file.mimetype.startsWith('image/') || file.mimetype === 'application/pdf') {
+    cb(null, true);
+  } else {
+    cb(new Error('Only image or PDF files are allowed'), false);
+  }
+};
+
+module.exports = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: 5 * 1024 * 1024 },
+});

--- a/backend/src/modules/payments/student.routes.js
+++ b/backend/src/modules/payments/student.routes.js
@@ -7,7 +7,16 @@ router.use(verifyToken, isStudent);
 
 router.get("/", controller.getMyPayments);
 router.post("/", controller.createPayment);
-router.post("/receipts", upload.single("receipt"), controller.uploadReceipt);
+router.post(
+  "/receipts",
+  (req, res, next) => {
+    upload.single("receipt")(req, res, (err) => {
+      if (err) return res.status(400).json({ message: err.message });
+      next();
+    });
+  },
+  controller.uploadReceipt
+);
 router.post("/:id/confirm", controller.confirmPayment);
 
 module.exports = router;

--- a/docs/student-enrollment-workflow.md
+++ b/docs/student-enrollment-workflow.md
@@ -31,6 +31,8 @@ The `/checkout` page requires the student to be logged in. A completed profile m
 ## 5. Payment Gateway
 Students are redirected to the configured payment processor (Stripe, Tap, PayPal or an NFT wallet). On successful payment they return to `/checkout/success` where the order is saved and the student is officially enrolled. Failures redirect to `/checkout/failure` with options to retry or contact support.
 
+If paying via bank transfer or another offline method, students may need to upload a payment receipt. Accepted formats are JPG, PNG or PDF files up to 5 MB.
+
 ## 6. Order & Invoicing
 - Administrators can view orders under `/dashboard/admin/orders`.
 - Students can download invoices from `/dashboard/student/invoices`.


### PR DESCRIPTION
## Summary
- restrict payment receipt uploads to images or PDFs under 5 MB
- return 400 for invalid receipt uploads
- document accepted receipt formats for students

## Testing
- `npm test` *(fails: Test Suites: 13 failed, 73 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa648ca8988328b3314637108e1a2d