### PR TITLE
feat: fetch invoices by payment

### DIFF
--- a/backend/src/modules/invoices/invoices.controller.js
+++ b/backend/src/modules/invoices/invoices.controller.js
@@ -27,6 +27,15 @@ exports.getMyInvoice = catchAsync(async (req, res) => {
   sendSuccess(res, invoice);
 });
 
+exports.getMyInvoiceByPaymentId = catchAsync(async (req, res) => {
+  const invoice = await service.getInvoiceByPaymentId(
+    req.params.paymentId
+  );
+  if (!invoice || invoice.user_id !== req.user.id)
+    throw new AppError("Invoice not found", 404);
+  sendSuccess(res, invoice);
+});
+
 exports.downloadInvoice = catchAsync(async (req, res) => {
   const invoice = await service.getInvoice(req.params.id);
   if (!invoice) throw new AppError("Invoice not found", 404);

--- a/backend/src/modules/invoices/invoices.service.js
+++ b/backend/src/modules/invoices/invoices.service.js
@@ -62,3 +62,5 @@ exports.generateFromPayment = async (payment, user) => {
 exports.getInvoices = () => model.getAll();
 exports.getInvoice = (id) => model.getById(id);
 exports.getInvoicesByUser = (user_id) => model.getByUser(user_id);
+exports.getInvoiceByPaymentId = (payment_id) =>
+  model.findByPayment(payment_id);

--- a/backend/src/modules/invoices/student.routes.js
+++ b/backend/src/modules/invoices/student.routes.js
@@ -5,7 +5,8 @@ const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware
 router.use(verifyToken, isStudent);
 
 router.get("/", controller.getMyInvoices);
-router.get("/:id", controller.getMyInvoice);
+router.get("/payment/:paymentId", controller.getMyInvoiceByPaymentId);
 router.get("/:id/download", controller.downloadInvoice);
+router.get("/:id", controller.getMyInvoice);
 
 module.exports = router;

--- a/frontend/src/pages/payments/success.js
+++ b/frontend/src/pages/payments/success.js
@@ -95,10 +95,14 @@ export default function PaymentSuccessPage() {
 
       if (payment_id) {
         try {
-          const payments = await fetchMyPayments();
-          const payment = payments.find((p) => String(p.id) === String(payment_id));
+          const [payments, invoice] = await Promise.all([
+            fetchMyPayments(),
+            fetchInvoiceByPaymentId(payment_id),
+          ]);
+          const payment = payments.find(
+            (p) => String(p.id) === String(payment_id)
+          );
           setPaymentInfo(payment || null);
-          const invoice = await fetchInvoiceByPaymentId(payment_id);
           setInvoiceInfo(invoice);
         } catch (_) {
           setFetchError('Failed to load payment details');

--- a/frontend/src/services/student/invoiceService.js
+++ b/frontend/src/services/student/invoiceService.js
@@ -1,7 +1,8 @@
 import api from "@/services/api/api";
 
 export const fetchInvoiceByPaymentId = async (paymentId) => {
-  const { data } = await api.get("/invoices/student");
-  const invoices = data?.data || [];
-  return invoices.find((inv) => String(inv.payment_id) === String(paymentId)) || null;
+  const { data } = await api.get(
+    `/invoices/student/payment/${paymentId}`
+  );
+  return data?.data || null;
 };


### PR DESCRIPTION
## Summary
- add student invoice lookup by payment id in API
- support invoice lookup by payment id in services and UI
- fetch payment and invoice details concurrently on payment success page

## Testing
- `npm test` (backend) *(fails: process.exit due to missing database configuration)*
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68b57a8b3ee88328afca837a749634e2