### PR TITLE
feat: add NowPayments crypto payment support

### DIFF
--- a/backend/src/modules/payments/crypto.controller.js
+++ b/backend/src/modules/payments/crypto.controller.js
@@ -1,0 +1,124 @@
+const logger = require('../../utils/logger.js');
+const catchAsync = require('../../utils/catchAsync');
+const AppError = require('../../utils/AppError');
+const { sendSuccess } = require('../../utils/response');
+const paymentsService = require('./payments.service');
+const paymentConfigService = require('../paymentConfig/paymentConfig.service');
+const paymentMethodsService = require('../paymentMethods/paymentMethods.service');
+const nowPayments = require('../../services/nowPaymentsService');
+const { v4: uuidv4 } = require('uuid');
+
+const DEFAULT_PLATFORM_CUT = {
+  class: 15,
+  book: 10,
+  tutorial: 20,
+};
+
+const ALLOWED_ITEM_TYPES = ['class', 'book', 'tutorial'];
+
+const SUPPORTED_FIAT = [
+  'USD','EUR','GBP','JPY','CNY','SAR','AED','KWD','INR','CAD','AUD','CHF','QAR','EGP','TRY','KRW','SGD','RUB',
+];
+
+exports.initiateCryptoPayment = catchAsync(async (req, res) => {
+  const { item_type, item_id, amount, currency, method_type } = req.body;
+  const user_id = req.user?.id;
+  if (!user_id || !item_type || !item_id || amount === undefined) {
+    throw new AppError('Missing required fields', 400);
+  }
+  if (!ALLOWED_ITEM_TYPES.includes(item_type)) {
+    throw new AppError('Invalid item type', 400);
+  }
+  const numericAmount = Number(amount);
+  if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+    throw new AppError('Amount must be a positive number', 400);
+  }
+  const currencyCode = currency || 'USD';
+  if (!SUPPORTED_FIAT.includes(currencyCode)) {
+    throw new AppError('Unsupported currency', 400);
+  }
+
+  const method = await paymentMethodsService.getByType(method_type || 'crypto');
+  if (!method) {
+    throw new AppError('Crypto payment method not configured', 400);
+  }
+  const settings = method.settings || {};
+  if (!settings.api_key) {
+    throw new AppError('Crypto payment method missing API key', 500);
+  }
+
+  const paymentId = uuidv4();
+
+  let platform_fee = 0;
+  let instructor_amount = numericAmount;
+  try {
+    const cfg = await paymentConfigService.getSettings();
+    const cut = cfg?.platformCut?.[item_type] ?? DEFAULT_PLATFORM_CUT[item_type] ?? 0;
+    platform_fee = (numericAmount * cut) / 100;
+    instructor_amount = numericAmount - platform_fee;
+  } catch (err) {
+    logger.error('Failed to load payment settings:', err);
+  }
+
+  const params = {
+    price_amount: numericAmount,
+    price_currency: currencyCode,
+    pay_currency: settings.currency || 'USDT',
+    order_id: paymentId,
+  };
+  if (settings.ipn_secret) {
+    params.ipn_callback_url = `${process.env.BACKEND_URL || ''}/api/payments/crypto/ipn`;
+  }
+  if (process.env.FRONTEND_URL) {
+    params.success_url = `${process.env.FRONTEND_URL}/payments/success`;
+    params.cancel_url = `${process.env.FRONTEND_URL}/payments/error`;
+  }
+
+  const invoice = await nowPayments.createInvoice(settings.api_key, params);
+
+  const paymentData = {
+    id: paymentId,
+    user_id,
+    method_id: method.id,
+    item_type,
+    item_id,
+    amount: numericAmount,
+    currency: currencyCode,
+    status: 'pending_payment',
+    reference_id: invoice.id?.toString() || null,
+    receipt_url: invoice.invoice_url,
+    platform_fee,
+    instructor_amount,
+  };
+  const payment = await paymentsService.create(paymentData);
+
+  sendSuccess(res, { invoice_url: invoice.invoice_url, payment }, 'Crypto payment initiated');
+});
+
+exports.handleIPN = catchAsync(async (req, res) => {
+  const signature = req.get('x-nowpayments-sig');
+  const payload = req.body || {};
+  const paymentId = payload.order_id;
+  if (!paymentId) return res.status(400).end();
+
+  const payment = await paymentsService.getById(paymentId);
+  if (!payment) return res.status(404).end();
+  const method = await paymentMethodsService.getById(payment.method_id);
+  const secret = method?.settings?.ipn_secret;
+  if (!nowPayments.verifyIpnSignature(payload, signature, secret)) {
+    return res.status(400).end();
+  }
+
+  let statusUpdate = {};
+  const status = payload.payment_status;
+  if (status === 'finished') {
+    statusUpdate = { status: 'paid', reference_id: payload.payment_id, paid_at: new Date() };
+  } else if (status === 'failed') {
+    statusUpdate = { status: 'rejected', reference_id: payload.payment_id };
+  }
+  if (Object.keys(statusUpdate).length) {
+    await paymentsService.update(paymentId, statusUpdate);
+  }
+  res.json({ ok: true });
+});
+

--- a/backend/src/modules/payments/crypto.routes.js
+++ b/backend/src/modules/payments/crypto.routes.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const controller = require('./crypto.controller');
+const { verifyToken, isStudent } = require('../../middleware/auth/authMiddleware');
+
+router.post('/ipn', controller.handleIPN);
+router.post('/initiate', verifyToken, isStudent, controller.initiateCryptoPayment);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -158,6 +158,7 @@ app.use(
 );
 app.use("/api/payments/student", require("./modules/payments/student.routes"));
 app.use("/api/payments/bank", require("./modules/payments/bank.routes"));
+app.use("/api/payments/crypto", require("./modules/payments/crypto.routes"));
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
 app.use(
   "/api/admin/payments/bank",

--- a/backend/src/services/nowPaymentsService.js
+++ b/backend/src/services/nowPaymentsService.js
@@ -1,0 +1,52 @@
+const crypto = require('crypto');
+
+// Use native fetch if available, otherwise fall back to node-fetch via dynamic import.
+const fetchFn =
+  typeof fetch === 'function'
+    ? fetch
+    : (...args) => import('node-fetch').then(({ default: f }) => f(...args));
+
+const BASE_URL = 'https://api.nowpayments.io/v1';
+
+/**
+ * Create a NowPayments invoice.
+ * @param {string} apiKey - NowPayments API key.
+ * @param {object} params - Invoice parameters.
+ * @returns {Promise<object>} Invoice response.
+ */
+exports.createInvoice = async (apiKey, params) => {
+  const res = await fetchFn(`${BASE_URL}/invoice`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+    },
+    body: JSON.stringify(params),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`NowPayments createInvoice failed: ${text}`);
+  }
+  return res.json();
+};
+
+/**
+ * Verify NowPayments IPN signature using HMAC SHA512.
+ * @param {object} payload - Parsed JSON body received from NowPayments.
+ * @param {string} signature - Value from the 'x-nowpayments-sig' header.
+ * @param {string} secret - IPN secret from payment method settings.
+ * @returns {boolean} True if signature matches, else false.
+ */
+exports.verifyIpnSignature = (payload, signature, secret) => {
+  if (!signature || !secret) return false;
+  try {
+    const hmac = crypto
+      .createHmac('sha512', secret)
+      .update(JSON.stringify(payload))
+      .digest('hex');
+    return hmac === signature;
+  } catch (_) {
+    return false;
+  }
+};
+

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -4,7 +4,7 @@ import { fetchPaymentMethods, fetchPayPalClientId } from '@/services/paymentMeth
 import { fetchClassDetails } from '@/services/classService';
 import { fetchTutorialDetails } from '@/services/tutorialService';
 import { validateCode } from '@/services/couponService';
-import { initiateBankPayment } from '@/services/paymentService';
+import { initiateBankPayment, initiateCryptoPayment } from '@/services/paymentService';
 import { createPayment as createStudentPayment } from '@/services/student/paymentService';
 import useCartStore from '@/store/cart/cartStore';
 import Navbar from '@/components/website/sections/Navbar';
@@ -197,6 +197,26 @@ export default function CheckoutPage() {
         setInvoicePreview(true);
       } catch (err) {
         console.error('Failed to initiate bank transfer', err);
+      } finally {
+        setPaymentStatus('idle');
+      }
+      return;
+    }
+    if (selectedMethod === 'usdt' || selectedMethod === 'nft') {
+      try {
+        setPaymentStatus('processing');
+        const method = methods.find((m) => m.type === selectedMethod);
+        const payload = {
+          item_id: itemInfo.id,
+          item_type: itemType,
+          amount: Math.max((itemInfo.price ?? 0) - discount, 0),
+          method_type: method?.type,
+        };
+        if (couponId) payload.coupon_id = couponId;
+        const data = await initiateCryptoPayment(payload);
+        if (data?.invoice_url) window.location.href = data.invoice_url;
+      } catch (err) {
+        console.error('Failed to initiate crypto payment', err);
       } finally {
         setPaymentStatus('idle');
       }
@@ -407,11 +427,10 @@ export default function CheckoutPage() {
           ) : selectedMethod === 'usdt' || selectedMethod === 'nft' ? (
             <div className="bg-gray-900 p-4 rounded text-sm text-gray-300">
               <p><strong>Crypto Payment</strong></p>
-              <p className="mb-2">Connect your wallet to verify ownership.</p>
+              <p className="mb-2">You'll be redirected to complete this payment.</p>
               <button onClick={handlePayment} className="mt-2 bg-yellow-500 text-black px-4 py-2 rounded font-bold">
-                Connect Wallet & Verify
+                Pay with Crypto
               </button>
-              <p className="text-yellow-400 mt-2">You'll be redirected after validation.</p>
             </div>
           ) : invoicePreview && selectedMethod === 'bank' ? (
             <div className="bg-gray-900 p-4 rounded text-sm text-gray-300">

--- a/frontend/src/services/paymentService.js
+++ b/frontend/src/services/paymentService.js
@@ -6,3 +6,9 @@ export const initiateBankPayment = async (payload) => {
   return data?.data ?? data;
 };
 
+// Initiate crypto payment via NowPayments
+export const initiateCryptoPayment = async (payload) => {
+  const { data } = await api.post("/payments/crypto/initiate", payload);
+  return data?.data ?? data;
+};
+


### PR DESCRIPTION
## Summary
- integrate NowPayments for crypto payments with invoice creation and IPN handling
- expose `/api/payments/crypto` routes and wire frontend checkout to initiate crypto invoices
- add client service helper for launching NowPayments payment flow

## Testing
- `npm test` (backend) – 13 failed, 73 passed
- `npm test` (frontend) – 37 passed

------
https://chatgpt.com/codex/tasks/task_e_68aa679a23a4832896ffcabb0354f4ec