### PR TITLE
Add Google social login seed

### DIFF
--- a/backend/src/seeds/08_social_login_settings_seed.js
+++ b/backend/src/seeds/08_social_login_settings_seed.js
@@ -1,0 +1,27 @@
+exports.seed = async function (knex) {
+  await knex('settings').where({ key: 'social_login_settings' }).del();
+  const now = new Date();
+  const config = {
+    enabled: true,
+    providers: {
+      google: {
+        active: true,
+        clientId: '707378564878-smi89kqne0snc1usv9s1l465hs6lb9a0.apps.googleusercontent.com',
+        clientSecret: 'YOUR_GOOGLE_CLIENT_SECRET',
+        redirectUrl: 'https://www.eduskillbridge.net/api/auth/google/callback',
+        label: 'Sign in with Google',
+        icon: 'google',
+      },
+      facebook: { active: false },
+      apple: { active: false },
+      github: { active: false },
+    },
+    recaptcha: { active: false, siteKey: '', secretKey: '' },
+  };
+  await knex('settings').insert({
+    key: 'social_login_settings',
+    value: JSON.stringify(config),
+    created_at: now,
+    updated_at: now,
+  });
+};


### PR DESCRIPTION
## Summary
- seed Google social login settings with provided client ID and callback URL

## Testing
- `npm test` *(fails: DATABASE_URL not defined, multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68adfaf2a1c88328b0aff335ba1ed3d1