### PR TITLE
Validate class date fields and add negative tests

### DIFF
--- a/backend/src/modules/classes/__tests__/class.validator.test.js
+++ b/backend/src/modules/classes/__tests__/class.validator.test.js
@@ -1,0 +1,44 @@
+const validator = require('../class.validator');
+
+const base = {
+  instructor_id: '00000000-0000-0000-0000-000000000000',
+  title: 'Test Class'
+};
+
+describe('class validator date handling', () => {
+  test('rejects invalid start_date', () => {
+    const result = validator.create.safeParse({
+      body: { ...base, start_date: 'not-a-date' }
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects invalid end_date', () => {
+    const result = validator.create.safeParse({
+      body: { ...base, end_date: '32/13/2024' }
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects end_date earlier than start_date', () => {
+    const result = validator.create.safeParse({
+      body: {
+        ...base,
+        start_date: '2024-05-10',
+        end_date: '2024-05-01'
+      }
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('accepts valid dates in order', () => {
+    const result = validator.create.safeParse({
+      body: {
+        ...base,
+        start_date: '2024-05-01',
+        end_date: '2024-05-10'
+      }
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/backend/src/modules/classes/class.validator.js
+++ b/backend/src/modules/classes/class.validator.js
@@ -13,8 +13,18 @@ exports.create = z.object({
     description: z.string().optional(),
     level: z.string().optional(),
     cover_image: z.string().optional(),
-    start_date: z.string().optional(),
-    end_date: z.string().optional(),
+    start_date: z
+      .string()
+      .refine((val) => !isNaN(Date.parse(val)), {
+        message: "Invalid date format",
+      })
+      .optional(),
+    end_date: z
+      .string()
+      .refine((val) => !isNaN(Date.parse(val)), {
+        message: "Invalid date format",
+      })
+      .optional(),
     category_id: z.string().uuid().optional(),
     price: z.preprocess(toNumber, z.number().optional()),
     max_students: z.preprocess(toNumber, z.number().int().optional()),
@@ -28,30 +38,61 @@ exports.create = z.object({
     slug: z.string().optional(),
     status: z.enum(["draft", "published", "archived"]).optional(),
   })
+    .refine(
+      (data) =>
+        !data.start_date ||
+        !data.end_date ||
+        new Date(data.end_date) >= new Date(data.start_date),
+      {
+        message: "end_date cannot be earlier than start_date",
+        path: ["end_date"],
+      }
+    )
 });
 
 exports.update = z.object({
-  body: z.object({
-    instructor_id: z.string().uuid().optional(),
-    title: z.string().min(3).max(255).optional(),
-    description: z.string().optional(),
-    level: z.string().optional(),
-    cover_image: z.string().optional(),
-    start_date: z.string().optional(),
-    end_date: z.string().optional(),
-    category_id: z.string().uuid().optional(),
-    price: z.preprocess(toNumber, z.number().optional()),
-    max_students: z.preprocess(toNumber, z.number().int().optional()),
-    language: z.string().optional(),
-    demo_video_url: z.string().optional(),
-    allow_installments: z.preprocess(
-      (v) => (typeof v === 'string' ? v === 'true' : v),
-      z.boolean().optional()
-    ),
-    tags: z.string().optional(),
-    slug: z.string().optional(),
-    status: z.enum(["draft", "published", "archived"]).optional(),
-  })
+  body: z
+    .object({
+      instructor_id: z.string().uuid().optional(),
+      title: z.string().min(3).max(255).optional(),
+      description: z.string().optional(),
+      level: z.string().optional(),
+      cover_image: z.string().optional(),
+      start_date: z
+        .string()
+        .refine((val) => !isNaN(Date.parse(val)), {
+          message: "Invalid date format",
+        })
+        .optional(),
+      end_date: z
+        .string()
+        .refine((val) => !isNaN(Date.parse(val)), {
+          message: "Invalid date format",
+        })
+        .optional(),
+      category_id: z.string().uuid().optional(),
+      price: z.preprocess(toNumber, z.number().optional()),
+      max_students: z.preprocess(toNumber, z.number().int().optional()),
+      language: z.string().optional(),
+      demo_video_url: z.string().optional(),
+      allow_installments: z.preprocess(
+        (v) => (typeof v === 'string' ? v === 'true' : v),
+        z.boolean().optional()
+      ),
+      tags: z.string().optional(),
+      slug: z.string().optional(),
+      status: z.enum(["draft", "published", "archived"]).optional(),
+    })
+    .refine(
+      (data) =>
+        !data.start_date ||
+        !data.end_date ||
+        new Date(data.end_date) >= new Date(data.start_date),
+      {
+        message: "end_date cannot be earlier than start_date",
+        path: ["end_date"],
+      }
+    )
 });
 
 exports.reject = z.object({


### PR DESCRIPTION
## Summary
- enforce ISO date validation for class start and end dates
- ensure end_date is not before start_date
- add validator tests for invalid date inputs

## Testing
- `npm test` *(fails: multiple suites due to missing database config)*

------
https://chatgpt.com/codex/tasks/task_e_68b22a82e2948328a96b44d12c01c9a3