### PR TITLE
Check ownership before returning ad analytics

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -565,6 +565,16 @@ exports.getAdAnalytics = catchAsync(async (req, res) => {
     throw new AppError("Unauthorized", 401);
   }
   const isAdmin = isAdminRole(req.user.roles || req.user.role);
+
+  // Fetch the ad and verify ownership when the requester is not an admin
+  const ad = await service.getAdById(req.params.id);
+  if (!ad) {
+    throw new AppError("Ad not found", 404);
+  }
+  if (!isAdmin && ad.created_by !== req.user.id) {
+    throw new AppError("Forbidden", 403);
+  }
+
   const canShowAnalytics =
     req.user.plan?.showAnalytics || req.user.subscription?.showAnalytics;
   if (!isAdmin && !canShowAnalytics) {


### PR DESCRIPTION
## Summary
- Ensure only the ad creator or an admin can view analytics by verifying `created_by`
- Return 403 when a non-owner attempts to access analytics

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got undefined; numerous process.exit errors due to missing DB config)*

------
https://chatgpt.com/codex/tasks/task_e_68b449cb637c832883427f5347b9eaa3