### PR TITLE
Restrict instructor changes to instructor ID

### DIFF
--- a/backend/src/modules/classes/__tests__/class.controller.test.js
+++ b/backend/src/modules/classes/__tests__/class.controller.test.js
@@ -9,6 +9,8 @@ jest.mock('../class.service', () => ({
   createClass: jest.fn(),
   addClassTags: jest.fn(),
   getClassTags: jest.fn(),
+  getClassById: jest.fn(),
+  updateClass: jest.fn(),
 }));
 
 jest.mock('../classTag.service', () => ({
@@ -44,6 +46,7 @@ describe('class.controller createClass', () => {
       body: { instructor_id: 'other', title: 'Test', status: 'published' },
       user: { id: 'instructor1', role: 'instructor' },
       files: {},
+      subscription: { current_courses: 0, max_courses: 5 },
     };
     const res = {
       status: jest.fn().mockReturnThis(),
@@ -65,6 +68,90 @@ describe('class.controller createClass', () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ instructor_id: 'instructor1' }),
+      })
+    );
+  });
+});
+
+describe('class.controller updateClass', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('instructor cannot change instructor_id', async () => {
+    service.getClassById.mockResolvedValue({
+      id: 'class1',
+      instructor_id: 'instructor1',
+      title: 'Title',
+    });
+    service.updateClass.mockImplementation(async (_id, data) => data);
+
+    const req = {
+      params: { id: 'class1' },
+      body: { instructor_id: 'other' },
+      user: { id: 'instructor1', role: 'instructor' },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      res.json.mockImplementation((data) => {
+        resolve();
+        return data;
+      });
+      controller.updateClass(req, res, next);
+    });
+
+    expect(service.updateClass).toHaveBeenCalledWith(
+      'class1',
+      expect.objectContaining({ instructor_id: 'instructor1' })
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ instructor_id: 'instructor1' }),
+      })
+    );
+  });
+
+  test('admin can change instructor_id', async () => {
+    service.getClassById.mockResolvedValue({
+      id: 'class1',
+      instructor_id: 'admin1',
+      title: 'Title',
+    });
+    service.updateClass.mockImplementation(async (_id, data) => data);
+
+    const req = {
+      params: { id: 'class1' },
+      body: { instructor_id: 'newInst' },
+      user: { id: 'admin1', role: 'admin', full_name: 'Admin' },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      res.json.mockImplementation((data) => {
+        resolve();
+        return data;
+      });
+      controller.updateClass(req, res, next);
+    });
+
+    expect(service.updateClass).toHaveBeenCalledWith(
+      'class1',
+      expect.objectContaining({ instructor_id: 'newInst' })
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ instructor_id: 'newInst' }),
       })
     );
   });

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -203,6 +203,9 @@ exports.updateClass = catchAsync(async (req, res) => {
     }
     data.demo_video_url = `/uploads/classes/${req.files.demo_video[0].filename}`;
   }
+  if (req.user.role === 'instructor') {
+    data.instructor_id = existing.instructor_id;
+  }
   const tags = rawTags ? JSON.parse(rawTags) : null;
   const cls = await service.updateClass(req.params.id, data);
   if (tags) {

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -85,7 +85,7 @@ router.put(
   verifyToken,
   isAdmin,
   upload,
-  validate(validator.update),
+  validate(validator.adminUpdate),
   controller.updateClass
 );
 router.delete(

--- a/backend/src/modules/classes/class.validator.js
+++ b/backend/src/modules/classes/class.validator.js
@@ -53,6 +53,50 @@ exports.create = z.object({
 exports.update = z.object({
   body: z
     .object({
+      title: z.string().min(3).max(255).optional(),
+      description: z.string().optional(),
+      level: z.string().optional(),
+      cover_image: z.string().optional(),
+      start_date: z
+        .string()
+        .refine((val) => !isNaN(Date.parse(val)), {
+          message: "Invalid date format",
+        })
+        .optional(),
+      end_date: z
+        .string()
+        .refine((val) => !isNaN(Date.parse(val)), {
+          message: "Invalid date format",
+        })
+        .optional(),
+      category_id: z.string().uuid().optional(),
+      price: z.preprocess(toNumber, z.number().optional()),
+      max_students: z.preprocess(toNumber, z.number().int().optional()),
+      language: z.string().optional(),
+      demo_video_url: z.string().optional(),
+      allow_installments: z.preprocess(
+        (v) => (typeof v === 'string' ? v === 'true' : v),
+        z.boolean().optional()
+      ),
+      tags: z.string().optional(),
+      slug: z.string().optional(),
+      status: z.enum(["draft", "published", "archived"]).optional(),
+    })
+    .refine(
+      (data) =>
+        !data.start_date ||
+        !data.end_date ||
+        new Date(data.end_date) >= new Date(data.start_date),
+      {
+        message: "end_date cannot be earlier than start_date",
+        path: ["end_date"],
+      }
+    )
+});
+
+exports.adminUpdate = z.object({
+  body: z
+    .object({
       instructor_id: z.string().uuid().optional(),
       title: z.string().min(3).max(255).optional(),
       description: z.string().optional(),


### PR DESCRIPTION
## Summary
- Split class update validator: instructors cannot submit `instructor_id`, admins can via `adminUpdate`
- Force instructors' updates to retain original `instructor_id`
- Test coverage for instructor vs admin ability to change `instructor_id`

## Testing
- `npm test -- src/modules/classes/__tests__/class.controller.test.js`
- `npm test` *(fails: process.exit called due to missing DB config and other pre-existing failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b31eb8fa4883288681d3b836df9392