### PR TITLE
Fix message mark-as-read actions

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -234,7 +234,11 @@ export default function Header() {
                       <span className="mr-2 flex-1">{m.message}</span>
                       {!m.read ? (
                         <button
-                          onClick={() => markMessageRead(m.id)}
+                          onClick={async (e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            await markMessageRead(m.id);
+                          }}
                           className="ml-auto text-xs bg-blue-500 text-white px-2 py-1 rounded hover:bg-blue-600"
                         >
                           {t('mark_as_read')}

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -264,7 +264,11 @@ const Navbar = () => {
                         <span className="mr-2 flex-1">{msg.message}</span>
                         {!msg.read ? (
                           <button
-                            onClick={() => markMessageRead(msg.id)}
+                            onClick={async (e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              await markMessageRead(msg.id);
+                            }}
                             className="ml-auto text-xs bg-blue-500 text-white px-2 py-1 rounded hover:bg-blue-600"
                           >
                             {t('mark_as_read', 'Mark as Read')}

--- a/frontend/src/pages/messages/index.js
+++ b/frontend/src/pages/messages/index.js
@@ -169,8 +169,8 @@ const MessagesPage = () => {
                   {messages.map((msg) => (
                     <li
                       key={msg.id}
-                      onClick={() => {
-                        if (!msg.read) markMessageRead(msg.id);
+                      onClick={async () => {
+                        if (!msg.read) await markMessageRead(msg.id);
                         const user = users.find((u) => u.id === msg.sender_id);
                         setSelectedChat(
                           user || { id: msg.sender_id, name: msg.sender_name }


### PR DESCRIPTION
## Summary
- ensure message dropdown buttons await mark-as-read updates
- handle async marking of system messages on messages page

## Testing
- `cd backend && npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])* 
- `cd frontend && npm test` *(fails: Warning: React does not recognize the `whileInView` prop on a DOM element)*

------
https://chatgpt.com/codex/tasks/task_e_68b502f845288328bcd253f62d433af3