### PR TITLE
feat: enforce ad limits based on instructor plan

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -7,11 +7,23 @@ const service = require("./ads.service");
 const userModel = require("../users/user.model");
 const notificationService = require("../notifications/notifications.service");
 const messageService = require("../messages/messages.service");
+const db = require("../../config/database");
+const planService = require("../plans/plans.service");
 const {
   sendAdSubmissionEmail,
   sendAdApprovalEmail,
   sendNewAdAdminEmail,
 } = require("../../utils/email");
+
+// Retrieve the active plan for a user
+const getUserPlan = async (userId) => {
+  const sub = await db("user_subscriptions")
+    .where({ user_id: userId, status: "active" })
+    .orderBy("start_date", "desc")
+    .first();
+  if (!sub) return null;
+  return planService.getPlanById(sub.plan_id);
+};
 
 /**
  * Controller functions for managing advertisement banners.
@@ -45,6 +57,50 @@ exports.createAd = catchAsync(async (req, res) => {
       !req.body.image_url &&
       !req.body.video_url) {
     throw new AppError("Image or video is required", 400);
+  }
+
+  // Retrieve instructor plan and validate limits
+  const plan = await getUserPlan(req.user.id);
+  if (!plan) throw new AppError("No active plan found", 403);
+  const features = plan.features || [];
+  const maxAds = Number(
+    features.find((f) => f.feature_key === "ads_max_ads")?.value || 0
+  );
+  const maxDuration = Number(
+    features.find((f) => f.feature_key === "ads_max_ad_duration")?.value || 0
+  );
+  const adCredits = plan.ad_credits;
+
+  if (maxAds) {
+    const [{ count }] = await db("ads")
+      .where({ created_by: req.user.id })
+      .andWhere({ is_active: true })
+      .count("id as count");
+    if (Number(count) >= maxAds) {
+      throw new AppError("Ad limit reached for your plan", 403);
+    }
+  }
+
+  if (maxDuration && start_at && end_at) {
+    const duration = Math.ceil(
+      (new Date(end_at) - new Date(start_at)) / (1000 * 60 * 60 * 24)
+    );
+    if (duration > maxDuration) {
+      throw new AppError(
+        `Ad duration exceeds plan limit of ${maxDuration} days`,
+        400
+      );
+    }
+  }
+
+  if (adCredits !== null && adCredits !== undefined) {
+    const [{ count: purchased }] = await db("ads")
+      .where({ created_by: req.user.id })
+      .whereNotNull("purchased_at")
+      .count("id as count");
+    if (Number(purchased) >= Number(adCredits)) {
+      throw new AppError("No ad credits available", 403);
+    }
   }
 
   const data = {
@@ -292,6 +348,25 @@ exports.deleteAd = catchAsync(async (req, res) => {
  * Purchase an ad.
  */
 exports.purchaseAd = catchAsync(async (req, res) => {
+  const plan = await getUserPlan(req.user.id);
+  if (!plan) throw new AppError("No active plan found", 403);
+  const features = plan.features || [];
+  const maxAds = Number(
+    features.find((f) => f.feature_key === "ads_max_ads")?.value || 0
+  );
+  const adCredits = plan.ad_credits;
+  const [{ count: purchased }] = await db("ads")
+    .where({ created_by: req.user.id })
+    .whereNotNull("purchased_at")
+    .count("id as count");
+  if (maxAds && Number(purchased) >= maxAds) {
+    throw new AppError("Ad limit reached for your plan", 403);
+  }
+  if (adCredits !== null && adCredits !== undefined) {
+    if (Number(purchased) >= Number(adCredits)) {
+      throw new AppError("No ad credits available", 403);
+    }
+  }
   const ad = await service.purchaseAd(req.params.id, req.user.id);
   if (!ad) throw new AppError("Ad not found or already purchased", 400);
   sendSuccess(res, ad, "Ad purchased");

--- a/frontend/src/config/plansConfig.js
+++ b/frontend/src/config/plansConfig.js
@@ -4,6 +4,7 @@ const plansConfig = {
     basic: {
       maxAds: 1,
       maxAdDuration: 3, // days
+      adCredits: 1,
       placements: ["dashboard"],
       allowBranding: false,
       showAnalytics: false
@@ -11,6 +12,7 @@ const plansConfig = {
     regular: {
       maxAds: 3,
       maxAdDuration: 7,
+      adCredits: 3,
       placements: ["dashboard", "homepage"],
       allowBranding: false,
       showAnalytics: true
@@ -18,6 +20,7 @@ const plansConfig = {
     prime: {
       maxAds: 10,
       maxAdDuration: 30,
+      adCredits: 10,
       placements: ["dashboard", "homepage", "email", "sidebar"],
       allowBranding: true,
       showAnalytics: true

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -4,7 +4,7 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import plansConfig from "@/config/plansConfig";
-import { createAd, checkAdTitle } from "@/services/admin/adService";
+import { createAd, checkAdTitle, fetchAds } from "@/services/admin/adService";
 import { FaSpinner, FaTrash, FaImage, FaVideo } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -42,7 +42,12 @@ export default function CreateAdPage() {
 
   const planKey = user?.plan || 'basic';
   const { allowBranding: allowBrandingEnabled } = plansConfig[planKey] || { allowBranding: false };
-  
+  const [existingAds, setExistingAds] = useState([]);
+
+  useEffect(() => {
+    fetchAds().then(setExistingAds).catch(() => setExistingAds([]));
+  }, []);
+
   const [formData, setFormData] = useState({
     title: "",
     description: "",
@@ -218,7 +223,40 @@ export default function CreateAdPage() {
       setError(t('end_before_start'));
       return;
     }
-    
+
+    const config = plansConfig[planKey] || {};
+    const activeAds = existingAds.filter((a) => a.isActive).length;
+    if (config.maxAds && activeAds >= config.maxAds) {
+      const msg = tp('max_ads_reached', 'You have reached your ad limit');
+      setError(msg);
+      toast.error(msg);
+      return;
+    }
+
+    const duration = Math.ceil(
+      (new Date(formData.endAt) - new Date(formData.startAt)) /
+        (1000 * 60 * 60 * 24)
+    );
+    if (config.maxAdDuration && duration > config.maxAdDuration) {
+      const msg = tp('duration_exceeds_plan', {
+        defaultValue: `Ad duration exceeds ${config.maxAdDuration} days`,
+        days: config.maxAdDuration,
+      });
+      setError(msg);
+      toast.error(msg);
+      return;
+    }
+
+    if (config.adCredits !== undefined) {
+      const purchased = existingAds.filter((a) => a.purchasedAt).length;
+      if (purchased >= config.adCredits) {
+        const msg = tp('no_ad_credits', 'No ad credits available');
+        setError(msg);
+        toast.error(msg);
+        return;
+      }
+    }
+
     if (titleError || isCheckingTitle) return;
 
     setIsSubmitting(true);

--- a/frontend/src/pages/dashboard/admin/ads/purchase.js
+++ b/frontend/src/pages/dashboard/admin/ads/purchase.js
@@ -3,18 +3,32 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchAds, purchaseAd } from "@/services/admin/adService";
+import plansConfig from "@/config/plansConfig";
 import { toast } from "react-toastify";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import useAuthStore from "@/store/auth/authStore";
 
 export default function PurchaseAdsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "adsPurchasePage" });
   const [ads, setAds] = useState([]);
+  const user = useAuthStore((s) => s.user);
+  const planKey = user?.plan || 'basic';
 
   useEffect(() => {
     fetchAds().then(setAds).catch(() => setAds([]));
   }, []);
 
   const handlePurchase = async (id) => {
+    const config = plansConfig[planKey] || {};
+    const purchased = ads.filter((a) => a.purchasedAt).length;
+    if (config.maxAds && purchased >= config.maxAds) {
+      toast.error(t('max_ads_reached', 'Ad limit reached'));
+      return;
+    }
+    if (config.adCredits !== undefined && purchased >= config.adCredits) {
+      toast.error(t('no_ad_credits', 'No ad credits available'));
+      return;
+    }
     try {
       await purchaseAd(id);
       toast.success(t("purchased"));
@@ -23,8 +37,9 @@ export default function PurchaseAdsPage() {
           ad.id === id ? { ...ad, purchasedAt: new Date().toISOString() } : ad
         )
       );
-    } catch {
-      toast.error(t("purchase_failed"));
+    } catch (err) {
+      const message = err?.response?.data?.message || t("purchase_failed");
+      toast.error(message);
     }
   };
 

--- a/frontend/src/pages/dashboard/instructor/ads/create.js
+++ b/frontend/src/pages/dashboard/instructor/ads/create.js
@@ -4,7 +4,7 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import plansConfig from "@/config/plansConfig";
-import { createAd } from "@/services/admin/adService";
+import { createAd, fetchAds } from "@/services/admin/adService";
 import { FaSpinner, FaTrash, FaImage, FaVideo } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -42,7 +42,12 @@ export default function CreateAdPage() {
 
   const planKey = user?.plan || 'basic';
   const { allowBranding: allowBrandingEnabled } = plansConfig[planKey] || { allowBranding: false };
-  
+  const [existingAds, setExistingAds] = useState([]);
+
+  useEffect(() => {
+    fetchAds().then(setExistingAds).catch(() => setExistingAds([]));
+  }, []);
+
   const [formData, setFormData] = useState({
     title: "",
     description: "",
@@ -192,7 +197,40 @@ export default function CreateAdPage() {
       setError(t('end_before_start'));
       return;
     }
-    
+
+    const config = plansConfig[planKey] || {};
+    const activeAds = existingAds.filter((a) => a.isActive).length;
+    if (config.maxAds && activeAds >= config.maxAds) {
+      const msg = tp('max_ads_reached', 'You have reached your ad limit');
+      setError(msg);
+      toast.error(msg);
+      return;
+    }
+
+    const duration = Math.ceil(
+      (new Date(formData.endAt) - new Date(formData.startAt)) /
+        (1000 * 60 * 60 * 24)
+    );
+    if (config.maxAdDuration && duration > config.maxAdDuration) {
+      const msg = tp('duration_exceeds_plan', {
+        defaultValue: `Ad duration exceeds ${config.maxAdDuration} days`,
+        days: config.maxAdDuration,
+      });
+      setError(msg);
+      toast.error(msg);
+      return;
+    }
+
+    if (config.adCredits !== undefined) {
+      const purchased = existingAds.filter((a) => a.purchasedAt).length;
+      if (purchased >= config.adCredits) {
+        const msg = tp('no_ad_credits', 'No ad credits available');
+        setError(msg);
+        toast.error(msg);
+        return;
+      }
+    }
+
     if (titleError) return;
 
     setIsSubmitting(true);


### PR DESCRIPTION
## Summary
- validate ad creation against instructor plan limits and credits
- gate ad purchases based on remaining credits
- surface plan-limit errors in ad creation and purchase UIs

## Testing
- `npm test` (backend) *(fails: process.exit called with "1" and multiple failing tests)*
- `npm test` (frontend) *(partial output, numerous warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f88fa5bc83288b2473aef0369707