### PR TITLE
Allow datetime-local format for ad scheduling

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -88,7 +88,9 @@ exports.createAd = catchAsync(async (req, res) => {
   }
 
   // Load instructor plan and verify ad creation permissions
-  const plan = await planService.getPlanById(req.user.plan_id);
+  const planId =
+    req.user.plan_id || req.user.plan?.id || req.user.subscription?.plan_id;
+  const plan = planId ? await planService.getPlanById(planId) : null;
   if (!plan) {
     throw new AppError("Plan not found", 403);
   }
@@ -293,7 +295,9 @@ exports.updateAd = catchAsync(async (req, res) => {
   }
 
   // Load instructor plan and enforce ad feature limits
-  const plan = await planService.getPlanById(req.user.plan_id);
+  const planId =
+    req.user.plan_id || req.user.plan?.id || req.user.subscription?.plan_id;
+  const plan = planId ? await planService.getPlanById(planId) : null;
   if (!plan) {
     throw new AppError("Plan not found", 403);
   }

--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -7,8 +7,9 @@ exports.create = {
     image_url: z.string().min(1).optional(),
     video_url: z.string().min(1).optional(),
     link_url: z.string().url().optional(),
-    start_at: z.string().datetime().optional(),
-    end_at: z.string().datetime().optional(),
+    // Allow broader date formats from HTML datetime-local inputs
+    start_at: z.coerce.date().optional(),
+    end_at: z.coerce.date().optional(),
     target_roles: z.string().optional(),
     ad_type: z.string().optional(),
     priority: z.coerce.number().optional(),
@@ -24,8 +25,9 @@ exports.update = {
     image_url: z.string().min(1).optional(),
     video_url: z.string().min(1).optional(),
     link_url: z.string().url().optional(),
-    start_at: z.string().datetime().optional(),
-    end_at: z.string().datetime().optional(),
+    // Allow broader date formats from HTML datetime-local inputs
+    start_at: z.coerce.date().optional(),
+    end_at: z.coerce.date().optional(),
     target_roles: z.string().optional(),
     ad_type: z.string().optional(),
     priority: z.coerce.number().optional(),


### PR DESCRIPTION
## Summary
- accept HTML datetime-local inputs for ad start/end dates
- gracefully handle missing plan IDs when creating or updating ads

## Testing
- `npm test tests/paymentCommission.test.js` *(fails: Route.post() requires a callback function but got a [object Undefined])*

------
https://chatgpt.com/codex/tasks/task_e_68b3fcec9bfc8328b4f108591abe2fb5