### PR TITLE
Preserve playback when navigating videos

### DIFF
--- a/frontend/src/components/shared/CustomVideoPlayer.js
+++ b/frontend/src/components/shared/CustomVideoPlayer.js
@@ -27,10 +27,24 @@ export default function CustomVideoPlayer({
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return;
+
+    const playIfNeeded = () => {
+      if (isPlaying) {
+        const playPromise = video.play();
+        if (playPromise !== undefined) {
+          playPromise.catch(() => {});
+        }
+      }
+    };
+
+    video.addEventListener('loadeddata', playIfNeeded);
     video.load();
-    setIsPlaying(false);
     setProgress(0);
-  }, [currentVideo]);
+
+    return () => {
+      video.removeEventListener('loadeddata', playIfNeeded);
+    };
+  }, [currentVideo, isPlaying]);
 
   // Seek to provided start time whenever it changes and metadata is already loaded
   useEffect(() => {
@@ -123,16 +137,12 @@ export default function CustomVideoPlayer({
   const handleNext = () => {
     if (currentIndex < videos.length - 1) {
       setCurrentIndex(currentIndex + 1);
-      setIsPlaying(true);
-      videoRef.current.play();
     }
   };
 
   const handlePrev = () => {
     if (currentIndex > 0) {
       setCurrentIndex(currentIndex - 1);
-      setIsPlaying(true);
-      videoRef.current.play();
     }
   };
 


### PR DESCRIPTION
## Summary
- resume playback automatically after loading a new video
- simplify next/previous handlers to rely on existing play state

## Testing
- `npm test src/tests/__tests__/ChatHeader.test.js` *(fails: ReferenceError: lastActive is not defined)*
- `npm run lint` *(fails: 34 errors, 306 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b361ced6748328bcc15b0acd2eaa9d