### PR TITLE
test: cover consumeAdCredit ad credit use

### DIFF
--- a/backend/src/modules/plans/__tests__/consumeAdCredit.test.js
+++ b/backend/src/modules/plans/__tests__/consumeAdCredit.test.js
@@ -1,5 +1,5 @@
 jest.mock('../../../config/database', () => {
-  const plans = { 1: { ad_credits: 2 }, 2: { ad_credits: 0 } };
+  const plans = { 1: { ad_credits: 1 }, 2: { ad_credits: 0 } };
   const db = jest.fn(() => ({
     where: jest.fn(({ id }) => ({
       andWhere: jest.fn((column, operator, threshold) => ({
@@ -23,13 +23,13 @@ const { consumeAdCredit } = require('../plans.service');
 describe('consumeAdCredit', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    db.__plans[1].ad_credits = 2;
+    db.__plans[1].ad_credits = 1;
     db.__plans[2].ad_credits = 0;
   });
 
   it('decrements ad_credits when positive', async () => {
     await consumeAdCredit(1);
-    expect(db.__plans[1].ad_credits).toBe(1);
+    expect(db.__plans[1].ad_credits).toBe(0);
   });
 
   it('does not decrement when ad_credits is zero', async () => {
@@ -40,6 +40,12 @@ describe('consumeAdCredit', () => {
   it('does nothing if planId is missing', async () => {
     await consumeAdCredit();
     expect(db).not.toHaveBeenCalled();
+  });
+
+  it('does not decrement below zero', async () => {
+    await consumeAdCredit(1);
+    await consumeAdCredit(1);
+    expect(db.__plans[1].ad_credits).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- test ad credit consumption to ensure credits decrement only when positive
- ensure calls without planId or with zero credits do not change ad credits
- guard against decrementing below zero

## Testing
- `npx jest --runTestsByPath src/modules/plans/__tests__/consumeAdCredit.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3521921e08328a3b69a90a9bc4b76