### PR TITLE
Allow bank transfers for plan checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -121,7 +121,6 @@ export function filterEligibleMethods(methods, itemType) {
     return active.filter((m) => {
       const identifier = getMethodIdentifier(m).toLowerCase();
       return (
-        identifier !== 'bank' &&
         identifier !== 'paypal' &&
         !isCryptoMethod(identifier)
       );

--- a/frontend/src/tests/__tests__/filterEligibleMethods.test.js
+++ b/frontend/src/tests/__tests__/filterEligibleMethods.test.js
@@ -19,8 +19,8 @@ describe('filterEligibleMethods', () => {
     ]);
   });
 
-  it('excludes bank, PayPal, and crypto for plan items', () => {
+  it('excludes PayPal and crypto for plan items but keeps bank', () => {
     const result = filterEligibleMethods(methods, 'plan');
-    expect(result.map((m) => m.name)).toEqual(['Stripe']);
+    expect(result.map((m) => m.name)).toEqual(['Stripe', 'Bank']);
   });
 });


### PR DESCRIPTION
## Summary
- allow bank transfer payment method when purchasing plans
- update filterEligibleMethods test to expect bank transfer for plans

## Testing
- `npm test -- src/tests/__tests__/filterEligibleMethods.test.js`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3d21193883288595f4d698d16afc