### PR TITLE
Expose last message metadata for chat users and groups

### DIFF
--- a/backend/src/modules/chat/chat.service.js
+++ b/backend/src/modules/chat/chat.service.js
@@ -11,6 +11,25 @@ exports.searchUsers = async (currentUserId, term) => {
     .groupBy("sender_id")
     .as("unread");
 
+  const lastMessageSub = db.raw(
+    `(
+      SELECT DISTINCT ON (other_user)
+        other_user AS user_id,
+        message,
+        EXTRACT(EPOCH FROM sent_at) * 1000 AS last_message_at
+      FROM (
+        SELECT
+          CASE WHEN sender_id = ? THEN receiver_id ELSE sender_id END AS other_user,
+          message,
+          sent_at
+        FROM messages
+        WHERE sender_id = ? OR receiver_id = ?
+      ) m
+      ORDER BY other_user, sent_at DESC
+    ) as last_msg`,
+    [currentUserId, currentUserId, currentUserId]
+  );
+
   return db("users")
     .select(
       "users.id",
@@ -20,9 +39,12 @@ exports.searchUsers = async (currentUserId, term) => {
       db.raw("COALESCE(users.avatar_url, '') as profileImage"),
       db.raw("COALESCE(unread.count, 0) as unreadMessages"),
       db.raw("COALESCE(users.is_online, false) as \"isOnline\""),
-      db.raw("EXTRACT(EPOCH FROM users.updated_at) * 1000 as \"lastActive\"")
+      db.raw("EXTRACT(EPOCH FROM users.updated_at) * 1000 as \"lastActive\""),
+      db.raw("COALESCE(last_msg.message, '') as last_message"),
+      db.raw("COALESCE(last_msg.last_message_at, 0) as last_message_at")
     )
     .leftJoin(subquery, "users.id", "unread.sender_id")
+    .leftJoin(lastMessageSub, "users.id", "last_msg.user_id")
     .modify((query) => {
       if (term) {
         const t = `%${term}%`;

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -133,11 +133,23 @@ exports.cancelJoinRequest = async (groupId, userId) => {
 };
 
 exports.getUserGroups = async (userId) => {
+  const lastMessageSub = db.raw(
+    `(
+      SELECT DISTINCT ON (group_id)
+        group_id,
+        message,
+        EXTRACT(EPOCH FROM sent_at) * 1000 AS last_message_at
+      FROM group_messages
+      ORDER BY group_id, sent_at DESC
+    ) as last_msg`
+  );
+
   const memberQuery = db("group_members as gm")
     .join("groups as g", "gm.group_id", "g.id")
     .leftJoin("users as u", "g.creator_id", "u.id")
     .leftJoin("categories as c", "g.category_id", "c.id")
     .leftJoin("group_members as gm2", "g.id", "gm2.group_id")
+    .leftJoin(lastMessageSub, "g.id", "last_msg.group_id")
     .select(
       "g.*",
       "gm.role",
@@ -145,14 +157,25 @@ exports.getUserGroups = async (userId) => {
       db.raw("COALESCE(u.role, '') as creator_role"),
       db.raw("COALESCE(c.name, '') as category"),
       db.raw("COUNT(DISTINCT gm2.id) as members_count"),
+      db.raw("COALESCE(last_msg.message, '') as last_message"),
+      db.raw("COALESCE(last_msg.last_message_at, 0) as last_message_at"),
     )
     .where("gm.user_id", userId)
-    .groupBy("g.id", "gm.role", "u.full_name", "u.role", "c.name");
+    .groupBy(
+      "g.id",
+      "gm.role",
+      "u.full_name",
+      "u.role",
+      "c.name",
+      "last_msg.message",
+      "last_msg.last_message_at"
+    );
 
   const creatorQuery = db("groups as g")
     .leftJoin("users as u", "g.creator_id", "u.id")
     .leftJoin("categories as c", "g.category_id", "c.id")
     .leftJoin("group_members as gm2", "g.id", "gm2.group_id")
+    .leftJoin(lastMessageSub, "g.id", "last_msg.group_id")
     .select(
       "g.*",
       db.raw("'admin' as role"),
@@ -160,15 +183,25 @@ exports.getUserGroups = async (userId) => {
       db.raw("COALESCE(u.role, '') as creator_role"),
       db.raw("COALESCE(c.name, '') as category"),
       db.raw("COUNT(DISTINCT gm2.id) as members_count"),
+      db.raw("COALESCE(last_msg.message, '') as last_message"),
+      db.raw("COALESCE(last_msg.last_message_at, 0) as last_message_at"),
     )
     .where("g.creator_id", userId)
-    .groupBy("g.id", "u.full_name", "u.role", "c.name");
+    .groupBy(
+      "g.id",
+      "u.full_name",
+      "u.role",
+      "c.name",
+      "last_msg.message",
+      "last_msg.last_message_at"
+    );
 
   const pendingQuery = db("group_join_requests as gj")
     .join("groups as g", "gj.group_id", "g.id")
     .leftJoin("users as u", "g.creator_id", "u.id")
     .leftJoin("categories as c", "g.category_id", "c.id")
     .leftJoin("group_members as gm2", "g.id", "gm2.group_id")
+    .leftJoin(lastMessageSub, "g.id", "last_msg.group_id")
     .select(
       "g.*",
       db.raw("'pending' as role"),
@@ -176,10 +209,19 @@ exports.getUserGroups = async (userId) => {
       db.raw("COALESCE(u.role, '') as creator_role"),
       db.raw("COALESCE(c.name, '') as category"),
       db.raw("COUNT(DISTINCT gm2.id) as members_count"),
+      db.raw("COALESCE(last_msg.message, '') as last_message"),
+      db.raw("COALESCE(last_msg.last_message_at, 0) as last_message_at"),
     )
     .where("gj.user_id", userId)
     .andWhere("gj.status", "pending")
-    .groupBy("g.id", "u.full_name", "u.role", "c.name");
+    .groupBy(
+      "g.id",
+      "u.full_name",
+      "u.role",
+      "c.name",
+      "last_msg.message",
+      "last_msg.last_message_at"
+    );
 
   const [createdRows, memberRows, pendingRows] = await Promise.all([
     creatorQuery,

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -9,12 +9,22 @@ import socket from "@/services/socketService";
 
 export const getUsers = async () => {
   const res = await api.get("/chat/users");
-  return res.data.data || res.data;
+  const data = res.data.data || res.data;
+  return (data || []).map((u) => ({
+    ...u,
+    lastMessage: u.lastMessage || u.last_message,
+    lastMessageAt: u.lastMessageAt || u.last_message_at,
+  }));
 };
 
 export const getGroups = async () => {
   const res = await api.get("/groups/my");
-  return res.data.data || res.data;
+  const data = res.data.data || res.data;
+  return (data || []).map((g) => ({
+    ...g,
+    lastMessage: g.lastMessage || g.last_message,
+    lastMessageAt: g.lastMessageAt || g.last_message_at,
+  }));
 };
 
 export const getMessages = async ({ limit, offset } = {}) => {


### PR DESCRIPTION
## Summary
- surface each user's latest message details in chat search
- include latest group message in user group listing
- expose `lastMessage` data to the frontend message service

## Testing
- `cd backend && npm test` *(fails: process.exit called because database config missing)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b35dc54e588328a8719585d068a5fe