### PR TITLE
Secure ad analytics route

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -334,8 +334,11 @@ exports.recordAdView = catchAsync(async (req, res) => {
  * Return basic analytics for an ad.
  */
 exports.getAdAnalytics = catchAsync(async (req, res) => {
+  if (!req.user) {
+    throw new AppError("Unauthorized", 401);
+  }
   const canShowAnalytics =
-    req.user?.plan?.showAnalytics || req.user?.subscription?.showAnalytics;
+    req.user.plan?.showAnalytics || req.user.subscription?.showAnalytics;
   if (!canShowAnalytics) {
     throw new AppError("Analytics not available for your current plan", 403);
   }

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -29,7 +29,12 @@ router.get(
 );
 router.get("/", controller.getAds);
 router.post("/:id/view", controller.recordAdView);
-router.get("/:id/analytics", controller.getAdAnalytics);
+router.get(
+  "/:id/analytics",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.getAdAnalytics
+);
 router.post("/:id/click", controller.recordAdClick);
 router.post(
   "/:id/purchase",

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -43,6 +43,7 @@ jest.mock('../src/middleware/auth/authMiddleware', () => {
       roles: ['instructor'],
       email: 'inst@example.com',
       full_name: 'Instructor One',
+      plan: { showAnalytics: true },
     };
     next();
   });
@@ -163,6 +164,9 @@ describe('POST /api/ads/admin', () => {
 describe('PUT /api/ads/:id', () => {
   it('updates ad', async () => {
     const payload = { title: 'Updated' };
+    service.getAdById = jest
+      .fn()
+      .mockResolvedValue({ id: '1', created_by: 'user1', is_active: false });
     service.updateAd = jest.fn().mockResolvedValue({ id: '1', ...payload });
     const res = await request(app).put('/api/ads/1').send(payload);
     expect(res.status).toBe(200);
@@ -172,6 +176,9 @@ describe('PUT /api/ads/:id', () => {
 
 describe('DELETE /api/ads/:id', () => {
   it('deletes ad', async () => {
+    service.getAdById = jest
+      .fn()
+      .mockResolvedValue({ id: '1', created_by: 'user1' });
     service.deleteAd = jest.fn().mockResolvedValue(1);
     const res = await request(app).delete('/api/ads/1');
     expect(res.status).toBe(200);
@@ -180,7 +187,7 @@ describe('DELETE /api/ads/:id', () => {
 });
 
 describe('GET /api/ads/:id/analytics', () => {
-  it('returns ad analytics', async () => {
+  it('returns ad analytics when user has access', async () => {
     const analytics = { views: 5, ctr: 1, clicks: 2, unique_viewers: 3 };
     service.getAdAnalytics = jest.fn().mockResolvedValue(analytics);
     const res = await request(app).get('/api/ads/1/analytics');
@@ -188,6 +195,28 @@ describe('GET /api/ads/:id/analytics', () => {
     expect(service.getAdAnalytics).toHaveBeenCalledWith('1');
     expect(res.body.data.views).toBe(5);
     expect(res.body.data.conversions).toBe(2);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => next());
+    const res = await request(app).get('/api/ads/1/analytics');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when plan lacks analytics access', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = {
+        id: 'user1',
+        role: 'instructor',
+        roles: ['instructor'],
+        email: 'inst@example.com',
+        full_name: 'Instructor One',
+        plan: { showAnalytics: false },
+      };
+      next();
+    });
+    const res = await request(app).get('/api/ads/1/analytics');
+    expect(res.status).toBe(403);
   });
 });
 


### PR DESCRIPTION
## Summary
- require authentication and instructor/admin role to view ad analytics
- enforce presence of `req.user` and plan-based analytics access
- cover analytics access with tests for auth and plan restrictions

## Testing
- `npm test tests/adsRoutes.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b2114d12c08328abb7d63be5f564b2