### PR TITLE
Optimize ad analytics queries and add tests

### DIFF
--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -145,42 +145,50 @@ exports.deleteAd = (id) => {
 
 // Retrieve aggregated analytics for a given ad.
 exports.getAdAnalytics = async (adId) => {
-  // Aggregate total views and unique viewers from ad_views table
-  const [agg] = await db("ad_views")
+  // Prepare all analytics queries
+  const aggQuery = db("ad_views")
     .where({ ad_id: adId })
     .count("* as views")
-    .countDistinct("user_id as unique_viewers");
+    .countDistinct("user_id as unique_viewers")
+    .first();
 
-  // Group views by day for line chart data
-  const daily = await db("ad_views")
+  const dailyQuery = db("ad_views")
     .select(db.raw("DATE(viewed_at) as day"))
     .count("* as views")
     .where({ ad_id: adId })
     .groupBy("day")
     .orderBy("day", "asc");
 
-  // Aggregate views by device and IP
-  const deviceRows = await db("ad_views")
+  const deviceQuery = db("ad_views")
     .select("user_agent")
     .count("* as views")
     .where({ ad_id: adId })
     .groupBy("user_agent")
     .orderBy("views", "desc");
 
-  const ipRows = await db("ad_views")
+  const ipQuery = db("ad_views")
     .select("ip_address")
     .count("* as views")
     .where({ ad_id: adId })
     .groupBy("ip_address")
     .orderBy("views", "desc");
 
-  // Optional stored analytics such as clicks/ctr
-  const row = await db("ad_analytics").where({ ad_id: adId }).first();
+  const analyticsRowQuery = db("ad_analytics").where({ ad_id: adId }).first();
+
+  const [agg, daily, deviceRows, ipRows, row] = await Promise.all([
+    aggQuery,
+    dailyQuery,
+    deviceQuery,
+    ipQuery,
+    analyticsRowQuery,
+  ]);
+
   const clicks = row?.clicks ?? 0;
-  const ctr = row?.ctr ?? calculateCtr(clicks, agg.views);
+  const views = Number(agg?.views) || 0;
+  const ctr = row?.ctr ?? calculateCtr(clicks, views);
 
   return {
-    views: Number(agg?.views) || 0,
+    views,
     clicks,
     ctr: Number(ctr) || 0,
     unique_viewers: Number(agg?.unique_viewers) || 0,

--- a/backend/tests/adsAnalytics.test.js
+++ b/backend/tests/adsAnalytics.test.js
@@ -1,0 +1,114 @@
+const { newDb } = require('pg-mem');
+
+const db = newDb();
+// Minimal uuid implementation for pg-mem
+const { v4: uuidv4 } = require('uuid');
+db.public.registerFunction({ name: 'uuid_generate_v4', returns: 'uuid', implementation: uuidv4 });
+
+// Support DATE() calls used in analytics queries
+db.public.registerFunction({
+  name: 'date',
+  args: ['timestamptz'],
+  returns: 'date',
+  implementation: (x) => new Date(x.getFullYear(), x.getMonth(), x.getDate()),
+});
+
+const mockDb = db.adapters.createKnex();
+
+jest.mock('../src/config/database.js', () => mockDb);
+
+const service = require('../src/modules/ads/ads.service');
+
+describe('ads.service getAdAnalytics', () => {
+  let adId;
+
+  beforeAll(async () => {
+    await mockDb.schema.createTable('ad_views', (table) => {
+      table.increments('id').primary();
+      table.uuid('ad_id').notNullable();
+      table.uuid('user_id');
+      table.timestamp('viewed_at').defaultTo(mockDb.fn.now());
+      table.string('ip_address');
+      table.text('user_agent');
+    });
+
+    await mockDb.schema.createTable('ad_analytics', (table) => {
+      table.uuid('ad_id').primary();
+      table.integer('views').defaultTo(0);
+      table.integer('clicks').defaultTo(0);
+      table.float('ctr').defaultTo(0);
+      table.integer('unique_viewers').defaultTo(0);
+    });
+  });
+
+  beforeEach(async () => {
+    await mockDb('ad_views').del();
+    await mockDb('ad_analytics').del();
+    adId = uuidv4();
+
+    await mockDb('ad_views').insert([
+      {
+        ad_id: adId,
+        user_id: uuidv4(),
+        viewed_at: new Date('2024-01-01T10:00:00Z'),
+        ip_address: 'ip1',
+        user_agent: 'Chrome',
+      },
+      {
+        ad_id: adId,
+        user_id: uuidv4(),
+        viewed_at: new Date('2024-01-01T12:00:00Z'),
+        ip_address: 'ip2',
+        user_agent: 'Chrome',
+      },
+      {
+        ad_id: adId,
+        user_id: null,
+        viewed_at: new Date('2024-01-02T15:00:00Z'),
+        ip_address: 'ip3',
+        user_agent: 'Firefox',
+      },
+    ]);
+
+    await mockDb('ad_analytics').insert({
+      ad_id: adId,
+      views: 3,
+      clicks: 1,
+      ctr: null,
+      unique_viewers: 2,
+    });
+  });
+
+  afterAll(async () => {
+    await mockDb.destroy();
+  });
+
+  it('returns aggregated analytics with computed ctr', async () => {
+    const analytics = await service.getAdAnalytics(adId);
+
+    expect(analytics.views).toBe(3);
+    expect(analytics.clicks).toBe(1);
+    expect(analytics.unique_viewers).toBe(2);
+    expect(analytics.ctr).toBeCloseTo((1 / 3) * 100);
+
+    expect(analytics.devices).toEqual([
+      { user_agent: 'Chrome', views: 2 },
+      { user_agent: 'Firefox', views: 1 },
+    ]);
+
+    expect(analytics.ip_stats).toHaveLength(3);
+    expect(analytics.ip_stats).toEqual(
+      expect.arrayContaining([
+        { ip_address: 'ip1', views: 1 },
+        { ip_address: 'ip2', views: 1 },
+        { ip_address: 'ip3', views: 1 },
+      ])
+    );
+
+    expect(analytics.analytics.map((d) => d.day.toISOString().slice(0, 10))).toEqual([
+      '2024-01-01',
+      '2024-01-02',
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- run ad analytics queries concurrently with Promise.all
- compute CTR after all analytics queries resolve
- add unit test verifying analytics aggregation and CTR

## Testing
- `npm test` *(fails: Route.post() requires a callback function)*
- `npx jest --runTestsByPath tests/adsAnalytics.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b451994a6483289f1b65aee1984f46