### PR TITLE
Fix missing payment methods service import

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -14,6 +14,7 @@ const couponService = require("../coupons/coupons.service");
 const plansService = require("../plans/plans.service");
 const subscriptionService = require("../subscriptions/subscription.service");
 const invoiceService = require("../invoices/invoices.service");
+const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const { validatePaymentData } = require("./helpers/validation");
 const { calculatePlatformFee } = require("./helpers/platformFee");
 const { creditInstructorWallet } = require("./helpers/wallet");


### PR DESCRIPTION
## Summary
- add paymentMethodsService require to payments controller

## Testing
- `npm test` *(fails: paymentInvoiceEmail.test.js, paymentCommission.test.js, tutorialCreate.test.js, tutorialRoutes.test.js, messageRoutes.test.js, bookRoutes.test.js, tutorialEnrollmentRoutes.test.js, paymentDuplicateEnrollment.test.js, tutorialUpdateTransaction.test.js, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b89eec80a8832893623d3b8055fd71