### PR TITLE
feat: debounce ad search

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/index.js
+++ b/frontend/src/pages/dashboard/admin/ads/index.js
@@ -11,6 +11,7 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import useDebounce from "@/hooks/useDebounce";
 
 export default function AdminAdsPage() {
     // ─────────────────────
@@ -21,6 +22,7 @@ export default function AdminAdsPage() {
     const [ads, setAds] = useState([]);
     const [meta, setMeta] = useState({ total: 0 });
     const [search, setSearch] = useState("");
+    const debouncedSearch = useDebounce(search, 500);
     const [filterStatus, setFilterStatus] = useState("all");
     const [filterRole, setFilterRole] = useState("all");
     const [filterType, setFilterType] = useState("all");
@@ -39,7 +41,7 @@ export default function AdminAdsPage() {
             role: filterRole !== "all" ? filterRole : undefined,
             status: filterStatus !== "all" ? filterStatus : undefined,
             type: filterType !== "all" ? filterType : undefined,
-            search: search || undefined,
+            search: debouncedSearch || undefined,
         })
             .then((res) => {
                 setAds(res.data);
@@ -49,7 +51,7 @@ export default function AdminAdsPage() {
                 setAds([]);
                 setMeta({ total: 0 });
             });
-    }, [currentPage, filterRole, filterStatus, filterType, search]);
+    }, [currentPage, filterRole, filterStatus, filterType, debouncedSearch]);
 
     // ─────────────────────
     // Handlers

--- a/frontend/src/pages/dashboard/instructor/ads/index.js
+++ b/frontend/src/pages/dashboard/instructor/ads/index.js
@@ -16,6 +16,7 @@ import useMessageStore from "@/store/messages/messageStore";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import useDebounce from "@/hooks/useDebounce";
 
 export default function InstructorAdsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "adsPage" });
@@ -23,6 +24,7 @@ export default function InstructorAdsPage() {
   const [ads, setAds] = useState([]);
   const [meta, setMeta] = useState({ total: 0 });
   const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, 500);
   const [filterStatus, setFilterStatus] = useState("all");
   const [filterType, setFilterType] = useState("all");
   const [currentPage, setCurrentPage] = useState(1);
@@ -51,14 +53,14 @@ export default function InstructorAdsPage() {
       offset: (currentPage - 1) * ITEMS_PER_PAGE,
       status: filterStatus !== "all" ? filterStatus : undefined,
       type: filterType !== "all" ? filterType : undefined,
-      search: search || undefined,
+      search: debouncedSearch || undefined,
     })
       .then((res) => {
         setAds(res.data);
         setMeta(res.meta || {});
       })
       .catch(() => setAds([]));
-  }, [user?.id, currentPage, filterStatus, filterType, search]);
+  }, [user?.id, currentPage, filterStatus, filterType, debouncedSearch]);
 
   const handleEdit = (ad) => {
     router.push(`/dashboard/instructor/ads/edit/${ad.id}`);


### PR DESCRIPTION
## Summary
- debounce search in admin ads page to avoid rapid fetches
- debounce search in instructor ads page

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*
- `npx eslint src/pages/dashboard/admin/ads/index.js src/pages/dashboard/instructor/ads/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4471e7a50832892a969a0ef60e83b