### PR TITLE
Filter unsupported payment methods for plan checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -215,7 +215,17 @@ export default function CheckoutPage() {
         const methodsList = Array.isArray(data) ? data : [];
         setMethods(methodsList);
         const activeMethods = methodsList.filter((m) => m.active !== false);
-        const eligibleMethods = activeMethods;
+        const eligibleMethods =
+          itemType === 'plan'
+            ? activeMethods.filter((m) => {
+                const identifier = getMethodIdentifier(m).toLowerCase();
+                return (
+                  identifier !== 'bank' &&
+                  identifier !== 'paypal' &&
+                  !isCryptoMethod(identifier)
+                );
+              })
+            : activeMethods;
         if (eligibleMethods.length > 0) {
           const defaultMethod =
             eligibleMethods.find((m) => m.is_default) || eligibleMethods[0];
@@ -415,14 +425,21 @@ export default function CheckoutPage() {
       return { number: i + 1, date: d.toLocaleDateString(), amount: amount.toFixed(2) };
     });
   }, [finalPrice, allowInstallments, installments]);
-
-  if (checkoutError) return <div className="text-white text-center mt-32">{checkoutError}</div>;
-  if (!itemInfo) return <div className="text-white text-center mt-32">{t('loading')}</div>;
   // Filter out inactive methods if any; the API already returns active ones
   const availableMethods = Array.isArray(methods)
     ? methods.filter((m) => m.active !== false)
     : [];
-  const filteredMethods = availableMethods;
+  const filteredMethods =
+    itemType === 'plan'
+      ? availableMethods.filter((m) => {
+          const identifier = getMethodIdentifier(m).toLowerCase();
+          return (
+            identifier !== 'bank' &&
+            identifier !== 'paypal' &&
+            !isCryptoMethod(identifier)
+          );
+        })
+      : availableMethods;
   const selectedMethodObj = filteredMethods.find(
     (m) => getMethodIdentifier(m).toLowerCase() === normalizedMethod
   );
@@ -433,6 +450,22 @@ export default function CheckoutPage() {
   const isCryptoSelected = isCryptoMethod(
     selectedMethodObj || selectedMethodIdentifier
   );
+
+  useEffect(() => {
+    if (
+      filteredMethods.length > 0 &&
+      !filteredMethods.some(
+        (m) => getMethodIdentifier(m).toLowerCase() === normalizedMethod
+      )
+    ) {
+      const defaultMethod =
+        filteredMethods.find((m) => m.is_default) || filteredMethods[0];
+      setSelectedMethod(getMethodIdentifier(defaultMethod));
+    }
+  }, [filteredMethods, normalizedMethod]);
+
+  if (checkoutError) return <div className="text-white text-center mt-32">{checkoutError}</div>;
+  if (!itemInfo) return <div className="text-white text-center mt-32">{t('loading')}</div>;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-950 to-gray-900 text-white">


### PR DESCRIPTION
## Summary
- omit bank transfer, PayPal, and crypto methods when purchasing plans
- ensure checkout defaults to a supported method after filtering

## Testing
- `npm test --runTestsByPath src/tests/__tests__/resolveIconElement.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5027e7de48328b1b19a53e124c2ee