### PR TITLE
Handle reactivating cancelled class enrollments

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -16,6 +16,7 @@ jest.mock('../../../../config/database', () => {
 jest.mock('../classEnrollment.service', () => ({
   findEnrollment: jest.fn(),
   createEnrollment: jest.fn(),
+  updateEnrollment: jest.fn(),
   countEnrollments: jest.fn(),
   markCompleted: jest.fn(),
   getByUser: jest.fn(),
@@ -129,6 +130,46 @@ describe('Class enrollment routes', () => {
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(200);
     expect(service.createEnrollment).toHaveBeenCalled();
+  });
+
+  test('reactivate cancelled enrollment when capacity available', async () => {
+    classService.getClassById.mockResolvedValue({
+      status: 'published',
+      moderation_status: 'Approved',
+      max_students: 1,
+    });
+    service.countEnrollments.mockResolvedValue(0);
+    service.findEnrollment.mockResolvedValue({
+      user_id: 'test-user',
+      class_id: 'abc',
+      status: 'cancelled',
+    });
+    service.updateEnrollment.mockResolvedValue(1);
+    const res = await request(app).post('/classes/enroll/abc');
+    expect(res.statusCode).toBe(200);
+    expect(service.updateEnrollment).toHaveBeenCalledWith(
+      'test-user',
+      'abc',
+      expect.objectContaining({ status: 'enrolled' })
+    );
+    expect(service.createEnrollment).not.toHaveBeenCalled();
+  });
+
+  test('prevent re-enrollment if class full after cancellation', async () => {
+    classService.getClassById.mockResolvedValue({
+      status: 'published',
+      moderation_status: 'Approved',
+      max_students: 1,
+    });
+    service.countEnrollments.mockResolvedValue(1);
+    service.findEnrollment.mockResolvedValue({
+      user_id: 'test-user',
+      class_id: 'abc',
+      status: 'cancelled',
+    });
+    const res = await request(app).post('/classes/enroll/abc');
+    expect(res.statusCode).toBe(400);
+    expect(service.updateEnrollment).not.toHaveBeenCalled();
   });
 
   test('get my enrollments', async () => {

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.service.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.service.test.js
@@ -1,0 +1,61 @@
+const { newDb } = require('pg-mem');
+const { v4: uuidv4 } = require('uuid');
+
+const db = newDb();
+db.public.registerFunction({ name: 'uuid_generate_v4', returns: 'uuid', implementation: uuidv4 });
+const mockDb = db.adapters.createKnex();
+
+jest.mock('../../../../config/database', () => mockDb);
+
+const service = require('../classEnrollment.service');
+
+describe('classEnrollment.service capacity', () => {
+  beforeAll(async () => {
+    await mockDb.schema.createTable('class_enrollments', (table) => {
+      table.uuid('id').primary();
+      table.uuid('user_id');
+      table.uuid('class_id');
+      table.string('status');
+      table.timestamp('enrolled_at');
+    });
+  });
+
+  afterAll(async () => {
+    await mockDb.destroy();
+  });
+
+  beforeEach(async () => {
+    await mockDb('class_enrollments').del();
+  });
+
+  test('countEnrollments ignores cancelled', async () => {
+    const classId = uuidv4();
+    await mockDb('class_enrollments').insert([
+      { id: uuidv4(), user_id: uuidv4(), class_id: classId, status: 'enrolled' },
+      { id: uuidv4(), user_id: uuidv4(), class_id: classId, status: 'cancelled' },
+    ]);
+    const count = await service.countEnrollments(classId);
+    expect(count).toBe(1);
+  });
+
+  test('capacity updates when cancelling and re-enrolling', async () => {
+    const classId = uuidv4();
+    const userId = uuidv4();
+    await mockDb('class_enrollments').insert({
+      id: uuidv4(),
+      user_id: userId,
+      class_id: classId,
+      status: 'enrolled',
+    });
+    let count = await service.countEnrollments(classId);
+    expect(count).toBe(1);
+
+    await service.updateEnrollment(userId, classId, { status: 'cancelled' });
+    count = await service.countEnrollments(classId);
+    expect(count).toBe(0);
+
+    await service.updateEnrollment(userId, classId, { status: 'enrolled' });
+    count = await service.countEnrollments(classId);
+    expect(count).toBe(1);
+  });
+});

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -24,7 +24,8 @@ exports.enroll = catchAsync(async (req, res) => {
     }
   }
   const exists = await service.findEnrollment(user_id, classId);
-  if (exists) return sendSuccess(res, exists, "Already enrolled");
+  if (exists && exists.status !== "cancelled")
+    return sendSuccess(res, exists, "Already enrolled");
 
   if (Number(cls.price) > 0) {
     const payment = await db("payments")
@@ -39,6 +40,18 @@ exports.enroll = catchAsync(async (req, res) => {
     if (!payment && !hasSubscription) {
       throw new AppError("Payment required", 400);
     }
+  }
+  if (exists && exists.status === "cancelled") {
+    const enrolled_at = new Date();
+    await service.updateEnrollment(user_id, classId, {
+      status: "enrolled",
+      enrolled_at,
+    });
+    return sendSuccess(
+      res,
+      { ...exists, status: "enrolled", enrolled_at },
+      "Enrolled successfully"
+    );
   }
 
   const data = { id: uuidv4(), user_id, class_id: classId, status: "enrolled" };

--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -16,6 +16,7 @@ exports.updateEnrollment = async (user_id, class_id, data) => {
 exports.countEnrollments = async (class_id) => {
   const [row] = await db("class_enrollments")
     .where({ class_id })
+    .whereNot({ status: "cancelled" })
     .count("id as count");
   return parseInt(row.count, 10) || 0;
 };


### PR DESCRIPTION
## Summary
- ignore cancelled records when counting class enrollments
- allow re-enrolling a previously cancelled student
- cover cancellation and reactivation flows with unit tests

## Testing
- `npm test src/modules/classes/enrollments/__tests__/classEnrollment.service.test.js src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js`
- `npm test` *(fails: process.exit(1) due to missing database config)*

------
https://chatgpt.com/codex/tasks/task_e_68b31ebaac188328b64175e01bd84958