### PR TITLE
Allow relative paths for tutorial media URLs

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -18,6 +18,9 @@ const parseJson = (val) => {
   return val;
 };
 
+// Accept either a full URL (http/https) or a server-relative path
+const urlOrPath = z.string().url().or(z.string().startsWith("/"));
+
 exports.create = z.object({
   body: z.object({
     title: z.string().min(3),
@@ -45,7 +48,7 @@ exports.create = z.object({
             z.object({
               title: z.string(),
               content: z.string().optional(),
-              video_url: z.string().url().optional(),
+              video_url: urlOrPath.optional(),
               duration: z.preprocess(
                 (val) => (val === '' || val === undefined ? undefined : parseInt(val, 10)),
                 z.number().int().nonnegative()
@@ -56,8 +59,8 @@ exports.create = z.object({
           )
           .optional()
       ),
-    cover_image: z.string().url().optional(),
-    preview_video: z.string().url().optional(),
+    cover_image: urlOrPath.optional(),
+    preview_video: urlOrPath.optional(),
   }),
 });
 

--- a/backend/tests/tutorialValidator.test.js
+++ b/backend/tests/tutorialValidator.test.js
@@ -1,0 +1,20 @@
+const validator = require('../src/modules/users/tutorials/tutorial.validator');
+
+describe('tutorial validator', () => {
+  test('allows relative paths for media fields', () => {
+    const sample = {
+      body: {
+        title: 'Test Tutorial',
+        category_id: 'cat',
+        level: 'beginner',
+        chapters: JSON.stringify([
+          { title: 'Intro', order: 1, video_url: '/uploads/tutorials/chapters/admin/video.mp4' }
+        ]),
+        cover_image: '/uploads/tutorials/thumb.png',
+        preview_video: '/uploads/tutorials/preview.mp4'
+      }
+    };
+
+    expect(() => validator.create.parse(sample)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- allow tutorial validator to accept server-relative media URLs
- add tests for validator path handling

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*
- `npx jest tests/tutorialValidator.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b40df6c68c8328847597d0d43ab8e1