### PR TITLE
Validate checkout item types during checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -122,17 +122,26 @@ export function filterEligibleMethods(methods, itemType) {
 export function resolveCheckoutItem(query, cartItems) {
   const { itemId, itemType, items } = query;
 
+  const isSupportedType = (type) =>
+    ['class', 'tutorial', 'book', 'plan'].includes((type || '').toLowerCase());
+
   if (itemId && itemType) {
+    if (!isSupportedType(itemType)) return null;
     return { id: itemId, type: itemType };
   }
 
   const resolvedFromItems = parseCheckoutItems(items);
-  if (resolvedFromItems) return resolvedFromItems;
+  if (resolvedFromItems) {
+    if (!isSupportedType(resolvedFromItems.type)) return null;
+    return resolvedFromItems;
+  }
 
   if (Array.isArray(cartItems) && cartItems.length === 1) {
     const c = cartItems[0];
     if (c && c.id) {
-      return { id: c.id, type: c.item_type || 'class' };
+      const type = c.item_type || 'class';
+      if (!isSupportedType(type)) return null;
+      return { id: c.id, type };
     }
   }
 

--- a/frontend/src/tests/__tests__/resolveCheckoutItem.test.js
+++ b/frontend/src/tests/__tests__/resolveCheckoutItem.test.js
@@ -22,4 +22,9 @@ describe('resolveCheckoutItem', () => {
     const cart = [{ id: '1' }, { id: '2' }];
     expect(resolveCheckoutItem({}, cart)).toBeNull();
   });
+
+  it('rejects unsupported item types', () => {
+    const query = { itemId: '99', itemType: 'invalid' };
+    expect(resolveCheckoutItem(query, [])).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `resolveCheckoutItem` only accepts class, tutorial, book, or plan types
- test that unsupported checkout item types are rejected

## Testing
- `npm test -- src/tests/__tests__/resolveCheckoutItem.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b784b2a870832897879bb718f1db55