### PR TITLE
feat: checkout uses transactional enrollment

### DIFF
--- a/backend/src/modules/users/student/student.class.js
+++ b/backend/src/modules/users/student/student.class.js
@@ -2,7 +2,7 @@ const classService = require("../../classes/class.service");
 const wishlistService = require("../../classes/wishlist/classWishlist.service");
 const cartService = require("../../cart/cart.service");
 const enrollmentService = require("../../classes/enrollments/classEnrollment.service");
-const paymentsService = require("../../payments/payments.service");
+const db = require("../../../config/database");
 const { v4: uuidv4 } = require("uuid");
 
 class Student {
@@ -53,29 +53,47 @@ class Student {
 
   async checkout(paymentMethodId) {
     const cartItems = await cartService.list(this.userId);
-    const results = [];
-    for (const item of cartItems) {
-      const cls = await classService.getClassById(item.id);
-      if (!cls) continue;
-      const enrollment = await enrollmentService.createEnrollment({
-        id: uuidv4(),
-        user_id: this.userId,
-        class_id: item.id,
-        status: "enrolled",
-      });
-      const payment = await paymentsService.create({
-        user_id: this.userId,
-        method_id: paymentMethodId,
-        item_type: item.item_type,
-        item_id: item.id,
-        amount: item.price || 0,
-        status: "paid",
-        paid_at: new Date(),
-      });
-      await cartService.remove(this.userId, item.id);
-      results.push({ enrollment, payment });
-    }
-    return results;
+    return db.transaction(async (trx) => {
+      const results = [];
+      const processedIds = [];
+      for (const item of cartItems) {
+        if (item.item_type !== "class") {
+          throw new Error("Invalid cart item type");
+        }
+        const cls = await trx("online_classes").where({ id: item.id }).first();
+        if (!cls) {
+          throw new Error("Class not found");
+        }
+        const [enrollment] = await trx("class_enrollments")
+          .insert({
+            id: uuidv4(),
+            user_id: this.userId,
+            class_id: item.id,
+            status: "enrolled",
+          })
+          .returning("*");
+        const [payment] = await trx("payments")
+          .insert({
+            user_id: this.userId,
+            method_id: paymentMethodId,
+            item_type: item.item_type,
+            item_id: item.id,
+            amount: item.price || 0,
+            status: "paid",
+            paid_at: new Date(),
+          })
+          .returning("*");
+        processedIds.push(item.id);
+        results.push({ enrollment, payment });
+      }
+      if (processedIds.length) {
+        await trx("cart_items")
+          .where({ user_id: this.userId })
+          .whereIn("item_id", processedIds)
+          .del();
+      }
+      return results;
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap student checkout in a database transaction
- validate cart items as classes before enrollment and payment
- remove processed items from cart after successful transaction

## Testing
- `npm test` *(fails: POST /api/ads/admin creates ad)*


------
https://chatgpt.com/codex/tasks/task_e_68ac1cbd56bc8328a2b630c8b588123b