### PR TITLE
feat: guard ad analytics by plan

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -311,6 +311,12 @@ exports.recordAdView = catchAsync(async (req, res) => {
  * Return basic analytics for an ad.
  */
 exports.getAdAnalytics = catchAsync(async (req, res) => {
+  const canShowAnalytics =
+    req.user?.plan?.showAnalytics || req.user?.subscription?.showAnalytics;
+  if (!canShowAnalytics) {
+    throw new AppError("Analytics not available for your current plan", 403);
+  }
+
   const data = await service.getAdAnalytics(req.params.id);
   /**
    * Default analytics values used when no data exists

--- a/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
@@ -4,6 +4,7 @@ import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { useEffect, useState } from "react";
 import PageHead from "@/components/common/PageHead";
 import { fetchAdById, fetchAdAnalytics } from "@/services/admin/adService";
+import useAuthStore from "@/store/auth/authStore";
 import {
   LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid,
   BarChart, Bar, ResponsiveContainer
@@ -18,9 +19,14 @@ export default function InstructorAdAnalyticsPage() {
   const router = useRouter();
   const { id } = router.query;
   const [ad, setAd] = useState(null);
+  const user = useAuthStore((s) => s.user);
 
   useEffect(() => {
-    if (!id) return;
+    if (user && !user?.plan?.showAnalytics) {
+      router.replace("/dashboard/instructor/ads");
+      return;
+    }
+    if (!id || !user?.plan?.showAnalytics) return;
     Promise.all([fetchAdById(id), fetchAdAnalytics(id)])
       .then(([adData, analytics]) => {
         if (adData) {
@@ -29,8 +35,8 @@ export default function InstructorAdAnalyticsPage() {
           setAd(null);
         }
       })
-      .catch(() => setAd(null));
-  }, [id]);
+      .catch(() => router.replace("/dashboard/instructor/ads"));
+  }, [id, user, router]);
 
   if (!ad) {
     return (


### PR DESCRIPTION
## Summary
- check instructor plan has analytics access before returning ad metrics
- redirect instructors lacking analytics access back to ads overview

## Testing
- `npm test tests/adsRoutes.test.js` *(fails: expect 200 received 403)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b1f897303483289a3a4e9e2b0fa4dd