### PR TITLE
feat: support generic database env var

### DIFF
--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -21,6 +21,6 @@ module.exports = {
   },
   production: {
     ...baseConfig,
-    connection: process.env.PRODUCTION_DATABASE_URL
+    connection: process.env.DATABASE_URL || process.env.PRODUCTION_DATABASE_URL
   }
 };


### PR DESCRIPTION
## Summary
- allow production database to use `DATABASE_URL` or fallback to `PRODUCTION_DATABASE_URL`

## Testing
- `npm test` *(fails: Test Suites: 26 failed, 61 passed, 87 total)*
- `docker compose build backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae03fbd2a48328804ffb2e45b14b9a