### PR TITLE
Add guard for missing DATABASE_URL in database config

### DIFF
--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -2,6 +2,11 @@ const logger = require('../utils/logger.js');
 require("dotenv").config();
 const knex = require("knex");
 
+if (!process.env.DATABASE_URL) {
+  logger.error("DATABASE_URL is not defined");
+  process.exit(1);
+}
+
 const db = knex({
   client: "pg",
   connection: process.env.DATABASE_URL,


### PR DESCRIPTION
## Summary
- exit with clear message if `DATABASE_URL` isn't provided
- initialize Knex only when `DATABASE_URL` exists

## Testing
- `DATABASE_URL=postgres://localhost/test npm test` *(fails: 16 test suites failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad62c735ac8328811f19b8a3fb43a3