### PR TITLE
Add certificate upload size limit and revoke preview URLs

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -266,6 +266,9 @@ export default function InstructorProfileEdit() {
         }]
       }));
 
+      if (newCertificate.preview) {
+        URL.revokeObjectURL(newCertificate.preview);
+      }
       setNewCertificate({ title: "", file: null, preview: null });
         toast.success(t('certificate_upload_success'));
     } catch (error) {
@@ -821,6 +824,11 @@ export default function InstructorProfileEdit() {
                       onChange={(e) => {
                         const file = e.target.files[0];
                         if (!file) return;
+
+                        if (file.size > 10 * 1024 * 1024) {
+                          toast.error('File size must be 10MB or less');
+                          return;
+                        }
 
                         // Preview for images
                         let preview = null;


### PR DESCRIPTION
## Summary
- enforce 10MB max certificate file size in instructor profile editing
- free memory by revoking certificate preview URLs after upload

## Testing
- `npm test`
- `npm run lint` *(fails: 34 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cb8bea808328a765c0cfc52be368