### PR TITLE
Enforce subscription checks on instructor class updates

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -14,6 +14,7 @@ jest.mock('../class.service', () => ({
   createClass: jest.fn(),
   getAllClasses: jest.fn(),
   getClassesByInstructor: jest.fn(),
+  updateClass: jest.fn(),
   togglePublishStatus: jest.fn(),
   updateModeration: jest.fn()
 }));
@@ -39,6 +40,14 @@ jest.mock('../enrollments/classEnrollment.service', () => ({
   markCompleted: jest.fn(),
   getByUser: jest.fn(),
 }));
+jest.mock('../classUploadMiddleware', () => (req, _res, next) => next());
+const mockVerifyClassOwnership = jest.fn((req, _res, next) => next());
+jest.mock('../../../middleware/auth/verifyClassOwnership', () => mockVerifyClassOwnership);
+jest.mock('../../../middleware/validate', () => () => (req, _res, next) => next());
+const mockVerifyInstructorSubscription = jest.fn((req, res, _next) =>
+  res.status(403).json({ message: 'Active instructor subscription required' })
+);
+jest.mock('../../plans/verifyInstructorSubscription', () => mockVerifyInstructorSubscription);
 // Mock auth middleware to bypass authentication
 jest.mock('../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
@@ -144,5 +153,21 @@ describe('Class routes', () => {
     expect(res.statusCode).toBe(200);
     expect(service.updateModeration).toHaveBeenCalledWith('1', 'Approved');
     expect(res.body.data).toEqual(approved);
+  });
+
+  test('instructor update blocked without active plan', async () => {
+    const res = await request(app)
+      .put('/classes/instructor/1')
+      .send({ title: 'Update' });
+    expect(res.statusCode).toBe(403);
+    expect(mockVerifyInstructorSubscription).toHaveBeenCalled();
+    expect(service.updateClass).not.toHaveBeenCalled();
+  });
+
+  test('instructor publish blocked without active plan', async () => {
+    const res = await request(app).patch('/classes/instructor/1/status');
+    expect(res.statusCode).toBe(403);
+    expect(mockVerifyInstructorSubscription).toHaveBeenCalled();
+    expect(service.togglePublishStatus).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -170,6 +170,7 @@ router.put(
   verifyToken,
   isInstructor,
   verifyClassOwnership,
+  verifyInstructorSubscription,
   upload,
   validate(validator.update),
   controller.updateClass
@@ -186,6 +187,7 @@ router.patch(
   verifyToken,
   isInstructor,
   verifyClassOwnership,
+  verifyInstructorSubscription,
   controller.toggleClassStatus
 );
 


### PR DESCRIPTION
## Summary
- protect instructor update and status endpoints with subscription middleware
- add tests ensuring instructors without active plans cannot modify or publish classes

## Testing
- `npm test -- src/modules/classes/__tests__/class.routes.test.js`
- `npm test` *(fails: process.exit called with missing database configuration and other test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b31ebba7a483289372f7c59acf8a35