### PR TITLE
Handle non-string payment method identifiers

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -93,8 +93,16 @@ export function resolveIconElement(method) {
 }
 
 function getMethodIdentifier(method) {
-  if (method?.type && method.type.trim()) return method.type.trim();
-  if (method?.name && method.name.trim()) return method.name.trim();
+  const type = method?.type;
+  if (type !== undefined && type !== null) {
+    const typeStr = String(type).trim();
+    if (typeStr) return typeStr;
+  }
+  const name = method?.name;
+  if (name !== undefined && name !== null) {
+    const nameStr = String(name).trim();
+    if (nameStr) return nameStr;
+  }
   return '';
 }
 

--- a/frontend/src/tests/__tests__/filterEligibleMethods.test.js
+++ b/frontend/src/tests/__tests__/filterEligibleMethods.test.js
@@ -23,4 +23,14 @@ describe('filterEligibleMethods', () => {
     const result = filterEligibleMethods(methods, 'plan');
     expect(result.map((m) => m.name)).toEqual(['Stripe', 'Bank']);
   });
+
+  it('handles methods with non-string identifiers', () => {
+    const weirdMethods = [
+      { id: 6, name: 123, type: undefined, active: true },
+      { id: 7, name: 'Some', type: 456, active: true },
+    ];
+    expect(() => filterEligibleMethods(weirdMethods, 'class')).not.toThrow();
+    const result = filterEligibleMethods(weirdMethods, 'plan');
+    expect(result.map((m) => m.id)).toEqual([6, 7]);
+  });
 });


### PR DESCRIPTION
## Summary
- Safely convert payment method `type` and `name` to strings before trimming
- Add unit test covering non-string identifiers in `filterEligibleMethods`

## Testing
- `npm test src/tests/__tests__/filterEligibleMethods.test.js`
- `npm test src/tests/__tests__/checkoutPaymentFlow.test.js` *(fails: shows available payment methods for plans)*

------
https://chatgpt.com/codex/tasks/task_e_68ba406d5e708328a391991dcbf35998