### PR TITLE
Standardize CTR calculations across backend and frontend

### DIFF
--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -1,5 +1,8 @@
 const db = require("../../config/database");
 
+// Helper to calculate Click Through Rate (CTR) as a percentage
+const calculateCtr = (clicks, views) => (views ? (clicks / views) * 100 : 0);
+
 exports.createAd = async (data) => {
   const [row] = await db("ads").insert(data).returning("*");
   return row;
@@ -109,7 +112,7 @@ exports.getAdAnalytics = async (adId) => {
   // Optional stored analytics such as clicks/ctr
   const row = await db("ad_analytics").where({ ad_id: adId }).first();
   const clicks = row?.clicks ?? 0;
-  const ctr = row?.ctr ?? (agg.views ? clicks / agg.views : 0);
+  const ctr = row?.ctr ?? calculateCtr(clicks, agg.views);
 
   return {
     views: Number(agg?.views) || 0,
@@ -145,7 +148,7 @@ exports.recordView = async (adId, userId) => {
       const clicks = analytics.clicks;
       const updates = {
         views,
-        ctr: views ? (clicks / views) * 100 : 0,
+        ctr: calculateCtr(clicks, views),
       };
       if (isUnique) {
         updates.unique_viewers = analytics.unique_viewers + 1;
@@ -169,7 +172,7 @@ exports.recordClick = async (adId) => {
     const analytics = await trx("ad_analytics").where({ ad_id: adId }).first();
     if (analytics) {
       const clicks = analytics.clicks + 1;
-      const ctr = analytics.views ? (clicks / analytics.views) * 100 : 0;
+      const ctr = calculateCtr(clicks, analytics.views);
       await trx("ad_analytics").where({ ad_id: adId }).update({
         clicks,
         ctr,

--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -149,7 +149,7 @@ export default function AdAnalyticsPage({ ad: initialAd, error }) {
           <div className="grid md:grid-cols-3 gap-4 text-sm text-gray-700">
             {[
               { label: "Views", value: ad.views, icon: "👁️" },
-              { label: "CTR", value: ad.ctr, icon: "📈" },
+              { label: "CTR", value: `${(ad.ctr ?? 0).toFixed(2)}%`, icon: "📈" },
               { label: "Conversions", value: ad.conversions, icon: "🎯" },
               { label: "Reach", value: ad.reach, icon: "📊" },
               { label: "Top Devices", value: deviceList.length ? deviceList.join(", ") : "-", icon: "📱" }

--- a/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
@@ -83,7 +83,7 @@ export default function InstructorAdAnalyticsPage() {
                 <div className="text-xs uppercase mb-1">{label}</div>
                 <div className="text-base font-bold">
                   {label === "Views" ? ad.views :
-                   label === "CTR" ? ad.ctr :
+                   label === "CTR" ? `${(ad.ctr ?? 0).toFixed(2)}%` :
                    label === "Conversions" ? ad.conversions : ad.reach}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- ensure CTR is calculated in percentage across ad analytics service
- format CTR display with percentage in admin and instructor dashboards

## Testing
- `cd backend && npm test` *(fails: many suites requiring db setup)*
- `cd frontend && npm test` *(fails: ChatHeader.test due to lastActive undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68b413d85d9c83288dba907fb729d530