### PR TITLE
Improve checkout payment flows and coverage

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -28,6 +28,24 @@ const iconMap = {
   coinbase: <FaEthereum />,
 };
 
+function resolveIconElement(method) {
+  if (method.icon) {
+    const lower = method.icon.toLowerCase();
+    const isUrl = /^(https?:)?\/\//.test(method.icon) || method.icon.includes('.');
+    if (isUrl) {
+      return (
+        <img
+          src={method.icon}
+          alt={method.name}
+          className="w-8 h-8 object-contain"
+        />
+      );
+    }
+    if (iconMap[lower]) return iconMap[lower];
+  }
+  return iconMap[method.type?.toLowerCase()] || <FaMoneyCheckAlt />;
+}
+
 export function resolveCheckoutItem(query, cartItems) {
   const { itemId, itemType, items } = query;
 
@@ -377,16 +395,8 @@ export default function CheckoutPage() {
                   className={`flex flex-col items-center justify-center gap-2 py-3 px-4 rounded-xl font-semibold text-sm text-center transition-all border
                   ${selectedMethod === method.type ? 'bg-yellow-500 text-black border-yellow-400' : 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600'}`}
                 >
-                  <div className="text-2xl">
-                    {method.icon ? (
-                      <img
-                        src={method.icon}
-                        alt={method.name}
-                        className="w-8 h-8 object-contain"
-                      />
-                    ) : (
-                      iconMap[method.type?.toLowerCase()] || <FaMoneyCheckAlt />
-                    )}
+                  <div className="text-2xl" data-testid={`payment-icon-${method.type}`}>
+                    {resolveIconElement(method)}
                   </div>
                   <div>{method.name}</div>
                 </button>
@@ -479,7 +489,9 @@ export default function CheckoutPage() {
                   <input type="text" placeholder="CVC" required className="w-full mb-6 p-3 text-sm rounded bg-gray-700 text-white" />
                 </>
               )}
-              {selectedMethod === 'paypal' && <div id="paypal-button-container" className="mb-4"></div>}
+              {selectedMethod === 'paypal' && (
+                <div id="paypal-button-container" data-testid="paypal-button-container" className="mb-4"></div>
+              )}
               {selectedMethod !== 'paypal' && (
                 <button type="submit" disabled={paymentStatus === 'processing'} className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all">
                   {paymentStatus === 'processing'

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CheckoutPage from '../../pages/payments/checkout';
+import { fetchClassDetails } from '../../services/classService';
+import { fetchPaymentMethods, fetchPayPalClientId } from '../../services/paymentMethodService';
+import { initiateBankPayment } from '../../services/paymentService';
+
+jest.mock('react-toastify', () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+
+const mockRemoveItem = jest.fn();
+jest.mock('../../store/cart/cartStore', () => ({
+  __esModule: true,
+  default: (selector) => selector({ items: [], removeItem: mockRemoveItem }),
+}));
+
+jest.mock('../../components/website/sections/Navbar', () => {
+  function MockNavbar() { return <div />; }
+  MockNavbar.displayName = 'Navbar';
+  return MockNavbar;
+});
+jest.mock('../../components/website/sections/Footer', () => {
+  function MockFooter() { return <div />; }
+  MockFooter.displayName = 'Footer';
+  return MockFooter;
+});
+
+jest.mock('../../services/classService', () => ({ fetchClassDetails: jest.fn() }));
+jest.mock('../../services/tutorialService', () => ({ fetchTutorialDetails: jest.fn() }));
+jest.mock('../../services/paymentMethodService', () => ({
+  fetchPaymentMethods: jest.fn(),
+  fetchPayPalClientId: jest.fn(),
+}));
+jest.mock('../../services/paymentService', () => ({
+  initiateBankPayment: jest.fn(),
+  initiateCryptoPayment: jest.fn(),
+}));
+jest.mock('../../services/student/paymentService', () => ({ createPayment: jest.fn() }));
+
+const mockUseRouter = jest.fn();
+jest.mock('next/router', () => ({ useRouter: () => mockUseRouter() }));
+
+beforeEach(() => {
+  mockUseRouter.mockReturnValue({
+    query: { itemId: '1', itemType: 'class' },
+    isReady: true,
+    push: jest.fn(),
+  });
+  fetchClassDetails.mockResolvedValue({
+    data: { id: 1, title: 'Test Class', instructor: 'Inst', price: 100, cover_image: '' },
+  });
+  fetchPayPalClientId.mockResolvedValue('');
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders payment logos from url and fallback', async () => {
+  fetchPaymentMethods.mockResolvedValue([
+    { id: 1, name: 'Stripe', type: 'stripe', icon: 'https://example.com/stripe.png' },
+    { id: 2, name: 'PayPal', type: 'paypal' },
+  ]);
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+  const stripeIcon = screen.getByTestId('payment-icon-stripe').querySelector('img');
+  expect(stripeIcon).toHaveAttribute('src', 'https://example.com/stripe.png');
+  const paypalIcon = screen.getByTestId('payment-icon-paypal').querySelector('svg');
+  expect(paypalIcon).not.toBeNull();
+});
+
+test('adjusts inputs based on payment selection and displays invoice for bank', async () => {
+  fetchPaymentMethods.mockResolvedValue([
+    { id: 1, name: 'Stripe', type: 'stripe' },
+    { id: 2, name: 'PayPal', type: 'paypal' },
+    { id: 3, name: 'Bank', type: 'bank' },
+  ]);
+  initiateBankPayment.mockResolvedValue({
+    invoiceNumber: 'INV-1',
+    bankName: 'Test Bank',
+    accountNumber: '123',
+    iban: 'IBAN',
+  });
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+  expect(screen.getByPlaceholderText('Card Number')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('PayPal'));
+  expect(screen.queryByPlaceholderText('Card Number')).toBeNull();
+  expect(screen.getByTestId('paypal-button-container')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Bank'));
+  expect(screen.queryByPlaceholderText('Card Number')).toBeNull();
+  expect(screen.queryByTestId('paypal-button-container')).toBeNull();
+  fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'John' } });
+  fireEvent.change(screen.getByPlaceholderText('Email Address'), { target: { value: 'john@example.com' } });
+  fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Bank/i }));
+  await waitFor(() => expect(initiateBankPayment).toHaveBeenCalled());
+  expect(await screen.findByText(/Invoice #INV-1/)).toBeInTheDocument();
+  expect(screen.getByText(/Test Bank/)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- handle payment icons from URLs or named keys
- render payment-specific inputs and PayPal container with test IDs
- add tests for payment logos, input selection, and bank invoice flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab7649e188328b4669256bc7a45cc