### PR TITLE
fix: handle PayPal methods with descriptive names

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -32,12 +32,17 @@ const iconMap = {
   usdt: <FaEthereum />,
   binance: <FaEthereum />,
   coinbase: <FaEthereum />,
+  nowpayments: <FaEthereum />,
 };
 
-function resolveIconElement(method) {
+export function resolveIconElement(method) {
   if (method.icon) {
     const lower = method.icon.toLowerCase();
-    const isUrl = /^(https?:)?\/\//.test(method.icon) || method.icon.includes('.');
+    const base = lower.split('/').pop().split('.')[0];
+    if (iconMap[lower]) return iconMap[lower];
+    if (iconMap[base]) return iconMap[base];
+    if (isPayPalMethod(base)) return iconMap.paypal;
+    const isUrl = /^(https?:)?\/\//.test(method.icon);
     if (isUrl) {
       return (
         <img
@@ -47,11 +52,10 @@ function resolveIconElement(method) {
         />
       );
     }
-    if (iconMap[lower]) return iconMap[lower];
   }
-  return (
-    iconMap[getMethodIdentifier(method).toLowerCase()] || <FaMoneyCheckAlt />
-  );
+  const identifier = getMethodIdentifier(method).toLowerCase();
+  if (isPayPalMethod(identifier)) return iconMap.paypal;
+  return iconMap[identifier] || <FaMoneyCheckAlt />;
 }
 
 function getMethodIdentifier(method) {
@@ -60,7 +64,23 @@ function getMethodIdentifier(method) {
   return '';
 }
 
-const CRYPTO_IDENTIFIERS = ['usdt', 'nft', 'binance', 'coinbase'];
+function normalizeIdentifier(value) {
+  return (value || '')
+    .toString()
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function isPayPalMethod(methodOrIdentifier) {
+  if (!methodOrIdentifier) return false;
+  const id =
+    typeof methodOrIdentifier === 'string'
+      ? methodOrIdentifier
+      : getMethodIdentifier(methodOrIdentifier);
+  return normalizeIdentifier(id).includes('paypal');
+}
+
+const CRYPTO_IDENTIFIERS = ['usdt', 'nft', 'binance', 'coinbase', 'nowpayments'];
 
 function isCryptoMethod(methodOrIdentifier) {
   if (!methodOrIdentifier) return false;
@@ -306,7 +326,7 @@ export default function CheckoutPage() {
       }
       return;
     }
-    if (identifier === 'paypal') {
+    if (isPayPalMethod(method || identifier)) {
       try {
         setPaymentStatus('processing');
         const payload = {
@@ -398,6 +418,9 @@ export default function CheckoutPage() {
     : normalizedMethod;
   const selectedMethodLabel = selectedMethodObj?.name || selectedMethod;
   const isCryptoSelected = isCryptoMethod(
+    selectedMethodObj || selectedMethodIdentifier
+  );
+  const isPayPalSelected = isPayPalMethod(
     selectedMethodObj || selectedMethodIdentifier
   );
 
@@ -511,7 +534,7 @@ export default function CheckoutPage() {
             <div className="text-yellow-400 text-center text-lg py-6">
               {t('bank_transfer_pending')}
             </div>
-          ) : selectedMethodIdentifier === 'paypal' ? (
+          ) : isPayPalSelected ? (
             <PayPalForm
               onSubmit={handlePayment}
               processing={paymentStatus === 'processing'}

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -68,30 +68,33 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-test('renders payment logos from url and fallback', async () => {
+test('renders payment logos using library icons with url fallback', async () => {
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Stripe', type: 'stripe', icon: 'https://example.com/stripe.png' },
     { id: 2, name: 'PayPal', type: null },
+    { id: 3, name: 'Custom', type: 'custom', icon: 'https://example.com/custom.png' },
   ]);
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
-  const stripeIcon = screen.getByTestId('payment-icon-stripe').querySelector('img');
-  expect(stripeIcon).toHaveAttribute('src', 'https://example.com/stripe.png');
+  const stripeIcon = screen.getByTestId('payment-icon-stripe').querySelector('svg');
+  expect(stripeIcon).not.toBeNull();
   const paypalIcon = screen.getByTestId('payment-icon-paypal').querySelector('svg');
   expect(paypalIcon).not.toBeNull();
+  const customIcon = screen.getByTestId('payment-icon-custom').querySelector('img');
+  expect(customIcon).toHaveAttribute('src', 'https://example.com/custom.png');
 });
 
 test('adjusts inputs based on payment selection and submits bank details', async () => {
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Stripe', type: 'stripe' },
-    { id: 2, name: 'PayPal', type: null },
+    { id: 2, name: 'PayPal Payment Gateway', type: null },
     { id: 3, name: 'Bank', type: 'bank' },
   ]);
   initiateBankPayment.mockResolvedValue({});
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
   expect(screen.getByPlaceholderText('Card Number')).toBeInTheDocument();
-  fireEvent.click(screen.getByText('PayPal'));
+  fireEvent.click(screen.getByText('PayPal Payment Gateway'));
   expect(screen.queryByPlaceholderText('Card Number')).toBeNull();
   expect(screen.getByRole('button', { name: /Pay \$100 with PayPal/i })).toBeInTheDocument();
   fireEvent.click(screen.getByText('Bank'));

--- a/frontend/src/tests/__tests__/resolveIconElement.test.js
+++ b/frontend/src/tests/__tests__/resolveIconElement.test.js
@@ -1,0 +1,32 @@
+import { resolveIconElement } from '@/pages/payments/checkout';
+import { FaPaypal } from 'react-icons/fa';
+
+describe('resolveIconElement', () => {
+  it('returns react icon for known provider names', () => {
+    const el = resolveIconElement({ icon: 'paypal' });
+    expect(el.type).toBe(FaPaypal);
+  });
+
+  it('returns react icon for file-like names', () => {
+    const el = resolveIconElement({ icon: 'paypal.svg' });
+    expect(el.type).toBe(FaPaypal);
+  });
+
+  it('returns react icon for file names containing paypal', () => {
+    const el = resolveIconElement({ icon: 'paypal_payment.png' });
+    expect(el.type).toBe(FaPaypal);
+  });
+
+  it('returns react icon when provider name contains paypal', () => {
+    const el = resolveIconElement({ name: 'PayPal Payment Gateway' });
+    expect(el.type).toBe(FaPaypal);
+  });
+
+  it('returns img for full URLs of unknown providers', () => {
+    const url = 'https://cdn.example.com/custom.png';
+    const el = resolveIconElement({ icon: url, name: 'Custom' });
+    expect(el.type).toBe('img');
+    expect(el.props.src).toBe(url);
+  });
+});
+


### PR DESCRIPTION
## Summary
- normalize payment identifiers so PayPal icons and forms render even when method names include extra words
- test PayPal detection for descriptive provider names

## Testing
- `npm test`
- `npm run lint` *(fails: 35 errors, 304 warnings)*
- `npx eslint src/pages/payments/checkout.js src/tests/__tests__/checkoutPaymentFlow.test.js src/tests/__tests__/resolveIconElement.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ac441294348328a1e380961d39e732