### PR TITLE
test: cover zero-amount payment invoices

### DIFF
--- a/backend/tests/paymentInvoiceEmail.test.js
+++ b/backend/tests/paymentInvoiceEmail.test.js
@@ -65,14 +65,15 @@ describe('invoice email dispatch', () => {
     expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
   });
 
-  it('sends invoice email for free payments', async () => {
+  it('sends invoice email for zero-amount payments', async () => {
     paymentMethodsService.getById.mockResolvedValue({ id: 'm2', type: 'free', active: true });
-    paymentsService.create.mockResolvedValue({ id: 'p2', user_id: 'u1', method_id: 'm2', item_type: 'book', item_id: 'b1', amount: 100, currency: 'USD', status: 'paid' });
+    paymentsService.create.mockResolvedValue({ id: 'p2', user_id: 'u1', method_id: 'm2', item_type: 'book', item_id: 'b1', amount: 0, currency: 'USD', status: 'paid' });
 
-    const req = { body: { method_id: 'm2', item_type: 'book', item_id: 'b1', amount: 100, status: 'paid' }, user: { id: 'u1' } };
+    const req = { body: { method_id: 'm2', item_type: 'book', item_id: 'b1', amount: 0, status: 'paid' }, user: { id: 'u1' } };
     const res = mockRes();
     await paymentsController.createPayment(req, res, () => {});
 
+    expect(paymentsService.create).toHaveBeenCalledWith(expect.objectContaining({ amount: 0, status: 'paid' }));
     expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
   });
 


### PR DESCRIPTION
## Summary
- rename free payment case to zero-amount payments and update request body to use amount 0
- assert createPayment called with amount 0 and status paid, ensuring invoice email still dispatched

## Testing
- `npm test tests/paymentInvoiceEmail.test.js` *(fails: Expected mailService.sendMail to be called)*

------
https://chatgpt.com/codex/tasks/task_e_68b63a2875cc83288b74f31c1ddd39f5