### PR TITLE
Handle invoice fetch errors in student settings

### DIFF
--- a/frontend/src/pages/dashboard/student/settings/index.js
+++ b/frontend/src/pages/dashboard/student/settings/index.js
@@ -17,14 +17,17 @@ export default function StudentSettingsPage() {
   const fetchSubscription = useSubscriptionStore((state) => state.fetch);
   const [invoices, setInvoices] = useState([]);
   const [loadingInvoices, setLoadingInvoices] = useState(true);
+  const [invoiceError, setInvoiceError] = useState(null);
 
   const loadInvoices = async () => {
     setLoadingInvoices(true);
+    setInvoiceError(null);
     try {
       const { data } = await api.get("/invoices/student");
       setInvoices(data?.data || []);
     } catch (err) {
       console.error("Failed to fetch invoices", err);
+      setInvoiceError(err);
       setInvoices([]);
     } finally {
       setLoadingInvoices(false);
@@ -174,6 +177,16 @@ export default function StudentSettingsPage() {
               <h3 className="font-medium">Invoices</h3>
               {loadingInvoices ? (
                 <p>Loading invoices...</p>
+              ) : invoiceError ? (
+                <div>
+                  <p className="text-red-600">Failed to load invoices.</p>
+                  <button
+                    onClick={loadInvoices}
+                    className="text-blue-600 underline"
+                  >
+                    Retry
+                  </button>
+                </div>
               ) : invoices.length ? (
                 <ul className="list-disc list-inside space-y-1">
                   {invoices.map((inv) => (


### PR DESCRIPTION
## Summary
- track invoice fetch failures in state to display errors
- show a retry button when invoice retrieval fails

## Testing
- `npm test` *(fails: 1 failed, 50 passed)*
- `npm run lint` *(fails: 42 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68baeba092c483289e402320c728fcc3