### PR TITLE
Fix message mark-as-read functionality in navbars

### DIFF
--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -1,5 +1,6 @@
 
 import api from "@/services/api/api";
+import { getCsrfToken } from "@/services/api/csrf";
 import useCallStore from "@/store/call/callStore";
 import useAuthStore from "@/store/auth/authStore";
 import useMessageStore from "@/store/messages/messageStore";
@@ -25,13 +26,18 @@ export const getMessages = async ({ limit, offset } = {}) => {
 };
 
 export const markMessageAsRead = async (id) => {
-  const res = await api.patch(`/messages/${id}/read`);
+  const headers = {};
+  const token = getCsrfToken();
+  if (token) headers["x-csrf-token"] = token;
+  const res = await api.patch(`/messages/${id}/read`, {}, { headers });
   return res.data.data || res.data;
-
 };
 
 export const deleteMessage = async (id) => {
-  const res = await api.delete(`/messages/${id}`);
+  const headers = {};
+  const token = getCsrfToken();
+  if (token) headers["x-csrf-token"] = token;
+  const res = await api.delete(`/messages/${id}`, { headers });
   return res.data.data || res.data;
 };
 

--- a/frontend/src/store/messages/messageStore.js
+++ b/frontend/src/store/messages/messageStore.js
@@ -1,11 +1,18 @@
 import { create } from "zustand";
 import { toast } from "react-toastify";
+import i18next from "i18next";
 import {
   getMessages,
   markMessageAsRead,
   deleteMessage as apiDeleteMessage,
 } from "@/services/messageService";
-const HOUR_MS = 60 * 60 * 1000;
+
+const RETENTION_MS =
+  parseInt(process.env.NEXT_PUBLIC_MESSAGE_RETENTION_HOURS || "24", 10) *
+  60 *
+  60 *
+  1000;
+
 // how often to poll for new messages
 const POLL_INTERVAL_MS = 60000;
 
@@ -41,28 +48,47 @@ const useMessageStore = create((set, get) => ({
   },
 
   markRead: async (id) => {
-    const res = await markMessageAsRead(id);
-    const readAt = res.read_at || new Date().toISOString();
     const idStr = String(id);
+    const prevItems = get().items;
+    const tempReadAt = new Date().toISOString();
+
+    // Optimistically update UI
     set((state) => ({
       items: state.items.map((m) =>
-        String(m.id) === idStr ? { ...m, read: true, read_at: readAt } : m,
+        String(m.id) === idStr ? { ...m, read: true, read_at: tempReadAt } : m,
       ),
     }));
 
-    setTimeout(() => {
+    try {
+      const res = await markMessageAsRead(id);
+      const readAt = res.read_at || tempReadAt;
       set((state) => ({
-        items: state.items.filter(
-          (m) =>
-            !(
-              String(m.id) === idStr &&
-              m.read &&
-              m.read_at &&
-              new Date() - new Date(m.read_at) >= RETENTION_MS
-            ),
+        items: state.items.map((m) =>
+          String(m.id) === idStr ? { ...m, read_at: readAt } : m,
         ),
       }));
-    }, RETENTION_MS);
+
+      setTimeout(() => {
+        set((state) => ({
+          items: state.items.filter(
+            (m) =>
+              !(
+                String(m.id) === idStr &&
+                m.read &&
+                m.read_at &&
+                new Date() - new Date(m.read_at) >= RETENTION_MS
+              ),
+          ),
+        }));
+      }, RETENTION_MS);
+
+      return true;
+    } catch (err) {
+      // Revert on failure
+      set({ items: prevItems });
+      toast.error(i18next.t("failed_to_mark_message_as_read"));
+      return false;
+    }
   },
 
   delete: async (id) => {


### PR DESCRIPTION
## Summary
- send CSRF token when marking or deleting messages
- prevent undefined retention constant and add error handling for message store

## Testing
- `npm test`
- `npx eslint src/services/messageService.js src/store/messages/messageStore.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2096937048328b41ff42574417cbc