### PR TITLE
Validate ad existence before recording metrics

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -364,8 +364,15 @@ exports.purchaseAd = catchAsync(async (req, res) => {
  * request is unauthenticated the view will be stored without a user id.
  */
 exports.recordAdView = catchAsync(async (req, res) => {
+  const ad = await service.getAdById(req.params.id);
+  if (!ad) {
+    throw new AppError("Ad not found", 404);
+  }
+  if (!ad.is_active) {
+    throw new AppError("Ad is inactive", 403);
+  }
   const userId = req.user?.id || null;
-  await service.recordView(req.params.id, userId);
+  await service.recordView(ad.id, userId);
   sendSuccess(res, null, "View recorded");
 });
 
@@ -417,6 +424,13 @@ exports.getAdAnalytics = catchAsync(async (req, res) => {
  * Record a click for the given ad.
  */
 exports.recordAdClick = catchAsync(async (req, res) => {
-  await service.recordClick(req.params.id);
+  const ad = await service.getAdById(req.params.id);
+  if (!ad) {
+    throw new AppError("Ad not found", 404);
+  }
+  if (!ad.is_active) {
+    throw new AppError("Ad is inactive", 403);
+  }
+  await service.recordClick(ad.id);
   sendSuccess(res, null, "Click recorded");
 });

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -15,6 +15,7 @@ jest.mock('../src/modules/ads/ads.service', () => ({
   deleteAd: jest.fn(),
   getAdAnalytics: jest.fn(),
   recordView: jest.fn(),
+  recordClick: jest.fn(),
   purchaseAd: jest.fn(),
 }));
 
@@ -280,11 +281,52 @@ describe('GET /api/ads/:id/analytics', () => {
 });
 
 describe('POST /api/ads/:id/view', () => {
-  it('records ad view', async () => {
+  it('records ad view for active existing ad', async () => {
+    service.getAdById.mockResolvedValue({ id: '1', is_active: true });
     service.recordView.mockResolvedValue();
     const res = await request(app).post('/api/ads/1/view');
     expect(res.status).toBe(200);
+    expect(service.getAdById).toHaveBeenCalledWith('1');
     expect(service.recordView).toHaveBeenCalledWith('1', null);
+  });
+
+  it('returns 404 for missing ad', async () => {
+    service.getAdById.mockResolvedValue(null);
+    const res = await request(app).post('/api/ads/1/view');
+    expect(res.status).toBe(404);
+    expect(service.recordView).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for inactive ad', async () => {
+    service.getAdById.mockResolvedValue({ id: '1', is_active: false });
+    const res = await request(app).post('/api/ads/1/view');
+    expect(res.status).toBe(403);
+    expect(service.recordView).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/ads/:id/click', () => {
+  it('records ad click for active existing ad', async () => {
+    service.getAdById.mockResolvedValue({ id: '1', is_active: true });
+    service.recordClick.mockResolvedValue();
+    const res = await request(app).post('/api/ads/1/click');
+    expect(res.status).toBe(200);
+    expect(service.getAdById).toHaveBeenCalledWith('1');
+    expect(service.recordClick).toHaveBeenCalledWith('1');
+  });
+
+  it('returns 404 for missing ad', async () => {
+    service.getAdById.mockResolvedValue(null);
+    const res = await request(app).post('/api/ads/1/click');
+    expect(res.status).toBe(404);
+    expect(service.recordClick).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for inactive ad', async () => {
+    service.getAdById.mockResolvedValue({ id: '1', is_active: false });
+    const res = await request(app).post('/api/ads/1/click');
+    expect(res.status).toBe(403);
+    expect(service.recordClick).not.toHaveBeenCalled();
   });
 });
 // Service-level test ensuring getAds filters by start and end dates


### PR DESCRIPTION
## Summary
- Ensure ads are fetched and active before recording views or clicks
- Return 404 for missing ads and 403 for inactive ads
- Test metrics recording only occurs for active, existing ads

## Testing
- `npm test tests/adsRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b21ed7bf2883289986bb8a30b97335