### PR TITLE
feat(ads): auto-activate admin ads

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -61,6 +61,8 @@ exports.createAd = catchAsync(async (req, res) => {
     );
   }
 
+  const isAdmin = isAdminRole(req.user.roles || req.user.role);
+
   const data = {
     id: uuidv4(),
     title,
@@ -72,7 +74,7 @@ exports.createAd = catchAsync(async (req, res) => {
     priority: priority ? Number(priority) : 0,
     allow_branding: allow_branding === "true" || allow_branding === true,
     created_by: req.user.id,
-    is_active: false,
+    is_active: isAdmin,
     price: price ? Number(price) : 0,
   };
 
@@ -99,8 +101,6 @@ exports.createAd = catchAsync(async (req, res) => {
     data.video_url = req.body.video_url;
     data.image_url = null;
   }
-
-  const isAdmin = isAdminRole(req.user.roles || req.user.role);
 
   let ad;
   if (!isAdmin) {

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -217,6 +217,44 @@ describe('POST /api/ads/admin', () => {
       receiver_id: 'admin1',
       message: 'New ad created: Test',
     });
+    const callData = service.createAd.mock.calls[0][0];
+    expect(callData.is_active).toBe(false);
+  });
+
+  it('sets is_active false for instructor-created ads', async () => {
+    const payload = { title: 'Test', image_url: 'img.jpg' };
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      ad_credits: 1,
+      features: [
+        { feature_key: 'ads_max_ads', value: '5' },
+        { feature_key: 'ads_allow_branding', value: 'true' },
+      ],
+    });
+    service.getAds.mockResolvedValue({ data: [], meta: {} });
+    service.createAd.mockResolvedValue({ id: '1', ...payload });
+    const res = await request(app).post('/api/ads/admin').send(payload);
+    expect(res.status).toBe(200);
+    expect(service.createAd.mock.calls[0][0].is_active).toBe(false);
+  });
+
+  it('activates ad immediately for admin-created ads', async () => {
+    auth.verifyToken.mockImplementationOnce((req, _res, next) => {
+      req.user = {
+        id: 'admin1',
+        role: 'admin',
+        roles: ['admin'],
+        email: 'admin@example.com',
+        full_name: 'Admin One',
+      };
+      next();
+    });
+    const payload = { title: 'Admin Ad', image_url: 'img.jpg' };
+    service.createAd.mockResolvedValue({ id: '1', ...payload });
+    const res = await request(app).post('/api/ads/admin').send(payload);
+    expect(res.status).toBe(200);
+    expect(service.createAd.mock.calls[0][0].is_active).toBe(true);
+    expect(planService.getPlanById).not.toHaveBeenCalled();
   });
 
   it('rejects creation when ad credits exhausted', async () => {


### PR DESCRIPTION
## Summary
- activate ads automatically when created by admins
- ensure instructor-created ads remain inactive
- cover admin and instructor ad creation states in tests

## Testing
- `cd backend && npm test -- adsRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b420bb453883289de6c7c0f68498ad