### PR TITLE
secure book review updates

### DIFF
--- a/backend/src/modules/bookReviews/bookReview.controller.js
+++ b/backend/src/modules/bookReviews/bookReview.controller.js
@@ -2,6 +2,7 @@ const service = require("./bookReview.service");
 const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
+const { isAdminRole } = require("../../utils/role");
 
 exports.listReviews = catchAsync(async (req, res) => {
   const data = await service.listReviews(req.params.bookId);
@@ -16,12 +17,23 @@ exports.createReview = catchAsync(async (req, res) => {
 });
 
 exports.updateReview = catchAsync(async (req, res) => {
+  const existing = await service.findById(req.params.id);
+  if (!existing) throw new AppError("Review not found", 404);
+  const isAdmin = isAdminRole(req.user.roles || req.user.role);
+  if (existing.user_id !== req.user.id && !isAdmin) {
+    throw new AppError("Access denied", 403);
+  }
   const review = await service.updateReview(req.params.id, req.body);
-  if (!review) throw new AppError("Review not found", 404);
   sendSuccess(res, review, "Review updated");
 });
 
 exports.deleteReview = catchAsync(async (req, res) => {
+  const existing = await service.findById(req.params.id);
+  if (!existing) throw new AppError("Review not found", 404);
+  const isAdmin = isAdminRole(req.user.roles || req.user.role);
+  if (existing.user_id !== req.user.id && !isAdmin) {
+    throw new AppError("Access denied", 403);
+  }
   await service.deleteReview(req.params.id);
   sendSuccess(res, null, "Review deleted");
 });

--- a/backend/src/modules/bookReviews/bookReview.service.js
+++ b/backend/src/modules/bookReviews/bookReview.service.js
@@ -12,6 +12,8 @@ exports.ensurePurchased = async (studentId, bookId) => {
 
 exports.createReview = (data) => model.create(data);
 
+exports.findById = (id) => model.findById(id);
+
 exports.listReviews = async (bookId) => {
   const reviews = await model.listByBook(bookId);
   const averageRating = await model.averageRating(bookId);

--- a/backend/tests/bookReviewRoutes.test.js
+++ b/backend/tests/bookReviewRoutes.test.js
@@ -1,0 +1,78 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/bookReviews/bookReview.service', () => ({
+  listReviews: jest.fn(),
+  createReview: jest.fn(),
+  updateReview: jest.fn(),
+  deleteReview: jest.fn(),
+  ensurePurchased: jest.fn(),
+  findById: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: jest.fn((req, _res, next) => next()),
+}));
+
+const service = require('../src/modules/bookReviews/bookReview.service');
+const routes = require('../src/modules/bookReviews/bookReview.routes');
+const auth = require('../src/middleware/auth/authMiddleware');
+
+const app = express();
+app.use(express.json());
+app.use('/api/book-reviews', routes);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PUT /api/book-reviews/:id', () => {
+  it('allows author to update own review', async () => {
+    auth.verifyToken.mockImplementation((req, _res, next) => {
+      req.user = { id: 'u1', role: 'student', roles: ['student'] };
+      next();
+    });
+    service.findById.mockResolvedValue({ id: 'r1', user_id: 'u1' });
+    service.updateReview.mockResolvedValue({ id: 'r1', user_id: 'u1', text: 'new' });
+    const res = await request(app).put('/api/book-reviews/r1').send({ text: 'new' });
+    expect(res.status).toBe(200);
+    expect(service.updateReview).toHaveBeenCalledWith('r1', { text: 'new' });
+  });
+
+  it('forbids updating others review', async () => {
+    auth.verifyToken.mockImplementation((req, _res, next) => {
+      req.user = { id: 'u2', role: 'student', roles: ['student'] };
+      next();
+    });
+    service.findById.mockResolvedValue({ id: 'r1', user_id: 'u1' });
+    const res = await request(app).put('/api/book-reviews/r1').send({ text: 'new' });
+    expect(res.status).toBe(403);
+    expect(service.updateReview).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/book-reviews/:id', () => {
+  it('allows author to delete own review', async () => {
+    auth.verifyToken.mockImplementation((req, _res, next) => {
+      req.user = { id: 'u1', role: 'student', roles: ['student'] };
+      next();
+    });
+    service.findById.mockResolvedValue({ id: 'r1', user_id: 'u1' });
+    service.deleteReview.mockResolvedValue();
+    const res = await request(app).delete('/api/book-reviews/r1');
+    expect(res.status).toBe(200);
+    expect(service.deleteReview).toHaveBeenCalledWith('r1');
+  });
+
+  it('forbids deleting others review', async () => {
+    auth.verifyToken.mockImplementation((req, _res, next) => {
+      req.user = { id: 'u2', role: 'student', roles: ['student'] };
+      next();
+    });
+    service.findById.mockResolvedValue({ id: 'r1', user_id: 'u1' });
+    const res = await request(app).delete('/api/book-reviews/r1');
+    expect(res.status).toBe(403);
+    expect(service.deleteReview).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- restrict review updates/deletes to authors unless admin
- add service helper to fetch review by id
- cover self-edit/delete and cross-user 403 cases

## Testing
- `cd backend && npm test tests/bookReviewRoutes.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b356e3ae888328a36c5864f738ceb1