### PR TITLE
Forward cookies to ad analytics fetch functions

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -217,11 +217,12 @@ export default function AdAnalyticsPage({ ad: initialAd, error }) {
   );
 }
 
-export async function getServerSideProps({ params, locale }) {
+export async function getServerSideProps({ params, locale, req }) {
   try {
+    const headers = req.headers?.cookie ? { cookie: req.headers.cookie } : {};
     const [adData, analytics] = await Promise.all([
-      fetchAdById(params.id),
-      fetchAdAnalytics(params.id),
+      fetchAdById(params.id, headers),
+      fetchAdAnalytics(params.id, headers),
     ]);
     if (!adData) {
       return { notFound: true };

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -46,9 +46,9 @@ export const fetchAds = async () => {
   }
 };
 
-export const fetchAdById = async (id) => {
+export const fetchAdById = async (id, headers = {}) => {
   try {
-    const { data } = await api.get(`/ads/${id}`);
+    const { data } = await api.get(`/ads/${id}`, { headers });
     const ad = data?.data;
     if (!ad) return null;
     const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
@@ -122,8 +122,8 @@ export const purchaseAd = async (id) => {
   }
 };
 
-export const fetchAdAnalytics = async (id) => {
-  const { data } = await api.get(`/ads/${id}/analytics`);
+export const fetchAdAnalytics = async (id, headers = {}) => {
+  const { data } = await api.get(`/ads/${id}/analytics`, { headers });
   const res = data?.data || {};
   return {
     views: res.views ?? 0,


### PR DESCRIPTION
## Summary
- pass request cookies from admin ad analytics page to service calls
- allow ad service functions to accept custom headers

## Testing
- `npm test` *(fails: renders fallback when lastActive is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b40dd67f7c8328b56adec8739d1a97