### PR TITLE
Validate student plans for class inclusion

### DIFF
--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -11,6 +11,9 @@ async function runSchema(schema, data) {
   if (!schema) return data;
 
   // Zod schema
+  if (typeof schema.parseAsync === "function") {
+    return await schema.parseAsync(data);
+  }
   if (typeof schema.parse === "function") {
     return schema.parse(data);
   }

--- a/backend/src/modules/classes/__tests__/class.controller.test.js
+++ b/backend/src/modules/classes/__tests__/class.controller.test.js
@@ -1,8 +1,23 @@
 jest.mock('../../../config/database', () => {
-  const db = jest.fn(() => db);
-  db.where = jest.fn(() => db);
-  db.first = jest.fn(() => Promise.resolve(null));
-  return db;
+  const plans = {
+    'plan-student': { id: 'plan-student', slug: 'student-slug', target_role: 'student' },
+    'student-slug': { id: 'plan-student', slug: 'student-slug', target_role: 'student' },
+    'plan-inst': { id: 'plan-inst', slug: 'inst-slug', target_role: 'instructor' },
+    'inst-slug': { id: 'plan-inst', slug: 'inst-slug', target_role: 'instructor' }
+  };
+  return jest.fn((table) => ({
+    where(cond) {
+      this.cond = cond;
+      return this;
+    },
+    first() {
+      if (table === 'plans') {
+        const key = this.cond.id || this.cond.slug;
+        return Promise.resolve(plans[key] || null);
+      }
+      return Promise.resolve(null);
+    }
+  }));
 });
 
 jest.mock('../class.service', () => ({
@@ -29,6 +44,10 @@ jest.mock('../../messages/messages.service', () => ({
 jest.mock('../../users/user.model', () => ({
   findAdmins: jest.fn(() => []),
   findById: jest.fn(() => ({ id: 'instructor1', full_name: 'Test Instructor' })),
+}));
+
+jest.mock('../../plans/instructor.helper', () => ({
+  getActiveInstructorPlan: jest.fn(() => Promise.resolve({}))
 }));
 
 const controller = require('../class.controller');
@@ -58,9 +77,14 @@ describe('class.controller createClass', () => {
         resolve();
         return data;
       });
+      next.mockImplementation((err) => {
+        resolve();
+        return err;
+      });
       controller.createClass(req, res, next);
     });
 
+    expect(next).not.toHaveBeenCalled();
     expect(service.createClass).toHaveBeenCalledWith(
       expect.objectContaining({ instructor_id: 'instructor1' })
     );
@@ -69,6 +93,66 @@ describe('class.controller createClass', () => {
         data: expect.objectContaining({ instructor_id: 'instructor1' }),
       })
     );
+  });
+
+  test('resolves plan slugs to ids', async () => {
+    service.createClass.mockImplementation(async (data) => data);
+
+    const req = {
+      body: { title: 'Test', included_plans: ['student-slug'] },
+      user: { id: 'admin1', role: 'admin' },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      res.json.mockImplementation((data) => {
+        resolve();
+        return data;
+      });
+      next.mockImplementation((err) => {
+        resolve();
+        return err;
+      });
+      controller.createClass(req, res, next);
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ included_plans: ['plan-student'] })
+      })
+    );
+  });
+
+  test('rejects non-student plan', async () => {
+    service.createClass.mockImplementation(async (data) => data);
+
+    const req = {
+      body: { title: 'Test', included_plans: ['inst-slug'] },
+      user: { id: 'admin1', role: 'admin' },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      next.mockImplementation((err) => {
+        resolve();
+        return err;
+      });
+      controller.createClass(req, res, next);
+    });
+
+    expect(next).toHaveBeenCalled();
+    expect(next.mock.calls[0][0].message).toBe('Invalid included plan');
   });
 });
 

--- a/backend/src/modules/classes/__tests__/class.validator.test.js
+++ b/backend/src/modules/classes/__tests__/class.validator.test.js
@@ -1,3 +1,21 @@
+jest.mock('../../../config/database', () => {
+  const plans = {
+    'student-id': { id: 'student-id', slug: 'student-slug', target_role: 'student' },
+    'student-slug': { id: 'student-id', slug: 'student-slug', target_role: 'student' },
+    'inst-id': { id: 'inst-id', slug: 'inst-slug', target_role: 'instructor' },
+    'inst-slug': { id: 'inst-id', slug: 'inst-slug', target_role: 'instructor' }
+  };
+  return jest.fn(() => ({
+    where(cond) {
+      this.key = cond.id || cond.slug;
+      return this;
+    },
+    first() {
+      return Promise.resolve(plans[this.key] || null);
+    }
+  }));
+});
+
 const validator = require('../class.validator');
 
 const base = {
@@ -6,22 +24,22 @@ const base = {
 };
 
 describe('class validator date handling', () => {
-  test('rejects invalid start_date', () => {
-    const result = validator.create.safeParse({
+  test('rejects invalid start_date', async () => {
+    const result = await validator.create.safeParseAsync({
       body: { ...base, start_date: 'not-a-date' }
     });
     expect(result.success).toBe(false);
   });
 
-  test('rejects invalid end_date', () => {
-    const result = validator.create.safeParse({
+  test('rejects invalid end_date', async () => {
+    const result = await validator.create.safeParseAsync({
       body: { ...base, end_date: '32/13/2024' }
     });
     expect(result.success).toBe(false);
   });
 
-  test('rejects end_date earlier than start_date', () => {
-    const result = validator.create.safeParse({
+  test('rejects end_date earlier than start_date', async () => {
+    const result = await validator.create.safeParseAsync({
       body: {
         ...base,
         start_date: '2024-05-10',
@@ -31,8 +49,8 @@ describe('class validator date handling', () => {
     expect(result.success).toBe(false);
   });
 
-  test('accepts valid dates in order', () => {
-    const result = validator.create.safeParse({
+  test('accepts valid dates in order', async () => {
+    const result = await validator.create.safeParseAsync({
       body: {
         ...base,
         start_date: '2024-05-01',
@@ -40,5 +58,21 @@ describe('class validator date handling', () => {
       }
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe('included_plans validation', () => {
+  test('accepts existing student plan', async () => {
+    const result = await validator.create.safeParseAsync({
+      body: { ...base, included_plans: ['student-id'] }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects non-student plan', async () => {
+    const result = await validator.create.safeParseAsync({
+      body: { ...base, included_plans: ['inst-id'] }
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -37,11 +37,27 @@ exports.createClass = catchAsync(async (req, res) => {
     moderation_status: "Pending",
   };
   if (included_plans) {
-    try {
-      data.included_plans = JSON.parse(included_plans);
-    } catch {
-      data.included_plans = included_plans;
+    let plansList = included_plans;
+    if (typeof plansList === "string") {
+      try {
+        plansList = JSON.parse(plansList);
+      } catch {
+        plansList = [plansList];
+      }
     }
+    if (!Array.isArray(plansList)) plansList = [plansList];
+    const ids = [];
+    for (const ref of plansList) {
+      let plan = await db("plans").where({ id: ref }).first();
+      if (!plan) {
+        plan = await db("plans").where({ slug: ref }).first();
+      }
+      if (!plan || plan.target_role !== "student") {
+        throw new AppError("Invalid included plan", 400);
+      }
+      ids.push(plan.id);
+    }
+    data.included_plans = ids;
   }
   if (access_type) {
     data.access_type = access_type;
@@ -199,11 +215,27 @@ exports.updateClass = catchAsync(async (req, res) => {
   const { tags: rawTags, included_plans, access_type, ...body } = req.body;
   let data = { ...body };
   if (included_plans !== undefined) {
-    try {
-      data.included_plans = JSON.parse(included_plans);
-    } catch {
-      data.included_plans = included_plans;
+    let plansList = included_plans;
+    if (typeof plansList === "string") {
+      try {
+        plansList = JSON.parse(plansList);
+      } catch {
+        plansList = [plansList];
+      }
     }
+    if (!Array.isArray(plansList)) plansList = [plansList];
+    const ids = [];
+    for (const ref of plansList) {
+      let plan = await db("plans").where({ id: ref }).first();
+      if (!plan) {
+        plan = await db("plans").where({ slug: ref }).first();
+      }
+      if (!plan || plan.target_role !== "student") {
+        throw new AppError("Invalid included plan", 400);
+      }
+      ids.push(plan.id);
+    }
+    data.included_plans = ids;
   }
   if (access_type !== undefined) {
     data.access_type = access_type;

--- a/backend/src/modules/classes/class.validator.js
+++ b/backend/src/modules/classes/class.validator.js
@@ -1,4 +1,5 @@
 const { z } = require("zod");
+const db = require("../../config/database");
 
 const toNumber = (val) => {
   if (typeof val === 'number') return val;
@@ -18,6 +19,27 @@ const toStringArray = (val) => {
   }
   return undefined;
 };
+
+const validateStudentPlans = async (plans) => {
+  if (!plans) return true;
+  for (const p of plans) {
+    let plan = await db("plans").where({ id: p }).first();
+    if (!plan) {
+      plan = await db("plans").where({ slug: p }).first();
+    }
+    if (!plan || plan.target_role !== "student") {
+      return false;
+    }
+  }
+  return true;
+};
+
+const includedPlans = z.preprocess(
+  toStringArray,
+  z.array(z.string()).optional()
+).refine(validateStudentPlans, {
+  message: "Included plans must exist and target students",
+});
 
 exports.create = z.object({
   body: z.object({
@@ -51,10 +73,7 @@ exports.create = z.object({
     slug: z.string().optional(),
     status: z.enum(["draft", "published", "archived"]).optional(),
     access_type: z.enum(["paid", "free"]).optional(),
-    included_plans: z.preprocess(
-      toStringArray,
-      z.array(z.string()).optional()
-    ),
+    included_plans: includedPlans,
   })
     .refine(
       (data) =>
@@ -100,10 +119,7 @@ exports.update = z.object({
       slug: z.string().optional(),
       status: z.enum(["draft", "published", "archived"]).optional(),
       access_type: z.enum(["paid", "free"]).optional(),
-      included_plans: z.preprocess(
-        toStringArray,
-        z.array(z.string()).optional()
-      ),
+      included_plans: includedPlans,
     })
     .refine(
       (data) =>
@@ -150,10 +166,7 @@ exports.adminUpdate = z.object({
       slug: z.string().optional(),
       status: z.enum(["draft", "published", "archived"]).optional(),
       access_type: z.enum(["paid", "free"]).optional(),
-      included_plans: z.preprocess(
-        toStringArray,
-        z.array(z.string()).optional()
-      ),
+      included_plans: includedPlans,
     })
     .refine(
       (data) =>


### PR DESCRIPTION
## Summary
- ensure included plans exist and target students during validation
- resolve plan slugs to IDs in class creation and updates
- support async Zod checks in validation middleware and add tests

## Testing
- `npm test` *(fails: database configuration is missing)*
- `npm test -- src/modules/classes/__tests__/class.validator.test.js src/modules/classes/__tests__/class.controller.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bc11115d688328939c04463c9fcdcf