### PR TITLE
Validate ad recording within active window

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -524,6 +524,13 @@ exports.recordAdView = catchAsync(async (req, res) => {
   if (!ad.is_active) {
     throw new AppError("Ad is inactive", 403);
   }
+  const now = Date.now();
+  if (
+    (ad.start_at && new Date(ad.start_at).getTime() > now) ||
+    (ad.end_at && new Date(ad.end_at).getTime() < now)
+  ) {
+    throw new AppError("Ad is outside its active window", 403);
+  }
   const userId = req.user?.id || null;
   const viewerIp = req.ip;
   const userAgent = req.get("user-agent");
@@ -588,6 +595,13 @@ exports.recordAdClick = catchAsync(async (req, res) => {
   }
   if (!ad.is_active) {
     throw new AppError("Ad is inactive", 403);
+  }
+  const now = Date.now();
+  if (
+    (ad.start_at && new Date(ad.start_at).getTime() > now) ||
+    (ad.end_at && new Date(ad.end_at).getTime() < now)
+  ) {
+    throw new AppError("Ad is outside its active window", 403);
   }
   await service.recordClick(ad.id);
   sendSuccess(res, null, "Click recorded");

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -434,6 +434,36 @@ describe('POST /api/ads/:id/view', () => {
     expect(res.status).toBe(403);
     expect(service.recordView).not.toHaveBeenCalled();
   });
+
+  it('returns 403 for ad not yet started', async () => {
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(new Date('2024-01-01').getTime());
+    service.getAdById.mockResolvedValue({
+      id: '1',
+      is_active: true,
+      start_at: '2024-02-01',
+    });
+    const res = await request(app).post('/api/ads/1/view');
+    expect(res.status).toBe(403);
+    expect(service.recordView).not.toHaveBeenCalled();
+    nowSpy.mockRestore();
+  });
+
+  it('returns 403 for ad that has ended', async () => {
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(new Date('2024-03-01').getTime());
+    service.getAdById.mockResolvedValue({
+      id: '1',
+      is_active: true,
+      end_at: '2024-02-01',
+    });
+    const res = await request(app).post('/api/ads/1/view');
+    expect(res.status).toBe(403);
+    expect(service.recordView).not.toHaveBeenCalled();
+    nowSpy.mockRestore();
+  });
 });
 
 describe('POST /api/ads/:id/click', () => {
@@ -458,6 +488,36 @@ describe('POST /api/ads/:id/click', () => {
     const res = await request(app).post('/api/ads/1/click');
     expect(res.status).toBe(403);
     expect(service.recordClick).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for ad not yet started', async () => {
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(new Date('2024-01-01').getTime());
+    service.getAdById.mockResolvedValue({
+      id: '1',
+      is_active: true,
+      start_at: '2024-02-01',
+    });
+    const res = await request(app).post('/api/ads/1/click');
+    expect(res.status).toBe(403);
+    expect(service.recordClick).not.toHaveBeenCalled();
+    nowSpy.mockRestore();
+  });
+
+  it('returns 403 for ad that has ended', async () => {
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(new Date('2024-03-01').getTime());
+    service.getAdById.mockResolvedValue({
+      id: '1',
+      is_active: true,
+      end_at: '2024-02-01',
+    });
+    const res = await request(app).post('/api/ads/1/click');
+    expect(res.status).toBe(403);
+    expect(service.recordClick).not.toHaveBeenCalled();
+    nowSpy.mockRestore();
   });
 });
 // Service-level test ensuring getAds filters by start and end dates


### PR DESCRIPTION
## Summary
- ensure ad views and clicks only record when within start/end dates
- add tests for views and clicks outside active window

## Testing
- `npm test` *(fails: process.exit called due to missing database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b42ec2e4408328a3579f6ef69886ee