### PR TITLE
feat: add subscription interval toggle

### DIFF
--- a/frontend/src/components/website/sections/SubscriptionPlans.js
+++ b/frontend/src/components/website/sections/SubscriptionPlans.js
@@ -11,6 +11,7 @@ const SubscriptionPlans = ({ role = "student" }) => {
   const { t } = useTranslation("website");
   const router = useRouter();
   const [plans, setPlans] = useState([]);
+  const [interval, setInterval] = useState("monthly");
 
   useEffect(() => {
     const load = async () => {
@@ -38,6 +39,29 @@ const SubscriptionPlans = ({ role = "student" }) => {
           {t("subscription_description")}
 
         </p>
+
+        <div className="mb-8 flex justify-center gap-4">
+          <button
+            className={`px-4 py-2 rounded-l ${
+              interval === "monthly"
+                ? "bg-yellow-500 text-gray-900"
+                : "bg-gray-700"
+            }`}
+            onClick={() => setInterval("monthly")}
+          >
+            Monthly
+          </button>
+          <button
+            className={`px-4 py-2 rounded-r ${
+              interval === "yearly"
+                ? "bg-yellow-500 text-gray-900"
+                : "bg-gray-700"
+            }`}
+            onClick={() => setInterval("yearly")}
+          >
+            Yearly
+          </button>
+        </div>
 
         {/* Subscription Plans */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto relative z-10">
@@ -85,7 +109,9 @@ const SubscriptionPlans = ({ role = "student" }) => {
 
                 <h3 className="text-2xl font-extrabold mb-2">{plan.name}</h3>
                 <p className="text-3xl font-bold mb-4">
-                  {plan.price_monthly} {plan.currency}/mo
+                  {interval === "monthly"
+                    ? `${plan.price_monthly} ${plan.currency}/mo`
+                    : `${plan.price_yearly} ${plan.currency}/yr`}
                 </p>
 
                 <ul className="space-y-2 text-gray-300">
@@ -100,7 +126,7 @@ const SubscriptionPlans = ({ role = "student" }) => {
                   className="mt-6 px-6 py-3 rounded-lg font-semibold hover:opacity-90"
                   style={buttonStyles}
                   onClick={() => {
-                    const checkoutUrl = `/payments/checkout?itemType=plan&itemId=${plan.id}`;
+                    const checkoutUrl = `/payments/checkout?itemType=plan&itemId=${plan.id}&interval=${interval}`;
                     if (useAuthStore.getState().isAuthenticated()) {
                       router.push(checkoutUrl);
                     } else {

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -155,6 +155,10 @@ export default function CheckoutPage() {
   }, [router.isReady, router.query, cartItems]);
   const itemId = resolvedItem?.id;
   const itemType = resolvedItem?.type;
+  const interval = useMemo(() => {
+    if (!router.isReady) return 'monthly';
+    return router.query.interval === 'yearly' ? 'yearly' : 'monthly';
+  }, [router.isReady, router.query.interval]);
   const checkoutError = router.isReady && !resolvedItem
     ? t('checkout_single_item_warning')
     : '';
@@ -193,7 +197,11 @@ export default function CheckoutPage() {
         } else if (itemType === 'plan') {
           details = await fetchPlanDetails(itemId);
           const data = details?.data ?? details;
-          details = { ...data, title: data.name, price: Number(data.price_monthly) };
+          const price =
+            interval === 'yearly'
+              ? Number(data.price_yearly)
+              : Number(data.price_monthly);
+          details = { ...data, title: data.name, price };
         } else {
           details = await fetchClassDetails(itemId);
         }
@@ -232,7 +240,7 @@ export default function CheckoutPage() {
     return () => {
       active = false;
     };
-  }, [itemId, itemType]);
+  }, [itemId, itemType, interval]);
 
 
   const handleApplyPromo = async () => {
@@ -387,6 +395,7 @@ export default function CheckoutPage() {
         allow_installments: allowInstallments,
         installments,
       };
+      if (itemType === 'plan') payload.interval = interval;
       if (couponId) payload.coupon_id = couponId;
       const response = await createPayment(payload);
       if (response?.status === 'paid') {


### PR DESCRIPTION
## Summary
- allow selecting monthly or yearly subscription intervals
- pass interval to checkout and handle yearly pricing
- include interval when creating payments

## Testing
- `npx jest src/tests/__tests__/checkoutPaymentFlow.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b4fb3e05848328b15afa341a22a601