### PR TITLE
Add ad pricing and purchase flow

### DIFF
--- a/backend/src/migrations/20250916000000_add_pricing_and_purchase_fields_to_ads.js
+++ b/backend/src/migrations/20250916000000_add_pricing_and_purchase_fields_to_ads.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('ads', function(table) {
+    table.decimal('price', 10, 2).defaultTo(0);
+    table.uuid('purchased_by').references('id').inTable('users').onDelete('SET NULL');
+    table.timestamp('purchased_at');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('ads', function(table) {
+    table.dropColumn('price');
+    table.dropColumn('purchased_by');
+    table.dropColumn('purchased_at');
+  });
+};

--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -31,6 +31,7 @@ exports.createAd = catchAsync(async (req, res) => {
     ad_type,
     priority,
     allow_branding,
+    price,
   } = req.body;
 
   const title = rawTitle?.trim();
@@ -58,6 +59,7 @@ exports.createAd = catchAsync(async (req, res) => {
     allow_branding: allow_branding === "true" || allow_branding === true,
     created_by: req.user.id,
     is_active: false,
+    price: price ? Number(price) : 0,
   };
 
   if (target_roles) {
@@ -141,7 +143,7 @@ exports.checkTitle = catchAsync(async (req, res) => {
  */
 exports.getAds = catchAsync(async (req, res) => {
   const role = req.query.role?.toLowerCase();
-  const ads = await service.getAds(false, undefined, role);
+  const ads = await service.getAds(false, undefined, role, true);
   sendSuccess(res, ads);
 });
 
@@ -160,7 +162,8 @@ exports.getAllAds = catchAsync(async (req, res) => {
   const ads = await service.getAds(
     true,
     isAdmin ? undefined : req.user.id,
-    role
+    role,
+    false
   );
   sendSuccess(res, ads);
 });
@@ -188,6 +191,7 @@ exports.updateAd = catchAsync(async (req, res) => {
     ad_type,
     priority,
     allow_branding,
+    price,
   } = req.body;
   const title = rawTitle?.trim();
   const updates = {
@@ -199,6 +203,7 @@ exports.updateAd = catchAsync(async (req, res) => {
     ad_type,
     priority: priority ? Number(priority) : undefined,
     allow_branding: allow_branding === "true" || allow_branding === true,
+    price: price ? Number(price) : undefined,
   };
 
   if (target_roles) {
@@ -281,6 +286,15 @@ exports.deleteAd = catchAsync(async (req, res) => {
   // Skip sending system-wide notifications when ads are removed
 
   sendSuccess(res, null, "Ad deleted");
+});
+
+/**
+ * Purchase an ad.
+ */
+exports.purchaseAd = catchAsync(async (req, res) => {
+  const ad = await service.purchaseAd(req.params.id, req.user.id);
+  if (!ad) throw new AppError("Ad not found or already purchased", 400);
+  sendSuccess(res, ad, "Ad purchased");
 });
 
 /**

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -31,6 +31,12 @@ router.get("/", controller.getAds);
 router.post("/:id/view", controller.recordAdView);
 router.get("/:id/analytics", controller.getAdAnalytics);
 router.post("/:id/click", controller.recordAdClick);
+router.post(
+  "/:id/purchase",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.purchaseAd
+);
 router.get("/:id", controller.getAdById);
 router.put(
   "/:id",

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -6,8 +6,14 @@ exports.createAd = async (data) => {
 };
 
 // Fetch ads with optional inclusion of inactive ones and ability to
-// restrict results to a specific creator or target role
-exports.getAds = async (includeInactive = false, createdBy, targetRole) => {
+// restrict results to a specific creator or target role. When
+// `onlyPurchased` is true, only ads that have been purchased are returned.
+exports.getAds = async (
+  includeInactive = false,
+  createdBy,
+  targetRole,
+  onlyPurchased = false
+) => {
   return db("ads")
     .modify((qb) => {
       if (!includeInactive) qb.where({ is_active: true });
@@ -20,8 +26,22 @@ exports.getAds = async (includeInactive = false, createdBy, targetRole) => {
           );
         });
       }
+      if (onlyPurchased) qb.whereNotNull("purchased_at");
     })
     .orderBy("created_at", "desc");
+};
+
+// Mark an ad as purchased by a user
+exports.purchaseAd = async (id, userId) => {
+  const [row] = await db("ads")
+    .where({ id, purchased_at: null })
+    .update({
+      purchased_by: userId,
+      purchased_at: db.fn.now(),
+      is_active: true,
+    })
+    .returning("*");
+  return row;
 };
 
 exports.getAdById = async (id) => {

--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -13,6 +13,7 @@ exports.create = {
     ad_type: z.string().optional(),
     priority: z.coerce.number().optional(),
     allow_branding: z.coerce.boolean().optional(),
+    price: z.coerce.number().optional(),
   }),
 };
 
@@ -29,5 +30,6 @@ exports.update = {
     ad_type: z.string().optional(),
     priority: z.coerce.number().optional(),
     allow_branding: z.coerce.boolean().optional(),
+    price: z.coerce.number().optional(),
   }),
 };

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1863,5 +1863,13 @@
     "settings_updated": "Social login settings updated",
     "provider_settings_saved": "{{name}} settings saved",
     "provider_settings_updated": "{{name}} settings updated"
+  },
+  "adsPurchasePage": {
+    "title": "Purchase Ads",
+    "purchase": "Purchase",
+    "purchased": "Purchased",
+    "purchase_failed": "Purchase failed",
+    "price": "Price",
+    "none_available": "No ad slots available"
   }
 }

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1922,5 +1922,13 @@
     "settings_updated": "Social login settings updated",
     "provider_settings_saved": "{{name}} settings saved",
     "provider_settings_updated": "{{name}} settings updated"
+  },
+  "adsPurchasePage": {
+    "title": "Purchase Ads",
+    "purchase": "Purchase",
+    "purchased": "Purchased",
+    "purchase_failed": "Purchase failed",
+    "price": "Price",
+    "none_available": "No ad slots available"
   }
 }

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1906,5 +1906,13 @@
     "settings_updated": "Social login settings updated",
     "provider_settings_saved": "{{name}} settings saved",
     "provider_settings_updated": "{{name}} settings updated"
+  },
+  "adsPurchasePage": {
+    "title": "Purchase Ads",
+    "purchase": "Purchase",
+    "purchased": "Purchased",
+    "purchase_failed": "Purchase failed",
+    "price": "Price",
+    "none_available": "No ad slots available"
   }
 }

--- a/frontend/src/pages/dashboard/admin/ads/purchase.js
+++ b/frontend/src/pages/dashboard/admin/ads/purchase.js
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import AdminLayout from "@/components/layouts/AdminLayout";
+import { fetchAds, purchaseAd } from "@/services/admin/adService";
+import { toast } from "react-toastify";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
+
+export default function PurchaseAdsPage() {
+  const { t } = useTranslation("dashboard", { keyPrefix: "adsPurchasePage" });
+  const [ads, setAds] = useState([]);
+
+  useEffect(() => {
+    fetchAds().then(setAds).catch(() => setAds([]));
+  }, []);
+
+  const handlePurchase = async (id) => {
+    try {
+      await purchaseAd(id);
+      toast.success(t("purchased"));
+      setAds((prev) =>
+        prev.map((ad) =>
+          ad.id === id ? { ...ad, purchasedAt: new Date().toISOString() } : ad
+        )
+      );
+    } catch {
+      toast.error(t("purchase_failed"));
+    }
+  };
+
+  const availableAds = ads.filter((ad) => !ad.purchasedAt);
+
+  return (
+    <AdminLayout>
+      <div className="p-6">
+        <h1 className="text-2xl font-bold mb-4">{t("title")}</h1>
+        {availableAds.length === 0 ? (
+          <p className="text-gray-500">{t("none_available")}</p>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {availableAds.map((ad) => (
+              <div key={ad.id} className="border p-4 rounded">
+                <h2 className="font-semibold mb-2">{ad.title}</h2>
+                {ad.image && (
+                  <img
+                    src={ad.image}
+                    alt={ad.title}
+                    className="w-full h-40 object-cover mb-2"
+                  />
+                )}
+                <p className="mb-2">{ad.description}</p>
+                <p className="mb-2">
+                  {t("price")}: ${ad.price}
+                </p>
+                <button
+                  onClick={() => handlePurchase(ad.id)}
+                  className="bg-yellow-600 text-white px-4 py-2 rounded hover:bg-yellow-700"
+                >
+                  {t("purchase")}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/online-classes/index.js
+++ b/frontend/src/pages/online-classes/index.js
@@ -7,6 +7,7 @@ import ClassFilters from '@/components/online-classes/ClassFilters';
 import ClassesGrid from '@/components/online-classes/ClassesGrid';
 import LoadMoreButton from '@/components/online-classes/LoadMoreButton';
 import { fetchPublishedClasses } from '@/services/classService';
+import { fetchAds as fetchAdBanners } from '@/services/adService';
 
 export default function OnlineClassesPage({ initialClasses = [] }) {
   const [allClasses, setAllClasses] = useState(initialClasses);
@@ -15,6 +16,7 @@ export default function OnlineClassesPage({ initialClasses = [] }) {
   const [error, setError] = useState(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [filters, setFilters] = useState({ search: '', category: '', date: '', priceRange: '' });
+  const [ads, setAds] = useState([]);
 
   useEffect(() => {
     if (initialClasses.length > 0) {
@@ -39,6 +41,10 @@ export default function OnlineClassesPage({ initialClasses = [] }) {
     };
     load();
   }, [initialClasses]);
+
+  useEffect(() => {
+    fetchAdBanners().then(setAds).catch(() => {});
+  }, []);
 
   useEffect(() => {
     setVisibleCount(6);
@@ -85,6 +91,19 @@ export default function OnlineClassesPage({ initialClasses = [] }) {
 
       <main className="container mx-auto px-6 py-12 mt-16 max-w-7xl">
         <OnlineClassesHero />
+        {ads.map((ad) => (
+          <div key={ad.id} className="my-6">
+            <a href={ad.link} target="_blank" rel="noopener noreferrer">
+              {ad.image && (
+                <img
+                  src={ad.image}
+                  alt={ad.title}
+                  className="w-full h-48 object-cover rounded"
+                />
+              )}
+            </a>
+          </div>
+        ))}
 
         <section className="mt-10 space-y-10">
           <ClassFilters filters={filters} onChange={setFilters} />

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -22,6 +22,7 @@ import {
 import { formatCurrency } from "@/utils/currency";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
+import { fetchAds as fetchAdBanners } from "@/services/adService";
 
 /**
  * Retrieves enrollment status and progress percentage for a tutorial.
@@ -96,6 +97,7 @@ const TutorialsSection = () => {
   const loader = useRef(null);
   const { t } = useTranslation("tutorials", { keyPrefix: "list" });
   const addItem = useCartStore((state) => state.addItem);
+  const [ads, setAds] = useState([]);
 
   const toggleFavorite = async (id) => {
     if (!user) return router.push('/auth/login');
@@ -143,6 +145,10 @@ const TutorialsSection = () => {
     };
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    fetchAdBanners().then(setAds).catch(() => {});
   }, []);
 
   const handleFilterChange = (f) => {
@@ -270,7 +276,20 @@ const TutorialsSection = () => {
     <section className="min-h-screen relative bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
       <div className="absolute inset-0 bg-[url('/grid-pattern.svg')] bg-center opacity-10" />
       <Navbar />
-      
+      {ads.map((ad) => (
+        <div key={ad.id} className="max-w-7xl mx-auto mt-4">
+          <a href={ad.link} target="_blank" rel="noopener noreferrer">
+            {ad.image && (
+              <img
+                src={ad.image}
+                alt={ad.title}
+                className="w-full h-48 object-cover rounded"
+              />
+            )}
+          </a>
+        </div>
+      ))}
+
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 relative z-10">
         <motion.div
           initial={{ opacity: 0, y: 20 }}

--- a/frontend/src/services/adService.js
+++ b/frontend/src/services/adService.js
@@ -1,0 +1,15 @@
+import api from "@/services/api/api";
+import { API_BASE_URL } from "@/config/config";
+
+export const fetchAds = async () => {
+  const { data } = await api.get("/ads");
+  const ads = data?.data ?? [];
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+  return ads.map((ad) => ({
+    ...ad,
+    image: ad.image_url ? `${base}${ad.image_url}` : null,
+    video: ad.video_url ? `${base}${ad.video_url}` : null,
+    link: ad.link_url,
+    adType: ad.ad_type ?? ad.adType,
+  }));
+};

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -33,6 +33,9 @@ export const fetchAds = async () => {
     priority: ad.priority ?? 0,
     allowBranding: ad.allow_branding ?? false,
     isActive: ad.is_active ?? ad.isActive ?? false,
+    price: ad.price ?? 0,
+    purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
+    purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
   }));
 };
 
@@ -53,6 +56,9 @@ export const fetchAdById = async (id) => {
     priority: ad.priority ?? 0,
     allowBranding: ad.allow_branding ?? false,
     isActive: ad.is_active ?? ad.isActive ?? false,
+    price: ad.price ?? 0,
+    purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
+    purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
   };
 };
 
@@ -70,6 +76,14 @@ export const deleteAd = async (id) => {
   const csrfToken = getCsrfToken();
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
   await api.delete(`/ads/${id}`, { headers });
+};
+
+export const purchaseAd = async (id) => {
+  const headers = {};
+  const csrfToken = getCsrfToken();
+  if (csrfToken) headers["x-csrf-token"] = csrfToken;
+  const { data } = await api.post(`/ads/${id}/purchase`, null, { headers });
+  return data?.data;
 };
 
 export const fetchAdAnalytics = async (id) => {


### PR DESCRIPTION
## Summary
- add price and purchase columns to ads
- allow purchasing ads and track buyer
- show purchased ads on tutorials and class listings with admin purchase UI

## Testing
- `npm test` (backend) *(fails: process.exit and expectation mismatches)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b1f38ae9148328bb513433162f850f