### PR TITLE
refactor: let axios set formdata content-type

### DIFF
--- a/frontend/src/services/admin/adService.js
+++ b/frontend/src/services/admin/adService.js
@@ -6,7 +6,6 @@ export const createAd = async (payload) => {
   const headers = {};
   const csrfToken = getCsrfToken();
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
-  if (payload instanceof FormData) headers["Content-Type"] = "multipart/form-data";
   const { data } = await api.post("/ads/admin", payload, { headers });
   return data?.data;
 };
@@ -65,7 +64,6 @@ export const updateAd = async (id, payload) => {
   const headers = {};
   const csrfToken = getCsrfToken();
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
-  if (payload instanceof FormData) headers["Content-Type"] = "multipart/form-data";
   try {
     const { data } = await api.put(`/ads/${id}`, payload, { headers });
     return data?.data;


### PR DESCRIPTION
## Summary
- remove manual multipart header from admin ad service so axios can set boundaries

## Testing
- `npm test src/tests/__tests__/adminAdService.test.js`
- `npx eslint src/services/admin/adService.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4fa345678832885db298c9bf369e5