### PR TITLE
Render Elements only for Stripe in checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -122,6 +122,7 @@ export function filterEligibleMethods(methods, itemType) {
       const identifier = getMethodIdentifier(m).toLowerCase();
       return (
         identifier !== 'paypal' &&
+        identifier !== 'bank' &&
         !isCryptoMethod(identifier)
       );
     });
@@ -697,7 +698,7 @@ export default function CheckoutPage() {
               processing={paymentStatus === 'processing'}
               finalPrice={finalPrice}
             />
-          ) : (
+          ) : selectedMethodIdentifier === 'stripe' ? (
             <Elements stripe={stripePromise}>
               <CardPaymentForm
                 onSubmit={handlePayment}
@@ -709,6 +710,16 @@ export default function CheckoutPage() {
                 selectedMethodLabel={selectedMethodLabel}
               />
             </Elements>
+          ) : (
+            <CardPaymentForm
+              onSubmit={handlePayment}
+              processing={paymentStatus === 'processing'}
+              allowInstallments={allowInstallments}
+              installments={installments}
+              perInstallment={perInstallment}
+              finalPrice={finalPrice}
+              selectedMethodLabel={selectedMethodLabel}
+            />
           )}
         </div>
       </main>

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -154,6 +154,7 @@ test('adjusts inputs based on payment selection and submits bank reference', asy
   initiateBankPayment.mockResolvedValue({ id: 42 });
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
+  expect(screen.getByTestId('elements-wrapper')).toBeInTheDocument();
   expect(screen.getByTestId('card-element')).toBeInTheDocument();
   fireEvent.click(screen.getByText('PayPal'));
   expect(screen.queryByTestId('card-element')).toBeNull();
@@ -184,6 +185,30 @@ test('completes payment for unhandled methods on success', async () => {
   await waitFor(() => expect(global.mockStripeCreateToken).toHaveBeenCalled());
   await waitFor(() => expect(createPayment).toHaveBeenCalledWith(expect.objectContaining({ token: 'tok_123' })));
   expect(await screen.findByText(/payment_successful_redirecting/i)).toBeInTheDocument();
+});
+
+test('renders card form without Elements for non-stripe processors', async () => {
+  fetchPaymentMethods.mockResolvedValue([
+    { id: 1, name: 'Paystack', type: 'paystack' },
+  ]);
+  createPayment.mockResolvedValue({ status: 'paid' });
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+  expect(screen.queryByTestId('elements-wrapper')).toBeNull();
+  fireEvent.change(screen.getByPlaceholderText('Full Name'), {
+    target: { value: 'John Doe' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Email Address'), {
+    target: { value: 'john@example.com' },
+  });
+  fireEvent.click(
+    screen.getByRole('button', { name: /Pay \$100 with Paystack/i })
+  );
+  await waitFor(() =>
+    expect(createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'tok_123' })
+    )
+  );
 });
 
 test('shows error when unhandled payment fails', async () => {

--- a/frontend/src/tests/setupTests.js
+++ b/frontend/src/tests/setupTests.js
@@ -7,7 +7,8 @@ jest.mock('@stripe/react-stripe-js', () => {
     CardElement: (props) => React.createElement('div', { 'data-testid': 'card-element', ...props }),
     useStripe: () => ({ createToken: mockCreateToken }),
     useElements: () => ({ getElement: () => ({}) }),
-    Elements: ({ children }) => React.createElement('div', null, children),
+    Elements: ({ children }) =>
+      React.createElement('div', { 'data-testid': 'elements-wrapper' }, children),
     __esModule: true,
   };
 });


### PR DESCRIPTION
## Summary
- Only wrap card payments in Stripe `<Elements>` when the selected processor is Stripe
- Render `CardPaymentForm` directly for other processors and exclude bank transfers for plan purchases
- Expand checkout payment tests and mocks to cover both Stripe and non-Stripe card flows

## Testing
- `npm test src/tests/__tests__/checkoutPaymentFlow.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba40689d3083288eee789f02e75eca