### PR TITLE
fix: prevent PayPal script loop on checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { fetchPaymentMethods, fetchPayPalClientId } from '@/services/paymentMethodService';
 import { fetchClassDetails } from '@/services/classService';
 import { fetchTutorialDetails } from '@/services/tutorialService';
@@ -100,7 +100,7 @@ export default function CheckoutPage() {
   const [bankInfo, setBankInfo] = useState(null);
   const [paymentStatus, setPaymentStatus] = useState('idle');
   const [allowInstallments, setAllowInstallments] = useState(false);
-  const [paypalLoaded, setPaypalLoaded] = useState(false);
+  const paypalLoaded = useRef(false);
   const [paypalClientId, setPaypalClientId] = useState('');
 
   useEffect(() => {
@@ -245,11 +245,13 @@ export default function CheckoutPage() {
     const amountValue = itemInfo.price - discount;
     if (amountValue <= 0) return;
     const amount = amountValue.toString();
-    if (!paypalLoaded) {
+    if (!paypalClientId) return;
+
+    if (!paypalLoaded.current) {
       const script = document.createElement('script');
       script.src = `https://www.paypal.com/sdk/js?client-id=${paypalClientId}`;
       script.addEventListener('load', () => {
-        setPaypalLoaded(true);
+        paypalLoaded.current = true;
         renderPayPalButton(amount);
       });
       document.body.appendChild(script);
@@ -257,7 +259,7 @@ export default function CheckoutPage() {
       renderPayPalButton(amount);
     }
 
-  }, [selectedMethod, itemInfo, discount, paypalLoaded]);
+  }, [selectedMethod, itemInfo, discount, paypalClientId]);
 
   useEffect(() => {
     if (selectedMethod !== 'bank') {


### PR DESCRIPTION
## Summary
- avoid max update depth by tracking PayPal script load with a ref
- rerender PayPal button only after client id is ready

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa69594b788328a321da7d843c6a48