### PR TITLE
feat: render payment icons from library

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -32,12 +32,16 @@ const iconMap = {
   usdt: <FaEthereum />,
   binance: <FaEthereum />,
   coinbase: <FaEthereum />,
+  nowpayments: <FaEthereum />,
 };
 
-function resolveIconElement(method) {
+export function resolveIconElement(method) {
   if (method.icon) {
     const lower = method.icon.toLowerCase();
-    const isUrl = /^(https?:)?\/\//.test(method.icon) || method.icon.includes('.');
+    const base = lower.split('/').pop().split('.')[0];
+    if (iconMap[lower]) return iconMap[lower];
+    if (iconMap[base]) return iconMap[base];
+    const isUrl = /^(https?:)?\/\//.test(method.icon);
     if (isUrl) {
       return (
         <img
@@ -47,7 +51,6 @@ function resolveIconElement(method) {
         />
       );
     }
-    if (iconMap[lower]) return iconMap[lower];
   }
   return (
     iconMap[getMethodIdentifier(method).toLowerCase()] || <FaMoneyCheckAlt />
@@ -60,7 +63,7 @@ function getMethodIdentifier(method) {
   return '';
 }
 
-const CRYPTO_IDENTIFIERS = ['usdt', 'nft', 'binance', 'coinbase'];
+const CRYPTO_IDENTIFIERS = ['usdt', 'nft', 'binance', 'coinbase', 'nowpayments'];
 
 function isCryptoMethod(methodOrIdentifier) {
   if (!methodOrIdentifier) return false;

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -68,17 +68,20 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-test('renders payment logos from url and fallback', async () => {
+test('renders payment logos using library icons with url fallback', async () => {
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Stripe', type: 'stripe', icon: 'https://example.com/stripe.png' },
     { id: 2, name: 'PayPal', type: null },
+    { id: 3, name: 'Custom', type: 'custom', icon: 'https://example.com/custom.png' },
   ]);
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
-  const stripeIcon = screen.getByTestId('payment-icon-stripe').querySelector('img');
-  expect(stripeIcon).toHaveAttribute('src', 'https://example.com/stripe.png');
+  const stripeIcon = screen.getByTestId('payment-icon-stripe').querySelector('svg');
+  expect(stripeIcon).not.toBeNull();
   const paypalIcon = screen.getByTestId('payment-icon-paypal').querySelector('svg');
   expect(paypalIcon).not.toBeNull();
+  const customIcon = screen.getByTestId('payment-icon-custom').querySelector('img');
+  expect(customIcon).toHaveAttribute('src', 'https://example.com/custom.png');
 });
 
 test('adjusts inputs based on payment selection and submits bank details', async () => {

--- a/frontend/src/tests/__tests__/resolveIconElement.test.js
+++ b/frontend/src/tests/__tests__/resolveIconElement.test.js
@@ -1,0 +1,22 @@
+import { resolveIconElement } from '@/pages/payments/checkout';
+import { FaPaypal } from 'react-icons/fa';
+
+describe('resolveIconElement', () => {
+  it('returns react icon for known provider names', () => {
+    const el = resolveIconElement({ icon: 'paypal' });
+    expect(el.type).toBe(FaPaypal);
+  });
+
+  it('returns react icon for file-like names', () => {
+    const el = resolveIconElement({ icon: 'paypal.svg' });
+    expect(el.type).toBe(FaPaypal);
+  });
+
+  it('returns img for full URLs of unknown providers', () => {
+    const url = 'https://cdn.example.com/custom.png';
+    const el = resolveIconElement({ icon: url, name: 'Custom' });
+    expect(el.type).toBe('img');
+    expect(el.props.src).toBe(url);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure checkout uses React icons for known payment providers
- add NowPayments to crypto icon list
- test icon resolution and checkout icon rendering

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac441294348328a1e380961d39e732