### PR TITLE
Fix Hero ad loader naming conflict

### DIFF
--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -83,7 +83,7 @@ const Hero = () => {
   ];
 
   useEffect(() => {
-    const fetchAds = async () => {
+    const loadAds = async () => {
       setLoadingAds(true);
       try {
         const normalizedRole = userRole?.toLowerCase();
@@ -101,7 +101,7 @@ const Hero = () => {
         setLoadingAds(false);
       }
     };
-    fetchAds();
+    loadAds();
   }, [userRole]);
 
   const AD_ROTATION_INTERVAL = 10000; // ms


### PR DESCRIPTION
## Summary
- rename local ad fetcher to `loadAds` to avoid shadowing the `fetchAds` service
- use `fetchAds` service inside the loader and invoke `loadAds` in `useEffect`

## Testing
- `npm test src/tests/__tests__/Footer.test.js`
- `npm run lint` *(fails: 41 errors, 306 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ec8bb26083289de52aae857036c1