### PR TITLE
chore: remove unused upload progress state

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -111,7 +111,6 @@ export default function InstructorProfileEdit() {
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [newExpertise, setNewExpertise] = useState("");
-  const [uploadProgress, setUploadProgress] = useState(0);
   const [newCertificate, setNewCertificate] = useState({
     title: "",
     file: null,


### PR DESCRIPTION
## Summary
- remove unused upload progress state from instructor profile edit page

## Testing
- `npm test`
- `npm run lint` *(fails: 34 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cb88ea5083288f9cb21116de8ae9