### PR TITLE
Restrict instructors to creating their own classes

### DIFF
--- a/backend/src/modules/classes/__tests__/class.controller.test.js
+++ b/backend/src/modules/classes/__tests__/class.controller.test.js
@@ -1,0 +1,71 @@
+jest.mock('../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn(() => Promise.resolve(null));
+  return db;
+});
+
+jest.mock('../class.service', () => ({
+  createClass: jest.fn(),
+  addClassTags: jest.fn(),
+  getClassTags: jest.fn(),
+}));
+
+jest.mock('../classTag.service', () => ({
+  findByName: jest.fn(),
+  createTag: jest.fn(),
+}));
+
+jest.mock('../../notifications/notifications.service', () => ({
+  createNotification: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../messages/messages.service', () => ({
+  createMessage: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../users/user.model', () => ({
+  findAdmins: jest.fn(() => []),
+  findById: jest.fn(() => ({ id: 'instructor1', full_name: 'Test Instructor' })),
+}));
+
+const controller = require('../class.controller');
+const service = require('../class.service');
+
+describe('class.controller createClass', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('instructor cannot create class for another instructor', async () => {
+    service.createClass.mockImplementation(async (data) => data);
+
+    const req = {
+      body: { instructor_id: 'other', title: 'Test', status: 'published' },
+      user: { id: 'instructor1', role: 'instructor' },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      res.json.mockImplementation((data) => {
+        resolve();
+        return data;
+      });
+      controller.createClass(req, res, next);
+    });
+
+    expect(service.createClass).toHaveBeenCalledWith(
+      expect.objectContaining({ instructor_id: 'instructor1' })
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ instructor_id: 'instructor1' }),
+      })
+    );
+  });
+});

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -34,6 +34,9 @@ exports.createClass = catchAsync(async (req, res) => {
     status: status === "published" ? "published" : "draft",
     moderation_status: "Pending",
   };
+  if (req.user?.role === "instructor") {
+    data.instructor_id = req.user.id;
+  }
   if (req.files?.cover_image?.[0]) {
     data.cover_image = `/uploads/classes/${req.files.cover_image[0].filename}`;
   }

--- a/backend/src/modules/classes/class.validator.js
+++ b/backend/src/modules/classes/class.validator.js
@@ -8,7 +8,7 @@ const toNumber = (val) => {
 
 exports.create = z.object({
   body: z.object({
-    instructor_id: z.string().uuid(),
+    instructor_id: z.string().uuid().optional(),
     title: z.string().min(3).max(255),
     description: z.string().optional(),
     level: z.string().optional(),


### PR DESCRIPTION
## Summary
- Override `instructor_id` with the caller's id when the user role is instructor
- Allow instructors to omit `instructor_id` in class creation validator
- Add unit test ensuring instructors can't create classes for others

## Testing
- `npm test` *(fails: configuration and other test issues)*
- `npm test -- src/modules/classes/__tests__/class.controller.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b22a73f9e88328811b5a9e1e631c67