### PR TITLE
Validate active books during checkout

### DIFF
--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -61,6 +61,7 @@ beforeAll(async () => {
       instructor_id: '1',
       created_at: new Date('2023-01-01'),
       price: 10,
+      status: 'active',
     },
     {
       id: 2,
@@ -71,6 +72,7 @@ beforeAll(async () => {
       instructor_id: '2',
       created_at: new Date('2023-01-02'),
       price: 15,
+      status: 'active',
     },
     {
       id: 3,
@@ -81,6 +83,7 @@ beforeAll(async () => {
       instructor_id: '1',
       created_at: new Date('2023-01-03'),
       price: 20,
+      status: 'active',
     },
   ];
   await db('books').insert(books);
@@ -152,9 +155,29 @@ describe('checkout', () => {
     expect(cart).toHaveLength(0);
   });
 
+  test('throws error when book is inactive', async () => {
+    await db('books').insert({
+      id: 4,
+      title: 'D',
+      author: 'Author4',
+      short_description: 'ShortDesc4',
+      detailed_description: 'DetailedDesc4',
+      instructor_id: '1',
+      created_at: new Date('2023-01-04'),
+      price: 25,
+      status: 'inactive',
+    });
+    await db('book_cart').insert({ student_id: studentId, book_id: 4 });
+    await expect(checkout(studentId)).rejects.toThrow('inactive or not found');
+    const cart = await db('book_cart').where({ student_id: studentId });
+    expect(cart).toHaveLength(1);
+    const purchases = await db('book_purchases').where({ student_id: studentId });
+    expect(purchases).toHaveLength(0);
+  });
+
   test('throws error when book ID is missing', async () => {
     await db('book_cart').insert({ student_id: studentId, book_id: 999 });
-    await expect(checkout(studentId)).rejects.toThrow('Book not found');
+    await expect(checkout(studentId)).rejects.toThrow('inactive or not found');
     const cart = await db('book_cart').where({ student_id: studentId });
     expect(cart).toHaveLength(1);
     const purchases = await db('book_purchases').where({ student_id: studentId });

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -256,12 +256,13 @@ exports.checkout = async (studentId) => {
 
     const books = await trx('books')
       .whereIn('id', bookIds)
+      .where('status', 'active')
       .select('id', 'price');
 
-    const validIds = books.map((b) => b.id);
     if (books.length !== bookIds.length) {
+      const validIds = books.map((b) => b.id);
       const missing = bookIds.filter((id) => !validIds.includes(id));
-      throw new AppError(`Book not found: ${missing.join(', ')}`, 404);
+      throw new AppError(`Book inactive or not found: ${missing.join(', ')}`, 404);
     }
 
     const rows = books.map((b) => ({
@@ -274,7 +275,7 @@ exports.checkout = async (studentId) => {
       .returning('*');
     await trx('book_cart')
       .where({ student_id: studentId })
-      .whereIn('book_id', validIds)
+      .whereIn('book_id', bookIds)
       .del();
     return purchases;
   });


### PR DESCRIPTION
## Summary
- require books to be active during checkout and error on inactive or missing ids
- seed tests with active books and add coverage for inactive books during checkout

## Testing
- `npm test` *(fails: Test Suites: 28 failed, 61 passed, 89 total)*
- `npm test -- src/modules/books/__tests__/book.service.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b225174dc483289b7401bebed8eadd