### PR TITLE
Prevent duplicate class enrollments

### DIFF
--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -9,6 +9,10 @@ exports.createEnrollment = async (data) => {
   return row;
 };
 
+exports.updateEnrollment = async (user_id, class_id, data) => {
+  return db("class_enrollments").where({ user_id, class_id }).update(data);
+};
+
 exports.countEnrollments = async (class_id) => {
   const [row] = await db("class_enrollments")
     .where({ class_id })

--- a/backend/src/modules/payments/paymentAccess.js
+++ b/backend/src/modules/payments/paymentAccess.js
@@ -9,12 +9,24 @@ exports.grantAccess = async (payment) => {
     if (payment.item_type === 'book') {
       await libraryService.recordPurchase(payment.user_id, payment.item_id, payment.amount);
     } else if (payment.item_type === 'class') {
-      await enrollmentService.createEnrollment({
-        id: uuidv4(),
-        user_id: payment.user_id,
-        class_id: payment.item_id,
-        status: 'enrolled',
-      });
+      const existing = await enrollmentService.findEnrollment(
+        payment.user_id,
+        payment.item_id
+      );
+      if (existing) {
+        if (existing.status !== 'enrolled') {
+          await enrollmentService.updateEnrollment(payment.user_id, payment.item_id, {
+            status: 'enrolled',
+          });
+        }
+      } else {
+        await enrollmentService.createEnrollment({
+          id: uuidv4(),
+          user_id: payment.user_id,
+          class_id: payment.item_id,
+          status: 'enrolled',
+        });
+      }
     } else if (payment.item_type === 'tutorial') {
       await tutorialEnrollmentService.createEnrollment({
         id: uuidv4(),

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -195,12 +195,24 @@ exports.createPayment = catchAsync(async (req, res) => {
 
   if (item_type === "class" && payment.status === STATUS.PAID) {
     try {
+      const existingEnrollment = await enrollmentService.findEnrollment(
+        user_id,
+        item_id
+      );
+      if (existingEnrollment) {
+        if (existingEnrollment.status !== "enrolled") {
+          await enrollmentService.updateEnrollment(user_id, item_id, {
+            status: "enrolled",
+          });
+        }
+      } else {
         await enrollmentService.createEnrollment({
           id: uuidv4(),
           user_id,
           class_id: item_id,
           status: "enrolled",
         });
+      }
     } catch (err) {
       logger.error("Failed to enroll after payment:", err);
     }

--- a/backend/tests/paymentDuplicateEnrollment.test.js
+++ b/backend/tests/paymentDuplicateEnrollment.test.js
@@ -14,25 +14,17 @@ jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
   getById: jest.fn().mockResolvedValue({ id: 'm1', type: 'card', active: true }),
 }));
 
-jest.mock('../src/services/paypalService', () => ({
-  captureOrder: jest.fn(),
-}));
-
-jest.mock('../src/middleware/auth/authMiddleware', () => ({
-  verifyToken: (req, _res, next) => { req.user = { id: 'admin1' }; next(); },
-  isAdmin: (_req, _res, next) => next(),
-}));
-
 jest.mock('../src/services/smsService', () => ({ sendSMS: jest.fn() }));
 jest.mock('../src/modules/users/user.model', () => ({ findById: jest.fn().mockResolvedValue({}) }));
 jest.mock('../src/modules/library/library.service', () => ({ recordPurchase: jest.fn() }));
+
 jest.mock('../src/modules/classes/enrollments/classEnrollment.service', () => ({
-  findEnrollment: jest.fn().mockResolvedValue(null),
+  findEnrollment: jest.fn(),
   createEnrollment: jest.fn(),
   updateEnrollment: jest.fn(),
 }));
 jest.mock('../src/modules/users/tutorials/enrollments/tutorialEnrollment.service', () => ({
-  findEnrollment: jest.fn().mockResolvedValue(null),
+  findEnrollment: jest.fn(),
   createEnrollment: jest.fn(),
   updateEnrollment: jest.fn(),
 }));
@@ -43,9 +35,15 @@ jest.mock('../src/modules/coupons/coupons.service', () => ({
   incrementUsage: jest.fn(),
 }));
 
-const service = require('../src/modules/payments/payments.service');
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (_req, _res, next) => { _req.user = { id: 'u1' }; next(); },
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const paymentsService = require('../src/modules/payments/payments.service');
 const enrollmentService = require('../src/modules/classes/enrollments/classEnrollment.service');
 const routes = require('../src/modules/payments/payments.routes');
+const { grantAccess } = require('../src/modules/payments/paymentAccess');
 
 const app = express();
 app.use(express.json());
@@ -53,23 +51,35 @@ app.use('/api/payments/admin', routes);
 const errorHandler = require('../src/middleware/errorHandler');
 app.use(errorHandler);
 
-describe('POST /api/payments/admin', () => {
-  it('creates payment with installments and enrolls', async () => {
-    service.create.mockResolvedValue({ id: 'p1', status: 'paid' });
+describe('duplicate enrollment prevention', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates existing class enrollment instead of creating new one', async () => {
+    paymentsService.create.mockResolvedValue({ id: 'p1', status: 'paid' });
+    enrollmentService.findEnrollment.mockResolvedValue({ user_id: 'u1', class_id: 'c1', status: 'pending' });
+
     const res = await request(app).post('/api/payments/admin').send({
       user_id: 'u1',
       method_id: 'm1',
       item_type: 'class',
       item_id: 'c1',
-      amount: 10,
-      allow_installments: true,
-      installments: 3,
+      amount: 100,
       status: 'paid',
     });
     expect(res.status).toBe(200);
-    const args = service.create.mock.calls[0];
-    expect(args[0].installments).toBe(3);
-    expect(args[1]).toHaveLength(2);
-    expect(enrollmentService.createEnrollment).toHaveBeenCalled();
+    expect(enrollmentService.findEnrollment).toHaveBeenCalledWith('u1', 'c1');
+    expect(enrollmentService.createEnrollment).not.toHaveBeenCalled();
+    expect(enrollmentService.updateEnrollment).toHaveBeenCalledWith('u1', 'c1', { status: 'enrolled' });
+  });
+
+  it('skips creation when enrollment already enrolled in grantAccess', async () => {
+    enrollmentService.findEnrollment.mockResolvedValue({ user_id: 'u1', class_id: 'c1', status: 'enrolled' });
+
+    await grantAccess({ item_type: 'class', item_id: 'c1', user_id: 'u1', amount: 100 });
+    expect(enrollmentService.findEnrollment).toHaveBeenCalledWith('u1', 'c1');
+    expect(enrollmentService.createEnrollment).not.toHaveBeenCalled();
+    expect(enrollmentService.updateEnrollment).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- check for existing class enrollment before creating new records in payment creation and access flows
- add service helper to update existing enrollments
- test duplicate prevention when processing payments

## Testing
- `npm test tests/paymentInstallments.test.js tests/paymentDuplicateEnrollment.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b2cb7848788328ba815aa6b63aa622