### PR TITLE
feat: filter subscriptions by role

### DIFF
--- a/backend/src/modules/subscriptions/subscription.service.js
+++ b/backend/src/modules/subscriptions/subscription.service.js
@@ -37,12 +37,16 @@ exports.createOrRenewSubscription = async ({ user_id, plan_id, interval }) => {
   });
 };
 
-exports.getActiveByUser = (user_id) => {
+exports.getActiveByUser = (user_id, role) => {
   const now = new Date();
-  return db("user_subscriptions as us")
+  const query = db("user_subscriptions as us")
     .join("plans as p", "us.plan_id", "p.id")
     .select("us.*", "p.name", "p.slug")
     .where("us.user_id", user_id)
     .andWhere("us.status", "active")
     .andWhere("us.end_date", ">", now);
+
+  if (role) query.where("p.target_role", role);
+
+  return query;
 };

--- a/backend/src/modules/subscriptions/subscriptions.controller.js
+++ b/backend/src/modules/subscriptions/subscriptions.controller.js
@@ -5,7 +5,8 @@ const service = require("./subscription.service");
 const paymentsService = require("../payments/payments.service");
 
 exports.getMySubscriptions = catchAsync(async (req, res) => {
-  const subs = await service.getActiveByUser(req.user.id);
+  const role = req.query.role || req.user.role;
+  const subs = await service.getActiveByUser(req.user.id, role);
   sendSuccess(res, subs);
 });
 

--- a/backend/tests/subscriptionRoutes.test.js
+++ b/backend/tests/subscriptionRoutes.test.js
@@ -28,10 +28,10 @@ describe('GET /api/user-subscriptions/me', () => {
     const mock = [{ id: 's1', plan_id: 'p1' }];
     service.getActiveByUser.mockResolvedValue(mock);
 
-    const res = await request(app).get('/api/user-subscriptions/me');
+    const res = await request(app).get('/api/user-subscriptions/me?role=instructor');
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual(mock);
-    expect(service.getActiveByUser).toHaveBeenCalledWith('user1');
+    expect(service.getActiveByUser).toHaveBeenCalledWith('user1', 'instructor');
   });
 });
 


### PR DESCRIPTION
## Summary
- allow querying subscriptions by user role
- propagate role filter into subscription service
- update route test to pass role parameter

## Testing
- `npm test` *(fails: paymentInvoiceEmail.test.js, paymentCommission.test.js, tutorialCreate.test.js, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b89eda68548328ad88e15fba854525