### PR TITLE
Show detailed ad validation errors

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -255,12 +255,22 @@ export default function CreateAdPage() {
       await notify('ad_created', msg);
       router.push("/dashboard/admin/ads");
     } catch (err) {
-      const message = err?.response?.data?.message || t('failed');
-      if (message.toLowerCase().includes("title")) {
+      const data = err?.response?.data || {};
+      const baseMessage = data.message || t('failed');
+      if (data.errors?.length) {
+        const details = data.errors
+          .map((e) => {
+            const path = Array.isArray(e.path) ? e.path.join('.') : '';
+            return path ? `${path}: ${e.message}` : e.message;
+          })
+          .join(', ');
+        setError(details);
+        toast.error(details);
+      } else if (baseMessage.toLowerCase().includes('title')) {
         setTitleError(t('title_exists'));
       } else {
-        setError(message);
-        toast.error(message);
+        setError(baseMessage);
+        toast.error(baseMessage);
       }
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
## Summary
- Improve ad creation error handling by surfacing specific validation messages in the admin dashboard

## Testing
- `cd backend && npm test` (fails: Test Suites: 17 failed, 70 passed)
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb851152c8328bb3db3195e14df63