### PR TITLE
Send invoice emails on paid payments

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -285,7 +285,15 @@ exports.approveBankPayment = catchAsync(async (req, res) => {
 
   try {
     if (user) {
-      await invoiceService.generateFromPayment(payment, user);
+      const invoice = await invoiceService.generateFromPayment(payment, user);
+      if (user.email && !user.invoice_email_opt_out && invoice?.pdf_url) {
+        await mailService.sendMail({
+          to: user.email,
+          subject: "Payment Invoice",
+          html: `<p>Please find your invoice attached.</p>`,
+          attachments: [{ path: invoice.pdf_url }],
+        });
+      }
     }
   } catch (err) {
     logger.error("Failed to generate invoice:", err);

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -342,7 +342,15 @@ exports.createPayment = catchAsync(async (req, res) => {
       if (!user) {
         user = await userModel.findById(user_id);
       }
-      await invoiceService.generateFromPayment(payment, user);
+      const invoice = await invoiceService.generateFromPayment(payment, user);
+      if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
+        await mailService.sendMail({
+          to: user.email,
+          subject: "Payment Invoice",
+          html: `<p>Please find your invoice attached.</p>`,
+          attachments: [{ path: invoice.pdf_url }],
+        });
+      }
     } catch (err) {
       logger.error("Failed to generate invoice:", err);
     }
@@ -420,7 +428,15 @@ exports.updatePayment = catchAsync(async (req, res) => {
         message = `Your payment ${payment.id} has been approved.`;
         subject = "Payment Approved";
         try {
-          await invoiceService.generateFromPayment(payment, user);
+          const invoice = await invoiceService.generateFromPayment(payment, user);
+          if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
+            await mailService.sendMail({
+              to: user.email,
+              subject: "Payment Invoice",
+              html: `<p>Please find your invoice attached.</p>`,
+              attachments: [{ path: invoice.pdf_url }],
+            });
+          }
         } catch (err) {
           logger.error("Failed to generate invoice:", err);
         }

--- a/backend/src/services/mailService.js
+++ b/backend/src/services/mailService.js
@@ -5,7 +5,7 @@ const { getSettings } = require("../modules/emailConfig/emailConfig.service");
 const createTransporter = require("../utils/email").createTransporter;
 
 module.exports = {
-  sendMail: async ({ to, subject, html, from }) => {
+  sendMail: async ({ to, subject, html, from, attachments }) => {
     const cfg = (await getSettings()) || {};
     const transporter = await createTransporter();
 
@@ -17,6 +17,7 @@ module.exports = {
       to,
       subject,
       html,
+      attachments,
     };
     try {
       await transporter.sendMail(mailOptions);

--- a/backend/tests/paymentInvoiceEmail.test.js
+++ b/backend/tests/paymentInvoiceEmail.test.js
@@ -1,0 +1,87 @@
+jest.mock('../src/modules/payments/payments.service', () => ({
+  STATUS: { PAID: 'paid', AWAITING_APPROVAL: 'awaiting_approval', REJECTED: 'rejected' },
+  create: jest.fn(),
+  update: jest.fn(),
+  approveBankPayment: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({ sendSMS: jest.fn() }));
+jest.mock('../src/modules/users/user.model', () => ({ findById: jest.fn() }));
+jest.mock('../src/modules/library/library.service', () => ({ recordPurchase: jest.fn() }));
+jest.mock('../src/modules/classes/enrollments/classEnrollment.service', () => ({ findEnrollment: jest.fn(), updateEnrollment: jest.fn(), createEnrollment: jest.fn() }));
+jest.mock('../src/modules/users/tutorials/enrollments/tutorialEnrollment.service', () => ({ createEnrollment: jest.fn() }));
+jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({ getSettings: jest.fn() }));
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({ getById: jest.fn(), getByType: jest.fn() }));
+jest.mock('../src/services/paypalService', () => ({ captureOrder: jest.fn() }));
+jest.mock('../src/modules/notifications/notifications.service', () => ({ createNotification: jest.fn() }));
+jest.mock('../src/services/mailService', () => ({ sendMail: jest.fn() }));
+jest.mock('../src/modules/coupons/coupons.service', () => ({ getCouponById: jest.fn(), incrementUsage: jest.fn() }));
+jest.mock('../src/modules/plans/plans.service', () => ({ getPlanById: jest.fn() }));
+jest.mock('../src/modules/subscriptions/subscription.service', () => ({ createOrRenewSubscription: jest.fn() }));
+jest.mock('../src/modules/payouts/wallet.service', () => ({ increment: jest.fn() }));
+jest.mock('../src/modules/classes/class.service', () => ({ getClassById: jest.fn() }));
+jest.mock('../src/modules/books/book.service', () => ({ getBookById: jest.fn() }));
+jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({ getTutorialById: jest.fn() }));
+jest.mock('../src/modules/invoices/invoices.service', () => ({ generateFromPayment: jest.fn() }));
+jest.mock('../src/modules/payments/paymentAccess', () => ({ grantAccess: jest.fn() }));
+
+const paymentsController = require('../src/modules/payments/payments.controller');
+const bankController = require('../src/modules/payments/bank.controller');
+
+const paymentsService = require('../src/modules/payments/payments.service');
+const paymentMethodsService = require('../src/modules/paymentMethods/paymentMethods.service');
+const paymentConfigService = require('../src/modules/paymentConfig/paymentConfig.service');
+const userModel = require('../src/modules/users/user.model');
+const bookService = require('../src/modules/books/book.service');
+const invoiceService = require('../src/modules/invoices/invoices.service');
+const mailService = require('../src/services/mailService');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  invoiceService.generateFromPayment.mockResolvedValue({ pdf_url: '/inv.pdf' });
+  mailService.sendMail.mockResolvedValue();
+  paymentConfigService.getSettings.mockResolvedValue({ platformCut: {} });
+  userModel.findById.mockResolvedValue({ id: 'u1', email: 'u@test.com', full_name: 'User' });
+  bookService.getBookById.mockResolvedValue({ price: 100, instructor_id: 'i1' });
+  paymentsService.approveBankPayment.mockResolvedValue({ id: 'p3', user_id: 'u1', item_type: 'book', item_id: 'b1', instructor_amount: 90 });
+});
+
+function mockRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+}
+
+describe('invoice email dispatch', () => {
+  it('sends invoice email for card payments', async () => {
+    paymentMethodsService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
+    paymentsService.create.mockResolvedValue({ id: 'p1', user_id: 'u1', method_id: 'm1', item_type: 'book', item_id: 'b1', amount: 100, currency: 'USD', status: 'paid' });
+
+    const req = { body: { method_id: 'm1', item_type: 'book', item_id: 'b1', amount: 100, status: 'paid' }, user: { id: 'u1' } };
+    const res = mockRes();
+    await paymentsController.createPayment(req, res, () => {});
+
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+  });
+
+  it('sends invoice email for free payments', async () => {
+    paymentMethodsService.getById.mockResolvedValue({ id: 'm2', type: 'free', active: true });
+    paymentsService.create.mockResolvedValue({ id: 'p2', user_id: 'u1', method_id: 'm2', item_type: 'book', item_id: 'b1', amount: 100, currency: 'USD', status: 'paid' });
+
+    const req = { body: { method_id: 'm2', item_type: 'book', item_id: 'b1', amount: 100, status: 'paid' }, user: { id: 'u1' } };
+    const res = mockRes();
+    await paymentsController.createPayment(req, res, () => {});
+
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+  });
+
+  it('sends invoice email for bank payments upon approval', async () => {
+    const req = { params: { id: 'p3' }, body: {}, user: { id: 'admin1' } };
+    const res = mockRes();
+    await bankController.approveBankPayment(req, res, () => {});
+
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+  });
+});
+


### PR DESCRIPTION
## Summary
- attach invoices as PDFs when payments are marked paid
- respect user opt-out flag before emailing invoices
- expose attachment support in mailService and add tests for email dispatch

## Testing
- `npm test -- --runTestsByPath tests/paymentInvoiceEmail.test.js` *(fails: Expected mailService.sendMail to be called)*

------
https://chatgpt.com/codex/tasks/task_e_68b57a8bc4108328bb0c7bb6567abd97