### PR TITLE
Handle duplicate phone/email on instructor profile update

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -168,6 +168,17 @@ exports.updateProfile = async (req, res) => {
     res.json(updated);
   } catch (err) {
     logger.error("Profile update error:", err);
+
+    // Handle unique constraint violations for email and phone
+    if (err.code === "23505") {
+      if (err.constraint === "users_email_unique") {
+        return res.status(400).json({ message: "Email already exists" });
+      }
+      if (err.constraint === "users_phone_unique") {
+        return res.status(400).json({ message: "Phone number already exists" });
+      }
+    }
+
     res.status(500).json({ message: "Failed to update profile" });
   }
 };


### PR DESCRIPTION
## Summary
- gracefully handle unique constraint errors when updating instructor profile

## Testing
- `npm test` *(fails: process.exit called due to missing database configuration; multiple failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b31eabc38c8328ad254947db0e716d