### PR TITLE
Use EPSILON tolerance for free checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -177,7 +177,7 @@ export default function CheckoutPage() {
     () => Math.max((itemInfo?.price ?? 0) - discountAmount, 0),
     [itemInfo, discountAmount]
   );
-  const isFree = finalPrice === 0;
+  const isFree = finalPrice <= Number.EPSILON;
   // Normalize the selected payment method to avoid case or whitespace mismatches
   const normalizedMethod = (selectedMethod || '')
     .toString()

--- a/frontend/src/tests/__tests__/checkoutPromo.test.js
+++ b/frontend/src/tests/__tests__/checkoutPromo.test.js
@@ -108,3 +108,32 @@ test('handles network failure when applying promo code', async () => {
     expect(toast.error).toHaveBeenCalledWith('promo_code_apply_failed');
   });
 });
+
+test('treats near-zero final price as free', async () => {
+  // Simulate a price that suffers from floating point precision, e.g. 0.1 + 0.2
+  const price = 0.1 + 0.2;
+  const percent = (0.3 / (0.1 + 0.2)) * 100;
+  fetchClassDetails.mockResolvedValueOnce({
+    data: {
+      id: 1,
+      title: 'Tiny Price',
+      instructor: 'Inst',
+      price,
+      cover_image: '',
+    },
+  });
+  validateCode.mockResolvedValue({ discount_percent: percent });
+
+  render(<CheckoutPage />);
+  await screen.findByText('checkout');
+  fireEvent.change(screen.getByPlaceholderText('enter_promo_code'), {
+    target: { value: 'FREE' },
+  });
+  fireEvent.click(screen.getByText('apply'));
+
+  await waitFor(() => expect(validateCode).toHaveBeenCalled());
+  // Payment methods should be hidden and free enrollment message shown
+  await screen.findByText('free_item_notice');
+  expect(screen.getByText('enroll_for_free')).toBeInTheDocument();
+  expect(screen.queryByText('Stripe')).toBeNull();
+});


### PR DESCRIPTION
## Summary
- Treat payment totals within floating point epsilon as free during checkout
- Add regression test ensuring near-zero final prices bypass payment methods

## Testing
- `npm test -- checkoutPromo.test.js`
- `npm test -- checkoutPaymentFlow.test.js` *(fails: Unable to find PayPal element)*

------
https://chatgpt.com/codex/tasks/task_e_68b55764b9708328b7d67fbb005057b7