### PR TITLE
Add plan checkout payment flow tests

### DIFF
--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -4,6 +4,8 @@ import { fetchClassDetails } from '../../services/classService';
 import { fetchPaymentMethods } from '../../services/paymentMethodService';
 import { initiateBankPayment } from '../../services/paymentService';
 import { createPayment } from '../../services/student/paymentService';
+import { fetchPlanDetails } from '../../services/public/planService';
+import PaymentSuccessPage from '../../pages/payments/success';
 jest.mock('next-i18next', () => ({
   useTranslation: () => ({
     t: (key, params) => {
@@ -12,6 +14,7 @@ jest.mock('next-i18next', () => ({
         bank_transfer_pending: 'Your bank transfer request has been submitted and is pending admin approval.',
       };
       if (key === 'pay_with_paypal') return `Pay $${params?.price} with PayPal`;
+      if (typeof params === 'string') return params;
       return translations[key] || key;
     },
   }),
@@ -38,6 +41,7 @@ jest.mock('../../components/website/sections/Footer', () => {
 
 jest.mock('../../services/classService', () => ({ fetchClassDetails: jest.fn() }));
 jest.mock('../../services/tutorialService', () => ({ fetchTutorialDetails: jest.fn() }));
+jest.mock('../../services/public/planService', () => ({ fetchPlanDetails: jest.fn() }));
 jest.mock('../../services/paymentMethodService', () => ({
   fetchPaymentMethods: jest.fn(),
 }));
@@ -49,9 +53,20 @@ jest.mock('../../services/paymentService', () => ({
 jest.mock('../../services/student/paymentService', () => ({
   createPayment: jest.fn(),
 }));
+jest.mock('../../store/libraryStore', () => ({
+  __esModule: true,
+  default: (selector) => {
+    const state = { fetchLibrary: jest.fn().mockResolvedValue() };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+}));
 
 const mockUseRouter = jest.fn();
 jest.mock('next/router', () => ({ useRouter: () => mockUseRouter() }));
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }) => <a href={href}>{children}</a>,
+}));
 
 beforeEach(() => {
   mockUseRouter.mockReturnValue({
@@ -141,4 +156,75 @@ test('shows error when unhandled payment fails', async () => {
   fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Stripe/i }));
   await waitFor(() => expect(createPayment).toHaveBeenCalled());
   expect(require('react-toastify').toast.error).toHaveBeenCalled();
+});
+
+test('processes plan card payments and redirects to billing for students', async () => {
+  jest.useFakeTimers();
+  const push = jest.fn();
+  mockUseRouter.mockReturnValue({
+    query: { itemId: '1', itemType: 'plan' },
+    isReady: true,
+    push,
+  });
+  const planDetails = { data: { id: 1, name: 'Starter Plan', price_monthly: 50 } };
+  fetchPlanDetails.mockResolvedValue(planDetails);
+  fetchPaymentMethods.mockResolvedValue([{ id: 1, name: 'Stripe', type: 'stripe' }]);
+  createPayment.mockResolvedValue({ status: 'paid' });
+
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+  expect(
+    screen.getByText(
+      'Bank transfer, PayPal, and cryptocurrency payment methods are not available for plans.'
+    )
+  ).toBeInTheDocument();
+
+  fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'Jane Doe' } });
+  fireEvent.change(screen.getByPlaceholderText('Email Address'), { target: { value: 'jane@example.com' } });
+  fireEvent.change(screen.getByPlaceholderText('Card Number'), { target: { value: '4242424242424242' } });
+  fireEvent.change(screen.getByPlaceholderText('Expiration Date (MM/YY)'), { target: { value: '12/30' } });
+  fireEvent.change(screen.getByPlaceholderText('CVC'), { target: { value: '123' } });
+  fireEvent.click(screen.getByRole('button', { name: /Pay \$50 with Stripe/i }));
+
+  await waitFor(() => expect(createPayment).toHaveBeenCalled());
+  jest.runAllTimers();
+  await waitFor(() =>
+    expect(push).toHaveBeenCalledWith('/payments/success?itemType=plan&itemId=1')
+  );
+  jest.useRealTimers();
+
+  mockUseRouter.mockReturnValue({
+    query: { itemType: 'plan', itemId: '1' },
+  });
+  fetchPlanDetails.mockResolvedValue(planDetails);
+  render(<PaymentSuccessPage />);
+  const billingLink = await screen.findByRole('link', { name: /Manage Billing/i });
+  expect(billingLink).toHaveAttribute('href', '/dashboard/student/settings?tab=billing');
+});
+
+test('filters out bank and PayPal methods for plans', async () => {
+  mockUseRouter.mockReturnValue({
+    query: { itemId: '1', itemType: 'plan' },
+    isReady: true,
+    push: jest.fn(),
+  });
+  fetchPlanDetails.mockResolvedValue({
+    data: { id: 1, name: 'Starter Plan', price_monthly: 50 },
+  });
+  fetchPaymentMethods.mockResolvedValue([
+    { id: 1, name: 'Stripe', type: 'stripe' },
+    { id: 2, name: 'PayPal', type: null },
+    { id: 3, name: 'Bank', type: 'bank' },
+  ]);
+
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+  expect(
+    screen.getByText(
+      'Bank transfer, PayPal, and cryptocurrency payment methods are not available for plans.'
+    )
+  ).toBeInTheDocument();
+  expect(screen.queryByText('PayPal')).toBeNull();
+  expect(screen.queryByText('Bank')).toBeNull();
+  expect(screen.getByText('Stripe')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add translation fallback support in checkout flow tests
- mock plan service and library store
- test plan checkout with card payment and billing redirect
- ensure bank and PayPal methods are filtered for plans

## Testing
- `cd frontend && npm test -- src/tests/__tests__/checkoutPaymentFlow.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4fb3f2f088328b0cf81bebe7f0cda