### PR TITLE
Add database migration and seed scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Alternatively, launch the backend and open [`/install`](http://localhost:5002/in
 2. Initialize the database (run migrations and seeds):
 
    ```bash
-   npx knex migrate:latest --knexfile backend/knexfile.js
-   npx knex seed:run --knexfile backend/knexfile.js
+   npm --prefix backend run migrate
+   npm --prefix backend run seed
    ```
 
    If `ADMIN_INITIAL_PASSWORD` or `SUPERADMIN_INITIAL_PASSWORD` are not set in

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
-    "test": "jest"
+    "test": "jest",
+    "migrate": "knex migrate:latest --knexfile knexfile.js",
+    "seed": "knex seed:run --knexfile knexfile.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `migrate` and `seed` scripts to backend package.json
- document database initialization scripts in README

## Testing
- `npm --prefix backend test` *(fails: Test Suites: 16 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad62cad13c832897571a415d7cadfd