### PR TITLE
Expose full plan features

### DIFF
--- a/backend/src/modules/plans/plans.controller.js
+++ b/backend/src/modules/plans/plans.controller.js
@@ -99,8 +99,9 @@ exports.getPlans = catchAsync(async (req, res) => {
   sendSuccess(res, plans);
 });
 
-exports.getPlanFeatures = catchAsync(async (_req, res) => {
-  const features = await service.getPlanFeatures();
+exports.getPlanFeatures = catchAsync(async (req, res) => {
+  const { prefix } = req.query;
+  const features = await service.getPlanFeatures(prefix);
   sendSuccess(res, features);
 });
 

--- a/backend/src/modules/plans/plans.service.js
+++ b/backend/src/modules/plans/plans.service.js
@@ -66,21 +66,29 @@ exports.setFeatures = async (planId, features = []) => {
   });
 };
 
-exports.getPlanFeatures = async () => {
+exports.getPlanFeatures = async (prefix) => {
   const plans = await db("plans").select("id", "slug");
-  const features = await db("plan_features").select(
+  let featureQuery = db("plan_features").select(
     "plan_id",
     "feature_key",
     "value"
   );
+  if (prefix) featureQuery = featureQuery.where("feature_key", "like", `${prefix}_%`);
+  const features = await featureQuery;
+
   const result = {};
   const toCamel = (s) => s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+  const stripPrefix = (key) => {
+    const idx = key.indexOf("_");
+    return idx >= 0 ? key.slice(idx + 1) : key;
+  };
+
   plans.forEach((plan) => {
     const feats = {};
     features
-      .filter((f) => f.plan_id === plan.id && f.feature_key.startsWith("ads_"))
+      .filter((f) => f.plan_id === plan.id)
       .forEach((f) => {
-        const key = toCamel(f.feature_key.replace(/^ads_/, ""));
+        const key = toCamel(stripPrefix(f.feature_key));
         let val;
         try {
           val = JSON.parse(f.value);

--- a/backend/tests/planFeaturesRoutes.test.js
+++ b/backend/tests/planFeaturesRoutes.test.js
@@ -19,4 +19,10 @@ describe('GET /api/plans/features', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
   });
+
+  it('forwards prefix query param to service', async () => {
+    service.getPlanFeatures.mockResolvedValue({});
+    await request(app).get('/api/plans/features?prefix=ads');
+    expect(service.getPlanFeatures).toHaveBeenCalledWith('ads');
+  });
 });

--- a/frontend/src/services/planFeatureService.js
+++ b/frontend/src/services/planFeatureService.js
@@ -1,6 +1,8 @@
 import api from "@/services/api/api";
 
-export const fetchPlanFeatures = async () => {
-  const { data } = await api.get("/plans/features");
+export const fetchPlanFeatures = async (prefix) => {
+  const { data } = await api.get("/plans/features", {
+    params: prefix ? { prefix } : {},
+  });
   return data?.data ?? {};
 };


### PR DESCRIPTION
## Summary
- Allow retrieving plan features with arbitrary prefixes
- Forward optional prefix query to plans API
- Support prefix parameter in frontend planFeatureService

## Testing
- `npm test` (backend) *(fails: database configuration is missing)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b349c7633483288775164d41674a45