### PR TITLE
feat: add payment-specific checkout forms

### DIFF
--- a/frontend/src/components/payments/forms/BankTransferForm.js
+++ b/frontend/src/components/payments/forms/BankTransferForm.js
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+export default function BankTransferForm({ onSubmit, processing, finalPrice }) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit({ name, email });
+      }}
+      className="space-y-4"
+    >
+      <label className="block">
+        <span className="text-sm">Account Holder Name</span>
+        <input
+          type="text"
+          required
+          placeholder="Account Holder Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full p-3 text-sm rounded bg-gray-700 text-white"
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm">Email Address</span>
+        <input
+          type="email"
+          required
+          placeholder="Email Address"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full p-3 text-sm rounded bg-gray-700 text-white"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={processing}
+        className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all"
+      >
+        {processing ? 'Processing...' : `Pay $${finalPrice} with Bank`}
+      </button>
+      <p className="text-sm text-gray-500 text-center">
+        Bank transfer instructions will be provided after submission.
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/components/payments/forms/CardPaymentForm.js
+++ b/frontend/src/components/payments/forms/CardPaymentForm.js
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+export default function CardPaymentForm({ onSubmit, processing, allowInstallments, installments, perInstallment, finalPrice, selectedMethodLabel }) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [card, setCard] = useState('');
+  const [expiry, setExpiry] = useState('');
+  const [cvc, setCvc] = useState('');
+
+  const buttonText = processing
+    ? 'Processing...'
+    : allowInstallments
+      ? `Pay $${perInstallment.toFixed(2)} (1/${installments}) with ${selectedMethodLabel}`
+      : `Pay $${finalPrice} with ${selectedMethodLabel}`;
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit({ name, email, card, expiry, cvc });
+      }}
+    >
+      <input
+        type="text"
+        placeholder="Full Name"
+        required
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white"
+      />
+      <input
+        type="email"
+        placeholder="Email Address"
+        required
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white"
+      />
+      <input
+        type="tel"
+        placeholder="Card Number"
+        required
+        inputMode="numeric"
+        value={card}
+        onChange={(e) => setCard(e.target.value)}
+        className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white"
+      />
+      <input
+        type="text"
+        placeholder="Expiration Date (MM/YY)"
+        required
+        value={expiry}
+        onChange={(e) => setExpiry(e.target.value)}
+        className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white"
+      />
+      <input
+        type="text"
+        placeholder="CVC"
+        required
+        value={cvc}
+        onChange={(e) => setCvc(e.target.value)}
+        className="w-full mb-6 p-3 text-sm rounded bg-gray-700 text-white"
+      />
+      <button
+        type="submit"
+        disabled={processing}
+        className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all"
+      >
+        {buttonText}
+      </button>
+      <p className="text-sm text-gray-500 mt-2 text-center">You&apos;ll be redirected after successful payment.</p>
+    </form>
+  );
+}

--- a/frontend/src/components/payments/forms/CryptoPaymentForm.js
+++ b/frontend/src/components/payments/forms/CryptoPaymentForm.js
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+export default function CryptoPaymentForm({ onSubmit, processing, finalPrice }) {
+  const [email, setEmail] = useState('');
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit({ email });
+      }}
+      className="bg-gray-900 p-4 rounded text-sm text-gray-300 space-y-4"
+    >
+      <p><strong>Crypto Payment</strong></p>
+      <p className="text-xs text-gray-400">You&apos;ll be redirected to our crypto provider to complete this payment.</p>
+      <label className="block">
+        <span className="text-gray-400">Email Address</span>
+        <input
+          type="email"
+          required
+          placeholder="Email Address"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full mt-1 p-2 rounded bg-gray-700 text-white"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={processing}
+        className="bg-yellow-500 text-black px-4 py-2 rounded font-bold w-full"
+      >
+        {processing ? 'Processing...' : `Pay $${finalPrice} with Crypto`}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/payments/forms/PayPalForm.js
+++ b/frontend/src/components/payments/forms/PayPalForm.js
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+export default function PayPalForm({ onSubmit, processing, finalPrice }) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit({ name, email });
+      }}
+      className="bg-gray-900 p-4 rounded text-sm text-gray-300 space-y-4"
+    >
+      <p><strong>PayPal Payment</strong></p>
+      <label className="block">
+        <span className="text-gray-400">Full Name</span>
+        <input
+          type="text"
+          required
+          placeholder="Full Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full mt-1 p-2 rounded bg-gray-700 text-white"
+        />
+      </label>
+      <label className="block">
+        <span className="text-gray-400">PayPal Email</span>
+        <input
+          type="email"
+          required
+          placeholder="PayPal Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full mt-1 p-2 rounded bg-gray-700 text-white"
+        />
+      </label>
+        <p className="text-xs text-gray-400">You&apos;ll be redirected to PayPal to complete this payment.</p>
+      <button
+        type="submit"
+        disabled={processing}
+        className="bg-yellow-500 text-black px-4 py-2 rounded font-bold w-full"
+      >
+        {processing ? 'Processing...' : `Pay $${finalPrice} with PayPal`}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -10,6 +10,10 @@ import { useShallow } from 'zustand/react/shallow';
 import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import { toast } from 'react-toastify';
+import PayPalForm from '@/components/payments/forms/PayPalForm';
+import BankTransferForm from '@/components/payments/forms/BankTransferForm';
+import CryptoPaymentForm from '@/components/payments/forms/CryptoPaymentForm';
+import CardPaymentForm from '@/components/payments/forms/CardPaymentForm';
 import {
   FaCcStripe, FaPaypal, FaMoneyCheckAlt, FaUniversity,
   FaEthereum, FaFileInvoice, FaDownload, FaCheckCircle
@@ -43,8 +47,14 @@ function resolveIconElement(method) {
     if (iconMap[lower]) return iconMap[lower];
   }
   return (
-    iconMap[(method.type || '').toString().trim().toLowerCase()] || <FaMoneyCheckAlt />
+    iconMap[getMethodIdentifier(method).toLowerCase()] || <FaMoneyCheckAlt />
   );
+}
+
+function getMethodIdentifier(method) {
+  if (method?.type && method.type.trim()) return method.type.trim();
+  if (method?.name && method.name.trim()) return method.name.trim();
+  return '';
 }
 
 export function resolveCheckoutItem(query, cartItems) {
@@ -165,7 +175,7 @@ export default function CheckoutPage() {
         if (!active) return;
         setMethods(Array.isArray(data) ? data : []);
         if (Array.isArray(data) && data.length > 0) {
-          setSelectedMethod((prev) => prev || (data[0].type || '').trim());
+          setSelectedMethod((prev) => prev || getMethodIdentifier(data[0]));
         }
       } catch (err) {
         console.error('Failed to load payment methods', err);
@@ -219,7 +229,7 @@ export default function CheckoutPage() {
     );
   };
 
-  const handlePayment = async () => {
+  const handlePayment = async (_formData = {}) => {
     if (normalizedMethod === 'bank') {
       try {
         setPaymentStatus('processing');
@@ -260,13 +270,13 @@ export default function CheckoutPage() {
       try {
         setPaymentStatus('processing');
         const method = methods.find(
-          (m) => (m.type || '').toString().trim().toLowerCase() === normalizedMethod
+          (m) => getMethodIdentifier(m).toLowerCase() === normalizedMethod
         );
         const payload = {
           item_id: itemInfo.id,
           item_type: itemType,
           amount: finalPrice,
-          method_type: method?.type,
+          method_type: method?.type || getMethodIdentifier(method),
         };
         if (couponId) payload.coupon_id = couponId;
         const data = await initiateCryptoPayment(payload);
@@ -328,7 +338,7 @@ export default function CheckoutPage() {
     : [];
   const selectedMethodLabel =
     availableMethods.find(
-      (m) => (m.type || '').toString().trim().toLowerCase() === normalizedMethod
+      (m) => getMethodIdentifier(m).toLowerCase() === normalizedMethod
     )?.name || selectedMethod;
 
   return (
@@ -355,19 +365,22 @@ export default function CheckoutPage() {
           <div className="bg-gray-800 p-6 rounded-xl shadow-md mb-6">
             <h2 className="text-lg font-semibold mb-4 flex items-center gap-2"><FaFileInvoice /> Select Payment Method</h2>
             <div className="grid grid-cols-2 sm:grid-cols-4 md:grid-cols-5 gap-4">
-              {availableMethods.map((method) => (
-                <button
-                  key={method.id || method.type}
-                  onClick={() => setSelectedMethod((method.type || '').trim())}
-                  className={`flex flex-col items-center justify-center gap-2 py-3 px-4 rounded-xl font-semibold text-sm text-center transition-all border
-                  ${selectedMethod === (method.type || '').trim() ? 'bg-yellow-500 text-black border-yellow-400' : 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600'}`}
-                >
-                  <div className="text-2xl" data-testid={`payment-icon-${(method.type || '').trim()}`}>
-                    {resolveIconElement(method)}
-                  </div>
-                  <div>{method.name}</div>
-                </button>
-              ))}
+              {availableMethods.map((method) => {
+                const identifier = getMethodIdentifier(method);
+                return (
+                  <button
+                    key={method.id || identifier}
+                    onClick={() => setSelectedMethod(identifier)}
+                    className={`flex flex-col items-center justify-center gap-2 py-3 px-4 rounded-xl font-semibold text-sm text-center transition-all border
+                  ${selectedMethod === identifier ? 'bg-yellow-500 text-black border-yellow-400' : 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600'}`}
+                  >
+                    <div className="text-2xl" data-testid={`payment-icon-${identifier.toLowerCase()}`}>
+                      {resolveIconElement(method)}
+                    </div>
+                    <div>{method.name}</div>
+                  </button>
+                );
+              })}
             </div>
           </div>
         )}
@@ -420,26 +433,6 @@ export default function CheckoutPage() {
             <div className="text-green-400 text-center text-lg py-6">
               <FaCheckCircle className="inline mr-2 text-2xl" /> Payment Successful! Redirecting...
             </div>
-          ) : normalizedMethod === 'usdt' || normalizedMethod === 'nft' ? (
-            <div className="bg-gray-900 p-4 rounded text-sm text-gray-300">
-              <p><strong>Crypto Payment</strong></p>
-              <p className="mb-2">You'll be redirected to complete this payment.</p>
-              <button onClick={handlePayment} className="mt-2 bg-yellow-500 text-black px-4 py-2 rounded font-bold">
-                Pay with Crypto
-              </button>
-            </div>
-          ) : normalizedMethod === 'paypal' ? (
-            <div className="bg-gray-900 p-4 rounded text-sm text-gray-300 text-center">
-              <p><strong>PayPal Payment</strong></p>
-              <p className="mb-2">You'll be redirected to PayPal to complete this payment.</p>
-              <button
-                onClick={handlePayment}
-                disabled={paymentStatus === 'processing'}
-                className="mt-2 bg-yellow-500 text-black px-4 py-2 rounded font-bold"
-              >
-                {paymentStatus === 'processing' ? 'Processing...' : 'Pay with PayPal'}
-              </button>
-            </div>
           ) : invoicePreview && normalizedMethod === 'bank' ? (
             <div className="bg-gray-900 p-4 rounded text-sm text-gray-300">
               <p><strong>Invoice #{bankInfo?.invoiceNumber || bankInfo?.invoice_number || bankInfo?.reference}</strong></p>
@@ -457,26 +450,34 @@ export default function CheckoutPage() {
                 onClick={() => router.push('/payments')}
               >Go to My Payments</button>
             </div>
+          ) : normalizedMethod === 'paypal' ? (
+            <PayPalForm
+              onSubmit={handlePayment}
+              processing={paymentStatus === 'processing'}
+              finalPrice={finalPrice}
+            />
+          ) : normalizedMethod === 'bank' ? (
+            <BankTransferForm
+              onSubmit={handlePayment}
+              processing={paymentStatus === 'processing'}
+              finalPrice={finalPrice}
+            />
+          ) : normalizedMethod === 'usdt' || normalizedMethod === 'nft' ? (
+            <CryptoPaymentForm
+              onSubmit={handlePayment}
+              processing={paymentStatus === 'processing'}
+              finalPrice={finalPrice}
+            />
           ) : (
-            <form onSubmit={(e) => { e.preventDefault(); handlePayment(); }}>
-              <input type="text" placeholder="Full Name" required className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white" />
-              <input type="email" placeholder="Email Address" required className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white" />
-              {normalizedMethod !== 'bank' && (
-                <>
-                  <input type="tel" placeholder="Card Number" required inputMode="numeric" className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white" />
-                  <input type="text" placeholder="Expiration Date (MM/YY)" required className="w-full mb-3 p-3 text-sm rounded bg-gray-700 text-white" />
-                  <input type="text" placeholder="CVC" required className="w-full mb-6 p-3 text-sm rounded bg-gray-700 text-white" />
-                </>
-              )}
-              <button type="submit" disabled={paymentStatus === 'processing'} className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all">
-                {paymentStatus === 'processing'
-                  ? 'Processing...'
-                  : allowInstallments
-                  ? `Pay $${perInstallment.toFixed(2)} (1/${installments}) with ${selectedMethodLabel}`
-                  : `Pay $${finalPrice} with ${selectedMethodLabel}`}
-              </button>
-              <p className="text-sm text-gray-500 mt-2 text-center">You'll be redirected after successful payment.</p>
-            </form>
+            <CardPaymentForm
+              onSubmit={handlePayment}
+              processing={paymentStatus === 'processing'}
+              allowInstallments={allowInstallments}
+              installments={installments}
+              perInstallment={perInstallment}
+              finalPrice={finalPrice}
+              selectedMethodLabel={selectedMethodLabel}
+            />
           )}
         </div>
       </main>

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -55,7 +55,7 @@ afterEach(() => {
 test('renders payment logos from url and fallback', async () => {
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Stripe', type: 'stripe', icon: 'https://example.com/stripe.png' },
-    { id: 2, name: 'PayPal', type: 'paypal ' },
+    { id: 2, name: 'PayPal', type: null },
   ]);
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
@@ -68,7 +68,7 @@ test('renders payment logos from url and fallback', async () => {
 test('adjusts inputs based on payment selection and displays invoice for bank', async () => {
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Stripe', type: 'stripe' },
-    { id: 2, name: 'PayPal', type: 'PayPal ' },
+    { id: 2, name: 'PayPal', type: null },
     { id: 3, name: 'Bank', type: 'bank' },
   ]);
   initiateBankPayment.mockResolvedValue({
@@ -83,15 +83,15 @@ test('adjusts inputs based on payment selection and displays invoice for bank', 
   expect(screen.getByPlaceholderText('Full Name')).toBeInTheDocument();
   fireEvent.click(screen.getByText('PayPal'));
   expect(screen.queryByPlaceholderText('Card Number')).toBeNull();
-  expect(screen.queryByPlaceholderText('Full Name')).toBeNull();
-  expect(screen.queryByPlaceholderText('Email Address')).toBeNull();
-  expect(screen.getByRole('button', { name: /Pay with PayPal/i })).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('Full Name')).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('PayPal Email')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Pay \$100 with PayPal/i })).toBeInTheDocument();
   fireEvent.click(screen.getByText('Bank'));
   expect(screen.queryByPlaceholderText('Card Number')).toBeNull();
-  expect(screen.getByPlaceholderText('Full Name')).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('Account Holder Name')).toBeInTheDocument();
   expect(screen.getByPlaceholderText('Email Address')).toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: /Pay with PayPal/i })).toBeNull();
-  fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'John' } });
+  expect(screen.queryByRole('button', { name: /Pay \$100 with PayPal/i })).toBeNull();
+  fireEvent.change(screen.getByPlaceholderText('Account Holder Name'), { target: { value: 'John' } });
   fireEvent.change(screen.getByPlaceholderText('Email Address'), { target: { value: 'john@example.com' } });
   fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Bank/i }));
   await waitFor(() => expect(initiateBankPayment).toHaveBeenCalled());


### PR DESCRIPTION
## Summary
- add dedicated forms for PayPal, bank transfer, crypto, and card payments
- render payment-specific form in checkout page
- expand checkout tests for new payment flow
- detect PayPal by name when type is missing so the correct form renders

## Testing
- `npm test`
- `npm run lint` *(fails: 345 problems (38 errors, 307 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68aacf4698608328989e7e4c519c86c7