### PR TITLE
Handle default checkout payments via backend

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -6,6 +6,7 @@ import { fetchTutorialDetails } from '@/services/tutorialService';
 import { fetchBook } from '@/services/bookService';
 import { validateCode } from '@/services/couponService';
 import { initiateBankPayment, initiateCryptoPayment, initiatePayPalPayment } from '@/services/paymentService';
+import { createPayment } from '@/services/student/paymentService';
 import useCartStore from '@/store/cart/cartStore';
 import { useShallow } from 'zustand/react/shallow';
 import Navbar from '@/components/website/sections/Navbar';
@@ -344,8 +345,28 @@ export default function CheckoutPage() {
       }
       return;
     }
-    setPaymentStatus('processing');
-    setTimeout(completePayment, 1500);
+    try {
+      setPaymentStatus('processing');
+      const payload = {
+        method_id: method?.id,
+        item_type: itemType,
+        item_id: itemInfo.id,
+        amount: finalPrice,
+        allow_installments: allowInstallments,
+        installments,
+      };
+      if (couponId) payload.coupon_id = couponId;
+      const response = await createPayment(payload);
+      if (response?.status === 'paid') {
+        await completePayment();
+      } else {
+        throw new Error('Payment not confirmed');
+      }
+    } catch (err) {
+      console.error('Failed to process payment', err);
+      toast.error('Failed to process payment. Please try again.');
+      setPaymentStatus('idle');
+    }
   };
 
   const installments = 3;

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -3,6 +3,7 @@ import CheckoutPage from '../../pages/payments/checkout';
 import { fetchClassDetails } from '../../services/classService';
 import { fetchPaymentMethods } from '../../services/paymentMethodService';
 import { initiateBankPayment } from '../../services/paymentService';
+import { createPayment } from '../../services/student/paymentService';
 jest.mock('next-i18next', () => ({
   useTranslation: () => ({
     t: (key, params) => {
@@ -44,6 +45,9 @@ jest.mock('../../services/paymentService', () => ({
   initiateBankPayment: jest.fn(),
   initiateCryptoPayment: jest.fn(),
   initiatePayPalPayment: jest.fn(),
+}));
+jest.mock('../../services/student/paymentService', () => ({
+  createPayment: jest.fn(),
 }));
 
 const mockUseRouter = jest.fn();
@@ -100,4 +104,38 @@ test('adjusts inputs based on payment selection and submits bank details', async
   fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Bank/i }));
   await waitFor(() => expect(initiateBankPayment).toHaveBeenCalled());
   expect(await screen.findByText(/bank transfer request has been submitted/i)).toBeInTheDocument();
+});
+
+test('completes payment for unhandled methods on success', async () => {
+  fetchPaymentMethods.mockResolvedValue([
+    { id: 1, name: 'Stripe', type: 'stripe' },
+  ]);
+  createPayment.mockResolvedValue({ status: 'paid' });
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+  fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'John Doe' } });
+  fireEvent.change(screen.getByPlaceholderText('Email Address'), { target: { value: 'john@example.com' } });
+  fireEvent.change(screen.getByPlaceholderText('Card Number'), { target: { value: '4242424242424242' } });
+  fireEvent.change(screen.getByPlaceholderText('Expiration Date (MM/YY)'), { target: { value: '12/30' } });
+  fireEvent.change(screen.getByPlaceholderText('CVC'), { target: { value: '123' } });
+  fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Stripe/i }));
+  await waitFor(() => expect(createPayment).toHaveBeenCalled());
+  expect(await screen.findByText(/payment_successful_redirecting/i)).toBeInTheDocument();
+});
+
+test('shows error when unhandled payment fails', async () => {
+  fetchPaymentMethods.mockResolvedValue([
+    { id: 1, name: 'Stripe', type: 'stripe' },
+  ]);
+  createPayment.mockRejectedValue(new Error('fail'));
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+  fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'John Doe' } });
+  fireEvent.change(screen.getByPlaceholderText('Email Address'), { target: { value: 'john@example.com' } });
+  fireEvent.change(screen.getByPlaceholderText('Card Number'), { target: { value: '4242424242424242' } });
+  fireEvent.change(screen.getByPlaceholderText('Expiration Date (MM/YY)'), { target: { value: '12/30' } });
+  fireEvent.change(screen.getByPlaceholderText('CVC'), { target: { value: '123' } });
+  fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Stripe/i }));
+  await waitFor(() => expect(createPayment).toHaveBeenCalled());
+  expect(require('react-toastify').toast.error).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- Initiate backend payment for generic checkout methods and handle failure states
- Cover success and error paths for generic payment flow in tests

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac1cbf3aec83288f740745c37d8f7e