### PR TITLE
Limit ads image upload size to 5MB

### DIFF
--- a/backend/src/modules/ads/adsUploadMiddleware.js
+++ b/backend/src/modules/ads/adsUploadMiddleware.js
@@ -37,11 +37,32 @@ const fileFilter = (_req, file, cb) => {
   }
 };
 
-module.exports = multer({
+const upload = multer({
   storage,
   fileFilter,
-  limits: { fileSize: 50 * 1024 * 1024 }, // 50MB for videos
+  limits: { fileSize: 50 * 1024 * 1024 }, // 50MB max per file
 }).fields([
   { name: "image", maxCount: 1 },
   { name: "video", maxCount: 1 },
 ]);
+
+module.exports = (req, res, next) => {
+  upload(req, res, (err) => {
+    if (err) {
+      if (err.code === "LIMIT_FILE_SIZE") {
+        const field = err.field === "image" ? "Image" : "Video";
+        const limit = err.field === "image" ? "5MB" : "50MB";
+        return next(new Error(`${field} exceeds ${limit} limit.`));
+      }
+      return next(err);
+    }
+
+    const image = req.files?.image?.[0];
+    if (image && image.size > 5 * 1024 * 1024) {
+      fs.unlink(image.path, () => {});
+      return next(new Error("Image exceeds 5MB limit."));
+    }
+
+    next();
+  });
+};


### PR DESCRIPTION
## Summary
- Limit uploaded ad images to 5MB while keeping 50MB cap for videos
- Return clear errors for image and video size violations

## Testing
- `npm test` *(fails: Test Suites: 31 failed, 1 skipped, 69 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b40dd331588328bb37540c6f90cb06