### PR TITLE
fix: wrap checkout form with stripe elements

### DIFF
--- a/frontend/src/pages/checkout/index.js
+++ b/frontend/src/pages/checkout/index.js
@@ -1,0 +1,13 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function CheckoutRedirect() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/payments/checkout' + window.location.search);
+  }, [router]);
+
+  return <p>Redirecting…</p>;
+}
+

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -18,6 +18,8 @@ import PayPalForm from '@/components/payments/forms/PayPalForm';
 import BankTransferForm from '@/components/payments/forms/BankTransferForm';
 import CryptoPaymentForm from '@/components/payments/forms/CryptoPaymentForm';
 import CardPaymentForm from '@/components/payments/forms/CardPaymentForm';
+import { Elements } from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
 import {
   FaCcStripe, FaPaypal, FaMoneyCheckAlt, FaUniversity,
   FaEthereum, FaFileInvoice, FaDownload, FaCheckCircle
@@ -25,8 +27,10 @@ import {
 import { useTranslation } from 'next-i18next';
 import { parseCheckoutItems } from '@/utils/parseCheckoutItems';
 
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY);
+
 const iconMap = {
-  stripe: <FaCcStripe />,
+  stripe: <FaCcStripe />, 
   paypal: <FaPaypal />,
   moyasar: <FaMoneyCheckAlt />,
   paystack: <FaMoneyCheckAlt />,
@@ -695,15 +699,17 @@ export default function CheckoutPage() {
               finalPrice={finalPrice}
             />
           ) : (
-            <CardPaymentForm
-              onSubmit={handlePayment}
-              processing={paymentStatus === 'processing'}
-              allowInstallments={allowInstallments}
-              installments={installments}
-              perInstallment={perInstallment}
-              finalPrice={finalPrice}
-              selectedMethodLabel={selectedMethodLabel}
-            />
+            <Elements stripe={stripePromise}>
+              <CardPaymentForm
+                onSubmit={handlePayment}
+                processing={paymentStatus === 'processing'}
+                allowInstallments={allowInstallments}
+                installments={installments}
+                perInstallment={perInstallment}
+                finalPrice={finalPrice}
+                selectedMethodLabel={selectedMethodLabel}
+              />
+            </Elements>
           )}
         </div>
       </main>

--- a/frontend/src/tests/setupTests.js
+++ b/frontend/src/tests/setupTests.js
@@ -7,8 +7,13 @@ jest.mock('@stripe/react-stripe-js', () => {
     CardElement: (props) => React.createElement('div', { 'data-testid': 'card-element', ...props }),
     useStripe: () => ({ createToken: mockCreateToken }),
     useElements: () => ({ getElement: () => ({}) }),
+    Elements: ({ children }) => React.createElement('div', null, children),
     __esModule: true,
   };
 });
+
+jest.mock('@stripe/stripe-js', () => ({
+  loadStripe: () => Promise.resolve({}),
+}));
 
 global.mockStripeCreateToken = mockCreateToken;


### PR DESCRIPTION
## Summary
- redirect /checkout to payments checkout
- wrap checkout card payment form in Stripe Elements and mock Stripe in tests

## Testing
- `npm test -- --runTestsByPath src/tests/__tests__/checkoutPaymentFlow.test.js`
- `npx eslint src/pages/payments/checkout.js src/tests/setupTests.js`
- `npm run lint` *(fails: 42 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ba341dc100832886f2a853541b4263