### PR TITLE
feat: localize bank transfer and crypto payment forms

### DIFF
--- a/frontend/public/locales/ar/common.json
+++ b/frontend/public/locales/ar/common.json
@@ -92,5 +92,22 @@
   "promo_code_apply_failed": "Failed to apply promo code. Please try again.",
   "paypal_payment": "PayPal Payment",
   "paypal_redirect_notice": "You'll be redirected to PayPal to complete this payment.",
-  "pay_with_paypal": "Pay ${{price}} with PayPal"
+  "pay_with_paypal": "Pay ${{price}} with PayPal",
+  "bank_name_label": "Bank Name",
+  "bank_name_placeholder": "Bank Name",
+  "account_holder_label": "Account Holder Name",
+  "account_holder_placeholder": "Account Holder Name",
+  "account_number_label": "Account Number / IBAN",
+  "account_number_placeholder": "Account Number / IBAN",
+  "swift_code_label": "SWIFT Code",
+  "swift_code_placeholder": "SWIFT Code",
+  "branch_address_label": "Branch Address (optional)",
+  "branch_address_placeholder": "Branch Address",
+  "instructions_label": "Extra Instructions",
+  "instructions_placeholder": "Extra Instructions",
+  "pay_with_bank": "Pay ${{price}} with Bank",
+  "crypto_payment": "Crypto Payment",
+  "crypto_redirect_notice": "You'll be redirected to our crypto provider to complete this payment.",
+  "pay_with_crypto": "Pay ${{price}} with Crypto",
+  "processing": "Processing..."
 }

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -84,5 +84,22 @@
   "promo_code_apply_failed": "Failed to apply promo code. Please try again.",
   "paypal_payment": "PayPal-Zahlung",
   "paypal_redirect_notice": "Sie werden zu PayPal weitergeleitet, um diese Zahlung abzuschließen.",
-  "pay_with_paypal": "Bezahle ${{price}} mit PayPal"
+  "pay_with_paypal": "Bezahle ${{price}} mit PayPal",
+  "bank_name_label": "Bank Name",
+  "bank_name_placeholder": "Bank Name",
+  "account_holder_label": "Account Holder Name",
+  "account_holder_placeholder": "Account Holder Name",
+  "account_number_label": "Account Number / IBAN",
+  "account_number_placeholder": "Account Number / IBAN",
+  "swift_code_label": "SWIFT Code",
+  "swift_code_placeholder": "SWIFT Code",
+  "branch_address_label": "Branch Address (optional)",
+  "branch_address_placeholder": "Branch Address",
+  "instructions_label": "Extra Instructions",
+  "instructions_placeholder": "Extra Instructions",
+  "pay_with_bank": "Pay ${{price}} with Bank",
+  "crypto_payment": "Crypto Payment",
+  "crypto_redirect_notice": "You'll be redirected to our crypto provider to complete this payment.",
+  "pay_with_crypto": "Pay ${{price}} with Crypto",
+  "processing": "Processing..."
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -92,6 +92,23 @@
   "promo_code_apply_failed": "Failed to apply promo code. Please try again.",
   "paypal_payment": "PayPal Payment",
   "paypal_redirect_notice": "You'll be redirected to PayPal to complete this payment.",
-  "pay_with_paypal": "Pay ${{price}} with PayPal"
+  "pay_with_paypal": "Pay ${{price}} with PayPal",
+  "bank_name_label": "Bank Name",
+  "bank_name_placeholder": "Bank Name",
+  "account_holder_label": "Account Holder Name",
+  "account_holder_placeholder": "Account Holder Name",
+  "account_number_label": "Account Number / IBAN",
+  "account_number_placeholder": "Account Number / IBAN",
+  "swift_code_label": "SWIFT Code",
+  "swift_code_placeholder": "SWIFT Code",
+  "branch_address_label": "Branch Address (optional)",
+  "branch_address_placeholder": "Branch Address",
+  "instructions_label": "Extra Instructions",
+  "instructions_placeholder": "Extra Instructions",
+  "pay_with_bank": "Pay ${{price}} with Bank",
+  "crypto_payment": "Crypto Payment",
+  "crypto_redirect_notice": "You'll be redirected to our crypto provider to complete this payment.",
+  "pay_with_crypto": "Pay ${{price}} with Crypto",
+  "processing": "Processing..."
 }
   

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -84,5 +84,22 @@
   "promo_code_apply_failed": "Failed to apply promo code. Please try again.",
   "paypal_payment": "Pago con PayPal",
   "paypal_redirect_notice": "Serás redirigido a PayPal para completar este pago.",
-  "pay_with_paypal": "Pagar ${{price}} con PayPal"
+  "pay_with_paypal": "Pagar ${{price}} con PayPal",
+  "bank_name_label": "Bank Name",
+  "bank_name_placeholder": "Bank Name",
+  "account_holder_label": "Account Holder Name",
+  "account_holder_placeholder": "Account Holder Name",
+  "account_number_label": "Account Number / IBAN",
+  "account_number_placeholder": "Account Number / IBAN",
+  "swift_code_label": "SWIFT Code",
+  "swift_code_placeholder": "SWIFT Code",
+  "branch_address_label": "Branch Address (optional)",
+  "branch_address_placeholder": "Branch Address",
+  "instructions_label": "Extra Instructions",
+  "instructions_placeholder": "Extra Instructions",
+  "pay_with_bank": "Pay ${{price}} with Bank",
+  "crypto_payment": "Crypto Payment",
+  "crypto_redirect_notice": "You'll be redirected to our crypto provider to complete this payment.",
+  "pay_with_crypto": "Pay ${{price}} with Crypto",
+  "processing": "Processing..."
 }

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -92,5 +92,22 @@
   "promo_code_apply_failed": "Failed to apply promo code. Please try again.",
   "paypal_payment": "Paiement PayPal",
   "paypal_redirect_notice": "Vous serez redirigé vers PayPal pour terminer ce paiement.",
-  "pay_with_paypal": "Payer ${{price}} avec PayPal"
+  "pay_with_paypal": "Payer ${{price}} avec PayPal",
+  "bank_name_label": "Bank Name",
+  "bank_name_placeholder": "Bank Name",
+  "account_holder_label": "Account Holder Name",
+  "account_holder_placeholder": "Account Holder Name",
+  "account_number_label": "Account Number / IBAN",
+  "account_number_placeholder": "Account Number / IBAN",
+  "swift_code_label": "SWIFT Code",
+  "swift_code_placeholder": "SWIFT Code",
+  "branch_address_label": "Branch Address (optional)",
+  "branch_address_placeholder": "Branch Address",
+  "instructions_label": "Extra Instructions",
+  "instructions_placeholder": "Extra Instructions",
+  "pay_with_bank": "Pay ${{price}} with Bank",
+  "crypto_payment": "Crypto Payment",
+  "crypto_redirect_notice": "You'll be redirected to our crypto provider to complete this payment.",
+  "pay_with_crypto": "Pay ${{price}} with Crypto",
+  "processing": "Processing..."
 }

--- a/frontend/public/locales/hi/common.json
+++ b/frontend/public/locales/hi/common.json
@@ -92,5 +92,22 @@
   "promo_code_apply_failed": "Failed to apply promo code. Please try again.",
   "paypal_payment": "PayPal भुगतान",
   "paypal_redirect_notice": "इस भुगतान को पूरा करने के लिए आपको PayPal पर भेजा जाएगा।",
-  "pay_with_paypal": "PayPal से ${{price}} का भुगतान करें"
+  "pay_with_paypal": "PayPal से ${{price}} का भुगतान करें",
+  "bank_name_label": "Bank Name",
+  "bank_name_placeholder": "Bank Name",
+  "account_holder_label": "Account Holder Name",
+  "account_holder_placeholder": "Account Holder Name",
+  "account_number_label": "Account Number / IBAN",
+  "account_number_placeholder": "Account Number / IBAN",
+  "swift_code_label": "SWIFT Code",
+  "swift_code_placeholder": "SWIFT Code",
+  "branch_address_label": "Branch Address (optional)",
+  "branch_address_placeholder": "Branch Address",
+  "instructions_label": "Extra Instructions",
+  "instructions_placeholder": "Extra Instructions",
+  "pay_with_bank": "Pay ${{price}} with Bank",
+  "crypto_payment": "Crypto Payment",
+  "crypto_redirect_notice": "You'll be redirected to our crypto provider to complete this payment.",
+  "pay_with_crypto": "Pay ${{price}} with Crypto",
+  "processing": "Processing..."
 }

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -92,5 +92,22 @@
   "promo_code_apply_failed": "Failed to apply promo code. Please try again.",
   "paypal_payment": "PayPal 支付",
   "paypal_redirect_notice": "您将被重定向到 PayPal 完成此付款。",
-  "pay_with_paypal": "使用 PayPal 支付 ${{price}}"
+  "pay_with_paypal": "使用 PayPal 支付 ${{price}}",
+  "bank_name_label": "Bank Name",
+  "bank_name_placeholder": "Bank Name",
+  "account_holder_label": "Account Holder Name",
+  "account_holder_placeholder": "Account Holder Name",
+  "account_number_label": "Account Number / IBAN",
+  "account_number_placeholder": "Account Number / IBAN",
+  "swift_code_label": "SWIFT Code",
+  "swift_code_placeholder": "SWIFT Code",
+  "branch_address_label": "Branch Address (optional)",
+  "branch_address_placeholder": "Branch Address",
+  "instructions_label": "Extra Instructions",
+  "instructions_placeholder": "Extra Instructions",
+  "pay_with_bank": "Pay ${{price}} with Bank",
+  "crypto_payment": "Crypto Payment",
+  "crypto_redirect_notice": "You'll be redirected to our crypto provider to complete this payment.",
+  "pay_with_crypto": "Pay ${{price}} with Crypto",
+  "processing": "Processing..."
 }

--- a/frontend/src/components/payments/forms/BankTransferForm.js
+++ b/frontend/src/components/payments/forms/BankTransferForm.js
@@ -1,6 +1,12 @@
 import { useState } from 'react';
+import { useTranslation } from 'next-i18next';
 
 export default function BankTransferForm({ onSubmit, processing, finalPrice }) {
+  const { t } = useTranslation('common');
+  const tr = (key, def, opts) => {
+    const res = t(key, opts);
+    return res === key ? def : res;
+  };
   const [bankName, setBankName] = useState('');
   const [accountHolder, setAccountHolder] = useState('');
   const [accountNumber, setAccountNumber] = useState('');
@@ -24,63 +30,63 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice }) {
       className="space-y-4"
     >
       <label className="block">
-        <span className="text-sm">Bank Name</span>
+        <span className="text-sm">{tr('bank_name_label', 'Bank Name')}</span>
         <input
           type="text"
           required
-          placeholder="Bank Name"
+          placeholder={tr('bank_name_placeholder', 'Bank Name')}
           value={bankName}
           onChange={(e) => setBankName(e.target.value)}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white"
         />
       </label>
       <label className="block">
-        <span className="text-sm">Account Holder Name</span>
+        <span className="text-sm">{tr('account_holder_label', 'Account Holder Name')}</span>
         <input
           type="text"
           required
-          placeholder="Account Holder Name"
+          placeholder={tr('account_holder_placeholder', 'Account Holder Name')}
           value={accountHolder}
           onChange={(e) => setAccountHolder(e.target.value)}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white"
         />
       </label>
       <label className="block">
-        <span className="text-sm">Account Number / IBAN</span>
+        <span className="text-sm">{tr('account_number_label', 'Account Number / IBAN')}</span>
         <input
           type="text"
           required
-          placeholder="Account Number / IBAN"
+          placeholder={tr('account_number_placeholder', 'Account Number / IBAN')}
           value={accountNumber}
           onChange={(e) => setAccountNumber(e.target.value)}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white"
         />
       </label>
       <label className="block">
-        <span className="text-sm">SWIFT Code</span>
+        <span className="text-sm">{tr('swift_code_label', 'SWIFT Code')}</span>
         <input
           type="text"
           required
-          placeholder="SWIFT Code"
+          placeholder={tr('swift_code_placeholder', 'SWIFT Code')}
           value={swiftCode}
           onChange={(e) => setSwiftCode(e.target.value)}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white"
         />
       </label>
       <label className="block">
-        <span className="text-sm">Branch Address (optional)</span>
+        <span className="text-sm">{tr('branch_address_label', 'Branch Address (optional)')}</span>
         <input
           type="text"
-          placeholder="Branch Address"
+          placeholder={tr('branch_address_placeholder', 'Branch Address')}
           value={branchAddress}
           onChange={(e) => setBranchAddress(e.target.value)}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white"
         />
       </label>
       <label className="block">
-        <span className="text-sm">Extra Instructions</span>
+        <span className="text-sm">{tr('instructions_label', 'Extra Instructions')}</span>
         <textarea
-          placeholder="Extra Instructions"
+          placeholder={tr('instructions_placeholder', 'Extra Instructions')}
           value={instructions}
           onChange={(e) => setInstructions(e.target.value)}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white"
@@ -91,7 +97,9 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice }) {
         disabled={processing}
         className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all"
       >
-        {processing ? 'Processing...' : `Pay $${finalPrice} with Bank`}
+        {processing
+          ? tr('processing', 'Processing...')
+          : tr('pay_with_bank', `Pay $${finalPrice} with Bank`, { price: finalPrice })}
       </button>
     </form>
   );

--- a/frontend/src/components/payments/forms/CryptoPaymentForm.js
+++ b/frontend/src/components/payments/forms/CryptoPaymentForm.js
@@ -1,11 +1,18 @@
+import { useTranslation } from 'next-i18next';
+
 export default function CryptoPaymentForm({ onSubmit, processing, finalPrice }) {
+  const { t } = useTranslation('common');
+  const tr = (key, def, opts) => {
+    const res = t(key, opts);
+    return res === key ? def : res;
+  };
   return (
     <div className="bg-gray-900 p-4 rounded text-sm text-gray-300 space-y-4">
       <p>
-        <strong>Crypto Payment</strong>
+        <strong>{tr('crypto_payment', 'Crypto Payment')}</strong>
       </p>
       <p className="text-xs text-gray-400">
-        You&apos;ll be redirected to our crypto provider to complete this payment.
+        {tr('crypto_redirect_notice', "You'll be redirected to our crypto provider to complete this payment.")}
       </p>
       <button
         type="button"
@@ -13,7 +20,9 @@ export default function CryptoPaymentForm({ onSubmit, processing, finalPrice }) 
         disabled={processing}
         className="bg-yellow-500 text-black px-4 py-2 rounded font-bold w-full"
       >
-        {processing ? 'Processing...' : `Pay $${finalPrice} with Crypto`}
+        {processing
+          ? tr('processing', 'Processing...')
+          : tr('pay_with_crypto', `Pay $${finalPrice} with Crypto`, { price: finalPrice })}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- integrate `next-i18next` translations into bank transfer and crypto payment forms
- add translation keys for payment form labels, placeholders, and buttons across locales

## Testing
- `npm test`
- `npm run lint` *(fails: 36 errors, 305 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac16364e8483289ab3d4d78016f4f2