### PR TITLE
Remove unused user tracking param

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -52,7 +52,6 @@ const Hero = () => {
   const configLoaded = useAppConfigStore((s) => s.loaded);
   const { t } = useTranslation("website");
   const userRole = useAuthStore((s) => s.user?.roles?.[0] || s.user?.role);
-  const userId = useAuthStore((s) => s.user?.id);
 
   const [heroBg, setHeroBg] = useState("");
 
@@ -487,7 +486,7 @@ const Hero = () => {
                 </p>
                 <a
                   href={ads[currentAd].link}
-                  onClick={() => recordAdClick(ads[currentAd].id, userId)}
+                  onClick={() => recordAdClick(ads[currentAd].id)}
                   className="inline-flex items-center gap-2 px-5 py-2.5 bg-yellow-500 text-black rounded-lg hover:bg-yellow-600 transition font-semibold shadow-md"
                 >
                   {t('learn_more')} <FaArrowRight />

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -55,7 +55,10 @@ export const recordAdView = async (id) => {
   }
 };
 
-// Notify backend that an ad was clicked
+/**
+ * Notify backend that an ad was clicked.
+ * @param {number|string} id Identifier of the clicked ad
+ */
 export const recordAdClick = async (id) => {
   try {
     await api.post(`/ads/${id}/click`);

--- a/frontend/src/tests/__tests__/HeroAdRotation.test.js
+++ b/frontend/src/tests/__tests__/HeroAdRotation.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import { act } from 'react';
 import Hero from '../../components/website/sections/Hero';
-import { getAds, recordAdView } from '../../services/adsService';
+import { getAds, recordAdView, recordAdClick } from '../../services/adsService';
 
 jest.mock('next/image', () => ({ src, alt, ...rest }) => <img src={src} alt={alt} {...rest} />);
 jest.mock('next/link', () => ({ children }) => <>{children}</>);
@@ -69,5 +69,15 @@ describe('Hero ad rotations', () => {
       jest.advanceTimersByTime(10000);
     });
     await waitFor(() => expect(recordAdView).toHaveBeenCalledTimes(3));
+  });
+
+  test('records a click when ad link is followed', async () => {
+    const { findByText } = render(<Hero />);
+
+    await waitFor(() => expect(getAds).toHaveBeenCalled());
+
+    fireEvent.click(await findByText('learn_more'));
+
+    expect(recordAdClick).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary
- Drop unused `userId` argument from Hero ad click handler
- Document ad click tracking helper and test clicking a hero ad

## Testing
- `npm test` (frontend)
- `npm test` (backend) *(fails: Route.post() requires a callback function)*

------
https://chatgpt.com/codex/tasks/task_e_68b4471d05048328be38e62d013b63da