### PR TITLE
Ensure non-empty target roles for ad creation

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -101,6 +101,9 @@ exports.createAd = catchAsync(async (req, res) => {
         ? target_roles
         : [target_roles];
     }
+    if (!data.target_roles || data.target_roles.length === 0) {
+      throw new AppError("At least one target role required", 400);
+    }
   }
 
   if (req.files?.image?.[0]) {


### PR DESCRIPTION
## Summary
- validate that non-admin ad creation includes at least one target role

## Testing
- `npm test` (fails: Route.post requires a callback, process.exit called)


------
https://chatgpt.com/codex/tasks/task_e_68b4fa36557083289f6036453ee02919