### PR TITLE
Use shared API client for AI requests to include CSRF token

### DIFF
--- a/frontend/src/pages/ai-tutoring/voice.js
+++ b/frontend/src/pages/ai-tutoring/voice.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaMicrophone, FaVolumeUp, FaStop } from "react-icons/fa";
+import api from "@/services/api/api";
 
 export default function AIVoiceTutor() {
   const [isListening, setIsListening] = useState(false);
@@ -29,12 +30,7 @@ export default function AIVoiceTutor() {
   };
 
   const fetchAIResponse = async (query) => {
-    const response = await fetch("/api/ai-voice-tutor", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query }),
-    });
-    const data = await response.json();
+    const { data } = await api.post("/ai-voice-tutor", { query });
     setAiResponse(data.response);
     speakResponse(data.response);
   };

--- a/frontend/src/pages/community/ask.js
+++ b/frontend/src/pages/community/ask.js
@@ -8,9 +8,7 @@ import ReactMarkdown from "react-markdown";
 import { toast } from "react-toastify";
 import { createDiscussion, searchTags, createReply } from "@/services/communityService";
 import { fetchThirdPartyConfig } from "@/services/thirdPartyService";
-
-// ✅ AI API URL - Update with your actual backend API endpoint
-const AI_API_URL = "/api/ai-assistance";
+import { askAI } from "@/services/aiService";
 
 // ✅ Predefined Popular Tags for Suggestions
 const popularTags = ["React", "Next.js", "JavaScript", "Node.js", "API", "MongoDB", "Tailwind CSS"];
@@ -158,30 +156,21 @@ const AskQuestionPage = () => {
     setConfidenceScore(null);
 
     try {
-      const response = await fetch(AI_API_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          question: title,
-          provider: selectedAI,
-          model: selectedAI === 'chatgpt' ? selectedModel : undefined,
-        }),
-      });
-
-      const data = await response.json();
-      if (!response.ok) {
-        setAIResponse(`⚠️ ${data.message || 'Error generating AI response.'}`);
-        return;
-      }
-      const ans = data.data?.answer ?? data.answer;
-      const conf = data.data?.confidence ?? data.confidence;
+      const data = await askAI(
+        selectedAI,
+        title,
+        selectedAI === 'chatgpt' ? selectedModel : undefined
+      );
+      const ans = data.answer;
+      const conf = data.confidence;
       setAIResponse(ans);
       setEditableResponse(ans);
       setConfidenceScore(conf);
-      setRelatedQuestions(data.data?.relatedQuestions || data.relatedQuestions || []);
+      setRelatedQuestions(data.relatedQuestions || []);
     } catch (error) {
       console.error("AI Response Error:", error);
-      setAIResponse("⚠️ Error generating AI response.");
+      const msg = error.response?.data?.message || 'Error generating AI response.';
+      setAIResponse(`⚠️ ${msg}`);
     } finally {
       setIsProcessingAI(false);
     }


### PR DESCRIPTION
## Summary
- Use shared `askAI` service in Ask page so CSRF token is sent with requests
- Leverage shared API instance in AI Voice Tutor page for proper CSRF handling

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities, @next/next/no-html-link-for-pages, react-hooks/rules-of-hooks, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af2ff4c3fc8328b94a8627f654db73