### PR TITLE
Ensure tutorial endpoints validate auth and IDs

### DIFF
--- a/backend/src/modules/users/tutorials/assignments/submission.controller.js
+++ b/backend/src/modules/users/tutorials/assignments/submission.controller.js
@@ -4,33 +4,37 @@ const { sendSuccess } = require("../../../../utils/response");
 const service = require("./submission.service");
 const assignmentService = require("./tutorialAssignment.service");
 const enrollmentService = require("../enrollments/tutorialEnrollment.service");
+const { requireUser } = require("../utils");
 
 exports.getMySubmission = catchAsync(async (req, res) => {
+  const userId = requireUser(req);
   const submission = await service.getMySubmission(
     req.params.assignmentId,
-    req.user.id
+    userId
   );
   sendSuccess(res, submission);
 });
 
 exports.createSubmission = catchAsync(async (req, res) => {
+  const userId = requireUser(req);
   const data = {
     ...req.body,
     id: uuidv4(),
     assignment_id: req.params.assignmentId,
-    user_id: req.user.id,
+    user_id: userId,
   };
   const submission = await service.createSubmission(data);
   const assignment = await assignmentService.getById(req.params.assignmentId);
   if (assignment)
     await enrollmentService.recalculateProgress(
-      req.user.id,
+      userId,
       assignment.tutorial_id
     );
   sendSuccess(res, submission, "Submission created");
 });
 
 exports.updateSubmission = catchAsync(async (req, res) => {
+  const userId = requireUser(req);
   const submission = await service.updateSubmission(
     req.params.submissionId,
     req.body
@@ -38,7 +42,7 @@ exports.updateSubmission = catchAsync(async (req, res) => {
   const assignment = await assignmentService.getById(submission.assignment_id);
   if (assignment)
     await enrollmentService.recalculateProgress(
-      req.user.id,
+      userId,
       assignment.tutorial_id
     );
   sendSuccess(res, submission, "Submission updated");

--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.controller.js
@@ -8,24 +8,26 @@ const enrollmentService = require('../enrollments/tutorialEnrollment.service');
 const notificationService = require('../../../notifications/notifications.service');
 const smsService = require('../../../../services/smsService');
 const { sendAssignmentEmail } = require('../../../../utils/email');
+const { requireValidTutorialId } = require('../utils');
 
 exports.getAssignmentsByTutorial = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
+  const tutorialId = requireValidTutorialId(req);
   const assignments = await service.getByTutorial(tutorialId);
   sendSuccess(res, assignments);
 });
 
 exports.createAssignment = catchAsync(async (req, res) => {
+  const tutorialId = requireValidTutorialId(req);
   const data = {
     ...req.body,
     id: uuidv4(),
-    tutorial_id: req.params.tutorialId,
+    tutorial_id: tutorialId,
   };
   const assignment = await service.createAssignment(data);
 
   try {
-    const tutorial = await tutorialService.getTutorialById(req.params.tutorialId);
-    const students = await enrollmentService.getByTutorial(req.params.tutorialId);
+    const tutorial = await tutorialService.getTutorialById(tutorialId);
+    const students = await enrollmentService.getByTutorial(tutorialId);
     if (tutorial && students.length) {
       const message = `New assignment "${assignment.title}" posted for tutorial "${tutorial.title}".`;
       await Promise.all(

--- a/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
@@ -4,10 +4,10 @@ const { sendSuccess } = require("../../../../utils/response");
 const AppError = require("../../../../utils/AppError");
 const db = require("../../../../config/database");
 const notificationService = require("../../../notifications/notifications.service");
+const { requireUserAndTutorial } = require("../utils");
 
 exports.generateCertificate = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
-  const userId = req.user.id;
+  const { userId, tutorialId } = requireUserAndTutorial(req);
 
   // 1. Validate completion (including assignments)
   const completed = await service.isUserCompletedTutorial(userId, tutorialId);

--- a/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
+++ b/backend/src/modules/users/tutorials/chapters/tutorialChapter.controller.js
@@ -5,9 +5,12 @@ const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 const uploadChapterVideo = require("./uploadChapterVideo");
 const db = require("../../../../config/database");
+const { requireUser, requireValidTutorialId } = require("../utils");
 
 // Ensure the requesting user is the tutorial's instructor or an admin
 const assertTutorialAccess = async (req, tutorialId) => {
+  requireUser(req);
+  requireValidTutorialId({ params: { tutorialId } });
   const tutorial = await db("tutorials")
     .select("instructor_id")
     .where({ id: tutorialId })
@@ -84,7 +87,7 @@ exports.deleteChapter = catchAsync(async (req, res) => {
 
 // List chapters by tutorial
 exports.getChaptersByTutorial = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
+  const tutorialId = requireValidTutorialId(req);
   const tutorial = await db("tutorials")
     .where({ id: tutorialId, status: "published" })
     .first();
@@ -109,7 +112,7 @@ exports.getChaptersByTutorial = catchAsync(async (req, res) => {
 
 // Reorder chapters within a tutorial
 exports.reorderChapters = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
+  const tutorialId = requireValidTutorialId(req);
   const { orderedIds } = req.body;
 
   if (!Array.isArray(orderedIds)) {

--- a/backend/src/modules/users/tutorials/comments/tutorialComment.controller.js
+++ b/backend/src/modules/users/tutorials/comments/tutorialComment.controller.js
@@ -3,12 +3,13 @@ const catchAsync = require("../../../../utils/catchAsync");
 const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 const AppError = require("../../../../utils/AppError");
+const { requireUserAndTutorial, requireValidTutorialId } = require("../utils");
 
 // Post a comment
 exports.createComment = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
+  const { userId, tutorialId } = requireUserAndTutorial(req);
   const { message, parent_id } = req.body;
-  const user_id = req.user.id;
+  const user_id = userId;
 
   const enrolled = await db("tutorial_enrollments")
     .where({ tutorial_id: tutorialId, user_id })
@@ -33,7 +34,7 @@ exports.createComment = catchAsync(async (req, res) => {
 
 // Get comments for a tutorial
 exports.getComments = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
+  const tutorialId = requireValidTutorialId(req);
 
   const comments = await db("tutorial_comments")
     .join("users", "users.id", "tutorial_comments.user_id")

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -3,11 +3,12 @@ const catchAsync = require("../../../../utils/catchAsync");
 const AppError = require("../../../../utils/AppError");
 const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
+const { requireUser, requireUserAndTutorial } = require("../utils");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
-  const user_id = req.user.id;
+  const { userId, tutorialId } = requireUserAndTutorial(req);
+  const user_id = userId;
 
   const tutorial = await db("tutorials").where({ id: tutorialId }).first();
   if (!tutorial) throw new AppError("Tutorial not found", 404);
@@ -55,8 +56,8 @@ exports.enroll = catchAsync(async (req, res) => {
 
 // Mark as completed
 exports.complete = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
-  const user_id = req.user.id;
+  const { userId, tutorialId } = requireUserAndTutorial(req);
+  const user_id = userId;
 
   // Ensure enrollment exists
   const enrollment = await db("tutorial_enrollments")
@@ -124,7 +125,7 @@ exports.complete = catchAsync(async (req, res) => {
 
 // Get all enrolled tutorials for student
 exports.getMyEnrollments = catchAsync(async (req, res) => {
-  const user_id = req.user.id;
+  const user_id = requireUser(req);
 
   const rows = await db("tutorial_enrollments")
     .join("tutorials", "tutorials.id", "tutorial_enrollments.tutorial_id")
@@ -136,8 +137,8 @@ exports.getMyEnrollments = catchAsync(async (req, res) => {
 
 // Get enrollment status and progress for a tutorial
 exports.getStatus = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
-  const user_id = req.user.id;
+  const { userId, tutorialId } = requireUserAndTutorial(req);
+  const user_id = userId;
 
   const enrollment = await db("tutorial_enrollments")
     .where({ user_id, tutorial_id: tutorialId })
@@ -163,9 +164,9 @@ exports.getStatus = catchAsync(async (req, res) => {
 
 // Update progress percentage for a tutorial
 exports.updateProgress = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
+  const { userId, tutorialId } = requireUserAndTutorial(req);
   let { progress } = req.body;
-  const user_id = req.user.id;
+  const user_id = userId;
 
   const enrollment = await db("tutorial_enrollments")
     .where({ user_id, tutorial_id: tutorialId })

--- a/backend/src/modules/users/tutorials/favorites/tutorialFavorite.controller.js
+++ b/backend/src/modules/users/tutorials/favorites/tutorialFavorite.controller.js
@@ -1,18 +1,22 @@
 const catchAsync = require('../../../../utils/catchAsync');
 const { sendSuccess } = require('../../../../utils/response');
 const service = require('./tutorialFavorite.service');
+const { requireUser, requireUserAndTutorial } = require('../utils');
 
 exports.add = catchAsync(async (req, res) => {
-  await service.add(req.user.id, req.params.tutorialId);
+  const { userId, tutorialId } = requireUserAndTutorial(req);
+  await service.add(userId, tutorialId);
   sendSuccess(res, null, 'Added to favorites');
 });
 
 exports.remove = catchAsync(async (req, res) => {
-  await service.remove(req.user.id, req.params.tutorialId);
+  const { userId, tutorialId } = requireUserAndTutorial(req);
+  await service.remove(userId, tutorialId);
   sendSuccess(res, null, 'Removed from favorites');
 });
 
 exports.listMine = catchAsync(async (req, res) => {
-  const list = await service.listByUser(req.user.id);
+  const userId = requireUser(req);
+  const list = await service.listByUser(userId);
   sendSuccess(res, list);
 });

--- a/backend/src/modules/users/tutorials/reviews/tutorialReview.controller.js
+++ b/backend/src/modules/users/tutorials/reviews/tutorialReview.controller.js
@@ -2,12 +2,12 @@ const db = require("../../../../config/database");
 const catchAsync = require("../../../../utils/catchAsync");
 const { sendSuccess } = require("../../../../utils/response");
 const AppError = require("../../../../utils/AppError");
+const { requireUserAndTutorial, requireValidTutorialId } = require("../utils");
 
 // Submit or update a review
 exports.submitReview = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
+  const { userId, tutorialId } = requireUserAndTutorial(req);
   const { rating, comment } = req.body;
-  const userId = req.user.id;
 
   const enrolled = await db("tutorial_enrollments")
     .where({ tutorial_id: tutorialId, user_id: userId })
@@ -41,7 +41,7 @@ exports.submitReview = catchAsync(async (req, res) => {
 
 // Get reviews for a tutorial
 exports.getReviews = catchAsync(async (req, res) => {
-  const { tutorialId } = req.params;
+  const tutorialId = requireValidTutorialId(req);
 
   const reviews = await db("tutorial_reviews")
     .join("users", "users.id", "tutorial_reviews.user_id")

--- a/backend/src/modules/users/tutorials/utils.js
+++ b/backend/src/modules/users/tutorials/utils.js
@@ -1,0 +1,26 @@
+const { validate: isUUID } = require('uuid');
+const AppError = require('../../../utils/AppError');
+
+exports.requireUser = (req) => {
+  if (!req.user || !req.user.id) {
+    throw new AppError('Authentication required', 401);
+  }
+  return req.user.id;
+};
+
+exports.requireUserAndTutorial = (req) => {
+  const userId = exports.requireUser(req);
+  const { tutorialId } = req.params;
+  if (!isUUID(tutorialId)) {
+    throw new AppError('Invalid tutorial ID', 400);
+  }
+  return { userId, tutorialId };
+};
+
+exports.requireValidTutorialId = (req) => {
+  const { tutorialId } = req.params;
+  if (!isUUID(tutorialId)) {
+    throw new AppError('Invalid tutorial ID', 400);
+  }
+  return tutorialId;
+};

--- a/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.controller.js
+++ b/backend/src/modules/users/tutorials/wishlist/tutorialWishlist.controller.js
@@ -1,18 +1,22 @@
 const catchAsync = require('../../../../utils/catchAsync');
 const { sendSuccess } = require('../../../../utils/response');
 const service = require('./tutorialWishlist.service');
+const { requireUser, requireUserAndTutorial } = require('../utils');
 
 exports.add = catchAsync(async (req, res) => {
-  await service.add(req.user.id, req.params.tutorialId);
+  const { userId, tutorialId } = requireUserAndTutorial(req);
+  await service.add(userId, tutorialId);
   sendSuccess(res, null, 'Added to wishlist');
 });
 
 exports.remove = catchAsync(async (req, res) => {
-  await service.remove(req.user.id, req.params.tutorialId);
+  const { userId, tutorialId } = requireUserAndTutorial(req);
+  await service.remove(userId, tutorialId);
   sendSuccess(res, null, 'Removed from wishlist');
 });
 
 exports.listMine = catchAsync(async (req, res) => {
-  const list = await service.listByUser(req.user.id);
+  const userId = requireUser(req);
+  const list = await service.listByUser(userId);
   sendSuccess(res, list);
 });


### PR DESCRIPTION
## Summary
- add shared utilities to require authenticated users and validate tutorial UUIDs
- guard tutorial favorite, wishlist, comments, reviews, enrollment, assignments, certificate, and chapter controllers with new validation
- prevent DB queries when authentication or tutorial ID checks fail

## Testing
- `npm test` *(fails: process.exit called and multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b35bf662b48328b00bb4f3b67084c8