### PR TITLE
Add configurable PayPal environment

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,6 +40,11 @@ APPLE_TEAM_ID=your_team_id
 APPLE_KEY_ID=your_key_id
 APPLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMII...\n-----END PRIVATE KEY-----"
 
+# PayPal credentials (optional)
+PAYPAL_CLIENT_ID=
+PAYPAL_CLIENT_SECRET=
+PAYPAL_MODE=sandbox
+
 # Initial credentials for seeded admin accounts
 # If unset, the seeding process generates random passwords and logs them
 # ADMIN_INITIAL_PASSWORD=

--- a/backend/src/modules/paymentMethods/paymentMethods.controller.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.controller.js
@@ -165,18 +165,22 @@ exports.getPayPalCredentials = catchAsync(async (_req, res) => {
   sendSuccess(res, {
     client_id: settings.client_id || null,
     has_client_secret: Boolean(settings.client_secret),
+    mode: settings.mode,
   });
 });
 
 exports.updatePayPalCredentials = catchAsync(async (req, res) => {
-  const { client_id, client_secret } = req.body;
+  const { client_id, client_secret, mode } = req.body;
   if (!client_id || !client_secret) {
     throw new AppError("Client ID and secret are required", 400);
   }
-  await service.updatePayPalSettings({ client_id, client_secret });
+  if (mode && !["sandbox", "live"].includes(mode)) {
+    throw new AppError("Invalid PayPal mode", 400);
+  }
+  await service.updatePayPalSettings({ client_id, client_secret, mode });
   sendSuccess(
     res,
-    { client_id, has_client_secret: true },
+    { client_id, has_client_secret: true, mode: mode || "sandbox" },
     "PayPal credentials updated"
   );
 });

--- a/backend/src/modules/paymentMethods/paymentMethods.service.js
+++ b/backend/src/modules/paymentMethods/paymentMethods.service.js
@@ -50,7 +50,12 @@ exports.delete = (id) => {
 
 exports.getPayPalSettings = async () => {
   const row = await exports.getByType("paypal");
-  return row?.settings || {};
+  const settings = row?.settings || {};
+  return {
+    client_id: settings.client_id || process.env.PAYPAL_CLIENT_ID,
+    client_secret: settings.client_secret || process.env.PAYPAL_CLIENT_SECRET,
+    mode: settings.mode || process.env.PAYPAL_MODE || "sandbox",
+  };
 };
 
 exports.updatePayPalSettings = async (settings) => {

--- a/backend/src/seeds/08_payment_methods_seed.js
+++ b/backend/src/seeds/08_payment_methods_seed.js
@@ -26,7 +26,8 @@ exports.seed = async function(knex) {
       active: true,
       settings: {
         client_id: '',
-        client_secret: ''
+        client_secret: '',
+        mode: 'sandbox'
       },
       is_default: false,
       created_at: now,

--- a/backend/src/services/paypalService.js
+++ b/backend/src/services/paypalService.js
@@ -9,11 +9,17 @@ async function getClient() {
   if (!settings?.client_id || !settings?.client_secret) {
     throw new Error('PayPal credentials are not configured');
   }
-  // Default to sandbox environment; adjust as needed
-  const environment = new paypal.core.SandboxEnvironment(
-    settings.client_id,
-    settings.client_secret
-  );
+  const mode = settings.mode === 'live' ? 'live' : 'sandbox';
+  const environment =
+    mode === 'live'
+      ? new paypal.core.LiveEnvironment(
+          settings.client_id,
+          settings.client_secret
+        )
+      : new paypal.core.SandboxEnvironment(
+          settings.client_id,
+          settings.client_secret
+        );
   client = new paypal.core.PayPalHttpClient(environment);
   return client;
 }


### PR DESCRIPTION
## Summary
- allow PayPal credentials to be configured via environment variables
- support sandbox or live PayPal environment
- expose and validate PayPal mode in API and seeds

## Testing
- `npm test` *(fails: 13 failed, 73 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6619c9b48328ba74e9bfd94e535b