### PR TITLE
Validate advertisement date ranges

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -49,6 +49,17 @@ exports.createAd = catchAsync(async (req, res) => {
     throw new AppError("Image or video is required", 400);
   }
 
+  if (
+    start_at &&
+    end_at &&
+    new Date(end_at).getTime() < new Date(start_at).getTime()
+  ) {
+    throw new AppError(
+      "end_at must be greater than or equal to start_at",
+      400
+    );
+  }
+
   const data = {
     id: uuidv4(),
     title,
@@ -279,6 +290,19 @@ exports.updateAd = catchAsync(async (req, res) => {
     throw new AppError("Only admins can change ad status", 403);
   }
   const previousAd = ad;
+
+  const newStart = start_at ?? ad.start_at;
+  const newEnd = end_at ?? ad.end_at;
+  if (
+    newStart &&
+    newEnd &&
+    new Date(newEnd).getTime() < new Date(newStart).getTime()
+  ) {
+    throw new AppError(
+      "end_at must be greater than or equal to start_at",
+      400
+    );
+  }
 
   if (title) {
     const existing = await service.findByTitle(title);


### PR DESCRIPTION
## Summary
- ensure ad creation checks end_at is not before start_at
- enforce same date range validation when updating ads

## Testing
- `npm test --silent 2>&1 | tail -n 20` *(fails: Jest worker exceptions and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b40dd12bb48328810314cbb0daeac5