### PR TITLE
Enforce plan limits for ad creation

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -4,6 +4,7 @@ const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
 const service = require("./ads.service");
+const planService = require("../plans/plans.service");
 const userModel = require("../users/user.model");
 const notificationService = require("../notifications/notifications.service");
 const messageService = require("../messages/messages.service");
@@ -86,7 +87,45 @@ exports.createAd = catchAsync(async (req, res) => {
     data.image_url = null;
   }
 
+  // Load instructor plan and verify ad creation permissions
+  const plan = await planService.getPlanById(req.user.plan_id);
+  if (!plan) {
+    throw new AppError("Plan not found", 403);
+  }
+
+  const features = {};
+  (plan.features || []).forEach((f) => {
+    let val = f.value;
+    try {
+      val = JSON.parse(f.value);
+    } catch {
+      if (f.value === "true") val = true;
+      else if (f.value === "false") val = false;
+      else if (!isNaN(f.value)) val = Number(f.value);
+    }
+    features[f.feature_key] = val;
+  });
+
+  const maxAds = Number(features["ads_max_ads"] || 0);
+  if (maxAds) {
+    const existing = await service.getAds(true, req.user.id);
+    if (existing.length >= maxAds) {
+      throw new AppError("Ad limit reached for your plan", 403);
+    }
+  }
+
+  const brandingAllowed = !!features["ads_allow_branding"];
+  if (data.allow_branding && !brandingAllowed) {
+    throw new AppError("Branding not allowed for your plan", 403);
+  }
+
+  if ((plan.ad_credits ?? 0) <= 0) {
+    throw new AppError("Insufficient ad credits", 403);
+  }
+
   const ad = await service.createAd(data);
+  await planService.consumeAdCredit(plan.id);
+
   try {
     if (req.user?.email) {
       await sendAdSubmissionEmail(

--- a/backend/src/modules/plans/plans.service.js
+++ b/backend/src/modules/plans/plans.service.js
@@ -31,6 +31,15 @@ exports.getPlanById = async (id) => {
   return plan;
 };
 
+// Decrement available ad credits for a plan
+exports.consumeAdCredit = async (planId) => {
+  if (!planId) return;
+  await db("plans")
+    .where({ id: planId })
+    .andWhere("ad_credits", ">", 0)
+    .decrement("ad_credits", 1);
+};
+
 exports.updatePlan = async (id, data) => {
   const updateData = { ...data };
   if (data.max_courses !== undefined) updateData.max_courses = data.max_courses;

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 jest.mock('../src/modules/plans/plans.service', () => ({
   consumeAdCredit: jest.fn(),
+  getPlanById: jest.fn(),
 }));
 
 jest.mock('../src/modules/ads/ads.service', () => ({
@@ -43,6 +44,8 @@ jest.mock('../src/middleware/auth/authMiddleware', () => {
       roles: ['instructor'],
       email: 'inst@example.com',
       full_name: 'Instructor One',
+      plan_id: 'plan1',
+      plan: { showAnalytics: true },
     };
     next();
   });
@@ -64,7 +67,14 @@ const routes = require('../src/modules/ads/ads.routes');
 
 const app = express();
 app.use(express.json());
+app.use((req, _res, next) => {
+  req.user = { plan: { showAnalytics: true } };
+  next();
+});
 app.use('/api/ads', routes);
+app.use((err, _req, res, _next) => {
+  res.status(err.statusCode || 500).json({ message: err.message });
+});
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -131,12 +141,22 @@ describe('GET /api/ads/admin/check-title', () => {
 });
 
 describe('POST /api/ads/admin', () => {
-  it('creates ad', async () => {
-    const payload = { title: 'Test', image_url: 'img.jpg' };
+  it('creates ad within plan limits and consumes credit', async () => {
+    const payload = { title: 'Test', image_url: 'img.jpg', allow_branding: true };
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      ad_credits: 2,
+      features: [
+        { feature_key: 'ads_max_ads', value: '5' },
+        { feature_key: 'ads_allow_branding', value: 'true' },
+      ],
+    });
+    service.getAds.mockResolvedValue([]);
     service.createAd.mockResolvedValue({ id: '1', ...payload });
     const res = await request(app).post('/api/ads/admin').send(payload);
     expect(res.status).toBe(200);
     expect(service.createAd).toHaveBeenCalled();
+    expect(planService.consumeAdCredit).toHaveBeenCalledWith('plan1');
     expect(sendAdSubmissionEmail).toHaveBeenCalledWith(
       'inst@example.com',
       'Instructor One',
@@ -158,11 +178,60 @@ describe('POST /api/ads/admin', () => {
       message: 'New ad created: Test',
     });
   });
+
+  it('rejects creation when ad credits exhausted', async () => {
+    const payload = { title: 'Test', image_url: 'img.jpg' };
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      ad_credits: 0,
+      features: [
+        { feature_key: 'ads_max_ads', value: '5' },
+        { feature_key: 'ads_allow_branding', value: 'true' },
+      ],
+    });
+    service.getAds.mockResolvedValue([]);
+    const res = await request(app).post('/api/ads/admin').send(payload);
+    expect(res.status).toBe(403);
+    expect(service.createAd).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation when branding not allowed', async () => {
+    const payload = { title: 'Test', image_url: 'img.jpg', allow_branding: true };
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      ad_credits: 2,
+      features: [
+        { feature_key: 'ads_max_ads', value: '5' },
+        { feature_key: 'ads_allow_branding', value: 'false' },
+      ],
+    });
+    service.getAds.mockResolvedValue([]);
+    const res = await request(app).post('/api/ads/admin').send(payload);
+    expect(res.status).toBe(403);
+    expect(service.createAd).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation when max ads exceeded', async () => {
+    const payload = { title: 'Test', image_url: 'img.jpg' };
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      ad_credits: 2,
+      features: [
+        { feature_key: 'ads_max_ads', value: '1' },
+        { feature_key: 'ads_allow_branding', value: 'true' },
+      ],
+    });
+    service.getAds.mockResolvedValue([{ id: 'existing' }]);
+    const res = await request(app).post('/api/ads/admin').send(payload);
+    expect(res.status).toBe(403);
+    expect(service.createAd).not.toHaveBeenCalled();
+  });
 });
 
 describe('PUT /api/ads/:id', () => {
   it('updates ad', async () => {
     const payload = { title: 'Updated' };
+    service.getAdById.mockResolvedValue({ id: '1', created_by: 'user1' });
     service.updateAd = jest.fn().mockResolvedValue({ id: '1', ...payload });
     const res = await request(app).put('/api/ads/1').send(payload);
     expect(res.status).toBe(200);
@@ -172,6 +241,7 @@ describe('PUT /api/ads/:id', () => {
 
 describe('DELETE /api/ads/:id', () => {
   it('deletes ad', async () => {
+    service.getAdById.mockResolvedValue({ id: '1', created_by: 'user1' });
     service.deleteAd = jest.fn().mockResolvedValue(1);
     const res = await request(app).delete('/api/ads/1');
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- load instructor plan and verify ad limits and branding permissions
- consume ad credits on ad creation
- add tests for ad creation allowed and forbidden paths

## Testing
- `cd backend && npm test -- tests/adsRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2114c53908328afc88fa2e856a0b4