### PR TITLE
Handle missing payment URLs for PayPal and crypto methods

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -465,11 +465,15 @@ export default function CheckoutPage() {
         };
         if (couponId) payload.coupon_id = couponId;
         const data = await initiatePayPalPayment(payload);
-        if (data?.approval_url) window.location.href = data.approval_url;
+        if (data?.approval_url) {
+          window.location.href = data.approval_url;
+        } else {
+          toast.error(t('payment_paypal_failure'));
+          setPaymentStatus('idle');
+        }
       } catch (err) {
         console.error('Failed to initiate PayPal payment', err);
         toast.error(t('payment_paypal_failure'));
-      } finally {
         setPaymentStatus('idle');
       }
       return;
@@ -485,11 +489,15 @@ export default function CheckoutPage() {
         };
         if (couponId) payload.coupon_id = couponId;
         const data = await initiateCryptoPayment(payload);
-        if (data?.invoice_url) window.location.href = data.invoice_url;
+        if (data?.invoice_url) {
+          window.location.href = data.invoice_url;
+        } else {
+          toast.error(t('payment_crypto_failure'));
+          setPaymentStatus('idle');
+        }
       } catch (err) {
         console.error('Failed to initiate crypto payment', err);
         toast.error(t('payment_crypto_failure'));
-      } finally {
         setPaymentStatus('idle');
       }
       return;

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CheckoutPage from '../../pages/payments/checkout';
 import { fetchClassDetails } from '../../services/classService';
 import { fetchPaymentMethods } from '../../services/paymentMethodService';
-import { initiateBankPayment } from '../../services/paymentService';
+import { initiateBankPayment, initiateCryptoPayment, initiatePayPalPayment } from '../../services/paymentService';
 import { createPayment } from '../../services/student/paymentService';
 import { fetchPlanDetails } from '../../services/public/planService';
 import PaymentSuccessPage from '../../pages/payments/success';
@@ -133,6 +133,12 @@ test('renders payment logos using library icons with url fallback', async () => 
 });
 
 test('adjusts inputs based on payment selection and submits bank reference', async () => {
+  const push = jest.fn();
+  mockUseRouter.mockReturnValue({
+    query: { itemId: '1', itemType: 'class' },
+    isReady: true,
+    push,
+  });
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Stripe', type: 'stripe' },
     { id: 2, name: 'PayPal', type: null },
@@ -186,6 +192,34 @@ test('shows error when unhandled payment fails', async () => {
   await waitFor(() => expect(global.mockStripeCreateToken).toHaveBeenCalled());
   await waitFor(() => expect(createPayment).toHaveBeenCalledWith(expect.objectContaining({ token: 'tok_123' })));
   expect(require('react-toastify').toast.error).toHaveBeenCalled();
+});
+
+test('shows error when PayPal payment lacks approval_url', async () => {
+  fetchPaymentMethods.mockResolvedValue([
+    { id: 1, name: 'PayPal', type: null },
+  ]);
+  initiatePayPalPayment.mockResolvedValue({});
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+  const button = screen.getByRole('button', { name: /Pay \$100 with PayPal/i });
+  fireEvent.click(button);
+  await waitFor(() => expect(initiatePayPalPayment).toHaveBeenCalled());
+  await waitFor(() => expect(require('react-toastify').toast.error).toHaveBeenCalled());
+  expect(button).not.toBeDisabled();
+});
+
+test('shows error when crypto payment lacks invoice_url', async () => {
+  fetchPaymentMethods.mockResolvedValue([
+    { id: 1, name: 'USDT', type: 'usdt' },
+  ]);
+  initiateCryptoPayment.mockResolvedValue({});
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+  const button = screen.getByRole('button', { name: /Pay \$100 with Crypto/i });
+  fireEvent.click(button);
+  await waitFor(() => expect(initiateCryptoPayment).toHaveBeenCalled());
+  await waitFor(() => expect(require('react-toastify').toast.error).toHaveBeenCalled());
+  expect(button).not.toBeDisabled();
 });
 
 test('processes plan card payments and redirects to billing for students', async () => {


### PR DESCRIPTION
## Summary
- Add explicit failure handling when PayPal or crypto payment initiation fails to return redirect URLs
- Re-enable submit button and show error toast on missing URLs
- Test missing URL scenarios for PayPal and crypto payment flows

## Testing
- `npm test src/tests/__tests__/checkoutPaymentFlow.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b784b6f0f0832881aae0633b799efc