### PR TITLE
Process crypto IPN enrollments

### DIFF
--- a/backend/src/modules/payments/crypto.controller.js
+++ b/backend/src/modules/payments/crypto.controller.js
@@ -7,6 +7,9 @@ const paymentConfigService = require('../paymentConfig/paymentConfig.service');
 const paymentMethodsService = require('../paymentMethods/paymentMethods.service');
 const nowPayments = require('../../services/nowPaymentsService');
 const { v4: uuidv4 } = require('uuid');
+const libraryService = require('../library/library.service');
+const enrollmentService = require('../classes/enrollments/classEnrollment.service');
+const tutorialEnrollmentService = require('../users/tutorials/enrollments/tutorialEnrollment.service');
 
 const DEFAULT_PLATFORM_CUT = {
   class: 15,
@@ -117,7 +120,34 @@ exports.handleIPN = catchAsync(async (req, res) => {
     statusUpdate = { status: 'rejected', reference_id: payload.payment_id };
   }
   if (Object.keys(statusUpdate).length) {
-    await paymentsService.update(paymentId, statusUpdate);
+    const updated = await paymentsService.update(paymentId, statusUpdate);
+    if (updated.status === 'paid') {
+      try {
+        if (updated.item_type === 'book') {
+          await libraryService.recordPurchase(
+            updated.user_id,
+            updated.item_id,
+            updated.amount
+          );
+        } else if (updated.item_type === 'class') {
+          await enrollmentService.createEnrollment({
+            id: uuidv4(),
+            user_id: updated.user_id,
+            class_id: updated.item_id,
+            status: 'enrolled',
+          });
+        } else if (updated.item_type === 'tutorial') {
+          await tutorialEnrollmentService.createEnrollment({
+            id: uuidv4(),
+            user_id: updated.user_id,
+            tutorial_id: updated.item_id,
+            status: 'enrolled',
+          });
+        }
+      } catch (err) {
+        logger.error('Failed to finalize enrollment after Crypto payment:', err);
+      }
+    }
   }
   res.json({ ok: true });
 });


### PR DESCRIPTION
## Summary
- trigger book purchase or class/tutorial enrollment after crypto IPN marks payment as paid
- log errors from post-payment processing and keep existing failure responses

## Testing
- `npm test --silent` (fails: Test Suites: 13 failed, 74 passed, 87 total)

------
https://chatgpt.com/codex/tasks/task_e_68ac162cea3483288ac6356fbbcd227b