### PR TITLE
Validate book IDs during checkout

### DIFF
--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -151,4 +151,13 @@ describe('checkout', () => {
     const cart = await db('book_cart').where({ student_id: studentId });
     expect(cart).toHaveLength(0);
   });
+
+  test('throws error when book ID is missing', async () => {
+    await db('book_cart').insert({ student_id: studentId, book_id: 999 });
+    await expect(checkout(studentId)).rejects.toThrow('Book not found');
+    const cart = await db('book_cart').where({ student_id: studentId });
+    expect(cart).toHaveLength(1);
+    const purchases = await db('book_purchases').where({ student_id: studentId });
+    expect(purchases).toHaveLength(0);
+  });
 });

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const tagService = require("./bookTag.service");
 const slugify = require("slugify");
+const AppError = require("../../utils/AppError");
 
 exports.createBook = async (data) => {
   const [row] = await db("books").insert(data).returning("*");
@@ -256,6 +257,13 @@ exports.checkout = async (studentId) => {
     const books = await trx('books')
       .whereIn('id', bookIds)
       .select('id', 'price');
+
+    const validIds = books.map((b) => b.id);
+    if (books.length !== bookIds.length) {
+      const missing = bookIds.filter((id) => !validIds.includes(id));
+      throw new AppError(`Book not found: ${missing.join(', ')}`, 404);
+    }
+
     const rows = books.map((b) => ({
       student_id: studentId,
       book_id: b.id,
@@ -264,7 +272,10 @@ exports.checkout = async (studentId) => {
     const purchases = await trx('book_purchases')
       .insert(rows)
       .returning('*');
-    await trx('book_cart').where({ student_id: studentId }).del();
+    await trx('book_cart')
+      .where({ student_id: studentId })
+      .whereIn('book_id', validIds)
+      .del();
     return purchases;
   });
 };


### PR DESCRIPTION
## Summary
- ensure checkout verifies all cart book IDs exist before purchase
- throw AppError when book IDs are missing and only remove validated cart items
- test checkout behavior for missing book IDs

## Testing
- `npm test src/modules/books/__tests__/book.service.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac1cbc3d2c83288bd4c0b27ff17dcc