### PR TITLE
feat: add instructor plan limits

### DIFF
--- a/backend/src/seeds/09_plans_seed.js
+++ b/backend/src/seeds/09_plans_seed.js
@@ -62,6 +62,8 @@ exports.seed = async function (knex) {
         buttonTextColor: '#FFFFFF'
       }),
       target_role: 'instructor',
+      max_courses: 5,
+      ad_credits: 10,
       created_at: now,
       updated_at: now
     },
@@ -83,6 +85,8 @@ exports.seed = async function (knex) {
         buttonTextColor: '#1F2937'
       }),
       target_role: 'instructor',
+      max_courses: 50,
+      ad_credits: 100,
       created_at: now,
       updated_at: now
     }


### PR DESCRIPTION
## Summary
- seed realistic course and advertising limits for instructor plans

## Testing
- `npm run seed`
- `curl -s http://localhost:5002/api/plans?role=instructor | jq '.data[] | {name, max_courses, ad_credits}'`
- `npm test` *(fails: connection issues and missing mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68b329c72c748328a514dceae77df377