### PR TITLE
feat: add transactional wallet decrement

### DIFF
--- a/backend/src/modules/payouts/payouts.controller.js
+++ b/backend/src/modules/payouts/payouts.controller.js
@@ -38,12 +38,14 @@ exports.updatePayout = catchAsync(async (req, res) => {
 
   const updateData = { ...req.body };
   if (req.body.status === "approved" && existing.status !== "approved") {
-    const wallet = await walletService.getByInstructor(existing.instructor_id);
-    const balance = wallet ? Number(wallet.balance) : 0;
-    if (balance < Number(existing.amount)) {
-      throw new AppError("Insufficient wallet balance", 400);
+    try {
+      await walletService.decrement(existing.instructor_id, existing.amount);
+    } catch (err) {
+      if (err.message === "Insufficient balance") {
+        throw new AppError("Insufficient wallet balance", 400);
+      }
+      throw err;
     }
-    await walletService.decrement(existing.instructor_id, existing.amount);
     updateData.processed_at = new Date();
   }
   const payout = await service.update(req.params.id, updateData);

--- a/backend/src/modules/payouts/wallet.service.js
+++ b/backend/src/modules/payouts/wallet.service.js
@@ -14,14 +14,25 @@ exports.increment = async (instructor_id, amount) => {
 };
 
 exports.decrement = async (instructor_id, amount) => {
-  const wallet = await exports.getByInstructor(instructor_id);
-  const balance = wallet ? Number(wallet.balance) : 0;
-  if (balance < Number(amount)) {
-    throw new Error("Insufficient balance");
-  }
-  const [row] = await db("instructor_wallets")
-    .where({ instructor_id })
-    .update({ balance: db.raw('?? - ?', ['balance', amount]), updated_at: db.fn.now() })
-    .returning("*");
-  return row;
+  return db.transaction(async (trx) => {
+    const wallet = await trx("instructor_wallets")
+      .where({ instructor_id })
+      .forUpdate()
+      .first();
+
+    const balance = wallet ? Number(wallet.balance) : 0;
+    if (balance < Number(amount)) {
+      throw new Error("Insufficient balance");
+    }
+
+    const [row] = await trx("instructor_wallets")
+      .where({ instructor_id })
+      .update({
+        balance: trx.raw('?? - ?', ['balance', amount]),
+        updated_at: trx.fn.now(),
+      })
+      .returning("*");
+
+    return row;
+  });
 };

--- a/backend/tests/paymentCommission.test.js
+++ b/backend/tests/paymentCommission.test.js
@@ -268,12 +268,12 @@ describe('wallet credit and debit', () => {
 
   it('rejects payout when balance insufficient', async () => {
     payoutService.getById.mockResolvedValue({ id: 'po2', instructor_id: 'inst1', amount: 80, status: 'pending' });
-    walletService.getByInstructor.mockResolvedValue({ balance: 50 });
+    walletService.decrement.mockImplementation(() => { throw new Error('Insufficient balance'); });
 
     const res = await request(app).patch('/api/payouts/po2').send({ status: 'approved' });
 
     expect(res.status).toBe(400);
-    expect(walletService.decrement).not.toHaveBeenCalled();
+    expect(walletService.decrement).toHaveBeenCalledWith('inst1', 80);
     expect(payoutService.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- ensure wallet decrements lock the row by running in a transaction and using `forUpdate`
- rely on transactional decrement in payout approval flow
- update paymentCommission test for new balance check logic

## Testing
- `npm test tests/paymentCommission.test.js` *(fails: Route.post() requires a callback function but got a [object Undefined])*

------
https://chatgpt.com/codex/tasks/task_e_68b7ef163dc483289d3d6b0634bff10d