### PR TITLE
Show activated ads in hero section

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -223,7 +223,7 @@ exports.getAds = catchAsync(async (req, res) => {
     false,
     undefined,
     role,
-    true,
+    false,
     false,
     limit,
     offset

--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -33,6 +33,7 @@ exports.update = {
     priority: z.coerce.number().optional(),
     allow_branding: z.coerce.boolean().optional(),
     price: z.coerce.number().optional(),
+    is_active: z.coerce.boolean().optional(),
   }),
 };
 

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -99,7 +99,7 @@ describe('GET /api/ads', () => {
     service.getAds.mockResolvedValue({ data: mock, meta: {} });
     const res = await request(app).get('/api/ads').query({ role: 'student' });
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(false, undefined, 'student', true, false, undefined, undefined);
+    expect(service.getAds).toHaveBeenCalledWith(false, undefined, 'student', false, false, undefined, undefined);
     expect(res.body.data).toEqual(mock);
   });
 });


### PR DESCRIPTION
## Summary
- allow `is_active` in ad update validation to permit toggling ad status
- return active ads even if not purchased so they appear in hero section
- adjust ad route tests to match new behavior

## Testing
- `cd backend && npm test` *(fails: Route.post() requires a callback function, database configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b416bb3e188328864ad0911228aa25