### PR TITLE
test: add ad credit consumption tests

### DIFF
--- a/backend/src/modules/plans/__tests__/consumeAdCredit.test.js
+++ b/backend/src/modules/plans/__tests__/consumeAdCredit.test.js
@@ -1,0 +1,45 @@
+jest.mock('../../../config/database', () => {
+  const plans = { 1: { ad_credits: 2 }, 2: { ad_credits: 0 } };
+  const db = jest.fn(() => ({
+    where: jest.fn(({ id }) => ({
+      andWhere: jest.fn((column, operator, threshold) => ({
+        decrement: jest.fn((col, amount) => {
+          const plan = plans[id];
+          if (plan && plan.ad_credits > threshold) {
+            plan.ad_credits -= amount;
+          }
+          return Promise.resolve();
+        }),
+      })),
+    })),
+  }));
+  db.__plans = plans;
+  return db;
+});
+
+const db = require('../../../config/database');
+const { consumeAdCredit } = require('../plans.service');
+
+describe('consumeAdCredit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    db.__plans[1].ad_credits = 2;
+    db.__plans[2].ad_credits = 0;
+  });
+
+  it('decrements ad_credits when positive', async () => {
+    await consumeAdCredit(1);
+    expect(db.__plans[1].ad_credits).toBe(1);
+  });
+
+  it('does not decrement when ad_credits is zero', async () => {
+    await consumeAdCredit(2);
+    expect(db.__plans[2].ad_credits).toBe(0);
+  });
+
+  it('does nothing if planId is missing', async () => {
+    await consumeAdCredit();
+    expect(db).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests verifying ad credit consumption only decreases when credits are positive
- cover missing planId and zero-credit scenarios

## Testing
- `npm test` *(fails: Route.post() requires a callback function, multiple other failing suites)*
- `npx jest --runTestsByPath src/modules/plans/__tests__/consumeAdCredit.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b349ca0c688328a74ff711e55afc02