### PR TITLE
feat: support platform currency for tutorials

### DIFF
--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -1,12 +1,29 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "next-i18next";
 import { fetchTutorialTags, createTutorialTag } from "@/services/instructor/tutorialTagService";
+import { getCurrencies } from "@/services/currencyService";
 
 export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, categories = [] }) {
   const { t } = useTranslation("tutorials");
   const [errors, setErrors] = useState({});
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [tagInput, setTagInput] = useState("");
+  const [currencyOptions, setCurrencyOptions] = useState([]);
+
+  useEffect(() => {
+    getCurrencies()
+      .then((currs) => {
+        setCurrencyOptions(currs);
+        const def = currs.find((c) => c.is_default) || currs[0];
+        if (def) {
+          setTutorialData((prev) => ({
+            ...prev,
+            currency: prev.currency || def.code,
+          }));
+        }
+      })
+      .catch(() => {});
+  }, [setTutorialData]);
 
   useEffect(() => {
     if (!tagInput) {
@@ -116,8 +133,15 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
     if (
       !tutorialData.isFree &&
       (!tutorialData.price || isNaN(tutorialData.price))
-    )
+    ) {
       newErrors.price = t("create.basic.validation.price_required");
+    }
+    if (!tutorialData.isFree && !tutorialData.currency) {
+      newErrors.currency = t(
+        "create.basic.validation.currency_required",
+        "Currency is required"
+      );
+    }
 
     setErrors(newErrors);
 
@@ -334,15 +358,32 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
       {!tutorialData.isFree && (
         <div>
           <label className="font-semibold">{t("create.basic.price_label")}</label>
-          <input
-            type="number"
-            className="w-full p-2 border rounded mt-1"
-            value={tutorialData.price}
-            onChange={(e) => handleChange("price", e.target.value)}
-            placeholder={t("create.basic.price_placeholder")}
-          />
+          <div className="flex gap-2">
+            <input
+              type="number"
+              className="w-full p-2 border rounded mt-1"
+              value={tutorialData.price}
+              onChange={(e) => handleChange("price", e.target.value)}
+              placeholder={t("create.basic.price_placeholder")}
+            />
+            <select
+              className="p-2 border rounded mt-1"
+              value={tutorialData.currency || ""}
+              onChange={(e) => handleChange("currency", e.target.value)}
+            >
+              <option value="">{t("create.basic.select_currency", "Select")}</option>
+              {currencyOptions.map((c) => (
+                <option key={c.code} value={c.code}>
+                  {c.code}
+                </option>
+              ))}
+            </select>
+          </div>
           {errors.price && (
             <p className="text-red-500 text-sm mt-1">{errors.price}</p>
+          )}
+          {errors.currency && (
+            <p className="text-red-500 text-sm mt-1">{errors.currency}</p>
           )}
         </div>
       )}

--- a/frontend/src/components/tutorials/create/ReviewStep.js
+++ b/frontend/src/components/tutorials/create/ReviewStep.js
@@ -1,5 +1,6 @@
 import { FaCheckCircle } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
+import { formatCurrency } from "@/utils/currency";
 
 export default function ReviewStep({
   tutorialData,
@@ -114,7 +115,10 @@ export default function ReviewStep({
             <p className="text-green-600 font-semibold">{t("create.review.free")}</p>
           ) : (
             <p className="text-gray-800">
-              <strong>{t("create.review.price_label")}</strong> ${tutorialData.price}
+              <strong>{t("create.review.price_label")}</strong>{" "}
+              {formatCurrency(tutorialData.price, {
+                currency: tutorialData.currency,
+              })}
             </p>
           )}
         </div>

--- a/frontend/src/components/tutorials/detail/EnrollBanner.js
+++ b/frontend/src/components/tutorials/detail/EnrollBanner.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { formatCurrency } from "@/utils/currency";
 
 const EnrollBanner = ({
   onEnroll,
@@ -9,10 +10,7 @@ const EnrollBanner = ({
   currency = "USD",
 }) => {
   const formattedPrice = isPaid
-    ? new Intl.NumberFormat(undefined, {
-        style: "currency",
-        currency,
-      }).format(Number(price))
+    ? formatCurrency(price, { currency })
     : "Free";
 
   let actionButton;

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -30,6 +30,7 @@ export default function CreateTutorialPage() {
     thumbnail: null,
     preview: null,
     price: "",
+    currency: "",
     isFree: false,
   });
 
@@ -45,6 +46,7 @@ export default function CreateTutorialPage() {
         preview: null,
         language: draft.language || "",
         lessonCount: draft.lessonCount || 1,
+        currency: draft.currency || "",
       });
     }
 
@@ -80,6 +82,9 @@ export default function CreateTutorialPage() {
     formData.append("is_paid", (!tutorialData.isFree).toString());
     if (!tutorialData.isFree) {
       formData.append("price", tutorialData.price);
+      if (tutorialData.currency) {
+        formData.append("currency", tutorialData.currency);
+      }
     }
     if (tutorialData.tags.length) {
       formData.append("tags", JSON.stringify(tutorialData.tags));

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -19,6 +19,7 @@ import useTutorialProgress from "@/hooks/useTutorialProgress";
 import EnrollBanner from "@/components/tutorials/detail/EnrollBanner";
 import LoginPrompt from "@/components/tutorials/detail/LoginPrompt";
 import { FaBookmark, FaHeart } from "react-icons/fa";
+import { formatCurrency } from "@/utils/currency";
 
 const RelatedTutorials = dynamic(() => import("@/components/tutorials/detail/RelatedTutorials"), { ssr: false });
 const CommentsSection = dynamic(() => import("@/components/tutorials/detail/CommentsSection"), { ssr: false });
@@ -466,7 +467,11 @@ export default function TutorialDetail() {
 
         <TutorialHeader
           {...tutorial}
-          price={Number(tutorial.price) > 0 ? `$${tutorial.price}` : t("free")}
+          price={
+            Number(tutorial.price) > 0
+              ? formatCurrency(tutorial.price, { currency: tutorial.currency })
+              : t("free")
+          }
         />
         <InstructorBio
           name={tutorial.instructor}


### PR DESCRIPTION
## Summary
- allow instructors to choose platform currencies when pricing tutorials
- format tutorial prices using configured currency

## Testing
- `npm test`
- `npm run lint` *(fails: 41 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aac2ed98108328a455793701d96369