### PR TITLE
Conditionally append payment_id in checkout redirect

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -414,13 +414,12 @@ export default function CheckoutPage() {
       }
     }
     setPaymentStatus('success');
-    setTimeout(
-      () =>
-        router.push(
-          `/payments/success?itemType=${itemType}&itemId=${itemInfo.id}&payment_id=${payment?.id}`
-        ),
-      1500
-    );
+    setTimeout(() => {
+      const paymentIdParam = payment?.id ? `&payment_id=${payment.id}` : '';
+      router.push(
+        `/payments/success?itemType=${itemType}&itemId=${itemInfo.id}${paymentIdParam}`
+      );
+    }, 1500);
   };
 
   const handlePayment = async (_formData = {}) => {


### PR DESCRIPTION
## Summary
- only include `payment_id` in checkout success redirect when available

## Testing
- `npm test` *(fails: checkoutPaymentFlow.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b784b059008328af99fb9baf0de9e2