### PR TITLE
Add environment configs and NODE_ENV handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .env
+.env.production
 dist/
 coverage/
 .vscode/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,10 @@
 # Default API port. Docker Compose and nginx expect 5002.
 PORT=5002
 DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge
+# Connection string for automated tests. Use a separate isolated database.
+TEST_DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge_test
+# Production database connection. Store the actual value securely outside version control.
+PRODUCTION_DATABASE_URL=
 JWT_SECRET=your_jwt_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret
 MAX_BLOG_IMAGE_BYTES=10485760

--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -1,12 +1,26 @@
+require('dotenv').config();
+
+const baseConfig = {
+  client: 'pg',
+  migrations: {
+    directory: './src/migrations'
+  },
+  seeds: {
+    directory: './src/seeds'
+  }
+};
+
 module.exports = {
   development: {
-    client: 'pg',
-    connection: process.env.DATABASE_URL,
-    migrations: {
-      directory: './src/migrations'
-    },
-    seeds: {
-      directory: './src/seeds'
-    }
+    ...baseConfig,
+    connection: process.env.DATABASE_URL
+  },
+  test: {
+    ...baseConfig,
+    connection: process.env.TEST_DATABASE_URL
+  },
+  production: {
+    ...baseConfig,
+    connection: process.env.PRODUCTION_DATABASE_URL
   }
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
-    "test": "jest",
+    "test": "NODE_ENV=test jest",
     "migrate": "knex migrate:latest --knexfile knexfile.js",
     "seed": "knex seed:run --knexfile knexfile.js"
   },

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -1,23 +1,23 @@
 const logger = require('../utils/logger.js');
-require("dotenv").config();
-const knex = require("knex");
+require('dotenv').config();
+const knex = require('knex');
+const knexfile = require('../../knexfile.js');
 
-if (!process.env.DATABASE_URL) {
-  logger.error("DATABASE_URL is not defined");
+const environment = process.env.NODE_ENV || 'development';
+const config = knexfile[environment];
+
+if (!config || !config.connection) {
+  logger.error(`${environment} database configuration is missing`);
   process.exit(1);
 }
 
-const db = knex({
-  client: "pg",
-  connection: process.env.DATABASE_URL,
-  pool: { min: 2, max: 10 },
-});
+const db = knex({ ...config, pool: { min: 2, max: 10 } });
 
-if (process.env.NODE_ENV !== "test") {
-  db.raw("SELECT 1")
-    .then(() => logger.log("✅ PostgreSQL Database Connected"))
+if (environment !== 'test') {
+  db.raw('SELECT 1')
+    .then(() => logger.log('✅ PostgreSQL Database Connected'))
     .catch((err) => {
-      logger.error("❌ Database Connection Error:", err);
+      logger.error('❌ Database Connection Error:', err);
       process.exit(1);
     });
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - REFRESH_TOKEN_SECRET=SkillBr1dge-!Refresh.JWT-Key!
       - FRONTEND_URL=https://eduskillbridge.net
       - MAX_BLOG_IMAGE_BYTES=10485760
+      - NODE_ENV=production
     depends_on:
       - db
     volumes:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "jest"
+    "test": "NODE_ENV=test jest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/deploy_server.sh
+++ b/scripts/deploy_server.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export NODE_ENV=production
+
 # Script to configure nginx for a provided domain and obtain Let's Encrypt certificates.
 # Usage: ./scripts/deploy_server.sh <domain>
 


### PR DESCRIPTION
## Summary
- extend knexfile with test and production database configs and load them via environment-specific settings
- run tests and deployments with NODE_ENV set appropriately
- document test and production database URLs and ignore production env files

## Testing
- `npm test` (backend) *(fails: 26 failed, 61 passed)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68adfb21ac608328ae053f22d9d18f39