### PR TITLE
Handle missing plan payment methods

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -536,6 +536,11 @@ export default function CheckoutPage() {
     if (itemType === 'plan' && !payment) {
       setPaymentStatus('processing');
       const eligible = filterEligibleMethods(methods, itemType);
+      if (eligible.length === 0) {
+        toast.error('No payment methods available for this plan');
+        setPaymentStatus('idle');
+        return;
+      }
       const defaultMethod = eligible[0];
       try {
         const payload = {

--- a/frontend/src/tests/__tests__/filterEligibleMethods.test.js
+++ b/frontend/src/tests/__tests__/filterEligibleMethods.test.js
@@ -24,6 +24,16 @@ describe('filterEligibleMethods', () => {
     expect(result.map((m) => m.name)).toEqual(['Stripe']);
   });
 
+  it('returns empty array when no eligible methods for plan', () => {
+    const onlyIneligible = [
+      { id: 1, name: 'PayPal', type: null, active: true },
+      { id: 2, name: 'Bank', type: 'bank', active: true },
+      { id: 3, name: 'USDT', type: 'usdt', active: true },
+    ];
+    const result = filterEligibleMethods(onlyIneligible, 'plan');
+    expect(result).toEqual([]);
+  });
+
   it('handles methods with non-string identifiers', () => {
     const weirdMethods = [
       { id: 6, name: 123, type: undefined, active: true },


### PR DESCRIPTION
## Summary
- prevent plan checkout from proceeding when no eligible payment methods exist
- add coverage for plans with no eligible payment options

## Testing
- `npm test src/tests/__tests__/filterEligibleMethods.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb32e35f408328affe12fee9eebb68