### PR TITLE
Skip redundant enrollment when payment has id

### DIFF
--- a/frontend/src/pages/payments/success.js
+++ b/frontend/src/pages/payments/success.js
@@ -59,11 +59,13 @@ export default function PaymentSuccessPage() {
 
     try {
       if (itemType === 'class') {
-        try {
-          await enrollInClass(itemId);
-          await removeItem(itemId);
-        } catch (_) {
-          toast.error('Failed to register for class');
+        if (!payment_id) {
+          try {
+            await enrollInClass(itemId);
+            await removeItem(itemId);
+          } catch (_) {
+            toast.error('Failed to register for class');
+          }
         }
         try {
           const details = await fetchClassDetails(itemId);
@@ -79,10 +81,12 @@ export default function PaymentSuccessPage() {
           setItemInfo(null);
         }
       } else if (itemType === 'tutorial') {
-        try {
-          await enrollInTutorial(itemId);
-        } catch (_) {
-          toast.error('Failed to enroll in tutorial');
+        if (!payment_id) {
+          try {
+            await enrollInTutorial(itemId);
+          } catch (_) {
+            toast.error('Failed to enroll in tutorial');
+          }
         }
         try {
           const details = await fetchTutorialDetails(itemId);

--- a/frontend/src/tests/__tests__/paymentSuccessPage.test.js
+++ b/frontend/src/tests/__tests__/paymentSuccessPage.test.js
@@ -1,0 +1,101 @@
+import { render, waitFor } from '@testing-library/react';
+import PaymentSuccessPage from '../../pages/payments/success';
+import { enrollInClass, fetchClassDetails } from '../../services/classService';
+import { enrollInTutorial, fetchTutorialDetails } from '../../services/tutorialService';
+import { fetchMyPayments } from '../../services/student/paymentService';
+import { fetchInvoiceByPaymentId } from '../../services/student/invoiceService';
+
+jest.mock('../../components/website/sections/Navbar', () => () => <div />);
+jest.mock('../../components/website/sections/Footer', () => () => <div />);
+
+jest.mock('../../services/classService', () => ({
+  enrollInClass: jest.fn(),
+  fetchClassDetails: jest.fn(),
+}));
+
+jest.mock('../../services/tutorialService', () => ({
+  enrollInTutorial: jest.fn(),
+  fetchTutorialDetails: jest.fn(),
+}));
+
+jest.mock('../../services/student/paymentService', () => ({
+  fetchMyPayments: jest.fn(),
+}));
+
+jest.mock('../../services/student/invoiceService', () => ({
+  fetchInvoiceByPaymentId: jest.fn(),
+  downloadInvoice: jest.fn(),
+}));
+
+jest.mock('../../services/bookService', () => ({ fetchBook: jest.fn() }));
+jest.mock('../../services/public/planService', () => ({ fetchPlanDetails: jest.fn() }));
+jest.mock('../../services/instructor/subscriptionService', () => ({
+  subscribeToPlan: jest.fn(),
+  fetchMySubscription: jest.fn(),
+}));
+
+jest.mock('../../store/libraryStore', () => ({
+  __esModule: true,
+  default: (selector) => {
+    const state = { fetchLibrary: jest.fn() };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+}));
+
+jest.mock('../../store/cart/cartStore', () => ({
+  __esModule: true,
+  default: (selector) => selector({ removeItem: jest.fn() }),
+}));
+
+jest.mock('react-toastify', () => ({ toast: { error: jest.fn() } }));
+
+const mockUseRouter = jest.fn();
+jest.mock('next/router', () => ({ useRouter: () => mockUseRouter() }));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('enrolls in class when payment_id is missing', async () => {
+  mockUseRouter.mockReturnValue({ query: { itemType: 'class', itemId: '1' } });
+  fetchClassDetails.mockResolvedValue({ data: { id: 1, title: 'Class' } });
+
+  render(<PaymentSuccessPage />);
+  await waitFor(() => expect(fetchClassDetails).toHaveBeenCalled());
+  expect(enrollInClass).toHaveBeenCalledWith('1');
+  expect(fetchMyPayments).not.toHaveBeenCalled();
+});
+
+test('skips class enrollment when payment_id is present', async () => {
+  mockUseRouter.mockReturnValue({ query: { itemType: 'class', itemId: '1', payment_id: '10' } });
+  fetchClassDetails.mockResolvedValue({ data: { id: 1, title: 'Class' } });
+  fetchMyPayments.mockResolvedValue([{ id: 10 }]);
+  fetchInvoiceByPaymentId.mockResolvedValue({ id: 5 });
+
+  render(<PaymentSuccessPage />);
+  await waitFor(() => expect(fetchClassDetails).toHaveBeenCalled());
+  expect(enrollInClass).not.toHaveBeenCalled();
+  expect(fetchMyPayments).toHaveBeenCalled();
+});
+
+test('enrolls in tutorial when payment_id is missing', async () => {
+  mockUseRouter.mockReturnValue({ query: { itemType: 'tutorial', itemId: '1' } });
+  fetchTutorialDetails.mockResolvedValue({ data: { id: 1, title: 'Tut' } });
+
+  render(<PaymentSuccessPage />);
+  await waitFor(() => expect(fetchTutorialDetails).toHaveBeenCalled());
+  expect(enrollInTutorial).toHaveBeenCalledWith('1');
+  expect(fetchMyPayments).not.toHaveBeenCalled();
+});
+
+test('skips tutorial enrollment when payment_id is present', async () => {
+  mockUseRouter.mockReturnValue({ query: { itemType: 'tutorial', itemId: '1', payment_id: '22' } });
+  fetchTutorialDetails.mockResolvedValue({ data: { id: 1, title: 'Tut' } });
+  fetchMyPayments.mockResolvedValue([{ id: 22 }]);
+  fetchInvoiceByPaymentId.mockResolvedValue({ id: 5 });
+
+  render(<PaymentSuccessPage />);
+  await waitFor(() => expect(fetchTutorialDetails).toHaveBeenCalled());
+  expect(enrollInTutorial).not.toHaveBeenCalled();
+  expect(fetchMyPayments).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- Avoid duplicate class and tutorial enrollment when `payment_id` is present
- Add PaymentSuccessPage tests for enrollment behavior

## Testing
- `npm test`
- `npm test paymentSuccessPage.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b63a27265c83289fc02147c226c3a1