### PR TITLE
Guard database seeding for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
 curl -s https://example.com/install.sh | bash
 ```
 
-The script checks prerequisites, copies example env files, builds containers and seeds the database.
+The script checks prerequisites, copies example env files, builds containers and seeds the database for development setups.
 
 
 Alternatively, launch the backend and open [`/install`](http://localhost:5002/install) to use a simple web-based installer that checks prerequisites and runs the setup scripts after entering configuration values.
@@ -34,6 +34,7 @@ Alternatively, launch the backend and open [`/install`](http://localhost:5002/in
    npm --prefix backend run migrate
    npm --prefix backend run seed
    ```
+   Seeding is meant for development environments only and should not be executed in production.
 
    If `ADMIN_INITIAL_PASSWORD` or `SUPERADMIN_INITIAL_PASSWORD` are not set in
    `backend/.env`, the seed scripts will generate secure random passwords and

--- a/backend/src/scripts/seedDatabase.js
+++ b/backend/src/scripts/seedDatabase.js
@@ -7,8 +7,12 @@ async function seedDatabase() {
   const db = knex(knexConfig[environment]);
   try {
     await db.migrate.latest();
-    await db.seed.run();
-    console.log('Database migrated and seeded successfully');
+    if (environment !== 'production') {
+      await db.seed.run();
+      console.log('Database migrated and seeded successfully');
+    } else {
+      console.log('Database migrated successfully');
+    }
   } catch (error) {
     console.error('Database seeding failed:', error);
   } finally {

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -14,9 +14,13 @@ fi
 if [ -n "$($DOCKER_COMPOSE ps -q backend 2>/dev/null)" ]; then
   echo "Running migrations inside backend container..."
   $DOCKER_COMPOSE exec backend npx knex migrate:latest --knexfile knexfile.js
-  $DOCKER_COMPOSE exec backend npx knex seed:run --knexfile knexfile.js
+  if [ "$NODE_ENV" != "production" ]; then
+    $DOCKER_COMPOSE exec backend npx knex seed:run --knexfile knexfile.js
+  fi
 else
   echo "Running migrations locally..."
   npx knex migrate:latest --knexfile backend/knexfile.js
-  npx knex seed:run --knexfile backend/knexfile.js
+  if [ "$NODE_ENV" != "production" ]; then
+    npx knex seed:run --knexfile backend/knexfile.js
+  fi
 fi


### PR DESCRIPTION
## Summary
- Only execute Knex seeds when `NODE_ENV` is not `production`
- Document that database seeding is intended for development setups only

## Testing
- `bash -n scripts/init_db.sh`
- `npm --prefix backend test` *(fails: DATABASE_URL not defined and multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68adfb14fae88328b9c907fc17ef62a4