### PR TITLE
refactor: unify ad media handling

### DIFF
--- a/frontend/src/hooks/useAdMedia.js
+++ b/frontend/src/hooks/useAdMedia.js
@@ -1,0 +1,129 @@
+import { useState, useEffect } from "react";
+
+export const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+export const MAX_VIDEO_SIZE = 50 * 1024 * 1024; // 50MB
+export const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+export const ALLOWED_VIDEO_TYPES = ["video/mp4", "video/webm"];
+
+/**
+ * Reusable hook for handling ad media (image & video) selection and cleanup.
+ * Expects translation function `t`, error setter `setError`, and optional
+ * `setFormData` to update parent form state when media changes.
+ */
+export default function useAdMedia({ t, setError, setFormData }) {
+  const [mediaType, setMediaType] = useState("image");
+  const [videoFile, setVideoFile] = useState(null);
+  const [videoPreview, setVideoPreview] = useState("");
+  const [imagePreview, setImagePreview] = useState("");
+
+  const handleImageChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      setError?.(t("invalid_image_type"));
+      return;
+    }
+
+    if (file.size > MAX_IMAGE_SIZE) {
+      setError?.(t("image_too_large", { size: "5MB" }));
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      setError?.(null);
+      setFormData?.((prev) => ({ ...prev, image: file }));
+      if (imagePreview && imagePreview.startsWith("blob:")) {
+        URL.revokeObjectURL(imagePreview);
+      }
+      setImagePreview(ev.target.result);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleVideoChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!ALLOWED_VIDEO_TYPES.includes(file.type)) {
+      setError?.(t("invalid_video_type"));
+      return;
+    }
+
+    if (file.size > MAX_VIDEO_SIZE) {
+      setError?.(t("video_too_large", { size: "50MB" }));
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      if (videoPreview && videoPreview.startsWith("blob:")) {
+        URL.revokeObjectURL(videoPreview);
+      }
+      setVideoFile(file);
+      setVideoPreview(ev.target.result);
+      setError?.(null);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleMediaTypeChange = (e) => {
+    const type = e.target.value;
+    setMediaType(type);
+    if (type === "image") {
+      if (videoPreview && videoPreview.startsWith("blob:")) {
+        URL.revokeObjectURL(videoPreview);
+      }
+      setVideoFile(null);
+      setVideoPreview("");
+    } else {
+      if (imagePreview && imagePreview.startsWith("blob:")) {
+        URL.revokeObjectURL(imagePreview);
+      }
+      setFormData?.((prev) => ({ ...prev, image: null }));
+      setImagePreview("");
+    }
+  };
+
+  const removeMedia = () => {
+    if (mediaType === "image") {
+      if (imagePreview && imagePreview.startsWith("blob:")) {
+        URL.revokeObjectURL(imagePreview);
+      }
+      setFormData?.((prev) => ({ ...prev, image: null }));
+      setImagePreview("");
+    } else {
+      if (videoPreview && videoPreview.startsWith("blob:")) {
+        URL.revokeObjectURL(videoPreview);
+      }
+      setVideoFile(null);
+      setVideoPreview("");
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (videoPreview && videoPreview.startsWith("blob:")) {
+        URL.revokeObjectURL(videoPreview);
+      }
+      if (imagePreview && imagePreview.startsWith("blob:")) {
+        URL.revokeObjectURL(imagePreview);
+      }
+    };
+  }, [videoPreview, imagePreview]);
+
+  return {
+    mediaType,
+    setMediaType,
+    imagePreview,
+    setImagePreview,
+    videoFile,
+    videoPreview,
+    setVideoPreview,
+    handleImageChange,
+    handleVideoChange,
+    handleMediaTypeChange,
+    removeMedia,
+  };
+}

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -15,11 +15,10 @@ import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
-
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
-const MAX_VIDEO_SIZE = 50 * 1024 * 1024; // 50MB
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm'];
+import useAdMedia, {
+  ALLOWED_IMAGE_TYPES,
+  ALLOWED_VIDEO_TYPES,
+} from "@/hooks/useAdMedia";
 
 export default function CreateAdPage() {
   const router = useRouter();
@@ -62,10 +61,16 @@ export default function CreateAdPage() {
   const [titleError, setTitleError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCheckingTitle, setIsCheckingTitle] = useState(false);
-  const [mediaType, setMediaType] = useState('image');
-  const [videoFile, setVideoFile] = useState(null);
-  const [videoPreview, setVideoPreview] = useState('');
-  const [imagePreview, setImagePreview] = useState('');
+  const {
+    mediaType,
+    handleMediaTypeChange,
+    handleImageChange,
+    handleVideoChange,
+    removeMedia,
+    videoFile,
+    videoPreview,
+    imagePreview,
+  } = useAdMedia({ setFormData, t, setError });
   const [showPreview, setShowPreview] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
 
@@ -107,30 +112,6 @@ export default function CreateAdPage() {
     };
   }, [formData.title, t]);
 
-  const handleImageChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    
-    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-      setError(t('invalid_image_type'));
-      return;
-    }
-    
-    if (file.size > MAX_IMAGE_SIZE) {
-      setError(t('image_too_large', { size: '5MB' }));
-      return;
-    }
-    
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      setError(null);
-      setFormData((prev) => ({ ...prev, image: file }));
-      if (imagePreview) URL.revokeObjectURL(imagePreview);
-      setImagePreview(e.target.result);
-    };
-    reader.readAsDataURL(file);
-  };
-
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
     if (name === "targetRoles") {
@@ -149,63 +130,6 @@ export default function CreateAdPage() {
       setFormData((prev) => ({ ...prev, [name]: value }));
     }
   };
-
-  const handleVideoChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    
-    if (!ALLOWED_VIDEO_TYPES.includes(file.type)) {
-      setError(t('invalid_video_type'));
-      return;
-    }
-    
-    if (file.size > MAX_VIDEO_SIZE) {
-      setError(t('video_too_large', { size: '50MB' }));
-      return;
-    }
-    
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      if (videoPreview) URL.revokeObjectURL(videoPreview);
-      setVideoFile(file);
-      setVideoPreview(e.target.result);
-      setError(null);
-    };
-    reader.readAsDataURL(file);
-  };
-
-  const handleMediaTypeChange = (e) => {
-    const type = e.target.value;
-    setMediaType(type);
-    if (type === 'image') {
-      if (videoPreview) URL.revokeObjectURL(videoPreview);
-      setVideoFile(null);
-      setVideoPreview('');
-    } else {
-      if (imagePreview) URL.revokeObjectURL(imagePreview);
-      setFormData((prev) => ({ ...prev, image: null }));
-      setImagePreview('');
-    }
-  };
-
-  const removeMedia = () => {
-    if (mediaType === 'image') {
-      if (imagePreview) URL.revokeObjectURL(imagePreview);
-      setFormData((prev) => ({ ...prev, image: null }));
-      setImagePreview('');
-    } else {
-      if (videoPreview) URL.revokeObjectURL(videoPreview);
-      setVideoFile(null);
-      setVideoPreview('');
-    }
-  };
-
-  useEffect(() => {
-    return () => {
-      if (videoPreview) URL.revokeObjectURL(videoPreview);
-      if (imagePreview) URL.revokeObjectURL(imagePreview);
-    };
-  }, [videoPreview, imagePreview]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/frontend/src/pages/dashboard/admin/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/edit/[id].js
@@ -12,11 +12,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { FaSpinner, FaTrash, FaImage, FaVideo } from "react-icons/fa";
 import PreviewModal from "@/components/admin/ads/PreviewModal";
-
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
-const MAX_VIDEO_SIZE = 50 * 1024 * 1024; // 50MB
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm'];
+import useAdMedia, { ALLOWED_VIDEO_TYPES } from "@/hooks/useAdMedia";
 
 export default function EditAdPage() {
   const router = useRouter();
@@ -31,9 +27,16 @@ export default function EditAdPage() {
   
   const [formData, setFormData] = useState(null);
   const [error, setError] = useState(null);
-  const [mediaType, setMediaType] = useState('image');
-  const [videoFile, setVideoFile] = useState(null);
-  const [videoPreview, setVideoPreview] = useState('');
+  const {
+    mediaType,
+    setMediaType,
+    handleVideoChange,
+    handleMediaTypeChange,
+    removeMedia,
+    videoFile,
+    videoPreview,
+    setVideoPreview,
+  } = useAdMedia({ setFormData, t, setError });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
@@ -66,14 +69,6 @@ export default function EditAdPage() {
     }
   }, [id, t]);
 
-  useEffect(() => {
-    return () => {
-      if (videoPreview && videoPreview.startsWith('blob:')) {
-        URL.revokeObjectURL(videoPreview);
-      }
-    };
-  }, [videoPreview]);
-
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
     if (name === "targetRoles") {
@@ -90,49 +85,6 @@ export default function EditAdPage() {
       setFormData((prev) => ({ ...prev, priority: Number(value) }));
     } else {
       setFormData((prev) => ({ ...prev, [name]: value }));
-    }
-  };
-
-  const handleVideoChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    
-    if (!ALLOWED_VIDEO_TYPES.includes(file.type)) {
-      setError(t('invalid_video_type'));
-      return;
-    }
-    
-    if (file.size > MAX_VIDEO_SIZE) {
-      setError(t('video_too_large', { size: '50MB' }));
-      return;
-    }
-    
-    if (videoPreview && videoPreview.startsWith('blob:')) {
-      URL.revokeObjectURL(videoPreview);
-    }
-    
-    setVideoFile(file);
-    setVideoPreview(URL.createObjectURL(file));
-    setError(null);
-  };
-
-  const handleMediaTypeChange = (e) => {
-    const type = e.target.value;
-    setMediaType(type);
-    if (type === 'video' && videoPreview) {
-      setFormData(prev => ({ ...prev, image: null }));
-    }
-  };
-
-  const removeMedia = () => {
-    if (mediaType === 'image') {
-      setFormData(prev => ({ ...prev, image: null }));
-    } else {
-      if (videoPreview && videoPreview.startsWith('blob:')) {
-        URL.revokeObjectURL(videoPreview);
-      }
-      setVideoFile(null);
-      setVideoPreview('');
     }
   };
 

--- a/frontend/src/pages/dashboard/instructor/ads/create.js
+++ b/frontend/src/pages/dashboard/instructor/ads/create.js
@@ -15,11 +15,10 @@ import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
-
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
-const MAX_VIDEO_SIZE = 50 * 1024 * 1024; // 50MB
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm'];
+import useAdMedia, {
+  ALLOWED_IMAGE_TYPES,
+  ALLOWED_VIDEO_TYPES,
+} from "@/hooks/useAdMedia";
 
 export default function CreateAdPage() {
   const router = useRouter();
@@ -61,10 +60,16 @@ export default function CreateAdPage() {
   const [error, setError] = useState(null);
   const [titleError, setTitleError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [mediaType, setMediaType] = useState('image');
-  const [videoFile, setVideoFile] = useState(null);
-  const [videoPreview, setVideoPreview] = useState('');
-  const [imagePreview, setImagePreview] = useState('');
+  const {
+    mediaType,
+    handleMediaTypeChange,
+    handleImageChange,
+    handleVideoChange,
+    removeMedia,
+    videoFile,
+    videoPreview,
+    imagePreview,
+  } = useAdMedia({ setFormData, t, setError });
   const [showPreview, setShowPreview] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
 
@@ -80,30 +85,6 @@ export default function CreateAdPage() {
     formData.endAt &&
     ((mediaType === 'image' && formData.image) || (mediaType === 'video' && videoFile));
   const disableSubmit = !isFormValid || isSubmitting || titleError;
-
-  const handleImageChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    
-    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-      setError(t('invalid_image_type'));
-      return;
-    }
-    
-    if (file.size > MAX_IMAGE_SIZE) {
-      setError(t('image_too_large', { size: '5MB' }));
-      return;
-    }
-    
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      setError(null);
-      setFormData((prev) => ({ ...prev, image: file }));
-      if (imagePreview) URL.revokeObjectURL(imagePreview);
-      setImagePreview(e.target.result);
-    };
-    reader.readAsDataURL(file);
-  };
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -123,63 +104,6 @@ export default function CreateAdPage() {
       setFormData((prev) => ({ ...prev, [name]: value }));
     }
   };
-
-  const handleVideoChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    
-    if (!ALLOWED_VIDEO_TYPES.includes(file.type)) {
-      setError(t('invalid_video_type'));
-      return;
-    }
-    
-    if (file.size > MAX_VIDEO_SIZE) {
-      setError(t('video_too_large', { size: '50MB' }));
-      return;
-    }
-    
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      if (videoPreview) URL.revokeObjectURL(videoPreview);
-      setVideoFile(file);
-      setVideoPreview(e.target.result);
-      setError(null);
-    };
-    reader.readAsDataURL(file);
-  };
-
-  const handleMediaTypeChange = (e) => {
-    const type = e.target.value;
-    setMediaType(type);
-    if (type === 'image') {
-      if (videoPreview) URL.revokeObjectURL(videoPreview);
-      setVideoFile(null);
-      setVideoPreview('');
-    } else {
-      if (imagePreview) URL.revokeObjectURL(imagePreview);
-      setFormData((prev) => ({ ...prev, image: null }));
-      setImagePreview('');
-    }
-  };
-
-  const removeMedia = () => {
-    if (mediaType === 'image') {
-      if (imagePreview) URL.revokeObjectURL(imagePreview);
-      setFormData((prev) => ({ ...prev, image: null }));
-      setImagePreview('');
-    } else {
-      if (videoPreview) URL.revokeObjectURL(videoPreview);
-      setVideoFile(null);
-      setVideoPreview('');
-    }
-  };
-
-  useEffect(() => {
-    return () => {
-      if (videoPreview) URL.revokeObjectURL(videoPreview);
-      if (imagePreview) URL.revokeObjectURL(imagePreview);
-    };
-  }, [videoPreview, imagePreview]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
@@ -18,9 +18,7 @@ import { FaVideo, FaImage, FaTrash } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
-
-const MAX_VIDEO_SIZE = 50 * 1024 * 1024; // 50MB
-const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm'];
+import useAdMedia, { ALLOWED_VIDEO_TYPES } from "@/hooks/useAdMedia";
 
 export default function EditAdPage() {
   const router = useRouter();
@@ -37,9 +35,16 @@ export default function EditAdPage() {
   const [error, setError] = useState(null);
   const refreshNotifications = useNotificationStore((s) => s.fetch);
   const refreshMessages = useMessageStore((s) => s.fetch);
-  const [mediaType, setMediaType] = useState('image');
-  const [videoFile, setVideoFile] = useState(null);
-  const [videoPreview, setVideoPreview] = useState('');
+  const {
+    mediaType,
+    setMediaType,
+    handleVideoChange,
+    handleMediaTypeChange,
+    removeMedia,
+    videoFile,
+    videoPreview,
+    setVideoPreview,
+  } = useAdMedia({ setFormData, t, setError });
 
   const notify = async (type, message) => {
     try {
@@ -88,14 +93,6 @@ export default function EditAdPage() {
     }
   }, [id, t, router]);
 
-  useEffect(() => {
-    return () => {
-      if (videoPreview && videoPreview.startsWith('blob:')) {
-        URL.revokeObjectURL(videoPreview);
-      }
-    };
-  }, [videoPreview]);
-
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
     if (name === "targetRoles") {
@@ -112,55 +109,6 @@ export default function EditAdPage() {
       setFormData((prev) => ({ ...prev, priority: Number(value) }));
     } else {
       setFormData((prev) => ({ ...prev, [name]: value }));
-    }
-  };
-
-  const handleVideoChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    if (!ALLOWED_VIDEO_TYPES.includes(file.type)) {
-      setError(t('invalid_video_type'));
-      return;
-    }
-
-    if (file.size > MAX_VIDEO_SIZE) {
-      setError(t('video_too_large', { size: '50MB' }));
-      return;
-    }
-
-    if (videoPreview && videoPreview.startsWith('blob:')) {
-      URL.revokeObjectURL(videoPreview);
-    }
-
-    setVideoFile(file);
-    setVideoPreview(URL.createObjectURL(file));
-    setError(null);
-  };
-
-  const handleMediaTypeChange = (e) => {
-    const type = e.target.value;
-    setMediaType(type);
-    if (type === 'image') {
-      if (videoPreview && videoPreview.startsWith('blob:')) {
-        URL.revokeObjectURL(videoPreview);
-      }
-      setVideoFile(null);
-      setVideoPreview('');
-    } else {
-      setFormData((prev) => ({ ...prev, image: null }));
-    }
-  };
-
-  const removeMedia = () => {
-    if (mediaType === 'image') {
-      setFormData((prev) => ({ ...prev, image: null }));
-    } else {
-      if (videoPreview && videoPreview.startsWith('blob:')) {
-        URL.revokeObjectURL(videoPreview);
-      }
-      setVideoFile(null);
-      setVideoPreview('');
     }
   };
 


### PR DESCRIPTION
## Summary
- extract shared ad media logic into `useAdMedia` hook
- reuse `useAdMedia` in ad create and edit pages for admin and instructors

## Testing
- `npm test` *(fails: renders fallback when lastActive is missing)*
- `npm run lint` *(fails: 34 errors, 308 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b40dd61e208328ad42072373439ec6