### PR TITLE
feat: add role-aware subscription store

### DIFF
--- a/frontend/src/pages/dashboard/student/settings/index.js
+++ b/frontend/src/pages/dashboard/student/settings/index.js
@@ -32,14 +32,14 @@ export default function StudentSettingsPage() {
   };
 
   useEffect(() => {
-    fetchSubscription();
+    fetchSubscription("student");
     loadInvoices();
   }, [fetchSubscription]);
 
   const handleUpgrade = async () => {
     try {
       await api.post("/user-subscriptions/upgrade");
-      await fetchSubscription();
+      await fetchSubscription("student");
     } catch (err) {
       console.error("Upgrade failed", err);
     }
@@ -48,7 +48,7 @@ export default function StudentSettingsPage() {
   const handleCancel = async () => {
     try {
       await api.post("/user-subscriptions/cancel");
-      await fetchSubscription();
+      await fetchSubscription("student");
     } catch (err) {
       console.error("Cancel failed", err);
     }

--- a/frontend/src/services/student/subscriptionService.js
+++ b/frontend/src/services/student/subscriptionService.js
@@ -1,0 +1,18 @@
+import api from "@/services/api/api";
+
+export const subscribeToPlan = async (
+  planId,
+  interval = "monthly",
+  paymentId
+) => {
+  const payload = { plan_id: planId, interval };
+  if (paymentId) payload.payment_id = paymentId;
+  const { data } = await api.post("/user-subscriptions", payload);
+  return { subscription: data?.data ?? null, message: data?.message };
+};
+
+export const fetchMySubscription = async () => {
+  const { data } = await api.get("/user-subscriptions/me");
+  return data?.data ?? null;
+};
+

--- a/frontend/src/store/subscriptionStore.js
+++ b/frontend/src/store/subscriptionStore.js
@@ -1,16 +1,24 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { fetchMySubscription } from "@/services/instructor/subscriptionService";
+import { fetchMySubscription as fetchInstructorSubscription } from "@/services/instructor/subscriptionService";
+import { fetchMySubscription as fetchStudentSubscription } from "@/services/student/subscriptionService";
+import useAuthStore from "@/store/auth/authStore";
 
 const useSubscriptionStore = create(
   persist(
     (set) => ({
       plan: null,
       loading: false,
-      async fetch() {
+      async fetch(role) {
         set({ loading: true });
         try {
-          const sub = await fetchMySubscription();
+          const userRole =
+            (role || useAuthStore.getState().user?.role || "")?.toLowerCase();
+          const service =
+            userRole === "student"
+              ? fetchStudentSubscription
+              : fetchInstructorSubscription;
+          const sub = await service();
           set({ plan: sub || null, loading: false });
         } catch (err) {
           set({ plan: null, loading: false });


### PR DESCRIPTION
## Summary
- add student subscription service for user-subscription endpoints
- switch subscription store to pick service based on user role
- ensure student dashboard settings fetches subscriptions using student role

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89edad37083289798690a4328e192