### PR TITLE
Fix missing ConfirmModal import in currency settings

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/currency/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/currency/index.js
@@ -3,6 +3,7 @@
 // Lists currencies with pagination and allows editing.
 // ─────────────────────
 import AdminLayout from "@/components/layouts/AdminLayout";
+import ConfirmModal from "@/components/common/ConfirmModal";
 import { useState, useMemo, useEffect } from "react";
 import { toast } from "react-toastify";
 import useAdminNotice from "@/hooks/useAdminNotice";


### PR DESCRIPTION
## Summary
- import ConfirmModal component on admin currency settings page to avoid runtime ReferenceError

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb63e86948328a873d5221fc194c9