### PR TITLE
feat: guard localStorage in checkout and tests

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -330,7 +330,14 @@ export default function CheckoutPage() {
         : itemType === 'book'
         ? 'purchasedBooks'
         : 'enrolledClasses';
-    const enrolled = JSON.parse(localStorage.getItem(storageKey) || '[]');
+    let enrolled = [];
+    if (typeof window !== 'undefined') {
+      try {
+        enrolled = JSON.parse(localStorage.getItem(storageKey) || '[]');
+      } catch {
+        enrolled = [];
+      }
+    }
     const newItem =
       itemType === 'book'
         ? {
@@ -347,7 +354,16 @@ export default function CheckoutPage() {
             status: 'Live',
             joined: true,
           };
-    localStorage.setItem(storageKey, JSON.stringify([...enrolled, newItem]));
+    if (typeof window !== 'undefined') {
+      try {
+        localStorage.setItem(
+          storageKey,
+          JSON.stringify([...enrolled, newItem])
+        );
+      } catch {
+        // ignore storage write errors in non-browser environments
+      }
+    }
     try {
       await Promise.resolve(removeItem(itemInfo.id));
     } catch (err) {

--- a/frontend/src/tests/setupTests.js
+++ b/frontend/src/tests/setupTests.js
@@ -1,1 +1,28 @@
 import '@testing-library/jest-dom';
+
+// Provide a minimal localStorage mock for test environments without it
+if (typeof window === 'undefined') {
+  // eslint-disable-next-line no-global-assign
+  global.window = {};
+}
+
+if (typeof window !== 'undefined' && !window.localStorage) {
+  let store = {};
+  window.localStorage = {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+}
+
+// Ensure global.localStorage references the mock as well
+if (typeof global.localStorage === 'undefined' && typeof window !== 'undefined') {
+  global.localStorage = window.localStorage;
+}


### PR DESCRIPTION
## Summary
- skip localStorage usage in checkout when `window` is missing
- polyfill localStorage in test setup for non-browser environments

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b557606348832899fe4bf46f09ffe3