### PR TITLE
Allow all payment methods for plans

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -418,11 +418,10 @@ export default function CheckoutPage() {
 
   if (checkoutError) return <div className="text-white text-center mt-32">{checkoutError}</div>;
   if (!itemInfo) return <div className="text-white text-center mt-32">{t('loading')}</div>;
-  // Filter out inactive methods if any; the API already returns active ones
-  const availableMethods = Array.isArray(methods)
+  // Include all active payment methods returned by the API
+  const filteredMethods = Array.isArray(methods)
     ? methods.filter((m) => m.active !== false)
     : [];
-  const filteredMethods = availableMethods;
   const selectedMethodObj = filteredMethods.find(
     (m) => getMethodIdentifier(m).toLowerCase() === normalizedMethod
   );
@@ -475,14 +474,6 @@ export default function CheckoutPage() {
         {!isFree && (
           <div className="bg-gray-800 p-6 rounded-xl shadow-md mb-6">
             <h2 className="text-lg font-semibold mb-4 flex items-center gap-2"><FaFileInvoice /> {t('select_payment_method')}</h2>
-            {itemType === 'plan' && (
-              <p className="text-sm text-yellow-400 mb-4">
-                {t(
-                  'plans_payment_methods_notice',
-                  'Bank transfer, PayPal, and cryptocurrency payment methods are not available for plans.'
-                )}
-              </p>
-            )}
             <div className="grid grid-cols-2 sm:grid-cols-4 md:grid-cols-5 gap-4">
               {filteredMethods.map((method) => {
                 const identifier = getMethodIdentifier(method);

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -173,11 +173,6 @@ test('processes plan card payments and redirects to billing for students', async
 
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
-  expect(
-    screen.getByText(
-      'Bank transfer, PayPal, and cryptocurrency payment methods are not available for plans.'
-    )
-  ).toBeInTheDocument();
 
   fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'Jane Doe' } });
   fireEvent.change(screen.getByPlaceholderText('Email Address'), { target: { value: 'jane@example.com' } });
@@ -202,7 +197,7 @@ test('processes plan card payments and redirects to billing for students', async
   expect(billingLink).toHaveAttribute('href', '/dashboard/student/settings?tab=billing');
 });
 
-test('filters out bank and PayPal methods for plans', async () => {
+test('shows all payment methods for plans', async () => {
   mockUseRouter.mockReturnValue({
     query: { itemId: '1', itemType: 'plan' },
     isReady: true,
@@ -219,12 +214,7 @@ test('filters out bank and PayPal methods for plans', async () => {
 
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
-  expect(
-    screen.getByText(
-      'Bank transfer, PayPal, and cryptocurrency payment methods are not available for plans.'
-    )
-  ).toBeInTheDocument();
-  expect(screen.queryByText('PayPal')).toBeNull();
-  expect(screen.queryByText('Bank')).toBeNull();
+  expect(screen.getByText('PayPal')).toBeInTheDocument();
+  expect(screen.getByText('Bank')).toBeInTheDocument();
   expect(screen.getByText('Stripe')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- remove plan-only payment method notice from checkout screen
- ensure checkout uses all active payment methods
- update payment flow test to expect PayPal and bank buttons for plans

## Testing
- `npm test -- src/tests/__tests__/checkoutPaymentFlow.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b501550f108328b432d7c0e4e06463