### PR TITLE
fix: ensure dynamic ad edit pages use SSR

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/edit/[id].js
@@ -69,7 +69,7 @@ export default function EditAdPage() {
   );
 }
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),

--- a/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
@@ -68,7 +68,7 @@ export default function EditAdPage() {
   );
 }
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),


### PR DESCRIPTION
## Summary
- fix admin ads edit page to use getServerSideProps
- fix instructor ads edit page to use getServerSideProps

## Testing
- `npm test src/tests/__tests__/AdminAdsBulkDelete.test.js`
- `npm run lint` *(fails: Component definition is missing display name)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b44ce22ec883289a42ac72633b7a7c