### PR TITLE
fix: remove duplicate installments declaration

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -341,13 +341,6 @@ export default function CheckoutPage() {
 
   if (checkoutError) return <div className="text-white text-center mt-32">{checkoutError}</div>;
   if (!itemInfo) return <div className="text-white text-center mt-32">{t('loading')}</div>;
-  const installments = 3;
-  const perInstallment = finalPrice / installments;
-  const schedule = Array.from({ length: installments }, (_, i) => {
-    const d = new Date();
-    d.setMonth(d.getMonth() + i);
-    return { number: i + 1, date: d.toLocaleDateString(), amount: perInstallment.toFixed(2) };
-  });
   // Filter out inactive methods if any; the API already returns active ones
   const availableMethods = Array.isArray(methods)
     ? methods.filter((m) => m.active !== false)


### PR DESCRIPTION
## Summary
- remove duplicate installments variables on checkout page

## Testing
- `npm test` *(fails: Unable to find text: Checkout)*
- `npm run lint` *(fails: 36 errors, 305 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abf56a738c83289de6588dfccac631