### PR TITLE
Persist enrollment after checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -408,9 +408,12 @@ export default function CheckoutPage() {
           };
     if (typeof window !== 'undefined') {
       try {
+        enrolled.push(newItem);
+        localStorage.setItem(storageKey, JSON.stringify(enrolled));
         await Promise.resolve(removeItem(itemInfo.id));
       } catch (err) {
-        console.error('Failed to remove from cart', err);
+        console.error('Failed to persist enrollment', err);
+        toast.error(t('payment_generic_failure'));
       }
     }
     setPaymentStatus('success');


### PR DESCRIPTION
## Summary
- Ensure completePayment persists enrolled items in localStorage before removing cart entries
- Add error handling around localStorage persistence

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b784aef428832880eb6560c3c07263