### PR TITLE
Localize promotion pages

### DIFF
--- a/frontend/public/locales/ar/promotions.json
+++ b/frontend/public/locales/ar/promotions.json
@@ -10,5 +10,34 @@
   "what_people_are_saying": "What People Are Saying:",
   "enter_discount_code": "Enter Discount Code",
   "applied_code": "Applied Code: {{code}}",
-  "claim_offer_now": "Claim Offer Now"
+  "claim_offer_now": "Claim Offer Now",
+  "mockPromotions": {
+    "1": {
+      "title": "🔥 Black Friday Deal: 50% Off!",
+      "description": "All courses now at half price!",
+      "reviews": [
+        "Great deal!",
+        "Loved it!",
+        "Highly recommended!"
+      ]
+    },
+    "2": {
+      "title": "📢 Python Bootcamp Enrollment Open!",
+      "description": "Join our advanced Python bootcamp!",
+      "reviews": [
+        "Super informative!",
+        "Best bootcamp!",
+        "Worth every penny!"
+      ]
+    },
+    "3": {
+      "title": "🚀 AI Masterclass Discount!",
+      "description": "Learn AI from top instructors!",
+      "reviews": [
+        "Perfect for beginners!",
+        "Very detailed",
+        "Loved the instructors!"
+      ]
+    }
+  }
 }

--- a/frontend/public/locales/de/promotions.json
+++ b/frontend/public/locales/de/promotions.json
@@ -10,5 +10,34 @@
   "what_people_are_saying": "What People Are Saying:",
   "enter_discount_code": "Enter Discount Code",
   "applied_code": "Applied Code: {{code}}",
-  "claim_offer_now": "Claim Offer Now"
+  "claim_offer_now": "Claim Offer Now",
+  "mockPromotions": {
+    "1": {
+      "title": "🔥 Black Friday Deal: 50% Off!",
+      "description": "All courses now at half price!",
+      "reviews": [
+        "Great deal!",
+        "Loved it!",
+        "Highly recommended!"
+      ]
+    },
+    "2": {
+      "title": "📢 Python Bootcamp Enrollment Open!",
+      "description": "Join our advanced Python bootcamp!",
+      "reviews": [
+        "Super informative!",
+        "Best bootcamp!",
+        "Worth every penny!"
+      ]
+    },
+    "3": {
+      "title": "🚀 AI Masterclass Discount!",
+      "description": "Learn AI from top instructors!",
+      "reviews": [
+        "Perfect for beginners!",
+        "Very detailed",
+        "Loved the instructors!"
+      ]
+    }
+  }
 }

--- a/frontend/public/locales/en/promotions.json
+++ b/frontend/public/locales/en/promotions.json
@@ -10,5 +10,34 @@
   "what_people_are_saying": "What People Are Saying:",
   "enter_discount_code": "Enter Discount Code",
   "applied_code": "Applied Code: {{code}}",
-  "claim_offer_now": "Claim Offer Now"
+  "claim_offer_now": "Claim Offer Now",
+  "mockPromotions": {
+    "1": {
+      "title": "🔥 Black Friday Deal: 50% Off!",
+      "description": "All courses now at half price!",
+      "reviews": [
+        "Great deal!",
+        "Loved it!",
+        "Highly recommended!"
+      ]
+    },
+    "2": {
+      "title": "📢 Python Bootcamp Enrollment Open!",
+      "description": "Join our advanced Python bootcamp!",
+      "reviews": [
+        "Super informative!",
+        "Best bootcamp!",
+        "Worth every penny!"
+      ]
+    },
+    "3": {
+      "title": "🚀 AI Masterclass Discount!",
+      "description": "Learn AI from top instructors!",
+      "reviews": [
+        "Perfect for beginners!",
+        "Very detailed",
+        "Loved the instructors!"
+      ]
+    }
+  }
 }

--- a/frontend/public/locales/es/promotions.json
+++ b/frontend/public/locales/es/promotions.json
@@ -10,5 +10,34 @@
   "what_people_are_saying": "What People Are Saying:",
   "enter_discount_code": "Enter Discount Code",
   "applied_code": "Applied Code: {{code}}",
-  "claim_offer_now": "Claim Offer Now"
+  "claim_offer_now": "Claim Offer Now",
+  "mockPromotions": {
+    "1": {
+      "title": "🔥 Black Friday Deal: 50% Off!",
+      "description": "All courses now at half price!",
+      "reviews": [
+        "Great deal!",
+        "Loved it!",
+        "Highly recommended!"
+      ]
+    },
+    "2": {
+      "title": "📢 Python Bootcamp Enrollment Open!",
+      "description": "Join our advanced Python bootcamp!",
+      "reviews": [
+        "Super informative!",
+        "Best bootcamp!",
+        "Worth every penny!"
+      ]
+    },
+    "3": {
+      "title": "🚀 AI Masterclass Discount!",
+      "description": "Learn AI from top instructors!",
+      "reviews": [
+        "Perfect for beginners!",
+        "Very detailed",
+        "Loved the instructors!"
+      ]
+    }
+  }
 }

--- a/frontend/public/locales/fr/promotions.json
+++ b/frontend/public/locales/fr/promotions.json
@@ -10,5 +10,34 @@
   "what_people_are_saying": "What People Are Saying:",
   "enter_discount_code": "Enter Discount Code",
   "applied_code": "Applied Code: {{code}}",
-  "claim_offer_now": "Claim Offer Now"
+  "claim_offer_now": "Claim Offer Now",
+  "mockPromotions": {
+    "1": {
+      "title": "🔥 Black Friday Deal: 50% Off!",
+      "description": "All courses now at half price!",
+      "reviews": [
+        "Great deal!",
+        "Loved it!",
+        "Highly recommended!"
+      ]
+    },
+    "2": {
+      "title": "📢 Python Bootcamp Enrollment Open!",
+      "description": "Join our advanced Python bootcamp!",
+      "reviews": [
+        "Super informative!",
+        "Best bootcamp!",
+        "Worth every penny!"
+      ]
+    },
+    "3": {
+      "title": "🚀 AI Masterclass Discount!",
+      "description": "Learn AI from top instructors!",
+      "reviews": [
+        "Perfect for beginners!",
+        "Very detailed",
+        "Loved the instructors!"
+      ]
+    }
+  }
 }

--- a/frontend/public/locales/hi/promotions.json
+++ b/frontend/public/locales/hi/promotions.json
@@ -10,5 +10,34 @@
   "what_people_are_saying": "What People Are Saying:",
   "enter_discount_code": "Enter Discount Code",
   "applied_code": "Applied Code: {{code}}",
-  "claim_offer_now": "Claim Offer Now"
+  "claim_offer_now": "Claim Offer Now",
+  "mockPromotions": {
+    "1": {
+      "title": "🔥 Black Friday Deal: 50% Off!",
+      "description": "All courses now at half price!",
+      "reviews": [
+        "Great deal!",
+        "Loved it!",
+        "Highly recommended!"
+      ]
+    },
+    "2": {
+      "title": "📢 Python Bootcamp Enrollment Open!",
+      "description": "Join our advanced Python bootcamp!",
+      "reviews": [
+        "Super informative!",
+        "Best bootcamp!",
+        "Worth every penny!"
+      ]
+    },
+    "3": {
+      "title": "🚀 AI Masterclass Discount!",
+      "description": "Learn AI from top instructors!",
+      "reviews": [
+        "Perfect for beginners!",
+        "Very detailed",
+        "Loved the instructors!"
+      ]
+    }
+  }
 }

--- a/frontend/public/locales/it/promotions.json
+++ b/frontend/public/locales/it/promotions.json
@@ -10,5 +10,34 @@
   "what_people_are_saying": "What People Are Saying:",
   "enter_discount_code": "Enter Discount Code",
   "applied_code": "Applied Code: {{code}}",
-  "claim_offer_now": "Claim Offer Now"
+  "claim_offer_now": "Claim Offer Now",
+  "mockPromotions": {
+    "1": {
+      "title": "🔥 Black Friday Deal: 50% Off!",
+      "description": "All courses now at half price!",
+      "reviews": [
+        "Great deal!",
+        "Loved it!",
+        "Highly recommended!"
+      ]
+    },
+    "2": {
+      "title": "📢 Python Bootcamp Enrollment Open!",
+      "description": "Join our advanced Python bootcamp!",
+      "reviews": [
+        "Super informative!",
+        "Best bootcamp!",
+        "Worth every penny!"
+      ]
+    },
+    "3": {
+      "title": "🚀 AI Masterclass Discount!",
+      "description": "Learn AI from top instructors!",
+      "reviews": [
+        "Perfect for beginners!",
+        "Very detailed",
+        "Loved the instructors!"
+      ]
+    }
+  }
 }

--- a/frontend/public/locales/zh/promotions.json
+++ b/frontend/public/locales/zh/promotions.json
@@ -10,5 +10,34 @@
   "what_people_are_saying": "What People Are Saying:",
   "enter_discount_code": "Enter Discount Code",
   "applied_code": "Applied Code: {{code}}",
-  "claim_offer_now": "Claim Offer Now"
+  "claim_offer_now": "Claim Offer Now",
+  "mockPromotions": {
+    "1": {
+      "title": "🔥 Black Friday Deal: 50% Off!",
+      "description": "All courses now at half price!",
+      "reviews": [
+        "Great deal!",
+        "Loved it!",
+        "Highly recommended!"
+      ]
+    },
+    "2": {
+      "title": "📢 Python Bootcamp Enrollment Open!",
+      "description": "Join our advanced Python bootcamp!",
+      "reviews": [
+        "Super informative!",
+        "Best bootcamp!",
+        "Worth every penny!"
+      ]
+    },
+    "3": {
+      "title": "🚀 AI Masterclass Discount!",
+      "description": "Learn AI from top instructors!",
+      "reviews": [
+        "Perfect for beginners!",
+        "Very detailed",
+        "Loved the instructors!"
+      ]
+    }
+  }
 }

--- a/frontend/src/pages/promotions/[id].js
+++ b/frontend/src/pages/promotions/[id].js
@@ -55,7 +55,7 @@ export default function PromotionPage() {
   };
 
   if (loading) {
-    return <div className="min-h-screen flex justify-center items-center text-xl text-gray-500">{t('common:loading')}</div>;
+    return <div className="min-h-screen flex justify-center items-center text-xl text-gray-500">{t('loading_promotion_details')}</div>;
   }
 
   if (!promotion) {

--- a/frontend/src/pages/promotions/index.js
+++ b/frontend/src/pages/promotions/index.js
@@ -8,12 +8,6 @@ import PageHead from "@/components/common/PageHead";
 import Head from "next/head";
 import { useTranslation } from "next-i18next";
 
-const mockPromotions = {
-  1: { title: "🔥 Black Friday Deal: 50% Off!", description: "All courses now at half price!", image: "/shared/assets/images/ads/black-friday.jpg", timeLeft: 3600, reviews: ["Great deal!", "Loved it!", "Highly recommended!"] },
-  2: { title: "📢 Python Bootcamp Enrollment Open!", description: "Join our advanced Python bootcamp!", image: "/shared/assets/images/ads/python-bootcamp.jpg", timeLeft: 7200, reviews: ["Super informative!", "Best bootcamp!", "Worth every penny!"] },
-  3: { title: "🚀 AI Masterclass Discount!", description: "Learn AI from top instructors!", image: "/shared/assets/images/ads/ai-masterclass.jpg", timeLeft: 5400, reviews: ["Perfect for beginners!", "Very detailed", "Loved the instructors!"] },
-};
-
 const PromotionsPage = () => {
   const router = useRouter();
   const { t } = useTranslation("promotions");
@@ -22,6 +16,30 @@ const PromotionsPage = () => {
   const [loading, setLoading] = useState(true);
   const [timeLeft, setTimeLeft] = useState(0);
   const [discountCode, setDiscountCode] = useState("");
+
+  const mockPromotions = {
+    1: {
+      title: t('mockPromotions.1.title'),
+      description: t('mockPromotions.1.description'),
+      image: '/shared/assets/images/ads/black-friday.jpg',
+      timeLeft: 3600,
+      reviews: t('mockPromotions.1.reviews', { returnObjects: true }),
+    },
+    2: {
+      title: t('mockPromotions.2.title'),
+      description: t('mockPromotions.2.description'),
+      image: '/shared/assets/images/ads/python-bootcamp.jpg',
+      timeLeft: 7200,
+      reviews: t('mockPromotions.2.reviews', { returnObjects: true }),
+    },
+    3: {
+      title: t('mockPromotions.3.title'),
+      description: t('mockPromotions.3.description'),
+      image: '/shared/assets/images/ads/ai-masterclass.jpg',
+      timeLeft: 5400,
+      reviews: t('mockPromotions.3.reviews', { returnObjects: true }),
+    },
+  };
 
   // Fetch Promotion Data or Use Mock Data
   useEffect(() => {
@@ -35,7 +53,7 @@ const PromotionsPage = () => {
       setTimeLeft(mockPromotions[1].timeLeft);
     }
     setLoading(false);
-  }, [id]);
+  }, [id, t]);
 
   // Countdown Timer
   useEffect(() => {


### PR DESCRIPTION
## Summary
- localize mock promotion data and messages using `useTranslation`
- add translation entries for mock promotions across all locales
- unify promotion loading text with translation lookup

## Testing
- `npm test`
- `npm run lint` *(fails: 34 errors, 306 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b21ba1521083288c59654aeb039718