### PR TITLE
feat: add payment step to book checkout

### DIFF
--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -23,6 +23,8 @@ jest.mock('../../../config/database', () => mockDb);
 
 const db = require('../../../config/database');
 const { listBooks, checkout, updateBook } = require('../book.service');
+const paymentsService = require('../../payments/payments.service');
+const { grantAccess } = require('../../payments/paymentAccess');
 
 beforeAll(async () => {
   await db.schema.createTable('books', (table) => {
@@ -54,6 +56,34 @@ beforeAll(async () => {
     table.integer('book_id');
     table.decimal('price_paid').notNullable().defaultTo(0);
     table.timestamp('purchased_at');
+  });
+
+  await db.schema.createTable('payment_methods_config', (table) => {
+    table.uuid('id');
+    table.string('type');
+    table.boolean('active');
+    table.string('name');
+    table.json('settings');
+  });
+  await db('payment_methods_config').insert({
+    id: 'bank1',
+    type: 'bank',
+    active: 1,
+    name: 'Bank',
+  });
+
+  await db.schema.createTable('payments', (table) => {
+    table.uuid('id').primary();
+    table.uuid('user_id');
+    table.uuid('method_id');
+    table.string('item_type');
+    table.integer('item_id');
+    table.decimal('amount', 10, 2);
+    table.string('currency');
+    table.string('status');
+    table.decimal('platform_fee', 10, 2).defaultTo(0);
+    table.decimal('instructor_amount', 10, 2).defaultTo(0);
+    table.timestamp('paid_at');
   });
 
   const books = [
@@ -131,6 +161,7 @@ describe('checkout', () => {
   beforeEach(async () => {
     await db('book_cart').del();
     await db('book_purchases').del();
+    await db('payments').del();
   });
 
   test('throws error when book already purchased', async () => {
@@ -145,19 +176,36 @@ describe('checkout', () => {
 
     const purchases = await db('book_purchases').where({ student_id: studentId });
     expect(purchases).toHaveLength(1);
+    const payments = await db('payments');
+    expect(payments).toHaveLength(0);
   });
 
   test('completes checkout when no duplicates', async () => {
     await db('book_cart').insert({ student_id: studentId, book_id: 2 });
-    const purchases = await checkout(studentId);
-    expect(purchases).toHaveLength(1);
-    const inDb = await db('book_purchases').where({
+    const payments = await checkout(studentId);
+    expect(payments).toHaveLength(1);
+    const payInDb = await db('payments').where({
+      user_id: studentId,
+      item_id: 2,
+      item_type: 'book',
+    });
+    expect(payInDb).toHaveLength(1);
+    const cart = await db('book_cart').where({ student_id: studentId });
+    expect(cart).toHaveLength(0);
+    const purchases = await db('book_purchases').where({ student_id: studentId });
+    expect(purchases).toHaveLength(0);
+
+    const approved = await paymentsService.approveBankPayment(payments[0].id, {
+      amount: 15,
+      item_id: 2,
+      item_type: 'book',
+    });
+    await grantAccess(approved);
+    const after = await db('book_purchases').where({
       student_id: studentId,
       book_id: 2,
     });
-    expect(inDb).toHaveLength(1);
-    const cart = await db('book_cart').where({ student_id: studentId });
-    expect(cart).toHaveLength(0);
+    expect(after).toHaveLength(1);
   });
 
   test('throws error when book is inactive', async () => {
@@ -178,6 +226,8 @@ describe('checkout', () => {
     expect(cart).toHaveLength(1);
     const purchases = await db('book_purchases').where({ student_id: studentId });
     expect(purchases).toHaveLength(0);
+    const payments = await db('payments');
+    expect(payments).toHaveLength(0);
   });
 
   test('throws error when book ID is missing', async () => {
@@ -187,6 +237,8 @@ describe('checkout', () => {
     expect(cart).toHaveLength(1);
     const purchases = await db('book_purchases').where({ student_id: studentId });
     expect(purchases).toHaveLength(0);
+    const payments = await db('payments');
+    expect(payments).toHaveLength(0);
   });
 });
 

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -5,6 +5,15 @@ const path = require("path");
 const tagService = require("./bookTag.service");
 const slugify = require("slugify");
 const AppError = require("../../utils/AppError");
+const paymentsService = require("../payments/payments.service");
+const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
+const paymentConfigService = require("../paymentConfig/paymentConfig.service");
+const libraryService = require("../library/library.service");
+const { v4: uuidv4 } = require("uuid");
+
+const { STATUS: PAYMENT_STATUS } = paymentsService;
+
+const DEFAULT_PLATFORM_CUT = { book: 10 };
 
 exports.createBook = async (data) => {
   const [row] = await db("books").insert(data).returning("*");
@@ -254,6 +263,9 @@ exports.removeFromCart = (studentId, bookId) =>
   db('book_cart').where({ student_id: studentId, book_id: bookId }).del();
 
 exports.checkout = async (studentId) => {
+  const bankMethod = await paymentMethodsService.getByType('bank');
+  if (!bankMethod) throw new AppError('Bank payment method not configured', 400);
+
   return db.transaction(async (trx) => {
     const items = await trx('book_cart')
       .where({ student_id: studentId })
@@ -282,19 +294,49 @@ exports.checkout = async (studentId) => {
       throw new AppError(`Book inactive or not found: ${missing.join(', ')}`, 404);
     }
 
-    const rows = books.map((b) => ({
-      student_id: studentId,
-      book_id: b.id,
-      price_paid: b.price,
-    }));
-    const purchases = await trx('book_purchases')
-      .insert(rows)
-      .returning('*');
+    let settings = null;
+    try {
+      settings = await paymentConfigService.getSettings();
+    } catch (err) {
+      settings = null;
+    }
+
+    const payments = [];
+    for (const b of books) {
+      let platform_fee = 0;
+      let instructor_amount = Number(b.price);
+      try {
+        const cut =
+          settings?.platformCut?.book ?? DEFAULT_PLATFORM_CUT.book;
+        platform_fee = (Number(b.price) * cut) / 100;
+        instructor_amount = Number(b.price) - platform_fee;
+      } catch (_) {}
+
+      const paymentData = {
+        id: uuidv4(),
+        user_id: studentId,
+        method_id: bankMethod.id,
+        item_type: 'book',
+        item_id: b.id,
+        amount: b.price,
+        status: PAYMENT_STATUS.AWAITING_APPROVAL,
+        platform_fee,
+        instructor_amount,
+      };
+
+      const payment = await paymentsService.create(paymentData);
+      if (payment.status === PAYMENT_STATUS.PAID) {
+        await libraryService.recordPurchase(studentId, b.id, b.price);
+      }
+      payments.push(payment);
+    }
+
     await trx('book_cart')
       .where({ student_id: studentId })
       .whereIn('book_id', bookIds)
       .del();
-    return purchases;
+
+    return payments;
   });
 };
 


### PR DESCRIPTION
## Summary
- create bank transfer payments before recording book purchases
- finalize book purchase only after payment approval
- test book checkout flow for payment approval before purchase

## Testing
- `npm test` *(fails: Route.post() requires a callback function; process.exit(1))*

------
https://chatgpt.com/codex/tasks/task_e_68b89eef9c3c8328a5b688228567ead1