### PR TITLE
Check payment or subscription before class enrollment

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -40,6 +40,13 @@ jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   isInstructor: (_req, _res, next) => next(),
 }));
 
+jest.mock('../../../plans/subscription.helper', () => ({
+  hasActiveStudentSubscription: jest.fn(),
+}));
+
+const { hasActiveStudentSubscription } = require('../../../plans/subscription.helper');
+const db = require('../../../../config/database');
+
 const routes = require('../../class.routes');
 
 const app = express();
@@ -91,6 +98,37 @@ describe('Class enrollment routes', () => {
     service.countEnrollments.mockResolvedValue(1);
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(400);
+  });
+
+  test('reject enrollment if class requires payment and user has not paid or subscribed', async () => {
+    classService.getClassById.mockResolvedValue({
+      status: 'published',
+      moderation_status: 'Approved',
+      price: 50,
+    });
+    service.countEnrollments.mockResolvedValue(0);
+    service.findEnrollment.mockResolvedValue(null);
+    db.first.mockResolvedValueOnce(null); // payment check
+    db.first.mockResolvedValueOnce(null); // subscription check
+    hasActiveStudentSubscription.mockResolvedValue(false);
+    const res = await request(app).post('/classes/enroll/abc');
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('allow enrollment if class requires payment but user has active subscription', async () => {
+    classService.getClassById.mockResolvedValue({
+      status: 'published',
+      moderation_status: 'Approved',
+      price: 50,
+    });
+    service.countEnrollments.mockResolvedValue(0);
+    service.findEnrollment.mockResolvedValue(null);
+    db.first.mockResolvedValueOnce(null); // payment check
+    hasActiveStudentSubscription.mockResolvedValue(true);
+    service.createEnrollment.mockResolvedValue({ id: '1' });
+    const res = await request(app).post('/classes/enroll/abc');
+    expect(res.statusCode).toBe(200);
+    expect(service.createEnrollment).toHaveBeenCalled();
   });
 
   test('get my enrollments', async () => {

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -5,6 +5,9 @@ const { sendSuccess } = require("../../../utils/response");
 const AppError = require("../../../utils/AppError");
 const service = require("./classEnrollment.service");
 const classService = require("../class.service");
+const db = require("../../../config/database");
+const paymentsService = require("../../payments/payments.service");
+const { hasActiveStudentSubscription } = require("../../plans/subscription.helper");
 
 exports.enroll = catchAsync(async (req, res) => {
   const { classId } = req.params;
@@ -22,6 +25,21 @@ exports.enroll = catchAsync(async (req, res) => {
   }
   const exists = await service.findEnrollment(user_id, classId);
   if (exists) return sendSuccess(res, exists, "Already enrolled");
+
+  if (Number(cls.price) > 0) {
+    const payment = await db("payments")
+      .where({
+        user_id,
+        item_id: classId,
+        item_type: "class",
+        status: paymentsService.STATUS.PAID,
+      })
+      .first();
+    const hasSubscription = await hasActiveStudentSubscription(user_id);
+    if (!payment && !hasSubscription) {
+      throw new AppError("Payment required", 400);
+    }
+  }
 
   const data = { id: uuidv4(), user_id, class_id: classId, status: "enrolled" };
   await service.createEnrollment(data);

--- a/backend/src/modules/plans/subscription.helper.js
+++ b/backend/src/modules/plans/subscription.helper.js
@@ -1,0 +1,12 @@
+const db = require("../../config/database");
+
+exports.hasActiveStudentSubscription = async (userId) => {
+  const sub = await db("user_subscriptions")
+    .where({ user_id: userId })
+    .where({ status: "active" })
+    .first();
+  if (!sub) return false;
+  if (sub.end_date && new Date(sub.end_date) < new Date()) return false;
+  return true;
+};
+


### PR DESCRIPTION
## Summary
- Validate payments or subscription status before enrolling in paid classes
- Add helper to verify active student subscriptions
- Test enrollments for unpaid and subscription scenarios

## Testing
- `npm test` *(fails: process.exit called with "1" – missing database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cb7a5b1083289a52811cb90738d1