### PR TITLE
Require explicit flag before running database seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
 curl -s https://example.com/install.sh | bash
 ```
 
-The script checks prerequisites, copies example env files, builds containers and seeds the database for development setups.
+The script checks prerequisites, copies example env files, builds containers and can seed the database for development setups when `SEED_DB=true`.
 
 
 Alternatively, launch the backend and open [`/install`](http://localhost:5002/install) to use a simple web-based installer that checks prerequisites and runs the setup scripts after entering configuration values.

--- a/backend/src/scripts/seedDatabase.js
+++ b/backend/src/scripts/seedDatabase.js
@@ -2,12 +2,13 @@ const knex = require('knex');
 const knexConfig = require('../../knexfile');
 
 const environment = process.env.NODE_ENV || 'development';
+const seedEnabled = process.env.SEED_DB === 'true';
 
 async function seedDatabase() {
   const db = knex(knexConfig[environment]);
   try {
     await db.migrate.latest();
-    if (environment !== 'production') {
+    if (environment !== 'production' && seedEnabled) {
       await db.seed.run();
       console.log('Database migrated and seeded successfully');
     } else {

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -14,13 +14,13 @@ fi
 if [ -n "$($DOCKER_COMPOSE ps -q backend 2>/dev/null)" ]; then
   echo "Running migrations inside backend container..."
   $DOCKER_COMPOSE exec backend npx knex migrate:latest --knexfile knexfile.js
-  if [ "$NODE_ENV" != "production" ]; then
+  if [ "$NODE_ENV" != "production" ] && [ "$SEED_DB" = "true" ]; then
     $DOCKER_COMPOSE exec backend npx knex seed:run --knexfile knexfile.js
   fi
 else
   echo "Running migrations locally..."
   npx knex migrate:latest --knexfile backend/knexfile.js
-  if [ "$NODE_ENV" != "production" ]; then
+  if [ "$NODE_ENV" != "production" ] && [ "$SEED_DB" = "true" ]; then
     npx knex seed:run --knexfile backend/knexfile.js
   fi
 fi


### PR DESCRIPTION
## Summary
- prevent accidental reseeding by requiring `SEED_DB=true` before executing seed scripts
- document optional seeding in install script

## Testing
- `npm --prefix backend test src/modules/classes/assignments/__tests__/classAssignment.routes.test.js` *(fails: Cannot find module 'sanitize-filename')*

------
https://chatgpt.com/codex/tasks/task_e_68b80925ef6483288105f575e8cb7a80