### PR TITLE
Load real payment data and invoices

### DIFF
--- a/frontend/src/pages/payments/index.js
+++ b/frontend/src/pages/payments/index.js
@@ -1,46 +1,40 @@
 // pages/payments/index.js
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
-
-const mockPayments = [
-  {
-    id: 1,
-    tutorial: "Mastering React.js",
-    user: "ayman@example.com",
-    amount: 49,
-    status: "Paid",
-    date: "2025-04-05",
-  },
-  {
-    id: 2,
-    tutorial: "React Hooks Deep Dive",
-    user: "john.doe@example.com",
-    amount: 39,
-    status: "Pending",
-    date: "2025-04-04",
-  },
-];
+import { fetchMyPayments } from "@/services/student/paymentService";
 
 export default function PaymentsPage() {
   const [payments, setPayments] = useState([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const ITEMS_PER_PAGE = 10;
 
   useEffect(() => {
-    setPayments(mockPayments);
+    const load = async () => {
+      try {
+        const data = await fetchMyPayments();
+        setPayments(Array.isArray(data) ? data : []);
+      } catch (_) {
+        setError("Failed to load payments");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, []);
 
-  const filteredPayments = payments.filter(
-    (p) =>
-      p.user.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      p.tutorial.toLowerCase().includes(searchTerm.toLowerCase())
-  );
+  const filteredPayments = payments.filter((p) => {
+    const item = (p.item_name || p.tutorial || "").toLowerCase();
+    return item.includes(searchTerm.toLowerCase());
+  });
 
   const totalPaid = filteredPayments
-    .filter((p) => p.status === "Paid")
-    .reduce((sum, p) => sum + p.amount, 0);
+    .filter((p) => (p.status || "").toLowerCase() === "paid")
+    .reduce((sum, p) => sum + Number(p.amount || 0), 0);
 
   const totalPages = Math.ceil(filteredPayments.length / ITEMS_PER_PAGE);
   const paginatedPayments = filteredPayments.slice(
@@ -50,13 +44,12 @@ export default function PaymentsPage() {
 
   const exportToCSV = () => {
     const csvContent = [
-      ["Tutorial", "User", "Amount", "Status", "Date"],
+      ["Item", "Amount", "Status", "Date"],
       ...filteredPayments.map((p) => [
-        p.tutorial,
-        p.user,
+        p.item_name || p.tutorial || "N/A",
         p.amount,
         p.status,
-        p.date,
+        p.date || p.created_at,
       ]),
     ]
       .map((e) => e.join(","))
@@ -87,7 +80,7 @@ export default function PaymentsPage() {
         <div className="mb-8 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
           <input
             type="text"
-            placeholder="Search by user or tutorial"
+            placeholder="Search by item"
             className="px-4 py-2 rounded bg-gray-800 text-white w-full md:w-1/3 border border-gray-700"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
@@ -109,7 +102,11 @@ export default function PaymentsPage() {
           </p>
         </div>
 
-        {filteredPayments.length === 0 ? (
+        {loading ? (
+          <div className="text-center text-gray-500 py-12">Loading...</div>
+        ) : error ? (
+          <div className="text-center text-red-500 py-12">{error}</div>
+        ) : filteredPayments.length === 0 ? (
           <div className="text-center text-gray-500 py-12">
             No payment records found.
           </div>
@@ -119,11 +116,11 @@ export default function PaymentsPage() {
               <thead className="bg-gray-700 text-sm uppercase text-gray-300">
                 <tr>
                   <th className="text-left px-5 py-4">#</th>
-                  <th className="text-left px-5 py-4">Tutorial</th>
-                  <th className="text-left px-5 py-4">User</th>
+                  <th className="text-left px-5 py-4">Item</th>
                   <th className="text-left px-5 py-4">Amount</th>
                   <th className="text-left px-5 py-4">Status</th>
                   <th className="text-left px-5 py-4">Date</th>
+                  <th className="text-left px-5 py-4">Invoice</th>
                 </tr>
               </thead>
               <tbody>
@@ -133,13 +130,12 @@ export default function PaymentsPage() {
                     className="border-t border-gray-700 hover:bg-gray-700 transition"
                   >
                     <td className="px-5 py-4">{(currentPage - 1) * ITEMS_PER_PAGE + index + 1}</td>
-                    <td className="px-5 py-4 font-medium">{payment.tutorial}</td>
-                    <td className="px-5 py-4">{payment.user}</td>
+                    <td className="px-5 py-4 font-medium">{payment.item_name || payment.tutorial || 'N/A'}</td>
                     <td className="px-5 py-4 text-green-400 font-semibold">${payment.amount}</td>
                     <td className="px-5 py-4">
                       <span
                         className={`px-3 py-1 rounded-full text-sm font-medium ${
-                          payment.status === "Paid"
+                          (payment.status || '').toLowerCase() === "paid"
                             ? "bg-green-600 text-white"
                             : "bg-yellow-400 text-black"
                         }`}
@@ -147,7 +143,12 @@ export default function PaymentsPage() {
                         {payment.status}
                       </span>
                     </td>
-                    <td className="px-5 py-4 text-gray-400">{payment.date}</td>
+                    <td className="px-5 py-4 text-gray-400">{payment.date || payment.created_at}</td>
+                    <td className="px-5 py-4">
+                      <Link href={`/payments/invoice/${payment.id}`} className="text-yellow-400 underline">
+                        View
+                      </Link>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/pages/payments/invoice/[id].js
+++ b/frontend/src/pages/payments/invoice/[id].js
@@ -6,6 +6,10 @@ import Footer from '@/components/website/sections/Footer';
 import { FaDownload } from 'react-icons/fa';
 import QRCode from 'react-qr-code';
 import { uploadReceipt } from '@/services/student/paymentService';
+import {
+  fetchInvoiceByPaymentId,
+  downloadInvoice,
+} from '@/services/student/invoiceService';
 
 export default function InvoicePage() {
   const router = useRouter();
@@ -13,32 +17,35 @@ export default function InvoicePage() {
   const [invoiceData, setInvoiceData] = useState(null);
 
   useEffect(() => {
-    if (id) {
-      // Replace with API fetch in production
-      setInvoiceData({
-        id: id,
-        studentName: 'Ali Al-Omari',
-        classTitle: 'React & Next.js Bootcamp',
-        instructor: 'Ayman Khalid',
-        date: '2025-05-13',
-        paymentMethod: 'bank', // stripe | paypal | moyasar | bank
-        status: 'pending', // or 'paid'
-        price: 49,
-        discount: 10,
-        iban: 'SA442000000123456789',
-        bankName: 'Al Rajhi'
-      });
-    }
+    if (!id) return;
+    let active = true;
+    const load = async () => {
+      try {
+        const data = await fetchInvoiceByPaymentId(id);
+        if (active) setInvoiceData(data);
+      } catch (err) {
+        console.error('Failed to load invoice', err);
+      }
+    };
+    load();
+    return () => {
+      active = false;
+    };
   }, [id]);
 
   const downloadPDF = () => {
-    window.print();
+    if (invoiceData?.id) {
+      downloadInvoice(invoiceData.id);
+    }
   };
 
   if (!invoiceData) return <div className="text-white text-center mt-32">Loading Invoice...</div>;
 
-  const total = invoiceData.price - invoiceData.discount;
-  const isBank = invoiceData.paymentMethod === 'bank';
+  const subtotal = Number(invoiceData.price ?? invoiceData.amount ?? 0);
+  const discount = Number(invoiceData.discount ?? invoiceData.discount_amount ?? 0);
+  const total = invoiceData.total ?? subtotal - discount;
+  const method = (invoiceData.payment_method || invoiceData.paymentMethod || '').toLowerCase();
+  const isBank = method === 'bank';
 
   const handleReceiptUpload = async (e) => {
     const file = e.target.files?.[0];
@@ -63,21 +70,21 @@ export default function InvoicePage() {
           </div>
 
           <div className="mb-4 text-sm text-gray-300">
-            <p><strong>Student:</strong> {invoiceData.studentName}</p>
-            <p><strong>Class:</strong> {invoiceData.classTitle}</p>
-            <p><strong>Instructor:</strong> {invoiceData.instructor}</p>
-            <p><strong>Date:</strong> {invoiceData.date}</p>
-            <p><strong>Payment Method:</strong> {invoiceData.paymentMethod}</p>
+            <p><strong>Student:</strong> {invoiceData.studentName || invoiceData.student_name}</p>
+            <p><strong>Class:</strong> {invoiceData.classTitle || invoiceData.item_name}</p>
+            <p><strong>Instructor:</strong> {invoiceData.instructor || invoiceData.instructor_name}</p>
+            <p><strong>Date:</strong> {invoiceData.date || invoiceData.created_at}</p>
+            <p><strong>Payment Method:</strong> {method}</p>
           </div>
 
           <div className="my-6 border-t border-gray-700 pt-6">
             <div className="flex justify-between mb-2 text-gray-400">
               <span>Subtotal:</span>
-              <span>${invoiceData.price}</span>
+              <span>${subtotal}</span>
             </div>
             <div className="flex justify-between mb-2 text-gray-400">
               <span>Discount:</span>
-              <span className="text-red-400">-${invoiceData.discount}</span>
+              <span className="text-red-400">-${discount}</span>
             </div>
             <div className="flex justify-between font-semibold text-lg">
               <span>Total:</span>
@@ -88,8 +95,8 @@ export default function InvoicePage() {
           {isBank && (
             <div className="mt-8 bg-gray-900 p-4 rounded">
               <p className="mb-1 text-yellow-400 font-bold">Bank Transfer Details</p>
-              <p><strong>Bank:</strong> {invoiceData.bankName}</p>
-              <p><strong>IBAN:</strong> {invoiceData.iban}</p>
+              <p><strong>Bank:</strong> {invoiceData.bankName || invoiceData.bank_name}</p>
+              <p><strong>IBAN:</strong> {invoiceData.iban || invoiceData.bank_iban}</p>
               <p className="mt-2 text-sm text-gray-400">Send transfer proof to <strong>support@skillbridge.com</strong></p>
 
               <div className="mt-4">
@@ -103,9 +110,9 @@ export default function InvoicePage() {
             </div>
           )}
 
-          {['stripe', 'paypal', 'moyasar'].includes(invoiceData.paymentMethod) && (
+          {['stripe', 'paypal', 'moyasar'].includes(method) && (
             <div className="mt-10 text-sm text-gray-400">
-              <p>You will be redirected to complete your payment securely via <strong className="capitalize">{invoiceData.paymentMethod}</strong>.</p>
+              <p>You will be redirected to complete your payment securely via <strong className="capitalize">{method}</strong>.</p>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Fetch payment history from API instead of mock data
- Load real invoice details and download link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b79d362128832887fb2ecf4c4cb35d