### PR TITLE
feat: add ads pagination

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -126,7 +126,13 @@ exports.createAd = catchAsync(async (req, res) => {
 
     const maxAds = Number(features["ads_max_ads"] || 0);
     if (maxAds) {
-      const existing = await service.getAds(true, req.user.id, undefined, false, true);
+      const { data: existing } = await service.getAds(
+        true,
+        req.user.id,
+        undefined,
+        false,
+        true
+      );
       if (existing.length >= maxAds) {
         throw new AppError("Ad limit reached for your plan", 403);
       }
@@ -203,8 +209,18 @@ exports.checkTitle = catchAsync(async (req, res) => {
  */
 exports.getAds = catchAsync(async (req, res) => {
   const role = req.query.role?.toLowerCase();
-  const ads = await service.getAds(false, undefined, role, true);
-  sendSuccess(res, ads);
+  const limit = req.query.limit ? Number(req.query.limit) : undefined;
+  const offset = req.query.offset ? Number(req.query.offset) : undefined;
+  const result = await service.getAds(
+    false,
+    undefined,
+    role,
+    true,
+    false,
+    limit,
+    offset
+  );
+  sendSuccess(res, result.data, undefined, result.meta);
 });
 
 /**
@@ -219,14 +235,18 @@ exports.getAllAds = catchAsync(async (req, res) => {
   const isAdmin =
     normalized.includes("admin") || normalized.includes("superadmin");
   const role = req.query.role?.toLowerCase();
-  const ads = await service.getAds(
+  const limit = req.query.limit ? Number(req.query.limit) : undefined;
+  const offset = req.query.offset ? Number(req.query.offset) : undefined;
+  const result = await service.getAds(
     true,
     isAdmin ? undefined : req.user.id,
     role,
     false,
-    true
+    true,
+    limit,
+    offset
   );
-  sendSuccess(res, ads);
+  sendSuccess(res, result.data, undefined, result.meta);
 });
 
 /**
@@ -360,7 +380,13 @@ exports.updateAd = catchAsync(async (req, res) => {
 
     const maxAds = Number(features["ads_max_ads"] || 0);
     if (maxAds) {
-      const existing = await service.getAds(true, req.user.id, undefined, false, true);
+      const { data: existing } = await service.getAds(
+        true,
+        req.user.id,
+        undefined,
+        false,
+        true
+      );
       if (existing.length > maxAds) {
         throw new AppError("Ad limit reached for your plan", 403);
       }

--- a/backend/src/modules/ads/ads.routes.js
+++ b/backend/src/modules/ads/ads.routes.js
@@ -25,9 +25,10 @@ router.get(
   "/admin",
   verifyToken,
   isInstructorOrAdmin,
+  validate(validator.list),
   controller.getAllAds
 );
-router.get("/", controller.getAds);
+router.get("/", validate(validator.list), controller.getAds);
 router.post("/:id/view", controller.recordAdView);
 router.get(
   "/:id/analytics",

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -13,9 +13,11 @@ exports.getAds = async (
   createdBy,
   targetRole,
   onlyPurchased = false,
-  includeAllDates = false
+  includeAllDates = false,
+  limit,
+  offset
 ) => {
-  return db("ads")
+  const query = db("ads")
     .modify((qb) => {
       if (!includeInactive) qb.where({ is_active: true });
       if (createdBy) qb.where({ created_by: createdBy });
@@ -34,6 +36,28 @@ exports.getAds = async (
       }
     })
     .orderBy("created_at", "desc");
+
+  const countQuery = query
+    .clone()
+    .clearSelect()
+    .clearOrder()
+    .count("* as count")
+    .first();
+
+  if (Number.isFinite(limit)) query.limit(limit);
+  if (Number.isFinite(offset)) query.offset(offset);
+
+  const [rows, totalResult] = await Promise.all([query, countQuery]);
+  const total = parseInt(totalResult.count, 10) || 0;
+
+  return {
+    data: rows,
+    meta: {
+      total,
+      limit: Number.isFinite(limit) ? limit : undefined,
+      offset: Number.isFinite(offset) ? offset : undefined,
+    },
+  };
 };
 
 // Mark an ad as purchased by a user

--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -35,3 +35,11 @@ exports.update = {
     price: z.coerce.number().optional(),
   }),
 };
+
+exports.list = {
+  query: z.object({
+    role: z.string().optional(),
+    limit: z.coerce.number().int().positive().max(100).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+  }),
+};

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -81,7 +81,7 @@ beforeEach(() => {
 describe('GET /api/ads', () => {
   it('returns ads list', async () => {
     const mock = [{ id: '1' }];
-    service.getAds.mockResolvedValue(mock);
+    service.getAds.mockResolvedValue({ data: mock, meta: {} });
     const res = await request(app).get('/api/ads');
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
@@ -89,10 +89,10 @@ describe('GET /api/ads', () => {
 
   it('filters ads by role', async () => {
     const mock = [{ id: '1' }];
-    service.getAds.mockResolvedValue(mock);
+    service.getAds.mockResolvedValue({ data: mock, meta: {} });
     const res = await request(app).get('/api/ads').query({ role: 'student' });
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(false, undefined, 'student', true);
+    expect(service.getAds).toHaveBeenCalledWith(false, undefined, 'student', true, false, undefined, undefined);
     expect(res.body.data).toEqual(mock);
   });
 });
@@ -100,19 +100,19 @@ describe('GET /api/ads', () => {
 describe('GET /api/ads/admin', () => {
   it('returns ads for the authenticated instructor', async () => {
     const mock = [{ id: '1', created_by: 'user1' }];
-    service.getAds.mockResolvedValue(mock);
+    service.getAds.mockResolvedValue({ data: mock, meta: {} });
     const res = await request(app).get('/api/ads/admin');
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', undefined, false, true);
+    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', undefined, false, true, undefined, undefined);
     expect(res.body.data).toEqual(mock);
   });
 
   it('filters ads by target role', async () => {
     const mock = [{ id: '1', created_by: 'user1' }];
-    service.getAds.mockResolvedValue(mock);
+    service.getAds.mockResolvedValue({ data: mock, meta: {} });
     const res = await request(app).get('/api/ads/admin').query({ role: 'student' });
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', 'student', false, true);
+    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', 'student', false, true, undefined, undefined);
   });
 });
 
@@ -181,7 +181,7 @@ describe('POST /api/ads/admin', () => {
         { feature_key: 'ads_allow_branding', value: 'true' },
       ],
     });
-    service.getAds.mockResolvedValue([]);
+    service.getAds.mockResolvedValue({ data: [], meta: {} });
     service.createAd.mockResolvedValue({ id: '1', ...payload });
     const res = await request(app).post('/api/ads/admin').send(payload);
     expect(res.status).toBe(200);
@@ -219,7 +219,7 @@ describe('POST /api/ads/admin', () => {
         { feature_key: 'ads_allow_branding', value: 'true' },
       ],
     });
-    service.getAds.mockResolvedValue([]);
+    service.getAds.mockResolvedValue({ data: [], meta: {} });
     const res = await request(app).post('/api/ads/admin').send(payload);
     expect(res.status).toBe(403);
     expect(service.createAd).not.toHaveBeenCalled();
@@ -235,7 +235,7 @@ describe('POST /api/ads/admin', () => {
         { feature_key: 'ads_allow_branding', value: 'false' },
       ],
     });
-    service.getAds.mockResolvedValue([]);
+    service.getAds.mockResolvedValue({ data: [], meta: {} });
     const res = await request(app).post('/api/ads/admin').send(payload);
     expect(res.status).toBe(403);
     expect(service.createAd).not.toHaveBeenCalled();
@@ -251,7 +251,7 @@ describe('POST /api/ads/admin', () => {
         { feature_key: 'ads_allow_branding', value: 'true' },
       ],
     });
-    service.getAds.mockResolvedValue([{ id: 'existing' }]);
+    service.getAds.mockResolvedValue({ data: [{ id: 'existing' }], meta: {} });
     const res = await request(app).post('/api/ads/admin').send(payload);
     expect(res.status).toBe(403);
     expect(service.createAd).not.toHaveBeenCalled();
@@ -269,7 +269,7 @@ describe('PUT /api/ads/:id', () => {
         { feature_key: 'ads_allow_branding', value: 'true' },
       ],
     });
-    service.getAds.mockResolvedValue([{ id: '1' }]);
+    service.getAds.mockResolvedValue({ data: [{ id: '1' }], meta: {} });
     service.updateAd = jest.fn().mockResolvedValue({ id: '1', ...payload });
     const res = await request(app).put('/api/ads/1').send(payload);
     expect(res.status).toBe(200);
@@ -286,7 +286,7 @@ describe('PUT /api/ads/:id', () => {
         { feature_key: 'ads_allow_branding', value: 'false' },
       ],
     });
-    service.getAds.mockResolvedValue([{ id: '1' }]);
+    service.getAds.mockResolvedValue({ data: [{ id: '1' }], meta: {} });
     const res = await request(app).put('/api/ads/1').send(payload);
     expect(res.status).toBe(403);
     expect(service.updateAd).not.toHaveBeenCalled();
@@ -302,7 +302,7 @@ describe('PUT /api/ads/:id', () => {
         { feature_key: 'ads_allow_branding', value: 'true' },
       ],
     });
-    service.getAds.mockResolvedValue([{ id: '1' }, { id: '2' }]);
+    service.getAds.mockResolvedValue({ data: [{ id: '1' }, { id: '2' }], meta: {} });
     const res = await request(app).put('/api/ads/1').send(payload);
     expect(res.status).toBe(403);
     expect(service.updateAd).not.toHaveBeenCalled();
@@ -421,6 +421,14 @@ describe('ads.service getAds active date filtering', () => {
         fn(builder);
         return builder;
       },
+      clone: () => builder,
+      clearSelect: () => builder,
+      clearOrder: () => builder,
+      count: () => builder,
+      first: () => Promise.resolve({ count: 0 }),
+      limit: () => builder,
+      offset: () => builder,
+      then: (resolve) => resolve([]),
     };
     const dbMock = () => builder;
     dbMock.fn = { now: () => 'NOW()' };

--- a/backend/tests/adsService.test.js
+++ b/backend/tests/adsService.test.js
@@ -50,7 +50,7 @@ describe('ads.service getAds', () => {
       { id: adOther, title: 'Other', image_url: 'c.jpg', created_by: userId, is_active: true, target_roles: ['instructor'] },
     ]);
 
-    const ads = await service.getAds(false, undefined, 'student');
+      const { data: ads } = await service.getAds(false, undefined, 'student', false, true);
     const ids = ads.map((a) => a.id).sort();
     const expected = [adEmpty, adNull].sort();
     expect(ids).toEqual(expected);

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -92,7 +92,7 @@ const Hero = () => {
           normalizedRole === "admin" || normalizedRole === "superadmin"
             ? undefined
             : normalizedRole;
-        const data = await getAds(roleParam);
+        const { data } = await getAds(roleParam);
         setAds(data);
         setAdsError(false);
       } catch (_err) {

--- a/frontend/src/pages/dashboard/admin/ads/index.js
+++ b/frontend/src/pages/dashboard/admin/ads/index.js
@@ -19,6 +19,7 @@ export default function AdminAdsPage() {
     const { t } = useTranslation('dashboard', { keyPrefix: 'adsPage' });
     const router = useRouter();
     const [ads, setAds] = useState([]);
+    const [meta, setMeta] = useState({ total: 0 });
     const [search, setSearch] = useState("");
     const [filterStatus, setFilterStatus] = useState("all");
     const [filterRole, setFilterRole] = useState("all");
@@ -32,8 +33,16 @@ export default function AdminAdsPage() {
     // Fetch ads on mount
     // ─────────────────────
     useEffect(() => {
-        fetchAds().then(setAds).catch(() => setAds([]));
-    }, []);
+        fetchAds({ limit: ITEMS_PER_PAGE, offset: (currentPage - 1) * ITEMS_PER_PAGE })
+            .then((res) => {
+                setAds(res.data);
+                setMeta(res.meta || {});
+            })
+            .catch(() => {
+                setAds([]);
+                setMeta({ total: 0 });
+            });
+    }, [currentPage]);
 
     // ─────────────────────
     // Handlers
@@ -113,11 +122,7 @@ export default function AdminAdsPage() {
         });
     }, [ads, search, filterStatus, filterRole, filterType]);
 
-    const totalPages = Math.ceil(filteredAds.length / ITEMS_PER_PAGE);
-    const paginatedAds = filteredAds.slice(
-        (currentPage - 1) * ITEMS_PER_PAGE,
-        currentPage * ITEMS_PER_PAGE
-    );
+    const totalPages = Math.ceil((meta.total || 0) / ITEMS_PER_PAGE);
 
     // ─────────────────────
     // Render
@@ -182,12 +187,12 @@ export default function AdminAdsPage() {
                     </div>
                 )}
 
-                {paginatedAds.length === 0 ? (
+                {filteredAds.length === 0 ? (
                     <p className="text-gray-500 text-center mt-10">{t('no_ads')}</p>
                 ) : (
                     <>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                            {paginatedAds.map((ad) => (
+                            {filteredAds.map((ad) => (
                                 <AdCard
                                     key={ad.id}
                                     ad={ad}
@@ -206,10 +211,11 @@ export default function AdminAdsPage() {
                                 <button
                                     key={i + 1}
                                     onClick={() => setCurrentPage(i + 1)}
-                                    className={`px-3 py-1 rounded border text-sm font-medium transition-colors duration-200 ${currentPage === i + 1
+                                    className={`px-3 py-1 rounded border text-sm font-medium transition-colors duration-200 ${
+                                        currentPage === i + 1
                                             ? "bg-blue-600 text-white border-blue-600"
                                             : "bg-white text-gray-700 border-gray-300 hover:bg-gray-100"
-                                        }`}
+                                    }`}
                                 >
                                     {i + 1}
                                 </button>

--- a/frontend/src/pages/dashboard/admin/ads/purchase.js
+++ b/frontend/src/pages/dashboard/admin/ads/purchase.js
@@ -11,7 +11,7 @@ export default function PurchaseAdsPage() {
   const [ads, setAds] = useState([]);
 
   useEffect(() => {
-    fetchAds().then(setAds).catch(() => setAds([]));
+    fetchAds().then((res) => setAds(res.data)).catch(() => setAds([]));
   }, []);
 
   const handlePurchase = async (id) => {

--- a/frontend/src/pages/dashboard/instructor/ads/index.js
+++ b/frontend/src/pages/dashboard/instructor/ads/index.js
@@ -21,6 +21,7 @@ export default function InstructorAdsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "adsPage" });
   const router = useRouter();
   const [ads, setAds] = useState([]);
+  const [meta, setMeta] = useState({ total: 0 });
   const [search, setSearch] = useState("");
   const [filterStatus, setFilterStatus] = useState("all");
   const [filterType, setFilterType] = useState("all");
@@ -45,15 +46,13 @@ export default function InstructorAdsPage() {
 
   useEffect(() => {
     if (!user?.id) return;
-    fetchAds()
-      .then((data) => {
-        const mine = data.filter(
-          (ad) => ad.created_by === user.id || ad.createdBy === user.id
-        );
-        setAds(mine);
+    fetchAds({ limit: ITEMS_PER_PAGE, offset: (currentPage - 1) * ITEMS_PER_PAGE })
+      .then((res) => {
+        setAds(res.data);
+        setMeta(res.meta || {});
       })
       .catch(() => setAds([]));
-  }, [user?.id]);
+  }, [user?.id, currentPage]);
 
   const handleEdit = (ad) => {
     router.push(`/dashboard/instructor/ads/edit/${ad.id}`);
@@ -99,11 +98,7 @@ export default function InstructorAdsPage() {
     });
   }, [ads, search, filterStatus, filterType]);
 
-  const totalPages = Math.ceil(filteredAds.length / ITEMS_PER_PAGE);
-  const paginatedAds = filteredAds.slice(
-    (currentPage - 1) * ITEMS_PER_PAGE,
-    currentPage * ITEMS_PER_PAGE
-  );
+  const totalPages = Math.ceil((meta.total || 0) / ITEMS_PER_PAGE);
 
   return (
     <InstructorLayout>
@@ -146,12 +141,12 @@ export default function InstructorAdsPage() {
           </select>
         </section>
 
-        {paginatedAds.length === 0 ? (
+        {filteredAds.length === 0 ? (
           <p className="text-gray-500 text-center mt-10">{t("no_ads")}</p>
         ) : (
           <>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {paginatedAds.map((ad) => (
+              {filteredAds.map((ad) => (
                 <AdCard
                   key={ad.id}
                   ad={ad}

--- a/frontend/src/pages/online-classes/index.js
+++ b/frontend/src/pages/online-classes/index.js
@@ -43,7 +43,7 @@ export default function OnlineClassesPage({ initialClasses = [] }) {
   }, [initialClasses]);
 
   useEffect(() => {
-    fetchAdBanners().then(setAds).catch(() => {});
+    fetchAdBanners({ limit: 10 }).then((res) => setAds(res.data)).catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -148,7 +148,7 @@ const TutorialsSection = () => {
   }, []);
 
   useEffect(() => {
-    fetchAdBanners().then(setAds).catch(() => {});
+    fetchAdBanners({ limit: 10 }).then((res) => setAds(res.data)).catch(() => {});
   }, []);
 
   const handleFilterChange = (f) => {

--- a/frontend/src/services/adService.js
+++ b/frontend/src/services/adService.js
@@ -1,15 +1,18 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
 
-export const fetchAds = async () => {
-  const { data } = await api.get("/ads");
+export const fetchAds = async ({ limit, offset } = {}) => {
+  const params = { ...(limit !== undefined ? { limit } : {}), ...(offset !== undefined ? { offset } : {}) };
+  const config = Object.keys(params).length ? { params } : undefined;
+  const { data } = await api.get("/ads", config);
   const ads = data?.data ?? [];
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-  return ads.map((ad) => ({
+  const mapped = ads.map((ad) => ({
     ...ad,
     image: ad.image_url ? `${base}${ad.image_url}` : null,
     video: ad.video_url ? `${base}${ad.video_url}` : null,
     link: ad.link_url,
     adType: ad.ad_type ?? ad.adType,
   }));
+  return { data: mapped, meta: data?.meta };
 };

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -16,13 +16,15 @@ export const checkAdTitle = async (title) => {
   return data?.data?.exists;
 };
 
-export const fetchAds = async () => {
+export const fetchAds = async ({ limit, offset } = {}) => {
   try {
-    const { data } = await api.get("/ads/admin");
+    const params = { ...(limit !== undefined ? { limit } : {}), ...(offset !== undefined ? { offset } : {}) };
+    const config = Object.keys(params).length ? { params } : undefined;
+    const { data } = await api.get("/ads/admin", config);
 
     const ads = data?.data ?? [];
     const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-    return ads.map((ad) => ({
+    const mapped = ads.map((ad) => ({
       ...ad,
       image: ad.image_url ? `${base}${ad.image_url}` : null,
       video: ad.video_url ? `${base}${ad.video_url}` : null,
@@ -38,9 +40,10 @@ export const fetchAds = async () => {
       purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
       purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
     }));
+    return { data: mapped, meta: data?.meta };
   } catch (err) {
     if (err.response && err.response.status === 403) {
-      return [];
+      return { data: [], meta: {} };
     }
     throw err;
   }

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -1,9 +1,10 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
 
-export const getAds = async (role) => {
+export const getAds = async (role, { limit, offset } = {}) => {
   try {
-    const config = role ? { params: { role } } : undefined;
+    const params = { ...((role && { role }) || {}), ...(limit !== undefined ? { limit } : {}), ...(offset !== undefined ? { offset } : {}) };
+    const config = Object.keys(params).length ? { params } : undefined;
     const { data } = await api.get("/ads", config);
     // Backend already filters out inactive ads so simply map the returned list.
     const ads = data?.data ?? [];
@@ -26,7 +27,7 @@ export const getAds = async (role) => {
       const path = url.startsWith("/") ? url : `/${url}`;
       return `${base}${path}`;
     };
-    return ads.map((ad) => ({
+    const mapped = ads.map((ad) => ({
       id: ad.id,
       title: ad.title,
       description: ad.description,
@@ -34,11 +35,12 @@ export const getAds = async (role) => {
       video: formatUrl(ad.video_url || ad.video),
       link: ad.link_url || ad.link,
     }));
+    return { data: mapped, meta: data?.meta };
   } catch (error) {
     if (process.env.NODE_ENV !== "production") {
       console.error("Failed to fetch ads", error);
     }
-    return [];
+    return { data: [], meta: {} };
   }
 };
 


### PR DESCRIPTION
## Summary
- support limit/offset and metadata in ad listings
- wire pagination through ads routes and validator
- request and render paginated ads in admin, instructor and public pages

## Testing
- `npm test tests/adsRoutes.test.js tests/adsService.test.js`
- `npm test` *(fails: database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b413d7aa408328a3b84612abb52950