### PR TITLE
Add video error handling with fallback UI

### DIFF
--- a/frontend/src/components/shared/CustomVideoPlayer.js
+++ b/frontend/src/components/shared/CustomVideoPlayer.js
@@ -19,6 +19,7 @@ export default function CustomVideoPlayer({
   const [progress, setProgress] = useState(0);
   const [playbackRate, setPlaybackRate] = useState(1);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [error, setError] = useState(false);
   const videoRef = useRef(null);
   const playerRef = useRef(null);
 
@@ -30,6 +31,7 @@ export default function CustomVideoPlayer({
     video.load();
     setIsPlaying(false);
     setProgress(0);
+    setError(false);
   }, [currentVideo]);
 
   // Seek to provided start time whenever it changes and metadata is already loaded
@@ -167,6 +169,19 @@ export default function CustomVideoPlayer({
     }
   };
 
+  const handleError = () => {
+    setError(true);
+    setIsPlaying(false);
+  };
+
+  const handleRetry = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    setError(false);
+    video.load();
+    video.play().then(() => setIsPlaying(true)).catch(() => {});
+  };
+
   return (
     <div
       ref={playerRef}
@@ -178,6 +193,7 @@ export default function CustomVideoPlayer({
         className={`w-full ${videoClassName}`}
         src={currentVideo}
         onClick={togglePlay}
+        onError={handleError}
         autoPlay={isPlaying}
         muted={isMuted}
         preload="metadata"
@@ -187,6 +203,28 @@ export default function CustomVideoPlayer({
       {locked && (
         <div className="absolute inset-0 bg-black/70 flex items-center justify-center text-white text-center p-4">
           <p>Login and enroll to watch full tutorial</p>
+        </div>
+      )}
+
+      {error && (
+        <div className="absolute inset-0 bg-black/70 flex flex-col items-center justify-center text-white text-center p-4">
+          <p>Video unavailable</p>
+          <div className="mt-2 space-x-2">
+            <button
+              onClick={handleRetry}
+              className="px-4 py-2 bg-yellow-500 rounded"
+            >
+              Retry
+            </button>
+            {currentVideo && (
+              <button
+                onClick={downloadVideo}
+                className="px-4 py-2 bg-gray-700 rounded"
+              >
+                Download
+              </button>
+            )}
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/tutorials/detail/VideoPlayer.js
+++ b/frontend/src/components/tutorials/detail/VideoPlayer.js
@@ -1,14 +1,54 @@
+import { useRef, useState } from "react";
+
 // components/tutorials/detail/VideoPlayer.js
-const VideoPlayer = ({ videoUrl, onEnded }) => (
+const VideoPlayer = ({ videoUrl, onEnded }) => {
+  const [error, setError] = useState(false);
+  const videoRef = useRef(null);
+
+  const handleRetry = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    setError(false);
+    video.load();
+    video.play().catch(() => {});
+  };
+
+  return (
     <div className="w-full aspect-video rounded-xl overflow-hidden shadow-lg bg-black">
-      <video
-        src={videoUrl}
-        controls
-        onEnded={onEnded}
-        className="w-full h-full object-cover"
-      />
+      {error ? (
+        <div className="flex flex-col items-center justify-center w-full h-full text-white p-4">
+          <p>Video unavailable</p>
+          <div className="mt-2 space-x-2">
+            <button
+              onClick={handleRetry}
+              className="px-4 py-2 bg-yellow-500 rounded"
+            >
+              Retry
+            </button>
+            {videoUrl && (
+              <a
+                href={videoUrl}
+                download
+                className="px-4 py-2 bg-gray-700 rounded"
+              >
+                Download
+              </a>
+            )}
+          </div>
+        </div>
+      ) : (
+        <video
+          ref={videoRef}
+          src={videoUrl}
+          controls
+          onEnded={onEnded}
+          onError={() => setError(true)}
+          className="w-full h-full object-cover"
+        />
+      )}
     </div>
   );
-  
-  export default VideoPlayer;
-  
+};
+
+export default VideoPlayer;
+


### PR DESCRIPTION
## Summary
- handle video loading errors in shared CustomVideoPlayer with retry and download fallback
- show friendly fallback message for tutorial VideoPlayer when video fails

## Testing
- `npm test --silent 2>&1 | tail -n 20` *(fails: ChatHeader.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b361ccb8bc8328b4c1ea6d12f2262c