### PR TITLE
feat: validate pagination inputs

### DIFF
--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -11,10 +11,10 @@ exports.createBook = async (data) => {
   return row;
 };
 
+const { parsePagination } = require("../../utils/pagination");
+
 exports.listBooks = async (params = {}) => {
   const {
-    page = 1,
-    perPage = 10,
     search,
     category,
     status,
@@ -24,6 +24,11 @@ exports.listBooks = async (params = {}) => {
     sortBy = "newest",
     instructorId,
   } = params;
+
+  const { page, limit: perPage, offset } = parsePagination({
+    page: params.page,
+    limit: params.perPage,
+  });
 
   const query = db("books as b");
 
@@ -78,16 +83,13 @@ exports.listBooks = async (params = {}) => {
   const { count } = await countQuery;
   const total = Number(count) || 0;
 
-  const books = await query
-    .clone()
-    .offset((page - 1) * perPage)
-    .limit(perPage);
+  const books = await query.clone().offset(offset).limit(perPage);
 
   return {
     data: books,
     meta: {
-      page: Number(page),
-      perPage: Number(perPage),
+      page,
+      perPage,
       total,
       totalPages: Math.ceil(total / perPage),
     },

--- a/backend/src/modules/certificates/certificates.service.js
+++ b/backend/src/modules/certificates/certificates.service.js
@@ -7,8 +7,10 @@ const db = require("../../config/database");
  * Fetch all certificates with related student and class info
  * Supports simple pagination via `page` and `limit` parameters
  */
+const { parsePagination } = require("../../utils/pagination");
+
 exports.getAll = async ({ page = 1, limit = 10 } = {}) => {
-  const offset = (page - 1) * limit;
+  const { limit: lim, offset } = parsePagination({ page, limit });
 
   return db("certificates")
     .leftJoin("users", "certificates.user_id", "users.id")
@@ -20,5 +22,5 @@ exports.getAll = async ({ page = 1, limit = 10 } = {}) => {
     )
     .orderBy("certificates.created_at", "desc")
     .offset(offset)
-    .limit(limit);
+    .limit(lim);
 };

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -1,12 +1,13 @@
 const db = require("../../config/database");
 const ClassModel = require("./class.model");
+const { parsePagination } = require("../../utils/pagination");
 
 exports.createClass = async (data) => {
   return ClassModel.create(data);
 };
 
 exports.getAllClasses = async ({ page = 1, limit = 10 } = {}) => {
-  const offset = (page - 1) * limit;
+  const { page: pg, limit: lim, offset } = parsePagination({ page, limit });
   const totalRow = await db("online_classes").count("id as count").first();
   const total = parseInt(totalRow.count, 10) || 0;
 
@@ -49,16 +50,16 @@ exports.getAllClasses = async ({ page = 1, limit = 10 } = {}) => {
       "cat.name"
     )
     .orderBy("c.created_at", "desc")
-    .limit(limit)
+    .limit(lim)
     .offset(offset);
 
   return {
     data: classes,
     meta: {
-      page: Number(page),
-      limit: Number(limit),
+      page: pg,
+      limit: lim,
       total,
-      totalPages: Math.ceil(total / limit),
+      totalPages: Math.ceil(total / lim),
     },
   };
 };
@@ -88,7 +89,7 @@ exports.getClassById = async (id) => {
 };
 
 exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } = {}) => {
-  const offset = (page - 1) * limit;
+  const { page: pg, limit: lim, offset } = parsePagination({ page, limit });
   const totalRow = await db("online_classes")
     .where({ instructor_id: instructorId })
     .count("id as count")
@@ -132,16 +133,16 @@ exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } =
       "cat.name"
     )
     .orderBy("c.created_at", "desc")
-    .limit(limit)
+    .limit(lim)
     .offset(offset);
 
   return {
     data: classes,
     meta: {
-      page: Number(page),
-      limit: Number(limit),
+      page: pg,
+      limit: lim,
       total,
-      totalPages: Math.ceil(total / limit),
+      totalPages: Math.ceil(total / lim),
     },
   };
 };
@@ -180,7 +181,7 @@ exports.updateModeration = async (id, status, reason = null) => {
 };
 
 exports.getPublishedClasses = async ({ page = 1, limit = 10 } = {}) => {
-  const offset = (page - 1) * limit;
+  const { page: pg, limit: lim, offset } = parsePagination({ page, limit });
 
   const totalRow = await db("online_classes")
     .where({ status: "published", moderation_status: "Approved" })
@@ -202,7 +203,7 @@ exports.getPublishedClasses = async ({ page = 1, limit = 10 } = {}) => {
       db.raw("COALESCE(e.recent_enrollments, 0) as recent_enrollments")
     )
     .orderBy("c.created_at", "desc")
-    .limit(limit)
+    .limit(lim)
     .offset(offset);
 
   const classes = rows.map((cls) => ({
@@ -214,10 +215,10 @@ exports.getPublishedClasses = async ({ page = 1, limit = 10 } = {}) => {
   return {
     data: classes,
     meta: {
-      page: Number(page),
-      limit: Number(limit),
+      page: pg,
+      limit: lim,
       total,
-      totalPages: Math.ceil(total / limit),
+      totalPages: Math.ceil(total / lim),
     },
   };
 };

--- a/backend/src/modules/users/categories/category.service.js
+++ b/backend/src/modules/users/categories/category.service.js
@@ -3,6 +3,7 @@
  * See docs/admin-category-management.md
  */
 const db = require("../../../config/database");
+const { parsePagination } = require("../../../utils/pagination");
 
 exports.create = async (data) => db("categories").insert(data).returning("*").then(rows => rows[0]);
 
@@ -38,7 +39,7 @@ exports.updateStatus = async (id, status) =>
   db("categories").where({ id }).update({ status });
 
 exports.getAll = async ({ search, status, page = 1, limit = 10 }) => {
-  const offset = (page - 1) * limit;
+  const { page: pg, limit: lim, offset } = parsePagination({ page, limit });
 
   const baseQuery = db("categories").modify((query) => {
     if (search) query.whereILike("name", `%${search}%`);
@@ -46,15 +47,19 @@ exports.getAll = async ({ search, status, page = 1, limit = 10 }) => {
   });
 
   const totalQuery = baseQuery.clone().count("* as count").first();
-  const dataQuery = baseQuery.clone().limit(limit).offset(offset).orderBy("created_at", "desc");
+  const dataQuery = baseQuery
+    .clone()
+    .limit(lim)
+    .offset(offset)
+    .orderBy("created_at", "desc");
 
   const [totalResult, data] = await Promise.all([totalQuery, dataQuery]);
 
   return {
     total: parseInt(totalResult.count),
     data,
-    page: Number(page),
-    limit: Number(limit),
+    page: pg,
+    limit: lim,
   };
 };
 

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -8,16 +8,11 @@ exports.createTutorial = async (data, trx = db) => {
   return tutorial;
 };
 
-exports.getAllTutorials = async (filters = {}) => {
-  const {
-    status,
-    category,
-    search,
-    page = 1,
-    limit = 10,
-  } = filters;
+const { parsePagination } = require("../../../utils/pagination");
 
-  const offset = (page - 1) * limit;
+exports.getAllTutorials = async (filters = {}) => {
+  const { status, category, search } = filters;
+  const { page, limit, offset } = parsePagination(filters);
 
   const baseQuery = db("tutorials as t")
     .leftJoin("categories as c", "t.category_id", "c.id")
@@ -57,8 +52,8 @@ exports.getAllTutorials = async (filters = {}) => {
   return {
     data: tutorials,
     meta: {
-      page: Number(page),
-      limit: Number(limit),
+      page,
+      limit,
       total,
       totalPages: Math.ceil(total / limit),
     },

--- a/backend/src/utils/pagination.js
+++ b/backend/src/utils/pagination.js
@@ -1,0 +1,20 @@
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+exports.parsePagination = ({ page = DEFAULT_PAGE, limit = DEFAULT_LIMIT } = {}) => {
+  let pageNum = parseInt(page, 10);
+  let limitNum = parseInt(limit, 10);
+
+  if (!Number.isInteger(pageNum) || pageNum < 1) {
+    pageNum = DEFAULT_PAGE;
+  }
+  if (!Number.isInteger(limitNum) || limitNum < 1) {
+    limitNum = DEFAULT_LIMIT;
+  }
+  if (limitNum > MAX_LIMIT) {
+    limitNum = MAX_LIMIT;
+  }
+  return { page: pageNum, limit: limitNum, offset: (pageNum - 1) * limitNum };
+};
+


### PR DESCRIPTION
## Summary
- add reusable `parsePagination` helper with positive integer validation and a 100-item cap
- apply pagination validation across book, certificate, tutorial, category, and class services

## Testing
- `npm test` *(fails: process exit errors and failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b35bfbd6fc8328859478650ef6c264