### PR TITLE
Add tutorial plan revenue tracking

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -134,6 +134,7 @@ describe('Class enrollment routes', () => {
     expect(res.statusCode).toBe(200);
     expect(service.createEnrollment).toHaveBeenCalled();
     expect(creditInstructorSubscription).toHaveBeenCalledWith(
+      'class',
       'abc',
       'plan1',
       expect.anything(),

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -60,9 +60,27 @@ exports.enroll = catchAsync(async (req, res) => {
         });
       }
 
-      await planRevenue.calculateInstructorAmount(activePlanId, classId, trx);
+      await planRevenue.calculateInstructorAmount(
+        activePlanId,
+        classId,
+        "class",
+        trx,
+      );
 
-      await creditInstructorSubscription(classId, activePlanId, trx);
+      await creditInstructorSubscription(
+        "class",
+        classId,
+        activePlanId,
+        trx,
+      );
+
+      await trx("payments").insert({
+        user_id,
+        item_id: classId,
+        item_type: "class",
+        source: "subscription",
+        amount: 0,
+      });
     } else if (Number(cls.price) > 0) {
       const payment = await trx("payments")
         .where({

--- a/backend/src/modules/payments/helpers/__tests__/planRevenue.test.js
+++ b/backend/src/modules/payments/helpers/__tests__/planRevenue.test.js
@@ -1,11 +1,10 @@
-jest.mock('../../../config/database', () => {
-  const db = jest.fn(() => db);
-  db.where = jest.fn(() => db);
-  db.first = jest.fn();
-  return db;
-});
+jest.mock('../../../../config/database.js', () => jest.fn());
+jest.mock('../platformFee', () => ({
+  calculatePlatformFee: jest.fn(),
+}));
 
-const db = require('../../../config/database');
+const db = require('../../../../config/database.js');
+const { calculatePlatformFee } = require('../platformFee');
 const { calculateInstructorAmount } = require('../planRevenue');
 
 describe('calculateInstructorAmount', () => {
@@ -13,21 +12,49 @@ describe('calculateInstructorAmount', () => {
     jest.clearAllMocks();
   });
 
-  it('applies commission rate to usage amount', async () => {
-    db.first
-      .mockResolvedValueOnce({ amount: 100 })
-      .mockResolvedValueOnce({ value: '0.2' });
+  function mockDb() {
+    const planUsageQuery = {
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue({ usage_count: 2 }),
+      insert: jest.fn().mockResolvedValue(),
+      update: jest.fn().mockResolvedValue(),
+    };
+    const plansQuery = {
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue({ price_monthly: 100 }),
+    };
+    db.mockImplementation((table) => {
+      if (table === 'plan_usage_metrics') return planUsageQuery;
+      if (table === 'plans') return plansQuery;
+    });
+    return { planUsageQuery, plansQuery };
+  }
 
-    const amt = await calculateInstructorAmount('plan1', 'class1');
-    expect(amt).toBeCloseTo(80);
-    expect(db).toHaveBeenCalledWith('plan_usage_metrics');
-    expect(db).toHaveBeenCalledWith('plan_features');
+  it('divides net plan revenue by usage count', async () => {
+    mockDb();
+    calculatePlatformFee.mockResolvedValueOnce({ instructor_amount: 80 });
+
+    const amt = await calculateInstructorAmount('plan1', 'item1', 'class');
+    expect(amt).toBeCloseTo(40);
   });
 
-  it('returns 0 when metrics missing', async () => {
-    db.first.mockResolvedValueOnce(null);
-    const amt = await calculateInstructorAmount('plan1', 'class1');
+  it('returns 0 when plan not found', async () => {
+    const planUsageQuery = {
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue({ usage_count: 2 }),
+      insert: jest.fn().mockResolvedValue(),
+      update: jest.fn().mockResolvedValue(),
+    };
+    const plansQuery = {
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+    };
+    db.mockImplementation((table) => {
+      if (table === 'plan_usage_metrics') return planUsageQuery;
+      if (table === 'plans') return plansQuery;
+    });
+
+    const amt = await calculateInstructorAmount('plan1', 'item1', 'class');
     expect(amt).toBe(0);
   });
 });
-

--- a/backend/src/modules/payments/helpers/planRevenue.js
+++ b/backend/src/modules/payments/helpers/planRevenue.js
@@ -1,21 +1,26 @@
 const db = require("../../../config/database");
 const { calculatePlatformFee } = require("./platformFee");
 
-// Calculate instructor share for a class enrollment covered by a subscription plan
+// Calculate instructor share for an enrollment covered by a subscription plan.
 // Uses plan usage metrics and the plan's commission rate to determine the
-// instructor's payout for the given plan and class.
-exports.calculateInstructorAmount = async (planId, classId, trx) => {
+// instructor's payout for the given plan and item.
+exports.calculateInstructorAmount = async (
+  planId,
+  itemId,
+  itemType = "class",
+  trx,
+) => {
   const query = trx || db;
   try {
     let row = await query("plan_usage_metrics")
-      .where({ plan_id: planId, item_type: "class", item_id: classId })
+      .where({ plan_id: planId, item_type: itemType, item_id: itemId })
       .first();
 
     if (!row) {
       await query("plan_usage_metrics").insert({
         plan_id: planId,
-        item_type: "class",
-        item_id: classId,
+        item_type: itemType,
+        item_id: itemId,
         usage_count: 1,
         instructor_amount: 0,
       });
@@ -25,11 +30,14 @@ exports.calculateInstructorAmount = async (planId, classId, trx) => {
     const plan = await query("plans").where({ id: planId }).first();
     if (!plan) return 0;
     const price = Number(plan.price_monthly || 0);
-    const { instructor_amount: net } = await calculatePlatformFee("class", price);
+    const { instructor_amount: net } = await calculatePlatformFee(
+      itemType,
+      price,
+    );
     const amount = row.usage_count > 0 ? net / row.usage_count : 0;
 
     await query("plan_usage_metrics")
-      .where({ plan_id: planId, item_type: "class", item_id: classId })
+      .where({ plan_id: planId, item_type: itemType, item_id: itemId })
       .update({ instructor_amount: amount });
 
     return Number(amount);

--- a/backend/src/modules/payments/helpers/wallet.js
+++ b/backend/src/modules/payments/helpers/wallet.js
@@ -28,13 +28,22 @@ async function creditInstructorWallet(item_type, item_id, amount) {
   }
 }
 
-async function creditInstructorSubscription(classId, planId, trx) {
+async function creditInstructorSubscription(item_type, item_id, planId, trx) {
   try {
-    const amount = await calculateInstructorAmount(planId, classId, trx);
+    const amount = await calculateInstructorAmount(planId, item_id, item_type, trx);
     if (amount <= 0) return;
-    const cls = await classService.getClassById(classId);
-    if (cls?.instructor_id) {
-      await walletService.increment(cls.instructor_id, amount, trx);
+
+    let instructorId;
+    if (item_type === "class") {
+      const cls = await classService.getClassById(item_id);
+      instructorId = cls?.instructor_id;
+    } else if (item_type === "tutorial") {
+      const tut = await tutorialService.getTutorialById(item_id);
+      instructorId = tut?.instructor_id;
+    }
+
+    if (instructorId) {
+      await walletService.increment(instructorId, amount, trx);
     }
   } catch (err) {
     logger.error("Failed to credit instructor wallet from subscription:", err);

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -4,6 +4,9 @@ const AppError = require("../../../../utils/AppError");
 const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
+const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
+const { creditInstructorSubscription } = require("../../../payments/helpers/wallet");
+const planRevenue = require("../../../payments/helpers/planRevenue");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -20,7 +23,61 @@ exports.enroll = catchAsync(async (req, res) => {
   const id = uuidv4();
 
   const enroll = async (trx) => {
-    if (Number(tutorial.price) > 0) {
+    const activePlanId = await getActiveStudentPlanId(user_id);
+    const includedPlans = Array.isArray(tutorial.included_plans)
+      ? tutorial.included_plans
+      : [];
+    const coveredBySubscription =
+      activePlanId && includedPlans.includes(activePlanId);
+
+    if (coveredBySubscription) {
+      const usage = await trx("plan_usage_metrics")
+        .where({
+          plan_id: activePlanId,
+          item_type: "tutorial",
+          item_id: tutorialId,
+        })
+        .first();
+
+      if (usage) {
+        await trx("plan_usage_metrics")
+          .where({
+            plan_id: activePlanId,
+            item_type: "tutorial",
+            item_id: tutorialId,
+          })
+          .update({ usage_count: usage.usage_count + 1 });
+      } else {
+        await trx("plan_usage_metrics").insert({
+          plan_id: activePlanId,
+          item_type: "tutorial",
+          item_id: tutorialId,
+          usage_count: 1,
+        });
+      }
+
+      await planRevenue.calculateInstructorAmount(
+        activePlanId,
+        tutorialId,
+        "tutorial",
+        trx,
+      );
+
+      await creditInstructorSubscription(
+        "tutorial",
+        tutorialId,
+        activePlanId,
+        trx,
+      );
+
+      await trx("payments").insert({
+        user_id,
+        item_id: tutorialId,
+        item_type: "tutorial",
+        source: "subscription",
+        amount: 0,
+      });
+    } else if (Number(tutorial.price) > 0) {
       const payment = await trx("payments")
         .where({ user_id, item_type: "tutorial", item_id: tutorialId })
         .first();


### PR DESCRIPTION
## Summary
- Generalize plan revenue helper to handle class and tutorial enrollments
- Credit instructor wallets for tutorial plan enrollments and log subscription payments
- Record plan revenue on class enrollments using explicit item type

## Testing
- `npm test -- src/modules/payments/helpers/__tests__/planRevenue.test.js src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc34a7d5f08328a846d068d26c8406