### PR TITLE
refactor ads plan feature parsing

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -15,6 +15,7 @@ const {
   sendNewAdAdminEmail,
 } = require("../../utils/email");
 const db = require("../../config/database");
+const { parsePlanFeatures } = require("./ads.utils");
 
 /**
  * Controller functions for managing advertisement banners.
@@ -121,18 +122,7 @@ exports.createAd = catchAsync(async (req, res) => {
       throw new AppError("Plan not found", 403);
     }
 
-    const features = {};
-    (plan.features || []).forEach((f) => {
-      let val = f.value;
-      try {
-        val = JSON.parse(f.value);
-      } catch {
-        if (f.value === "true") val = true;
-        else if (f.value === "false") val = false;
-        else if (!isNaN(f.value)) val = Number(f.value);
-      }
-      features[f.feature_key] = val;
-    });
+    const features = parsePlanFeatures(plan);
 
     const maxDuration = Number(features["ads_max_ad_duration"] || 0);
     if (!start) start = new Date();
@@ -397,18 +387,7 @@ exports.updateAd = catchAsync(async (req, res) => {
       throw new AppError("Plan not found", 403);
     }
 
-    const features = {};
-    (plan.features || []).forEach((f) => {
-      let val = f.value;
-      try {
-        val = JSON.parse(f.value);
-      } catch {
-        if (f.value === "true") val = true;
-        else if (f.value === "false") val = false;
-        else if (!isNaN(f.value)) val = Number(f.value);
-      }
-      features[f.feature_key] = val;
-    });
+    const features = parsePlanFeatures(plan);
 
     const maxDuration = Number(features["ads_max_ad_duration"] || 0);
     if (maxDuration && newStart && newEnd) {

--- a/backend/src/modules/ads/ads.utils.js
+++ b/backend/src/modules/ads/ads.utils.js
@@ -1,0 +1,22 @@
+const parsePlanFeatures = (plan = {}) => {
+  const result = {};
+  if (!plan || !Array.isArray(plan.features)) return result;
+
+  plan.features.forEach((f) => {
+    let val = f.value;
+    if (typeof val === 'string') {
+      try {
+        val = JSON.parse(val);
+      } catch {
+        if (val === 'true') val = true;
+        else if (val === 'false') val = false;
+        else if (!isNaN(val)) val = Number(val);
+      }
+    }
+    result[f.feature_key] = val;
+  });
+
+  return result;
+};
+
+module.exports = { parsePlanFeatures };

--- a/backend/tests/ads.utils.test.js
+++ b/backend/tests/ads.utils.test.js
@@ -1,0 +1,25 @@
+const { parsePlanFeatures } = require('../src/modules/ads/ads.utils');
+
+describe('parsePlanFeatures', () => {
+  it('converts feature list to keyed object with parsed values', () => {
+    const plan = {
+      features: [
+        { feature_key: 'ads_max_ads', value: '5' },
+        { feature_key: 'ads_allow_branding', value: 'true' },
+        { feature_key: 'ads_complex', value: '{"a":1}' },
+      ],
+    };
+
+    const result = parsePlanFeatures(plan);
+    expect(result).toEqual({
+      ads_max_ads: 5,
+      ads_allow_branding: true,
+      ads_complex: { a: 1 },
+    });
+  });
+
+  it('returns empty object when plan has no features', () => {
+    expect(parsePlanFeatures({})).toEqual({});
+    expect(parsePlanFeatures(null)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add `parsePlanFeatures` helper to convert plan feature arrays to keyed objects
- reuse helper in ad creation and update to eliminate duplicate parsing logic
- add unit tests for `parsePlanFeatures`

## Testing
- `npm test` *(fails: Route.post requires a callback function, process.exit called in database config)*

------
https://chatgpt.com/codex/tasks/task_e_68b42ec37f0c8328870e9ad970e1f732