### PR TITLE
Use recordView for ad view logging

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -289,7 +289,7 @@ exports.deleteAd = catchAsync(async (req, res) => {
  */
 exports.recordAdView = catchAsync(async (req, res) => {
   const userId = req.user?.id || null;
-  await service.recordAdView(req.params.id, userId);
+  await service.recordView(req.params.id, userId);
   sendSuccess(res, null, "View recorded");
 });
 

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -44,11 +44,6 @@ exports.deleteAd = (id) => {
   return db("ads").where({ id }).del();
 };
 
-// Record a single ad view. `userId` may be null for anonymous views.
-exports.recordAdView = async (adId, userId) => {
-  await db("ad_views").insert({ ad_id: adId, user_id: userId });
-};
-
 // Retrieve aggregated analytics for a given ad.
 exports.getAdAnalytics = async (adId) => {
   // Aggregate total views and unique viewers from ad_views table

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -9,7 +9,7 @@ jest.mock('../src/modules/ads/ads.service', () => ({
   updateAd: jest.fn(),
   deleteAd: jest.fn(),
   getAdAnalytics: jest.fn(),
-  recordAdView: jest.fn(),
+  recordView: jest.fn(),
 }));
 
 jest.mock('../src/modules/notifications/notifications.service', () => ({
@@ -181,9 +181,9 @@ describe('GET /api/ads/:id/analytics', () => {
 
 describe('POST /api/ads/:id/view', () => {
   it('records ad view', async () => {
-    service.recordAdView.mockResolvedValue();
+    service.recordView.mockResolvedValue();
     const res = await request(app).post('/api/ads/1/view');
     expect(res.status).toBe(200);
-    expect(service.recordAdView).toHaveBeenCalledWith('1', null);
+    expect(service.recordView).toHaveBeenCalledWith('1', null);
   });
 });


### PR DESCRIPTION
## Summary
- Replace ads controller's use of `recordAdView` with `recordView`
- Remove deprecated `recordAdView` service helper
- Update ads route tests to mock and verify `recordView`

## Testing
- `npm test tests/adsRoutes.test.js`
- `npm test` *(fails: database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dbca73d08328878a78985e47e21d