### PR TITLE
Add plan subscription handling

### DIFF
--- a/backend/src/modules/payments/paymentAccess.js
+++ b/backend/src/modules/payments/paymentAccess.js
@@ -3,6 +3,8 @@ const libraryService = require('../library/library.service');
 const enrollmentService = require('../classes/enrollments/classEnrollment.service');
 const tutorialEnrollmentService = require('../users/tutorials/enrollments/tutorialEnrollment.service');
 const { v4: uuidv4 } = require('uuid');
+const plansService = require('../plans/plans.service');
+const subscriptionService = require('../subscriptions/subscription.service');
 
 exports.grantAccess = async (payment) => {
   try {
@@ -22,6 +24,19 @@ exports.grantAccess = async (payment) => {
         tutorial_id: payment.item_id,
         status: 'enrolled',
       });
+    } else if (payment.item_type === 'plan') {
+      const plan = await plansService.getPlanById(payment.item_id);
+      if (plan) {
+        const interval =
+          Number(payment.amount) === Number(plan.price_yearly)
+            ? 'yearly'
+            : 'monthly';
+        await subscriptionService.createOrRenewSubscription({
+          user_id: payment.user_id,
+          plan_id: payment.item_id,
+          interval,
+        });
+      }
     }
   } catch (err) {
     logger.error('Failed to finalize enrollment after payment:', err);

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -16,6 +16,8 @@ const paypalService = require("../../services/paypalService");
 const notificationService = require("../notifications/notifications.service");
 const mailService = require("../../services/mailService");
 const couponService = require("../coupons/coupons.service");
+const plansService = require("../plans/plans.service");
+const subscriptionService = require("../subscriptions/subscription.service");
 
 const DEFAULT_PLATFORM_CUT = {
   class: 15,
@@ -216,6 +218,25 @@ exports.createPayment = catchAsync(async (req, res) => {
       });
     } catch (err) {
       logger.error("Failed to enroll in tutorial after payment:", err);
+    }
+  }
+
+  if (item_type === "plan" && payment.status === STATUS.PAID) {
+    try {
+      const plan = await plansService.getPlanById(item_id);
+      if (plan) {
+        const interval =
+          Number(verifiedAmount) === Number(plan.price_yearly)
+            ? "yearly"
+            : "monthly";
+        await subscriptionService.createOrRenewSubscription({
+          user_id,
+          plan_id: item_id,
+          interval,
+        });
+      }
+    } catch (err) {
+      logger.error("Failed to activate subscription after payment:", err);
     }
   }
 

--- a/backend/src/modules/subscriptions/subscription.service.js
+++ b/backend/src/modules/subscriptions/subscription.service.js
@@ -1,0 +1,48 @@
+const db = require("../../config/database");
+const { v4: uuidv4 } = require("uuid");
+
+const addInterval = (date, interval) => {
+  const d = new Date(date);
+  if (interval === "yearly") d.setFullYear(d.getFullYear() + 1);
+  else d.setMonth(d.getMonth() + 1);
+  return d;
+};
+
+exports.createOrRenewSubscription = async ({ user_id, plan_id, interval }) => {
+  return db.transaction(async (trx) => {
+    const existing = await trx("user_subscriptions")
+      .where({ user_id, plan_id })
+      .orderBy("end_date", "desc")
+      .first();
+    const now = new Date();
+    let start = now;
+    let base = now;
+    if (existing && existing.end_date && new Date(existing.end_date) > now) {
+      start = existing.start_date;
+      base = new Date(existing.end_date);
+    }
+    const end = addInterval(base, interval);
+    if (existing) {
+      const [row] = await trx("user_subscriptions")
+        .where({ id: existing.id })
+        .update({ start_date: start, end_date: end, status: "active" })
+        .returning("*");
+      return row;
+    } else {
+      const [row] = await trx("user_subscriptions")
+        .insert({ id: uuidv4(), user_id, plan_id, start_date: start, end_date: end, status: "active" })
+        .returning("*");
+      return row;
+    }
+  });
+};
+
+exports.getActiveByUser = (user_id) => {
+  const now = new Date();
+  return db("user_subscriptions as us")
+    .join("plans as p", "us.plan_id", "p.id")
+    .select("us.*", "p.name", "p.slug")
+    .where("us.user_id", user_id)
+    .andWhere("us.status", "active")
+    .andWhere("us.end_date", ">", now);
+};

--- a/backend/src/modules/subscriptions/subscriptions.controller.js
+++ b/backend/src/modules/subscriptions/subscriptions.controller.js
@@ -1,0 +1,8 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./subscription.service");
+
+exports.getMySubscriptions = catchAsync(async (req, res) => {
+  const subs = await service.getActiveByUser(req.user.id);
+  sendSuccess(res, subs);
+});

--- a/backend/src/modules/subscriptions/subscriptions.routes.js
+++ b/backend/src/modules/subscriptions/subscriptions.routes.js
@@ -1,0 +1,8 @@
+const router = require("express").Router();
+const controller = require("./subscriptions.controller");
+const { verifyToken } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken);
+router.get("/me", controller.getMySubscriptions);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -146,6 +146,10 @@ app.use("/api/community", require("./modules/community/public/public.routes"));
 app.use("/api/related-questions", require("./modules/community/public/relatedQuestions.routes"));
 app.use("/api/roles", require("./modules/roles/roles.routes"));
 app.use("/api/plans", require("./modules/plans/plans.routes"));
+app.use(
+  "/api/user-subscriptions",
+  require("./modules/subscriptions/subscriptions.routes")
+);
 // Register admin routes before public routes to prevent public routes from catching
 // requests intended for admin endpoints such as "/api/payment-methods/admin".
 app.use(

--- a/backend/tests/subscriptionRoutes.test.js
+++ b/backend/tests/subscriptionRoutes.test.js
@@ -1,0 +1,29 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/subscriptions/subscription.service', () => ({
+  getActiveByUser: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 'user1' }; next(); },
+}));
+
+const service = require('../src/modules/subscriptions/subscription.service');
+const routes = require('../src/modules/subscriptions/subscriptions.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/user-subscriptions', routes);
+
+describe('GET /api/user-subscriptions/me', () => {
+  it('returns active subscriptions for authenticated user', async () => {
+    const mock = [{ id: 's1', plan_id: 'p1' }];
+    service.getActiveByUser.mockResolvedValue(mock);
+
+    const res = await request(app).get('/api/user-subscriptions/me');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.getActiveByUser).toHaveBeenCalledWith('user1');
+  });
+});


### PR DESCRIPTION
## Summary
- handle `plan` payments and activate subscriptions
- grant plan access upon payment finalization
- add subscription service and routes to view active subscriptions
- add basic subscription route test

## Testing
- `npm test` *(fails: process.exit errors and other failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cb798c1883289ded213756857941