### PR TITLE
fix: validate ads creation body directly

### DIFF
--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -1,17 +1,19 @@
 const { z } = require("zod");
 
-exports.create = z.object({
+const emptyToUndefined = (v) => (v === "" || v === null ? undefined : v);
+
+exports.create = {
   body: z.object({
     title: z.string().min(3),
-    description: z.string().optional(),
-    image_url: z.string().min(1).optional(),
-    video_url: z.string().min(1).optional(),
-    link_url: z.string().url().optional(),
-    start_at: z.string().datetime().optional(),
-    end_at: z.string().datetime().optional(),
-    target_roles: z.string().optional(),
-    ad_type: z.string().optional(),
+    description: z.preprocess(emptyToUndefined, z.string().optional()),
+    image_url: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
+    video_url: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
+    link_url: z.preprocess(emptyToUndefined, z.string().url().optional()),
+    start_at: z.preprocess(emptyToUndefined, z.string().datetime().optional()),
+    end_at: z.preprocess(emptyToUndefined, z.string().datetime().optional()),
+    target_roles: z.preprocess(emptyToUndefined, z.string().optional()),
+    ad_type: z.preprocess(emptyToUndefined, z.string().optional()),
     priority: z.coerce.number().optional(),
     allow_branding: z.coerce.boolean().optional(),
-  })
-});
+  }),
+};

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -146,6 +146,21 @@ describe('POST /api/ads/admin', () => {
       message: 'New ad created: Test',
     });
   });
+
+  it('allows empty optional fields', async () => {
+    service.createAd.mockClear();
+    const payload = {
+      title: 'Blank',
+      image_url: 'img.jpg',
+      link_url: '',
+      start_at: '',
+      end_at: '',
+    };
+    service.createAd.mockResolvedValue({ id: '2', title: 'Blank' });
+    const res = await request(app).post('/api/ads/admin').send(payload);
+    expect(res.status).toBe(200);
+    expect(service.createAd).toHaveBeenCalled();
+  });
 });
 
 describe('PUT /api/ads/:id', () => {


### PR DESCRIPTION
## Summary
- sanitize optional ad fields so blank strings are treated as missing
- test ads creation with empty optional link and date fields

## Testing
- `npm test tests/adsRoutes.test.js`
- `npm test` *(fails: Test Suites: 16 failed, 71 passed, 87 total)*

------
https://chatgpt.com/codex/tasks/task_e_68acc2fbc74c8328900745301651048c