### PR TITLE
test: verify enroll_for_free translation exists

### DIFF
--- a/frontend/src/tests/__tests__/enrollForFreeTranslation.test.js
+++ b/frontend/src/tests/__tests__/enrollForFreeTranslation.test.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('enroll_for_free translations', () => {
+  it('should exist for all supported locales', () => {
+    const localesDir = path.join(__dirname, '../../../public/locales');
+    const locales = fs.readdirSync(localesDir);
+    const missing = [];
+
+    locales.forEach((locale) => {
+      const filePath = path.join(localesDir, locale, 'common.json');
+      const translations = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (!translations.enroll_for_free) {
+        missing.push(locale);
+      }
+    });
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test ensuring `enroll_for_free` translation is defined for each locale

## Testing
- `npm test src/tests/__tests__/enrollForFreeTranslation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b63a2169408328a49924fbcab8450d