### PR TITLE
feat: add PayPal integration and NOWPayments alias

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,11 @@ The `/api/system-errors` route reads the latest lines from `logs/error.log` and 
 
 Students can upload proof of manual transfers via `POST /api/payments/student/receipts` using a multipart form field named `receipt`. The uploaded file URL can then be referenced by admins when recording payments. Each payment may optionally store this URL in the new `receipt_url` column.
 
+### PayPal and crypto payments
+
+- Students can initiate PayPal payments via `POST /api/payments/paypal/create`. The endpoint returns an approval URL and records the pending payment. PayPal redirects to `/api/payments/paypal/callback` after approval.
+- Crypto payments use NOWPayments through `POST /api/payments/nowpayments/create` with webhook notifications to `/api/payments/nowpayments/ipn`.
+
 ### Failed login attempt cleanup
 
 Authentication keeps a short-lived in-memory map of failed login attempts. Each entry stores timestamps of failed tries and a `lockUntil` field. A background task runs every minute to remove entries whose lock has expired, preventing unbounded growth of this map.

--- a/backend/src/modules/payments/crypto.routes.js
+++ b/backend/src/modules/payments/crypto.routes.js
@@ -4,5 +4,7 @@ const { verifyToken, isStudent } = require('../../middleware/auth/authMiddleware
 
 router.post('/ipn', controller.handleIPN);
 router.post('/initiate', verifyToken, isStudent, controller.initiateCryptoPayment);
+// Alias to support `/api/payments/nowpayments/create`
+router.post('/create', verifyToken, isStudent, controller.initiateCryptoPayment);
 
 module.exports = router;

--- a/backend/src/modules/payments/paypal.controller.js
+++ b/backend/src/modules/payments/paypal.controller.js
@@ -1,0 +1,141 @@
+const logger = require('../../utils/logger.js');
+const catchAsync = require('../../utils/catchAsync');
+const AppError = require('../../utils/AppError');
+const { sendSuccess } = require('../../utils/response');
+const paymentsService = require('./payments.service');
+const paymentConfigService = require('../paymentConfig/paymentConfig.service');
+const paymentMethodsService = require('../paymentMethods/paymentMethods.service');
+const paypalService = require('../../services/paypalService');
+const libraryService = require('../library/library.service');
+const enrollmentService = require('../classes/enrollments/classEnrollment.service');
+const tutorialEnrollmentService = require('../users/tutorials/enrollments/tutorialEnrollment.service');
+const { v4: uuidv4 } = require('uuid');
+
+const DEFAULT_PLATFORM_CUT = {
+  class: 15,
+  book: 10,
+  tutorial: 20,
+};
+
+const ALLOWED_ITEM_TYPES = ['class', 'book', 'tutorial'];
+const SUPPORTED_CURRENCIES = [
+  'USD','EUR','GBP','JPY','CNY','SAR','AED','KWD','INR','CAD','AUD','CHF','QAR','EGP','TRY','KRW','SGD','RUB',
+];
+
+exports.createPayPalPayment = catchAsync(async (req, res) => {
+  const { item_type, item_id, amount, currency } = req.body;
+  const user_id = req.user?.id;
+  if (!user_id || !item_type || !item_id || amount === undefined) {
+    throw new AppError('Missing required fields', 400);
+  }
+  if (!ALLOWED_ITEM_TYPES.includes(item_type)) {
+    throw new AppError('Invalid item type', 400);
+  }
+  const numericAmount = Number(amount);
+  if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+    throw new AppError('Amount must be a positive number', 400);
+  }
+  const currencyCode = currency || 'USD';
+  if (!SUPPORTED_CURRENCIES.includes(currencyCode)) {
+    throw new AppError('Unsupported currency', 400);
+  }
+
+  const method = await paymentMethodsService.getByType('paypal');
+  if (!method) {
+    throw new AppError('PayPal payment method not configured', 400);
+  }
+
+  let platform_fee = 0;
+  let instructor_amount = numericAmount;
+  try {
+    const cfg = await paymentConfigService.getSettings();
+    const cut = cfg?.platformCut?.[item_type] ?? DEFAULT_PLATFORM_CUT[item_type] ?? 0;
+    platform_fee = (numericAmount * cut) / 100;
+    instructor_amount = numericAmount - platform_fee;
+  } catch (err) {
+    logger.error('Failed to load payment settings:', err);
+  }
+
+  const paymentId = uuidv4();
+
+  const order = await paypalService.createOrder({
+    amount: numericAmount,
+    currency: currencyCode,
+    returnUrl: `${process.env.BACKEND_URL || ''}/api/payments/paypal/callback?payment_id=${paymentId}`,
+    cancelUrl: process.env.FRONTEND_URL
+      ? `${process.env.FRONTEND_URL}/payments/error`
+      : undefined,
+  });
+  const approval = order.links?.find((l) => l.rel === 'approve')?.href;
+  if (!approval) {
+    throw new AppError('Unable to retrieve PayPal approval url', 500);
+  }
+
+  const paymentData = {
+    id: paymentId,
+    user_id,
+    method_id: method.id,
+    item_type,
+    item_id,
+    amount: numericAmount,
+    currency: currencyCode,
+    status: 'pending_payment',
+    reference_id: order.id,
+    platform_fee,
+    instructor_amount,
+  };
+  const payment = await paymentsService.create(paymentData);
+  sendSuccess(res, { approval_url: approval, payment }, 'PayPal payment initiated');
+});
+
+exports.handlePayPalCallback = catchAsync(async (req, res) => {
+  const { token: orderId, payment_id: paymentId } = req.query;
+  if (!orderId || !paymentId) {
+    throw new AppError('Missing order information', 400);
+  }
+  const payment = await paymentsService.getById(paymentId);
+  if (!payment || payment.reference_id !== orderId) {
+    throw new AppError('Payment not found', 404);
+  }
+  const capture = await paypalService.captureOrder(orderId);
+  const info = capture.purchase_units?.[0]?.payments?.captures?.[0];
+  let statusUpdate = { reference_id: info?.id || orderId };
+  if (capture.status === 'COMPLETED') {
+    statusUpdate.status = 'paid';
+    statusUpdate.paid_at = new Date();
+  } else {
+    statusUpdate.status = 'rejected';
+  }
+  const updated = await paymentsService.update(paymentId, statusUpdate);
+
+  if (updated.status === 'paid') {
+    try {
+      if (updated.item_type === 'book') {
+        await libraryService.recordPurchase(updated.user_id, updated.item_id, updated.amount);
+      } else if (updated.item_type === 'class') {
+        await enrollmentService.createEnrollment({
+          id: uuidv4(),
+          user_id: updated.user_id,
+          class_id: updated.item_id,
+          status: 'enrolled',
+        });
+      } else if (updated.item_type === 'tutorial') {
+        await tutorialEnrollmentService.createEnrollment({
+          id: uuidv4(),
+          user_id: updated.user_id,
+          tutorial_id: updated.item_id,
+          status: 'enrolled',
+        });
+      }
+    } catch (err) {
+      logger.error('Failed to finalize enrollment after PayPal payment:', err);
+    }
+  }
+
+  if (process.env.FRONTEND_URL) {
+    const redirectUrl = `${process.env.FRONTEND_URL}/payments/${updated.status === 'paid' ? 'success' : 'error'}`;
+    return res.redirect(redirectUrl);
+  }
+  sendSuccess(res, updated, 'PayPal payment processed');
+});
+

--- a/backend/src/modules/payments/paypal.routes.js
+++ b/backend/src/modules/payments/paypal.routes.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const controller = require('./paypal.controller');
+const { verifyToken, isStudent } = require('../../middleware/auth/authMiddleware');
+
+router.post('/create', verifyToken, isStudent, controller.createPayPalPayment);
+router.get('/callback', controller.handlePayPalCallback);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -159,6 +159,16 @@ app.use(
 app.use("/api/payments/student", require("./modules/payments/student.routes"));
 app.use("/api/payments/bank", require("./modules/payments/bank.routes"));
 app.use("/api/payments/crypto", require("./modules/payments/crypto.routes"));
+// Alias for NOWPayments crypto gateway
+app.use(
+  "/api/payments/nowpayments",
+  require("./modules/payments/crypto.routes")
+);
+// PayPal order creation and callback
+app.use(
+  "/api/payments/paypal",
+  require("./modules/payments/paypal.routes")
+);
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
 app.use(
   "/api/admin/payments/bank",

--- a/backend/src/services/paypalService.js
+++ b/backend/src/services/paypalService.js
@@ -28,10 +28,10 @@ exports.invalidateClient = () => {
   client = null;
 };
 
-exports.createOrder = async ({ amount, currency = 'USD' }) => {
+exports.createOrder = async ({ amount, currency = 'USD', returnUrl, cancelUrl }) => {
   const request = new paypal.orders.OrdersCreateRequest();
   request.prefer('return=representation');
-  request.requestBody({
+  const body = {
     intent: 'CAPTURE',
     purchase_units: [
       {
@@ -41,7 +41,13 @@ exports.createOrder = async ({ amount, currency = 'USD' }) => {
         },
       },
     ],
-  });
+  };
+  if (returnUrl || cancelUrl) {
+    body.application_context = {};
+    if (returnUrl) body.application_context.return_url = returnUrl;
+    if (cancelUrl) body.application_context.cancel_url = cancelUrl;
+  }
+  request.requestBody(body);
   const cli = await getClient();
   const response = await cli.execute(request);
   return response.result;

--- a/backend/tests/paypalPaymentRoutes.test.js
+++ b/backend/tests/paypalPaymentRoutes.test.js
@@ -1,0 +1,61 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/payments/payments.service', () => ({
+  create: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getByType: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn(),
+}));
+
+jest.mock('../src/services/paypalService', () => ({
+  createOrder: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'u1' }; next(); },
+  isStudent: (_req, _res, next) => next(),
+}));
+
+const paymentsService = require('../src/modules/payments/payments.service');
+const methodsService = require('../src/modules/paymentMethods/paymentMethods.service');
+const configService = require('../src/modules/paymentConfig/paymentConfig.service');
+const paypalService = require('../src/services/paypalService');
+const routes = require('../src/modules/payments/paypal.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payments/paypal', routes);
+const errorHandler = require('../src/middleware/errorHandler');
+app.use(errorHandler);
+
+describe('POST /api/payments/paypal/create', () => {
+  it('creates order and stores payment record', async () => {
+    methodsService.getByType.mockResolvedValue({ id: 'm2', settings: {} });
+    configService.getSettings.mockResolvedValue({ platformCut: { class: 15 } });
+    paypalService.createOrder.mockResolvedValue({
+      id: 'o1',
+      links: [{ rel: 'approve', href: 'https://paypal.test/approve' }],
+    });
+    paymentsService.create.mockResolvedValue({ id: 'p1' });
+
+    const res = await request(app)
+      .post('/api/payments/paypal/create')
+      .send({ item_type: 'class', item_id: 'c1', amount: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.approval_url).toBe('https://paypal.test/approve');
+    expect(paymentsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reference_id: 'o1',
+        platform_fee: 15,
+        instructor_amount: 85,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add PayPal payment creation & callback routes
- support NOWPayments create endpoint alias
- document PayPal and crypto payment flows

## Testing
- `cd backend && npm test` *(fails: POST /api/ads/admin creates ad, POST /api/books creates a book, PUT /api/books/:id updates a book, PUT /api/users/tutorials/admin/:id returns 403 when instructor updates another instructor's tutorial, PUT /api/users/tutorials/admin/:id updates tutorial with language and status, PATCH /api/messages/:id/read marks message as read, DELETE /api/messages/:id deletes message, POST /api/messages/:id/email sends email, POST /api/messages/:id/whatsapp sends whatsapp message, POST /api/messages/:id/video-call starts video call, POST /api/messages/call/:id/respond responds to call, updateTutorial tag transactions commits transaction when tag update succeeds, PUT /api/seo-config updates settings, POST /api/blog creates post)*

------
https://chatgpt.com/codex/tasks/task_e_68aabe79092c8328bc9dd59d03ed68b0