### PR TITLE
fix: proxy API routes to backend

### DIFF
--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -1,7 +1,8 @@
 // Import the configured passport instance
 const { passport } = require('../../../config/passport');
-const { refreshCookieOptions } = require('../../../utils/cookie');
+const { refreshCookieOptions, csrfCookieOptions } = require('../../../utils/cookie');
 const { frontendBase, allowedOrigins } = require('../../../utils/frontend');
+const crypto = require('crypto');
 
 // Shared callback handler for social auth providers
 const handleCallback = (provider) => (req, res, next) => {
@@ -10,7 +11,10 @@ const handleCallback = (provider) => (req, res, next) => {
       return res.redirect(`${frontendBase}/auth/login?error=social`);
     }
     const { refreshToken } = result;
-    res.cookie('refreshToken', refreshToken, refreshCookieOptions);
+    const csrfToken = crypto.randomBytes(24).toString('hex');
+    res
+      .cookie('refreshToken', refreshToken, refreshCookieOptions)
+      .cookie('csrfToken', csrfToken, csrfCookieOptions);
     let origin = req.query.origin;
     if (!allowedOrigins.includes(origin)) {
       const headerOrigin = req.get('origin');

--- a/backend/tests/authSocialRedirect.test.js
+++ b/backend/tests/authSocialRedirect.test.js
@@ -40,4 +40,14 @@ describe('social auth redirect', () => {
     expect(res.headers.location).toBe('http://frontend.com/auth/social-success');
     expect(res.headers.location).not.toContain('token=');
   });
+
+  it('sets refresh and csrf cookies', async () => {
+    const res = await request(app).get('/api/auth/google/callback');
+    expect(res.headers['set-cookie']).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('refreshToken=r'),
+        expect.stringContaining('csrfToken='),
+      ])
+    );
+  });
 });

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -63,6 +63,14 @@ const nextConfig = {
         ? { exclude: ['error', 'warn'] }
         : false,
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${apiBase}/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- ensure Next.js dev server forwards `/api` routes to backend so social auth callbacks reach Express API
- set CSRF token cookie during social auth callback so refresh token exchange succeeds

## Testing
- `npm test` (fails: DATABASE_URL is not defined)
- `npm test -- tests/authSocialRedirect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68addb17bebc83289f5af084bb02d7b9