### PR TITLE
Handle bank payment redirect and show pending instructions

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -294,11 +294,11 @@ export default function CheckoutPage() {
 
 
   const completePayment = async () => {
+    let payment;
     if (itemType === 'plan') {
       setPaymentStatus('processing');
       const eligible = filterEligibleMethods(methods, itemType);
       const defaultMethod = eligible[0];
-      let payment;
       try {
         const payload = {
           item_type: itemType,
@@ -402,8 +402,10 @@ export default function CheckoutPage() {
           ..._formData,
         };
         if (couponId) payload.coupon_id = couponId;
-        await initiateBankPayment(payload);
-        setPaymentStatus('submitted_bank');
+        const payment = await initiateBankPayment(payload);
+        router.push(
+          `/payments/success?itemType=${itemType}&itemId=${itemInfo.id}&payment_id=${payment?.id}`
+        );
       } catch (err) {
         console.error('Failed to initiate bank transfer', err);
         toast.error(t('payment_bank_failure'));
@@ -603,10 +605,6 @@ export default function CheckoutPage() {
           ) : paymentStatus === 'success' ? (
             <div className="text-green-400 text-center text-lg py-6">
               <FaCheckCircle className="inline mr-2 text-2xl" /> {t('payment_successful_redirecting')}
-            </div>
-          ) : paymentStatus === 'submitted_bank' ? (
-            <div className="text-yellow-400 text-center text-lg py-6">
-              {t('bank_transfer_pending')}
             </div>
           ) : selectedMethodIdentifier === 'paypal' ? (
             <PayPalForm

--- a/frontend/src/pages/payments/success.js
+++ b/frontend/src/pages/payments/success.js
@@ -18,10 +18,12 @@ import { subscribeToPlan, fetchMySubscription } from '@/services/instructor/subs
 import useCartStore from '@/store/cart/cartStore';
 import { toast } from 'react-toastify';
 import useLibraryStore from '@/store/libraryStore';
+import { useTranslation } from 'next-i18next';
 
 export default function PaymentSuccessPage() {
   const router = useRouter();
   const { itemType, itemId, payment_id } = router.query;
+  const { t } = useTranslation('common');
   const [itemInfo, setItemInfo] = useState(null);
   const [invoiceInfo, setInvoiceInfo] = useState(null);
   const [paymentInfo, setPaymentInfo] = useState(null);
@@ -183,6 +185,12 @@ export default function PaymentSuccessPage() {
           <FaCheckCircle size={64} className="text-green-400 animate-pulse" />
           <h1 className="text-4xl font-bold text-yellow-400">Payment Successful!</h1>
           <p className="text-lg text-gray-300">{message}</p>
+
+          {paymentInfo?.status === 'awaiting_approval' && (
+            <div className="bg-gray-800 px-6 py-5 rounded-xl shadow-md w-full text-left mt-4">
+              <p className="text-sm text-yellow-400">{t('bank_transfer_pending')}</p>
+            </div>
+          )}
 
           {itemType === 'class' && (
             <div className="bg-gray-800 px-6 py-5 rounded-xl shadow-md w-full text-left mt-4">

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -125,12 +125,18 @@ test('renders payment logos using library icons with url fallback', async () => 
 });
 
 test('adjusts inputs based on payment selection and submits bank details', async () => {
+  const push = jest.fn();
+  mockUseRouter.mockReturnValue({
+    query: { itemId: '1', itemType: 'class' },
+    isReady: true,
+    push,
+  });
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Stripe', type: 'stripe' },
     { id: 2, name: 'PayPal', type: null },
     { id: 3, name: 'Bank', type: 'bank' },
   ]);
-  initiateBankPayment.mockResolvedValue({});
+  initiateBankPayment.mockResolvedValue({ id: 42 });
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
   expect(screen.getByTestId('card-element')).toBeInTheDocument();
@@ -146,7 +152,11 @@ test('adjusts inputs based on payment selection and submits bank details', async
   fireEvent.change(screen.getByPlaceholderText('SWIFT Code'), { target: { value: 'ABCDEF' } });
   fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Bank/i }));
   await waitFor(() => expect(initiateBankPayment).toHaveBeenCalled());
-  expect(await screen.findByText(/bank transfer request has been submitted/i)).toBeInTheDocument();
+  await waitFor(() =>
+    expect(push).toHaveBeenCalledWith(
+      '/payments/success?itemType=class&itemId=1&payment_id=42'
+    )
+  );
 });
 
 test('completes payment for unhandled methods on success', async () => {


### PR DESCRIPTION
## Summary
- Redirect bank payments to the success page with payment ID and remove local pending state
- Show awaiting-approval bank transfer instructions on the payment success page
- Adjust checkout flow test for new bank transfer redirect

## Testing
- `npm test` (fails: ReferenceError register is not defined)
- `npm run lint` (fails: Component definition is missing display name)

------
https://chatgpt.com/codex/tasks/task_e_68b6512264e4832898aac40744af921b