### PR TITLE
Wrap plan feature updates in transaction

### DIFF
--- a/backend/src/modules/plans/plans.service.js
+++ b/backend/src/modules/plans/plans.service.js
@@ -51,17 +51,19 @@ exports.updatePlan = async (id, data) => {
 exports.deletePlan = (id) => db("plans").where({ id }).del();
 
 exports.setFeatures = async (planId, features = []) => {
-  await db("plan_features").where({ plan_id: planId }).del();
-  if (features.length) {
-    const rows = features.map((f) => ({
-      plan_id: planId,
-      feature_key: f.feature_key,
-      value: f.value,
-      description: f.description || null,
-    }));
-    await db("plan_features").insert(rows);
-  }
-  return db("plan_features").where({ plan_id: planId }).select("*");
+  return db.transaction(async (trx) => {
+    await trx("plan_features").where({ plan_id: planId }).del();
+    if (features.length) {
+      const rows = features.map((f) => ({
+        plan_id: planId,
+        feature_key: f.feature_key,
+        value: f.value,
+        description: f.description || null,
+      }));
+      await trx("plan_features").insert(rows);
+    }
+    return trx("plan_features").where({ plan_id: planId }).select("*");
+  });
 };
 
 exports.getPlanFeatures = async () => {


### PR DESCRIPTION
## Summary
- run plan feature deletions and insertions inside a single transaction
- roll back deletions if inserts fail, preserving previous features

## Testing
- `npm test` *(fails: 27 failed, 63 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b22a5980b883288b3416f4124f47bc