### PR TITLE
feat: support generic plan feature prefixes

### DIFF
--- a/backend/src/modules/plans/plans.service.js
+++ b/backend/src/modules/plans/plans.service.js
@@ -73,14 +73,22 @@ exports.getPlanFeatures = async (prefix) => {
     "feature_key",
     "value"
   );
-  if (prefix) featureQuery = featureQuery.where("feature_key", "like", `${prefix}_%`);
+  if (prefix)
+    featureQuery = featureQuery.where(
+      "feature_key",
+      "like",
+      `${prefix}_%`
+    );
   const features = await featureQuery;
 
   const result = {};
   const toCamel = (s) => s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
-  const stripPrefix = (key) => {
-    const idx = key.indexOf("_");
-    return idx >= 0 ? key.slice(idx + 1) : key;
+
+  const transformKey = (key) => {
+    if (prefix && key.startsWith(`${prefix}_`)) {
+      return toCamel(key.slice(prefix.length + 1));
+    }
+    return toCamel(key);
   };
 
   plans.forEach((plan) => {
@@ -88,7 +96,7 @@ exports.getPlanFeatures = async (prefix) => {
     features
       .filter((f) => f.plan_id === plan.id)
       .forEach((f) => {
-        const key = toCamel(stripPrefix(f.feature_key));
+        const key = transformKey(f.feature_key);
         let val;
         try {
           val = JSON.parse(f.value);

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -70,7 +70,7 @@ export default function CreateAdPage() {
   const [uploadProgress, setUploadProgress] = useState(0);
 
   useEffect(() => {
-    fetchPlanFeatures()
+    fetchPlanFeatures('ads')
       .then(setPlanFeatures)
       .catch(() => setPlanFeatures({}));
   }, []);

--- a/frontend/src/pages/dashboard/admin/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/edit/[id].js
@@ -39,7 +39,7 @@ export default function EditAdPage() {
   const [uploadProgress, setUploadProgress] = useState(0);
 
   useEffect(() => {
-    fetchPlanFeatures()
+    fetchPlanFeatures('ads')
       .then(setPlanFeatures)
       .catch(() => setPlanFeatures({}));
   }, []);

--- a/frontend/src/pages/dashboard/instructor/ads/create.js
+++ b/frontend/src/pages/dashboard/instructor/ads/create.js
@@ -69,7 +69,7 @@ export default function CreateAdPage() {
   const [uploadProgress, setUploadProgress] = useState(0);
 
   useEffect(() => {
-    fetchPlanFeatures()
+    fetchPlanFeatures('ads')
       .then(setPlanFeatures)
       .catch(() => setPlanFeatures({}));
   }, []);

--- a/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
@@ -53,7 +53,7 @@ export default function EditAdPage() {
   };
 
   useEffect(() => {
-    fetchPlanFeatures()
+    fetchPlanFeatures('ads')
       .then(setPlanFeatures)
       .catch(() => setPlanFeatures({}));
   }, []);


### PR DESCRIPTION
## Summary
- handle arbitrary or absent feature prefixes in plan feature lookup
- ads creation and edit screens request advertisement-specific features explicitly

## Testing
- `npm test` *(fails: Route.post requires a callback; database configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b352149c44832882a4855c87af3363