### PR TITLE
Check translations for all locales

### DIFF
--- a/scripts/checkTranslations.js
+++ b/scripts/checkTranslations.js
@@ -3,7 +3,13 @@ const path = require('path');
 
 const localesDir = path.join(__dirname, '..', 'frontend', 'public', 'locales');
 const baseLang = 'en';
-const languages = fs.readdirSync(localesDir).filter(l => l !== 'de');
+
+// Collect all language directories under locales. Previously German (de)
+// was excluded, but we now include every directory so that all translations
+// are checked.
+const languages = fs
+  .readdirSync(localesDir)
+  .filter((dir) => fs.statSync(path.join(localesDir, dir)).isDirectory());
 
 function getKeyPaths(obj, prefix = '') {
   let keys = [];
@@ -36,4 +42,11 @@ function compareFiles(file) {
   }
 }
 
-['auth.json', 'common.json', 'dashboard.json', 'website.json'].forEach(compareFiles);
+// Determine the files to compare based on the base language directory rather
+// than relying on a hard-coded list. This ensures new translation files are
+// automatically included in the checks.
+const files = fs
+  .readdirSync(path.join(localesDir, baseLang))
+  .filter((file) => file.endsWith('.json'));
+
+files.forEach(compareFiles);


### PR DESCRIPTION
## Summary
- Remove exclusion of `de` so every locale directory is checked
- Automatically collect JSON translation files from the base language

## Testing
- `node scripts/checkTranslations.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b22a633a9c83289237127bdd9886e7