### PR TITLE
feat: handle generic payment success

### DIFF
--- a/frontend/src/pages/payments/success.js
+++ b/frontend/src/pages/payments/success.js
@@ -6,39 +6,95 @@ import Navbar from '@/components/website/sections/Navbar';
 import Footer from '@/components/website/sections/Footer';
 import { FaCheckCircle, FaArrowRight, FaCalendarAlt, FaChalkboardTeacher, FaDownload, FaRegFilePdf } from 'react-icons/fa';
 import { enrollInClass, fetchClassDetails } from '@/services/classService';
+import { fetchBook } from '@/services/bookService';
+import { enrollInTutorial, fetchTutorialDetails } from '@/services/tutorialService';
 import useCartStore from '@/store/cart/cartStore';
 import { toast } from 'react-toastify';
 import useLibraryStore from '@/store/libraryStore';
 
 export default function PaymentSuccessPage() {
   const router = useRouter();
-  const { classId } = router.query;
-  const [classInfo, setClassInfo] = useState(null);
+  const { itemType, itemId } = router.query;
+  const [itemInfo, setItemInfo] = useState(null);
+  const [loading, setLoading] = useState(true);
   const removeItem = useCartStore((state) => state.removeItem);
   const { fetchLibrary } = useLibraryStore();
 
   useEffect(() => {
-    const enroll = async () => {
-      if (classId) {
-        try {
-          await enrollInClass(classId);
-          await removeItem(classId);
-        } catch (_) {
-          toast.error('Failed to register for class');
-        }
-        try {
-          const details = await fetchClassDetails(classId);
-          setClassInfo(details?.data ?? details);
-        } catch (_) {
-          setClassInfo(null);
-        }
+    const handle = async () => {
+      if (!itemType || !itemId) {
+        await fetchLibrary();
+        setLoading(false);
+        return;
       }
-      await fetchLibrary();
-    };
-    enroll();
-  }, [classId, fetchLibrary, removeItem]);
 
-  if (!classInfo) return <div className="text-white text-center mt-32">Loading...</div>;
+      try {
+        if (itemType === 'class') {
+          try {
+            await enrollInClass(itemId);
+            await removeItem(itemId);
+          } catch (_) {
+            toast.error('Failed to register for class');
+          }
+          try {
+            const details = await fetchClassDetails(itemId);
+            setItemInfo(details?.data ?? details);
+          } catch (_) {
+            setItemInfo(null);
+          }
+        } else if (itemType === 'book') {
+          try {
+            const details = await fetchBook(itemId);
+            setItemInfo(details?.data ?? details);
+          } catch (_) {
+            setItemInfo(null);
+          }
+        } else if (itemType === 'tutorial') {
+          try {
+            await enrollInTutorial(itemId);
+          } catch (_) {
+            toast.error('Failed to enroll in tutorial');
+          }
+          try {
+            const details = await fetchTutorialDetails(itemId);
+            setItemInfo(details?.data ?? details);
+          } catch (_) {
+            setItemInfo(null);
+          }
+        }
+      } finally {
+        await fetchLibrary();
+        setLoading(false);
+      }
+    };
+    handle();
+  }, [itemType, itemId, fetchLibrary, removeItem]);
+
+  if (loading) return <div className="text-white text-center mt-32">Loading...</div>;
+
+  let message = 'Your payment was successful!';
+  let link = '/';
+  let linkLabel = 'Go to Dashboard';
+
+  if (itemType === 'class') {
+    message = itemInfo
+      ? `You have successfully enrolled in ${itemInfo.title}.`
+      : 'You have successfully enrolled in the class.';
+    link = '/dashboard/student/online-classes';
+    linkLabel = 'Go to My Classes';
+  } else if (itemType === 'book') {
+    message = itemInfo
+      ? `You have successfully purchased ${itemInfo.title}.`
+      : 'Your book purchase was successful.';
+    link = '/dashboard/student/library';
+    linkLabel = 'Go to My Library';
+  } else if (itemType === 'tutorial') {
+    message = itemInfo
+      ? `You have successfully enrolled in ${itemInfo.title}.`
+      : 'You have successfully enrolled in the tutorial.';
+    link = '/dashboard/student/tutorials';
+    linkLabel = 'Go to My Tutorials';
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-950 to-gray-900 text-white">
@@ -48,18 +104,34 @@ export default function PaymentSuccessPage() {
         <div className="flex flex-col items-center space-y-6">
           <FaCheckCircle size={64} className="text-green-400 animate-pulse" />
           <h1 className="text-4xl font-bold text-yellow-400">Payment Successful!</h1>
-          <p className="text-lg text-gray-300">
-            You have successfully enrolled in <span className="font-semibold text-white">{classInfo.title}</span>.
-          </p>
+          <p className="text-lg text-gray-300">{message}</p>
 
-          <div className="bg-gray-800 px-6 py-5 rounded-xl shadow-md w-full text-left mt-4">
-            <p className="flex items-center gap-2 text-sm text-gray-300">
-              <FaChalkboardTeacher /> Instructor access and classroom link will be shown in your dashboard once class starts.
-            </p>
-            <p className="flex items-center gap-2 text-sm text-gray-300 mt-2">
-              <FaCalendarAlt /> You'll also receive updates via email, WhatsApp, SMS, and dashboard notifications.
-            </p>
-          </div>
+          {itemType === 'class' && (
+            <div className="bg-gray-800 px-6 py-5 rounded-xl shadow-md w-full text-left mt-4">
+              <p className="flex items-center gap-2 text-sm text-gray-300">
+                <FaChalkboardTeacher /> Instructor access and classroom link will be shown in your dashboard once class starts.
+              </p>
+              <p className="flex items-center gap-2 text-sm text-gray-300 mt-2">
+                <FaCalendarAlt /> You'll also receive updates via email, WhatsApp, SMS, and dashboard notifications.
+              </p>
+            </div>
+          )}
+
+          {itemType === 'book' && (
+            <div className="bg-gray-800 px-6 py-5 rounded-xl shadow-md w-full text-left mt-4">
+              <p className="flex items-center gap-2 text-sm text-gray-300">
+                <FaDownload /> Your book is available in your library for download.
+              </p>
+            </div>
+          )}
+
+          {itemType === 'tutorial' && (
+            <div className="bg-gray-800 px-6 py-5 rounded-xl shadow-md w-full text-left mt-4">
+              <p className="flex items-center gap-2 text-sm text-gray-300">
+                <FaChalkboardTeacher /> You can access this tutorial from your dashboard anytime.
+              </p>
+            </div>
+          )}
 
           <div className="text-left mt-6 text-sm text-gray-400 bg-gray-800 px-6 py-4 rounded-xl w-full">
             <p><strong>Invoice ID:</strong> INV-{Date.now().toString().slice(-6)}</p>
@@ -71,10 +143,10 @@ export default function PaymentSuccessPage() {
           </div>
 
           <Link
-            href="/dashboard/student/online-classes"
+            href={link}
             className="inline-flex items-center gap-2 mt-6 bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-semibold px-6 py-3 rounded-full transition-all"
           >
-            Go to My Classes <FaArrowRight />
+            {linkLabel} <FaArrowRight />
           </Link>
 
           <p className="text-sm text-gray-500 mt-4">


### PR DESCRIPTION
## Summary
- allow payment success page to handle class, book, or tutorial purchases using query params
- show type-specific messages and dashboard links with graceful fallback

## Testing
- `npm test`
- `npm run lint` *(fails: 36 errors, 305 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac16376e208328ad276f8f319409b7