### PR TITLE
feat: track ad view locations

### DIFF
--- a/backend/src/migrations/20250712161022_add_location_to_ad_views.js
+++ b/backend/src/migrations/20250712161022_add_location_to_ad_views.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table('ad_views', function (table) {
+    table.string('location');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('ad_views', function (table) {
+    table.dropColumn('location');
+  });
+};

--- a/backend/src/modules/ads/ads.service.js
+++ b/backend/src/modules/ads/ads.service.js
@@ -1,6 +1,32 @@
 const db = require("../../config/database");
 const { calculateCtr } = require("./ads.utils");
 
+// Use native fetch when available; otherwise fall back to node-fetch
+const fetchFn =
+  typeof global.fetch === "function"
+    ? (...args) => global.fetch(...args)
+    : (...args) => import("node-fetch").then(({ default: f }) => f(...args));
+
+const isIp = (ip) =>
+  /^(?:\d{1,3}\.){3}\d{1,3}$/.test(ip) ||
+  /^[0-9a-fA-F:]+$/.test(ip);
+
+async function lookupLocation(ip) {
+  if (!ip || !isIp(ip)) return null;
+  try {
+    const res = await fetchFn(
+      `http://ip-api.com/json/${ip}?fields=status,country`
+    );
+    const data = await res.json();
+    if (data.status === "success") {
+      return data.country || null;
+    }
+  } catch (e) {
+    // ignore network errors and return null
+  }
+  return null;
+}
+
 exports.createAd = async (data, trx) => {
   const query = trx || db;
   const [row] = await query("ads").insert(data).returning("*");
@@ -173,13 +199,22 @@ exports.getAdAnalytics = async (adId) => {
     .groupBy("ip_address")
     .orderBy("views", "desc");
 
+  const locationQuery = db("ad_views")
+    .select("location")
+    .count("* as views")
+    .where({ ad_id: adId })
+    .whereNotNull("location")
+    .groupBy("location")
+    .orderBy("views", "desc");
+
   const analyticsRowQuery = db("ad_analytics").where({ ad_id: adId }).first();
 
-  const [agg, daily, deviceRows, ipRows, row] = await Promise.all([
+  const [agg, daily, deviceRows, ipRows, locationRows, row] = await Promise.all([
     aggQuery,
     dailyQuery,
     deviceQuery,
     ipQuery,
+    locationQuery,
     analyticsRowQuery,
   ]);
 
@@ -194,13 +229,17 @@ exports.getAdAnalytics = async (adId) => {
     unique_viewers: Number(agg?.unique_viewers) || 0,
     devices: deviceRows.map((d) => ({ user_agent: d.user_agent, views: Number(d.views) })),
     ip_stats: ipRows.map((i) => ({ ip_address: i.ip_address, views: Number(i.views) })),
-    location_stats: [],
+    location_stats: locationRows.map((l) => ({
+      country: l.location,
+      views: Number(l.views),
+    })),
     analytics: daily.map((d) => ({ day: d.day, views: Number(d.views) })),
   };
 };
 
 // Increment view count and track unique viewers
 exports.recordView = async (adId, userId, ipAddress, userAgent) => {
+  const location = await lookupLocation(ipAddress);
   return db.transaction(async (trx) => {
     // Check if this viewer is unique before inserting the view record
     let isUnique = false;
@@ -226,6 +265,7 @@ exports.recordView = async (adId, userId, ipAddress, userAgent) => {
       user_id: userId || null,
       ip_address: ipAddress || null,
       user_agent: userAgent || null,
+      location: location || null,
     });
 
     const uniqueInc = isUnique ? 1 : 0;

--- a/backend/tests/adsAnalytics.test.js
+++ b/backend/tests/adsAnalytics.test.js
@@ -30,6 +30,7 @@ describe('ads.service getAdAnalytics', () => {
       table.timestamp('viewed_at').defaultTo(mockDb.fn.now());
       table.string('ip_address');
       table.text('user_agent');
+      table.string('location');
     });
 
     await mockDb.schema.createTable('ad_analytics', (table) => {
@@ -53,6 +54,7 @@ describe('ads.service getAdAnalytics', () => {
         viewed_at: new Date('2024-01-01T10:00:00Z'),
         ip_address: 'ip1',
         user_agent: 'Chrome',
+        location: 'USA',
       },
       {
         ad_id: adId,
@@ -60,6 +62,7 @@ describe('ads.service getAdAnalytics', () => {
         viewed_at: new Date('2024-01-01T12:00:00Z'),
         ip_address: 'ip2',
         user_agent: 'Chrome',
+        location: 'USA',
       },
       {
         ad_id: adId,
@@ -67,6 +70,7 @@ describe('ads.service getAdAnalytics', () => {
         viewed_at: new Date('2024-01-02T15:00:00Z'),
         ip_address: 'ip3',
         user_agent: 'Firefox',
+        location: 'Canada',
       },
     ]);
 
@@ -102,6 +106,13 @@ describe('ads.service getAdAnalytics', () => {
         { ip_address: 'ip1', views: 1 },
         { ip_address: 'ip2', views: 1 },
         { ip_address: 'ip3', views: 1 },
+      ])
+    );
+
+    expect(analytics.location_stats).toEqual(
+      expect.arrayContaining([
+        { country: 'USA', views: 2 },
+        { country: 'Canada', views: 1 },
       ])
     );
 

--- a/backend/tests/adsConcurrency.test.js
+++ b/backend/tests/adsConcurrency.test.js
@@ -26,6 +26,7 @@ describe('ads.service concurrency', () => {
       table.uuid('user_id');
       table.string('ip_address');
       table.text('user_agent');
+      table.string('location');
     });
 
     await mockDb.schema.createTable('ad_analytics', (table) => {

--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -189,15 +189,19 @@ export default function AdAnalyticsPage({ ad: initialAd, error }) {
         {/* Chart: Views by Country */}
         <div className="bg-white rounded-lg shadow p-6">
           <h2 className="text-xl font-semibold mb-4">🌍 {t('views_by_country')}</h2>
-          <ResponsiveContainer width="100%" height={250}>
-            <BarChart data={locationStats}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="country" />
-              <YAxis />
-              <Tooltip />
-              <Bar dataKey="views" fill="#10b981" />
-            </BarChart>
-          </ResponsiveContainer>
+          {locationStats.length ? (
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={locationStats}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="country" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="views" fill="#10b981" />
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <p className="text-center text-sm text-gray-500">{t('no_data', { defaultValue: 'No data' })}</p>
+          )}
         </div>
 
         {showDeleteModal && (

--- a/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/analytics/[id].js
@@ -106,15 +106,19 @@ export default function InstructorAdAnalyticsPage() {
 
         <div className="bg-white rounded-lg shadow p-6">
           <h2 className="text-xl font-semibold mb-4">🌍 {t('views_by_country')}</h2>
-          <ResponsiveContainer width="100%" height={250}>
-            <BarChart data={ad.locationStats}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="country" />
-              <YAxis />
-              <Tooltip />
-              <Bar dataKey="views" fill="#10b981" />
-            </BarChart>
-          </ResponsiveContainer>
+          { (ad.locationStats ?? []).length ? (
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={ad.locationStats}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="country" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="views" fill="#10b981" />
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <p className="text-center text-sm text-gray-500">{t('no_data', { defaultValue: 'No data' })}</p>
+          )}
         </div>
       </div>
     </InstructorLayout>


### PR DESCRIPTION
## Summary
- derive viewer country during ad view logging
- aggregate country stats in ad analytics API
- show location breakdown on ad analytics pages

## Testing
- `cd backend && npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*
- `cd frontend && npm test` *(fails: Jest worker encountered 4 child process exceptions, exceeding retry limit)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ec977e2083289cfa8b1669d081cb