### PR TITLE
Add rate limiting and view source tracking for ads

### DIFF
--- a/backend/src/migrations/20250712161021_add_ip_user_agent_to_ad_views.js
+++ b/backend/src/migrations/20250712161021_add_ip_user_agent_to_ad_views.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+  return knex.schema.table('ad_views', function (table) {
+    table.string('ip_address');
+    table.text('user_agent');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('ad_views', function (table) {
+    table.dropColumn('ip_address');
+    table.dropColumn('user_agent');
+  });
+};

--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -456,7 +456,9 @@ exports.recordAdView = catchAsync(async (req, res) => {
     throw new AppError("Ad is inactive", 403);
   }
   const userId = req.user?.id || null;
-  await service.recordView(ad.id, userId);
+  const viewerIp = req.ip;
+  const userAgent = req.get("user-agent");
+  await service.recordView(ad.id, userId, viewerIp, userAgent);
   sendSuccess(res, null, "View recorded");
 });
 
@@ -484,6 +486,7 @@ exports.getAdAnalytics = catchAsync(async (req, res) => {
     conversions: 0,
     reach: 0,
     devices: [],
+    ipStats: [],
     locationStats: [],
     analytics: [],
   };
@@ -499,6 +502,7 @@ exports.getAdAnalytics = catchAsync(async (req, res) => {
     reach: data.unique_viewers,
     // Include any additional analytics information if present on the record.
     devices: data.devices || base.devices,
+    ipStats: data.ip_stats || base.ipStats,
     locationStats: data.location_stats || base.locationStats,
     analytics: data.analytics || base.analytics,
   };

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -5,6 +5,10 @@ const validate = require("../../middleware/validate");
 const { verifyToken, isInstructorOrAdmin } = require("../../middleware/auth/authMiddleware");
 const validator = require("./ads.validator");
 const upload = require("./adsUploadMiddleware");
+const rateLimit = require("express-rate-limit");
+
+const viewLimiter = rateLimit({ windowMs: 60 * 1000, max: 30 });
+const clickLimiter = rateLimit({ windowMs: 60 * 1000, max: 30 });
 
 router.get(
   "/admin/check-title",
@@ -28,14 +32,14 @@ router.get(
   controller.getAllAds
 );
 router.get("/", controller.getAds);
-router.post("/:id/view", controller.recordAdView);
+router.post("/:id/view", viewLimiter, controller.recordAdView);
 router.get(
   "/:id/analytics",
   verifyToken,
   isInstructorOrAdmin,
   controller.getAdAnalytics
 );
-router.post("/:id/click", controller.recordAdClick);
+router.post("/:id/click", clickLimiter, controller.recordAdClick);
 router.post(
   "/:id/purchase",
   verifyToken,

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -106,6 +106,21 @@ exports.getAdAnalytics = async (adId) => {
     .groupBy("day")
     .orderBy("day", "asc");
 
+  // Aggregate views by device and IP
+  const deviceRows = await db("ad_views")
+    .select("user_agent")
+    .count("* as views")
+    .where({ ad_id: adId })
+    .groupBy("user_agent")
+    .orderBy("views", "desc");
+
+  const ipRows = await db("ad_views")
+    .select("ip_address")
+    .count("* as views")
+    .where({ ad_id: adId })
+    .groupBy("ip_address")
+    .orderBy("views", "desc");
+
   // Optional stored analytics such as clicks/ctr
   const row = await db("ad_analytics").where({ ad_id: adId }).first();
   const clicks = row?.clicks ?? 0;
@@ -116,14 +131,15 @@ exports.getAdAnalytics = async (adId) => {
     clicks,
     ctr: Number(ctr) || 0,
     unique_viewers: Number(agg?.unique_viewers) || 0,
-    devices: [],
+    devices: deviceRows.map((d) => ({ user_agent: d.user_agent, views: Number(d.views) })),
+    ip_stats: ipRows.map((i) => ({ ip_address: i.ip_address, views: Number(i.views) })),
     location_stats: [],
     analytics: daily.map((d) => ({ day: d.day, views: Number(d.views) })),
   };
 };
 
 // Increment view count and track unique viewers
-exports.recordView = async (adId, userId) => {
+exports.recordView = async (adId, userId, ipAddress, userAgent) => {
   return db.transaction(async (trx) => {
     // Check if this viewer is unique before inserting the view record
     let isUnique = false;
@@ -134,10 +150,22 @@ exports.recordView = async (adId, userId) => {
       if (!existing) {
         isUnique = true;
       }
+    } else if (ipAddress) {
+      const existing = await trx("ad_views")
+        .where({ ad_id: adId, ip_address: ipAddress })
+        .first();
+      if (!existing) {
+        isUnique = true;
+      }
     }
 
     // Log the view event
-    await trx("ad_views").insert({ ad_id: adId, user_id: userId || null });
+    await trx("ad_views").insert({
+      ad_id: adId,
+      user_id: userId || null,
+      ip_address: ipAddress || null,
+      user_agent: userAgent || null,
+    });
 
     const analytics = await trx("ad_analytics").where({ ad_id: adId }).first();
     if (analytics) {

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -360,7 +360,12 @@ describe('POST /api/ads/:id/view', () => {
     const res = await request(app).post('/api/ads/1/view');
     expect(res.status).toBe(200);
     expect(service.getAdById).toHaveBeenCalledWith('1');
-    expect(service.recordView).toHaveBeenCalledWith('1', null);
+  expect(service.recordView).toHaveBeenCalledWith(
+    '1',
+    null,
+    expect.any(String),
+    undefined
+  );
   });
 
   it('returns 404 for missing ad', async () => {


### PR DESCRIPTION
## Summary
- throttle ad view and click endpoints with express-rate-limit
- capture viewer IP and device for ads and expose IP stats in analytics
- track IP and user agent in ad view records

## Testing
- `npm test -- tests/adsRoutes.test.js`
- `npm test` *(fails: process.exit called with "1")*

------
https://chatgpt.com/codex/tasks/task_e_68b413db7dc8832893337bba6e7e1542