### PR TITLE
feat: sync language settings and add toasts

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/language-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/language-config/index.js
@@ -7,29 +7,27 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import useSWR, { mutate as mutateGlobal } from "swr";
 
 export default function LanguageConfigPage() {
   const { t, i18n } = useTranslation("dashboard");
   const [config, setConfig] = useState({ defaultLanguage: "en" });
-  const [languages, setLanguages] = useState([]);
+  const { data: configData } = useSWR("/app-config", fetchAppConfig, {
+    onError: () => toast.error(t("settings_load_failed")),
+  });
+  const { data: languages } = useSWR("/languages", getLanguages, {
+    onError: () => toast.error(t("settings_load_failed")),
+  });
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const [cfg, langs] = await Promise.all([
-          fetchAppConfig(),
-          getLanguages(),
-        ]);
-        setConfig({ ...cfg, defaultLanguage: cfg.defaultLanguage || "en" });
-        setLanguages(langs || []);
-      } catch (err) {
-        console.error("Failed to load data", err);
-        toast.error(t("settings_load_failed"));
-      }
-    };
-    load();
-  }, []);
+    if (configData) {
+      setConfig({
+        ...configData,
+        defaultLanguage: configData.defaultLanguage || "en",
+      });
+    }
+  }, [configData]);
 
   const handleSave = async () => {
     setLoading(true);
@@ -37,6 +35,8 @@ export default function LanguageConfigPage() {
       const updated = await updateAppConfig(config);
       setConfig(updated);
       toast.success(t("settings_saved"));
+      mutateGlobal("/app-config");
+      mutateGlobal("/languages");
     } catch (err) {
       console.error(err);
       toast.error(t("settings_save_failed"));
@@ -58,7 +58,7 @@ export default function LanguageConfigPage() {
               setConfig((prev) => ({ ...prev, defaultLanguage: e.target.value }))
             }
           >
-            {languages.map((l) => (
+            {languages?.map((l) => (
               <option key={l.id} value={l.code}>
                 {l.name}
               </option>

--- a/frontend/src/pages/dashboard/admin/settings/languages/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/index.js
@@ -1,6 +1,6 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
 import Link from "next/link";
-import useSWR from "swr";
+import useSWR, { mutate as mutateGlobal } from "swr";
 import api from "@/services/api/api";
 import { useRouter } from "next/router";
 import { useState } from "react";
@@ -8,6 +8,7 @@ import { FaEdit, FaTrashAlt } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import { toast } from "react-toastify";
 
 const fetcher = url => api.get(url).then(res => res.data.data);
 
@@ -19,19 +20,37 @@ export default function LanguagesPage() {
   const ITEMS_PER_PAGE = 5;
 
   const toggleActive = async (lang) => {
-    await api.put(`/languages/${lang.id}`, { ...lang, is_active: !lang.is_active });
-    mutate();
+    try {
+      await api.put(`/languages/${lang.id}`, { ...lang, is_active: !lang.is_active });
+      mutate();
+      mutateGlobal("/app-config");
+      toast.success(t('language_updated'));
+    } catch (err) {
+      toast.error(t('failed_to_save'));
+    }
   };
 
   const setDefault = async (lang) => {
-    await api.put(`/languages/${lang.id}`, { ...lang, is_default: true });
-    mutate();
+    try {
+      await api.put(`/languages/${lang.id}`, { ...lang, is_default: true });
+      mutate();
+      mutateGlobal("/app-config");
+      toast.success(t('language_updated'));
+    } catch (err) {
+      toast.error(t('failed_to_save'));
+    }
   };
 
   const remove = async (id) => {
     if (confirm(t('confirm_delete'))) {
-      await api.delete(`/languages/${id}`);
-      mutate();
+      try {
+        await api.delete(`/languages/${id}`);
+        mutate();
+        mutateGlobal("/app-config");
+        toast.success(t('language_updated'));
+      } catch (err) {
+        toast.error(t('failed_to_save'));
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- use SWR to keep language config and list pages in sync
- show toast feedback for language actions

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af27cdd498832892e757a6b7f78fcd