### PR TITLE
Seed email configuration with Hostinger settings

### DIFF
--- a/backend/src/seeds/12_email_settings_seed.js
+++ b/backend/src/seeds/12_email_settings_seed.js
@@ -1,0 +1,27 @@
+exports.seed = async function (knex) {
+  await knex('settings').where({ key: 'email_settings' }).del();
+  const now = new Date();
+  const config = {
+    fromName: 'SkillBridge Support',
+    fromEmail: 'support@eduskillbridge.net',
+    replyTo: 'support@eduskillbridge.net',
+    smtpHost: 'smtp.hostinger.com',
+    smtpPort: 465,
+    encryption: 'SSL',
+    username: 'support@eduskillbridge.net',
+    password: 'Javaheat@18880',
+    method: 'smtp',
+    imapHost: 'imap.hostinger.com',
+    imapPort: 993,
+    imapEncryption: 'SSL',
+    popHost: 'pop.hostinger.com',
+    popPort: 995,
+    popEncryption: 'SSL'
+  };
+  await knex('settings').insert({
+    key: 'email_settings',
+    value: JSON.stringify(config),
+    created_at: now,
+    updated_at: now,
+  });
+};


### PR DESCRIPTION
## Summary
- add seed file to populate Hostinger email settings for SkillBridge support mailbox

## Testing
- `npm test --prefix backend tests/emailConfigRoutes.test.js`
- `npm test --prefix backend` *(fails: POST /api/ads/admin creates ad expected 200 received 400)*

------
https://chatgpt.com/codex/tasks/task_e_68aca70db7f083288ecc5fe91bfa83f1