### PR TITLE
refactor: integrate react-hook-form into card payment form

### DIFF
--- a/frontend/src/components/payments/forms/CardPaymentForm.js
+++ b/frontend/src/components/payments/forms/CardPaymentForm.js
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import { CardElement, useStripe, useElements } from '@stripe/react-stripe-js';
+import { useForm } from 'react-hook-form';
 
 export default function CardPaymentForm({ onSubmit, processing, allowInstallments, installments, perInstallment, finalPrice, selectedMethodLabel }) {
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
   const [error, setError] = useState(null);
+  const { register, handleSubmit, formState: { errors } } = useForm();
   const stripe = useStripe();
   const elements = useElements();
   const buttonText = processing
@@ -13,25 +13,20 @@ export default function CardPaymentForm({ onSubmit, processing, allowInstallment
       ? `Pay $${perInstallment.toFixed(2)} (1/${installments}) with ${selectedMethodLabel}`
       : `Pay $${finalPrice} with ${selectedMethodLabel}`;
 
-  const submit = (data) => {
-    onSubmit(data);
+  const submit = async (data) => {
+    if (!stripe || !elements) return;
+    setError(null);
+    const cardElement = elements.getElement(CardElement);
+    const { error: stripeError, token } = await stripe.createToken(cardElement);
+    if (stripeError) {
+      setError(stripeError.message);
+      return;
+    }
+    onSubmit({ ...data, token: token.id });
   };
 
   return (
-    <form
-      onSubmit={async (e) => {
-        e.preventDefault();
-        if (!stripe || !elements) return;
-        setError(null);
-        const cardElement = elements.getElement(CardElement);
-        const { error: stripeError, token } = await stripe.createToken(cardElement);
-        if (stripeError) {
-          setError(stripeError.message);
-          return;
-        }
-        onSubmit({ name, email, token: token.id });
-      }}
-    >
+    <form onSubmit={handleSubmit(submit)}>
       <input
         type="text"
         placeholder="Full Name"

--- a/frontend/src/tests/__tests__/CardPaymentForm.test.js
+++ b/frontend/src/tests/__tests__/CardPaymentForm.test.js
@@ -2,8 +2,9 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import CardPaymentForm from '@/components/payments/forms/CardPaymentForm';
 
 describe('CardPaymentForm validation', () => {
-  it('shows error for invalid card number', async () => {
+  it('shows error when Stripe returns an error', async () => {
     const handleSubmit = jest.fn();
+    global.mockStripeCreateToken.mockResolvedValueOnce({ error: { message: 'Invalid card number' } });
     render(
       <CardPaymentForm
         onSubmit={handleSubmit}
@@ -16,9 +17,6 @@ describe('CardPaymentForm validation', () => {
 
     fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'John Doe' } });
     fireEvent.change(screen.getByPlaceholderText('Email Address'), { target: { value: 'john@example.com' } });
-    fireEvent.change(screen.getByPlaceholderText('Card Number'), { target: { value: '123' } });
-    fireEvent.change(screen.getByPlaceholderText('Expiration Date (MM/YY)'), { target: { value: '12/30' } });
-    fireEvent.change(screen.getByPlaceholderText('CVC'), { target: { value: '123' } });
 
     fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Stripe/i }));
 


### PR DESCRIPTION
## Summary
- refactor card payment form to use `react-hook-form` for handling name and email inputs
- wrap submission in `handleSubmit` and propagate stripe token
- update unit test to handle stripe token errors

## Testing
- `npm test src/tests/__tests__/CardPaymentForm.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b651207efc8328a71939ee93fb0434