### PR TITLE
Handle missing last active timestamp in chat header

### DIFF
--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -26,7 +26,14 @@ const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
 
   const isOnline =
     selectedChat.isOnline ?? selectedChat.is_online ?? selectedChat.status === "online";
-  const lastActive = selectedChat.lastActive || selectedChat.last_active;
+  const lastActiveRaw = selectedChat.lastActive || selectedChat.last_active;
+  let lastActiveText = "Last active: unknown.";
+  if (lastActiveRaw) {
+    const formatted = formatRelativeTime(lastActiveRaw);
+    if (formatted && formatted !== "Invalid date") {
+      lastActiveText = `Last active ${formatted}`;
+    }
+  }
   const hasPhone = !!selectedChat.phone;
   const email = selectedChat.email;
 
@@ -90,7 +97,7 @@ const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
           </h3>
           {!selectedChat.isGroup && (
             <div className="text-sm text-gray-400">
-              {isOnline ? "Online" : `Last active ${formatRelativeTime(lastActive)}`}
+              {isOnline ? "Online" : lastActiveText}
             </div>
           )}
         </div>

--- a/frontend/src/tests/__tests__/ChatHeader.test.js
+++ b/frontend/src/tests/__tests__/ChatHeader.test.js
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import ChatHeader from '@/components/chat/ChatHeader';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+test('renders fallback when lastActive is missing', () => {
+  const chat = {
+    id: 1,
+    name: 'Test User',
+    isGroup: false,
+    isOnline: false,
+    profileImage: '/avatar.png',
+  };
+
+  render(<ChatHeader selectedChat={chat} />);
+  expect(screen.getByText('Last active: unknown.')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- Safely format lastActive in ChatHeader, using "Last active: unknown." when timestamp is missing or invalid
- Add unit test to ensure ChatHeader renders fallback text when lastActive is absent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35dcc5ad48328be3aed8f63aee073