### PR TITLE
Validate student-only subscriptions

### DIFF
--- a/backend/src/modules/plans/__tests__/subscription.helper.test.js
+++ b/backend/src/modules/plans/__tests__/subscription.helper.test.js
@@ -1,0 +1,30 @@
+jest.mock('../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.join = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn();
+  return db;
+});
+
+const db = require('../../../config/database');
+const { hasActiveStudentSubscription } = require('../subscription.helper');
+
+describe('hasActiveStudentSubscription', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true for active student subscription', async () => {
+    db.first.mockResolvedValue({ end_date: new Date(Date.now() + 86400000) });
+    const result = await hasActiveStudentSubscription('user1');
+    expect(result).toBe(true);
+    expect(db.join).toHaveBeenCalledWith('plans as p', 'us.plan_id', 'p.id');
+    expect(db.where).toHaveBeenCalledWith('p.target_role', 'student');
+  });
+
+  it('returns false for instructor-only subscription', async () => {
+    db.first.mockResolvedValue(null);
+    const result = await hasActiveStudentSubscription('user1');
+    expect(result).toBe(false);
+  });
+});

--- a/backend/src/modules/plans/subscription.helper.js
+++ b/backend/src/modules/plans/subscription.helper.js
@@ -1,9 +1,10 @@
 const db = require("../../config/database");
 
 exports.hasActiveStudentSubscription = async (userId) => {
-  const sub = await db("user_subscriptions")
-    .where({ user_id: userId })
-    .where({ status: "active" })
+  const sub = await db("user_subscriptions as us")
+    .join("plans as p", "us.plan_id", "p.id")
+    .where({ "us.user_id": userId, "us.status": "active" })
+    .where("p.target_role", "student")
     .first();
   if (!sub) return false;
   if (sub.end_date && new Date(sub.end_date) < new Date()) return false;


### PR DESCRIPTION
## Summary
- Join plans table when checking active subscriptions and ensure only student plans qualify
- Cover subscription helper with tests verifying instructor plans are rejected

## Testing
- `npx jest --runTestsByPath src/modules/plans/__tests__/subscription.helper.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b31ebd3d9c8328a6a47186a241898f