### PR TITLE
Add ads update validator and apply validation middleware

### DIFF
--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -38,6 +38,7 @@ router.put(
   verifyToken,
   isInstructorOrAdmin,
   upload,
+  validate(validator.update),
   controller.updateAd
 );
 router.delete(

--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -15,3 +15,19 @@ exports.create = {
     allow_branding: z.coerce.boolean().optional(),
   }),
 };
+
+exports.update = {
+  body: z.object({
+    title: z.string().min(3).optional(),
+    description: z.string().optional(),
+    image_url: z.string().min(1).optional(),
+    video_url: z.string().min(1).optional(),
+    link_url: z.string().url().optional(),
+    start_at: z.string().datetime().optional(),
+    end_at: z.string().datetime().optional(),
+    target_roles: z.string().optional(),
+    ad_type: z.string().optional(),
+    priority: z.coerce.number().optional(),
+    allow_branding: z.coerce.boolean().optional(),
+  }),
+};


### PR DESCRIPTION
## Summary
- add optional-field update validator for ads
- enforce update validation in ad routes

## Testing
- `cd backend && npm test` *(fails: Test Suites: 26 failed, 61 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dbc916308328a49c19c4d4311945