### PR TITLE
feat: generate invoices after payments

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -33,6 +33,7 @@
         "passport-facebook": "^3.0.0",
         "passport-github2": "^0.1.12",
         "passport-google-oauth20": "^2.0.0",
+        "pdfkit": "^0.17.1",
         "pg": "^8.16.3",
         "redis": "^4.7.1",
         "sharp": "^0.34.2",
@@ -1662,6 +1663,15 @@
       "integrity": "sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==",
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2166,7 +2176,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2334,6 +2343,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -2726,6 +2744,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -3063,6 +3090,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -3216,6 +3249,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -3707,6 +3746,12 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3830,6 +3875,23 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.3",
@@ -5350,6 +5412,12 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5622,6 +5690,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -6624,6 +6711,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -6788,6 +6881,19 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+    },
+    "node_modules/pdfkit": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.1.tgz",
+      "integrity": "sha512-Kkf1I9no14O/uo593DYph5u3QwiMfby7JsBSErN1WqeyTgCBNJE3K4pXBn3TgkdKUIVu+buSl4bYUNC+8Up4xg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
     },
     "node_modules/pg": {
       "version": "8.16.3",
@@ -7011,6 +7117,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -7423,6 +7534,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/ret": {
       "version": "0.1.15",
@@ -8489,6 +8606,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -8541,8 +8664,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -8629,6 +8751,26 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "passport-facebook": "^3.0.0",
     "passport-github2": "^0.1.12",
     "passport-google-oauth20": "^2.0.0",
+    "pdfkit": "^0.17.1",
     "pg": "^8.16.3",
     "redis": "^4.7.1",
     "sharp": "^0.34.2",

--- a/backend/src/migrations/20250920000000_create_invoices_table.js
+++ b/backend/src/migrations/20250920000000_create_invoices_table.js
@@ -1,0 +1,16 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('invoices', function(table) {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('payment_id').notNullable().references('id').inTable('payments').onDelete('CASCADE');
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.decimal('amount', 10, 2).notNullable();
+    table.string('currency').notNullable().defaultTo('USD');
+    table.jsonb('details');
+    table.string('pdf_url');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('invoices');
+};

--- a/backend/src/modules/invoices/invoice.model.js
+++ b/backend/src/modules/invoices/invoice.model.js
@@ -1,0 +1,22 @@
+const db = require("../../config/database");
+
+exports.create = async (data) => {
+  const [row] = await db("invoices").insert(data).returning("*");
+  return row;
+};
+
+exports.getAll = () => {
+  return db("invoices").orderBy("created_at", "desc");
+};
+
+exports.getById = (id) => {
+  return db("invoices").where({ id }).first();
+};
+
+exports.getByUser = (user_id) => {
+  return db("invoices").where({ user_id }).orderBy("created_at", "desc");
+};
+
+exports.findByPayment = (payment_id) => {
+  return db("invoices").where({ payment_id }).first();
+};

--- a/backend/src/modules/invoices/invoices.controller.js
+++ b/backend/src/modules/invoices/invoices.controller.js
@@ -1,0 +1,46 @@
+const path = require("path");
+const catchAsync = require("../../utils/catchAsync");
+const AppError = require("../../utils/AppError");
+const { sendSuccess } = require("../../utils/response");
+const service = require("./invoices.service");
+
+exports.getInvoices = catchAsync(async (_req, res) => {
+  const data = await service.getInvoices();
+  sendSuccess(res, data);
+});
+
+exports.getInvoice = catchAsync(async (req, res) => {
+  const invoice = await service.getInvoice(req.params.id);
+  if (!invoice) throw new AppError("Invoice not found", 404);
+  sendSuccess(res, invoice);
+});
+
+exports.getMyInvoices = catchAsync(async (req, res) => {
+  const data = await service.getInvoicesByUser(req.user.id);
+  sendSuccess(res, data);
+});
+
+exports.getMyInvoice = catchAsync(async (req, res) => {
+  const invoice = await service.getInvoice(req.params.id);
+  if (!invoice || invoice.user_id !== req.user.id)
+    throw new AppError("Invoice not found", 404);
+  sendSuccess(res, invoice);
+});
+
+exports.downloadInvoice = catchAsync(async (req, res) => {
+  const invoice = await service.getInvoice(req.params.id);
+  if (!invoice) throw new AppError("Invoice not found", 404);
+  if (
+    req.user.role !== "Admin" &&
+    req.user.role !== "SuperAdmin" &&
+    invoice.user_id !== req.user.id
+  ) {
+    throw new AppError("Forbidden", 403);
+  }
+  const filePath = path.join(
+    __dirname,
+    "../../../",
+    invoice.pdf_url.replace(/^\//, "")
+  );
+  res.download(filePath);
+});

--- a/backend/src/modules/invoices/invoices.routes.js
+++ b/backend/src/modules/invoices/invoices.routes.js
@@ -1,0 +1,11 @@
+const router = require("express").Router();
+const controller = require("./invoices.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isAdmin);
+
+router.get("/", controller.getInvoices);
+router.get("/:id", controller.getInvoice);
+router.get("/:id/download", controller.downloadInvoice);
+
+module.exports = router;

--- a/backend/src/modules/invoices/invoices.service.js
+++ b/backend/src/modules/invoices/invoices.service.js
@@ -1,0 +1,64 @@
+const fs = require("fs");
+const path = require("path");
+const PDFDocument = require("pdfkit");
+const { v4: uuidv4 } = require("uuid");
+const model = require("./invoice.model");
+
+const uploadDir = path.join(__dirname, "../../../uploads/invoices");
+
+exports.generateFromPayment = async (payment, user) => {
+  const existing = await model.findByPayment(payment.id);
+  if (existing) return existing;
+
+  await fs.promises.mkdir(uploadDir, { recursive: true });
+
+  const id = uuidv4();
+  const fileName = `${id}.pdf`;
+  const filePath = path.join(uploadDir, fileName);
+
+  const doc = new PDFDocument();
+  const stream = fs.createWriteStream(filePath);
+  doc.pipe(stream);
+
+  doc.fontSize(20).text(`Invoice #${id}`);
+  doc.moveDown();
+  doc.fontSize(12);
+  doc.text(`Date: ${new Date().toISOString()}`);
+  doc.text(`Student: ${user.full_name} (${user.email})`);
+  doc.text(`Payment ID: ${payment.id}`);
+  doc.text(`Amount: ${payment.amount} ${payment.currency}`);
+  doc.text(`Status: ${payment.status}`);
+  doc.end();
+
+  await new Promise((resolve, reject) => {
+    stream.on("finish", resolve);
+    stream.on("error", reject);
+  });
+
+  const data = {
+    id,
+    payment_id: payment.id,
+    user_id: payment.user_id,
+    amount: payment.amount,
+    currency: payment.currency,
+    pdf_url: `/uploads/invoices/${fileName}`,
+    details: {
+      payment: {
+        id: payment.id,
+        item_type: payment.item_type,
+        item_id: payment.item_id,
+      },
+      user: {
+        id: user.id,
+        full_name: user.full_name,
+        email: user.email,
+      },
+    },
+  };
+
+  return model.create(data);
+};
+
+exports.getInvoices = () => model.getAll();
+exports.getInvoice = (id) => model.getById(id);
+exports.getInvoicesByUser = (user_id) => model.getByUser(user_id);

--- a/backend/src/modules/invoices/student.routes.js
+++ b/backend/src/modules/invoices/student.routes.js
@@ -1,0 +1,11 @@
+const router = require("express").Router();
+const controller = require("./invoices.controller");
+const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isStudent);
+
+router.get("/", controller.getMyInvoices);
+router.get("/:id", controller.getMyInvoice);
+router.get("/:id/download", controller.downloadInvoice);
+
+module.exports = router;

--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -12,6 +12,8 @@ const userModel = require("../users/user.model");
 const { grantAccess } = require("./paymentAccess");
 const { v4: uuidv4 } = require("uuid");
 
+const invoiceService = require("../invoices/invoices.service");
+
 const DEFAULT_PLATFORM_CUT = {
   class: 15,
   book: 10,
@@ -138,8 +140,9 @@ exports.approveBankPayment = catchAsync(async (req, res) => {
 
   await grantAccess(payment);
 
+  let user;
   try {
-    const user = await userModel.findById(payment.user_id);
+    user = await userModel.findById(payment.user_id);
     const message = `Your bank payment ${payment.id} has been approved.`;
     await notificationService.createNotification({
       user_id: payment.user_id,
@@ -155,6 +158,14 @@ exports.approveBankPayment = catchAsync(async (req, res) => {
     }
   } catch (err) {
     logger.error("Failed to notify student of payment approval:", err);
+  }
+
+  try {
+    if (user) {
+      await invoiceService.generateFromPayment(payment, user);
+    }
+  } catch (err) {
+    logger.error("Failed to generate invoice:", err);
   }
 
   sendSuccess(res, payment, "Bank payment approved");

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -21,6 +21,8 @@ const subscriptionService = require("../subscriptions/subscription.service");
 const walletService = require("../payouts/wallet.service");
 const classService = require("../classes/class.service");
 
+const invoiceService = require("../invoices/invoices.service");
+
 const DEFAULT_PLATFORM_CUT = {
   class: 15,
   book: 10,
@@ -263,6 +265,17 @@ exports.createPayment = catchAsync(async (req, res) => {
     }
   }
 
+  if (payment.status === STATUS.PAID) {
+    try {
+      if (!user) {
+        user = await userModel.findById(user_id);
+      }
+      await invoiceService.generateFromPayment(payment, user);
+    } catch (err) {
+      logger.error("Failed to generate invoice:", err);
+    }
+  }
+
   sendSuccess(res, payment, "Payment created");
 });
 
@@ -334,6 +347,11 @@ exports.updatePayment = catchAsync(async (req, res) => {
       if (req.body.status === STATUS.PAID) {
         message = `Your payment ${payment.id} has been approved.`;
         subject = "Payment Approved";
+        try {
+          await invoiceService.generateFromPayment(payment, user);
+        } catch (err) {
+          logger.error("Failed to generate invoice:", err);
+        }
       } else if (req.body.status === STATUS.REJECTED) {
         message = `Your payment ${payment.id} has been rejected.`;
         subject = "Payment Rejected";

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -174,6 +174,8 @@ app.use(
   require("./modules/payments/paypal.routes")
 );
 app.use("/api/payments/admin", require("./modules/payments/payments.routes"));
+app.use("/api/invoices/admin", require("./modules/invoices/invoices.routes"));
+app.use("/api/invoices/student", require("./modules/invoices/student.routes"));
 app.use(
   "/api/admin/payments/bank",
   require("./modules/payments/bank.admin.routes")


### PR DESCRIPTION
## Summary
- add invoices module with model, service, controllers and routes for admins and students
- generate PDF invoice and record details on payment completion
- register invoice APIs and migration for invoices table

## Testing
- `npm test` *(fails: process.exit called, various suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b33d6951c083289efd9af30a8da170