### PR TITLE
test: ensure ad analytics requires valid user

### DIFF
--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -67,10 +67,6 @@ const routes = require('../src/modules/ads/ads.routes');
 
 const app = express();
 app.use(express.json());
-app.use((req, _res, next) => {
-  req.user = { plan: { showAnalytics: true } };
-  next();
-});
 app.use('/api/ads', routes);
 app.use((err, _req, res, _next) => {
   res.status(err.statusCode || 500).json({ message: err.message });


### PR DESCRIPTION
## Summary
- secure ad analytics tests by removing default user to allow proper unauthenticated checks
- confirm ad analytics route requires authentication and proper plan via tests

## Testing
- `npm test -- adsRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b21ba056f483288b03984134630952