### PR TITLE
Lock payment rows before approval or rejection

### DIFF
--- a/backend/src/modules/payments/payments.service.js
+++ b/backend/src/modules/payments/payments.service.js
@@ -83,7 +83,7 @@ exports.approveBankPayment = async (
   { amount, item_id, item_type } = {}
 ) => {
   return db.transaction(async (trx) => {
-    const payment = await trx("payments").where({ id }).first();
+    const payment = await trx("payments").where({ id }).forUpdate().first();
     if (!payment) throw new AppError("Payment not found", 404);
 
     if (payment.status !== STATUS.AWAITING_APPROVAL) {
@@ -116,7 +116,7 @@ exports.rejectBankPayment = async (
   { amount, item_id, item_type } = {}
 ) => {
   return db.transaction(async (trx) => {
-    const payment = await trx("payments").where({ id }).first();
+    const payment = await trx("payments").where({ id }).forUpdate().first();
     if (!payment) throw new AppError("Payment not found", 404);
 
     if (payment.status !== STATUS.AWAITING_APPROVAL) {


### PR DESCRIPTION
## Summary
- Lock bank payment records using `.forUpdate()` when approving or rejecting to prevent concurrent processing

## Testing
- `npm test --silent` *(fails: Test Suites: 27 failed, 63 passed, 90 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b22a6105748328b176a765696a1432