### PR TITLE
feat: remove plan limits from admin ad creation

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -91,7 +91,7 @@ const Hero = () => {
         const roleParam =
           normalizedRole === "admin" || normalizedRole === "superadmin"
             ? undefined
-            : normalizedRole;
+            : normalizedRole || "student";
         const { data } = await getAds(roleParam);
         setAds(data);
         setAdsError(false);

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -3,8 +3,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import { createAd, checkAdTitle, fetchAds } from "@/services/admin/adService";
-import { fetchPlanFeatures } from "@/services/planFeatureService";
+import { createAd, checkAdTitle } from "@/services/admin/adService";
 import { FaSpinner, FaTrash, FaImage, FaVideo } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -39,14 +38,7 @@ export default function CreateAdPage() {
     }
   };
 
-  const planKey = user?.plan || 'basic';
-  const [planFeatures, setPlanFeatures] = useState(null);
-  const {
-    allowBranding: allowBrandingEnabled,
-    maxAdDuration,
-    maxAds,
-  } = planFeatures?.[planKey] || { allowBranding: false };
-  const [activeAdsCount, setActiveAdsCount] = useState(0);
+  const allowBrandingEnabled = true;
   
   const [formData, setFormData] = useState({
     title: "",
@@ -78,27 +70,6 @@ export default function CreateAdPage() {
   const [showPreview, setShowPreview] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
 
-  useEffect(() => {
-    fetchPlanFeatures('ads')
-      .then(setPlanFeatures)
-      .catch(() => setPlanFeatures({}));
-  }, []);
-
-  useEffect(() => {
-    if (!maxAds || !user?.id) return;
-    fetchAds()
-      .then((ads) => {
-        const count = ads.filter(
-          (a) =>
-            (a.createdBy ?? a.created_by) === user.id &&
-            a.isActive &&
-            new Date(a.endAt) >= new Date()
-        ).length;
-        setActiveAdsCount(count);
-      })
-      .catch(() => setActiveAdsCount(0));
-  }, [maxAds, user?.id]);
-
   const isFormValid =
     formData.title &&
     formData.startAt &&
@@ -108,8 +79,7 @@ export default function CreateAdPage() {
     !isFormValid ||
     isSubmitting ||
     isCheckingTitle ||
-    titleError ||
-    (maxAds && activeAdsCount >= maxAds);
+    titleError;
 
   useEffect(() => {
     if (!formData.title) {
@@ -172,19 +142,6 @@ export default function CreateAdPage() {
     
     if (new Date(formData.endAt) < new Date(formData.startAt)) {
       setError(t('end_before_start'));
-      return;
-    }
-
-    const start = new Date(formData.startAt);
-    const end = new Date(formData.endAt);
-    const diffInDays = Math.ceil((end - start) / (1000 * 60 * 60 * 24));
-    if (maxAdDuration && diffInDays > maxAdDuration) {
-      setError(t('duration_exceeded', { days: maxAdDuration }));
-      return;
-    }
-
-    if (maxAds && activeAdsCount >= maxAds) {
-      setError(t('ad_limit_reached', { count: maxAds }));
       return;
     }
 
@@ -265,17 +222,6 @@ export default function CreateAdPage() {
         {error && (
           <div className="bg-red-50 dark:bg-red-900/10 border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 px-4 py-3 rounded-lg mb-6">
             {error}
-          </div>
-        )}
-
-        {(maxAds || maxAdDuration) && (
-          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 text-blue-700 dark:text-blue-300 px-4 py-3 rounded-lg mb-6 space-y-1">
-            {maxAds && (
-              <p>{t('plan_limit_ads', { current: activeAdsCount, count: maxAds })}</p>
-            )}
-            {maxAdDuration && (
-              <p>{t('plan_limit_duration', { days: maxAdDuration })}</p>
-            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- ensure unauthenticated visitors load student-targeted ads so admin ads appear on hero
- ensure admin ad creation ignores plan features
- drop plan-based duration and count checks in admin ads

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b430ae7b288328b9e2c898849cf999