### PR TITLE
feat: add subscription plan coverage for class enrollment

### DIFF
--- a/backend/src/migrations/20250919000000_add_included_plans_to_online_classes.js
+++ b/backend/src/migrations/20250919000000_add_included_plans_to_online_classes.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('online_classes', function(table) {
+    table.jsonb('included_plans').notNullable().defaultTo('[]');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('online_classes', function(table) {
+    table.dropColumn('included_plans');
+  });
+};

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -25,6 +25,7 @@ exports.getAllClasses = async ({ page = 1, limit = 10 } = {}) => {
       "c.price",
       "c.status",
       "c.moderation_status",
+      "c.included_plans",
       "c.instructor_id",
       "u.full_name as instructor",
       "cat.name as category",
@@ -42,6 +43,7 @@ exports.getAllClasses = async ({ page = 1, limit = 10 } = {}) => {
       "c.price",
       "c.status",
       "c.moderation_status",
+      "c.included_plans",
       "c.instructor_id",
       "u.full_name",
       "cat.name"
@@ -108,6 +110,7 @@ exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } =
       "c.max_students",
       "c.status",
       "c.moderation_status",
+      "c.included_plans",
       "cat.name as category",
       db.raw(
         "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
@@ -125,6 +128,7 @@ exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } =
       "c.max_students",
       "c.status",
       "c.moderation_status",
+      "c.included_plans",
       "cat.name"
     )
     .orderBy("c.created_at", "desc")

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -42,10 +42,10 @@ jest.mock('../../../../middleware/auth/authMiddleware', () => ({
 }));
 
 jest.mock('../../../plans/subscription.helper', () => ({
-  hasActiveStudentSubscription: jest.fn(),
+  getActiveStudentPlanId: jest.fn(),
 }));
 
-const { hasActiveStudentSubscription } = require('../../../plans/subscription.helper');
+const { getActiveStudentPlanId } = require('../../../plans/subscription.helper');
 const db = require('../../../../config/database');
 
 const routes = require('../../class.routes');
@@ -110,26 +110,40 @@ describe('Class enrollment routes', () => {
     service.countEnrollments.mockResolvedValue(0);
     service.findEnrollment.mockResolvedValue(null);
     db.first.mockResolvedValueOnce(null); // payment check
-    db.first.mockResolvedValueOnce(null); // subscription check
-    hasActiveStudentSubscription.mockResolvedValue(false);
+    getActiveStudentPlanId.mockResolvedValue(null);
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(400);
   });
 
-  test('allow enrollment if class requires payment but user has active subscription', async () => {
+  test('allow enrollment when class covered by subscription', async () => {
     classService.getClassById.mockResolvedValue({
       status: 'published',
       moderation_status: 'Approved',
       price: 50,
+      included_plans: ['plan1'],
     });
     service.countEnrollments.mockResolvedValue(0);
     service.findEnrollment.mockResolvedValue(null);
-    db.first.mockResolvedValueOnce(null); // payment check
-    hasActiveStudentSubscription.mockResolvedValue(true);
+    getActiveStudentPlanId.mockResolvedValue('plan1');
     service.createEnrollment.mockResolvedValue({ id: '1' });
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(200);
     expect(service.createEnrollment).toHaveBeenCalled();
+  });
+
+  test('reject enrollment when subscription active but class not covered', async () => {
+    classService.getClassById.mockResolvedValue({
+      status: 'published',
+      moderation_status: 'Approved',
+      price: 50,
+      included_plans: ['plan2'],
+    });
+    service.countEnrollments.mockResolvedValue(0);
+    service.findEnrollment.mockResolvedValue(null);
+    db.first.mockResolvedValueOnce(null); // payment check
+    getActiveStudentPlanId.mockResolvedValue('plan1');
+    const res = await request(app).post('/classes/enroll/abc');
+    expect(res.statusCode).toBe(400);
   });
 
   test('reactivate cancelled enrollment when capacity available', async () => {

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -7,7 +7,7 @@ const service = require("./classEnrollment.service");
 const classService = require("../class.service");
 const db = require("../../../config/database");
 const paymentsService = require("../../payments/payments.service");
-const { hasActiveStudentSubscription } = require("../../plans/subscription.helper");
+const { getActiveStudentPlanId } = require("../../plans/subscription.helper");
 
 exports.enroll = catchAsync(async (req, res) => {
   const { classId } = req.params;
@@ -27,7 +27,12 @@ exports.enroll = catchAsync(async (req, res) => {
   if (exists && exists.status !== "cancelled")
     return sendSuccess(res, exists, "Already enrolled");
 
-  if (Number(cls.price) > 0) {
+  const activePlanId = await getActiveStudentPlanId(user_id);
+  const includedPlans = Array.isArray(cls.included_plans) ? cls.included_plans : [];
+  const coveredBySubscription =
+    activePlanId && includedPlans.includes(activePlanId);
+
+  if (Number(cls.price) > 0 && !coveredBySubscription) {
     const payment = await db("payments")
       .where({
         user_id,
@@ -36,8 +41,7 @@ exports.enroll = catchAsync(async (req, res) => {
         status: paymentsService.STATUS.PAID,
       })
       .first();
-    const hasSubscription = await hasActiveStudentSubscription(user_id);
-    if (!payment && !hasSubscription) {
+    if (!payment) {
       throw new AppError("Payment required", 400);
     }
   }

--- a/backend/src/modules/plans/subscription.helper.js
+++ b/backend/src/modules/plans/subscription.helper.js
@@ -11,3 +11,14 @@ exports.hasActiveStudentSubscription = async (userId) => {
   return true;
 };
 
+exports.getActiveStudentPlanId = async (userId) => {
+  const sub = await db("user_subscriptions as us")
+    .join("plans as p", "us.plan_id", "p.id")
+    .where({ "us.user_id": userId, "us.status": "active" })
+    .where("p.target_role", "student")
+    .first();
+  if (!sub) return null;
+  if (sub.end_date && new Date(sub.end_date) < new Date()) return null;
+  return sub.plan_id;
+};
+


### PR DESCRIPTION
## Summary
- add `included_plans` column to online classes
- expose `included_plans` in class service
- check active subscription plans before requiring class payments
- add helper to fetch user's active plan id
- cover subscription access logic in enrollment tests

## Testing
- `npm test src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js`
- `npm test src/modules/classes/enrollments/__tests__/classEnrollment.service.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b32f6dee1c8328a4019fb032afed7b