### PR TITLE
docs: clarify plan subscription fields

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -353,11 +353,11 @@
 - **Primary Key**: `id`
 - **Foreign Keys**: `—`
 - **Key Columns**:
-  - `price_monthly` – monthly subscription cost
-  - `price_yearly` – annual subscription cost
-  - `target_role` – limits plan to a specific user type (e.g., student or instructor)
-  - `max_courses` – caps how many courses an instructor can publish
-  - `ad_credits` – credits instructors can spend on promoting their classes
+  - `price_monthly` – monthly rate charged for a pay-as-you-go subscription
+  - `price_yearly` – annual rate, typically discounted for long-term commitment
+  - `target_role` – restricts eligibility to a specific user type (e.g., student or instructor)
+  - `max_courses` – sets how many courses an instructor may publish before needing to upgrade
+  - `ad_credits` – promotional credits instructors can spend to boost class visibility
 
 ### `plan_features`
 - **Purpose**: Matrix of toggles/limits


### PR DESCRIPTION
## Summary
- clarify plan table's subscription-related fields

## Testing
- `npm test` (backend) *(fails: Route.post requires a callback function)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b35217f4e48328982c75b3b2952572