### PR TITLE
feat: add instructor billing settings page

### DIFF
--- a/frontend/src/pages/dashboard/instructor/settings/index.js
+++ b/frontend/src/pages/dashboard/instructor/settings/index.js
@@ -1,0 +1,76 @@
+import InstructorLayout from "@/components/layouts/InstructorLayout";
+import { useEffect } from "react";
+import api from "@/services/api/api";
+import useSubscriptionStore from "@/store/subscriptionStore";
+
+export default function InstructorSettingsPage() {
+  const subscription = useSubscriptionStore((state) => state.plan);
+  const loadingSub = useSubscriptionStore((state) => state.loading);
+  const fetchSubscription = useSubscriptionStore((state) => state.fetch);
+
+  useEffect(() => {
+    fetchSubscription();
+  }, [fetchSubscription]);
+
+  const handleUpgrade = async () => {
+    try {
+      await api.post("/user-subscriptions/upgrade");
+      await fetchSubscription();
+    } catch (err) {
+      console.error("Upgrade failed", err);
+    }
+  };
+
+  const handleCancel = async () => {
+    try {
+      await api.post("/user-subscriptions/cancel");
+      await fetchSubscription();
+    } catch (err) {
+      console.error("Cancel failed", err);
+    }
+  };
+
+  return (
+    <InstructorLayout>
+      <div className="p-6 max-w-2xl mx-auto text-gray-800">
+        <h1 className="text-3xl font-bold mb-6 text-yellow-500">⚙️ Instructor Settings</h1>
+        <div className="bg-white rounded-xl shadow p-6 space-y-6">
+          <h2 className="text-lg font-semibold">Billing</h2>
+          {loadingSub ? (
+            <p>Loading subscription...</p>
+          ) : subscription ? (
+            <div className="space-y-2">
+              <p>
+                <span className="font-medium">Plan:</span> {subscription.name}
+              </p>
+              <p>
+                <span className="font-medium">Start:</span>{" "}
+                {new Date(subscription.start_date).toLocaleDateString()}
+              </p>
+              <p>
+                <span className="font-medium">End:</span>{" "}
+                {new Date(subscription.end_date).toLocaleDateString()}
+              </p>
+              <div className="flex gap-4 pt-2">
+                <button
+                  onClick={handleUpgrade}
+                  className="bg-yellow-500 px-4 py-2 rounded text-black font-medium hover:bg-yellow-600"
+                >
+                  Upgrade
+                </button>
+                <button
+                  onClick={handleCancel}
+                  className="bg-red-500 px-4 py-2 rounded text-white font-medium hover:bg-red-600"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <p>No active subscription.</p>
+          )}
+        </div>
+      </div>
+    </InstructorLayout>
+  );
+}

--- a/frontend/src/store/subscriptionStore.js
+++ b/frontend/src/store/subscriptionStore.js
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import api from "@/services/api/api";
+import { fetchMySubscription } from "@/services/instructor/subscriptionService";
 
 const useSubscriptionStore = create(
   persist(
@@ -10,12 +10,8 @@ const useSubscriptionStore = create(
       async fetch() {
         set({ loading: true });
         try {
-          const { data } = await api.get("/subscriptions");
-          const list = data?.data ?? data ?? [];
-          const active = Array.isArray(list)
-            ? list.find((s) => s.status === "active") || list[0] || null
-            : list;
-          set({ plan: active || null, loading: false });
+          const sub = await fetchMySubscription();
+          set({ plan: sub || null, loading: false });
         } catch (err) {
           set({ plan: null, loading: false });
         }

--- a/frontend/src/tests/__tests__/InstructorSettingsPage.test.js
+++ b/frontend/src/tests/__tests__/InstructorSettingsPage.test.js
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import InstructorSettingsPage from '../../pages/dashboard/instructor/settings';
+import useSubscriptionStore from '../../store/subscriptionStore';
+import { fetchMySubscription } from '../../services/instructor/subscriptionService';
+
+jest.mock('../../components/layouts/InstructorLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock('../../services/instructor/subscriptionService', () => ({
+  fetchMySubscription: jest.fn(),
+}));
+
+beforeEach(() => {
+  useSubscriptionStore.getState().clear();
+  window.localStorage.clear();
+});
+
+test('shows active subscription details', async () => {
+  fetchMySubscription.mockResolvedValue({
+    name: 'Pro Plan',
+    start_date: '2025-01-01',
+    end_date: '2025-12-31',
+  });
+
+  render(<InstructorSettingsPage />);
+
+  const planName = await screen.findByText('Pro Plan');
+  expect(planName).toBeInTheDocument();
+  const start = screen.getByText(/Start:/).parentElement;
+  expect(start).toHaveTextContent(
+    new Date('2025-01-01').toLocaleDateString()
+  );
+  const end = screen.getByText(/End:/).parentElement;
+  expect(end).toHaveTextContent(
+    new Date('2025-12-31').toLocaleDateString()
+  );
+});


### PR DESCRIPTION
## Summary
- add instructor billing page that displays plan info and upgrade/cancel actions
- refactor subscription store to use fetchMySubscription so it's shared across dashboards
- test instructor billing page shows active subscription details

## Testing
- `npm test src/tests/__tests__/InstructorSettingsPage.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b662043ca48328baae035f26f3747b