### PR TITLE
fix: resolve duplicate class service import

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -14,7 +14,6 @@ const classService = require("../classes/class.service");
 const { grantAccess } = require("./paymentAccess");
 const { v4: uuidv4 } = require("uuid");
 const couponService = require("../coupons/coupons.service");
-const classService = require("../classes/class.service");
 const bookService = require("../books/book.service");
 const tutorialService = require("../users/tutorials/tutorial.service");
 


### PR DESCRIPTION
## Summary
- remove duplicate classService import from bank controller to prevent SyntaxError

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined]; Test Suites: 28 failed, 1 skipped, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b349c12fb08328b238d14202023621