### PR TITLE
feat: add blog manager translations

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -468,6 +468,25 @@
     "next": "التالي",
     "no_alerts": "لا توجد تنبيهات."
   },
+  "blogManagerPage": {
+    "title": "Blog Manager",
+    "post_title_placeholder": "Enter post title",
+    "upload_image": "Upload Image",
+    "excerpt_placeholder": "Enter excerpt",
+    "save": "Save",
+    "cancel": "Cancel",
+    "add_post": "Add Post",
+    "edit": "Edit",
+    "delete": "Delete",
+    "load_failed": "Failed to load posts",
+    "create_success": "Post created",
+    "create_failed": "Failed to create post",
+    "confirm_delete": "Are you sure you want to delete this post?",
+    "delete_success": "Post deleted",
+    "delete_failed": "Failed to delete post",
+    "update_success": "Post updated",
+    "update_failed": "Failed to update post"
+  },
   "instructorProfilePage": {
     "title": "تعديل ملف المدرس",
     "profile_picture": "صورة الملف الشخصي",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -482,6 +482,25 @@
     "next": "Next",
     "no_alerts": "No alerts found."
   },
+  "blogManagerPage": {
+    "title": "Blog Manager",
+    "post_title_placeholder": "Enter post title",
+    "upload_image": "Upload Image",
+    "excerpt_placeholder": "Enter excerpt",
+    "save": "Save",
+    "cancel": "Cancel",
+    "add_post": "Add Post",
+    "edit": "Edit",
+    "delete": "Delete",
+    "load_failed": "Failed to load posts",
+    "create_success": "Post created",
+    "create_failed": "Failed to create post",
+    "confirm_delete": "Are you sure you want to delete this post?",
+    "delete_success": "Post deleted",
+    "delete_failed": "Failed to delete post",
+    "update_success": "Post updated",
+    "update_failed": "Failed to update post"
+  },
   "instructorProfilePage": {
     "title": "Edit Instructor Profile",
     "profile_picture": "Profile Picture",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -484,6 +484,25 @@
     "next": "Next",
     "no_alerts": "No alerts found."
   },
+  "blogManagerPage": {
+    "title": "Blog Manager",
+    "post_title_placeholder": "Enter post title",
+    "upload_image": "Upload Image",
+    "excerpt_placeholder": "Enter excerpt",
+    "save": "Save",
+    "cancel": "Cancel",
+    "add_post": "Add Post",
+    "edit": "Edit",
+    "delete": "Delete",
+    "load_failed": "Failed to load posts",
+    "create_success": "Post created",
+    "create_failed": "Failed to create post",
+    "confirm_delete": "Are you sure you want to delete this post?",
+    "delete_success": "Post deleted",
+    "delete_failed": "Failed to delete post",
+    "update_success": "Post updated",
+    "update_failed": "Failed to update post"
+  },
   "instructorProfilePage": {
     "title": "Edit Instructor Profile",
     "profile_picture": "Profile Picture",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -468,6 +468,25 @@
     "next": "Próximo",
     "no_alerts": "No se encontraron alertas."
   },
+  "blogManagerPage": {
+    "title": "Blog Manager",
+    "post_title_placeholder": "Enter post title",
+    "upload_image": "Upload Image",
+    "excerpt_placeholder": "Enter excerpt",
+    "save": "Save",
+    "cancel": "Cancel",
+    "add_post": "Add Post",
+    "edit": "Edit",
+    "delete": "Delete",
+    "load_failed": "Failed to load posts",
+    "create_success": "Post created",
+    "create_failed": "Failed to create post",
+    "confirm_delete": "Are you sure you want to delete this post?",
+    "delete_success": "Post deleted",
+    "delete_failed": "Failed to delete post",
+    "update_success": "Post updated",
+    "update_failed": "Failed to update post"
+  },
   "instructorProfilePage": {
     "title": "Editar perfil del instructor",
     "profile_picture": "Foto de perfil",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -468,6 +468,25 @@
     "next": "Suivant",
     "no_alerts": "Aucune alerte trouvée."
   },
+  "blogManagerPage": {
+    "title": "Blog Manager",
+    "post_title_placeholder": "Enter post title",
+    "upload_image": "Upload Image",
+    "excerpt_placeholder": "Enter excerpt",
+    "save": "Save",
+    "cancel": "Cancel",
+    "add_post": "Add Post",
+    "edit": "Edit",
+    "delete": "Delete",
+    "load_failed": "Failed to load posts",
+    "create_success": "Post created",
+    "create_failed": "Failed to create post",
+    "confirm_delete": "Are you sure you want to delete this post?",
+    "delete_success": "Post deleted",
+    "delete_failed": "Failed to delete post",
+    "update_success": "Post updated",
+    "update_failed": "Failed to update post"
+  },
   "instructorProfilePage": {
     "title": "Modifier le profil de l'instructeur",
     "profile_picture": "Photo de profil",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -468,6 +468,25 @@
     "next": "अगला",
     "no_alerts": "कोई अलर्ट नहीं मिला।"
   },
+  "blogManagerPage": {
+    "title": "Blog Manager",
+    "post_title_placeholder": "Enter post title",
+    "upload_image": "Upload Image",
+    "excerpt_placeholder": "Enter excerpt",
+    "save": "Save",
+    "cancel": "Cancel",
+    "add_post": "Add Post",
+    "edit": "Edit",
+    "delete": "Delete",
+    "load_failed": "Failed to load posts",
+    "create_success": "Post created",
+    "create_failed": "Failed to create post",
+    "confirm_delete": "Are you sure you want to delete this post?",
+    "delete_success": "Post deleted",
+    "delete_failed": "Failed to delete post",
+    "update_success": "Post updated",
+    "update_failed": "Failed to update post"
+  },
   "instructorProfilePage": {
     "title": "प्रशिक्षक प्रोफ़ाइल संपादित करें",
     "profile_picture": "प्रोफ़ाइल फोटो",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -482,6 +482,25 @@
     "next": "Prossimo",
     "no_alerts": "Nessun avviso trovato."
   },
+  "blogManagerPage": {
+    "title": "Blog Manager",
+    "post_title_placeholder": "Enter post title",
+    "upload_image": "Upload Image",
+    "excerpt_placeholder": "Enter excerpt",
+    "save": "Save",
+    "cancel": "Cancel",
+    "add_post": "Add Post",
+    "edit": "Edit",
+    "delete": "Delete",
+    "load_failed": "Failed to load posts",
+    "create_success": "Post created",
+    "create_failed": "Failed to create post",
+    "confirm_delete": "Are you sure you want to delete this post?",
+    "delete_success": "Post deleted",
+    "delete_failed": "Failed to delete post",
+    "update_success": "Post updated",
+    "update_failed": "Failed to update post"
+  },
   "instructorProfilePage": {
     "title": "Modifica profilo istruttore",
     "profile_picture": "Immagine del profilo",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -468,6 +468,25 @@
     "next": "下一个",
     "no_alerts": "找不到警报。"
   },
+  "blogManagerPage": {
+    "title": "Blog Manager",
+    "post_title_placeholder": "Enter post title",
+    "upload_image": "Upload Image",
+    "excerpt_placeholder": "Enter excerpt",
+    "save": "Save",
+    "cancel": "Cancel",
+    "add_post": "Add Post",
+    "edit": "Edit",
+    "delete": "Delete",
+    "load_failed": "Failed to load posts",
+    "create_success": "Post created",
+    "create_failed": "Failed to create post",
+    "confirm_delete": "Are you sure you want to delete this post?",
+    "delete_success": "Post deleted",
+    "delete_failed": "Failed to delete post",
+    "update_success": "Post updated",
+    "update_failed": "Failed to update post"
+  },
   "instructorProfilePage": {
     "title": "编辑讲师资料",
     "profile_picture": "个人资料图片",


### PR DESCRIPTION
## Summary
- add `blogManagerPage` translations for admin dashboard blog settings

## Testing
- `npm test`
- `npm run lint` *(fails: 34 errors, 304 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9b2a51788328b1bdb20a0687a0df