### PR TITLE
feat: unify ad media url building

### DIFF
--- a/frontend/src/services/adService.js
+++ b/frontend/src/services/adService.js
@@ -1,16 +1,15 @@
 import api from "@/services/api/api";
-import { API_BASE_URL } from "@/config/config";
+import { buildAdMediaUrl } from "@/utils/adMedia";
 
-export const fetchAds = async ({ limit, offset } = {}) => {
+export const fetchAds = async ({ limit, offset } = {}, origin) => {
   const params = { ...(limit !== undefined ? { limit } : {}), ...(offset !== undefined ? { offset } : {}) };
   const config = Object.keys(params).length ? { params } : undefined;
   const { data } = await api.get("/ads", config);
   const ads = data?.data ?? [];
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
   const mapped = ads.map((ad) => ({
     ...ad,
-    image: ad.image_url ? `${base}${ad.image_url}` : null,
-    video: ad.video_url ? `${base}${ad.video_url}` : null,
+    image: buildAdMediaUrl(ad.image_url, origin),
+    video: buildAdMediaUrl(ad.video_url, origin),
     link: ad.link_url,
     adType: ad.ad_type ?? ad.adType,
   }));

--- a/frontend/src/services/admin/mapApiAdToClient.js
+++ b/frontend/src/services/admin/mapApiAdToClient.js
@@ -1,11 +1,10 @@
-import { API_BASE_URL } from "@/config/config";
+import { buildAdMediaUrl } from "@/utils/adMedia";
 
-export const mapApiAdToClient = (ad) => {
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+export const mapApiAdToClient = (ad, origin) => {
   return {
     ...ad,
-    image: ad.image_url ? `${base}${ad.image_url}` : null,
-    video: ad.video_url ? `${base}${ad.video_url}` : null,
+    image: buildAdMediaUrl(ad.image_url, origin),
+    video: buildAdMediaUrl(ad.video_url, origin),
     link: ad.link_url,
     targetRoles: ad.targetRoles ?? ad.target_roles ?? [],
     startAt: ad.start_at ?? ad.startAt,

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -1,7 +1,7 @@
 import api from "@/services/api/api";
-import { API_BASE_URL } from "@/config/config";
+import { buildAdMediaUrl } from "@/utils/adMedia";
 
-export const getAds = async (role, { limit, offset } = {}) => {
+export const getAds = async (role, { limit, offset } = {}, origin) => {
   try {
     const params = { ...((role && { role }) || {}), ...(limit !== undefined ? { limit } : {}), ...(offset !== undefined ? { offset } : {}) };
     const config = Object.keys(params).length ? { params } : undefined;
@@ -9,30 +9,12 @@ export const getAds = async (role, { limit, offset } = {}) => {
     // Backend already filters out inactive ads so simply map the returned list.
     const ads = data?.data ?? [];
 
-    // Build a fully-qualified base URL so media links resolve regardless of
-    // whether NEXT_PUBLIC_API_BASE_URL is absolute ("https://api.com/api") or
-    // relative ("/api"). When relative, fall back to the current origin and
-    // retain the "/api" prefix so proxied media paths still work.
-    let base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-    if (!base.startsWith("http") && typeof window !== "undefined") {
-      base = window.location.origin + base;
-    }
-    base = base.replace(/\/$/, "");
-
-    const formatUrl = (url) => {
-      if (!url) return null;
-      if (url.startsWith("http") || url.startsWith("blob:") || url.startsWith("data:")) {
-        return url;
-      }
-      const path = url.startsWith("/") ? url : `/${url}`;
-      return `${base}${path}`;
-    };
     const mapped = ads.map((ad) => ({
       id: ad.id,
       title: ad.title,
       description: ad.description,
-      image: formatUrl(ad.image_url || ad.image),
-      video: formatUrl(ad.video_url || ad.video),
+      image: buildAdMediaUrl(ad.image_url || ad.image, origin),
+      video: buildAdMediaUrl(ad.video_url || ad.video, origin),
       link: ad.link_url || ad.link,
     }));
     return { data: mapped, meta: data?.meta };

--- a/frontend/src/utils/adMedia.js
+++ b/frontend/src/utils/adMedia.js
@@ -1,0 +1,31 @@
+import { API_BASE_URL } from "@/config/config";
+
+/**
+ * Build a fully-qualified media URL for ad assets. When the configured base
+ * URL is relative (e.g. "/api"), it will be prefixed with the current
+ * origin in the browser or an optional `origin` provided on the server.
+ * The base URL has any trailing slash removed before concatenating the path.
+ *
+ * @param {string|null|undefined} url Path or absolute URL to the media.
+ * @param {string} [origin] Optional origin for server-side usage.
+ * @returns {string|null} Fully-qualified media URL or null when input is falsy.
+ */
+export function buildAdMediaUrl(url, origin) {
+  if (!url) return null;
+  if (/^(?:https?:|blob:|data:)/.test(url)) return url;
+
+  let base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL || "";
+
+  if (base.startsWith("/")) {
+    if (typeof window !== "undefined") {
+      base = window.location.origin + base;
+    } else if (origin) {
+      base = origin + base;
+    }
+  }
+
+  base = base.replace(/\/$/, "");
+
+  const path = url.startsWith("/") ? url : `/${url}`;
+  return `${base}${path}`;
+}


### PR DESCRIPTION
## Summary
- centralize ad media URL construction with `buildAdMediaUrl`
- use shared helper for ads service mapping
- support relative base URLs by prefixing origin and trimming trailing slashes

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4518c4c40832881a21aeb31f30429