### PR TITLE
chore: raise page data limit

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -49,6 +49,11 @@ const nextConfig = {
     ],
   },
   i18n: nextI18NextConfig.i18n,
+  // Increase the page data size limit to suppress build warnings for
+  // larger translation bundles.
+  experimental: {
+    largePageDataBytes: 256 * 1024,
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- raise Next.js `largePageDataBytes` limit to 256kb to silence large translation warnings

## Testing
- `npm test`
- `npm run lint` *(fails: 34 errors, 304 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ad71ecf8488328bbef27b3d2f7ce2a