### PR TITLE
Log ad views once per rotation

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -105,12 +105,6 @@ const Hero = () => {
     fetchAds();
   }, [userRole]);
 
-  useEffect(() => {
-    if (ads.length) {
-      recordAdView(ads[currentAd].id, userId);
-    }
-  }, [ads, currentAd, userId]);
-
   const AD_ROTATION_INTERVAL = 10000; // ms
   // Auto-rotate Ads Every 10 Seconds, pause when focused/hovered
   useEffect(() => {

--- a/frontend/src/tests/__tests__/HeroAdRotation.test.js
+++ b/frontend/src/tests/__tests__/HeroAdRotation.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import Hero from '../../components/website/sections/Hero';
+import { getAds, recordAdView } from '../../services/adsService';
+
+jest.mock('next/image', () => ({ src, alt, ...rest }) => <img src={src} alt={alt} {...rest} />);
+jest.mock('next/link', () => ({ children }) => <>{children}</>);
+jest.mock('next-i18next', () => ({ useTranslation: () => ({ t: (key) => key }) }));
+jest.mock('framer-motion', () => {
+  const React = require('react');
+  const Mock = React.forwardRef(({ children, ...props }, ref) => (
+    <div ref={ref} {...props}>
+      {children}
+    </div>
+  ));
+  return {
+    motion: new Proxy({}, { get: () => Mock }),
+    AnimatePresence: ({ children }) => <>{children}</>,
+  };
+});
+jest.mock('react-swipeable', () => ({ useSwipeable: () => ({}) }));
+jest.mock('typewriter-effect', () => () => <div>Typewriter</div>);
+jest.mock('../../components/website/AdMediaModal', () => () => <div />);
+jest.mock('../../components/shared/SidebarMenu', () => () => <div />);
+jest.mock('../../components/shared/Chatbot', () => () => <div />);
+jest.mock('../../store/appConfigStore', () => {
+  const store = { settings: {}, fetch: jest.fn(), loaded: true };
+  return { __esModule: true, default: (selector) => selector(store) };
+});
+jest.mock('../../store/auth/authStore', () => ({
+  __esModule: true,
+  default: (selector) => selector({ user: { id: 1, roles: ['student'] } }),
+}));
+jest.mock('../../services/adsService', () => ({
+  getAds: jest.fn(),
+  recordAdView: jest.fn(),
+  recordAdClick: jest.fn(),
+}));
+
+describe('Hero ad rotations', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    getAds.mockResolvedValue({
+      data: [
+        { id: 1, title: 'Ad1', description: '', image: '', video: null, link: '#' },
+        { id: 2, title: 'Ad2', description: '', image: '', video: null, link: '#' },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('records a single view per ad rotation', async () => {
+    render(<Hero />);
+
+    await waitFor(() => expect(recordAdView).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
+    });
+    await waitFor(() => expect(recordAdView).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
+    });
+    await waitFor(() => expect(recordAdView).toHaveBeenCalledTimes(3));
+  });
+});


### PR DESCRIPTION
## Summary
- remove duplicate ad view logging in hero carousel
- drop unused userId parameter and log views by ad ID only
- add test confirming one view is recorded per ad rotation

## Testing
- `npm test src/tests/__tests__/HeroAdRotation.test.js`
- `npm test` *(fails: ChatHeader.test – ReferenceError: lastActive is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b420bcc6148328bdcfd392f0587bde