### PR TITLE
Add upgrade and cancel subscription endpoints

### DIFF
--- a/backend/src/modules/subscriptions/subscription.service.js
+++ b/backend/src/modules/subscriptions/subscription.service.js
@@ -50,3 +50,27 @@ exports.getActiveByUser = (user_id, role) => {
 
   return query;
 };
+
+exports.upgradeSubscription = async (user_id) => {
+  return db.transaction(async (trx) => {
+    const existing = await trx("user_subscriptions")
+      .where({ user_id, status: "active" })
+      .orderBy("end_date", "desc")
+      .first();
+    if (!existing) return null;
+    const end = addInterval(existing.end_date || new Date(), "yearly");
+    const [row] = await trx("user_subscriptions")
+      .where({ id: existing.id })
+      .update({ end_date: end })
+      .returning("*");
+    return row;
+  });
+};
+
+exports.cancelSubscription = async (user_id) => {
+  const [row] = await db("user_subscriptions")
+    .where({ user_id, status: "active" })
+    .update({ status: "cancelled", end_date: new Date() })
+    .returning("*");
+  return row;
+};

--- a/backend/src/modules/subscriptions/subscriptions.controller.js
+++ b/backend/src/modules/subscriptions/subscriptions.controller.js
@@ -36,3 +36,19 @@ exports.createOrRenewSubscription = catchAsync(async (req, res) => {
   });
   sendSuccess(res, subscription);
 });
+
+exports.upgradeSubscription = catchAsync(async (req, res) => {
+  const subscription = await service.upgradeSubscription(req.user.id);
+  if (!subscription) {
+    throw new AppError("No active subscription to upgrade", 400);
+  }
+  sendSuccess(res, subscription);
+});
+
+exports.cancelSubscription = catchAsync(async (req, res) => {
+  const subscription = await service.cancelSubscription(req.user.id);
+  if (!subscription) {
+    throw new AppError("No active subscription to cancel", 400);
+  }
+  sendSuccess(res, subscription);
+});

--- a/backend/src/modules/subscriptions/subscriptions.routes.js
+++ b/backend/src/modules/subscriptions/subscriptions.routes.js
@@ -5,5 +5,7 @@ const { verifyToken } = require("../../middleware/auth/authMiddleware");
 router.use(verifyToken);
 router.get("/me", controller.getMySubscriptions);
 router.post("/", controller.createOrRenewSubscription);
+router.post("/upgrade", controller.upgradeSubscription);
+router.post("/cancel", controller.cancelSubscription);
 
 module.exports = router;

--- a/backend/tests/subscriptionRoutes.test.js
+++ b/backend/tests/subscriptionRoutes.test.js
@@ -4,6 +4,8 @@ const express = require('express');
 jest.mock('../src/modules/subscriptions/subscription.service', () => ({
   getActiveByUser: jest.fn(),
   createOrRenewSubscription: jest.fn(),
+  upgradeSubscription: jest.fn(),
+  cancelSubscription: jest.fn(),
 }));
 
 jest.mock('../src/modules/payments/payments.service', () => ({
@@ -67,6 +69,48 @@ describe('POST /api/user-subscriptions', () => {
     const res = await request(app)
       .post('/api/user-subscriptions')
       .send({ plan_id: 'p1', payment_id: 'bad' });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/user-subscriptions/upgrade', () => {
+  it('upgrades an active subscription', async () => {
+    const mock = { id: 's1', plan_id: 'p1' };
+    service.upgradeSubscription.mockResolvedValue(mock);
+
+    const res = await request(app).post('/api/user-subscriptions/upgrade');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.upgradeSubscription).toHaveBeenCalledWith('user1');
+  });
+
+  it('returns 400 if no active subscription to upgrade', async () => {
+    service.upgradeSubscription.mockResolvedValue(null);
+
+    const res = await request(app).post('/api/user-subscriptions/upgrade');
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/user-subscriptions/cancel', () => {
+  it('cancels an active subscription', async () => {
+    const mock = { id: 's1', status: 'cancelled' };
+    service.cancelSubscription.mockResolvedValue(mock);
+
+    const res = await request(app).post('/api/user-subscriptions/cancel');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mock);
+    expect(service.cancelSubscription).toHaveBeenCalledWith('user1');
+  });
+
+  it('returns 400 if no active subscription to cancel', async () => {
+    service.cancelSubscription.mockResolvedValue(null);
+
+    const res = await request(app).post('/api/user-subscriptions/cancel');
 
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
## Summary
- add `/upgrade` and `/cancel` routes for user subscriptions
- implement controller and service logic for upgrading and cancelling
- cover success and failure cases in tests

## Testing
- `npm test -- tests/subscriptionRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68baeb9e6d60832885e6f5e1a63bf216