### PR TITLE
Restrict payment icon sources to HTTP(S)

### DIFF
--- a/docs/payment-icon-sources.md
+++ b/docs/payment-icon-sources.md
@@ -2,6 +2,10 @@
 
 SkillBridge displays icons for payment methods during checkout. To avoid loading images from untrusted locations, icons are only loaded from approved hosts or from assets bundled with the application.
 
+## Supported schemes
+
+Only `http` and `https` schemes are supported for payment method icons. Icons using other schemes (e.g. `javascript:` or `data:`) are rejected.
+
 ## Trusted domains
 
 Payment method icons may be served from the following domains:

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -42,7 +42,8 @@ export const TRUSTED_ICON_HOSTS = ['skillbridge.com', 'cdn.skillbridge.com'];
 
 function isTrustedIcon(url) {
   try {
-    const { hostname } = new URL(url, 'http://localhost');
+    const { protocol, hostname } = new URL(url, 'http://localhost');
+    if (protocol !== 'http:' && protocol !== 'https:') return false;
     return TRUSTED_ICON_HOSTS.some(
       (host) => hostname === host || hostname.endsWith(`.${host}`)
     );
@@ -70,10 +71,16 @@ export function resolveIconElement(method) {
     const base = lower.split('/').pop().split('.')[0];
     if (iconMap[lower]) return iconMap[lower];
     if (iconMap[base]) return iconMap[base];
-    const isUrl = /^(https?:)?\/\//.test(method.icon);
-    const trusted = !isUrl || isTrustedIcon(method.icon);
-    if (trusted) {
-      return <TrustedIcon src={method.icon} alt={method.name} />;
+    try {
+      const parsed = new URL(method.icon, 'http://localhost');
+      const isExternal = parsed.origin !== 'http://localhost';
+      const isHttp = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+      const trusted = isHttp && (!isExternal || isTrustedIcon(parsed.href));
+      if (trusted) {
+        return <TrustedIcon src={method.icon} alt={method.name} />;
+      }
+    } catch {
+      // Invalid URLs fall through to the default icon
     }
   }
   return (


### PR DESCRIPTION
## Summary
- ensure `isTrustedIcon` validates http/https schemes before host checks
- harden `resolveIconElement` against non-http(s) URLs
- document supported http/https schemes for payment icons

## Testing
- `npm test` *(fails: checkoutPaymentFlow.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b784b4176c8328a1cc54456aad51b5