### PR TITLE
refactor tutorial creation transaction

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -2,8 +2,6 @@ const logger = require('../../../utils/logger.js');
 // 📁 src/modules/users/tutorials/tutorial.controller.js
 const db = require("../../../config/database");
 const service = require("./tutorial.service");
-const chapterService = require("./chapters/tutorialChapter.service");
-const tagService = require("./tutorialTag.service");
 const notificationService = require("../../notifications/notifications.service");
 const messageService = require("../../messages/messages.service");
 const userModel = require("../user.model");
@@ -11,20 +9,17 @@ const analyticsService = require("../../../services/analyticsService");
 const certificateService = require("./certificate/certificate.service");
 const enrollmentService = require("./enrollments/tutorialEnrollment.service");
 const AppError = require("../../../utils/AppError");
-const {
-  sendTutorialCreatedAdminEmail,
-  sendTutorialCreatedInstructorEmail,
-  sendTutorialApprovedEmail,
-  sendTutorialRejectedEmail,
-} = require("../../../utils/email");
+const { sendTutorialApprovedEmail, sendTutorialRejectedEmail } = require(
+  "../../../utils/email"
+);
 
 const catchAsync = require("../../../utils/catchAsync");
 const { v4: uuidv4 } = require("uuid");
 
 
 const { sendSuccess } = require("../../../utils/response");
-const slugify = require("slugify");
-const { parseTags } = require("./tutorial.helpers");
+const { parseTags, parseChapters } = require("./tutorial.helpers");
+const { sendCreationNotifications } = require("./tutorial.notifications");
 
 // Helper to resolve uploads subdirectory based on user role
 const getRoleDir = (req) => {
@@ -32,10 +27,6 @@ const getRoleDir = (req) => {
   if (["superadmin", "admin"].includes(role)) role = "admin";
   return role;
 };
-
-// ✅ Helper: Generate a slug based on title
-const generateUniqueSlug = (title) =>
-  slugify(title, { lower: true, strict: true });
 
 // Ensure the acting instructor owns the tutorial
 const assertInstructorOwnsTutorial = async (userId, tutorialId) => {
@@ -54,24 +45,12 @@ exports.createTutorial = catchAsync(async (req, res) => {
     price,
     status = "draft",
     tags: rawTags,
-    chapters = [],
+    chapters: rawChapters,
     instructor_id: bodyInstructorId,
   } = req.body;
 
-  // In case chapters came as a serialized JSON string, parse it
-  let parsedChapters = chapters;
-  if (typeof parsedChapters === "string") {
-    try {
-      parsedChapters = JSON.parse(parsedChapters);
-    } catch (err) {
-      parsedChapters = [];
-    }
-  }
-
-  // Filter out any chapter objects missing a title
-  parsedChapters = Array.isArray(parsedChapters)
-    ? parsedChapters.filter((ch) => ch && ch.title)
-    : [];
+  const parsedChapters = parseChapters(rawChapters);
+  const tags = parseTags(rawTags);
 
   // 🚫 Prevent duplicate titles
   const existing = await db("tutorials")
@@ -81,13 +60,12 @@ exports.createTutorial = catchAsync(async (req, res) => {
     return res.status(400).json({ message: "Tutorial title already exists" });
   }
 
-  let instructor = null;
   let instructor_id;
   if (
     ["admin", "superadmin"].includes(req.user.role) &&
     bodyInstructorId
   ) {
-    instructor = await userModel.findById(bodyInstructorId);
+    const instructor = await userModel.findById(bodyInstructorId);
     if (!instructor) {
       return res.status(404).json({ message: "Instructor not found" });
     }
@@ -96,18 +74,14 @@ exports.createTutorial = catchAsync(async (req, res) => {
     instructor_id = req.user.id;
   }
 
-  let slug = generateUniqueSlug(title);
   const id = uuidv4();
-
   const roleDir = getRoleDir(req);
   const thumbnailFile = req.files?.thumbnail?.[0];
   const previewFile = req.files?.preview?.[0];
 
-  // Prepare tutorial data
   const tutorialData = {
     id,
     title,
-    slug,
     description,
     category_id,
     level,
@@ -125,109 +99,13 @@ exports.createTutorial = catchAsync(async (req, res) => {
       : null,
   };
 
-  // Parse tags safely
-  const tags = parseTags(rawTags);
-
-  let tutorial;
-  await db.transaction(async (trx) => {
-    try {
-      tutorial = await service.createTutorial(tutorialData, trx);
-    } catch (err) {
-      if (err.code === "23505") {
-        const randomSuffix = Math.random().toString(36).slice(2, 8);
-        slug = `${slug}-${randomSuffix}`;
-        tutorialData.slug = slug;
-        tutorial = await service.createTutorial(tutorialData, trx);
-      } else {
-        throw err;
-      }
-    }
-
-    if (tags.length) {
-      const tagIds = [];
-      for (const name of tags) {
-        const existing = await tagService.findByName(name, trx);
-        const tag =
-          existing ||
-          (await tagService.createTag(
-            { name, slug: slugify(name, { lower: true, strict: true }) },
-            trx
-          ));
-        tagIds.push(tag.id);
-      }
-      await service.addTutorialTags(id, tagIds, trx);
-      tutorial.tags = await service.getTutorialTags(id, trx);
-    }
-
-    // Save chapters (if any)
-    for (let i = 0; i < parsedChapters.length; i++) {
-      const ch = parsedChapters[i];
-      await chapterService.create(
-        {
-          id: uuidv4(),
-          tutorial_id: id,
-          title: ch.title,
-          video_url: ch.video_url,
-          duration: ch.duration,
-          order: ch.order ?? i + 1,
-          is_preview: ch.is_preview ?? false,
-        },
-        trx
-      );
-    }
-  });
-
-  await notificationService.createNotification({
-    user_id: instructor_id,
-    type: "tutorial_created",
-    message:
-      "New tutorial added successfully. It's under review and will be available after we approve it",
-  });
-
-  if (!instructor) {
-    instructor = await userModel.findById(instructor_id);
-  }
-  const admins = await userModel.findAdmins();
-  await Promise.all(
-    admins.map((admin) =>
-      notificationService.createNotification({
-        user_id: admin.id,
-        type: "new_tutorial",
-        message: `Instructor ${instructor.full_name} added new tutorial \"${title}\" waiting for review`,
-      })
-    )
-  );
-  // Email admins about the new tutorial
-  await Promise.all(
-    admins.map((admin) =>
-      sendTutorialCreatedAdminEmail(admin.email, instructor.full_name, title)
-    )
+  const tutorial = await service.createTutorialWithRelations(
+    tutorialData,
+    tags,
+    parsedChapters
   );
 
-  // Send direct messages to admins about the new tutorial
-  if (admins.length) {
-    await Promise.all(
-      admins.map((admin) =>
-        messageService.createMessage({
-          sender_id: instructor_id,
-          receiver_id: admin.id,
-          message: `New tutorial \"${title}\" created by ${instructor.full_name} and awaiting your review`,
-        })
-      )
-    );
-  }
-
-  // Optional message to the instructor confirming creation
-  await messageService.createMessage({
-    sender_id: instructor_id,
-    receiver_id: instructor_id,
-    message: "Your tutorial was submitted and is pending review",
-  });
-  try {
-    await sendTutorialCreatedInstructorEmail(instructor.email, title);
-  } catch (err) {
-    logger.error("Error sending tutorial created email:", err.message);
-  }
+  await sendCreationNotifications(instructor_id, title);
 
   sendSuccess(res, tutorial, "Tutorial with chapters created");
 });
@@ -285,15 +163,10 @@ exports.updateTutorial = catchAsync(async (req, res) => {
     tags = parseTags(rawTags);
   }
   if (tags) {
-    const trx = await db.transaction();
-    try {
-      await service.updateTutorialTags(tutorial.id, tags, trx);
-      await trx.commit();
-      tutorial.tags = await service.getTutorialTags(tutorial.id);
-    } catch (err) {
-      await trx.rollback();
-      throw err;
-    }
+    tutorial.tags = await service.updateTutorialTagsTransactional(
+      tutorial.id,
+      tags
+    );
   }
 
   sendSuccess(res, tutorial);

--- a/backend/src/modules/users/tutorials/tutorial.helpers.js
+++ b/backend/src/modules/users/tutorials/tutorial.helpers.js
@@ -32,4 +32,30 @@ function parseTags(rawTags) {
   throw new AppError('Invalid tags JSON', 400);
 }
 
-module.exports = { parseTags };
+/**
+ * Parse chapter data from request body into a normalized array.
+ * Accepts an array or JSON string; filters out chapters missing a title.
+ *
+ * @param {string|string[]|undefined|null} rawChapters
+ * @returns {Array<{title:string, video_url?:string, duration?:number, order?:number, is_preview?:boolean}>}
+ */
+function parseChapters(rawChapters) {
+  if (rawChapters === undefined || rawChapters === null || rawChapters === "") {
+    return [];
+  }
+
+  let parsed = rawChapters;
+  if (typeof rawChapters === "string") {
+    try {
+      parsed = JSON.parse(rawChapters);
+    } catch (err) {
+      return [];
+    }
+  }
+
+  if (!Array.isArray(parsed)) return [];
+
+  return parsed.filter((ch) => ch && ch.title);
+}
+
+module.exports = { parseTags, parseChapters };

--- a/backend/src/modules/users/tutorials/tutorial.notifications.js
+++ b/backend/src/modules/users/tutorials/tutorial.notifications.js
@@ -1,0 +1,59 @@
+const logger = require('../../../utils/logger.js');
+const notificationService = require('../../notifications/notifications.service');
+const messageService = require('../../messages/messages.service');
+const userModel = require('../user.model');
+const {
+  sendTutorialCreatedAdminEmail,
+  sendTutorialCreatedInstructorEmail,
+} = require('../../../utils/email');
+
+/**
+ * Send notifications, messages and emails after a tutorial is created.
+ */
+async function sendCreationNotifications(instructorId, title) {
+  const instructor = await userModel.findById(instructorId);
+  const admins = await userModel.findAdmins();
+
+  const adminNotifications = admins.map((admin) =>
+    notificationService.createNotification({
+      user_id: admin.id,
+      type: 'new_tutorial',
+      message: `Instructor ${instructor.full_name} added new tutorial "${title}" waiting for review`,
+    })
+  );
+
+  const adminMessages = admins.map((admin) =>
+    messageService.createMessage({
+      sender_id: instructorId,
+      receiver_id: admin.id,
+      message: `New tutorial "${title}" created by ${instructor.full_name} and awaiting your review`,
+    })
+  );
+
+  await Promise.all([
+    notificationService.createNotification({
+      user_id: instructorId,
+      type: 'tutorial_created',
+      message:
+        "New tutorial added successfully. It's under review and will be available after we approve it",
+    }),
+    ...adminNotifications,
+    ...adminMessages,
+    messageService.createMessage({
+      sender_id: instructorId,
+      receiver_id: instructorId,
+      message: 'Your tutorial was submitted and is pending review',
+    }),
+    ...admins.map((admin) =>
+      sendTutorialCreatedAdminEmail(admin.email, instructor.full_name, title)
+    ),
+  ]);
+
+  try {
+    await sendTutorialCreatedInstructorEmail(instructor.email, title);
+  } catch (err) {
+    logger.error('Error sending tutorial created email:', err.message);
+  }
+}
+
+module.exports = { sendCreationNotifications };

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -1,11 +1,100 @@
 // 📁 src/modules/users/tutorials/tutorial.service.js
 const db = require("../../../config/database");
 const tagService = require("./tutorialTag.service");
+const chapterService = require("./chapters/tutorialChapter.service");
+const { withTransaction } = require("../../../services/transaction.service");
+const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
 
 exports.createTutorial = async (data, trx = db) => {
   const [tutorial] = await trx("tutorials").insert(data).returning("*");
   return tutorial;
+};
+
+/**
+ * Generate a unique slug for the provided title.
+ * Retries by appending a numeric suffix if slug already exists.
+ */
+exports.generateUniqueSlug = async (title, trx = db) => {
+  const base = slugify(title, { lower: true, strict: true });
+  let slug = base;
+  let count = 1;
+  // eslint-disable-next-line no-await-in-loop
+  while (await trx("tutorials").where({ slug }).first()) {
+    slug = `${base}-${count++}`;
+  }
+  return slug;
+};
+
+/**
+ * Insert tutorial chapters.
+ */
+async function insertChapters(tutorialId, chapters, trx) {
+  for (let i = 0; i < chapters.length; i++) {
+    const ch = chapters[i];
+    // eslint-disable-next-line no-await-in-loop
+    await chapterService.create(
+      {
+        id: uuidv4(),
+        tutorial_id: tutorialId,
+        title: ch.title,
+        video_url: ch.video_url,
+        duration: ch.duration,
+        order: ch.order ?? i + 1,
+        is_preview: ch.is_preview ?? false,
+      },
+      trx
+    );
+  }
+}
+
+/**
+ * Create a tutorial along with tags and chapters using a managed transaction.
+ * Handles slug uniqueness with retry on conflicts.
+ */
+exports.createTutorialWithRelations = async (data, tags = [], chapters = []) => {
+  return withTransaction(async (trx) => {
+    let tutorial;
+    let attempts = 0;
+    // retry a few times in case of slug conflicts
+    while (!tutorial && attempts < 5) {
+      data.slug = await exports.generateUniqueSlug(data.title, trx);
+      try {
+        tutorial = await exports.createTutorial(data, trx);
+      } catch (err) {
+        if (err.constraint === "tutorials_slug_key") {
+          attempts += 1;
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    if (!tutorial) {
+      throw new Error("Unable to generate unique slug for tutorial");
+    }
+
+    if (tags.length) {
+      await exports.updateTutorialTags(tutorial.id, tags, trx);
+      tutorial.tags = await exports.getTutorialTags(tutorial.id, trx);
+    }
+
+    if (chapters.length) {
+      await insertChapters(tutorial.id, chapters, trx);
+    }
+
+    return tutorial;
+  });
+};
+
+/**
+ * Update tutorial tags within a managed transaction and return updated tags.
+ */
+exports.updateTutorialTagsTransactional = async (tutorialId, tags) => {
+  return withTransaction(async (trx) => {
+    await exports.updateTutorialTags(tutorialId, tags, trx);
+    return exports.getTutorialTags(tutorialId, trx);
+  });
 };
 
 exports.getAllTutorials = async (filters = {}) => {

--- a/backend/src/services/transaction.service.js
+++ b/backend/src/services/transaction.service.js
@@ -1,0 +1,22 @@
+const db = require('../config/database');
+
+/**
+ * Run the provided callback within a database transaction.
+ * Automatically commits if the callback resolves and rolls back on error.
+ *
+ * @param {(trx: import('knex').Knex.Transaction) => Promise<any>} handler
+ * @returns {Promise<any>}
+ */
+async function withTransaction(handler) {
+  const trx = await db.transaction();
+  try {
+    const result = await handler(trx);
+    await trx.commit();
+    return result;
+  } catch (err) {
+    await trx.rollback();
+    throw err;
+  }
+}
+
+module.exports = { withTransaction };


### PR DESCRIPTION
## Summary
- add generic `withTransaction` helper to manage commit/rollback
- move tutorial slug generation, tag handling, chapter creation to service layer
- streamline tutorial controller and centralize notifications for new tutorials

## Testing
- `npm test` *(fails: Route.post requires callback; numerous process.exit from missing DB config)*

------
https://chatgpt.com/codex/tasks/task_e_68b35bf1cf0483288ee6b805fa09dd3d