### PR TITLE
Handle partial failures when bulk deleting ads

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/index.js
+++ b/frontend/src/pages/dashboard/admin/ads/index.js
@@ -96,14 +96,24 @@ export default function AdminAdsPage() {
 
     const bulkDelete = async () => {
         if (!confirm(t('confirm_bulk_delete'))) return;
-        try {
-            await Promise.all(selectedAds.map((id) => deleteAd(id)));
-            setAds((prev) => prev.filter((ad) => !selectedAds.includes(ad.id)));
-            setSelectedAds([]);
+        const results = await Promise.allSettled(
+            selectedAds.map((id) => deleteAd(id))
+        );
+        const successfulIds = [];
+        results.forEach((res, index) => {
+            const id = selectedAds[index];
+            if (res.status === "fulfilled") {
+                successfulIds.push(id);
+            } else {
+                const ad = ads.find((a) => a.id === id);
+                toast.error(`${ad?.title || id}: ${t('delete_failed')}`);
+            }
+        });
+        if (successfulIds.length) {
+            setAds((prev) => prev.filter((ad) => !successfulIds.includes(ad.id)));
             toast.success(t('deleted'));
-        } catch {
-            toast.error(t('delete_failed'));
         }
+        setSelectedAds((prev) => prev.filter((id) => !successfulIds.includes(id)));
     };
 
     const filteredAds = useMemo(() => {

--- a/frontend/src/tests/__tests__/AdminAdsBulkDelete.test.js
+++ b/frontend/src/tests/__tests__/AdminAdsBulkDelete.test.js
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AdminAdsPage from '../../pages/dashboard/admin/ads/index';
+
+jest.mock('next-i18next', () => ({ useTranslation: () => ({ t: (key) => key }) }));
+jest.mock('next/router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('react-toastify', () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+jest.mock('../../components/layouts/AdminLayout', () => ({ __esModule: true, default: ({ children }) => <div>{children}</div> }));
+jest.mock('../../components/admin/ads/PreviewModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('react-csv', () => ({ CSVLink: ({ children }) => <a>{children}</a> }));
+jest.mock('next/link', () => ({ __esModule: true, default: ({ children, href }) => <a href={href}>{children}</a> }));
+
+const adsMock = [
+  { id: 1, title: 'Ad One', description: 'Desc1', isActive: true, targetRoles: [], adType: 'promotion' },
+  { id: 2, title: 'Ad Two', description: 'Desc2', isActive: false, targetRoles: [], adType: 'event' },
+];
+
+jest.mock('../../services/admin/adService', () => ({
+  fetchAds: jest.fn(),
+  deleteAd: jest.fn(),
+  updateAd: jest.fn(),
+}));
+
+describe('AdminAdsPage bulk deletion', () => {
+  beforeEach(() => {
+    const { fetchAds, deleteAd } = require('../../services/admin/adService');
+    fetchAds.mockResolvedValue({ data: adsMock, meta: { total: 2 } });
+    deleteAd.mockImplementation((id) =>
+      id === 1 ? Promise.resolve() : Promise.reject(new Error('fail'))
+    );
+  });
+
+  it('reports failures and keeps undeleted ads', async () => {
+    render(<AdminAdsPage />);
+    await screen.findByText('Ad One');
+    fireEvent.click(screen.getByLabelText('Select Ad One'));
+    fireEvent.click(screen.getByLabelText('Select Ad Two'));
+    window.confirm = jest.fn(() => true);
+    fireEvent.click(screen.getByText('delete_selected'));
+
+    await waitFor(() => {
+      const { toast } = require('react-toastify');
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Ad Two'));
+      expect(toast.success).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText('Ad One')).not.toBeInTheDocument();
+    expect(screen.getByText('Ad Two')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- use `Promise.allSettled` to process bulk ad deletions individually and report failures per ad
- keep undeleted ads in the list and surface a toast for each failed deletion
- add UI test covering partial deletion failures

## Testing
- `cd frontend && npm test -- AdminAdsBulkDelete.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b42ec6487083289a81acdd677bda3a