### PR TITLE
fix: validate ads creation body directly

### DIFF
--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -1,6 +1,6 @@
 const { z } = require("zod");
 
-exports.create = z.object({
+exports.create = {
   body: z.object({
     title: z.string().min(3),
     description: z.string().optional(),
@@ -13,5 +13,5 @@ exports.create = z.object({
     ad_type: z.string().optional(),
     priority: z.coerce.number().optional(),
     allow_branding: z.coerce.boolean().optional(),
-  })
-});
+  }),
+};


### PR DESCRIPTION
## Summary
- fix ads create validator to parse req.body directly and avoid extra `body` property

## Testing
- `cd backend && npm test` *(fails: Test Suites: 16 failed, 71 passed, 87 total)*

------
https://chatgpt.com/codex/tasks/task_e_68acc2fbc74c8328900745301651048c