### PR TITLE
Add instructor plan tiers and onboarding

### DIFF
--- a/backend/src/migrations/20250916000000_add_instructor_fields_to_plans.js
+++ b/backend/src/migrations/20250916000000_add_instructor_fields_to_plans.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('plans', (table) => {
+    table.integer('max_courses');
+    table.integer('ad_credits').defaultTo(0);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('plans', (table) => {
+    table.dropColumn('max_courses');
+    table.dropColumn('ad_credits');
+  });
+};

--- a/backend/src/modules/plans/plans.controller.js
+++ b/backend/src/modules/plans/plans.controller.js
@@ -19,6 +19,8 @@ exports.createPlan = catchAsync(async (req, res) => {
     style = null,
     features = [],
     target_role = 'student',
+    max_courses = null,
+    ad_credits = 0,
   } = req.body;
 
   if (!name) throw new AppError("Name is required", 400);
@@ -49,6 +51,13 @@ exports.createPlan = catchAsync(async (req, res) => {
   if (!['student', 'instructor'].includes(target_role))
     throw new AppError('Invalid target role', 400);
 
+  if (target_role === 'instructor') {
+    if (max_courses !== null && isNaN(Number(max_courses)))
+      throw new AppError('Invalid max courses', 400);
+    if (ad_credits !== null && isNaN(Number(ad_credits)))
+      throw new AppError('Invalid ad credits', 400);
+  }
+
   const plan = await service.createPlan({
     name,
     slug: planSlug,
@@ -60,6 +69,8 @@ exports.createPlan = catchAsync(async (req, res) => {
     color,
     style,
     target_role,
+    max_courses: target_role === 'instructor' ? max_courses : null,
+    ad_credits: target_role === 'instructor' ? ad_credits : 0,
   });
 
   await service.setFeatures(plan.id, Array.isArray(features) ? features : []);
@@ -108,6 +119,8 @@ exports.updatePlan = catchAsync(async (req, res) => {
     style,
     features,
     target_role,
+    max_courses,
+    ad_credits,
   } = req.body;
 
   const isHex = (val) => /^#([0-9A-F]{3}){1,2}$/i.test(val);
@@ -144,6 +157,16 @@ exports.updatePlan = catchAsync(async (req, res) => {
     if (!['student', 'instructor'].includes(target_role))
       throw new AppError('Invalid target role', 400);
     updates.target_role = target_role;
+  }
+  if (max_courses !== undefined) {
+    if (max_courses !== null && isNaN(Number(max_courses)))
+      throw new AppError('Invalid max courses', 400);
+    updates.max_courses = max_courses;
+  }
+  if (ad_credits !== undefined) {
+    if (ad_credits !== null && isNaN(Number(ad_credits)))
+      throw new AppError('Invalid ad credits', 400);
+    updates.ad_credits = ad_credits;
   }
 
   if (slug || name) {

--- a/backend/src/modules/plans/plans.service.js
+++ b/backend/src/modules/plans/plans.service.js
@@ -1,7 +1,12 @@
 const db = require("../../config/database");
 
 exports.createPlan = async (data) => {
-  const [row] = await db("plans").insert(data).returning("*");
+  const insertData = {
+    ...data,
+    max_courses: data.max_courses ?? null,
+    ad_credits: data.ad_credits ?? 0,
+  };
+  const [row] = await db("plans").insert(insertData).returning("*");
   return row;
 };
 
@@ -27,7 +32,10 @@ exports.getPlanById = async (id) => {
 };
 
 exports.updatePlan = async (id, data) => {
-  const [row] = await db("plans").where({ id }).update(data).returning("*");
+  const updateData = { ...data };
+  if (data.max_courses !== undefined) updateData.max_courses = data.max_courses;
+  if (data.ad_credits !== undefined) updateData.ad_credits = data.ad_credits;
+  const [row] = await db("plans").where({ id }).update(updateData).returning("*");
   return row;
 };
 

--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -28,6 +28,8 @@ export default function CreatePlanPage() {
     recommended: false,
     active: true,
     target_role: "student",
+    maxCourses: 0,
+    adCredits: 0,
   });
 
   const [features, setFeatures] = useState([]);
@@ -99,6 +101,14 @@ export default function CreatePlanPage() {
         style: JSON.stringify(style),
         recommended: form.recommended,
         active: form.active,
+        max_courses:
+          form.target_role === 'instructor'
+            ? Number(form.maxCourses || 0)
+            : undefined,
+        ad_credits:
+          form.target_role === 'instructor'
+            ? Number(form.adCredits || 0)
+            : undefined,
         features: features.filter(
           (f) => f.feature_key || f.value || f.description
         ),
@@ -182,6 +192,28 @@ export default function CreatePlanPage() {
             <option value="instructor">{t('instructor')}</option>
           </select>
         </div>
+        {form.target_role === 'instructor' && (
+          <>
+            <div>
+              <label className="block text-sm font-medium mb-1">{t('max_courses', 'Max Courses')}</label>
+              <input
+                type="number"
+                className="w-full border px-4 py-2 rounded"
+                value={form.maxCourses}
+                onChange={(e) => setForm({ ...form, maxCourses: e.target.value })}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">{t('ad_credits', 'Ad Credits')}</label>
+              <input
+                type="number"
+                className="w-full border px-4 py-2 rounded"
+                value={form.adCredits}
+                onChange={(e) => setForm({ ...form, adCredits: e.target.value })}
+              />
+            </div>
+          </>
+        )}
         <div>
           <label className="block text-sm font-medium mb-1">{t('plan_color')}</label>
           <input

--- a/frontend/src/pages/dashboard/admin/plans/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/plans/edit/[id].js
@@ -80,6 +80,8 @@ export default function EditPlanPage() {
             recommended: data.recommended,
             active: data.active,
             target_role: data.target_role || 'student',
+            maxCourses: data.max_courses || 0,
+            adCredits: data.ad_credits || 0,
           });
           setFeatures(data.features || []);
         }
@@ -136,6 +138,14 @@ export default function EditPlanPage() {
         style: JSON.stringify(style),
         recommended: form.recommended,
         active: form.active,
+        max_courses:
+          form.target_role === 'instructor'
+            ? Number(form.maxCourses || 0)
+            : undefined,
+        ad_credits:
+          form.target_role === 'instructor'
+            ? Number(form.adCredits || 0)
+            : undefined,
         features: features.filter(
           (f) => f.feature_key || f.value || f.description
         ),
@@ -227,6 +237,28 @@ export default function EditPlanPage() {
             <option value="instructor">{t('instructor')}</option>
           </select>
         </div>
+        {form.target_role === 'instructor' && (
+          <>
+            <div>
+              <label className="block text-sm font-medium mb-1">{t('max_courses', 'Max Courses')}</label>
+              <input
+                type="number"
+                className="w-full border px-4 py-2 rounded"
+                value={form.maxCourses}
+                onChange={(e) => setForm({ ...form, maxCourses: e.target.value })}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">{t('ad_credits', 'Ad Credits')}</label>
+              <input
+                type="number"
+                className="w-full border px-4 py-2 rounded"
+                value={form.adCredits}
+                onChange={(e) => setForm({ ...form, adCredits: e.target.value })}
+              />
+            </div>
+          </>
+        )}
         <div>
           <label className="block text-sm font-medium mb-1">{t('plan_color')}</label>
           <input

--- a/frontend/src/pages/dashboard/instructor/plans/index.js
+++ b/frontend/src/pages/dashboard/instructor/plans/index.js
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import { fetchPublicPlans } from "@/services/public/planService";
+import { subscribeToPlan } from "@/services/instructor/subscriptionService";
+import useAuthStore from "@/store/auth/authStore";
+import { toast } from "react-toastify";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
+
+export default function InstructorPlansPage() {
+  const [plans, setPlans] = useState([]);
+  const user = useAuthStore((s) => s.user);
+
+  useEffect(() => {
+    fetchPublicPlans("instructor").then(setPlans).catch(() => {});
+  }, []);
+
+  const handleSubscribe = async (id) => {
+    try {
+      await subscribeToPlan(id);
+      toast.success("Subscription updated");
+    } catch (err) {
+      toast.error("Failed to subscribe");
+    }
+  };
+
+  return (
+    <InstructorLayout title="Plans">
+      <h1 className="text-2xl font-semibold mb-4">Choose a Plan</h1>
+      <div className="grid md:grid-cols-3 gap-4">
+        {plans.map((p) => (
+          <div key={p.id} className="border p-4 rounded">
+            <h3 className="text-xl font-bold mb-2">{p.name}</h3>
+            <p className="mb-1">Max Courses: {p.max_courses ?? 'Unlimited'}</p>
+            <p className="mb-1">Ad Credits: {p.ad_credits ?? 0}</p>
+            <button
+              onClick={() => handleSubscribe(p.id)}
+              className="mt-2 bg-blue-600 text-white px-3 py-1 rounded"
+            >
+              {user?.plan_id === p.id ? 'Current Plan' : 'Select Plan'}
+            </button>
+          </div>
+        ))}
+      </div>
+    </InstructorLayout>
+  );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/services/instructor/subscriptionService.js
+++ b/frontend/src/services/instructor/subscriptionService.js
@@ -1,0 +1,11 @@
+import api from "@/services/api/api";
+
+export const subscribeToPlan = async (planId) => {
+  const { data } = await api.post("/user-subscriptions", { plan_id: planId });
+  return data?.data ?? null;
+};
+
+export const fetchMySubscription = async () => {
+  const { data } = await api.get("/user-subscriptions/me");
+  return data?.data ?? null;
+};

--- a/frontend/src/utils/plans/config.js
+++ b/frontend/src/utils/plans/config.js
@@ -13,6 +13,10 @@ export const initialPlanConfig = {
     community: {
       label: "Community",
       rules: ["canPost", "canReply"]
+    },
+    instructor: {
+      label: "Instructor",
+      rules: ["maxCourses", "adCredits"]
     }
   },
   plans: {
@@ -22,7 +26,9 @@ export const initialPlanConfig = {
       canViewPremium: { tutorials: false },
       canDownload: { tutorials: false },
       canPost: { community: false },
-      canReply: { community: false }
+      canReply: { community: false },
+      maxCourses: { instructor: 1 },
+      adCredits: { instructor: 0 }
     },
     Regular: {
       canJoin: { onlineClasses: true },
@@ -30,7 +36,9 @@ export const initialPlanConfig = {
       canViewPremium: { tutorials: true },
       canDownload: { tutorials: false },
       canPost: { community: true },
-      canReply: { community: true }
+      canReply: { community: true },
+      maxCourses: { instructor: 5 },
+      adCredits: { instructor: 100 }
     },
     Premium: {
       canJoin: { onlineClasses: true },
@@ -38,7 +46,9 @@ export const initialPlanConfig = {
       canViewPremium: { tutorials: true },
       canDownload: { tutorials: true },
       canPost: { community: true },
-      canReply: { community: true }
+      canReply: { community: true },
+      maxCourses: { instructor: 20 },
+      adCredits: { instructor: 1000 }
     }
   }
 };


### PR DESCRIPTION
## Summary
- support instructor-specific plan fields like max courses and ad credits
- allow admin to manage instructor plans and expose config
- add basic instructor plan subscription page and service

## Testing
- `cd backend && npm test` *(fails: database configuration missing and other tests)*
- `cd frontend && npm test` *(warnings emitted; run terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f388c060832894e05b7f3a381e97