### PR TITLE
feat: auto schedule ads based on plan duration

### DIFF
--- a/frontend/src/components/ads/AdForm.js
+++ b/frontend/src/components/ads/AdForm.js
@@ -18,6 +18,7 @@ export default function AdForm({
   checkTitle,
   submitLabel = "Submit",
   tPrefix,
+  hideSchedule = false,
 }) {
   const { t, i18n } = useTranslation("dashboard", { keyPrefix: tPrefix });
   const { t: tp } = useTranslation("dashboard", { keyPrefix: "adsPage" });
@@ -103,10 +104,11 @@ export default function AdForm({
     }
   };
 
+  const isScheduleValid = hideSchedule || (formData.startAt && formData.endAt);
+
   const isFormValid =
     formData.title &&
-    formData.startAt &&
-    formData.endAt &&
+    isScheduleValid &&
     ((mediaType === "image" && (formData.image || initialData.image)) ||
       (mediaType === "video" && (videoFile || initialData.video)));
 
@@ -123,7 +125,12 @@ export default function AdForm({
       return;
     }
 
-    if (new Date(formData.endAt) < new Date(formData.startAt)) {
+    if (
+      !hideSchedule &&
+      formData.startAt &&
+      formData.endAt &&
+      new Date(formData.endAt) < new Date(formData.startAt)
+    ) {
       setError(t("end_before_start"));
       return;
     }
@@ -137,8 +144,8 @@ export default function AdForm({
       payload.append("title", formData.title);
       payload.append("description", formData.description);
       payload.append("link_url", formData.link);
-      payload.append("start_at", formData.startAt);
-      payload.append("end_at", formData.endAt);
+      if (formData.startAt) payload.append("start_at", formData.startAt);
+      if (formData.endAt) payload.append("end_at", formData.endAt);
       payload.append("ad_type", formData.adType);
       payload.append("priority", String(formData.priority));
       payload.append(
@@ -361,41 +368,43 @@ export default function AdForm({
         </div>
       </section>
 
-      <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
-        <header className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
-          <h2 className="text-lg md:text-xl font-semibold text-gray-800 dark:text-gray-200">
-            🗓️ {t("schedule")}
-          </h2>
-        </header>
-        <div className="px-5 py-6 space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-                {t("start_at")} *
-              </label>
-              <input
-                type="date"
-                name="startAt"
-                value={formData.startAt}
-                onChange={handleChange}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm dark:bg-gray-700 dark:text-white"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-                {t("end_at")} *
-              </label>
-              <input
-                type="date"
-                name="endAt"
-                value={formData.endAt}
-                onChange={handleChange}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm dark:bg-gray-700 dark:text-white"
-              />
+      {!hideSchedule && (
+        <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
+          <header className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+            <h2 className="text-lg md:text-xl font-semibold text-gray-800 dark:text-gray-200">
+              🗓️ {t("schedule")}
+            </h2>
+          </header>
+          <div className="px-5 py-6 space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+                  {t("start_at")} *
+                </label>
+                <input
+                  type="date"
+                  name="startAt"
+                  value={formData.startAt}
+                  onChange={handleChange}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+                  {t("end_at")} *
+                </label>
+                <input
+                  type="date"
+                  name="endAt"
+                  value={formData.endAt}
+                  onChange={handleChange}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm dark:bg-gray-700 dark:text-white"
+                />
+              </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
 
       <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
         <header className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">

--- a/frontend/src/pages/dashboard/instructor/ads/create.js
+++ b/frontend/src/pages/dashboard/instructor/ads/create.js
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -26,6 +26,19 @@ export default function CreateAdPage() {
   const allowBrandingEnabled =
     planFeatures?.[planKey]?.allowBranding ?? false;
 
+  const maxAdDuration = planFeatures?.[planKey]?.maxAdDuration;
+  const hideSchedule = Boolean(maxAdDuration);
+
+  const initialData = useMemo(() => {
+    if (!hideSchedule) return {};
+    const start = new Date();
+    const end = new Date(start.getTime() + maxAdDuration * 24 * 60 * 60 * 1000);
+    return {
+      startAt: start.toISOString().split("T")[0],
+      endAt: end.toISOString().split("T")[0],
+    };
+  }, [hideSchedule, maxAdDuration]);
+
   const handleSubmit = async (payload, setUploadProgress) => {
     await createAd(payload, {
       onUploadProgress: (e) => {
@@ -40,10 +53,12 @@ export default function CreateAdPage() {
   return (
     <InstructorLayout>
       <AdForm
+        initialData={initialData}
         onSubmit={handleSubmit}
         allowBrandingEnabled={allowBrandingEnabled}
         submitLabel={t("submit", { defaultValue: "Submit" })}
         tPrefix="adsCreatePage"
+        hideSchedule={hideSchedule}
       />
     </InstructorLayout>
   );

--- a/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/instructor/ads/edit/[id].js
@@ -36,6 +36,9 @@ export default function EditAdPage() {
   const allowBrandingEnabled =
     planFeatures?.[planKey]?.allowBranding ?? false;
 
+  const maxAdDuration = planFeatures?.[planKey]?.maxAdDuration;
+  const hideSchedule = Boolean(maxAdDuration);
+
   const handleSubmit = async (payload, setUploadProgress) => {
     await updateAd(id, payload, {
       onUploadProgress: (e) => {
@@ -63,6 +66,7 @@ export default function EditAdPage() {
         allowBrandingEnabled={allowBrandingEnabled}
         submitLabel={t("submit", { defaultValue: "Submit" })}
         tPrefix="adsEditPage"
+        hideSchedule={hideSchedule}
       />
     </InstructorLayout>
   );


### PR DESCRIPTION
## Summary
- allow AdForm to hide start/end date fields and skip related validation
- auto-fill ad schedule on instructor create/edit pages when plan defines duration

## Testing
- `npm test` *(fails: HeroAdRotation.test.js)*
- `npm run lint` *(fails: 41 errors, 306 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ec8c2f2083289828c5d827028638