### PR TITLE
Handle non-string custom icons in checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -73,7 +73,7 @@ export function TrustedIcon({ src, alt }) {
 }
 
 export function resolveIconElement(method) {
-  if (method.icon) {
+  if (typeof method.icon === 'string' && method.icon) {
     const lower = method.icon.toLowerCase();
     const base = lower.split('/').pop().split('.')[0];
     if (iconMap[lower]) return iconMap[lower];

--- a/frontend/src/tests/__tests__/resolveIconElement.test.js
+++ b/frontend/src/tests/__tests__/resolveIconElement.test.js
@@ -37,6 +37,12 @@ describe('resolveIconElement', () => {
     expect(el.type.name).toBe(FaMoneyCheckAlt.name);
   });
 
+  it('falls back to default icon when icon is not a string', async () => {
+    const { resolveIconElement, FaMoneyCheckAlt } = await loadModule();
+    const el = resolveIconElement({ icon: { url: 'icon.png' }, name: 'Custom' });
+    expect(el.type.name).toBe(FaMoneyCheckAlt.name);
+  });
+
   it('honors NEXT_PUBLIC_TRUSTED_ICON_HOSTS', async () => {
     process.env.NEXT_PUBLIC_TRUSTED_ICON_HOSTS = 'example.com,assets.example.org';
     const { resolveIconElement, TrustedIcon, FaMoneyCheckAlt } = await loadModule();


### PR DESCRIPTION
## Summary
- safeguard `resolveIconElement` by ensuring `method.icon` is a string before using string operations
- default to standard icon when `icon` is not a string
- test fallback behavior when `icon` isn't a string

## Testing
- `npm test -- src/tests/__tests__/resolveIconElement.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb32e1a21883288900916e1241bc6f