### PR TITLE
feat: use atomic increments for ad analytics

### DIFF
--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -220,49 +220,53 @@ exports.recordView = async (adId, userId, ipAddress, userAgent) => {
       user_agent: userAgent || null,
     });
 
-    const analytics = await trx("ad_analytics").where({ ad_id: adId }).first();
-    if (analytics) {
-      const views = analytics.views + 1;
-      const clicks = analytics.clicks;
-      const updates = {
-        views,
-        ctr: calculateCtr(clicks, views),
-      };
-      if (isUnique) {
-        updates.unique_viewers = analytics.unique_viewers + 1;
-      }
-      await trx("ad_analytics").where({ ad_id: adId }).update(updates);
-    } else {
-      await trx("ad_analytics").insert({
+    const uniqueInc = isUnique ? 1 : 0;
+    await trx("ad_analytics")
+      .insert({
         ad_id: adId,
         views: 1,
         clicks: 0,
         ctr: 0,
-        unique_viewers: isUnique ? 1 : 0,
+        unique_viewers: uniqueInc,
+      })
+      .onConflict("ad_id")
+      .merge({
+        views: trx.raw("ad_analytics.views + 1"),
+        unique_viewers: trx.raw("ad_analytics.unique_viewers + ?", [uniqueInc]),
       });
-    }
+
+    await trx("ad_analytics")
+      .where({ ad_id: adId })
+      .update({
+        ctr: trx.raw(
+          "CASE WHEN views > 0 THEN (clicks::float / views) * 100 ELSE 0 END"
+        ),
+      });
   });
 };
 
 // Increment click count and recompute CTR
 exports.recordClick = async (adId) => {
   return db.transaction(async (trx) => {
-    const analytics = await trx("ad_analytics").where({ ad_id: adId }).first();
-    if (analytics) {
-      const clicks = analytics.clicks + 1;
-      const ctr = calculateCtr(clicks, analytics.views);
-      await trx("ad_analytics").where({ ad_id: adId }).update({
-        clicks,
-        ctr,
-      });
-    } else {
-      await trx("ad_analytics").insert({
+    await trx("ad_analytics")
+      .insert({
         ad_id: adId,
         views: 0,
         clicks: 1,
         ctr: 0,
         unique_viewers: 0,
+      })
+      .onConflict("ad_id")
+      .merge({
+        clicks: trx.raw("ad_analytics.clicks + 1"),
       });
-    }
+
+    await trx("ad_analytics")
+      .where({ ad_id: adId })
+      .update({
+        ctr: trx.raw(
+          "CASE WHEN views > 0 THEN (clicks::float / views) * 100 ELSE 0 END"
+        ),
+      });
   });
 };

--- a/backend/tests/adsConcurrency.test.js
+++ b/backend/tests/adsConcurrency.test.js
@@ -1,0 +1,75 @@
+const { newDb } = require('pg-mem');
+
+const db = newDb();
+// Minimal uuid function for pg-mem
+const { v4: uuidv4 } = require('uuid');
+db.public.registerFunction({ name: 'uuid_generate_v4', returns: 'uuid', implementation: uuidv4 });
+
+const mockDb = db.adapters.createKnex();
+
+jest.mock('../src/config/database.js', () => mockDb);
+
+const service = require('../src/modules/ads/ads.service');
+
+describe('ads.service concurrency', () => {
+  let adId;
+
+  beforeAll(async () => {
+    // Create minimal tables needed for analytics
+    await mockDb.schema.createTable('ads', (table) => {
+      table.uuid('id').primary();
+    });
+
+    await mockDb.schema.createTable('ad_views', (table) => {
+      table.increments('id').primary();
+      table.uuid('ad_id').notNullable();
+      table.uuid('user_id');
+      table.string('ip_address');
+      table.text('user_agent');
+    });
+
+    await mockDb.schema.createTable('ad_analytics', (table) => {
+      table.uuid('ad_id').primary();
+      table.integer('views').defaultTo(0);
+      table.integer('clicks').defaultTo(0);
+      table.float('ctr').defaultTo(0);
+      table.integer('unique_viewers').defaultTo(0);
+    });
+  });
+
+  beforeEach(async () => {
+    await mockDb('ad_views').del();
+    await mockDb('ad_analytics').del();
+    await mockDb('ads').del();
+    adId = uuidv4();
+    await mockDb('ads').insert({ id: adId });
+  });
+
+  afterAll(async () => {
+    await mockDb.destroy();
+  });
+
+  it('handles concurrent views without losing updates', async () => {
+    const views = Array.from({ length: 10 }, (_, i) =>
+      service.recordView(adId, null, `ip${i}`, 'ua')
+    );
+    await Promise.all(views);
+
+    const row = await mockDb('ad_analytics').where({ ad_id: adId }).first();
+    expect(Number(row.views)).toBe(10);
+    expect(Number(row.unique_viewers)).toBe(10);
+  });
+
+  it('handles concurrent clicks without losing updates', async () => {
+    await mockDb('ad_analytics').insert({ ad_id: adId, views: 10, clicks: 0, ctr: 0, unique_viewers: 0 });
+
+    const clicks = Array.from({ length: 10 }, () => service.recordClick(adId));
+    await Promise.all(clicks);
+
+    const row = await mockDb('ad_analytics').where({ ad_id: adId }).first();
+    expect(Number(row.clicks)).toBe(10);
+    expect(Number(row.views)).toBe(10);
+    expect(Number(row.ctr)).toBe(100);
+  });
+});
+


### PR DESCRIPTION
## Summary
- update ad view and click tracking to use atomic upserts instead of read-modify-write
- recalc CTR after increments to avoid race conditions
- add tests simulating concurrent views and clicks

## Testing
- `npx jest tests/adsConcurrency.test.js`
- `npx jest tests/adsService.test.js`
- `npm --prefix backend test` *(fails: process.exit called due to missing DB config)*

------
https://chatgpt.com/codex/tasks/task_e_68b449cd5afc83289f6c6d91b9474ac8