### PR TITLE
Refactor payment status handling with shared constants

### DIFF
--- a/backend/src/migrations/20250725001000_create_payments_table.js
+++ b/backend/src/migrations/20250725001000_create_payments_table.js
@@ -7,7 +7,7 @@ exports.up = function(knex) {
     table.uuid('item_id').notNullable();
     table.decimal('amount', 10, 2).notNullable();
     table.string('currency').notNullable().defaultTo('USD');
-    table.string('status').notNullable().defaultTo('pending');
+    table.string('status').notNullable().defaultTo('pending_payment');
     table.string('reference_id');
     table.timestamp('paid_at');
     table.timestamps(true, true);

--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -3,6 +3,7 @@ const catchAsync = require("../../utils/catchAsync");
 const AppError = require("../../utils/AppError");
 const { sendSuccess } = require("../../utils/response");
 const paymentsService = require("./payments.service");
+const { STATUS } = paymentsService;
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const { v4: uuidv4 } = require("uuid");
@@ -110,7 +111,7 @@ exports.initiateBankPayment = catchAsync(async (req, res) => {
     item_id,
     amount: numericAmount,
     currency: currencyCode,
-    status: "awaiting_approval",
+    status: STATUS.AWAITING_APPROVAL,
     platform_fee,
     instructor_amount,
     bank_details,

--- a/backend/src/modules/payments/crypto.controller.js
+++ b/backend/src/modules/payments/crypto.controller.js
@@ -3,6 +3,7 @@ const catchAsync = require('../../utils/catchAsync');
 const AppError = require('../../utils/AppError');
 const { sendSuccess } = require('../../utils/response');
 const paymentsService = require('./payments.service');
+const { STATUS } = paymentsService;
 const paymentConfigService = require('../paymentConfig/paymentConfig.service');
 const paymentMethodsService = require('../paymentMethods/paymentMethods.service');
 const nowPayments = require('../../services/nowPaymentsService');
@@ -84,7 +85,7 @@ exports.initiateCryptoPayment = catchAsync(async (req, res) => {
     item_id,
     amount: numericAmount,
     currency: currencyCode,
-    status: 'pending_payment',
+    status: STATUS.PENDING_PAYMENT,
     reference_id: invoice.id?.toString() || null,
     receipt_url: invoice.invoice_url,
     platform_fee,
@@ -112,9 +113,9 @@ exports.handleIPN = catchAsync(async (req, res) => {
   let statusUpdate = {};
   const status = payload.payment_status;
   if (status === 'finished') {
-    statusUpdate = { status: 'paid', reference_id: payload.payment_id, paid_at: new Date() };
+    statusUpdate = { status: STATUS.PAID, reference_id: payload.payment_id, paid_at: new Date() };
   } else if (status === 'failed') {
-    statusUpdate = { status: 'rejected', reference_id: payload.payment_id };
+    statusUpdate = { status: STATUS.REJECTED, reference_id: payload.payment_id };
   }
   if (Object.keys(statusUpdate).length) {
     await paymentsService.update(paymentId, statusUpdate);

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -67,7 +67,7 @@ exports.createPayment = catchAsync(async (req, res) => {
 
   let verifiedAmount = amount;
   let verifiedCurrency = currency || "USD";
-  let finalStatus = status || "pending";
+  let finalStatus = status || STATUS.PENDING_PAYMENT;
   let verifiedReference = reference_id;
 
   if (method.type === "paypal") {
@@ -81,7 +81,7 @@ exports.createPayment = catchAsync(async (req, res) => {
     verifiedAmount = parseFloat(info.amount?.value || amount);
     verifiedCurrency = info.amount?.currency_code || verifiedCurrency;
     verifiedReference = info.id || reference_id;
-    finalStatus = "paid";
+    finalStatus = STATUS.PAID;
   }
 
   if (coupon_id) {
@@ -134,7 +134,7 @@ exports.createPayment = catchAsync(async (req, res) => {
     receipt_url,
     platform_fee,
     instructor_amount,
-    paid_at: finalStatus === "paid" ? new Date() : null,
+    paid_at: finalStatus === STATUS.PAID ? new Date() : null,
     installments: totalInstallments,
     installment_number: 1,
     next_due_date,
@@ -143,7 +143,7 @@ exports.createPayment = catchAsync(async (req, res) => {
   if (schedules.length) createArgs.push(schedules);
   const payment = await service.create(...createArgs);
 
-  if (coupon_id && payment.status === "paid") {
+  if (coupon_id && payment.status === STATUS.PAID) {
     try {
       await couponService.incrementUsage(coupon_id);
     } catch (err) {
@@ -185,7 +185,7 @@ exports.createPayment = catchAsync(async (req, res) => {
     }
   }
 
-  if (item_type === "book" && payment.status === "paid") {
+  if (item_type === "book" && payment.status === STATUS.PAID) {
     try {
       await libraryService.recordPurchase(user_id, item_id, verifiedAmount);
     } catch (err) {
@@ -193,7 +193,7 @@ exports.createPayment = catchAsync(async (req, res) => {
     }
   }
 
-  if (item_type === "class" && payment.status === "paid") {
+  if (item_type === "class" && payment.status === STATUS.PAID) {
     try {
         await enrollmentService.createEnrollment({
           id: uuidv4(),
@@ -206,7 +206,7 @@ exports.createPayment = catchAsync(async (req, res) => {
     }
   }
 
-  if (item_type === "tutorial" && payment.status === "paid") {
+  if (item_type === "tutorial" && payment.status === STATUS.PAID) {
     try {
       await tutorialEnrollmentService.createEnrollment({
         id: uuidv4(),
@@ -287,10 +287,10 @@ exports.updatePayment = catchAsync(async (req, res) => {
       const user = await userModel.findById(payment.user_id);
       let message = "";
       let subject = "";
-      if (req.body.status === "paid") {
+      if (req.body.status === STATUS.PAID) {
         message = `Your payment ${payment.id} has been approved.`;
         subject = "Payment Approved";
-      } else if (req.body.status === "rejected") {
+      } else if (req.body.status === STATUS.REJECTED) {
         message = `Your payment ${payment.id} has been rejected.`;
         subject = "Payment Rejected";
       }

--- a/backend/src/modules/payments/payments.service.js
+++ b/backend/src/modules/payments/payments.service.js
@@ -4,7 +4,7 @@ const AppError = require("../../utils/AppError");
 const STATUS = {
   PENDING_PAYMENT: "pending_payment",
   AWAITING_APPROVAL: "awaiting_approval",
-  COMPLETED: "completed",
+  PAID: "paid",
   REJECTED: "rejected",
 };
 
@@ -104,7 +104,7 @@ exports.approveBankPayment = async (
 
     const [row] = await trx("payments")
       .where({ id })
-      .update({ status: STATUS.COMPLETED, paid_at: new Date() })
+      .update({ status: STATUS.PAID, paid_at: new Date() })
       .returning("*");
 
     return row;

--- a/backend/src/modules/payments/paypal.controller.js
+++ b/backend/src/modules/payments/paypal.controller.js
@@ -3,6 +3,7 @@ const catchAsync = require('../../utils/catchAsync');
 const AppError = require('../../utils/AppError');
 const { sendSuccess } = require('../../utils/response');
 const paymentsService = require('./payments.service');
+const { STATUS } = paymentsService;
 const paymentConfigService = require('../paymentConfig/paymentConfig.service');
 const paymentMethodsService = require('../paymentMethods/paymentMethods.service');
 const paypalService = require('../../services/paypalService');
@@ -79,7 +80,7 @@ exports.createPayPalPayment = catchAsync(async (req, res) => {
     item_id,
     amount: numericAmount,
     currency: currencyCode,
-    status: 'pending_payment',
+    status: STATUS.PENDING_PAYMENT,
     reference_id: order.id,
     platform_fee,
     instructor_amount,
@@ -101,14 +102,14 @@ exports.handlePayPalCallback = catchAsync(async (req, res) => {
   const info = capture.purchase_units?.[0]?.payments?.captures?.[0];
   let statusUpdate = { reference_id: info?.id || orderId };
   if (capture.status === 'COMPLETED') {
-    statusUpdate.status = 'paid';
+    statusUpdate.status = STATUS.PAID;
     statusUpdate.paid_at = new Date();
   } else {
-    statusUpdate.status = 'rejected';
+    statusUpdate.status = STATUS.REJECTED;
   }
   const updated = await paymentsService.update(paymentId, statusUpdate);
 
-  if (updated.status === 'paid') {
+  if (updated.status === STATUS.PAID) {
     try {
       if (updated.item_type === 'book') {
         await libraryService.recordPurchase(updated.user_id, updated.item_id, updated.amount);
@@ -133,7 +134,7 @@ exports.handlePayPalCallback = catchAsync(async (req, res) => {
   }
 
   if (process.env.FRONTEND_URL) {
-    const redirectUrl = `${process.env.FRONTEND_URL}/payments/${updated.status === 'paid' ? 'success' : 'error'}`;
+    const redirectUrl = `${process.env.FRONTEND_URL}/payments/${updated.status === STATUS.PAID ? 'success' : 'error'}`;
     return res.redirect(redirectUrl);
   }
   sendSuccess(res, updated, 'PayPal payment processed');

--- a/backend/tests/paymentCommission.test.js
+++ b/backend/tests/paymentCommission.test.js
@@ -51,7 +51,7 @@ describe('payment commission calculations', () => {
 
   it('calculates commission for class payments', async () => {
     configService.getSettings.mockResolvedValue({ platformCut: { class: 10 } });
-    service.create.mockResolvedValue({ id: 'p1', reference_id: 'ref', status: 'pending' });
+    service.create.mockResolvedValue({ id: 'p1', reference_id: 'ref', status: 'pending_payment' });
 
     const res = await request(app).post('/api/payments/admin').send({
       user_id: 'u1',
@@ -70,7 +70,7 @@ describe('payment commission calculations', () => {
 
   it('calculates commission for book payments', async () => {
     configService.getSettings.mockResolvedValue({ platformCut: { book: 20 } });
-    service.create.mockResolvedValue({ id: 'p2', reference_id: 'ref', status: 'pending' });
+    service.create.mockResolvedValue({ id: 'p2', reference_id: 'ref', status: 'pending_payment' });
 
     const res = await request(app).post('/api/payments/admin').send({
       user_id: 'u1',
@@ -89,7 +89,7 @@ describe('payment commission calculations', () => {
 
   it('calculates commission for tutorial payments', async () => {
     configService.getSettings.mockResolvedValue({ platformCut: { tutorial: 30 } });
-    service.create.mockResolvedValue({ id: 'p3', reference_id: 'ref', status: 'pending' });
+    service.create.mockResolvedValue({ id: 'p3', reference_id: 'ref', status: 'pending_payment' });
 
     const res = await request(app).post('/api/payments/admin').send({
       user_id: 'u1',
@@ -108,7 +108,7 @@ describe('payment commission calculations', () => {
 
   it('falls back to default cut when settings missing', async () => {
     configService.getSettings.mockResolvedValue(null);
-    service.create.mockResolvedValue({ id: 'p4', reference_id: 'ref', status: 'pending' });
+    service.create.mockResolvedValue({ id: 'p4', reference_id: 'ref', status: 'pending_payment' });
 
     const res = await request(app).post('/api/payments/admin').send({
       user_id: 'u1',

--- a/backend/tests/studentPaymentRoutes.test.js
+++ b/backend/tests/studentPaymentRoutes.test.js
@@ -62,7 +62,7 @@ describe('POST /api/payments/student', () => {
   it('creates a payment using authenticated user id', async () => {
     methodService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
     configService.getSettings.mockResolvedValue({ platformCut: {} });
-    service.create.mockResolvedValue({ id: 'p1', reference_id: 'ref', status: 'pending' });
+    service.create.mockResolvedValue({ id: 'p1', reference_id: 'ref', status: 'pending_payment' });
 
     const res = await request(app).post('/api/payments/student').send({
       user_id: 'other',


### PR DESCRIPTION
## Summary
- centralize payment status vocabulary in `payments.service`
- update payment controllers to use exported status constants
- adjust migrations and tests for unified status names

## Testing
- `npm test` (fails: adsRoutes, bookRoutes, messageRoutes, tutorialRoutes, book.service, class.routes)`

------
https://chatgpt.com/codex/tasks/task_e_68ac162a3b5c8328b25101470e77f980