### PR TITLE
Validate nonnegative ad priority and price

### DIFF
--- a/backend/src/modules/ads/ads.validator.js
+++ b/backend/src/modules/ads/ads.validator.js
@@ -12,9 +12,9 @@ exports.create = {
     end_at: z.coerce.date().optional(),
     target_roles: z.string().optional(),
     ad_type: z.string().optional(),
-    priority: z.coerce.number().optional(),
+    priority: z.coerce.number().nonnegative().optional(),
     allow_branding: z.coerce.boolean().optional(),
-    price: z.coerce.number().optional(),
+    price: z.coerce.number().nonnegative().optional(),
   }),
 };
 
@@ -30,9 +30,9 @@ exports.update = {
     end_at: z.coerce.date().optional(),
     target_roles: z.string().optional(),
     ad_type: z.string().optional(),
-    priority: z.coerce.number().optional(),
+    priority: z.coerce.number().nonnegative().optional(),
     allow_branding: z.coerce.boolean().optional(),
-    price: z.coerce.number().optional(),
+    price: z.coerce.number().nonnegative().optional(),
     is_active: z.coerce.boolean().optional(),
   }),
 };

--- a/frontend/src/components/ads/AdForm.js
+++ b/frontend/src/components/ads/AdForm.js
@@ -94,7 +94,10 @@ export default function AdForm({
     } else if (type === "checkbox") {
       setFormData((prev) => ({ ...prev, [name]: checked }));
     } else if (name === "priority") {
-      setFormData((prev) => ({ ...prev, priority: Number(value) }));
+      setFormData((prev) => ({
+        ...prev,
+        priority: Math.max(0, Number(value)),
+      }));
     } else {
       setFormData((prev) => ({ ...prev, [name]: value }));
     }
@@ -410,6 +413,7 @@ export default function AdForm({
               name="priority"
               value={formData.priority}
               onChange={handleChange}
+              min={0}
               className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm dark:bg-gray-700 dark:text-white"
             />
           </div>


### PR DESCRIPTION
## Summary
- Ensure ad priority and price are nonnegative in backend create/update validators
- Block negative priority input in AdForm

## Testing
- `cd backend && npm test` *(fails: process.exit called; database configuration is missing)*
- `cd frontend && npm test` *(fails: process.exit called; database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b449cc74fc832895458222d2f1562e