### PR TITLE
Protect class assignments routes

### DIFF
--- a/backend/src/middleware/auth/verifyAssignmentOwnership.js
+++ b/backend/src/middleware/auth/verifyAssignmentOwnership.js
@@ -1,0 +1,24 @@
+const logger = require('../../utils/logger.js');
+const db = require("../../config/database");
+const { isAdminRole } = require("../../utils/role");
+
+module.exports = async function verifyAssignmentOwnership(req, res, next) {
+  const assignmentId = req.params.assignmentId || req.params.id;
+  try {
+    const row = await db("class_assignments as ca")
+      .join("online_classes as c", "ca.class_id", "c.id")
+      .select("c.instructor_id")
+      .where("ca.id", assignmentId)
+      .first();
+    if (!row) return res.status(404).json({ message: "Assignment not found" });
+    const roles = req.user.roles || [req.user.role];
+    const isAdmin = isAdminRole(roles);
+    if (row.instructor_id !== req.user.id && !isAdmin) {
+      return res.status(403).json({ message: "Access denied" });
+    }
+    next();
+  } catch (err) {
+    logger.error("Failed to verify assignment ownership", err);
+    res.status(500).json({ message: "Failed to verify assignment ownership" });
+  }
+};

--- a/backend/src/middleware/auth/verifyEnrollment.js
+++ b/backend/src/middleware/auth/verifyEnrollment.js
@@ -1,23 +1,26 @@
 const logger = require('../../utils/logger.js');
 const db = require("../../config/database");
+const { isAdminRole } = require("../../utils/role");
 
 module.exports = async function verifyEnrollment(req, res, next) {
-  const { roomId } = req.params;
+  const classId = req.params.roomId || req.params.classId || req.params.id;
   try {
     const cls = await db("online_classes")
       .select("instructor_id")
-      .where({ id: roomId })
+      .where({ id: classId })
       .first();
     if (!cls) return res.status(404).json({ message: "Class not found" });
     const isInstructor = cls.instructor_id === req.user.id;
     let isStudent = false;
     if (!isInstructor) {
       const enrollment = await db("class_enrollments")
-        .where({ class_id: roomId, user_id: req.user.id })
+        .where({ class_id: classId, user_id: req.user.id })
         .first();
       if (enrollment) isStudent = true;
     }
-    if (!isInstructor && !isStudent)
+    const roles = req.user.roles || [req.user.role];
+    const isAdmin = isAdminRole(roles);
+    if (!isInstructor && !isStudent && !isAdmin)
       return res.status(403).json({ message: "Not allowed" });
     next();
   } catch (err) {

--- a/backend/src/modules/classes/assignments/__tests__/classAssignment.auth.test.js
+++ b/backend/src/modules/classes/assignments/__tests__/classAssignment.auth.test.js
@@ -1,0 +1,81 @@
+const request = require('supertest');
+const express = require('express');
+
+let mockClassInstructorId = 'owner';
+let mockAssignmentInstructorId = 'owner';
+let mockEnrolled = false;
+
+jest.mock('../../../../config/database', () => {
+  return jest.fn((table) => {
+    if (table.startsWith('online_classes')) {
+      const query = {};
+      query.select = () => query;
+      query.where = () => query;
+      query.first = () => Promise.resolve({ instructor_id: mockClassInstructorId });
+      return query;
+    }
+    if (table === 'class_enrollments') {
+      const query = {};
+      query.where = () => query;
+      query.first = () => Promise.resolve(mockEnrolled ? { id: 'e1' } : null);
+      return query;
+    }
+    if (table.startsWith('class_assignments')) {
+      const query = {};
+      query.join = () => query;
+      query.select = () => query;
+      query.where = () => query;
+      query.first = () => Promise.resolve({ instructor_id: mockAssignmentInstructorId });
+      return query;
+    }
+    return {};
+  });
+});
+
+jest.mock('../../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'user1', roles: ['instructor'] }; next(); },
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const routes = require('../classAssignment.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/assignments', routes);
+
+describe('class assignment authorization', () => {
+  beforeEach(() => {
+    mockClassInstructorId = 'owner';
+    mockAssignmentInstructorId = 'owner';
+    mockEnrolled = false;
+  });
+
+  test('rejects non-enrolled user from fetching assignments', async () => {
+    mockClassInstructorId = 'other';
+    const res = await request(app).get('/assignments/class/cls1');
+    expect(res.status).toBe(403);
+  });
+
+  test('rejects non-owner from creating assignment', async () => {
+    mockClassInstructorId = 'other';
+    const res = await request(app)
+      .post('/assignments/class/cls1')
+      .send({ title: 'A', due_date: '2024-01-01' });
+    expect(res.status).toBe(403);
+  });
+
+  test('rejects non-owner from updating assignment', async () => {
+    mockAssignmentInstructorId = 'other';
+    const res = await request(app)
+      .put('/assignments/assign1')
+      .send({ title: 'B' });
+    expect(res.status).toBe(403);
+  });
+
+  test('rejects non-owner from deleting assignment', async () => {
+    mockAssignmentInstructorId = 'other';
+    const res = await request(app).delete('/assignments/assign1');
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
+++ b/backend/src/modules/classes/assignments/__tests__/classAssignment.routes.test.js
@@ -52,6 +52,9 @@ jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   isAdmin: (_req, _res, next) => next(),
   isInstructor: (_req, _res, next) => next(),
 }));
+jest.mock('../../../../middleware/auth/verifyEnrollment', () => (_req, _res, next) => next());
+jest.mock('../../../../middleware/auth/verifyClassOwnership', () => (_req, _res, next) => next());
+jest.mock('../../../../middleware/auth/verifyAssignmentOwnership', () => (_req, _res, next) => next());
 
 const routes = require('../../class.routes');
 const emailUtil = require('../../../../utils/email');

--- a/backend/src/modules/classes/assignments/classAssignment.routes.js
+++ b/backend/src/modules/classes/assignments/classAssignment.routes.js
@@ -1,19 +1,44 @@
 const router = require("express").Router();
 const ctrl = require("./classAssignment.controller");
-const { verifyToken, isInstructorOrAdmin, isAdmin } = require("../../../middleware/auth/authMiddleware");
+const {
+  verifyToken,
+  isInstructorOrAdmin,
+  isAdmin,
+} = require("../../../middleware/auth/authMiddleware");
+const verifyEnrollment = require("../../../middleware/auth/verifyEnrollment");
+const verifyClassOwnership = require("../../../middleware/auth/verifyClassOwnership");
+const verifyAssignmentOwnership = require("../../../middleware/auth/verifyAssignmentOwnership");
 const validate = require("../../../middleware/validate");
 const validator = require("./classAssignment.validator");
 
 router.get("/admin", verifyToken, isAdmin, ctrl.getAllAssignments);
-router.get("/class/:classId", ctrl.getAssignmentsByClass);
+router.get(
+  "/class/:classId",
+  verifyToken,
+  verifyEnrollment,
+  ctrl.getAssignmentsByClass
+);
 router.post(
   "/class/:classId",
   verifyToken,
   isInstructorOrAdmin,
+  verifyClassOwnership,
   validate(validator.create),
   ctrl.createAssignment
 );
-router.put("/:assignmentId", verifyToken, isInstructorOrAdmin, ctrl.updateAssignment);
-router.delete("/:assignmentId", verifyToken, isInstructorOrAdmin, ctrl.deleteAssignment);
+router.put(
+  "/:assignmentId",
+  verifyToken,
+  isInstructorOrAdmin,
+  verifyAssignmentOwnership,
+  ctrl.updateAssignment
+);
+router.delete(
+  "/:assignmentId",
+  verifyToken,
+  isInstructorOrAdmin,
+  verifyAssignmentOwnership,
+  ctrl.deleteAssignment
+);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- enforce authentication and enrollment checks on class assignment listing
- verify class or assignment ownership for assignment creation, update and deletion
- add tests covering unauthorized access to class assignments

## Testing
- `npm test` *(fails: process.exit called with "1"; existing failing suites)*
- `npx jest src/modules/classes/assignments/__tests__/classAssignment.auth.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b22a813af883289f090852bdcd2d61