### PR TITLE
Centralize payment method filtering for plan checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -79,6 +79,23 @@ function isCryptoMethod(methodOrIdentifier) {
   );
 }
 
+export function filterEligibleMethods(methods, itemType) {
+  const active = Array.isArray(methods)
+    ? methods.filter((m) => m.active !== false)
+    : [];
+  if (itemType === 'plan') {
+    return active.filter((m) => {
+      const identifier = getMethodIdentifier(m).toLowerCase();
+      return (
+        identifier !== 'bank' &&
+        identifier !== 'paypal' &&
+        !isCryptoMethod(identifier)
+      );
+    });
+  }
+  return active;
+}
+
 export function resolveCheckoutItem(query, cartItems) {
   const { itemId, itemType, items } = query;
 
@@ -184,22 +201,10 @@ export default function CheckoutPage() {
     .trim()
     .toLowerCase();
 
-  const filteredMethods = useMemo(() => {
-    const active = Array.isArray(methods)
-      ? methods.filter((m) => m.active !== false)
-      : [];
-    if (itemType === 'plan') {
-      return active.filter((m) => {
-        const identifier = getMethodIdentifier(m).toLowerCase();
-        return (
-          identifier !== 'bank' &&
-          identifier !== 'paypal' &&
-          !isCryptoMethod(identifier)
-        );
-      });
-    }
-    return active;
-  }, [methods, itemType]);
+  const filteredMethods = useMemo(
+    () => filterEligibleMethods(methods, itemType),
+    [methods, itemType]
+  );
 
   const selectedMethodObj = filteredMethods.find(
     (m) => getMethodIdentifier(m).toLowerCase() === normalizedMethod
@@ -254,19 +259,8 @@ export default function CheckoutPage() {
         const data = await fetchPaymentMethods();
         if (!active) return;
         const methodsList = Array.isArray(data) ? data : [];
-        const activeMethods = methodsList.filter((m) => m.active !== false);
-        setMethods(activeMethods);
-        const eligibleMethods =
-          itemType === 'plan'
-            ? activeMethods.filter((m) => {
-                const identifier = getMethodIdentifier(m).toLowerCase();
-                return (
-                  identifier !== 'bank' &&
-                  identifier !== 'paypal' &&
-                  !isCryptoMethod(identifier)
-                );
-              })
-            : activeMethods;
+        setMethods(methodsList);
+        const eligibleMethods = filterEligibleMethods(methodsList, itemType);
         if (eligibleMethods.length > 0) {
           const defaultMethod =
             eligibleMethods.find((m) => m.is_default) || eligibleMethods[0];

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -197,7 +197,7 @@ test('processes plan card payments and redirects to billing for students', async
   expect(billingLink).toHaveAttribute('href', '/dashboard/student/settings?tab=billing');
 });
 
-test('shows all payment methods for plans', async () => {
+test('filters out bank, PayPal, and crypto for plans', async () => {
   mockUseRouter.mockReturnValue({
     query: { itemId: '1', itemType: 'plan' },
     isReady: true,
@@ -210,11 +210,13 @@ test('shows all payment methods for plans', async () => {
     { id: 1, name: 'Stripe', type: 'stripe' },
     { id: 2, name: 'PayPal', type: null },
     { id: 3, name: 'Bank', type: 'bank' },
+    { id: 4, name: 'USDT', type: 'usdt' },
   ]);
 
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
-  expect(screen.getByText('PayPal')).toBeInTheDocument();
-  expect(screen.getByText('Bank')).toBeInTheDocument();
   expect(screen.getByText('Stripe')).toBeInTheDocument();
+  expect(screen.queryByText('PayPal')).toBeNull();
+  expect(screen.queryByText('Bank')).toBeNull();
+  expect(screen.queryByText('USDT')).toBeNull();
 });

--- a/frontend/src/tests/__tests__/filterEligibleMethods.test.js
+++ b/frontend/src/tests/__tests__/filterEligibleMethods.test.js
@@ -1,0 +1,26 @@
+import { filterEligibleMethods } from '@/pages/payments/checkout';
+
+describe('filterEligibleMethods', () => {
+  const methods = [
+    { id: 1, name: 'Stripe', type: 'stripe', active: true },
+    { id: 2, name: 'PayPal', type: null, active: true },
+    { id: 3, name: 'Bank', type: 'bank', active: true },
+    { id: 4, name: 'USDT', type: 'usdt', active: true },
+    { id: 5, name: 'Inactive', type: 'stripe', active: false },
+  ];
+
+  it('returns active methods for non-plan items', () => {
+    const result = filterEligibleMethods(methods, 'class');
+    expect(result.map((m) => m.name)).toEqual([
+      'Stripe',
+      'PayPal',
+      'Bank',
+      'USDT',
+    ]);
+  });
+
+  it('excludes bank, PayPal, and crypto for plan items', () => {
+    const result = filterEligibleMethods(methods, 'plan');
+    expect(result.map((m) => m.name)).toEqual(['Stripe']);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `filterEligibleMethods` helper and reuse in checkout flow
- Filter bank, PayPal, and crypto methods for plan purchases
- Add unit tests for eligible method filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5575a621c8328967c7017c0df5585