### PR TITLE
feat: pass role to subscription plans

### DIFF
--- a/frontend/src/pages/website/index.js
+++ b/frontend/src/pages/website/index.js
@@ -21,16 +21,27 @@ import nextI18NextConfig from '../../../next-i18next.config.js';
 
 
 export default function Home() {
+  const { user } = useAuthStore();
+  const planRole = user?.role === "instructor" ? "instructor" : "student";
+
   const sections = [
-    Hero, OnlineClasses, TutorialsSection, BooksSection, LearningMarketplace, StudyCategories,
-    StudyGroups, InstructorBooking, SubscriptionPlans
-    , AITutoring, CommunityEngagement, Footer // ✅ Removed last section before the footer
+    { component: Hero },
+    { component: OnlineClasses },
+    { component: TutorialsSection },
+    { component: BooksSection },
+    { component: LearningMarketplace },
+    { component: StudyCategories },
+    { component: StudyGroups },
+    { component: InstructorBooking },
+    { component: SubscriptionPlans, props: { role: planRole } },
+    { component: AITutoring },
+    { component: CommunityEngagement },
+    { component: Footer }, // ✅ Removed last section before the footer
   ];
 
   const sectionRefs = useRef(sections.map(() => useRef(null)));
   const [currentSection, setCurrentSection] = useState(0);
   const [scrollProgress, setScrollProgress] = useState(0);
-  const { user, hasHydrated } = useAuthStore();
   // Intentionally no console logs to avoid leaking user data
 
   // Track scrolling position
@@ -67,9 +78,9 @@ export default function Home() {
       <Navbar />
       <IncompleteAlertModal />
 
-      {sections.map((Component, index) => (
+      {sections.map(({ component: Component, props }, index) => (
         <section key={index} ref={sectionRefs.current[index]}>
-          <Component />
+          <Component {...props} />
         </section>
       ))}
 


### PR DESCRIPTION
## Summary
- pass user role from auth store to SubscriptionPlans
- allow homepage sections array to include props per component
- apply props when rendering sections

## Testing
- `npm test src/tests/__tests__/bookService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4ecafa0fc8328894856f9c06e0c8b