### PR TITLE
Enable server-side ad filtering

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -156,7 +156,12 @@ exports.createAd = catchAsync(async (req, res) => {
         req.user.id,
         undefined,
         false,
-        true
+        true,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
       );
       if (existing.length >= maxAds) {
         throw new AppError("Ad limit reached for your plan", 403);
@@ -243,6 +248,9 @@ exports.getAds = catchAsync(async (req, res) => {
   const role = req.query.role?.toLowerCase();
   const limit = req.query.limit ? Number(req.query.limit) : undefined;
   const offset = req.query.offset ? Number(req.query.offset) : undefined;
+  const status = req.query.status ? String(req.query.status).toLowerCase() : undefined;
+  const type = req.query.type ? String(req.query.type).toLowerCase() : undefined;
+  const search = req.query.search;
   const result = await service.getAds(
     false,
     undefined,
@@ -250,7 +258,10 @@ exports.getAds = catchAsync(async (req, res) => {
     false,
     false,
     limit,
-    offset
+    offset,
+    status,
+    type,
+    search
   );
   sendSuccess(res, result.data, undefined, result.meta);
 });
@@ -269,6 +280,9 @@ exports.getAllAds = catchAsync(async (req, res) => {
   const role = req.query.role?.toLowerCase();
   const limit = req.query.limit ? Number(req.query.limit) : undefined;
   const offset = req.query.offset ? Number(req.query.offset) : undefined;
+  const status = req.query.status ? String(req.query.status).toLowerCase() : undefined;
+  const type = req.query.type ? String(req.query.type).toLowerCase() : undefined;
+  const search = req.query.search;
   const result = await service.getAds(
     true,
     isAdmin ? undefined : req.user.id,
@@ -276,7 +290,10 @@ exports.getAllAds = catchAsync(async (req, res) => {
     false,
     true,
     limit,
-    offset
+    offset,
+    status,
+    type,
+    search
   );
   sendSuccess(res, result.data, undefined, result.meta);
 });
@@ -428,7 +445,12 @@ exports.updateAd = catchAsync(async (req, res) => {
         req.user.id,
         undefined,
         false,
-        true
+        true,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
       );
       if (existing.length > maxAds) {
         throw new AppError("Ad limit reached for your plan", 403);

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -16,17 +16,36 @@ exports.getAds = async (
   onlyPurchased = false,
   includeAllDates = false,
   limit,
-  offset
+  offset,
+  status,
+  adType,
+  search
 ) => {
   const query = db("ads")
     .modify((qb) => {
-      if (!includeInactive) qb.where({ is_active: true });
+      const normalizedStatus = status?.toLowerCase();
+      const normalizedType = adType?.toLowerCase();
+      if (!includeInactive || normalizedStatus === "active") {
+        qb.where({ is_active: true });
+      } else if (normalizedStatus === "inactive") {
+        qb.where({ is_active: false });
+      }
       if (createdBy) qb.where({ created_by: createdBy });
       if (targetRole) {
         qb.where(function () {
           this.whereRaw(
             "target_roles IS NULL OR target_roles = '{}' OR ? = ANY(target_roles)",
             [targetRole]
+          );
+        });
+      }
+      if (normalizedType) qb.where({ ad_type: normalizedType });
+      if (search) {
+        const term = `%${search.toLowerCase()}%`;
+        qb.where(function () {
+          this.whereRaw("LOWER(title) LIKE ?", [term]).orWhereRaw(
+            "LOWER(description) LIKE ?",
+            [term]
           );
         });
       }

--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -42,5 +42,8 @@ exports.list = {
     role: z.string().optional(),
     limit: z.coerce.number().int().positive().max(100).optional(),
     offset: z.coerce.number().int().nonnegative().optional(),
+    status: z.enum(["active", "inactive"]).optional(),
+    type: z.string().optional(),
+    search: z.string().optional(),
   }),
 };

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -99,7 +99,18 @@ describe('GET /api/ads', () => {
     service.getAds.mockResolvedValue({ data: mock, meta: {} });
     const res = await request(app).get('/api/ads').query({ role: 'student' });
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(false, undefined, 'student', false, false, undefined, undefined);
+    expect(service.getAds).toHaveBeenCalledWith(
+      false,
+      undefined,
+      'student',
+      false,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    );
     expect(res.body.data).toEqual(mock);
   });
 });
@@ -110,7 +121,18 @@ describe('GET /api/ads/admin', () => {
     service.getAds.mockResolvedValue({ data: mock, meta: {} });
     const res = await request(app).get('/api/ads/admin');
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', undefined, false, true, undefined, undefined);
+    expect(service.getAds).toHaveBeenCalledWith(
+      true,
+      'user1',
+      undefined,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    );
     expect(res.body.data).toEqual(mock);
   });
 
@@ -119,7 +141,39 @@ describe('GET /api/ads/admin', () => {
     service.getAds.mockResolvedValue({ data: mock, meta: {} });
     const res = await request(app).get('/api/ads/admin').query({ role: 'student' });
     expect(res.status).toBe(200);
-    expect(service.getAds).toHaveBeenCalledWith(true, 'user1', 'student', false, true, undefined, undefined);
+    expect(service.getAds).toHaveBeenCalledWith(
+      true,
+      'user1',
+      'student',
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+
+  it('forwards status type and search filters', async () => {
+    const mock = [{ id: '1', created_by: 'user1' }];
+    service.getAds.mockResolvedValue({ data: mock, meta: {} });
+    const res = await request(app)
+      .get('/api/ads/admin')
+      .query({ status: 'active', type: 'promotion', search: 'hello' });
+    expect(res.status).toBe(200);
+    expect(service.getAds).toHaveBeenCalledWith(
+      true,
+      'user1',
+      undefined,
+      false,
+      true,
+      undefined,
+      undefined,
+      'active',
+      'promotion',
+      'hello'
+    );
   });
 });
 

--- a/backend/tests/adsService.test.js
+++ b/backend/tests/adsService.test.js
@@ -52,7 +52,18 @@ describe('ads.service getAds', () => {
       { id: adOther, title: 'Other', image_url: 'c.jpg', created_by: userId, is_active: true, target_roles: ['instructor'] },
     ]);
 
-    const { data: ads } = await service.getAds(false, undefined, 'student', false, true);
+    const { data: ads } = await service.getAds(
+      false,
+      undefined,
+      'student',
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    );
     const ids = ads.map((a) => a.id).sort();
     const expected = [adEmpty, adNull].sort();
     expect(ids).toEqual(expected);

--- a/frontend/src/pages/dashboard/admin/ads/index.js
+++ b/frontend/src/pages/dashboard/admin/ads/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { FaPlus } from "react-icons/fa";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -33,7 +33,14 @@ export default function AdminAdsPage() {
     // Fetch ads on mount
     // ─────────────────────
     useEffect(() => {
-        fetchAds({ limit: ITEMS_PER_PAGE, offset: (currentPage - 1) * ITEMS_PER_PAGE })
+        fetchAds({
+            limit: ITEMS_PER_PAGE,
+            offset: (currentPage - 1) * ITEMS_PER_PAGE,
+            role: filterRole !== "all" ? filterRole : undefined,
+            status: filterStatus !== "all" ? filterStatus : undefined,
+            type: filterType !== "all" ? filterType : undefined,
+            search: search || undefined,
+        })
             .then((res) => {
                 setAds(res.data);
                 setMeta(res.meta || {});
@@ -42,7 +49,7 @@ export default function AdminAdsPage() {
                 setAds([]);
                 setMeta({ total: 0 });
             });
-    }, [currentPage]);
+    }, [currentPage, filterRole, filterStatus, filterType, search]);
 
     // ─────────────────────
     // Handlers
@@ -105,22 +112,6 @@ export default function AdminAdsPage() {
             toast.error(t('delete_failed'));
         }
     };
-
-    const filteredAds = useMemo(() => {
-        return ads.filter((ad) => {
-            const matchesSearch = ad.title.toLowerCase().includes(search.toLowerCase()) ||
-                ad.description.toLowerCase().includes(search.toLowerCase());
-            const matchesStatus =
-                filterStatus === "all" ||
-                (filterStatus === "active" && ad.isActive) ||
-                (filterStatus === "inactive" && !ad.isActive);
-            const matchesRole =
-                filterRole === "all" || ad.targetRoles.includes(filterRole);
-            const matchesType = filterType === "all" || ad.adType === filterType;
-
-            return matchesSearch && matchesStatus && matchesRole && matchesType;
-        });
-    }, [ads, search, filterStatus, filterRole, filterType]);
 
     const totalPages = Math.ceil((meta.total || 0) / ITEMS_PER_PAGE);
 
@@ -187,12 +178,12 @@ export default function AdminAdsPage() {
                     </div>
                 )}
 
-                {filteredAds.length === 0 ? (
+                {ads.length === 0 ? (
                     <p className="text-gray-500 text-center mt-10">{t('no_ads')}</p>
                 ) : (
                     <>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                            {filteredAds.map((ad) => (
+                            {ads.map((ad) => (
                                 <AdCard
                                     key={ad.id}
                                     ad={ad}

--- a/frontend/src/pages/dashboard/instructor/ads/index.js
+++ b/frontend/src/pages/dashboard/instructor/ads/index.js
@@ -1,5 +1,5 @@
 // pages/dashboard/instructor/ads/index.js
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { FaPlus } from "react-icons/fa";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -46,13 +46,19 @@ export default function InstructorAdsPage() {
 
   useEffect(() => {
     if (!user?.id) return;
-    fetchAds({ limit: ITEMS_PER_PAGE, offset: (currentPage - 1) * ITEMS_PER_PAGE })
+    fetchAds({
+      limit: ITEMS_PER_PAGE,
+      offset: (currentPage - 1) * ITEMS_PER_PAGE,
+      status: filterStatus !== "all" ? filterStatus : undefined,
+      type: filterType !== "all" ? filterType : undefined,
+      search: search || undefined,
+    })
       .then((res) => {
         setAds(res.data);
         setMeta(res.meta || {});
       })
       .catch(() => setAds([]));
-  }, [user?.id, currentPage]);
+  }, [user?.id, currentPage, filterStatus, filterType, search]);
 
   const handleEdit = (ad) => {
     router.push(`/dashboard/instructor/ads/edit/${ad.id}`);
@@ -82,21 +88,6 @@ export default function InstructorAdsPage() {
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
     );
   };
-
-  const filteredAds = useMemo(() => {
-    return ads.filter((ad) => {
-      const matchesSearch =
-        ad.title.toLowerCase().includes(search.toLowerCase()) ||
-        ad.description.toLowerCase().includes(search.toLowerCase());
-      const matchesStatus =
-        filterStatus === "all" ||
-        (filterStatus === "active" && ad.isActive) ||
-        (filterStatus === "inactive" && !ad.isActive);
-      const matchesType = filterType === "all" || ad.adType === filterType;
-
-      return matchesSearch && matchesStatus && matchesType;
-    });
-  }, [ads, search, filterStatus, filterType]);
 
   const totalPages = Math.ceil((meta.total || 0) / ITEMS_PER_PAGE);
 
@@ -141,12 +132,12 @@ export default function InstructorAdsPage() {
           </select>
         </section>
 
-        {filteredAds.length === 0 ? (
+        {ads.length === 0 ? (
           <p className="text-gray-500 text-center mt-10">{t("no_ads")}</p>
         ) : (
           <>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filteredAds.map((ad) => (
+              {ads.map((ad) => (
                 <AdCard
                   key={ad.id}
                   ad={ad}

--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -16,9 +16,23 @@ export const checkAdTitle = async (title) => {
   return data?.data?.exists;
 };
 
-export const fetchAds = async ({ limit, offset } = {}) => {
+export const fetchAds = async ({
+  limit,
+  offset,
+  role,
+  status,
+  type,
+  search,
+} = {}) => {
   try {
-    const params = { ...(limit !== undefined ? { limit } : {}), ...(offset !== undefined ? { offset } : {}) };
+    const params = {
+      ...(limit !== undefined ? { limit } : {}),
+      ...(offset !== undefined ? { offset } : {}),
+      ...(role ? { role } : {}),
+      ...(status ? { status } : {}),
+      ...(type ? { type } : {}),
+      ...(search ? { search } : {}),
+    };
     const config = Object.keys(params).length ? { params } : undefined;
     const { data } = await api.get("/ads/admin", config);
 

--- a/frontend/src/tests/__tests__/adminAdService.test.js
+++ b/frontend/src/tests/__tests__/adminAdService.test.js
@@ -1,0 +1,34 @@
+import api from "../../services/api/api";
+import { fetchAds } from "../../services/admin/adService";
+
+jest.mock("../../services/api/api", () => ({
+  get: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("admin adService", () => {
+  it("forwards query params", async () => {
+    api.get.mockResolvedValueOnce({ data: { data: [], meta: {} } });
+    await fetchAds({
+      limit: 5,
+      offset: 10,
+      role: "student",
+      status: "active",
+      type: "promotion",
+      search: "hello",
+    });
+    expect(api.get).toHaveBeenCalledWith("/ads/admin", {
+      params: {
+        limit: 5,
+        offset: 10,
+        role: "student",
+        status: "active",
+        type: "promotion",
+        search: "hello",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extend ads admin endpoint to filter by status, type, and search text
- Forward filters through frontend services and admin/instructor pages
- Add tests covering new query parameters

## Testing
- `npm test` (backend) *(fails: Route.post requires a callback)*
- `npm test` (frontend) *(fails: ChatHeader.test ReferenceError: lastActive is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b42ec737848328ab2e26f7bacc1a84