### PR TITLE
Link offers to groups with fee tracking

### DIFF
--- a/backend/src/migrations/20250729000000_add_group_id_and_fee_to_offers.js
+++ b/backend/src/migrations/20250729000000_add_group_id_and_fee_to_offers.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('offers', function(table) {
+    table.uuid('group_id').references('id').inTable('groups').onDelete('CASCADE');
+    table.decimal('fee', 10, 2).defaultTo(0);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('offers', function(table) {
+    table.dropColumn('group_id');
+    table.dropColumn('fee');
+  });
+};

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -1,5 +1,6 @@
 const db = require("../../config/database");
 const { v4: uuidv4 } = require("uuid");
+const offerService = require("../offers/offers.service");
 
 exports.findByName = async (name) => {
   return db("groups").whereRaw("LOWER(name) = ?", [name.toLowerCase()]).first();
@@ -91,7 +92,8 @@ exports.getGroupById = async (id) => {
     .first();
   if (!group) return null;
   const tagsMap = await exports.getGroupTags(id);
-  return { ...group, tags: tagsMap[id] || [] };
+  const offerSummary = await offerService.getGroupOfferSummary(id);
+  return { ...group, tags: tagsMap[id] || [], offerSummary };
 };
 
 exports.updateGroup = async (id, data) => {

--- a/backend/src/modules/offers/offers.controller.js
+++ b/backend/src/modules/offers/offers.controller.js
@@ -7,6 +7,7 @@ const userModel = require("../users/user.model");
 const notificationService = require("../notifications/notifications.service");
 const messageService = require("../messages/messages.service");
 const mailService = require("../../services/mailService");
+const groupService = require("../groups/groups.service");
 const slugify = require("slugify");
 const db = require("../../config/database");
 
@@ -19,10 +20,19 @@ exports.createOffer = catchAsync(async (req, res) => {
     timeframe,
     offer_type,
     expires_at,
+    group_id,
   } = req.body;
+
+  // ensure the group exists
+  const group = await groupService.getGroupById(group_id);
+  if (!group) {
+    return res.status(404).json({ message: "Group not found" });
+  }
+
   const data = {
     id: uuidv4(),
     student_id: req.user.id,
+    group_id,
     title,
     description,
     budget,
@@ -30,6 +40,9 @@ exports.createOffer = catchAsync(async (req, res) => {
     offer_type,
     status: "open",
   };
+
+  const fee = service.calculateOfferFee(req.user);
+  if (fee > 0) data.fee = fee;
   if (expires_at) {
     if (new Date(expires_at) <= new Date()) {
       return res.status(400).json({ message: "Expiration must be in the future" });

--- a/backend/src/modules/offers/offers.service.js
+++ b/backend/src/modules/offers/offers.service.js
@@ -5,6 +5,31 @@ exports.createOffer = async (data) => {
   return row;
 };
 
+// Determine the fee to charge for an offer based on the creator's plan
+exports.calculateOfferFee = (user) => {
+  if (user?.role?.toLowerCase() !== "instructor") return 0;
+  // Instructors with a premium plan do not pay a fee
+  const plan = user.plan || user.subscription || "";
+  if (typeof plan === "string" && plan.toLowerCase() === "premium") {
+    return 0;
+  }
+  // Default fee for non-premium instructors
+  return 10; // flat fee; could be fetched from configuration later
+};
+
+// Summarise offers associated with a specific group
+exports.getGroupOfferSummary = async (groupId) => {
+  const row = await db("offers")
+    .where({ group_id: groupId })
+    .count("id as count")
+    .sum({ total_fee: "fee" })
+    .first();
+  return {
+    count: Number(row?.count || 0),
+    total_fee: Number(row?.total_fee || 0),
+  };
+};
+
 exports.getOffers = () => {
   return db("offers as o")
     .join("users as u", "o.student_id", "u.id")

--- a/backend/src/modules/offers/offers.validator.js
+++ b/backend/src/modules/offers/offers.validator.js
@@ -9,6 +9,7 @@ exports.create = z.object({
     offer_type: z.enum(["class", "tutorial"]),
     tags: z.string().optional(),
     expires_at: z.string().optional(),
+    group_id: z.string().uuid(),
   }),
 });
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -72,3 +72,9 @@ CREATE TABLE IF NOT EXISTS suspicious_logs (
   severity VARCHAR DEFAULT 'medium',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Link offers with groups and track fees
+ALTER TABLE IF EXISTS offers
+  ADD COLUMN IF NOT EXISTS group_id UUID REFERENCES groups(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS offers
+  ADD COLUMN IF NOT EXISTS fee DECIMAL(10,2) DEFAULT 0;

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -342,6 +342,15 @@ export default function AdminGroupDetailsPage() {
                       </span>
                     </p>
                   )}
+                  {group.offerSummary && (
+                    <>
+                      <p>Offers: {group.offerSummary.count}</p>
+                      <p>
+                        Fees Collected: $
+                        {Number(group.offerSummary.total_fee || 0).toFixed(2)}
+                      </p>
+                    </>
+                  )}
                 </div>
                 <div className="pt-3 border-t">
                   <p className="text-sm text-gray-600"><strong>Purpose:</strong> {group.purpose}</p>

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -40,6 +40,10 @@ const formatGroup = (g) => {
     contactPhone: g.contact_phone ?? g.contactPhone ?? null,
     phone: g.phone ?? g.contact_phone ?? g.contactPhone ?? null,
     tags,
+    offerSummary: g.offerSummary || g.offer_summary || {
+      count: g.offer_count ?? 0,
+      total_fee: g.total_fee ?? 0,
+    },
   };
 };
 


### PR DESCRIPTION
## Summary
- associate offers with groups and compute per-offer fee based on instructor plan
- include group offer fee summary in group details API and admin dashboard
- add migration and schema updates to support `group_id` and `fee` columns

## Testing
- `npm test` (backend) *(fails: database configuration is missing)*
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68b1f38abca883289391e16c97304dad