### PR TITLE
feat: improve offline progress storage

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "isomorphic-dompurify": "^2.26.0",
         "jspdf": "^3.0.1",
         "leo-profanity": "^1.7.0",
+        "localforage": "^1.10.0",
         "lodash": "^4.17.21",
         "lottie-react": "^2.4.1",
         "lucide-react": "^0.479.0",
@@ -7959,6 +7960,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immutable": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.1.tgz",
@@ -10249,6 +10256,15 @@
       "integrity": "sha512-VWwAdNeJgN7jFOD+wN4qx83DTPMVPPAUyx9/TUkBXKLiNkuWWk6anV0439tgdtwaJDrEdqkvdN22iA6J4bUCZg==",
       "license": "MIT"
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -10293,6 +10309,15 @@
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
       "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
       "license": "MIT"
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "jspdf": "^3.0.1",
     "leo-profanity": "^1.7.0",
     "lodash": "^4.17.21",
+    "localforage": "^1.10.0",
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.479.0",
     "moment": "^2.30.1",

--- a/frontend/src/store/tutorialProgressStore.js
+++ b/frontend/src/store/tutorialProgressStore.js
@@ -1,7 +1,31 @@
 import { create } from "zustand";
 import { fetchTutorialProgress, saveTutorialProgress } from "@/services/tutorialService";
+import localforage from "localforage";
 
 const OFFLINE_KEY = "skillbridge_offlineProgress";
+const MAX_OFFLINE_ENTRIES = 50;
+const OFFLINE_STORE = localforage.createInstance({
+  name: "skillbridge",
+  storeName: "offlineProgress",
+});
+
+async function enforceLimit() {
+  try {
+    const keys = await OFFLINE_STORE.keys();
+    if (keys.length <= MAX_OFFLINE_ENTRIES) return;
+    const records = await Promise.all(
+      keys.map(async (key) => {
+        const item = await OFFLINE_STORE.getItem(key);
+        return { key, ts: item?.ts || 0 };
+      })
+    );
+    records.sort((a, b) => b.ts - a.ts);
+    const toRemove = records.slice(MAX_OFFLINE_ENTRIES).map((r) => r.key);
+    await Promise.all(toRemove.map((k) => OFFLINE_STORE.removeItem(k)));
+  } catch (err) {
+    console.error("Failed to enforce offline entry limit", err);
+  }
+}
 
 const useTutorialProgressStore = create((set, get) => ({
   status: {}, // { [tutorialId]: { enrolled, progress, status } }
@@ -13,15 +37,26 @@ const useTutorialProgressStore = create((set, get) => ({
       set((state) => ({ status: { ...state.status, [id]: data } }));
       return data;
     } catch (err) {
-      // Fallback to offline progress if available
       if (typeof window !== "undefined") {
+        try {
+          const record = await OFFLINE_STORE.getItem(id.toString());
+          if (record) {
+            const data = { enrolled: false, status: null, progress: record.progress };
+            set((state) => ({ status: { ...state.status, [id]: data } }));
+            return data;
+          }
+        } catch (e) {
+          console.error("Failed to load offline progress", e);
+        }
         try {
           const offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
           const progress = offline[id] || 0;
           const data = { enrolled: false, status: null, progress };
           set((state) => ({ status: { ...state.status, [id]: data } }));
           return data;
-        } catch {}
+        } catch (parseErr) {
+          console.error("Failed to parse legacy offline progress", parseErr);
+        }
       }
       return { enrolled: false, status: null, progress: 0 };
     }
@@ -42,30 +77,37 @@ const useTutorialProgressStore = create((set, get) => ({
         },
       }));
       if (typeof window !== "undefined") {
-        const offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
-        delete offline[id];
-        localStorage.setItem(OFFLINE_KEY, JSON.stringify(offline));
+        try {
+          await OFFLINE_STORE.removeItem(id.toString());
+        } catch (e) {
+          console.error("Failed to remove offline progress", e);
+        }
+        try {
+          const offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
+          delete offline[id];
+          localStorage.setItem(OFFLINE_KEY, JSON.stringify(offline));
+        } catch (parseErr) {
+          console.error("Failed to clean legacy offline progress", parseErr);
+        }
       }
-    } catch {
+    } catch (err) {
       if (typeof window !== "undefined") {
-        const offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
-        offline[id] = progress;
-        localStorage.setItem(OFFLINE_KEY, JSON.stringify(offline));
+        try {
+          await OFFLINE_STORE.setItem(id.toString(), { progress, ts: Date.now() });
+          await enforceLimit();
+        } catch (e) {
+          console.error("Failed to save offline progress", e);
+        }
       }
     }
   },
   async syncOffline() {
     if (typeof window === "undefined") return;
-    let offline;
-    try {
-      offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
-    } catch {
-      offline = {};
-    }
-    const ids = Object.keys(offline);
-    for (const id of ids) {
+    const keys = await OFFLINE_STORE.keys();
+    for (const id of keys) {
       try {
-        const progress = offline[id];
+        const record = await OFFLINE_STORE.getItem(id);
+        const progress = record?.progress;
         const data = await saveTutorialProgress(id, progress);
         set((state) => ({
           status: {
@@ -79,12 +121,39 @@ const useTutorialProgressStore = create((set, get) => ({
               },
           },
         }));
-        delete offline[id];
-      } catch {
-        // keep if failed
+        await OFFLINE_STORE.removeItem(id);
+      } catch (err) {
+        console.error(`Failed to sync offline progress for ${id}`, err);
       }
     }
-    localStorage.setItem(OFFLINE_KEY, JSON.stringify(offline));
+    try {
+      const offline = JSON.parse(localStorage.getItem(OFFLINE_KEY) || "{}");
+      const ids = Object.keys(offline);
+      for (const id of ids) {
+        try {
+          const progress = offline[id];
+          const data = await saveTutorialProgress(id, progress);
+          set((state) => ({
+            status: {
+              ...state.status,
+              [id]:
+                data || {
+                  ...(state.status[id] || {}),
+                  enrolled: true,
+                  status: data?.status ?? state.status[id]?.status ?? null,
+                  progress,
+                },
+            },
+          }));
+          delete offline[id];
+        } catch (err) {
+          console.error(`Failed to sync legacy offline progress for ${id}`, err);
+        }
+      }
+      localStorage.setItem(OFFLINE_KEY, JSON.stringify(offline));
+    } catch (parseErr) {
+      console.error("Failed to parse legacy offline progress during sync", parseErr);
+    }
   },
 }));
 


### PR DESCRIPTION
## Summary
- use IndexedDB (via localforage) for offline tutorial progress
- limit offline cache to 50 recent entries
- log parsing errors instead of swallowing them silently

## Testing
- `npm test`
- `npm run lint` *(fails: 34 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b35bfb1c60832887ac9f42c583b1a0