### PR TITLE
Increase instructor avatar size limit to 10MB

### DIFF
--- a/backend/src/modules/users/instructor/instructorUploadMiddleware.js
+++ b/backend/src/modules/users/instructor/instructorUploadMiddleware.js
@@ -27,7 +27,7 @@ const avatarUpload = multer({
     if (file.mimetype.startsWith("image/")) cb(null, true);
     else cb(new Error("Only image files are allowed"), false);
   },
-  limits: { fileSize: 2 * 1024 * 1024 }, // 2MB
+  limits: { fileSize: 10 * 1024 * 1024 }, // 10MB
 });
 
 // ──────────────── Demo Video Upload ────────────────

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -534,7 +534,7 @@
     "certificate_upload_failed": "فشل رفع الشهادة",
     "certificate_removed": "تمت إزالة الشهادة بنجاح",
     "certificate_remove_failed": "فشل إزالة الشهادة",
-    "avatar_max_size": "الحجم الأقصى 2MB",
+    "avatar_max_size": "الحجم الأقصى 10MB",
     "avatar_upload_failed": "فشل رفع الصورة الشخصية",
     "profile_update_success": "تم تحديث الملف الشخصي بنجاح!",
     "profile_update_failed": "فشل تحديث الملف الشخصي",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -548,7 +548,7 @@
     "certificate_upload_failed": "Failed to upload certificate",
     "certificate_removed": "Certificate removed successfully",
     "certificate_remove_failed": "Failed to remove certificate",
-    "avatar_max_size": "Max size 2MB",
+    "avatar_max_size": "Max size 10MB",
     "avatar_upload_failed": "Failed to upload avatar",
     "profile_update_success": "Profile updated successfully!",
     "profile_update_failed": "Failed to update profile",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -550,7 +550,7 @@
     "certificate_upload_failed": "Failed to upload certificate",
     "certificate_removed": "Certificate removed successfully",
     "certificate_remove_failed": "Failed to remove certificate",
-    "avatar_max_size": "Max size 2MB",
+    "avatar_max_size": "Max size 10MB",
     "avatar_upload_failed": "Failed to upload avatar",
     "profile_update_success": "Profile updated successfully!",
     "profile_update_failed": "Failed to update profile",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -534,7 +534,7 @@
     "certificate_upload_failed": "No se pudo subir el certificado",
     "certificate_removed": "Certificado eliminado con éxito",
     "certificate_remove_failed": "No se pudo eliminar el certificado",
-    "avatar_max_size": "Tamaño máximo 2MB",
+    "avatar_max_size": "Tamaño máximo de 10 MB",
     "avatar_upload_failed": "No se pudo subir avatar",
     "profile_update_success": "Perfil actualizado con éxito!",
     "profile_update_failed": "No se pudo actualizar el perfil",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -534,7 +534,7 @@
     "certificate_upload_failed": "Échec du téléversement du certificat",
     "certificate_removed": "Certificat supprimé avec succès",
     "certificate_remove_failed": "Échec de la suppression du certificat",
-    "avatar_max_size": "Taille maximale 2 Mo",
+    "avatar_max_size": "Taille maximale 10 Mo",
     "avatar_upload_failed": "Échec du téléversement de l'avatar",
     "profile_update_success": "Profil mis à jour avec succès !",
     "profile_update_failed": "Échec de la mise à jour du profil",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -534,7 +534,7 @@
     "certificate_upload_failed": "प्रमाण पत्र अपलोड करने में विफल",
     "certificate_removed": "प्रमाणपत्र सफलतापूर्वक हटा दिया गया",
     "certificate_remove_failed": "प्रमाण पत्र निकालने में विफल",
-    "avatar_max_size": "अधिकतम आकार 2 एमबी",
+    "avatar_max_size": "अधिकतम आकार 10MB",
     "avatar_upload_failed": "अवतार अपलोड करने में विफल",
     "profile_update_success": "प्रोफ़ाइल सफलतापूर्वक अपडेट किया गया!",
     "profile_update_failed": "प्रोफ़ाइल अपडेट करने में विफल",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -548,7 +548,7 @@
     "certificate_upload_failed": "Impossibile caricare il certificato",
     "certificate_removed": "Certificato rimosso correttamente",
     "certificate_remove_failed": "Impossibile rimuovere il certificato",
-    "avatar_max_size": "Dimensione massima 2 MB",
+    "avatar_max_size": "Dimensione massima 10 MB",
     "avatar_upload_failed": "Impossibile caricare Avatar",
     "profile_update_success": "Profilo aggiornato correttamente!",
     "profile_update_failed": "Impossibile aggiornare il profilo",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -534,7 +534,7 @@
     "certificate_upload_failed": "无法上传证书",
     "certificate_removed": "证书成功删除",
     "certificate_remove_failed": "无法删除证书",
-    "avatar_max_size": "最大尺寸2MB",
+    "avatar_max_size": "最大尺寸10MB",
     "avatar_upload_failed": "无法上传头像",
     "profile_update_success": "个人资料成功更新了！",
     "profile_update_failed": "无法更新个人资料",

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -297,7 +297,7 @@ export default function InstructorProfileEdit() {
   const handleAvatarSelect = (e) => {
     const file = e.target.files[0];
     if (!file) return;
-    if (file.size > 2 * 1024 * 1024) return toast.error(t('avatar_max_size'));
+    if (file.size > 10 * 1024 * 1024) return toast.error(t('avatar_max_size'));
     setTempFileName(file.name);
     setTempAvatar(URL.createObjectURL(file));
     setShowCropper(true);


### PR DESCRIPTION
## Summary
- allow instructor avatar uploads up to 10MB on frontend and backend
- update localization strings to reference 10MB limit

## Testing
- `cd frontend && npm test`
- `cd backend && npm test` *(fails: database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cb8d62648328867fc69039f955ef