### PR TITLE
feat: restrict book uploads by field

### DIFF
--- a/backend/src/modules/books/__tests__/bookUploadMiddleware.test.js
+++ b/backend/src/modules/books/__tests__/bookUploadMiddleware.test.js
@@ -1,0 +1,31 @@
+const upload = require('../bookUploadMiddleware');
+const { fileFilter } = upload;
+
+describe('bookUploadMiddleware fileFilter', () => {
+  const runFilter = (fieldname, mimetype) => {
+    let error, accept;
+    fileFilter(null, { fieldname, mimetype }, (err, ok) => {
+      error = err;
+      accept = ok;
+    });
+    return { error, accept };
+  };
+
+  test('rejects non-image for cover_image', () => {
+    const { error, accept } = runFilter('cover_image', 'application/pdf');
+    expect(error).toBeInstanceOf(Error);
+    expect(accept).toBe(false);
+  });
+
+  test('rejects non-image for preview_pages', () => {
+    const { error, accept } = runFilter('preview_pages', 'application/pdf');
+    expect(error).toBeInstanceOf(Error);
+    expect(accept).toBe(false);
+  });
+
+  test('rejects non-pdf for book_file', () => {
+    const { error, accept } = runFilter('book_file', 'image/jpeg');
+    expect(error).toBeInstanceOf(Error);
+    expect(accept).toBe(false);
+  });
+});

--- a/backend/src/modules/books/bookUploadMiddleware.js
+++ b/backend/src/modules/books/bookUploadMiddleware.js
@@ -14,16 +14,24 @@ const storage = multer.diskStorage({
   },
 });
 
-const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
+const imageTypes = ['image/jpeg', 'image/png', 'image/webp'];
 const fileFilter = (_req, file, cb) => {
-  if (allowedTypes.includes(file.mimetype)) {
-    cb(null, true);
-  } else {
-    cb(new Error('Invalid file type'), false);
+  const { fieldname, mimetype } = file;
+
+  if (['cover_image', 'preview_pages'].includes(fieldname)) {
+    if (imageTypes.includes(mimetype)) return cb(null, true);
+    return cb(new Error('Invalid file type'), false);
   }
+
+  if (fieldname === 'book_file') {
+    if (mimetype === 'application/pdf') return cb(null, true);
+    return cb(new Error('Invalid file type'), false);
+  }
+
+  return cb(new Error('Invalid file field'), false);
 };
 
-module.exports = multer({
+const upload = multer({
   storage,
   fileFilter,
   limits: { fileSize: 50 * 1024 * 1024 },
@@ -32,3 +40,6 @@ module.exports = multer({
   { name: 'book_file', maxCount: 1 },
   { name: 'preview_pages', maxCount: 10 },
 ]);
+
+module.exports = upload;
+module.exports.fileFilter = fileFilter;


### PR DESCRIPTION
## Summary
- restrict book uploads to images for `cover_image` and `preview_pages`, and PDF for `book_file`
- add tests ensuring invalid file types are rejected for each field

## Testing
- `npm test` *(fails: Jest worker encountered exceptions; 28 failed, 62 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2252dc3708328948df2f1e09701d0