### PR TITLE
Handle ad toggle failures by reverting local state

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/index.js
+++ b/frontend/src/pages/dashboard/admin/ads/index.js
@@ -39,17 +39,19 @@ export default function AdminAdsPage() {
     // Handlers
     // ─────────────────────
     const toggleAdStatus = async (id) => {
+        const previousAds = [...ads];
         setAds((prev) =>
             prev.map((ad) =>
                 ad.id === id ? { ...ad, isActive: !ad.isActive } : ad
             )
         );
-        const ad = ads.find((a) => a.id === id);
+        const ad = previousAds.find((a) => a.id === id);
         if (ad) {
             try {
                 await updateAd(id, { is_active: !ad.isActive });
                 toast.success(t('status_updated'));
             } catch {
+                setAds(previousAds);
                 toast.error(t('error_generic'));
             }
         }


### PR DESCRIPTION
## Summary
- Preserve current ads state before toggling
- Restore previous state if `updateAd` fails to keep UI consistent

## Testing
- `npm test`
- `npm run lint` *(fails: 34 errors, 303 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dbccc9b88328838488106350d93d