### PR TITLE
fix: proxy API routes to backend

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -63,6 +63,14 @@ const nextConfig = {
         ? { exclude: ['error', 'warn'] }
         : false,
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${apiBase}/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- ensure Next.js dev server forwards `/api` routes to backend so social auth callbacks reach Express API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68addb17bebc83289f5af084bb02d7b9