### PR TITLE
Add notifications and loading states to dashboard settings

### DIFF
--- a/frontend/src/pages/dashboard/instructor/settings/index.js
+++ b/frontend/src/pages/dashboard/instructor/settings/index.js
@@ -1,5 +1,6 @@
 import InstructorLayout from "@/components/layouts/InstructorLayout";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
 import api from "@/services/api/api";
 import useSubscriptionStore from "@/store/subscriptionStore";
 
@@ -7,26 +8,38 @@ export default function InstructorSettingsPage() {
   const subscription = useSubscriptionStore((state) => state.plan);
   const loadingSub = useSubscriptionStore((state) => state.loading);
   const fetchSubscription = useSubscriptionStore((state) => state.fetch);
+  const [upgrading, setUpgrading] = useState(false);
+  const [canceling, setCanceling] = useState(false);
 
   useEffect(() => {
     fetchSubscription();
   }, [fetchSubscription]);
 
   const handleUpgrade = async () => {
+    setUpgrading(true);
     try {
       await api.post("/user-subscriptions/upgrade");
       await fetchSubscription();
+      toast.success("Subscription upgraded");
     } catch (err) {
+      toast.error("Failed to upgrade subscription");
       console.error("Upgrade failed", err);
+    } finally {
+      setUpgrading(false);
     }
   };
 
   const handleCancel = async () => {
+    setCanceling(true);
     try {
       await api.post("/user-subscriptions/cancel");
       await fetchSubscription();
+      toast.success("Subscription cancelled");
     } catch (err) {
+      toast.error("Failed to cancel subscription");
       console.error("Cancel failed", err);
+    } finally {
+      setCanceling(false);
     }
   };
 
@@ -54,13 +67,19 @@ export default function InstructorSettingsPage() {
               <div className="flex gap-4 pt-2">
                 <button
                   onClick={handleUpgrade}
-                  className="bg-yellow-500 px-4 py-2 rounded text-black font-medium hover:bg-yellow-600"
+                  disabled={upgrading}
+                  className={`bg-yellow-500 px-4 py-2 rounded text-black font-medium hover:bg-yellow-600 ${
+                    upgrading ? "opacity-50 cursor-not-allowed" : ""
+                  }`}
                 >
                   Upgrade
                 </button>
                 <button
                   onClick={handleCancel}
-                  className="bg-red-500 px-4 py-2 rounded text-white font-medium hover:bg-red-600"
+                  disabled={canceling}
+                  className={`bg-red-500 px-4 py-2 rounded text-white font-medium hover:bg-red-600 ${
+                    canceling ? "opacity-50 cursor-not-allowed" : ""
+                  }`}
                 >
                   Cancel
                 </button>

--- a/frontend/src/pages/dashboard/student/settings/index.js
+++ b/frontend/src/pages/dashboard/student/settings/index.js
@@ -1,5 +1,6 @@
 import StudentLayout from "@/components/layouts/StudentLayout";
 import { useState, useEffect } from "react";
+import { toast } from "react-toastify";
 import {
   FaUser,
   FaCogs,
@@ -17,6 +18,8 @@ export default function StudentSettingsPage() {
   const fetchSubscription = useSubscriptionStore((state) => state.fetch);
   const [invoices, setInvoices] = useState([]);
   const [loadingInvoices, setLoadingInvoices] = useState(true);
+  const [upgrading, setUpgrading] = useState(false);
+  const [canceling, setCanceling] = useState(false);
 
   const loadInvoices = async () => {
     setLoadingInvoices(true);
@@ -37,20 +40,30 @@ export default function StudentSettingsPage() {
   }, [fetchSubscription]);
 
   const handleUpgrade = async () => {
+    setUpgrading(true);
     try {
       await api.post("/user-subscriptions/upgrade");
       await fetchSubscription("student");
+      toast.success("Subscription upgraded");
     } catch (err) {
+      toast.error("Failed to upgrade subscription");
       console.error("Upgrade failed", err);
+    } finally {
+      setUpgrading(false);
     }
   };
 
   const handleCancel = async () => {
+    setCanceling(true);
     try {
       await api.post("/user-subscriptions/cancel");
       await fetchSubscription("student");
+      toast.success("Subscription cancelled");
     } catch (err) {
+      toast.error("Failed to cancel subscription");
       console.error("Cancel failed", err);
+    } finally {
+      setCanceling(false);
     }
   };
 
@@ -154,13 +167,19 @@ export default function StudentSettingsPage() {
                 <div className="flex gap-4 pt-2">
                   <button
                     onClick={handleUpgrade}
-                    className="bg-yellow-500 px-4 py-2 rounded text-black font-medium hover:bg-yellow-600"
+                    disabled={upgrading}
+                    className={`bg-yellow-500 px-4 py-2 rounded text-black font-medium hover:bg-yellow-600 ${
+                      upgrading ? "opacity-50 cursor-not-allowed" : ""
+                    }`}
                   >
                     Upgrade
                   </button>
                   <button
                     onClick={handleCancel}
-                    className="bg-red-500 px-4 py-2 rounded text-white font-medium hover:bg-red-600"
+                    disabled={canceling}
+                    className={`bg-red-500 px-4 py-2 rounded text-white font-medium hover:bg-red-600 ${
+                      canceling ? "opacity-50 cursor-not-allowed" : ""
+                    }`}
                   >
                     Cancel
                   </button>


### PR DESCRIPTION
## Summary
- show toast success/error when upgrading or cancelling subscriptions in dashboard settings
- prevent duplicate submissions by disabling buttons while requests are in flight

## Testing
- `npm test` *(fails: process hung; see logs)*
- `npm run lint` *(fails: 42 errors, 307 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68baeba05dac8328a1f957b0bc7c353b