### PR TITLE
Add subscription notification after payment

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -338,11 +338,33 @@ exports.createPayment = catchAsync(async (req, res) => {
           (Number(verifiedAmount) === Number(plan.price_yearly)
             ? "yearly"
             : "monthly");
-        await subscriptionService.createOrRenewSubscription({
+        const subscription = await subscriptionService.createOrRenewSubscription({
           user_id,
           plan_id: item_id,
           interval,
         });
+
+        try {
+          const start = new Date(subscription.start_date).toLocaleDateString();
+          const end = new Date(subscription.end_date).toLocaleDateString();
+          const message = `Your ${plan.name} plan is active from ${start} to ${end}.`;
+
+          await notificationService.createNotification({
+            user_id,
+            type: "plan_subscription",
+            message,
+          });
+
+          if (user?.email) {
+            await mailService.sendMail({
+              to: user.email,
+              subject: "Subscription Activated",
+              html: `<p>${message}</p>`,
+            });
+          }
+        } catch (err) {
+          logger.error("Failed to send subscription notification:", err);
+        }
       }
     } catch (err) {
       logger.error("Failed to activate subscription after payment:", err);

--- a/backend/tests/paymentInvoiceEmail.test.js
+++ b/backend/tests/paymentInvoiceEmail.test.js
@@ -36,6 +36,9 @@ const bookService = require('../src/modules/books/book.service');
 const invoiceService = require('../src/modules/invoices/invoices.service');
 const mailService = require('../src/services/mailService');
 const walletService = require('../src/modules/payouts/wallet.service');
+const plansService = require('../src/modules/plans/plans.service');
+const subscriptionService = require('../src/modules/subscriptions/subscription.service');
+const notificationService = require('../src/modules/notifications/notifications.service');
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -104,6 +107,23 @@ describe('invoice email dispatch', () => {
     expect(paymentsService.create.mock.calls[0][0].status).toBe('paid');
     expect(walletService.increment).toHaveBeenCalledWith('i1', 0);
     expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+  });
+
+  it('triggers notification for paid plan payments', async () => {
+    paymentMethodsService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
+    plansService.getPlanById.mockResolvedValue({ id: 'plan1', name: 'Gold', price_monthly: 100, price_yearly: 1000 });
+    subscriptionService.createOrRenewSubscription.mockResolvedValue({ start_date: '2024-01-01', end_date: '2024-02-01' });
+    paymentsService.create.mockResolvedValue({ id: 'p5', user_id: 'u1', method_id: 'm1', item_type: 'plan', item_id: 'plan1', amount: 100, currency: 'USD', status: 'paid' });
+
+    const req = { body: { method_id: 'm1', item_type: 'plan', item_id: 'plan1', amount: 100, status: 'paid' }, user: { id: 'u1' } };
+    const res = mockRes();
+    await paymentsController.createPayment(req, res, () => {});
+    await new Promise(process.nextTick);
+
+    expect(subscriptionService.createOrRenewSubscription).toHaveBeenCalledWith({ user_id: 'u1', plan_id: 'plan1', interval: 'monthly' });
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'u1', type: 'plan_subscription' })
+    );
   });
 });
 

--- a/frontend/src/pages/payments/success.js
+++ b/frontend/src/pages/payments/success.js
@@ -31,6 +31,7 @@ export default function PaymentSuccessPage() {
   const [fetchError, setFetchError] = useState(null);
   const [subscriptionError, setSubscriptionError] = useState(null);
   const [subscriptionInfo, setSubscriptionInfo] = useState(null);
+  const [bannerMessage, setBannerMessage] = useState(null);
   const removeItem = useCartStore((state) => state.removeItem);
   const { fetchLibrary } = useLibraryStore();
 
@@ -39,7 +40,8 @@ export default function PaymentSuccessPage() {
       let sub = await fetchMySubscription();
       let current = Array.isArray(sub) ? sub[0] : sub;
       if (!current || current.plan_id !== itemId) {
-        await subscribeToPlan(itemId);
+        const { message } = await subscribeToPlan(itemId);
+        if (message) setBannerMessage(message);
         sub = await fetchMySubscription();
         current = Array.isArray(sub) ? sub[0] : sub;
       }
@@ -181,6 +183,11 @@ export default function PaymentSuccessPage() {
       <Navbar />
 
       <main className="max-w-3xl mx-auto px-4 py-24 text-center">
+        {bannerMessage && (
+          <div className="bg-green-600 text-white px-4 py-3 rounded-md mb-6">
+            {bannerMessage}
+          </div>
+        )}
         <div className="flex flex-col items-center space-y-6">
           <FaCheckCircle size={64} className="text-green-400 animate-pulse" />
           <h1 className="text-4xl font-bold text-yellow-400">Payment Successful!</h1>

--- a/frontend/src/services/instructor/subscriptionService.js
+++ b/frontend/src/services/instructor/subscriptionService.js
@@ -8,7 +8,7 @@ export const subscribeToPlan = async (
   const payload = { plan_id: planId, interval };
   if (paymentId) payload.payment_id = paymentId;
   const { data } = await api.post("/user-subscriptions", payload);
-  return data?.data ?? null;
+  return { subscription: data?.data ?? null, message: data?.message };
 };
 
 export const fetchMySubscription = async () => {


### PR DESCRIPTION
## Summary
- notify users by email and in-app after plan payments create or renew a subscription
- display API confirmation message on payment success page
- cover subscription notifications in payment tests

## Testing
- `npm test` *(backend: fails - Route.post() requires a callback function but got a [object Undefined])*
- `npm test` *(frontend: fails - Nullish coalescing operator(??) requires parens when mixing with logical operators)*

------
https://chatgpt.com/codex/tasks/task_e_68b65a4ad99483288382b131b443fcbd