### PR TITLE
Fix activation toggle for admin ads

### DIFF
--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -33,6 +33,7 @@ exports.update = {
     priority: z.coerce.number().optional(),
     allow_branding: z.coerce.boolean().optional(),
     price: z.coerce.number().optional(),
+    is_active: z.coerce.boolean().optional(),
   }),
 };
 


### PR DESCRIPTION
## Summary
- allow `is_active` in ad update validation to permit toggling ad status

## Testing
- `cd backend && npm test` *(fails: Route.post() requires a callback function, database configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b416bb3e188328864ad0911228aa25