### PR TITLE
feat: enforce trusted payment method icons

### DIFF
--- a/docs/payment-icon-sources.md
+++ b/docs/payment-icon-sources.md
@@ -1,0 +1,18 @@
+# Payment Icon Sources
+
+SkillBridge displays icons for payment methods during checkout. To avoid loading images from untrusted locations, icons are only loaded from approved hosts or from assets bundled with the application.
+
+## Trusted domains
+
+Payment method icons may be served from the following domains:
+
+- `skillbridge.com`
+- `cdn.skillbridge.com`
+
+These domains are defined in `TRUSTED_ICON_HOSTS` within `frontend/src/pages/payments/checkout.js`. Update that array when adding new trusted sources.
+
+Relative paths (e.g. `/images/payments/stripe.png`) are also permitted and should be placed under `frontend/public/images`.
+
+## Fallback behaviour
+
+If an icon is missing, uses an unapproved domain, or fails to load, the checkout page falls back to a generic money icon so the interface remains functional.

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -36,6 +36,32 @@ const iconMap = {
   nowpayments: <FaEthereum />,
 };
 
+export const TRUSTED_ICON_HOSTS = ['skillbridge.com', 'cdn.skillbridge.com'];
+
+function isTrustedIcon(url) {
+  try {
+    const { hostname } = new URL(url, 'http://localhost');
+    return TRUSTED_ICON_HOSTS.some(
+      (host) => hostname === host || hostname.endsWith(`.${host}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function TrustedIcon({ src, alt }) {
+  const [error, setError] = useState(false);
+  if (!src || error) return <FaMoneyCheckAlt />;
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className="w-8 h-8 object-contain"
+      onError={() => setError(true)}
+    />
+  );
+}
+
 export function resolveIconElement(method) {
   if (method.icon) {
     const lower = method.icon.toLowerCase();
@@ -43,14 +69,9 @@ export function resolveIconElement(method) {
     if (iconMap[lower]) return iconMap[lower];
     if (iconMap[base]) return iconMap[base];
     const isUrl = /^(https?:)?\/\//.test(method.icon);
-    if (isUrl) {
-      return (
-        <img
-          src={method.icon}
-          alt={method.name}
-          className="w-8 h-8 object-contain"
-        />
-      );
+    const trusted = !isUrl || isTrustedIcon(method.icon);
+    if (trusted) {
+      return <TrustedIcon src={method.icon} alt={method.name} />;
     }
   }
   return (

--- a/frontend/src/tests/__tests__/resolveIconElement.test.js
+++ b/frontend/src/tests/__tests__/resolveIconElement.test.js
@@ -1,5 +1,9 @@
-import { resolveIconElement } from '@/pages/payments/checkout';
-import { FaPaypal } from 'react-icons/fa';
+import {
+  resolveIconElement,
+  TrustedIcon,
+  TRUSTED_ICON_HOSTS,
+} from '@/pages/payments/checkout';
+import { FaPaypal, FaMoneyCheckAlt } from 'react-icons/fa';
 
 describe('resolveIconElement', () => {
   it('returns react icon for known provider names', () => {
@@ -12,11 +16,17 @@ describe('resolveIconElement', () => {
     expect(el.type).toBe(FaPaypal);
   });
 
-  it('returns img for full URLs of unknown providers', () => {
+  it('returns TrustedIcon for URLs from trusted hosts', () => {
+    const url = `https://${TRUSTED_ICON_HOSTS[0]}/custom.png`;
+    const el = resolveIconElement({ icon: url, name: 'Custom' });
+    expect(el.type).toBe(TrustedIcon);
+    expect(el.props.src).toBe(url);
+  });
+
+  it('falls back to default icon for untrusted URLs', () => {
     const url = 'https://cdn.example.com/custom.png';
     const el = resolveIconElement({ icon: url, name: 'Custom' });
-    expect(el.type).toBe('img');
-    expect(el.props.src).toBe(url);
+    expect(el.type).toBe(FaMoneyCheckAlt);
   });
 });
 


### PR DESCRIPTION
## Summary
- restrict payment method icons to trusted hosts or local assets
- show default icon when icon missing, untrusted, or fails to load
- document permitted payment icon sources

## Testing
- `npm --prefix frontend test -- frontend/src/tests/__tests__/resolveIconElement.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b5575bf5688328a79ca6649ea1da01