### PR TITLE
Enforce plan-based ad duration and require admin dates

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -62,14 +62,23 @@ exports.createAd = catchAsync(async (req, res) => {
   }
 
   const isAdmin = isAdminRole(req.user.roles || req.user.role);
+  let start = start_at ? new Date(start_at) : null;
+  let end = end_at ? new Date(end_at) : null;
+
+  if (isAdmin) {
+    // Admins must explicitly set the ad duration
+    if (!start || !end) {
+      throw new AppError("start_at and end_at are required", 400);
+    }
+  }
 
   const data = {
     id: uuidv4(),
     title,
     description,
     link_url,
-    start_at,
-    end_at,
+    start_at: start,
+    end_at: end,
     ad_type,
     priority: priority ? Number(priority) : 0,
     allow_branding: allow_branding === "true" || allow_branding === true,
@@ -126,15 +135,19 @@ exports.createAd = catchAsync(async (req, res) => {
     });
 
     const maxDuration = Number(features["ads_max_ad_duration"] || 0);
-    if (maxDuration && start_at && end_at) {
+    if (!start) start = new Date();
+    if (!end && maxDuration) {
+      end = new Date(start.getTime() + maxDuration * 24 * 60 * 60 * 1000);
+    } else if (end) {
       const diffDays = Math.ceil(
-        (new Date(end_at).getTime() - new Date(start_at).getTime()) /
-          (1000 * 60 * 60 * 24)
+        (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
       );
-      if (diffDays > maxDuration) {
+      if (maxDuration && diffDays > maxDuration) {
         throw new AppError("Ad duration exceeds limit for your plan", 403);
       }
     }
+    data.start_at = start;
+    data.end_at = end;
 
     const maxAds = Number(features["ads_max_ads"] || 0);
     if (maxAds) {

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -249,7 +249,12 @@ describe('POST /api/ads/admin', () => {
       };
       next();
     });
-    const payload = { title: 'Admin Ad', image_url: 'img.jpg' };
+    const payload = {
+      title: 'Admin Ad',
+      image_url: 'img.jpg',
+      start_at: '2024-01-01',
+      end_at: '2024-02-01',
+    };
     service.createAd.mockResolvedValue({ id: '1', ...payload });
     const res = await request(app).post('/api/ads/admin').send(payload);
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- Require admin ads to specify explicit start and end dates
- Auto-assign instructor ad duration based on plan limits and consume credits
- Adjust tests for new admin ad requirements

## Testing
- `npm test` *(fails: database configuration missing and other unrelated test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b42b8627108328beb0c13a55e5ab82