### PR TITLE
feat: add promo code loading state

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -196,6 +196,7 @@ export default function CheckoutPage() {
   const [discountAmount, setDiscountAmount] = useState(0);
   const [discountPercent, setDiscountPercent] = useState(0);
   const [couponId, setCouponId] = useState(null);
+  const [promoLoading, setPromoLoading] = useState(false);
   const [paymentStatus, setPaymentStatus] = useState('idle');
   const [allowInstallments, setAllowInstallments] = useState(false);
   const finalPrice = useMemo(
@@ -333,6 +334,7 @@ export default function CheckoutPage() {
       return;
     }
     setPromoCode(formattedCode);
+    setPromoLoading(true);
     try {
       const data = await validateCode(formattedCode, itemType, itemId);
       const percent = data.discount_percent || 0;
@@ -350,6 +352,8 @@ export default function CheckoutPage() {
       } else {
         toast.error(t('promo_code_apply_failed'));
       }
+    } finally {
+      setPromoLoading(false);
     }
   };
 
@@ -642,8 +646,9 @@ export default function CheckoutPage() {
             />
             <button
               onClick={handleApplyPromo}
-              className="px-4 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600"
-            >{t('apply')}</button>
+              disabled={promoLoading}
+              className="px-4 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            >{promoLoading ? t('applying') : t('apply')}</button>
           </div>
         </div>
 

--- a/frontend/src/tests/__tests__/checkoutPromo.test.js
+++ b/frontend/src/tests/__tests__/checkoutPromo.test.js
@@ -117,6 +117,27 @@ test('handles network failure when applying promo code', async () => {
   });
 });
 
+test('disables apply button while processing promo code', async () => {
+  let resolve;
+  validateCode.mockImplementation(
+    () =>
+      new Promise((res) => {
+        resolve = res;
+      })
+  );
+  render(<CheckoutPage />);
+  await screen.findByText('checkout');
+  fireEvent.change(screen.getByPlaceholderText('enter_promo_code'), {
+    target: { value: 'SAVE10' },
+  });
+  const applyButton = screen.getByText('apply');
+  fireEvent.click(applyButton);
+  await waitFor(() => expect(applyButton).toBeDisabled());
+  expect(screen.getByText('applying')).toBeInTheDocument();
+  resolve({ discount_percent: 10 });
+  await waitFor(() => expect(applyButton).not.toBeDisabled());
+});
+
 test('skips fetching payment methods for free items', async () => {
   fetchClassDetails.mockResolvedValueOnce({
     data: {


### PR DESCRIPTION
## Summary
- add state to track promo code validation progress
- disable Apply button and show loading text during promo processing
- cover button disabled state with new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba406b84e48328b96ac46e5a3e2ca9