### PR TITLE
feat: add subscription create route

### DIFF
--- a/backend/src/modules/subscriptions/subscriptions.controller.js
+++ b/backend/src/modules/subscriptions/subscriptions.controller.js
@@ -6,3 +6,13 @@ exports.getMySubscriptions = catchAsync(async (req, res) => {
   const subs = await service.getActiveByUser(req.user.id);
   sendSuccess(res, subs);
 });
+
+exports.createOrRenewSubscription = catchAsync(async (req, res) => {
+  const { plan_id, interval = "monthly" } = req.body;
+  const subscription = await service.createOrRenewSubscription({
+    user_id: req.user.id,
+    plan_id,
+    interval,
+  });
+  sendSuccess(res, subscription);
+});

--- a/backend/src/modules/subscriptions/subscriptions.routes.js
+++ b/backend/src/modules/subscriptions/subscriptions.routes.js
@@ -4,5 +4,6 @@ const { verifyToken } = require("../../middleware/auth/authMiddleware");
 
 router.use(verifyToken);
 router.get("/me", controller.getMySubscriptions);
+router.post("/", controller.createOrRenewSubscription);
 
 module.exports = router;

--- a/backend/tests/subscriptionRoutes.test.js
+++ b/backend/tests/subscriptionRoutes.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 jest.mock('../src/modules/subscriptions/subscription.service', () => ({
   getActiveByUser: jest.fn(),
+  createOrRenewSubscription: jest.fn(),
 }));
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
@@ -25,5 +26,24 @@ describe('GET /api/user-subscriptions/me', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
     expect(service.getActiveByUser).toHaveBeenCalledWith('user1');
+  });
+});
+
+describe('POST /api/user-subscriptions', () => {
+  it('creates or renews a subscription for the authenticated user', async () => {
+    const mock = { id: 's1', plan_id: 'p1' };
+    service.createOrRenewSubscription.mockResolvedValue(mock);
+
+    const res = await request(app)
+      .post('/api/user-subscriptions')
+      .send({ plan_id: 'p1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.createOrRenewSubscription).toHaveBeenCalledWith({
+      user_id: 'user1',
+      plan_id: 'p1',
+      interval: 'monthly',
+    });
   });
 });

--- a/frontend/src/services/instructor/subscriptionService.js
+++ b/frontend/src/services/instructor/subscriptionService.js
@@ -1,7 +1,7 @@
 import api from "@/services/api/api";
 
-export const subscribeToPlan = async (planId) => {
-  const { data } = await api.post("/user-subscriptions", { plan_id: planId });
+export const subscribeToPlan = async (planId, interval = "monthly") => {
+  const { data } = await api.post("/user-subscriptions", { plan_id: planId, interval });
   return data?.data ?? null;
 };
 


### PR DESCRIPTION
## Summary
- add POST /user-subscriptions to create or renew subscription
- implement controller calling service
- cover new route with tests and expose interval option in frontend

## Testing
- `npm test` *(fails: process.exit called, multiple suites failed)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b329c046f08328811e5726181a0f66