### PR TITLE
Add Knex database seeding script

### DIFF
--- a/backend/src/scripts/seedDatabase.js
+++ b/backend/src/scripts/seedDatabase.js
@@ -1,0 +1,23 @@
+const knex = require('knex');
+const knexConfig = require('../../knexfile');
+
+const environment = process.env.NODE_ENV || 'development';
+
+async function seedDatabase() {
+  const db = knex(knexConfig[environment]);
+  try {
+    await db.migrate.latest();
+    await db.seed.run();
+    console.log('Database migrated and seeded successfully');
+  } catch (error) {
+    console.error('Database seeding failed:', error);
+  } finally {
+    await db.destroy();
+  }
+}
+
+if (require.main === module) {
+  seedDatabase();
+}
+
+module.exports = seedDatabase;


### PR DESCRIPTION
## Summary
- add `seedDatabase` script to run migrations and seeds

## Testing
- `npm test --silent >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log` *(fails: Test Suites: 16 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad62c7eea8832898bdd804d27d8185