### PR TITLE
refactor admin ad mapping into utility

### DIFF
--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -1,6 +1,6 @@
 import api from "@/services/api/api";
-import { API_BASE_URL } from "@/config/config";
 import { getCsrfToken } from "@/services/api/csrf";
+import { mapApiAdToClient } from "./mapApiAdToClient";
 
 export const createAd = async (payload) => {
   const headers = {};
@@ -37,23 +37,7 @@ export const fetchAds = async ({
     const { data } = await api.get("/ads/admin", config);
 
     const ads = data?.data ?? [];
-    const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-    const mapped = ads.map((ad) => ({
-      ...ad,
-      image: ad.image_url ? `${base}${ad.image_url}` : null,
-      video: ad.video_url ? `${base}${ad.video_url}` : null,
-      link: ad.link_url,
-      targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
-      startAt: ad.start_at ?? ad.startAt,
-      endAt: ad.end_at ?? ad.endAt,
-      adType: ad.ad_type ?? ad.adType,
-      priority: ad.priority ?? 0,
-      allowBranding: ad.allow_branding ?? false,
-      isActive: ad.is_active ?? ad.isActive ?? false,
-      price: ad.price ?? 0,
-      purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
-      purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
-    }));
+    const mapped = ads.map(mapApiAdToClient);
     return { data: mapped, meta: data?.meta };
   } catch (err) {
     if (err.response && err.response.status === 403) {
@@ -68,23 +52,7 @@ export const fetchAdById = async (id, headers = {}) => {
     const { data } = await api.get(`/ads/${id}`, { headers });
     const ad = data?.data;
     if (!ad) return null;
-    const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-    return {
-      ...ad,
-      image: ad.image_url ? `${base}${ad.image_url}` : null,
-      video: ad.video_url ? `${base}${ad.video_url}` : null,
-      link: ad.link_url,
-      targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
-      startAt: ad.start_at ?? ad.startAt,
-      endAt: ad.end_at ?? ad.endAt,
-      adType: ad.ad_type ?? ad.adType,
-      priority: ad.priority ?? 0,
-      allowBranding: ad.allow_branding ?? false,
-      isActive: ad.is_active ?? ad.isActive ?? false,
-      price: ad.price ?? 0,
-      purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
-      purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
-    };
+    return mapApiAdToClient(ad);
   } catch (err) {
     if (err.response && err.response.status === 403) {
       return null;

--- a/frontend/src/services/admin/mapApiAdToClient.js
+++ b/frontend/src/services/admin/mapApiAdToClient.js
@@ -1,0 +1,21 @@
+import { API_BASE_URL } from "@/config/config";
+
+export const mapApiAdToClient = (ad) => {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+  return {
+    ...ad,
+    image: ad.image_url ? `${base}${ad.image_url}` : null,
+    video: ad.video_url ? `${base}${ad.video_url}` : null,
+    link: ad.link_url,
+    targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
+    startAt: ad.start_at ?? ad.startAt,
+    endAt: ad.end_at ?? ad.endAt,
+    adType: ad.ad_type ?? ad.adType,
+    priority: ad.priority ?? 0,
+    allowBranding: ad.allow_branding ?? false,
+    isActive: ad.is_active ?? ad.isActive ?? false,
+    price: ad.price ?? 0,
+    purchasedAt: ad.purchased_at ?? ad.purchasedAt ?? null,
+    purchasedBy: ad.purchased_by ?? ad.purchasedBy ?? null,
+  };
+};


### PR DESCRIPTION
## Summary
- add `mapApiAdToClient` helper for consistent ad mapping
- refactor `fetchAds` and `fetchAdById` to use shared helper

## Testing
- `npm test -- src/tests/__tests__/adminAdService.test.js`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68b449ced3748328915c581056259fec