### PR TITLE
Add subscription store and refresh dashboard after plan purchase

### DIFF
--- a/frontend/src/pages/dashboard/student/settings/index.js
+++ b/frontend/src/pages/dashboard/student/settings/index.js
@@ -8,27 +8,15 @@ import {
   FaPalette,
 } from "react-icons/fa";
 import api from "@/services/api/api";
+import useSubscriptionStore from "@/store/subscriptionStore";
 
 export default function StudentSettingsPage() {
   const [activeTab, setActiveTab] = useState("account");
-  const [subscription, setSubscription] = useState(null);
+  const subscription = useSubscriptionStore((state) => state.plan);
+  const loadingSub = useSubscriptionStore((state) => state.loading);
+  const fetchSubscription = useSubscriptionStore((state) => state.fetch);
   const [invoices, setInvoices] = useState([]);
-  const [loadingSub, setLoadingSub] = useState(true);
   const [loadingInvoices, setLoadingInvoices] = useState(true);
-
-  const loadSubscription = async () => {
-    setLoadingSub(true);
-    try {
-      const { data } = await api.get("/user-subscriptions/me");
-      const subs = data?.data || [];
-      setSubscription(subs[0] || null);
-    } catch (err) {
-      console.error("Failed to fetch subscription", err);
-      setSubscription(null);
-    } finally {
-      setLoadingSub(false);
-    }
-  };
 
   const loadInvoices = async () => {
     setLoadingInvoices(true);
@@ -44,14 +32,14 @@ export default function StudentSettingsPage() {
   };
 
   useEffect(() => {
-    loadSubscription();
+    fetchSubscription();
     loadInvoices();
-  }, []);
+  }, [fetchSubscription]);
 
   const handleUpgrade = async () => {
     try {
       await api.post("/user-subscriptions/upgrade");
-      loadSubscription();
+      await fetchSubscription();
     } catch (err) {
       console.error("Upgrade failed", err);
     }
@@ -60,7 +48,7 @@ export default function StudentSettingsPage() {
   const handleCancel = async () => {
     try {
       await api.post("/user-subscriptions/cancel");
-      loadSubscription();
+      await fetchSubscription();
     } catch (err) {
       console.error("Cancel failed", err);
     }

--- a/frontend/src/pages/payments/success.js
+++ b/frontend/src/pages/payments/success.js
@@ -19,6 +19,7 @@ import useCartStore from '@/store/cart/cartStore';
 import { toast } from 'react-toastify';
 import useLibraryStore from '@/store/libraryStore';
 import { useTranslation } from 'next-i18next';
+import useSubscriptionStore from '@/store/subscriptionStore';
 
 export default function PaymentSuccessPage() {
   const router = useRouter();
@@ -33,6 +34,7 @@ export default function PaymentSuccessPage() {
   const [subscriptionInfo, setSubscriptionInfo] = useState(null);
   const removeItem = useCartStore((state) => state.removeItem);
   const { fetchLibrary } = useLibraryStore();
+  const fetchSubscription = useSubscriptionStore((state) => state.fetch);
 
   const confirmPlanSubscription = async () => {
     try {
@@ -45,6 +47,7 @@ export default function PaymentSuccessPage() {
       }
       setSubscriptionInfo(current);
       setSubscriptionError(null);
+      await fetchSubscription();
     } catch (_) {
       setSubscriptionError('Failed to activate subscription');
     }

--- a/frontend/src/store/subscriptionStore.js
+++ b/frontend/src/store/subscriptionStore.js
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import api from "@/services/api/api";
+
+const useSubscriptionStore = create(
+  persist(
+    (set) => ({
+      plan: null,
+      loading: false,
+      async fetch() {
+        set({ loading: true });
+        try {
+          const { data } = await api.get("/subscriptions");
+          const list = data?.data ?? data ?? [];
+          const active = Array.isArray(list)
+            ? list.find((s) => s.status === "active") || list[0] || null
+            : list;
+          set({ plan: active || null, loading: false });
+        } catch (err) {
+          set({ plan: null, loading: false });
+        }
+      },
+      clear: () => set({ plan: null }),
+    }),
+    { name: "subscription-store" }
+  )
+);
+
+export default useSubscriptionStore;


### PR DESCRIPTION
## Summary
- add subscription store to cache active plan via GET /subscriptions
- refresh subscription data after plan purchase on payment success
- use shared subscription store in student settings billing section

## Testing
- `npm test` *(fails: Nullish coalescing operator requires parens in checkout.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b65a4b5b448328a7fcd8887951557a