### PR TITLE
Record subscription payments for class enrollments

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -138,6 +138,15 @@ describe('Class enrollment routes', () => {
       'plan1',
       expect.anything(),
     );
+    expect(db.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'test-user',
+        item_id: 'abc',
+        item_type: 'class',
+        source: 'subscription',
+        amount: 0,
+      }),
+    );
   });
 
   test('reject enrollment when subscription active but class not covered', async () => {

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -42,6 +42,14 @@ exports.enroll = catchAsync(async (req, res) => {
       activePlanId && includedPlans.includes(activePlanId);
 
     if (coveredBySubscription) {
+      await trx("payments").insert({
+        user_id,
+        item_id: classId,
+        item_type: "class",
+        amount: 0,
+        status: paymentsService.STATUS.PAID,
+        source: "subscription",
+      });
       await creditInstructorSubscription(classId, activePlanId, trx);
     } else if (Number(cls.price) > 0) {
       const payment = await trx("payments")


### PR DESCRIPTION
## Summary
- Log a zero-amount payment sourced from subscriptions when enrolling in a class covered by the user's plan
- Extend enrollment tests to confirm payment creation for subscription-covered classes

## Testing
- `npm test` *(fails: process.exit called with "1" - database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc111304b88328acc77aebe638224f