### PR TITLE
Add auth check for subscription plan checkout

### DIFF
--- a/frontend/src/components/website/sections/SubscriptionPlans.js
+++ b/frontend/src/components/website/sections/SubscriptionPlans.js
@@ -3,9 +3,9 @@ import { motion } from "framer-motion";
 import { FaCheck } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+import useAuthStore from "@/store/auth/authStore";
 import { fetchPublicPlans } from "@/services/public/planService";
-
-
 
 const SubscriptionPlans = ({ role = "student" }) => {
   const { t } = useTranslation("website");
@@ -99,11 +99,17 @@ const SubscriptionPlans = ({ role = "student" }) => {
                 <button
                   className="mt-6 px-6 py-3 rounded-lg font-semibold hover:opacity-90"
                   style={buttonStyles}
-                  onClick={() =>
-                    router.push(
-                      `/payments/checkout?itemType=plan&itemId=${plan.id}`
-                    )
-                  }
+                  onClick={() => {
+                    const checkoutUrl = `/payments/checkout?itemType=plan&itemId=${plan.id}`;
+                    if (useAuthStore.getState().isAuthenticated()) {
+                      router.push(checkoutUrl);
+                    } else {
+                      toast.info(t("please_login_to_purchase"));
+                      router.push(
+                        `/auth/login?redirect=${encodeURIComponent(checkoutUrl)}`
+                      );
+                    }
+                  }}
                 >
                   {t("subscription_select_plan")}
                 </button>


### PR DESCRIPTION
## Summary
- require login before accessing subscription plan checkout and redirect to login if unauthenticated
- show informative toast when login is needed

## Testing
- `npm test src/tests/__tests__/Navbar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4ecb0985c832891d733eb5855b234