### PR TITLE
Enforce instructor plan limits

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -359,6 +359,11 @@
   - `max_courses` – sets how many courses an instructor may publish before needing to upgrade
   - `ad_credits` – promotional credits instructors can spend to boost class visibility
 
+**Instructor Feature Validation Map**
+
+- `max_courses` → validated when instructors create or publish classes
+- `ad_credits` → validated when instructors create ads
+
 ### `plan_features`
 - **Purpose**: Matrix of toggles/limits
 - **Primary Key**: `id`

--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -15,9 +15,11 @@ jest.mock('../class.service', () => ({
   getAllClasses: jest.fn(),
   getClassesByInstructor: jest.fn(),
   getPublishedClasses: jest.fn(),
+  getClassById: jest.fn(),
   updateClass: jest.fn(),
   togglePublishStatus: jest.fn(),
-  updateModeration: jest.fn()
+  updateModeration: jest.fn(),
+  countPublishedClasses: jest.fn(),
 }));
 const service = require('../class.service');
 jest.mock('../../notifications/notifications.service', () => ({
@@ -48,7 +50,7 @@ jest.mock('../../../middleware/validate', () => () => (req, _res, next) => next(
 // Mock auth middleware to bypass authentication
 jest.mock('../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
-    req.user = { id: 'test-user' };
+    req.user = { id: 'test-user', role: 'instructor' };
     next();
   },
   isStudent: (_req, _res, next) => next(),
@@ -58,14 +60,24 @@ jest.mock('../../../middleware/auth/authMiddleware', () => ({
 }));
 
 const routes = require('../class.routes');
+jest.mock('../../plans/instructor.helper', () => ({
+  getActiveInstructorPlan: jest.fn(),
+}));
+const { getActiveInstructorPlan } = require('../../plans/instructor.helper');
 
 const app = express();
 app.use(express.json());
 app.use('/classes', routes);
+app.use((err, _req, res, _next) => {
+  res.status(err.statusCode || 500).json({ message: err.message });
+});
 
 describe('Class routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getActiveInstructorPlan.mockResolvedValue({ id: 'plan1', max_courses: 10 });
+    service.countPublishedClasses.mockResolvedValue(0);
+    service.getClassById.mockResolvedValue({ id: '1', status: 'draft', instructor_id: 'test-user', title: 'Old' });
   });
 
   test.skip('create class', async () => {
@@ -167,7 +179,7 @@ describe('Class routes', () => {
     expect(res.body.data).toEqual(approved);
   });
 
-  test('instructor can create class without plan', async () => {
+  test('instructor can create class within plan limit', async () => {
     const data = { id: '1', instructor_id: 'test-user', title: 'Test Class' };
     service.createClass.mockResolvedValue(data);
     const res = await request(app).post('/classes/instructor').send(data);
@@ -184,11 +196,20 @@ describe('Class routes', () => {
     expect(service.updateClass).toHaveBeenCalledWith('1', expect.any(Object));
   });
 
-  test('instructor can publish class without plan', async () => {
+  test('instructor can publish class within plan limit', async () => {
     const updated = { id: '1', status: 'published', moderation_status: 'Pending' };
     service.togglePublishStatus.mockResolvedValue(updated);
     const res = await request(app).patch('/classes/instructor/1/status');
     expect(res.statusCode).toBe(200);
     expect(service.togglePublishStatus).toHaveBeenCalledWith('1');
+  });
+
+  test('blocks class creation when over plan limit', async () => {
+    getActiveInstructorPlan.mockResolvedValue({ id: 'plan1', max_courses: 1 });
+    service.countPublishedClasses.mockResolvedValue(1);
+    const data = { id: '1', instructor_id: 'test-user', title: 'Test Class', status: 'published' };
+    const res = await request(app).post('/classes/instructor').send(data);
+    expect(res.statusCode).toBe(403);
+    expect(service.createClass).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -7,6 +7,8 @@ const tagService = require("./classTag.service");
 const notificationService = require("../notifications/notifications.service");
 const messageService = require("../messages/messages.service");
 const userModel = require("../users/user.model");
+const { getActiveInstructorPlan } = require("../plans/instructor.helper");
+const AppError = require("../../utils/AppError");
 
 const slugify = require("slugify");
 const db = require("../../config/database");
@@ -46,6 +48,16 @@ exports.createClass = catchAsync(async (req, res) => {
   }
   if (req.user?.role === "instructor") {
     data.instructor_id = req.user.id;
+    const plan = await getActiveInstructorPlan(req.user.id);
+    if (!plan) {
+      throw new AppError("Active plan required", 403);
+    }
+    if (data.status === "published" && plan.max_courses) {
+      const count = await service.countPublishedClasses(req.user.id);
+      if (count >= plan.max_courses) {
+        throw new AppError("Course limit reached for your plan", 403);
+      }
+    }
   }
   if (req.files?.cover_image?.[0]) {
     data.cover_image = `/uploads/classes/${req.files.cover_image[0].filename}`;
@@ -324,6 +336,20 @@ exports.getClassAnalytics = catchAsync(async (req, res) => {
 });
 
 exports.toggleClassStatus = catchAsync(async (req, res) => {
+  const existing = await service.getClassById(req.params.id);
+  if (!existing) throw new AppError("Class not found", 404);
+  if (existing.status !== "published") {
+    const plan = await getActiveInstructorPlan(existing.instructor_id);
+    if (!plan) {
+      throw new AppError("Active plan required", 403);
+    }
+    if (plan.max_courses) {
+      const count = await service.countPublishedClasses(existing.instructor_id);
+      if (count >= plan.max_courses) {
+        throw new AppError("Course limit reached for your plan", 403);
+      }
+    }
+  }
   const cls = await service.togglePublishStatus(req.params.id);
   if (
     req.user.role !== "instructor" &&

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -6,6 +6,14 @@ exports.createClass = async (data) => {
   return ClassModel.create(data);
 };
 
+exports.countPublishedClasses = async (instructorId) => {
+  const row = await db("online_classes")
+    .where({ instructor_id: instructorId, status: "published" })
+    .count("id as count")
+    .first();
+  return parseInt(row.count, 10) || 0;
+};
+
 exports.getAllClasses = async ({ page = 1, limit = 10 } = {}) => {
   const { page: pg, limit: lim, offset } = parsePagination({ page, limit });
   const totalRow = await db("online_classes").count("id as count").first();

--- a/backend/src/modules/plans/__tests__/instructor.helper.test.js
+++ b/backend/src/modules/plans/__tests__/instructor.helper.test.js
@@ -1,0 +1,32 @@
+jest.mock('../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.join = jest.fn(() => db);
+  db.select = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn();
+  return db;
+});
+
+const db = require('../../../config/database');
+const { getActiveInstructorPlan } = require('../instructor.helper');
+
+describe('getActiveInstructorPlan', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns plan for active instructor subscription', async () => {
+    db.first.mockResolvedValue({ id: 'plan1', max_courses: 5 });
+    const plan = await getActiveInstructorPlan('user1');
+    expect(plan).toEqual({ id: 'plan1', max_courses: 5 });
+    expect(db.join).toHaveBeenCalledWith('plans as p', 'us.plan_id', 'p.id');
+    expect(db.where).toHaveBeenCalledWith('p.target_role', 'instructor');
+  });
+
+  it('returns null when no active subscription', async () => {
+    db.first.mockResolvedValue(null);
+    const plan = await getActiveInstructorPlan('user1');
+    expect(plan).toBeNull();
+  });
+});
+

--- a/backend/src/modules/plans/instructor.helper.js
+++ b/backend/src/modules/plans/instructor.helper.js
@@ -1,0 +1,23 @@
+const db = require("../../config/database");
+
+// Map of instructor-only plan features and where they are enforced
+// max_courses -> enforced on class creation/publishing
+// ad_credits  -> enforced on ad creation
+exports.INSTRUCTOR_FEATURE_VALIDATIONS = {
+  max_courses: "classes",
+  ad_credits: "ads",
+};
+
+// Fetch the active plan for an instructor, if any
+exports.getActiveInstructorPlan = async (userId) => {
+  const sub = await db("user_subscriptions as us")
+    .join("plans as p", "us.plan_id", "p.id")
+    .select("p.*", "us.end_date")
+    .where({ "us.user_id": userId, "us.status": "active" })
+    .where("p.target_role", "instructor")
+    .first();
+  if (!sub) return null;
+  if (sub.end_date && new Date(sub.end_date) < new Date()) return null;
+  return sub;
+};
+


### PR DESCRIPTION
## Summary
- add instructor plan helper with feature mapping
- enforce `max_courses` limit when creating or publishing classes
- document instructor plan validations and add coverage tests

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*

------
https://chatgpt.com/codex/tasks/task_e_68b89edce1308328a0bad246f3ad026e