### PR TITLE
Fix checkout price expression with nullish coalescing

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -273,7 +273,7 @@ export default function CheckoutPage() {
         console.error('Failed to load item', err);
       }
       const price =
-        existingPayment?.amount ?? Number((details?.data ?? details)?.price) || 0;
+        existingPayment?.amount ?? (Number((details?.data ?? details)?.price) || 0);
       if (price > Number.EPSILON) {
         try {
           const data = await fetchPaymentMethods();


### PR DESCRIPTION
## Summary
- wrap nullish coalescing expression with parentheses to satisfy syntax rules

## Testing
- `npm test -- src/tests/__tests__/checkoutPaymentFlow.test.js` *(fails: expect push to have been called with success URL)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b65f8689188328bd09a4ca47c57448