### PR TITLE
feat: add PayPal integration and NOWPayments alias

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,11 @@ The `/api/system-errors` route reads the latest lines from `logs/error.log` and 
 
 Students can upload proof of manual transfers via `POST /api/payments/student/receipts` using a multipart form field named `receipt`. The uploaded file URL can then be referenced by admins when recording payments. Each payment may optionally store this URL in the new `receipt_url` column.
 
+### PayPal and crypto payments
+
+- Students can initiate PayPal payments via `POST /api/payments/paypal/create`. The endpoint returns an approval URL and records the pending payment. PayPal redirects to `/api/payments/paypal/callback` after approval.
+- Crypto payments use NOWPayments through `POST /api/payments/nowpayments/create` with webhook notifications to `/api/payments/nowpayments/ipn`.
+
 ### Failed login attempt cleanup
 
 Authentication keeps a short-lived in-memory map of failed login attempts. Each entry stores timestamps of failed tries and a `lockUntil` field. A background task runs every minute to remove entries whose lock has expired, preventing unbounded growth of this map.

--- a/backend/src/modules/payments/crypto.routes.js
+++ b/backend/src/modules/payments/crypto.routes.js
@@ -4,5 +4,7 @@ const { verifyToken, isStudent } = require('../../middleware/auth/authMiddleware
 
 router.post('/ipn', controller.handleIPN);
 router.post('/initiate', verifyToken, isStudent, controller.initiateCryptoPayment);
+// Alias to support `/api/payments/nowpayments/create`
+router.post('/create', verifyToken, isStudent, controller.initiateCryptoPayment);
 
 module.exports = router;

--- a/backend/src/modules/payments/paypal.controller.js
+++ b/backend/src/modules/payments/paypal.controller.js
@@ -1,0 +1,141 @@
+const logger = require('../../utils/logger.js');
+const catchAsync = require('../../utils/catchAsync');
+const AppError = require('../../utils/AppError');
+const { sendSuccess } = require('../../utils/response');
+const paymentsService = require('./payments.service');
+const paymentConfigService = require('../paymentConfig/paymentConfig.service');
+const paymentMethodsService = require('../paymentMethods/paymentMethods.service');
+const paypalService = require('../../services/paypalService');
+const libraryService = require('../library/library.service');
+const enrollmentService = require('../classes/enrollments/classEnrollment.service');
+const tutorialEnrollmentService = require('../users/tutorials/enrollments/tutorialEnrollment.service');
+const { v4: uuidv4 } = require('uuid');
+
+const DEFAULT_PLATFORM_CUT = {
+  class: 15,
+  book: 10,
+  tutorial: 20,
+};
+
+const ALLOWED_ITEM_TYPES = ['class', 'book', 'tutorial'];
+const SUPPORTED_CURRENCIES = [
+  'USD','EUR','GBP','JPY','CNY','SAR','AED','KWD','INR','CAD','AUD','CHF','QAR','EGP','TRY','KRW','SGD','RUB',
+];
+
+exports.createPayPalPayment = catchAsync(async (req, res) => {
+  const { item_type, item_id, amount, currency } = req.body;
+  const user_id = req.user?.id;
+  if (!user_id || !item_type || !item_id || amount === undefined) {
+    throw new AppError('Missing required fields', 400);
+  }
+  if (!ALLOWED_ITEM_TYPES.includes(item_type)) {
+    throw new AppError('Invalid item type', 400);
+  }
+  const numericAmount = Number(amount);
+  if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+    throw new AppError('Amount must be a positive number', 400);
+  }
+  const currencyCode = currency || 'USD';
+  if (!SUPPORTED_CURRENCIES.includes(currencyCode)) {
+    throw new AppError('Unsupported currency', 400);
+  }
+
+  const method = await paymentMethodsService.getByType('paypal');
+  if (!method) {
+    throw new AppError('PayPal payment method not configured', 400);
+  }
+
+  let platform_fee = 0;
+  let instructor_amount = numericAmount;
+  try {
+    const cfg = await paymentConfigService.getSettings();
+    const cut = cfg?.platformCut?.[item_type] ?? DEFAULT_PLATFORM_CUT[item_type] ?? 0;
+    platform_fee = (numericAmount * cut) / 100;
+    instructor_amount = numericAmount - platform_fee;
+  } catch (err) {
+    logger.error('Failed to load payment settings:', err);
+  }
+
+  const paymentId = uuidv4();
+
+  const order = await paypalService.createOrder({
+    amount: numericAmount,
+    currency: currencyCode,
+    returnUrl: `${process.env.BACKEND_URL || ''}/api/payments/paypal/callback?payment_id=${paymentId}`,
+    cancelUrl: process.env.FRONTEND_URL
+      ? `${process.env.FRONTEND_URL}/payments/error`
+      : undefined,
+  });
+  const approval = order.links?.find((l) => l.rel === 'approve')?.href;
+  if (!approval) {
+    throw new AppError('Unable to retrieve PayPal approval url', 500);
+  }
+
+  const paymentData = {
+    id: paymentId,
+    user_id,
+    method_id: method.id,
+    item_type,
+    item_id,
+    amount: numericAmount,
+    currency: currencyCode,
+    status: 'pending_payment',
+    reference_id: order.id,
+    platform_fee,
+    instructor_amount,
+  };
+  const payment = await paymentsService.create(paymentData);
+  sendSuccess(res, { approval_url: approval, payment }, 'PayPal payment initiated');
+});
+
+exports.handlePayPalCallback = catchAsync(async (req, res) => {
+  const { token: orderId, payment_id: paymentId } = req.query;
+  if (!orderId || !paymentId) {
+    throw new AppError('Missing order information', 400);
+  }
+  const payment = await paymentsService.getById(paymentId);
+  if (!payment || payment.reference_id !== orderId) {
+    throw new AppError('Payment not found', 404);
+  }
+  const capture = await paypalService.captureOrder(orderId);
+  const info = capture.purchase_units?.[0]?.payments?.captures?.[0];
+  let statusUpdate = { reference_id: info?.id || orderId };
+  if (capture.status === 'COMPLETED') {
+    statusUpdate.status = 'paid';
+    statusUpdate.paid_at = new Date();
+  } else {
+    statusUpdate.status = 'rejected';
+  }
+  const updated = await paymentsService.update(paymentId, statusUpdate);
+
+  if (updated.status === 'paid') {
+    try {
+      if (updated.item_type === 'book') {
+        await libraryService.recordPurchase(updated.user_id, updated.item_id, updated.amount);
+      } else if (updated.item_type === 'class') {
+        await enrollmentService.createEnrollment({
+          id: uuidv4(),
+          user_id: updated.user_id,
+          class_id: updated.item_id,
+          status: 'enrolled',
+        });
+      } else if (updated.item_type === 'tutorial') {
+        await tutorialEnrollmentService.createEnrollment({
+          id: uuidv4(),
+          user_id: updated.user_id,
+          tutorial_id: updated.item_id,
+          status: 'enrolled',
+        });
+      }
+    } catch (err) {
+      logger.error('Failed to finalize enrollment after PayPal payment:', err);
+    }
+  }
+
+  if (process.env.FRONTEND_URL) {
+    const redirectUrl = `${process.env.FRONTEND_URL}/payments/${updated.status === 'paid' ? 'success' : 'error'}`;
+    return res.redirect(redirectUrl);
+  }
+  sendSuccess(res, updated, 'PayPal payment processed');
+});
+

--- a/backend/src/modules/payments/paypal.routes.js
+++ b/backend/src/modules/payments/paypal.routes.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const controller = require('./paypal.controller');
+const { verifyToken, isStudent } = require('../../middleware/auth/authMiddleware');
+
+router.post('/create', verifyToken, isStudent, controller.createPayPalPayment);
+router.get('/callback', controller.handlePayPalCallback);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -159,6 +159,16 @@ app.use(
 app.use("/api/payments/student", require("./modules/payments/student.routes"));
 app.use("/api/payments/bank", require("./modules/payments/bank.routes"));
 app.use("/api/payments/crypto", require("./modules/payments/crypto.routes"));
+// Alias for NOWPayments crypto gateway
+app.use(
+  "/api/payments/nowpayments",
+  require("./modules/payments/crypto.routes")
+);
+// PayPal order creation and callback
+app.use(
+  "/api/payments/paypal",
+  require("./modules/payments/paypal.routes")
+);
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
 app.use(
   "/api/admin/payments/bank",

--- a/backend/src/services/paypalService.js
+++ b/backend/src/services/paypalService.js
@@ -28,10 +28,10 @@ exports.invalidateClient = () => {
   client = null;
 };
 
-exports.createOrder = async ({ amount, currency = 'USD' }) => {
+exports.createOrder = async ({ amount, currency = 'USD', returnUrl, cancelUrl }) => {
   const request = new paypal.orders.OrdersCreateRequest();
   request.prefer('return=representation');
-  request.requestBody({
+  const body = {
     intent: 'CAPTURE',
     purchase_units: [
       {
@@ -41,7 +41,13 @@ exports.createOrder = async ({ amount, currency = 'USD' }) => {
         },
       },
     ],
-  });
+  };
+  if (returnUrl || cancelUrl) {
+    body.application_context = {};
+    if (returnUrl) body.application_context.return_url = returnUrl;
+    if (cancelUrl) body.application_context.cancel_url = cancelUrl;
+  }
+  request.requestBody(body);
   const cli = await getClient();
   const response = await cli.execute(request);
   return response.result;

--- a/backend/tests/paypalPaymentRoutes.test.js
+++ b/backend/tests/paypalPaymentRoutes.test.js
@@ -1,0 +1,61 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/payments/payments.service', () => ({
+  create: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getByType: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn(),
+}));
+
+jest.mock('../src/services/paypalService', () => ({
+  createOrder: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'u1' }; next(); },
+  isStudent: (_req, _res, next) => next(),
+}));
+
+const paymentsService = require('../src/modules/payments/payments.service');
+const methodsService = require('../src/modules/paymentMethods/paymentMethods.service');
+const configService = require('../src/modules/paymentConfig/paymentConfig.service');
+const paypalService = require('../src/services/paypalService');
+const routes = require('../src/modules/payments/paypal.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payments/paypal', routes);
+const errorHandler = require('../src/middleware/errorHandler');
+app.use(errorHandler);
+
+describe('POST /api/payments/paypal/create', () => {
+  it('creates order and stores payment record', async () => {
+    methodsService.getByType.mockResolvedValue({ id: 'm2', settings: {} });
+    configService.getSettings.mockResolvedValue({ platformCut: { class: 15 } });
+    paypalService.createOrder.mockResolvedValue({
+      id: 'o1',
+      links: [{ rel: 'approve', href: 'https://paypal.test/approve' }],
+    });
+    paymentsService.create.mockResolvedValue({ id: 'p1' });
+
+    const res = await request(app)
+      .post('/api/payments/paypal/create')
+      .send({ item_type: 'class', item_id: 'c1', amount: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.approval_url).toBe('https://paypal.test/approve');
+    expect(paymentsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reference_id: 'o1',
+        platform_fee: 15,
+        instructor_amount: 85,
+      })
+    );
+  });
+});

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -1,11 +1,10 @@
 import { useRouter } from 'next/router';
-import { useEffect, useState, useMemo, useRef } from 'react';
-import { fetchPaymentMethods, fetchPayPalClientId } from '@/services/paymentMethodService';
+import { useEffect, useState, useMemo } from 'react';
+import { fetchPaymentMethods } from '@/services/paymentMethodService';
 import { fetchClassDetails } from '@/services/classService';
 import { fetchTutorialDetails } from '@/services/tutorialService';
 import { validateCode } from '@/services/couponService';
-import { initiateBankPayment, initiateCryptoPayment } from '@/services/paymentService';
-import { createPayment as createStudentPayment } from '@/services/student/paymentService';
+import { initiateBankPayment, initiateCryptoPayment, initiatePayPalPayment } from '@/services/paymentService';
 import useCartStore from '@/store/cart/cartStore';
 import { useShallow } from 'zustand/react/shallow';
 import Navbar from '@/components/website/sections/Navbar';
@@ -120,9 +119,6 @@ export default function CheckoutPage() {
   const [bankInfo, setBankInfo] = useState(null);
   const [paymentStatus, setPaymentStatus] = useState('idle');
   const [allowInstallments, setAllowInstallments] = useState(false);
-  const paypalLoaded = useRef(false);
-  const paypalButtonRendered = useRef('');
-  const [paypalClientId, setPaypalClientId] = useState('');
   const finalPrice = useMemo(
     () => Math.max((itemInfo?.price ?? 0) - discount, 0),
     [itemInfo, discount]
@@ -159,17 +155,6 @@ export default function CheckoutPage() {
     };
   }, [itemId, itemType]);
 
-  useEffect(() => {
-    const loadId = async () => {
-      try {
-        const id = await fetchPayPalClientId();
-        setPaypalClientId(id || '');
-      } catch (err) {
-        console.error('Failed to load PayPal client ID', err);
-      }
-    };
-    loadId();
-  }, []);
 
   const handleApplyPromo = async () => {
     try {
@@ -232,6 +217,23 @@ export default function CheckoutPage() {
       }
       return;
     }
+    if (selectedMethod === 'paypal') {
+      try {
+        setPaymentStatus('processing');
+        const payload = {
+          item_id: itemInfo.id,
+          item_type: itemType,
+          amount: finalPrice,
+        };
+        const data = await initiatePayPalPayment(payload);
+        if (data?.approval_url) window.location.href = data.approval_url;
+      } catch (err) {
+        console.error('Failed to initiate PayPal payment', err);
+      } finally {
+        setPaymentStatus('idle');
+      }
+      return;
+    }
     if (selectedMethod === 'usdt' || selectedMethod === 'nft') {
       try {
         setPaymentStatus('processing');
@@ -256,67 +258,6 @@ export default function CheckoutPage() {
     setTimeout(completePayment, 1500);
   };
 
-  const renderPayPalButton = (amount) => {
-    if (!window.paypal) return;
-    const container = document.getElementById('paypal-button-container');
-    if (container) container.innerHTML = '';
-    paypalButtonRendered.current = amount;
-    window.paypal
-      .Buttons({
-      createOrder: (_, actions) =>
-        actions.order.create({
-          purchase_units: [{ amount: { value: amount } }],
-        }),
-      onApprove: async (data) => {
-        setPaymentStatus('processing');
-        try {
-          const method = methods.find((m) => m.type === 'paypal');
-          await createStudentPayment({
-            method_id: method?.id,
-            method_type: method?.type || 'paypal',
-            item_id: itemInfo.id,
-            item_type: itemType,
-            amount: parseFloat(amount),
-            reference_id: data.orderID,
-          });
-          completePayment();
-        } catch (err) {
-          console.error('Failed to record payment', err);
-          setPaymentStatus('idle');
-        }
-      },
-      onError: (err) => {
-        console.error('PayPal error', err);
-        setPaymentStatus('idle');
-      },
-    }).render('#paypal-button-container');
-  };
-
-  useEffect(() => {
-    if (selectedMethod !== 'paypal' || finalPrice <= 0 || !paypalClientId) return;
-    const amount = finalPrice.toString();
-    if (paypalButtonRendered.current === amount) return;
-
-    const render = () => renderPayPalButton(amount);
-
-    if (!paypalLoaded.current) {
-      const existing = document.querySelector('script[src*="paypal.com/sdk/js"]');
-      if (existing) {
-        paypalLoaded.current = true;
-        render();
-      } else {
-        const script = document.createElement('script');
-        script.src = `https://www.paypal.com/sdk/js?client-id=${paypalClientId}`;
-        script.addEventListener('load', () => {
-          paypalLoaded.current = true;
-          render();
-        });
-        document.body.appendChild(script);
-      }
-    } else {
-      render();
-    }
-  }, [selectedMethod, finalPrice, paypalClientId]);
 
   useEffect(() => {
     if (selectedMethod !== 'bank') {
@@ -461,6 +402,18 @@ export default function CheckoutPage() {
                 Pay with Crypto
               </button>
             </div>
+          ) : selectedMethod === 'paypal' ? (
+            <div className="bg-gray-900 p-4 rounded text-sm text-gray-300 text-center">
+              <p><strong>PayPal Payment</strong></p>
+              <p className="mb-2">You'll be redirected to PayPal to complete this payment.</p>
+              <button
+                onClick={handlePayment}
+                disabled={paymentStatus === 'processing'}
+                className="mt-2 bg-yellow-500 text-black px-4 py-2 rounded font-bold"
+              >
+                {paymentStatus === 'processing' ? 'Processing...' : 'Pay with PayPal'}
+              </button>
+            </div>
           ) : invoicePreview && selectedMethod === 'bank' ? (
             <div className="bg-gray-900 p-4 rounded text-sm text-gray-300">
               <p><strong>Invoice #{bankInfo?.invoiceNumber || bankInfo?.invoice_number || bankInfo?.reference}</strong></p>
@@ -477,11 +430,6 @@ export default function CheckoutPage() {
                 className="mt-4 py-2 px-6 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600"
                 onClick={() => router.push('/payments')}
               >Go to My Payments</button>
-            </div>
-          ) : selectedMethod === 'paypal' ? (
-            <div>
-              <div id="paypal-button-container" data-testid="paypal-button-container" className="mb-4"></div>
-              <p className="text-sm text-gray-500 mt-2 text-center">You'll be redirected after successful payment.</p>
             </div>
           ) : (
             <form onSubmit={(e) => { e.preventDefault(); handlePayment(); }}>

--- a/frontend/src/services/paymentMethodService.js
+++ b/frontend/src/services/paymentMethodService.js
@@ -4,8 +4,3 @@ export const fetchPaymentMethods = async () => {
   const { data } = await api.get("/payment-methods");
   return data?.data ?? [];
 };
-
-export const fetchPayPalClientId = async () => {
-  const { data } = await api.get("/payment-methods/paypal/client-id");
-  return data?.data?.clientId;
-};

--- a/frontend/src/services/paymentService.js
+++ b/frontend/src/services/paymentService.js
@@ -12,3 +12,9 @@ export const initiateCryptoPayment = async (payload) => {
   return data?.data ?? data;
 };
 
+// Initiate PayPal payment
+export const initiatePayPalPayment = async (payload) => {
+  const { data } = await api.post("/payments/paypal/create", payload);
+  return data?.data ?? data;
+};
+

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CheckoutPage from '../../pages/payments/checkout';
 import { fetchClassDetails } from '../../services/classService';
-import { fetchPaymentMethods, fetchPayPalClientId } from '../../services/paymentMethodService';
+import { fetchPaymentMethods } from '../../services/paymentMethodService';
 import { initiateBankPayment } from '../../services/paymentService';
 
 jest.mock('react-toastify', () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
@@ -27,13 +27,12 @@ jest.mock('../../services/classService', () => ({ fetchClassDetails: jest.fn() }
 jest.mock('../../services/tutorialService', () => ({ fetchTutorialDetails: jest.fn() }));
 jest.mock('../../services/paymentMethodService', () => ({
   fetchPaymentMethods: jest.fn(),
-  fetchPayPalClientId: jest.fn(),
 }));
 jest.mock('../../services/paymentService', () => ({
   initiateBankPayment: jest.fn(),
   initiateCryptoPayment: jest.fn(),
+  initiatePayPalPayment: jest.fn(),
 }));
-jest.mock('../../services/student/paymentService', () => ({ createPayment: jest.fn() }));
 
 const mockUseRouter = jest.fn();
 jest.mock('next/router', () => ({ useRouter: () => mockUseRouter() }));
@@ -47,7 +46,6 @@ beforeEach(() => {
   fetchClassDetails.mockResolvedValue({
     data: { id: 1, title: 'Test Class', instructor: 'Inst', price: 100, cover_image: '' },
   });
-  fetchPayPalClientId.mockResolvedValue('');
 });
 
 afterEach(() => {
@@ -87,12 +85,12 @@ test('adjusts inputs based on payment selection and displays invoice for bank', 
   expect(screen.queryByPlaceholderText('Card Number')).toBeNull();
   expect(screen.queryByPlaceholderText('Full Name')).toBeNull();
   expect(screen.queryByPlaceholderText('Email Address')).toBeNull();
-  expect(screen.getByTestId('paypal-button-container')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Pay with PayPal/i })).toBeInTheDocument();
   fireEvent.click(screen.getByText('Bank'));
   expect(screen.queryByPlaceholderText('Card Number')).toBeNull();
   expect(screen.getByPlaceholderText('Full Name')).toBeInTheDocument();
   expect(screen.getByPlaceholderText('Email Address')).toBeInTheDocument();
-  expect(screen.queryByTestId('paypal-button-container')).toBeNull();
+  expect(screen.queryByRole('button', { name: /Pay with PayPal/i })).toBeNull();
   fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'John' } });
   fireEvent.change(screen.getByPlaceholderText('Email Address'), { target: { value: 'john@example.com' } });
   fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Bank/i }));

--- a/frontend/src/tests/__tests__/checkoutPromo.test.js
+++ b/frontend/src/tests/__tests__/checkoutPromo.test.js
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CheckoutPage from '../../pages/payments/checkout';
 import { validateCode } from '../../services/couponService';
 import { fetchClassDetails } from '../../services/classService';
-import { fetchPaymentMethods, fetchPayPalClientId } from '../../services/paymentMethodService';
+import { fetchPaymentMethods } from '../../services/paymentMethodService';
 
 jest.mock('react-toastify', () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
 
@@ -37,7 +37,6 @@ jest.mock('../../services/tutorialService', () => ({
 
 jest.mock('../../services/paymentMethodService', () => ({
   fetchPaymentMethods: jest.fn(),
-  fetchPayPalClientId: jest.fn(),
 }));
 
 jest.mock('../../services/couponService', () => ({
@@ -61,7 +60,6 @@ beforeEach(() => {
   fetchPaymentMethods.mockResolvedValue([
     { name: 'stripe', label: 'Stripe', icon: 'stripe', active: true },
   ]);
-  fetchPayPalClientId.mockResolvedValue('');
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
- support PayPal payments on checkout by calling backend create endpoint and redirecting to approval URL
- expose a frontend service for initiating PayPal orders
- update checkout flow tests for PayPal option

## Testing
- `cd frontend && npm test`
- `cd backend && npm test` *(fails: tests/adsRoutes.test.js, tests/tutorialRoutes.test.js, src/modules/classes/__tests__/class.routes.test.js, tests/bookRoutes.test.js, tests/authSanitization.test.js, src/modules/books/__tests__/book.service.test.js, tests/seoConfigRoutes.test.js, tests/messageRoutes.test.js, tests/blogRoutes.test.js, tests/tutorialUpdateTransaction.test.js, tests/socialLoginConfigService.test.js, src/modules/community/public/__tests__/public.routes.test.js, tests/paymentInstallments.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aabe79092c8328bc9dd59d03ed68b0