### PR TITLE
Enforce ad ownership and handle forbidden responses

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -222,14 +222,15 @@ exports.updateAd = catchAsync(async (req, res) => {
   const normalizedRoles = roles.map((r) => String(r).toLowerCase());
   const isAdmin =
     normalizedRoles.includes("admin") || normalizedRoles.includes("superadmin");
-
-  let previousAd;
-  if (updates.is_active !== undefined) {
-    if (!isAdmin) {
-      throw new AppError("Only admins can change ad status", 403);
-    }
-    previousAd = await service.getAdById(req.params.id);
+  const ad = await service.getAdById(req.params.id);
+  if (!ad) throw new AppError("Ad not found", 404);
+  if (!isAdmin && ad.created_by !== req.user.id) {
+    throw new AppError("Forbidden", 403);
   }
+  if (updates.is_active !== undefined && !isAdmin) {
+    throw new AppError("Only admins can change ad status", 403);
+  }
+  const previousAd = ad;
 
   if (title) {
     const existing = await service.findByTitle(title);
@@ -280,6 +281,17 @@ exports.updateAd = catchAsync(async (req, res) => {
  * Delete an ad by id.
  */
 exports.deleteAd = catchAsync(async (req, res) => {
+  const roles = req.user.roles || [req.user.role];
+  const normalizedRoles = roles.map((r) => String(r).toLowerCase());
+  const isAdmin =
+    normalizedRoles.includes("admin") || normalizedRoles.includes("superadmin");
+
+  const ad = await service.getAdById(req.params.id);
+  if (!ad) throw new AppError("Ad not found", 404);
+  if (!isAdmin && ad.created_by !== req.user.id) {
+    throw new AppError("Forbidden", 403);
+  }
+
   const count = await service.deleteAd(req.params.id);
   if (!count) throw new AppError("Ad not found", 404);
 
@@ -292,9 +304,20 @@ exports.deleteAd = catchAsync(async (req, res) => {
  * Purchase an ad.
  */
 exports.purchaseAd = catchAsync(async (req, res) => {
-  const ad = await service.purchaseAd(req.params.id, req.user.id);
-  if (!ad) throw new AppError("Ad not found or already purchased", 400);
-  sendSuccess(res, ad, "Ad purchased");
+  const roles = req.user.roles || [req.user.role];
+  const normalizedRoles = roles.map((r) => String(r).toLowerCase());
+  const isAdmin =
+    normalizedRoles.includes("admin") || normalizedRoles.includes("superadmin");
+
+  const ad = await service.getAdById(req.params.id);
+  if (!ad) throw new AppError("Ad not found", 404);
+  if (!isAdmin && ad.created_by !== req.user.id) {
+    throw new AppError("Forbidden", 403);
+  }
+
+  const purchased = await service.purchaseAd(req.params.id, req.user.id);
+  if (!purchased) throw new AppError("Ad not found or already purchased", 400);
+  sendSuccess(res, purchased, "Ad purchased");
 });
 
 /**

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -17,49 +17,63 @@ export const checkAdTitle = async (title) => {
 };
 
 export const fetchAds = async () => {
-  const { data } = await api.get("/ads/admin");
+  try {
+    const { data } = await api.get("/ads/admin");
 
-  const ads = data?.data ?? [];
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-  return ads.map((ad) => ({
-    ...ad,
-    image: ad.image_url ? `${base}${ad.image_url}` : null,
-    video: ad.video_url ? `${base}${ad.video_url}` : null,
-    link: ad.link_url,
-    targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
-    startAt: ad.start_at ?? ad.startAt,
-    endAt: ad.end_at ?? ad.endAt,
-    adType: ad.ad_type ?? ad.adType,
-    priority: ad.priority ?? 0,
-    allowBranding: ad.allow_branding ?? false,
-    isActive: ad.is_active ?? ad.isActive ?? false,
-    price: ad.price ?? 0,
-    purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
-    purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
-  }));
+    const ads = data?.data ?? [];
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+    return ads.map((ad) => ({
+      ...ad,
+      image: ad.image_url ? `${base}${ad.image_url}` : null,
+      video: ad.video_url ? `${base}${ad.video_url}` : null,
+      link: ad.link_url,
+      targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
+      startAt: ad.start_at ?? ad.startAt,
+      endAt: ad.end_at ?? ad.endAt,
+      adType: ad.ad_type ?? ad.adType,
+      priority: ad.priority ?? 0,
+      allowBranding: ad.allow_branding ?? false,
+      isActive: ad.is_active ?? ad.isActive ?? false,
+      price: ad.price ?? 0,
+      purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
+      purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
+    }));
+  } catch (err) {
+    if (err.response && err.response.status === 403) {
+      return [];
+    }
+    throw err;
+  }
 };
 
 export const fetchAdById = async (id) => {
-  const { data } = await api.get(`/ads/${id}`);
-  const ad = data?.data;
-  if (!ad) return null;
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-  return {
-    ...ad,
-    image: ad.image_url ? `${base}${ad.image_url}` : null,
-    video: ad.video_url ? `${base}${ad.video_url}` : null,
-    link: ad.link_url,
-    targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
-    startAt: ad.start_at ?? ad.startAt,
-    endAt: ad.end_at ?? ad.endAt,
-    adType: ad.ad_type ?? ad.adType,
-    priority: ad.priority ?? 0,
-    allowBranding: ad.allow_branding ?? false,
-    isActive: ad.is_active ?? ad.isActive ?? false,
-    price: ad.price ?? 0,
-    purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
-    purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
-  };
+  try {
+    const { data } = await api.get(`/ads/${id}`);
+    const ad = data?.data;
+    if (!ad) return null;
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+    return {
+      ...ad,
+      image: ad.image_url ? `${base}${ad.image_url}` : null,
+      video: ad.video_url ? `${base}${ad.video_url}` : null,
+      link: ad.link_url,
+      targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
+      startAt: ad.start_at ?? ad.startAt,
+      endAt: ad.end_at ?? ad.endAt,
+      adType: ad.ad_type ?? ad.adType,
+      priority: ad.priority ?? 0,
+      allowBranding: ad.allow_branding ?? false,
+      isActive: ad.is_active ?? ad.isActive ?? false,
+      price: ad.price ?? 0,
+      purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
+      purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
+    };
+  } catch (err) {
+    if (err.response && err.response.status === 403) {
+      return null;
+    }
+    throw err;
+  }
 };
 
 export const updateAd = async (id, payload) => {
@@ -67,23 +81,45 @@ export const updateAd = async (id, payload) => {
   const csrfToken = getCsrfToken();
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
   if (payload instanceof FormData) headers["Content-Type"] = "multipart/form-data";
-  const { data } = await api.put(`/ads/${id}`, payload, { headers });
-  return data?.data;
+  try {
+    const { data } = await api.put(`/ads/${id}`, payload, { headers });
+    return data?.data;
+  } catch (err) {
+    if (err.response && err.response.status === 403) {
+      return null;
+    }
+    throw err;
+  }
 };
 
 export const deleteAd = async (id) => {
   const headers = {};
   const csrfToken = getCsrfToken();
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
-  await api.delete(`/ads/${id}`, { headers });
+  try {
+    await api.delete(`/ads/${id}`, { headers });
+    return true;
+  } catch (err) {
+    if (err.response && err.response.status === 403) {
+      return false;
+    }
+    throw err;
+  }
 };
 
 export const purchaseAd = async (id) => {
   const headers = {};
   const csrfToken = getCsrfToken();
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
-  const { data } = await api.post(`/ads/${id}/purchase`, null, { headers });
-  return data?.data;
+  try {
+    const { data } = await api.post(`/ads/${id}/purchase`, null, { headers });
+    return data?.data;
+  } catch (err) {
+    if (err.response && err.response.status === 403) {
+      return null;
+    }
+    throw err;
+  }
 };
 
 export const fetchAdAnalytics = async (id) => {


### PR DESCRIPTION
## Summary
- Require ad owners or admins for update, delete, and purchase operations
- Gracefully handle 403 errors in frontend ad service functions

## Testing
- `npm test` (backend) *(fails: database configuration missing, ads routes expectations)*
- `npm test` (frontend) *(passes with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f890b91c8328859ac2067b2d2b56