### PR TITLE
Add commission rates to student plans and compute subscription payouts

### DIFF
--- a/backend/src/modules/payments/helpers/__tests__/planRevenue.test.js
+++ b/backend/src/modules/payments/helpers/__tests__/planRevenue.test.js
@@ -1,0 +1,33 @@
+jest.mock('../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn();
+  return db;
+});
+
+const db = require('../../../config/database');
+const { calculateInstructorAmount } = require('../planRevenue');
+
+describe('calculateInstructorAmount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies commission rate to usage amount', async () => {
+    db.first
+      .mockResolvedValueOnce({ amount: 100 })
+      .mockResolvedValueOnce({ value: '0.2' });
+
+    const amt = await calculateInstructorAmount('plan1', 'class1');
+    expect(amt).toBeCloseTo(80);
+    expect(db).toHaveBeenCalledWith('plan_usage_metrics');
+    expect(db).toHaveBeenCalledWith('plan_features');
+  });
+
+  it('returns 0 when metrics missing', async () => {
+    db.first.mockResolvedValueOnce(null);
+    const amt = await calculateInstructorAmount('plan1', 'class1');
+    expect(amt).toBe(0);
+  });
+});
+

--- a/backend/src/modules/payments/helpers/planRevenue.js
+++ b/backend/src/modules/payments/helpers/planRevenue.js
@@ -1,8 +1,8 @@
 const db = require("../../../config/database");
 
 // Calculate instructor share for a class enrollment covered by a subscription plan
-// Uses plan usage metrics to determine how much revenue should be credited
-// to the instructor for the given plan and class.
+// Uses plan usage metrics and the plan's commission rate to determine the
+// instructor's payout for the given plan and class.
 exports.calculateInstructorAmount = async (planId, classId, trx) => {
   const query = trx || db;
   try {
@@ -10,8 +10,14 @@ exports.calculateInstructorAmount = async (planId, classId, trx) => {
       .where({ plan_id: planId, item_type: "class", item_id: classId })
       .first();
     if (!row) return 0;
-    // assume table stores instructor_amount column representing amount to credit
-    return Number(row.instructor_amount || row.amount || 0);
+
+    const feature = await query("plan_features")
+      .where({ plan_id: planId, feature_key: "commission_rate" })
+      .first();
+
+    const rate = feature ? Number(feature.value) : 0;
+    const amount = Number(row.amount || row.instructor_amount || 0);
+    return amount * (1 - rate);
   } catch (err) {
     // If metrics table missing or query fails, do not block enrollment
     return 0;

--- a/backend/src/seeds/09_plans_seed.js
+++ b/backend/src/seeds/09_plans_seed.js
@@ -124,6 +124,13 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.basic,
+      feature_key: 'commission_rate',
+      value: '0.3',
+      description: '30% platform fee'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.basic,
       feature_key: 'groups_create',
       value: 'false',
       description: 'Cannot create groups'
@@ -138,6 +145,13 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.regular,
+      feature_key: 'commission_rate',
+      value: '0.2',
+      description: '20% platform fee'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.regular,
       feature_key: 'groups_create',
       value: 'true',
       description: 'Can create groups'
@@ -148,6 +162,13 @@ exports.seed = async function (knex) {
       feature_key: 'groups_join_limit',
       value: '5',
       description: 'Join up to 5 groups'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'commission_rate',
+      value: '0.1',
+      description: '10% platform fee'
     },
     {
       id: knex.raw('uuid_generate_v4()'),


### PR DESCRIPTION
## Summary
- seed student plans with commission rate feature
- apply plan commission rate when allocating subscription revenue
- test subscription payout calculation uses plan's commission rate

## Testing
- `npm test` *(fails: process.exit called; database config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1112322c8328b532ae94ffd2f15d