### PR TITLE
Refactor payment handlers with helper functions and tests

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -170,6 +170,138 @@ export function resolveCheckoutItem(query, cartItems) {
   return null;
 }
 
+export async function handleBankPayment({
+  itemInfo,
+  itemType,
+  finalPrice,
+  couponId,
+  formData = {},
+  router,
+  t,
+  setPaymentStatus,
+}) {
+  try {
+    setPaymentStatus('processing');
+    const payload = new FormData();
+    payload.append('item_id', itemInfo.id);
+    payload.append('item_type', itemType);
+    payload.append('amount', finalPrice);
+    if (couponId) payload.append('coupon_id', couponId);
+    if (formData.reference) payload.append('reference', formData.reference);
+    if (formData.receipt) payload.append('receipt', formData.receipt);
+    const payment = await initiateBankPayment(payload);
+    router.push(
+      `/payments/success?itemType=${itemType}&itemId=${itemInfo.id}&payment_id=${payment?.id}`
+    );
+  } catch (err) {
+    console.error('Failed to initiate bank transfer', err);
+    toast.error(t('payment_bank_failure'));
+    setPaymentStatus('idle');
+  }
+}
+
+export async function handlePayPalPayment({
+  itemInfo,
+  itemType,
+  finalPrice,
+  couponId,
+  t,
+  setPaymentStatus,
+}) {
+  try {
+    setPaymentStatus('processing');
+    const payload = {
+      item_id: itemInfo.id,
+      item_type: itemType,
+      amount: finalPrice,
+    };
+    if (couponId) payload.coupon_id = couponId;
+    const data = await initiatePayPalPayment(payload);
+    if (data?.approval_url) {
+      window.location.href = data.approval_url;
+    } else {
+      toast.error(t('payment_paypal_failure'));
+      setPaymentStatus('idle');
+    }
+  } catch (err) {
+    console.error('Failed to initiate PayPal payment', err);
+    toast.error(t('payment_paypal_failure'));
+    setPaymentStatus('idle');
+  }
+}
+
+export async function handleCryptoPayment({
+  itemInfo,
+  itemType,
+  finalPrice,
+  couponId,
+  method,
+  t,
+  setPaymentStatus,
+}) {
+  try {
+    setPaymentStatus('processing');
+    const payload = {
+      item_id: itemInfo.id,
+      item_type: itemType,
+      amount: finalPrice,
+      method_type: method?.type || getMethodIdentifier(method),
+    };
+    if (couponId) payload.coupon_id = couponId;
+    const data = await initiateCryptoPayment(payload);
+    if (data?.invoice_url) {
+      window.location.href = data.invoice_url;
+    } else {
+      toast.error(t('payment_crypto_failure'));
+      setPaymentStatus('idle');
+    }
+  } catch (err) {
+    console.error('Failed to initiate crypto payment', err);
+    toast.error(t('payment_crypto_failure'));
+    setPaymentStatus('idle');
+  }
+}
+
+export async function handleDefaultPayment({
+  method,
+  itemInfo,
+  itemType,
+  finalPrice,
+  allowInstallments,
+  installments,
+  interval,
+  couponId,
+  formData = {},
+  t,
+  setPaymentStatus,
+  completePayment,
+}) {
+  try {
+    setPaymentStatus('processing');
+    const payload = {
+      method_id: method?.id,
+      item_type: itemType,
+      item_id: itemInfo.id,
+      amount: finalPrice,
+      allow_installments: allowInstallments,
+      installments,
+    };
+    if (formData.token) payload.token = formData.token;
+    if (itemType === 'plan') payload.interval = interval;
+    if (couponId) payload.coupon_id = couponId;
+    const response = await createPayment(payload);
+    if (response?.status === 'paid') {
+      await completePayment(response);
+    } else {
+      throw new Error('Payment not confirmed');
+    }
+  } catch (err) {
+    console.error('Failed to process payment', err);
+    toast.error(t('payment_generic_failure'));
+    setPaymentStatus('idle');
+  }
+}
+
 export default function CheckoutPage() {
   const router = useRouter();
   const { t } = useTranslation('common');
@@ -505,98 +637,37 @@ export default function CheckoutPage() {
     const identifier = getMethodIdentifier(method).toLowerCase();
     const isCrypto = isCryptoMethod(method || identifier);
 
-    if (identifier === 'bank') {
-      try {
-        setPaymentStatus('processing');
-        const formData = new FormData();
-        formData.append('item_id', itemInfo.id);
-        formData.append('item_type', itemType);
-        formData.append('amount', finalPrice);
-        if (couponId) formData.append('coupon_id', couponId);
-        if (_formData.reference) formData.append('reference', _formData.reference);
-        if (_formData.receipt) formData.append('receipt', _formData.receipt);
-        const payment = await initiateBankPayment(formData);
-        router.push(
-          `/payments/success?itemType=${itemType}&itemId=${itemInfo.id}&payment_id=${payment?.id}`
-        );
-      } catch (err) {
-        console.error('Failed to initiate bank transfer', err);
-        toast.error(t('payment_bank_failure'));
-        setPaymentStatus('idle');
-      }
-      return;
-    }
-    if (identifier === 'paypal') {
-      try {
-        setPaymentStatus('processing');
-        const payload = {
-          item_id: itemInfo.id,
-          item_type: itemType,
-          amount: finalPrice,
-        };
-        if (couponId) payload.coupon_id = couponId;
-        const data = await initiatePayPalPayment(payload);
-        if (data?.approval_url) {
-          window.location.href = data.approval_url;
-        } else {
-          toast.error(t('payment_paypal_failure'));
-          setPaymentStatus('idle');
-        }
-      } catch (err) {
-        console.error('Failed to initiate PayPal payment', err);
-        toast.error(t('payment_paypal_failure'));
-        setPaymentStatus('idle');
-      }
-      return;
-    }
-    if (isCrypto) {
-      try {
-        setPaymentStatus('processing');
-        const payload = {
-          item_id: itemInfo.id,
-          item_type: itemType,
-          amount: finalPrice,
-          method_type: method?.type || getMethodIdentifier(method),
-        };
-        if (couponId) payload.coupon_id = couponId;
-        const data = await initiateCryptoPayment(payload);
-        if (data?.invoice_url) {
-          window.location.href = data.invoice_url;
-        } else {
-          toast.error(t('payment_crypto_failure'));
-          setPaymentStatus('idle');
-        }
-      } catch (err) {
-        console.error('Failed to initiate crypto payment', err);
-        toast.error(t('payment_crypto_failure'));
-        setPaymentStatus('idle');
-      }
-      return;
-    }
-    try {
-      setPaymentStatus('processing');
-      const payload = {
-        method_id: method?.id,
-        item_type: itemType,
-        item_id: itemInfo.id,
-        amount: finalPrice,
-        allow_installments: allowInstallments,
-        installments,
-      };
-      if (_formData.token) payload.token = _formData.token;
-      if (itemType === 'plan') payload.interval = interval;
-      if (couponId) payload.coupon_id = couponId;
-      const response = await createPayment(payload);
-      if (response?.status === 'paid') {
-        await completePayment(response);
-      } else {
-        throw new Error('Payment not confirmed');
-      }
-    } catch (err) {
-      console.error('Failed to process payment', err);
-      toast.error(t('payment_generic_failure'));
-      setPaymentStatus('idle');
-    }
+    const handlers = {
+      bank: handleBankPayment,
+      paypal: handlePayPalPayment,
+      crypto: handleCryptoPayment,
+      default: handleDefaultPayment,
+    };
+
+    const key =
+      identifier === 'bank'
+        ? 'bank'
+        : identifier === 'paypal'
+        ? 'paypal'
+        : isCrypto
+        ? 'crypto'
+        : 'default';
+
+    await handlers[key]({
+      method,
+      itemInfo,
+      itemType,
+      finalPrice,
+      couponId,
+      formData: _formData,
+      router,
+      t,
+      setPaymentStatus,
+      allowInstallments,
+      installments,
+      interval,
+      completePayment,
+    });
   };
 
   const [installments, setInstallments] = useState(1);

--- a/frontend/src/tests/__tests__/paymentHandlers.test.js
+++ b/frontend/src/tests/__tests__/paymentHandlers.test.js
@@ -1,0 +1,102 @@
+import {
+  handleBankPayment,
+  handlePayPalPayment,
+  handleCryptoPayment,
+  handleDefaultPayment,
+} from '../../pages/payments/checkout';
+import {
+  initiateBankPayment,
+  initiatePayPalPayment,
+  initiateCryptoPayment,
+} from '../../services/paymentService';
+import { createPayment } from '../../services/student/paymentService';
+import { toast } from 'react-toastify';
+
+jest.mock('../../services/paymentService', () => ({
+  initiateBankPayment: jest.fn(),
+  initiatePayPalPayment: jest.fn(),
+  initiateCryptoPayment: jest.fn(),
+}));
+
+jest.mock('../../services/student/paymentService', () => ({
+  createPayment: jest.fn(),
+}));
+
+jest.mock('react-toastify', () => ({ toast: { error: jest.fn() } }));
+
+const baseArgs = () => ({
+  itemInfo: { id: 1 },
+  itemType: 'class',
+  finalPrice: 100,
+  couponId: null,
+  router: { push: jest.fn() },
+  t: (k) => k,
+  setPaymentStatus: jest.fn(),
+  allowInstallments: false,
+  installments: 1,
+  interval: 'monthly',
+  formData: {},
+  method: { id: 2, type: 'stripe' },
+  completePayment: jest.fn(),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete window.location;
+  window.location = { href: '' };
+});
+
+test('bank payment redirects on success and handles errors', async () => {
+  initiateBankPayment.mockResolvedValue({ id: 55 });
+  const args = baseArgs();
+  await handleBankPayment(args);
+  expect(initiateBankPayment).toHaveBeenCalled();
+  expect(args.router.push).toHaveBeenCalledWith(
+    '/payments/success?itemType=class&itemId=1&payment_id=55'
+  );
+
+  initiateBankPayment.mockRejectedValue(new Error('fail'));
+  const errArgs = baseArgs();
+  await handleBankPayment(errArgs);
+  expect(toast.error).toHaveBeenCalled();
+  expect(errArgs.setPaymentStatus).toHaveBeenCalledWith('idle');
+});
+
+test('paypal payment redirects on approval url and handles errors', async () => {
+  initiatePayPalPayment.mockResolvedValue({ approval_url: 'http://paypal' });
+  await handlePayPalPayment(baseArgs());
+  expect(window.location.href).toBe('http://paypal');
+
+  initiatePayPalPayment.mockResolvedValue({});
+  const args = baseArgs();
+  await handlePayPalPayment(args);
+  expect(toast.error).toHaveBeenCalled();
+  expect(args.setPaymentStatus).toHaveBeenCalledWith('idle');
+});
+
+test('crypto payment redirects to invoice and handles errors', async () => {
+  initiateCryptoPayment.mockResolvedValue({ invoice_url: 'http://invoice' });
+  const args = { ...baseArgs(), method: { type: 'usdt' } };
+  await handleCryptoPayment(args);
+  expect(window.location.href).toBe('http://invoice');
+
+  initiateCryptoPayment.mockResolvedValue({});
+  await handleCryptoPayment(args);
+  expect(toast.error).toHaveBeenCalled();
+  expect(args.setPaymentStatus).toHaveBeenCalledWith('idle');
+});
+
+test('default payment completes on success and handles errors', async () => {
+  createPayment.mockResolvedValue({ status: 'paid' });
+  const args = baseArgs();
+  await handleDefaultPayment(args);
+  expect(createPayment).toHaveBeenCalled();
+  expect(args.completePayment).toHaveBeenCalled();
+
+  createPayment.mockRejectedValue(new Error('fail'));
+  const errArgs = baseArgs();
+  await handleDefaultPayment(errArgs);
+  expect(toast.error).toHaveBeenCalled();
+  expect(errArgs.setPaymentStatus).toHaveBeenCalledWith('idle');
+});
+


### PR DESCRIPTION
## Summary
- Extract payment-method branches into helper functions
- Replace conditional chain with dispatch map
- Cover handlers with dedicated unit tests

## Testing
- `npm test src/tests/__tests__/paymentHandlers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68baeba18db88328b97cf2ca224d4c8a