### PR TITLE
Improve checkout item parsing for partial encoding

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -68,13 +68,28 @@ export function resolveCheckoutItem(query, cartItems) {
       // ignore decode errors; we'll attempt to parse whatever we have
     }
 
+    const attemptParse = (str) => {
+      try {
+        const parsed = JSON.parse(str);
+        if (Array.isArray(parsed) && parsed.length === 1) {
+          const p = parsed[0] || {};
+          if (!p.id) return null;
+          return { id: p.id, type: p.itemType || p.item_type || 'class' };
+        }
+      } catch {}
+      return null;
+    };
+
+    let result = attemptParse(decoded);
+    if (result) return result;
+
+    // Fallback: handle cases where the query was encoded without quoting keys/values
     try {
-      const parsed = JSON.parse(decoded);
-      if (Array.isArray(parsed) && parsed.length === 1) {
-        const p = parsed[0] || {};
-        if (!p.id) return null;
-        return { id: p.id, type: p.itemType || p.item_type || 'class' };
-      }
+      const fixed = decoded
+        .replace(/([{,]\s*)([A-Za-z0-9_]+)\s*:/g, '$1"$2":')
+        .replace(/:\s*([^,"}\]\s][^,}\]]*)/g, ':"$1"');
+      result = attemptParse(fixed);
+      if (result) return result;
     } catch (err) {
       console.error('Failed to parse checkout items', err);
     }

--- a/frontend/src/tests/__tests__/resolveCheckoutItem.test.js
+++ b/frontend/src/tests/__tests__/resolveCheckoutItem.test.js
@@ -7,6 +7,12 @@ describe('resolveCheckoutItem', () => {
     expect(resolveCheckoutItem(query, [])).toEqual({ id: '123', type: 'tutorial' });
   });
 
+  it('parses items when quotes are not URL-encoded', () => {
+    const items = '%5B%7B"id"%3A"123"%2C"itemType"%3A"tutorial"%7D%5D';
+    const query = { items };
+    expect(resolveCheckoutItem(query, [])).toEqual({ id: '123', type: 'tutorial' });
+  });
+
   it('falls back to cart items when query missing', () => {
     const cart = [{ id: '1', item_type: 'class' }];
     expect(resolveCheckoutItem({}, cart)).toEqual({ id: '1', type: 'class' });


### PR DESCRIPTION
## Summary
- handle checkout item queries where quotes weren't URL encoded
- cover partially encoded query parsing with test

## Testing
- `npm test`
- `npm run lint` *(fails: 41 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aacc55067c8328bfccbe615f744fc7