### PR TITLE
Show error toasts on payment initiation failures

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -248,6 +248,7 @@ export default function CheckoutPage() {
         setPaymentStatus('submitted_bank');
       } catch (err) {
         console.error('Failed to initiate bank transfer', err);
+        toast.error('Failed to initiate bank transfer. Please try again.');
         setPaymentStatus('idle');
       }
       return;
@@ -265,6 +266,7 @@ export default function CheckoutPage() {
         if (data?.approval_url) window.location.href = data.approval_url;
       } catch (err) {
         console.error('Failed to initiate PayPal payment', err);
+        toast.error('Failed to initiate PayPal payment. Please try again.');
       } finally {
         setPaymentStatus('idle');
       }
@@ -287,6 +289,7 @@ export default function CheckoutPage() {
         if (data?.invoice_url) window.location.href = data.invoice_url;
       } catch (err) {
         console.error('Failed to initiate crypto payment', err);
+        toast.error('Failed to initiate crypto payment. Please try again.');
       } finally {
         setPaymentStatus('idle');
       }


### PR DESCRIPTION
## Summary
- show toast notifications when bank transfer, PayPal, or crypto payment initiation fails
- reset payment status to allow retry after error

## Testing
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68ab7ad619e483288dcadbd122f62725