### PR TITLE
feat: grant access and notify on bank payment approval

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -5,6 +5,10 @@ const { sendSuccess } = require("../../utils/response");
 const paymentsService = require("./payments.service");
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
+const notificationService = require("../notifications/notifications.service");
+const mailService = require("../../services/mailService");
+const userModel = require("../users/user.model");
+const { grantAccess } = require("./paymentAccess");
 const { v4: uuidv4 } = require("uuid");
 
 const DEFAULT_PLATFORM_CUT = {
@@ -130,6 +134,28 @@ exports.approveBankPayment = catchAsync(async (req, res) => {
     req.params.id,
     req.body
   );
+
+  await grantAccess(payment);
+
+  try {
+    const user = await userModel.findById(payment.user_id);
+    const message = `Your bank payment ${payment.id} has been approved.`;
+    await notificationService.createNotification({
+      user_id: payment.user_id,
+      type: "payment_status",
+      message,
+    });
+    if (user?.email) {
+      await mailService.sendMail({
+        to: user.email,
+        subject: "Payment Approved",
+        html: `<p>${message}</p>`,
+      });
+    }
+  } catch (err) {
+    logger.error("Failed to notify student of payment approval:", err);
+  }
+
   sendSuccess(res, payment, "Bank payment approved");
 });
 

--- a/backend/src/modules/payments/paymentAccess.js
+++ b/backend/src/modules/payments/paymentAccess.js
@@ -1,0 +1,29 @@
+const logger = require('../../utils/logger.js');
+const libraryService = require('../library/library.service');
+const enrollmentService = require('../classes/enrollments/classEnrollment.service');
+const tutorialEnrollmentService = require('../users/tutorials/enrollments/tutorialEnrollment.service');
+const { v4: uuidv4 } = require('uuid');
+
+exports.grantAccess = async (payment) => {
+  try {
+    if (payment.item_type === 'book') {
+      await libraryService.recordPurchase(payment.user_id, payment.item_id, payment.amount);
+    } else if (payment.item_type === 'class') {
+      await enrollmentService.createEnrollment({
+        id: uuidv4(),
+        user_id: payment.user_id,
+        class_id: payment.item_id,
+        status: 'enrolled',
+      });
+    } else if (payment.item_type === 'tutorial') {
+      await tutorialEnrollmentService.createEnrollment({
+        id: uuidv4(),
+        user_id: payment.user_id,
+        tutorial_id: payment.item_id,
+        status: 'enrolled',
+      });
+    }
+  } catch (err) {
+    logger.error('Failed to finalize enrollment after payment:', err);
+  }
+};

--- a/backend/src/modules/payments/paypal.controller.js
+++ b/backend/src/modules/payments/paypal.controller.js
@@ -6,9 +6,7 @@ const paymentsService = require('./payments.service');
 const paymentConfigService = require('../paymentConfig/paymentConfig.service');
 const paymentMethodsService = require('../paymentMethods/paymentMethods.service');
 const paypalService = require('../../services/paypalService');
-const libraryService = require('../library/library.service');
-const enrollmentService = require('../classes/enrollments/classEnrollment.service');
-const tutorialEnrollmentService = require('../users/tutorials/enrollments/tutorialEnrollment.service');
+const { grantAccess } = require('./paymentAccess');
 const { v4: uuidv4 } = require('uuid');
 
 const DEFAULT_PLATFORM_CUT = {
@@ -109,27 +107,7 @@ exports.handlePayPalCallback = catchAsync(async (req, res) => {
   const updated = await paymentsService.update(paymentId, statusUpdate);
 
   if (updated.status === 'paid') {
-    try {
-      if (updated.item_type === 'book') {
-        await libraryService.recordPurchase(updated.user_id, updated.item_id, updated.amount);
-      } else if (updated.item_type === 'class') {
-        await enrollmentService.createEnrollment({
-          id: uuidv4(),
-          user_id: updated.user_id,
-          class_id: updated.item_id,
-          status: 'enrolled',
-        });
-      } else if (updated.item_type === 'tutorial') {
-        await tutorialEnrollmentService.createEnrollment({
-          id: uuidv4(),
-          user_id: updated.user_id,
-          tutorial_id: updated.item_id,
-          status: 'enrolled',
-        });
-      }
-    } catch (err) {
-      logger.error('Failed to finalize enrollment after PayPal payment:', err);
-    }
+    await grantAccess(updated);
   }
 
   if (process.env.FRONTEND_URL) {


### PR DESCRIPTION
## Summary
- extract reusable grantAccess helper for class, tutorial, and book access
- reuse helper in PayPal callback and bank payment approval
- notify students on bank payment approval via notifications and email

## Testing
- `npm test` *(fails: 13 failed, 74 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1630392c832887b63d703960c89b