### PR TITLE
feat: allow config overrides for ad admin service

### DIFF
--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -2,12 +2,12 @@ import api from "@/services/api/api";
 import { getCsrfToken } from "@/services/api/csrf";
 import { mapApiAdToClient } from "./mapApiAdToClient";
 
-export const createAd = async (payload) => {
+export const createAd = async (payload, config = {}) => {
   const headers = {};
   const csrfToken = getCsrfToken();
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
   if (payload instanceof FormData) headers["Content-Type"] = "multipart/form-data";
-  const { data } = await api.post("/ads/admin", payload, { headers });
+  const { data } = await api.post("/ads/admin", payload, { headers, ...config });
   return data?.data;
 };
 
@@ -61,13 +61,13 @@ export const fetchAdById = async (id, headers = {}) => {
   }
 };
 
-export const updateAd = async (id, payload) => {
+export const updateAd = async (id, payload, config = {}) => {
   const headers = {};
   const csrfToken = getCsrfToken();
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
   if (payload instanceof FormData) headers["Content-Type"] = "multipart/form-data";
   try {
-    const { data } = await api.put(`/ads/${id}`, payload, { headers });
+    const { data } = await api.put(`/ads/${id}`, payload, { headers, ...config });
     return data?.data;
   } catch (err) {
     if (err.response && err.response.status === 403) {


### PR DESCRIPTION
## Summary
- allow passing Axios config to `createAd` and `updateAd` so callers can supply options like progress handlers

## Testing
- `npm test src/tests/__tests__/adminAdService.test.js`
- `npm run lint` *(fails: 41 errors, 306 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fa395c5483289959cd4d9a63ea43