### PR TITLE
feat: add student payment retrieval endpoint

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -419,6 +419,13 @@ exports.getMyPayments = catchAsync(async (req, res) => {
   sendSuccess(res, data);
 });
 
+exports.getMyPayment = catchAsync(async (req, res) => {
+  const payment = await service.getById(req.params.id);
+  if (!payment || payment.user_id !== req.user.id)
+    throw new AppError("Payment not found", 404);
+  sendSuccess(res, payment);
+});
+
 exports.getPayment = catchAsync(async (req, res) => {
   const payment = await service.getById(req.params.id);
   if (!payment) throw new AppError("Payment not found", 404);

--- a/backend/src/modules/payments/student.routes.js
+++ b/backend/src/modules/payments/student.routes.js
@@ -6,6 +6,7 @@ const { verifyToken, isStudent } = require("../../middleware/auth/authMiddleware
 router.use(verifyToken, isStudent);
 
 router.get("/", controller.getMyPayments);
+router.get("/:id", controller.getMyPayment);
 router.post("/", controller.createPayment);
 router.post(
   "/receipts",

--- a/backend/tests/studentPaymentRoutes.test.js
+++ b/backend/tests/studentPaymentRoutes.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 jest.mock('../src/modules/payments/payments.service', () => ({
   getByUser: jest.fn(),
+  getById: jest.fn(),
   create: jest.fn(),
 }));
 
@@ -51,6 +52,29 @@ describe('GET /api/payments/student', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
     expect(service.getByUser).toHaveBeenCalledWith('user1');
+  });
+});
+
+describe('GET /api/payments/student/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a payment for the authenticated user', async () => {
+    const payment = { id: 'p1', user_id: 'user1' };
+    service.getById.mockResolvedValue(payment);
+
+    const res = await request(app).get('/api/payments/student/p1');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(payment);
+    expect(service.getById).toHaveBeenCalledWith('p1');
+  });
+
+  it('returns 404 when payment belongs to another user', async () => {
+    service.getById.mockResolvedValue({ id: 'p1', user_id: 'other' });
+
+    const res = await request(app).get('/api/payments/student/p1');
+    expect(res.status).toBe(404);
   });
 });
 

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -40,6 +40,11 @@ The backend exposes a REST API under the `/api` prefix. Below is a brief outline
 
 `/api/payments/admin` – CRUD operations for user payments (admin only).
 
+`/api/payments/student`
+
+- `GET /api/payments/student` – list payments for the logged in student
+- `GET /api/payments/student/:id` – retrieve a payment belonging to the authenticated student
+
 ## Community Management
 
 `/api/community/admin` – manage announcements, reports, tags and settings.


### PR DESCRIPTION
## Summary
- allow students to fetch individual payments
- document student payment retrieval API and test coverage

## Testing
- `npm test` *(fails: Route.post requires callback; db config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6511c52e88328bcd010da3e546b99