### PR TITLE
Validate class before enrollment

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -16,12 +16,18 @@ jest.mock('../../../../config/database', () => {
 jest.mock('../classEnrollment.service', () => ({
   findEnrollment: jest.fn(),
   createEnrollment: jest.fn(),
+  countEnrollments: jest.fn(),
   markCompleted: jest.fn(),
   getByUser: jest.fn(),
   getByClass: jest.fn(),
-  getStudent: jest.fn()
+  getStudent: jest.fn(),
 }));
 const service = require('../classEnrollment.service');
+
+jest.mock('../../class.service', () => ({
+  getClassById: jest.fn(),
+}));
+const classService = require('../../class.service');
 
 jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
@@ -46,11 +52,45 @@ describe('Class enrollment routes', () => {
   });
 
   test('enroll in class', async () => {
+    classService.getClassById.mockResolvedValue({
+      status: 'published',
+      moderation_status: 'Approved',
+    });
+    service.countEnrollments.mockResolvedValue(0);
     service.findEnrollment.mockResolvedValue(null);
     service.createEnrollment.mockResolvedValue({ id: '1' });
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(200);
     expect(service.createEnrollment).toHaveBeenCalled();
+  });
+
+  test('reject enrollment if class not published', async () => {
+    classService.getClassById.mockResolvedValue({
+      status: 'draft',
+      moderation_status: 'Approved',
+    });
+    const res = await request(app).post('/classes/enroll/abc');
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('reject enrollment if class not approved', async () => {
+    classService.getClassById.mockResolvedValue({
+      status: 'published',
+      moderation_status: 'Pending',
+    });
+    const res = await request(app).post('/classes/enroll/abc');
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('reject enrollment if class full', async () => {
+    classService.getClassById.mockResolvedValue({
+      status: 'published',
+      moderation_status: 'Approved',
+      max_students: 1,
+    });
+    service.countEnrollments.mockResolvedValue(1);
+    const res = await request(app).post('/classes/enroll/abc');
+    expect(res.statusCode).toBe(400);
   });
 
   test('get my enrollments', async () => {

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -2,11 +2,24 @@
 const { v4: uuidv4 } = require("uuid");
 const catchAsync = require("../../../utils/catchAsync");
 const { sendSuccess } = require("../../../utils/response");
+const AppError = require("../../../utils/AppError");
 const service = require("./classEnrollment.service");
+const classService = require("../class.service");
 
 exports.enroll = catchAsync(async (req, res) => {
   const { classId } = req.params;
   const user_id = req.user.id;
+  const cls = await classService.getClassById(classId);
+  if (!cls) throw new AppError("Class not found", 404);
+  if (cls.status !== "published" || cls.moderation_status !== "Approved") {
+    throw new AppError("Class is not available for enrollment", 400);
+  }
+  if (typeof cls.max_students === "number" && cls.max_students !== null) {
+    const count = await service.countEnrollments(classId);
+    if (count >= cls.max_students) {
+      throw new AppError("Class is full", 400);
+    }
+  }
   const exists = await service.findEnrollment(user_id, classId);
   if (exists) return sendSuccess(res, exists, "Already enrolled");
 

--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -9,6 +9,13 @@ exports.createEnrollment = async (data) => {
   return row;
 };
 
+exports.countEnrollments = async (class_id) => {
+  const [row] = await db("class_enrollments")
+    .where({ class_id })
+    .count("id as count");
+  return parseInt(row.count, 10) || 0;
+};
+
 exports.markCompleted = async (user_id, class_id) => {
   return db("class_enrollments")
     .where({ user_id, class_id })


### PR DESCRIPTION
## Summary
- ensure class exists, is published & approved, and has capacity before enrollment
- add helper to count class enrollments
- cover enrollment edge cases with new route tests

## Testing
- `npm test -- tests/tutorialRoutes.test.js` (fails: expected 403 but got 400)
- `npm test -- src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b22a78d970832898cdcd5e693c589b