### PR TITLE
feat: add student prime plan and require payment for subscriptions

### DIFF
--- a/backend/src/modules/subscriptions/subscriptions.controller.js
+++ b/backend/src/modules/subscriptions/subscriptions.controller.js
@@ -1,6 +1,8 @@
 const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
 const service = require("./subscription.service");
+const paymentsService = require("../payments/payments.service");
 
 exports.getMySubscriptions = catchAsync(async (req, res) => {
   const subs = await service.getActiveByUser(req.user.id);
@@ -8,7 +10,24 @@ exports.getMySubscriptions = catchAsync(async (req, res) => {
 });
 
 exports.createOrRenewSubscription = catchAsync(async (req, res) => {
-  const { plan_id, interval = "monthly" } = req.body;
+  const { plan_id, interval = "monthly", payment_id } = req.body;
+
+  if (!payment_id) {
+    throw new AppError("Payment is required", 400);
+  }
+
+  const payment = await paymentsService.getById(payment_id);
+
+  if (
+    !payment ||
+    payment.user_id !== req.user.id ||
+    payment.item_type !== "plan" ||
+    payment.item_id !== plan_id ||
+    payment.status !== paymentsService.STATUS.PAID
+  ) {
+    throw new AppError("Invalid or unpaid payment", 400);
+  }
+
   const subscription = await service.createOrRenewSubscription({
     user_id: req.user.id,
     plan_id,

--- a/backend/src/seeds/09_plans_seed.js
+++ b/backend/src/seeds/09_plans_seed.js
@@ -47,6 +47,26 @@ exports.seed = async function (knex) {
     },
     {
       id: knex.raw('uuid_generate_v4()'),
+      name: 'Prime',
+      slug: 'prime',
+      price_monthly: 19.99,
+      price_yearly: 199.99,
+      currency: 'USD',
+      recommended: false,
+      active: true,
+      color: '#10B981',
+      style: JSON.stringify({
+        gradientStart: '#059669',
+        gradientEnd: '#10B981',
+        buttonColor: '#34D399',
+        buttonTextColor: '#FFFFFF'
+      }),
+      target_role: 'student',
+      created_at: now,
+      updated_at: now
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
       name: 'Instructor Basic',
       slug: 'instructor-basic',
       price_monthly: 0,
@@ -198,6 +218,55 @@ exports.seed = async function (knex) {
       feature_key: 'groups_join_limit',
       value: '5',
       description: 'Join up to 5 groups'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'ads_max_ads',
+      value: '10',
+      description: 'Up to 10 active ads'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'ads_max_ad_duration',
+      value: '30',
+      description: 'Each ad runs for 30 days'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'ads_placements',
+      value: JSON.stringify(['dashboard','homepage','sidebar']),
+      description: 'All ad placements'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'ads_allow_branding',
+      value: 'true',
+      description: 'Custom branding'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'ads_show_analytics',
+      value: 'true',
+      description: 'Analytics access'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'groups_create',
+      value: 'true',
+      description: 'Can create groups'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'groups_join_limit',
+      value: 'unlimited',
+      description: 'Join unlimited groups'
     },
     {
       id: knex.raw('uuid_generate_v4()'),

--- a/backend/tests/subscriptionRoutes.test.js
+++ b/backend/tests/subscriptionRoutes.test.js
@@ -6,11 +6,17 @@ jest.mock('../src/modules/subscriptions/subscription.service', () => ({
   createOrRenewSubscription: jest.fn(),
 }));
 
+jest.mock('../src/modules/payments/payments.service', () => ({
+  getById: jest.fn(),
+  STATUS: { PAID: 'paid' },
+}));
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => { req.user = { id: 'user1' }; next(); },
 }));
 
 const service = require('../src/modules/subscriptions/subscription.service');
+const paymentsService = require('../src/modules/payments/payments.service');
 const routes = require('../src/modules/subscriptions/subscriptions.routes');
 
 const app = express();
@@ -33,10 +39,17 @@ describe('POST /api/user-subscriptions', () => {
   it('creates or renews a subscription for the authenticated user', async () => {
     const mock = { id: 's1', plan_id: 'p1' };
     service.createOrRenewSubscription.mockResolvedValue(mock);
+    paymentsService.getById.mockResolvedValue({
+      id: 'pay1',
+      user_id: 'user1',
+      item_type: 'plan',
+      item_id: 'p1',
+      status: 'paid',
+    });
 
     const res = await request(app)
       .post('/api/user-subscriptions')
-      .send({ plan_id: 'p1' });
+      .send({ plan_id: 'p1', payment_id: 'pay1' });
 
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
@@ -45,5 +58,16 @@ describe('POST /api/user-subscriptions', () => {
       plan_id: 'p1',
       interval: 'monthly',
     });
+    expect(paymentsService.getById).toHaveBeenCalledWith('pay1');
+  });
+
+  it('returns 400 if payment is missing or invalid', async () => {
+    paymentsService.getById.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/user-subscriptions')
+      .send({ plan_id: 'p1', payment_id: 'bad' });
+
+    expect(res.status).toBe(400);
   });
 });


### PR DESCRIPTION
## Summary
- add Prime student plan with platform-wide features and seed data
- require paid plan payment before creating or renewing a subscription
- test subscription flow validates payment

## Testing
- `npm test` *(fails: Route.post requires callback; process.exit due to missing DB config, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3657cec708328acc07c3d1e7ed5c3