### PR TITLE
Allow zero-amount payments and add tests

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -48,7 +48,7 @@ exports.createPayment = catchAsync(async (req, res) => {
 
   const user_id = req.user.id;
 
-  if (!method_id || !item_type || !item_id || !amount) {
+  if (amount === undefined || amount === null || !item_type || !item_id) {
     throw new AppError("Missing required fields", 400);
   }
 
@@ -68,14 +68,26 @@ exports.createPayment = catchAsync(async (req, res) => {
     next_due_date = schedules[0]?.due_date || null;
   }
 
-  const method = await paymentMethodsService.getById(method_id);
-  if (!method || !method.active) {
-    throw new AppError("Invalid payment method", 400);
+  let method;
+  if (method_id) {
+    method = await paymentMethodsService.getById(method_id);
+    if (!method || !method.active) {
+      throw new AppError("Invalid payment method", 400);
+    }
+  } else if (Number(amount) === 0) {
+    method = await paymentMethodsService.getByType("free");
+    if (!method) {
+      method = { id: null, type: "free", active: true };
+    } else if (!method.active) {
+      throw new AppError("Invalid payment method", 400);
+    }
+  } else {
+    throw new AppError("Missing required fields", 400);
   }
 
   let verifiedAmount = amount;
   let verifiedCurrency = currency || "USD";
-  let finalStatus = status || STATUS.PENDING_PAYMENT;
+  let finalStatus = status || (Number(amount) === 0 ? STATUS.PAID : STATUS.PENDING_PAYMENT);
   let verifiedReference = reference_id;
 
   if (method.type === "paypal") {
@@ -183,7 +195,7 @@ exports.createPayment = catchAsync(async (req, res) => {
   const createData = {
     id: uuidv4(),
     user_id,
-    method_id,
+    method_id: method?.id || method_id || null,
     item_type,
     item_id,
     amount: verifiedAmount,

--- a/backend/tests/paymentInvoiceEmail.test.js
+++ b/backend/tests/paymentInvoiceEmail.test.js
@@ -35,6 +35,7 @@ const userModel = require('../src/modules/users/user.model');
 const bookService = require('../src/modules/books/book.service');
 const invoiceService = require('../src/modules/invoices/invoices.service');
 const mailService = require('../src/services/mailService');
+const walletService = require('../src/modules/payouts/wallet.service');
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -61,6 +62,7 @@ describe('invoice email dispatch', () => {
     const req = { body: { method_id: 'm1', item_type: 'book', item_id: 'b1', amount: 100, status: 'paid' }, user: { id: 'u1' } };
     const res = mockRes();
     await paymentsController.createPayment(req, res, () => {});
+    await new Promise(process.nextTick);
 
     expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
   });
@@ -72,6 +74,7 @@ describe('invoice email dispatch', () => {
     const req = { body: { method_id: 'm2', item_type: 'book', item_id: 'b1', amount: 100, status: 'paid' }, user: { id: 'u1' } };
     const res = mockRes();
     await paymentsController.createPayment(req, res, () => {});
+    await new Promise(process.nextTick);
 
     expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
   });
@@ -80,7 +83,25 @@ describe('invoice email dispatch', () => {
     const req = { params: { id: 'p3' }, body: {}, user: { id: 'admin1' } };
     const res = mockRes();
     await bankController.approveBankPayment(req, res, () => {});
+    await new Promise(process.nextTick);
 
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+  });
+
+  it('handles zero-amount payments without a method', async () => {
+    bookService.getBookById.mockResolvedValue({ price: 0, instructor_id: 'i1' });
+    paymentMethodsService.getByType.mockResolvedValue({ id: 'free', type: 'free', active: true });
+    paymentsService.create.mockResolvedValue({ id: 'p4', user_id: 'u1', method_id: 'free', item_type: 'book', item_id: 'b1', amount: 0, currency: 'USD', status: 'paid' });
+
+    const req = { body: { item_type: 'book', item_id: 'b1', amount: 0 }, user: { id: 'u1' } };
+    const res = mockRes();
+    await paymentsController.createPayment(req, res, () => {});
+    await new Promise(process.nextTick);
+
+    expect(paymentMethodsService.getByType).toHaveBeenCalledWith('free');
+    expect(paymentsService.create).toHaveBeenCalled();
+    expect(paymentsService.create.mock.calls[0][0].status).toBe('paid');
+    expect(walletService.increment).toHaveBeenCalledWith('i1', 0);
     expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
   });
 });


### PR DESCRIPTION
## Summary
- Accept `amount` of 0 and default status to `paid`
- Use optional or fallback "free" payment method for zero-cost purchases
- Add unit test for zero-amount payment invoice generation

## Testing
- `cd backend && npm test -- tests/paymentInvoiceEmail.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b63a307e248328896d9f42c6a39941