### PR TITLE
fix: handle unique index rollback

### DIFF
--- a/backend/src/migrations/20250904000000_add_unique_user_tutorial_index_to_tutorial_enrollments.js
+++ b/backend/src/migrations/20250904000000_add_unique_user_tutorial_index_to_tutorial_enrollments.js
@@ -1,11 +1,21 @@
-exports.up = function(knex) {
+exports.up = function (knex) {
   return knex.raw(
     'CREATE UNIQUE INDEX IF NOT EXISTS tutorial_enrollments_user_id_tutorial_id_unique ON tutorial_enrollments (user_id, tutorial_id)'
   );
 };
 
-exports.down = function(knex) {
-  return knex.raw(
-    'DROP INDEX IF EXISTS tutorial_enrollments_user_id_tutorial_id_unique'
-  );
+exports.down = function (knex) {
+  // Drop the unique constraint first to avoid dependency errors, then drop the index.
+  return knex.schema
+    .alterTable('tutorial_enrollments', (table) => {
+      table.dropUnique(
+        ['user_id', 'tutorial_id'],
+        'tutorial_enrollments_user_id_tutorial_id_unique'
+      );
+    })
+    .then(() =>
+      knex.raw(
+        'DROP INDEX IF EXISTS tutorial_enrollments_user_id_tutorial_id_unique'
+      )
+    );
 };


### PR DESCRIPTION
## Summary
- fix unique index migration rollback by dropping constraint first

## Testing
- `npm test` *(fails: unable to acquire a connection, expect(received).toBe(expected) // Object.is equality, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f68f8e883288335a62b56503c14