### PR TITLE
Show device counts for ad analytics

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -152,7 +152,17 @@ export default function AdAnalyticsPage({ ad: initialAd, error }) {
               { label: "CTR", value: `${(ad.ctr ?? 0).toFixed(2)}%`, icon: "📈" },
               { label: "Conversions", value: ad.conversions, icon: "🎯" },
               { label: "Reach", value: ad.reach, icon: "📊" },
-              { label: "Top Devices", value: deviceList.length ? deviceList.join(", ") : "-", icon: "📱" }
+              {
+                label: "Top Devices",
+                value: deviceList.length
+                  ? deviceList
+                      .map((d) =>
+                        `${d.user_agent}${d.views ? ` (${d.views})` : ""}`
+                      )
+                      .join(", ")
+                  : "-",
+                icon: "📱",
+              }
             ].map((item) => (
               <div key={item.label} className="bg-gray-50 p-4 rounded border">
                 <div className="text-xs uppercase mb-1">{item.icon} {item.label}</div>

--- a/frontend/src/tests/__tests__/AdAnalyticsDeviceRendering.test.js
+++ b/frontend/src/tests/__tests__/AdAnalyticsDeviceRendering.test.js
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import AdAnalyticsPage from '../../pages/dashboard/admin/ads/analytics/[id]';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { id: '1' }, push: jest.fn() })
+}));
+
+jest.mock('../../components/layouts/AdminLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>
+}));
+
+jest.mock('react-toastify', () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+
+jest.mock('../../components/common/PageHead', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('AdAnalyticsPage device rendering', () => {
+  it('shows user agents with view counts', () => {
+    const ad = {
+      title: 'Ad',
+      description: '',
+      targetRoles: [],
+      startAt: '',
+      endAt: '',
+      adType: '',
+      isActive: true,
+      image: '',
+      views: 0,
+      ctr: 0,
+      conversions: 0,
+      reach: 0,
+      analytics: [],
+      locationStats: [],
+      devices: [
+        { user_agent: 'Chrome', views: 12 },
+        { user_agent: 'Firefox', views: 5 }
+      ]
+    };
+
+    render(<AdAnalyticsPage ad={ad} />);
+    expect(screen.getByText('Chrome (12), Firefox (5)')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- display top devices with their view counts in admin ad analytics
- add unit test verifying device list rendering

## Testing
- `npm test -- src/tests/__tests__/AdAnalyticsDeviceRendering.test.js`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68b4518bb8208328813aa1c1f7ef77f9