### PR TITLE
feat: enforce instructor plan limits

### DIFF
--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -25,6 +25,24 @@ const generateUniqueSlug = async (title) => {
 };
 
 exports.createClass = catchAsync(async (req, res) => {
+  if (req.user?.role === "instructor") {
+    const sub = req.subscription;
+    if (!sub) {
+      return res
+        .status(403)
+        .json({ message: "Active instructor subscription required" });
+    }
+    if (
+      sub.max_courses !== null &&
+      sub.max_courses !== undefined &&
+      sub.current_courses >= sub.max_courses
+    ) {
+      return res
+        .status(403)
+        .json({ message: "Maximum course limit reached" });
+    }
+  }
+
   const slug = await generateUniqueSlug(req.body.title);
   const { tags: rawTags, status, ...body } = req.body;
   const data = {

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -7,6 +7,7 @@ const validate = require("../../middleware/validate");
 const validator = require("./class.validator");
 const upload = require("./classUploadMiddleware");
 const verifyClassOwnership = require("../../middleware/auth/verifyClassOwnership");
+const verifyInstructorSubscription = require("../plans/verifyInstructorSubscription");
 const {
   verifyToken,
   isInstructorOrAdmin,
@@ -118,6 +119,7 @@ router.post(
   "/instructor",
   verifyToken,
   isInstructor,
+  verifyInstructorSubscription,
   upload,
   validate(validator.create),
   controller.createClass

--- a/backend/src/modules/plans/verifyInstructorSubscription.js
+++ b/backend/src/modules/plans/verifyInstructorSubscription.js
@@ -1,0 +1,51 @@
+const db = require("../../config/database");
+const catchAsync = require("../../utils/catchAsync");
+
+module.exports = catchAsync(async (req, res, next) => {
+  const userId = req.user?.id;
+  if (!userId) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  const subscription = await db("user_subscriptions as us")
+    .join("plans as p", "us.plan_id", "p.id")
+    .select(
+      "us.id",
+      "us.user_id",
+      "us.plan_id",
+      "us.start_date",
+      "us.end_date",
+      "us.status",
+      "p.max_courses",
+      "p.target_role",
+      "p.slug"
+    )
+    .where("us.user_id", userId)
+    .andWhere("us.status", "active")
+    .andWhere(function () {
+      this.whereNull("us.end_date").orWhere("us.end_date", ">", db.fn.now());
+    })
+    .first();
+
+  if (!subscription || subscription.target_role !== "instructor") {
+    return res
+      .status(403)
+      .json({ message: "Active instructor subscription required" });
+  }
+
+  if (subscription.max_courses !== null && subscription.max_courses !== undefined) {
+    const [{ count }] = await db("online_classes")
+      .where({ instructor_id: userId })
+      .count("* as count");
+    subscription.current_courses = Number(count);
+    if (subscription.current_courses >= subscription.max_courses) {
+      return res
+        .status(403)
+        .json({ message: "Maximum course limit reached" });
+    }
+  }
+
+  req.subscription = subscription;
+  next();
+});
+


### PR DESCRIPTION
## Summary
- add middleware to verify instructor subscriptions and course limits
- apply subscription check to instructor class creation route
- guard class creation against missing or exceeded plan limits

## Testing
- `npm test` *(fails: Jest worker exceeded retry limit, 29 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cb7bdf7c832884187cc80b322c09