### PR TITLE
Enforce plan feature limits on ad updates

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -292,6 +292,42 @@ exports.updateAd = catchAsync(async (req, res) => {
     updates.image_url = null;
   }
 
+  // Load instructor plan and enforce ad feature limits
+  const plan = await planService.getPlanById(req.user.plan_id);
+  if (!plan) {
+    throw new AppError("Plan not found", 403);
+  }
+
+  const features = {};
+  (plan.features || []).forEach((f) => {
+    let val = f.value;
+    try {
+      val = JSON.parse(f.value);
+    } catch {
+      if (f.value === "true") val = true;
+      else if (f.value === "false") val = false;
+      else if (!isNaN(f.value)) val = Number(f.value);
+    }
+    features[f.feature_key] = val;
+  });
+
+  const maxAds = Number(features["ads_max_ads"] || 0);
+  if (maxAds) {
+    const existing = await service.getAds(true, req.user.id);
+    if (existing.length > maxAds) {
+      throw new AppError("Ad limit reached for your plan", 403);
+    }
+  }
+
+  const brandingAllowed = !!features["ads_allow_branding"];
+  const newBranding =
+    updates.allow_branding !== undefined
+      ? updates.allow_branding
+      : ad.allow_branding;
+  if (newBranding && !brandingAllowed) {
+    throw new AppError("Branding not allowed for your plan", 403);
+  }
+
   const updated = await service.updateAd(req.params.id, updates);
   if (!updated) throw new AppError("Ad not found", 404);
 

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -227,11 +227,51 @@ describe('POST /api/ads/admin', () => {
 describe('PUT /api/ads/:id', () => {
   it('updates ad', async () => {
     const payload = { title: 'Updated' };
-    service.getAdById.mockResolvedValue({ id: '1', created_by: 'user1' });
+    service.getAdById.mockResolvedValue({ id: '1', created_by: 'user1', allow_branding: false });
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      features: [
+        { feature_key: 'ads_max_ads', value: '5' },
+        { feature_key: 'ads_allow_branding', value: 'true' },
+      ],
+    });
+    service.getAds.mockResolvedValue([{ id: '1' }]);
     service.updateAd = jest.fn().mockResolvedValue({ id: '1', ...payload });
     const res = await request(app).put('/api/ads/1').send(payload);
     expect(res.status).toBe(200);
     expect(service.updateAd).toHaveBeenCalledWith('1', expect.any(Object));
+  });
+
+  it('rejects update when branding not allowed', async () => {
+    const payload = { allow_branding: true };
+    service.getAdById.mockResolvedValue({ id: '1', created_by: 'user1', allow_branding: false });
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      features: [
+        { feature_key: 'ads_max_ads', value: '5' },
+        { feature_key: 'ads_allow_branding', value: 'false' },
+      ],
+    });
+    service.getAds.mockResolvedValue([{ id: '1' }]);
+    const res = await request(app).put('/api/ads/1').send(payload);
+    expect(res.status).toBe(403);
+    expect(service.updateAd).not.toHaveBeenCalled();
+  });
+
+  it('rejects update when max ads exceeded', async () => {
+    const payload = { title: 'Updated' };
+    service.getAdById.mockResolvedValue({ id: '1', created_by: 'user1', allow_branding: false });
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      features: [
+        { feature_key: 'ads_max_ads', value: '1' },
+        { feature_key: 'ads_allow_branding', value: 'true' },
+      ],
+    });
+    service.getAds.mockResolvedValue([{ id: '1' }, { id: '2' }]);
+    const res = await request(app).put('/api/ads/1').send(payload);
+    expect(res.status).toBe(403);
+    expect(service.updateAd).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Load instructor plan in `updateAd` and parse feature flags
- Enforce `ads_allow_branding` and `ads_max_ads` during ad updates
- Add tests covering plan restrictions for ad updates

## Testing
- `npx jest tests/adsRoutes.test.js`
- `npm test` *(fails: missing database configuration across unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b21ed702d88328856fb79ee1fdcb17