### PR TITLE
feat: enforce class enrollment limits

### DIFF
--- a/backend/src/migrations/20250925000000_enforce_class_capacity.js
+++ b/backend/src/migrations/20250925000000_enforce_class_capacity.js
@@ -1,0 +1,42 @@
+exports.up = function (knex) {
+  return knex.schema.raw(`
+    CREATE OR REPLACE FUNCTION check_class_capacity() RETURNS TRIGGER AS $$
+    DECLARE
+      enrolled_count integer;
+      max_cap integer;
+    BEGIN
+      IF NEW.status = 'cancelled' THEN
+        RETURN NEW;
+      END IF;
+
+      SELECT COUNT(*) INTO enrolled_count
+      FROM class_enrollments
+      WHERE class_id = NEW.class_id AND status <> 'cancelled';
+
+      SELECT max_students INTO max_cap
+      FROM online_classes
+      WHERE id = NEW.class_id;
+
+      IF max_cap IS NOT NULL AND enrolled_count > max_cap THEN
+        RAISE EXCEPTION 'Class is full';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    CREATE CONSTRAINT TRIGGER class_capacity_check
+    AFTER INSERT OR UPDATE ON class_enrollments
+    DEFERRABLE INITIALLY IMMEDIATE
+    FOR EACH ROW
+    EXECUTE FUNCTION check_class_capacity();
+  `);
+};
+
+exports.down = function (knex) {
+  return knex.schema.raw(`
+    DROP TRIGGER IF EXISTS class_capacity_check ON class_enrollments;
+    DROP FUNCTION IF EXISTS check_class_capacity;
+  `);
+};
+

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -4,12 +4,15 @@ const express = require('express');
 jest.mock('../../../../config/database', () => {
   const db = jest.fn(() => db);
   db.where = jest.fn(() => db);
+  db.whereNot = jest.fn(() => db);
   db.first = jest.fn(() => Promise.resolve(null));
   db.join = jest.fn(() => db);
   db.leftJoin = jest.fn(() => db);
   db.select = jest.fn(() => db);
   db.insert = jest.fn(() => db);
   db.update = jest.fn(() => db);
+  db.forUpdate = jest.fn(() => db);
+  db.transaction = jest.fn(async (fn) => fn(db));
   return db;
 });
 
@@ -24,11 +27,6 @@ jest.mock('../classEnrollment.service', () => ({
   getStudent: jest.fn(),
 }));
 const service = require('../classEnrollment.service');
-
-jest.mock('../../class.service', () => ({
-  getClassById: jest.fn(),
-}));
-const classService = require('../../class.service');
 
 jest.mock('../../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
@@ -60,7 +58,7 @@ describe('Class enrollment routes', () => {
   });
 
   test('enroll in class', async () => {
-    classService.getClassById.mockResolvedValue({
+    db.first.mockResolvedValueOnce({
       status: 'published',
       moderation_status: 'Approved',
     });
@@ -73,7 +71,7 @@ describe('Class enrollment routes', () => {
   });
 
   test('reject enrollment if class not published', async () => {
-    classService.getClassById.mockResolvedValue({
+    db.first.mockResolvedValueOnce({
       status: 'draft',
       moderation_status: 'Approved',
     });
@@ -82,7 +80,7 @@ describe('Class enrollment routes', () => {
   });
 
   test('reject enrollment if class not approved', async () => {
-    classService.getClassById.mockResolvedValue({
+    db.first.mockResolvedValueOnce({
       status: 'published',
       moderation_status: 'Pending',
     });
@@ -91,7 +89,7 @@ describe('Class enrollment routes', () => {
   });
 
   test('reject enrollment if class full', async () => {
-    classService.getClassById.mockResolvedValue({
+    db.first.mockResolvedValueOnce({
       status: 'published',
       moderation_status: 'Approved',
       max_students: 1,
@@ -102,21 +100,22 @@ describe('Class enrollment routes', () => {
   });
 
   test('reject enrollment if class requires payment and user has not paid or subscribed', async () => {
-    classService.getClassById.mockResolvedValue({
-      status: 'published',
-      moderation_status: 'Approved',
-      price: 50,
-    });
+    db.first
+      .mockResolvedValueOnce({
+        status: 'published',
+        moderation_status: 'Approved',
+        price: 50,
+      })
+      .mockResolvedValueOnce(null); // payment check
     service.countEnrollments.mockResolvedValue(0);
     service.findEnrollment.mockResolvedValue(null);
-    db.first.mockResolvedValueOnce(null); // payment check
     getActiveStudentPlanId.mockResolvedValue(null);
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(400);
   });
 
   test('allow enrollment when class covered by subscription', async () => {
-    classService.getClassById.mockResolvedValue({
+    db.first.mockResolvedValueOnce({
       status: 'published',
       moderation_status: 'Approved',
       price: 50,
@@ -132,22 +131,23 @@ describe('Class enrollment routes', () => {
   });
 
   test('reject enrollment when subscription active but class not covered', async () => {
-    classService.getClassById.mockResolvedValue({
-      status: 'published',
-      moderation_status: 'Approved',
-      price: 50,
-      included_plans: ['plan2'],
-    });
+    db.first
+      .mockResolvedValueOnce({
+        status: 'published',
+        moderation_status: 'Approved',
+        price: 50,
+        included_plans: ['plan2'],
+      })
+      .mockResolvedValueOnce(null); // payment check
     service.countEnrollments.mockResolvedValue(0);
     service.findEnrollment.mockResolvedValue(null);
-    db.first.mockResolvedValueOnce(null); // payment check
     getActiveStudentPlanId.mockResolvedValue('plan1');
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(400);
   });
 
   test('reactivate cancelled enrollment when capacity available', async () => {
-    classService.getClassById.mockResolvedValue({
+    db.first.mockResolvedValueOnce({
       status: 'published',
       moderation_status: 'Approved',
       max_students: 1,
@@ -164,13 +164,14 @@ describe('Class enrollment routes', () => {
     expect(service.updateEnrollment).toHaveBeenCalledWith(
       'test-user',
       'abc',
-      expect.objectContaining({ status: 'enrolled' })
+      expect.objectContaining({ status: 'enrolled' }),
+      expect.anything()
     );
     expect(service.createEnrollment).not.toHaveBeenCalled();
   });
 
   test('prevent re-enrollment if class full after cancellation', async () => {
-    classService.getClassById.mockResolvedValue({
+    db.first.mockResolvedValueOnce({
       status: 'published',
       moderation_status: 'Approved',
       max_students: 1,

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -4,7 +4,6 @@ const catchAsync = require("../../../utils/catchAsync");
 const { sendSuccess } = require("../../../utils/response");
 const AppError = require("../../../utils/AppError");
 const service = require("./classEnrollment.service");
-const classService = require("../class.service");
 const db = require("../../../config/database");
 const paymentsService = require("../../payments/payments.service");
 const { getActiveStudentPlanId } = require("../../plans/subscription.helper");
@@ -12,55 +11,75 @@ const { getActiveStudentPlanId } = require("../../plans/subscription.helper");
 exports.enroll = catchAsync(async (req, res) => {
   const { classId } = req.params;
   const user_id = req.user.id;
-  const cls = await classService.getClassById(classId);
-  if (!cls) throw new AppError("Class not found", 404);
-  if (cls.status !== "published" || cls.moderation_status !== "Approved") {
-    throw new AppError("Class is not available for enrollment", 400);
-  }
-  if (typeof cls.max_students === "number" && cls.max_students !== null) {
-    const count = await service.countEnrollments(classId);
-    if (count >= cls.max_students) {
-      throw new AppError("Class is full", 400);
-    }
-  }
-  const exists = await service.findEnrollment(user_id, classId);
-  if (exists && exists.status !== "cancelled")
-    return sendSuccess(res, exists, "Already enrolled");
+  let result;
 
-  const activePlanId = await getActiveStudentPlanId(user_id);
-  const includedPlans = Array.isArray(cls.included_plans) ? cls.included_plans : [];
-  const coveredBySubscription =
-    activePlanId && includedPlans.includes(activePlanId);
-
-  if (Number(cls.price) > 0 && !coveredBySubscription) {
-    const payment = await db("payments")
-      .where({
-        user_id,
-        item_id: classId,
-        item_type: "class",
-        status: paymentsService.STATUS.PAID,
-      })
+  await db.transaction(async (trx) => {
+    const cls = await trx("online_classes")
+      .where({ id: classId })
+      .forUpdate()
       .first();
-    if (!payment) {
-      throw new AppError("Payment required", 400);
+    if (!cls) throw new AppError("Class not found", 404);
+    if (cls.status !== "published" || cls.moderation_status !== "Approved") {
+      throw new AppError("Class is not available for enrollment", 400);
     }
-  }
-  if (exists && exists.status === "cancelled") {
-    const enrolled_at = new Date();
-    await service.updateEnrollment(user_id, classId, {
-      status: "enrolled",
-      enrolled_at,
-    });
-    return sendSuccess(
-      res,
-      { ...exists, status: "enrolled", enrolled_at },
-      "Enrolled successfully"
-    );
-  }
+    if (typeof cls.max_students === "number" && cls.max_students !== null) {
+      const count = await service.countEnrollments(classId, trx);
+      if (count >= cls.max_students) {
+        throw new AppError("Class is full", 400);
+      }
+    }
 
-  const data = { id: uuidv4(), user_id, class_id: classId, status: "enrolled" };
-  await service.createEnrollment(data);
-  sendSuccess(res, data, "Enrolled successfully");
+    const exists = await service.findEnrollment(user_id, classId, trx);
+    if (exists && exists.status !== "cancelled") {
+      result = { data: exists, message: "Already enrolled" };
+      return;
+    }
+
+    const activePlanId = await getActiveStudentPlanId(user_id);
+    const includedPlans = Array.isArray(cls.included_plans) ? cls.included_plans : [];
+    const coveredBySubscription =
+      activePlanId && includedPlans.includes(activePlanId);
+
+    if (Number(cls.price) > 0 && !coveredBySubscription) {
+      const payment = await trx("payments")
+        .where({
+          user_id,
+          item_id: classId,
+          item_type: "class",
+          status: paymentsService.STATUS.PAID,
+        })
+        .first();
+      if (!payment) {
+        throw new AppError("Payment required", 400);
+      }
+    }
+
+    if (exists && exists.status === "cancelled") {
+      const enrolled_at = new Date();
+      await service.updateEnrollment(
+        user_id,
+        classId,
+        { status: "enrolled", enrolled_at },
+        trx,
+      );
+      result = {
+        data: { ...exists, status: "enrolled", enrolled_at },
+        message: "Enrolled successfully",
+      };
+      return;
+    }
+
+    const data = {
+      id: uuidv4(),
+      user_id,
+      class_id: classId,
+      status: "enrolled",
+    };
+    await service.createEnrollment(data, trx);
+    result = { data, message: "Enrolled successfully" };
+  });
+
+  sendSuccess(res, result.data, result.message);
 });
 
 exports.complete = catchAsync(async (req, res) => {
@@ -84,3 +103,4 @@ exports.getStudent = catchAsync(async (req, res) => {
   const data = await service.getStudent(classId, studentId);
   sendSuccess(res, data);
 });
+

--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -1,24 +1,30 @@
 const db = require("../../../config/database");
 
-exports.findEnrollment = async (user_id, class_id) => {
-  return db("class_enrollments").where({ user_id, class_id }).first();
+// Helper to use either the provided transaction or the default knex instance
+const useDb = (trx) => trx || db;
+
+exports.findEnrollment = async (user_id, class_id, trx = null) => {
+  const query = useDb(trx)("class_enrollments").where({ user_id, class_id });
+  if (trx && trx.isTransaction) query.forUpdate();
+  return query.first();
 };
 
-exports.createEnrollment = async (data) => {
-  const [row] = await db("class_enrollments").insert(data).returning("*");
+exports.createEnrollment = async (data, trx = null) => {
+  const [row] = await useDb(trx)("class_enrollments").insert(data).returning("*");
   return row;
 };
 
-exports.updateEnrollment = async (user_id, class_id, data) => {
-  return db("class_enrollments").where({ user_id, class_id }).update(data);
+exports.updateEnrollment = async (user_id, class_id, data, trx = null) => {
+  return useDb(trx)("class_enrollments").where({ user_id, class_id }).update(data);
 };
 
-exports.countEnrollments = async (class_id) => {
-  const [row] = await db("class_enrollments")
+exports.countEnrollments = async (class_id, trx = null) => {
+  const query = useDb(trx)("class_enrollments")
     .where({ class_id })
-    .whereNot({ status: "cancelled" })
-    .count("id as count");
-  return parseInt(row.count, 10) || 0;
+    .whereNot({ status: "cancelled" });
+  if (trx && trx.isTransaction) query.forUpdate();
+  const rows = await query.select("id");
+  return rows.length;
 };
 
 exports.markCompleted = async (user_id, class_id) => {


### PR DESCRIPTION
## Summary
- add transactional locking for class enrollment operations
- ensure enrollment services work within transactions
- add constraint trigger to prevent exceeding class capacity

## Testing
- `npm test src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js`
- `npm test` *(fails: process.exit called due to missing database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ef12b8348328aa096dfc8c28e8b8