### PR TITLE
Secure ad details endpoint

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -227,6 +227,17 @@ exports.getAdById = catchAsync(async (req, res) => {
 });
 
 /**
+ * Public: Fetch a single ad by id with only public fields.
+ */
+exports.getPublicAd = catchAsync(async (req, res) => {
+  const ad = await service.getPublicAdById(req.params.id);
+  if (!ad) {
+    throw new AppError("Ad not found", 404);
+  }
+  sendSuccess(res, ad);
+});
+
+/**
  * Update an existing ad.
  */
 exports.updateAd = catchAsync(async (req, res) => {

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -42,7 +42,13 @@ router.post(
   isInstructorOrAdmin,
   controller.purchaseAd
 );
-router.get("/:id", controller.getAdById);
+router.get(
+  "/:id",
+  verifyToken,
+  isInstructorOrAdmin,
+  controller.getAdById
+);
+router.get("/public/:id", controller.getPublicAd);
 router.put(
   "/:id",
   verifyToken,

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -53,6 +53,24 @@ exports.getAdById = async (id) => {
   return db("ads").where({ id }).first();
 };
 
+exports.getPublicAdById = async (id) => {
+  return db("ads")
+    .select(
+      "id",
+      "title",
+      "description",
+      "link_url",
+      "start_at",
+      "end_at",
+      "image_url",
+      "video_url"
+    )
+    .where({ id, is_active: true })
+    .where("start_at", "<=", db.fn.now())
+    .where("end_at", ">=", db.fn.now())
+    .first();
+};
+
 exports.findByTitle = async (title) => {
   const normalized = title?.trim();
   if (!normalized) return null;

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -10,6 +10,7 @@ jest.mock('../src/modules/ads/ads.service', () => ({
   getAds: jest.fn(),
   createAd: jest.fn(),
   getAdById: jest.fn(),
+  getPublicAdById: jest.fn(),
   findByTitle: jest.fn(),
   updateAd: jest.fn(),
   deleteAd: jest.fn(),
@@ -102,7 +103,7 @@ describe('GET /api/ads/admin', () => {
     service.getAds.mockResolvedValue(mock);
     const res = await request(app).get('/api/ads/admin');
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', undefined, false);
+    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', undefined, false, true);
     expect(res.body.data).toEqual(mock);
   });
 
@@ -111,7 +112,7 @@ describe('GET /api/ads/admin', () => {
     service.getAds.mockResolvedValue(mock);
     const res = await request(app).get('/api/ads/admin').query({ role: 'student' });
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', 'student', false);
+    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', 'student', false, true);
   });
 });
 
@@ -134,6 +135,38 @@ describe('GET /api/ads/admin/check-title', () => {
     expect(res.status).toBe(200);
     expect(service.findByTitle).toHaveBeenCalledWith('Unknown');
     expect(res.body.data.exists).toBe(false);
+  });
+});
+
+describe('GET /api/ads/:id', () => {
+  it('requires auth and returns ad details', async () => {
+    const mock = { id: '1', title: 'Test' };
+    service.getAdById.mockResolvedValue(mock);
+    const res = await request(app).get('/api/ads/1');
+    expect(auth.verifyToken).toHaveBeenCalled();
+    expect(auth.isInstructorOrAdmin).toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+  });
+});
+
+describe('GET /api/ads/public/:id', () => {
+  it('returns only public ad fields', async () => {
+    const mock = {
+      id: '1',
+      title: 'Test',
+      description: 'Desc',
+      link_url: 'http://example.com',
+      start_at: '2024-01-01',
+      end_at: '2024-02-01',
+      image_url: '/img.jpg',
+      video_url: null,
+    };
+    service.getPublicAdById.mockResolvedValue(mock);
+    const res = await request(app).get('/api/ads/public/1');
+    expect(service.getPublicAdById).toHaveBeenCalledWith('1');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
   });
 });
 

--- a/frontend/src/pages/api/ads/[id].js
+++ b/frontend/src/pages/api/ads/[id].js
@@ -7,7 +7,7 @@ export default async function handler(req, res) {
 
   try {
     const { data } = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/ads/${id}`
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/ads/public/${id}`
     );
     if (!data?.data) {
       return res.status(404).json({ error: "Ad not found" });


### PR DESCRIPTION
## Summary
- restrict `GET /ads/:id` to instructors and admins
- expose sanitized `GET /ads/public/:id` for public ad access
- update frontend API route and tests

## Testing
- `npm test tests/adsRoutes.test.js`
- `npm test` (fails: Route.post() requires callback, failing suites)
- `npm test` (frontend, fails: ChatHeader.test.js)`

------
https://chatgpt.com/codex/tasks/task_e_68b40dd257c08328953d79474b90e643