### PR TITLE
test: add bank payment approval integration test

### DIFF
--- a/backend/tests/bankPaymentIntegration.test.js
+++ b/backend/tests/bankPaymentIntegration.test.js
@@ -1,0 +1,158 @@
+const request = require('supertest');
+const express = require('express');
+const { newDb } = require('pg-mem');
+
+const pgMem = newDb();
+const mockDb = pgMem.adapters.createKnex();
+jest.mock('../src/config/database', () => mockDb);
+const db = mockDb;
+
+jest.mock('../src/services/mailService', () => ({
+  sendMail: jest.fn(),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/invoices/invoices.service', () => ({
+  generateFromPayment: jest.fn(),
+}));
+
+jest.mock('../src/modules/payments/paymentAccess', () => ({
+  grantAccess: jest.fn(),
+}));
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'user1' };
+    next();
+  },
+  isStudent: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+const studentRoutes = require('../src/modules/payments/bank.routes');
+const adminRoutes = require('../src/modules/payments/bank.admin.routes');
+const errorHandler = require('../src/middleware/errorHandler');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payments/bank', studentRoutes);
+app.use('/api/admin/payments/bank', adminRoutes);
+app.use(errorHandler);
+
+describe('bank payment approval flow', () => {
+  beforeAll(async () => {
+    await db.schema.createTable('users', (table) => {
+      table.string('id').primary();
+      table.string('email');
+      table.string('full_name');
+      table.string('role');
+      table.string('avatar_url');
+      table.string('phone');
+      table.boolean('is_online');
+      table.string('status');
+      table.boolean('profile_complete');
+      table.boolean('is_email_verified');
+      table.boolean('is_phone_verified');
+    });
+
+    await db.schema.createTable('payment_methods_config', (table) => {
+      table.string('id').primary();
+      table.string('type').notNullable();
+      table.string('name');
+      table.boolean('active').defaultTo(true);
+      table.boolean('is_default').defaultTo(false);
+      table.jsonb('settings');
+    });
+
+    await db.schema.createTable('plans', (table) => {
+      table.string('id').primary();
+      table.string('slug');
+      table.float('price_monthly');
+      table.float('price_yearly');
+      table.string('target_role');
+    });
+
+    await db.schema.createTable('plan_features', (table) => {
+      table.string('id').primary();
+      table.string('plan_id');
+      table.string('feature_key');
+      table.string('value');
+      table.string('description');
+    });
+
+    await db.schema.createTable('payments', (table) => {
+      table.uuid('id').primary();
+      table.string('user_id').notNullable();
+      table.string('method_id').notNullable();
+      table.string('item_type').notNullable();
+      table.string('item_id').notNullable();
+      table.float('amount').notNullable();
+      table.string('currency').notNullable();
+      table.string('status').notNullable();
+      table.float('platform_fee').defaultTo(0);
+      table.float('instructor_amount').defaultTo(0);
+      table.jsonb('bank_details');
+      table.timestamp('paid_at');
+      table.timestamps(true, true);
+    });
+
+    await db.schema.createTable('settings', (table) => {
+      table.string('key').primary();
+      table.text('value').notNullable();
+      table.timestamps(true, true);
+    });
+
+    await db('users').insert({
+      id: 'user1',
+      email: 'user@example.com',
+      full_name: 'Test User',
+      role: 'student',
+    });
+    await db('payment_methods_config').insert({
+      id: 'pm1',
+      type: 'bank',
+      active: true,
+      settings: {},
+    });
+    await db('plans').insert({
+      id: 'plan1',
+      slug: 'basic',
+      price_monthly: 100,
+      price_yearly: 200,
+      target_role: 'student',
+    });
+  });
+
+  afterAll(async () => {
+    await db('payments').del();
+    await db('plans').del();
+    await db('payment_methods_config').del();
+    await db('users').del();
+    await db('settings').del();
+    await db.destroy();
+  });
+
+  it('approves bank payment and updates status to paid', async () => {
+    const initiateRes = await request(app)
+      .post('/api/payments/bank/initiate')
+      .send({ item_type: 'plan', item_id: 'plan1', amount: 100 });
+
+    expect(initiateRes.status).toBe(200);
+    const paymentId = initiateRes.body.data.id;
+    expect(initiateRes.body.data.status).toBe('awaiting_approval');
+
+    const approveRes = await request(app)
+      .post(`/api/admin/payments/bank/${paymentId}/approve`)
+      .send({});
+
+    expect(approveRes.status).toBe(200);
+    expect(approveRes.body.data.status).toBe('paid');
+
+    const payment = await db('payments').where({ id: paymentId }).first();
+    expect(payment.status).toBe('paid');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add integration test for bank payment initiation and admin approval
- use in-memory postgres with minimal mail/notification mocks
- clean up records after verifying status transitions

## Testing
- `cd backend && npm test tests/bankPaymentIntegration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b6511f63948328b3614f8da02384cb