### PR TITLE
Normalize promo code before validation

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -193,8 +193,10 @@ export default function CheckoutPage() {
 
 
   const handleApplyPromo = async () => {
+    const formattedCode = promoCode.trim().toUpperCase();
+    setPromoCode(formattedCode);
     try {
-      const data = await validateCode(promoCode, itemType, itemId);
+      const data = await validateCode(formattedCode, itemType, itemId);
       setDiscount(data.discount_percent);
       setCouponId(data.id);
       toast.success('Promo code applied');


### PR DESCRIPTION
## Summary
- Trim and uppercase promo codes prior to validation for consistent formatting

## Testing
- `npm test`
- `npm run lint` *(fails: 36 errors, 305 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68ab7ad69cd8832889e94f0acccd63a7