### PR TITLE
feat: add instructor payout routes

### DIFF
--- a/backend/src/modules/payouts/instructor.routes.js
+++ b/backend/src/modules/payouts/instructor.routes.js
@@ -1,0 +1,10 @@
+const router = require("express").Router();
+const controller = require("./payouts.controller");
+const { verifyToken, isInstructor } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isInstructor);
+
+router.get("/wallet", controller.getWallet);
+router.post("/", controller.requestPayout);
+
+module.exports = router;

--- a/backend/src/modules/payouts/payouts.controller.js
+++ b/backend/src/modules/payouts/payouts.controller.js
@@ -54,3 +54,39 @@ exports.deletePayout = catchAsync(async (req, res) => {
   await service.delete(req.params.id);
   sendSuccess(res, null, "Payout deleted");
 });
+
+// Instructor: Get wallet balance
+exports.getWallet = catchAsync(async (req, res) => {
+  const wallet = await walletService.getByInstructor(req.user.id);
+  sendSuccess(res, wallet || { balance: 0 });
+});
+
+// Instructor: Request payout for self after validating funds
+exports.requestPayout = catchAsync(async (req, res) => {
+  const { amount, currency, notes, instructor_id } = req.body;
+
+  if (instructor_id && instructor_id !== req.user.id) {
+    throw new AppError("Cannot request payout for another instructor", 403);
+  }
+
+  if (!amount) {
+    throw new AppError("Amount is required", 400);
+  }
+
+  const wallet = await walletService.getByInstructor(req.user.id);
+  const balance = wallet ? Number(wallet.balance) : 0;
+  if (balance < Number(amount)) {
+    throw new AppError("Insufficient wallet balance", 400);
+  }
+
+  const payout = await service.create({
+    id: uuidv4(),
+    instructor_id: req.user.id,
+    amount,
+    currency: currency || "USD",
+    status: "pending",
+    notes,
+  });
+
+  sendSuccess(res, payout, "Payout request created");
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -193,6 +193,7 @@ app.use("/api/seo-config", require("./modules/seoConfig/seoConfig.routes"));
 app.use("/api/popup-announcements", require("./modules/popupAnnouncements/popupAnnouncements.routes"));
 app.use("/api/policies", require("./modules/policies/policies.routes"));
 app.use("/api/payouts/admin", require("./modules/payouts/payouts.routes"));
+app.use("/api/payouts/instructor", require("./modules/payouts/instructor.routes"));
 app.use("/api/ads", require("./modules/ads/ads.routes"));
 app.use("/api/coupons", require("./modules/coupons/coupons.routes"));
 app.use("/api/groups", require("./modules/groups/groups.routes"));

--- a/backend/tests/instructorPayoutRoutes.test.js
+++ b/backend/tests/instructorPayoutRoutes.test.js
@@ -1,0 +1,83 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/payouts/wallet.service', () => ({
+  getByInstructor: jest.fn(),
+}));
+
+jest.mock('../src/modules/payouts/payouts.service', () => ({
+  create: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'instr1' };
+    next();
+  },
+  isInstructor: (_req, _res, next) => next(),
+}));
+
+const walletService = require('../src/modules/payouts/wallet.service');
+const payoutService = require('../src/modules/payouts/payouts.service');
+const routes = require('../src/modules/payouts/instructor.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payouts/instructor', routes);
+app.use((err, _req, res, _next) => {
+  res.status(err.statusCode || 500).json({ message: err.message });
+});
+
+describe('GET /api/payouts/instructor/wallet', () => {
+  it('returns wallet balance for instructor', async () => {
+    walletService.getByInstructor.mockResolvedValue({ balance: 100 });
+    const res = await request(app).get('/api/payouts/instructor/wallet');
+    expect(res.status).toBe(200);
+    expect(walletService.getByInstructor).toHaveBeenCalledWith('instr1');
+    expect(res.body.data).toEqual({ balance: 100 });
+  });
+});
+
+describe('POST /api/payouts/instructor', () => {
+  beforeEach(() => {
+    walletService.getByInstructor.mockReset();
+    payoutService.create.mockReset();
+  });
+
+  it('creates payout request when funds sufficient', async () => {
+    walletService.getByInstructor.mockResolvedValue({ balance: 200 });
+    payoutService.create.mockResolvedValue({ id: 'p1' });
+
+    const res = await request(app)
+      .post('/api/payouts/instructor')
+      .send({ amount: 50 });
+
+    expect(res.status).toBe(200);
+    expect(walletService.getByInstructor).toHaveBeenCalledWith('instr1');
+    expect(payoutService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ instructor_id: 'instr1', amount: 50 })
+    );
+  });
+
+  it('rejects when requesting for another instructor', async () => {
+    walletService.getByInstructor.mockResolvedValue({ balance: 200 });
+
+    const res = await request(app)
+      .post('/api/payouts/instructor')
+      .send({ amount: 50, instructor_id: 'other' });
+
+    expect(res.status).toBe(403);
+    expect(payoutService.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects when funds are insufficient', async () => {
+    walletService.getByInstructor.mockResolvedValue({ balance: 40 });
+
+    const res = await request(app)
+      .post('/api/payouts/instructor')
+      .send({ amount: 50 });
+
+    expect(res.status).toBe(400);
+    expect(payoutService.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- allow instructors to view wallet balance and request payouts
- ensure payouts only for authenticated instructor and require sufficient wallet funds
- cover instructor payout routes with tests

## Testing
- `npm test` *(fails: process.exit called - database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b33d687ad08328bd2e061a82cd17ec