### PR TITLE
Remove old book media on update

### DIFF
--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -1,5 +1,7 @@
 const knex = require('knex');
 const QueryBuilder = require('knex/lib/query/querybuilder');
+const fs = require('fs');
+const path = require('path');
 
 QueryBuilder.prototype.whereILike = function (column, value) {
   return this.whereRaw(`LOWER(${column}) LIKE LOWER(?)`, [value]);
@@ -20,7 +22,7 @@ const mockDb = knex({
 jest.mock('../../../config/database', () => mockDb);
 
 const db = require('../../../config/database');
-const { listBooks, checkout } = require('../book.service');
+const { listBooks, checkout, updateBook } = require('../book.service');
 
 beforeAll(async () => {
   await db.schema.createTable('books', (table) => {
@@ -35,6 +37,9 @@ beforeAll(async () => {
     table.string('language');
     table.string('instructor_id');
     table.timestamp('created_at');
+    table.string('cover_image_url');
+    table.string('pdf_url');
+    table.text('preview_pages');
   });
 
   await db.schema.createTable('book_cart', (table) => {
@@ -159,5 +164,39 @@ describe('checkout', () => {
     expect(cart).toHaveLength(1);
     const purchases = await db('book_purchases').where({ student_id: studentId });
     expect(purchases).toHaveLength(0);
+  });
+});
+
+describe('updateBook', () => {
+  test('removes old media files when new ones are uploaded', async () => {
+    const bookId = 100;
+    const uploadsDir = path.join(__dirname, '../../../../uploads/books');
+    fs.mkdirSync(uploadsDir, { recursive: true });
+    const oldCover = path.join(uploadsDir, 'oldcover.jpg');
+    const oldPdf = path.join(uploadsDir, 'oldbook.pdf');
+    fs.writeFileSync(oldCover, 'old cover');
+    fs.writeFileSync(oldPdf, 'old pdf');
+
+    await db('books').insert({
+      id: bookId,
+      title: 'UpdateMe',
+      instructor_id: '1',
+      created_at: new Date(),
+      price: 0,
+      cover_image_url: '/uploads/books/oldcover.jpg',
+      pdf_url: '/uploads/books/oldbook.pdf',
+    });
+
+    await updateBook(bookId, {
+      cover_image_url: '/uploads/books/newcover.jpg',
+      pdf_url: '/uploads/books/newbook.pdf',
+    });
+
+    expect(fs.existsSync(oldCover)).toBe(false);
+    expect(fs.existsSync(oldPdf)).toBe(false);
+
+    const updated = await db('books').where({ id: bookId }).first();
+    expect(updated.cover_image_url).toBe('/uploads/books/newcover.jpg');
+    expect(updated.pdf_url).toBe('/uploads/books/newbook.pdf');
   });
 });

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -159,11 +159,17 @@ const removeFiles = async (files = []) => {
 };
 
 exports.updateBook = async (id, data, { removePreviewPages = false } = {}) => {
+  const fields = [];
+  if (removePreviewPages || data.preview_pages) fields.push("preview_pages");
+  if (data.cover_image_url) fields.push("cover_image_url");
+  if (data.pdf_url) fields.push("pdf_url");
+
+  let existing = null;
+  if (fields.length) {
+    existing = await db("books").where({ id }).select(fields).first();
+  }
+
   if (removePreviewPages || data.preview_pages) {
-    const existing = await db("books")
-      .where({ id })
-      .select("preview_pages")
-      .first();
     let prev = [];
     if (existing?.preview_pages) {
       if (Array.isArray(existing.preview_pages)) prev = existing.preview_pages;
@@ -180,6 +186,15 @@ exports.updateBook = async (id, data, { removePreviewPages = false } = {}) => {
       data.preview_pages = null;
     }
   }
+
+  if (data.cover_image_url && existing?.cover_image_url) {
+    await removeFiles([existing.cover_image_url]);
+  }
+
+  if (data.pdf_url && existing?.pdf_url) {
+    await removeFiles([existing.pdf_url]);
+  }
+
   const [row] = await db("books").where({ id }).update(data).returning("*");
   return row;
 };


### PR DESCRIPTION
## Summary
- ensure `updateBook` removes previous cover and PDF files when uploading new media
- test book update removes old media paths

## Testing
- `npm test` *(fails: database configuration missing in unrelated suites)*
- `npm test src/modules/books/__tests__/book.service.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2252064748328a3b9303880b61bd4