### PR TITLE
feat: add instructor subscription helpers

### DIFF
--- a/backend/src/modules/plans/__tests__/subscription.helper.test.js
+++ b/backend/src/modules/plans/__tests__/subscription.helper.test.js
@@ -7,7 +7,11 @@ jest.mock('../../../config/database', () => {
 });
 
 const db = require('../../../config/database');
-const { hasActiveStudentSubscription } = require('../subscription.helper');
+const {
+  hasActiveStudentSubscription,
+  hasActiveInstructorSubscription,
+  getActiveInstructorPlanId,
+} = require('../subscription.helper');
 
 describe('hasActiveStudentSubscription', () => {
   beforeEach(() => {
@@ -26,5 +30,48 @@ describe('hasActiveStudentSubscription', () => {
     db.first.mockResolvedValue(null);
     const result = await hasActiveStudentSubscription('user1');
     expect(result).toBe(false);
+  });
+});
+
+describe('hasActiveInstructorSubscription', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true for active instructor subscription', async () => {
+    db.first.mockResolvedValue({ end_date: new Date(Date.now() + 86400000) });
+    const result = await hasActiveInstructorSubscription('user1');
+    expect(result).toBe(true);
+    expect(db.join).toHaveBeenCalledWith('plans as p', 'us.plan_id', 'p.id');
+    expect(db.where).toHaveBeenCalledWith('p.target_role', 'instructor');
+  });
+
+  it('returns false when no active instructor subscription', async () => {
+    db.first.mockResolvedValue(null);
+    const result = await hasActiveInstructorSubscription('user1');
+    expect(result).toBe(false);
+  });
+});
+
+describe('getActiveInstructorPlanId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns plan id for active instructor subscription', async () => {
+    db.first.mockResolvedValue({
+      end_date: new Date(Date.now() + 86400000),
+      plan_id: 'plan1',
+    });
+    const result = await getActiveInstructorPlanId('user1');
+    expect(result).toBe('plan1');
+    expect(db.join).toHaveBeenCalledWith('plans as p', 'us.plan_id', 'p.id');
+    expect(db.where).toHaveBeenCalledWith('p.target_role', 'instructor');
+  });
+
+  it('returns null when no active instructor subscription', async () => {
+    db.first.mockResolvedValue(null);
+    const result = await getActiveInstructorPlanId('user1');
+    expect(result).toBeNull();
   });
 });

--- a/backend/src/modules/plans/subscription.helper.js
+++ b/backend/src/modules/plans/subscription.helper.js
@@ -22,3 +22,25 @@ exports.getActiveStudentPlanId = async (userId) => {
   return sub.plan_id;
 };
 
+exports.hasActiveInstructorSubscription = async (userId) => {
+  const sub = await db("user_subscriptions as us")
+    .join("plans as p", "us.plan_id", "p.id")
+    .where({ "us.user_id": userId, "us.status": "active" })
+    .where("p.target_role", "instructor")
+    .first();
+  if (!sub) return false;
+  if (sub.end_date && new Date(sub.end_date) < new Date()) return false;
+  return true;
+};
+
+exports.getActiveInstructorPlanId = async (userId) => {
+  const sub = await db("user_subscriptions as us")
+    .join("plans as p", "us.plan_id", "p.id")
+    .where({ "us.user_id": userId, "us.status": "active" })
+    .where("p.target_role", "instructor")
+    .first();
+  if (!sub) return null;
+  if (sub.end_date && new Date(sub.end_date) < new Date()) return null;
+  return sub.plan_id;
+};
+


### PR DESCRIPTION
## Summary
- add helpers for checking instructor subscriptions
- add tests for instructor subscription helpers

## Testing
- `cd backend && npm test` *(fails: process.exit called due to missing database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b89edadeb8832899177fc20d90c2ef