### PR TITLE
feat: add bank transfer details and payment selection

### DIFF
--- a/backend/src/migrations/20250915120000_add_bank_details_to_payments.js
+++ b/backend/src/migrations/20250915120000_add_bank_details_to_payments.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('payments', function(table) {
+    table.jsonb('bank_details');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('payments', function(table) {
+    table.dropColumn('bank_details');
+  });
+};

--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -42,7 +42,18 @@ exports.getBankPayments = catchAsync(async (req, res) => {
 });
 
 exports.initiateBankPayment = catchAsync(async (req, res) => {
-  const { item_type, item_id, amount, currency } = req.body;
+  const {
+    item_type,
+    item_id,
+    amount,
+    currency,
+    bank_name,
+    account_holder_name,
+    account_number,
+    swift_code,
+    branch_address,
+    extra_instructions,
+  } = req.body;
   const user_id = req.user?.id;
 
   if (!user_id || !item_type || !item_id || amount === undefined) {
@@ -82,6 +93,15 @@ exports.initiateBankPayment = catchAsync(async (req, res) => {
     logger.error("Failed to load payment settings:", err);
   }
 
+  const bank_details = {
+    bank_name,
+    account_holder_name,
+    account_number,
+    swift_code,
+    branch_address,
+    extra_instructions,
+  };
+
   const paymentData = {
     id: uuidv4(),
     user_id,
@@ -90,14 +110,19 @@ exports.initiateBankPayment = catchAsync(async (req, res) => {
     item_id,
     amount: numericAmount,
     currency: currencyCode,
-    status: "pending_payment",
+    status: "awaiting_approval",
     platform_fee,
     instructor_amount,
+    bank_details,
   };
 
-  const invoice = await paymentsService.create(paymentData);
+  const payment = await paymentsService.create(paymentData);
 
-  sendSuccess(res, { settings: bankMethod.settings, invoice }, "Bank payment initiated");
+  sendSuccess(
+    res,
+    payment,
+    "Bank transfer request submitted and pending admin approval"
+  );
 });
 
 exports.approveBankPayment = catchAsync(async (req, res) => {

--- a/frontend/src/components/payments/forms/BankTransferForm.js
+++ b/frontend/src/components/payments/forms/BankTransferForm.js
@@ -1,36 +1,88 @@
 import { useState } from 'react';
 
 export default function BankTransferForm({ onSubmit, processing, finalPrice }) {
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
+  const [bankName, setBankName] = useState('');
+  const [accountHolder, setAccountHolder] = useState('');
+  const [accountNumber, setAccountNumber] = useState('');
+  const [swiftCode, setSwiftCode] = useState('');
+  const [branchAddress, setBranchAddress] = useState('');
+  const [instructions, setInstructions] = useState('');
 
   return (
     <form
       onSubmit={(e) => {
         e.preventDefault();
-        onSubmit({ name, email });
+        onSubmit({
+          bank_name: bankName,
+          account_holder_name: accountHolder,
+          account_number: accountNumber,
+          swift_code: swiftCode,
+          branch_address: branchAddress,
+          extra_instructions: instructions,
+        });
       }}
       className="space-y-4"
     >
+      <label className="block">
+        <span className="text-sm">Bank Name</span>
+        <input
+          type="text"
+          required
+          placeholder="Bank Name"
+          value={bankName}
+          onChange={(e) => setBankName(e.target.value)}
+          className="w-full p-3 text-sm rounded bg-gray-700 text-white"
+        />
+      </label>
       <label className="block">
         <span className="text-sm">Account Holder Name</span>
         <input
           type="text"
           required
           placeholder="Account Holder Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={accountHolder}
+          onChange={(e) => setAccountHolder(e.target.value)}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white"
         />
       </label>
       <label className="block">
-        <span className="text-sm">Email Address</span>
+        <span className="text-sm">Account Number / IBAN</span>
         <input
-          type="email"
+          type="text"
           required
-          placeholder="Email Address"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Account Number / IBAN"
+          value={accountNumber}
+          onChange={(e) => setAccountNumber(e.target.value)}
+          className="w-full p-3 text-sm rounded bg-gray-700 text-white"
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm">SWIFT Code</span>
+        <input
+          type="text"
+          required
+          placeholder="SWIFT Code"
+          value={swiftCode}
+          onChange={(e) => setSwiftCode(e.target.value)}
+          className="w-full p-3 text-sm rounded bg-gray-700 text-white"
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm">Branch Address (optional)</span>
+        <input
+          type="text"
+          placeholder="Branch Address"
+          value={branchAddress}
+          onChange={(e) => setBranchAddress(e.target.value)}
+          className="w-full p-3 text-sm rounded bg-gray-700 text-white"
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm">Extra Instructions</span>
+        <textarea
+          placeholder="Extra Instructions"
+          value={instructions}
+          onChange={(e) => setInstructions(e.target.value)}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white"
         />
       </label>
@@ -41,9 +93,6 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice }) {
       >
         {processing ? 'Processing...' : `Pay $${finalPrice} with Bank`}
       </button>
-      <p className="text-sm text-gray-500 text-center">
-        Bank transfer instructions will be provided after submission.
-      </p>
     </form>
   );
 }

--- a/frontend/src/pages/checkout/book/[id].js
+++ b/frontend/src/pages/checkout/book/[id].js
@@ -1,85 +1,15 @@
-import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
-import Navbar from "@/components/website/sections/Navbar";
-import Footer from "@/components/website/sections/Footer";
-import { fetchBook } from "@/services/bookService";
-import { purchaseBook } from "@/services/checkoutService";
-import useLibraryStore from "@/store/libraryStore";
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
-export default function BookCheckoutPage() {
+export default function BookCheckoutRedirect() {
   const router = useRouter();
   const { id } = router.query;
-  const [book, setBook] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-  const [processing, setProcessing] = useState(false);
-  const fetchLibrary = useLibraryStore((state) => state.fetchLibrary);
 
   useEffect(() => {
-    if (!id) return;
-    const load = async () => {
-      try {
-        const data = await fetchBook(id);
-        setBook(data);
-        setError("");
-      } catch (e) {
-        console.error("Failed to load book", e);
-        setError("Failed to load book");
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-  }, [id]);
-
-  const handlePurchase = async () => {
-    if (!id) return;
-    setProcessing(true);
-    try {
-      await purchaseBook(id);
-      await fetchLibrary();
-      router.push("/cart/confirmation");
-    } catch (e) {
-      console.error("Failed to purchase", e);
-      setError("Payment failed");
-      setProcessing(false);
+    if (id) {
+      router.replace(`/payments/checkout?itemType=book&itemId=${id}`);
     }
-  };
+  }, [id, router]);
 
-  if (loading) return <div className="text-white text-center mt-32">Loading...</div>;
-  if (error) return <div className="text-white text-center mt-32">{error}</div>;
-  if (!book) return null;
-
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-950 to-gray-900 text-white">
-      <Navbar />
-      <main className="max-w-3xl mx-auto px-4 py-20 mt-16">
-        <h1 className="text-3xl font-bold mb-6 text-yellow-400">Checkout</h1>
-        <div className="bg-gray-800 p-6 rounded-xl shadow-md mb-6 flex gap-6 items-center">
-          {book.cover_image_url && (
-            <img
-              src={book.cover_image_url}
-              alt={book.title}
-              className="w-32 h-32 object-cover rounded-lg"
-            />
-          )}
-          <div>
-            <h2 className="text-xl font-semibold">{book.title}</h2>
-            {book.author && (
-              <p className="text-sm text-gray-400">by {book.author}</p>
-            )}
-            <p className="mt-2 font-bold text-lg">Price: ${book.price}</p>
-          </div>
-        </div>
-        <button
-          onClick={handlePurchase}
-          disabled={processing}
-          className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all"
-        >
-          {processing ? "Processing..." : "Pay Now"}
-        </button>
-      </main>
-      <Footer />
-    </div>
-  );
+  return <p className="text-white text-center mt-32">Redirecting...</p>;
 }

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -143,8 +143,6 @@ export default function CheckoutPage() {
   const [promoCode, setPromoCode] = useState('');
   const [discount, setDiscount] = useState(0);
   const [couponId, setCouponId] = useState(null);
-  const [invoicePreview, setInvoicePreview] = useState(false);
-  const [bankInfo, setBankInfo] = useState(null);
   const [paymentStatus, setPaymentStatus] = useState('idle');
   const [allowInstallments, setAllowInstallments] = useState(false);
   const finalPrice = useMemo(
@@ -243,14 +241,13 @@ export default function CheckoutPage() {
           item_id: itemInfo.id,
           item_type: itemType,
           amount: finalPrice,
+          ..._formData,
         };
         if (couponId) payload.coupon_id = couponId;
-        const data = await initiateBankPayment(payload);
-        setBankInfo(data);
-        setInvoicePreview(true);
+        await initiateBankPayment(payload);
+        setPaymentStatus('submitted_bank');
       } catch (err) {
         console.error('Failed to initiate bank transfer', err);
-      } finally {
         setPaymentStatus('idle');
       }
       return;
@@ -299,36 +296,6 @@ export default function CheckoutPage() {
     setTimeout(completePayment, 1500);
   };
 
-
-  useEffect(() => {
-    if (normalizedMethod !== 'bank') {
-      setInvoicePreview(false);
-      setBankInfo(null);
-    }
-  }, [selectedMethod]);
-
-  const downloadInvoice = () => {
-    if (!bankInfo) return;
-    const invoiceNumber =
-      bankInfo.invoiceNumber || bankInfo.invoice_number || bankInfo.reference || Date.now();
-    const html = `<!DOCTYPE html><html><head><meta charset="utf-8" /><title>Invoice ${invoiceNumber}</title></head><body>` +
-      `<h1>Invoice #${invoiceNumber}</h1>` +
-      `<p>Item: ${itemInfo.title}</p>` +
-      `<p>Amount: $${finalPrice}</p>` +
-      `<p>Bank: ${bankInfo.bankName || bankInfo.bank_name}</p>` +
-      `<p>Account Number: ${bankInfo.accountNumber || bankInfo.account_number}</p>` +
-      `<p>IBAN: ${bankInfo.iban}</p>` +
-      `</body></html>`;
-    const blob = new Blob([html], { type: 'text/html' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `invoice-${invoiceNumber}.html`;
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    URL.revokeObjectURL(url);
-  };
 
   if (checkoutError) return <div className="text-white text-center mt-32">{checkoutError}</div>;
   if (!itemInfo) return <div className="text-white text-center mt-32">Loading...</div>;
@@ -440,22 +407,9 @@ export default function CheckoutPage() {
             <div className="text-green-400 text-center text-lg py-6">
               <FaCheckCircle className="inline mr-2 text-2xl" /> Payment Successful! Redirecting...
             </div>
-          ) : invoicePreview && normalizedMethod === 'bank' ? (
-            <div className="bg-gray-900 p-4 rounded text-sm text-gray-300">
-              <p><strong>Invoice #{bankInfo?.invoiceNumber || bankInfo?.invoice_number || bankInfo?.reference}</strong></p>
-              <p className="mt-2">{itemType === 'tutorial' ? 'Tutorial' : 'Class'}: {itemInfo.title}</p>
-              <p>Price: ${finalPrice}</p>
-              <p>Bank: {bankInfo?.bankName || bankInfo?.bank_name}</p>
-              <p>Account Number: {bankInfo?.accountNumber || bankInfo?.account_number}</p>
-              <p>IBAN: {bankInfo?.iban}</p>
-              <button onClick={downloadInvoice} className="flex items-center gap-2 bg-white text-black px-4 py-2 rounded mb-4">
-                <FaDownload /> Download Invoice
-              </button>
-              <p className="text-yellow-400">After completing the transfer, upload your receipt via "My Payments".</p>
-              <button
-                className="mt-4 py-2 px-6 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600"
-                onClick={() => router.push('/payments')}
-              >Go to My Payments</button>
+          ) : paymentStatus === 'submitted_bank' ? (
+            <div className="text-yellow-400 text-center text-lg py-6">
+              Your bank transfer request has been submitted and is pending admin approval.
             </div>
           ) : normalizedMethod === 'paypal' ? (
             <PayPalForm

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -65,18 +65,13 @@ test('renders payment logos from url and fallback', async () => {
   expect(paypalIcon).not.toBeNull();
 });
 
-test('adjusts inputs based on payment selection and displays invoice for bank', async () => {
+test('adjusts inputs based on payment selection and submits bank details', async () => {
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Stripe', type: 'stripe' },
     { id: 2, name: 'PayPal', type: null },
     { id: 3, name: 'Bank', type: 'bank' },
   ]);
-  initiateBankPayment.mockResolvedValue({
-    invoiceNumber: 'INV-1',
-    bankName: 'Test Bank',
-    accountNumber: '123',
-    iban: 'IBAN',
-  });
+  initiateBankPayment.mockResolvedValue({});
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
   expect(screen.getByPlaceholderText('Card Number')).toBeInTheDocument();
@@ -88,13 +83,12 @@ test('adjusts inputs based on payment selection and displays invoice for bank', 
   expect(screen.getByRole('button', { name: /Pay \$100 with PayPal/i })).toBeInTheDocument();
   fireEvent.click(screen.getByText('Bank'));
   expect(screen.queryByPlaceholderText('Card Number')).toBeNull();
-  expect(screen.getByPlaceholderText('Account Holder Name')).toBeInTheDocument();
-  expect(screen.getByPlaceholderText('Email Address')).toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: /Pay \$100 with PayPal/i })).toBeNull();
+  expect(screen.getByPlaceholderText('Bank Name')).toBeInTheDocument();
+  fireEvent.change(screen.getByPlaceholderText('Bank Name'), { target: { value: 'Test Bank' } });
   fireEvent.change(screen.getByPlaceholderText('Account Holder Name'), { target: { value: 'John' } });
-  fireEvent.change(screen.getByPlaceholderText('Email Address'), { target: { value: 'john@example.com' } });
+  fireEvent.change(screen.getByPlaceholderText('Account Number / IBAN'), { target: { value: '123' } });
+  fireEvent.change(screen.getByPlaceholderText('SWIFT Code'), { target: { value: 'ABCDEF' } });
   fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Bank/i }));
   await waitFor(() => expect(initiateBankPayment).toHaveBeenCalled());
-  expect(await screen.findByText(/Invoice #INV-1/)).toBeInTheDocument();
-  expect(screen.getByText(/Test Bank/)).toBeInTheDocument();
+  expect(await screen.findByText(/bank transfer request has been submitted/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- store bank transfer details on payments
- redirect book checkout to unified checkout page
- capture bank account info on checkout and show pending notice

## Testing
- `npm test` (backend) *(failed: POST /api/ads/admin › creates ad, POST /api/books › creates a book, PUT /api/books/:id › updates a book, PUT /api/users/tutorials/admin/:id › returns 403 when instructor updates another instructor's tutorial, PATCH /api/messages/:id/read › marks message as read, DELETE /api/messages/:id › deletes message, PUT /api/seo-config › updates settings, POST /api/blog › creates post, POST /api/payments/admin › creates payment with installments and enrolls, community public routes › create discussion)*
- `npm test` (frontend) *(failed: PUT /api/seo-config › updates settings, community public routes › create discussion, socialLoginConfigService.getSettings returns null when settings table is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6da434b88328be2e3cb5e06162d5