### PR TITLE
Support plan-based tutorial enrollment

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -4,6 +4,7 @@ const AppError = require("../../../../utils/AppError");
 const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
+const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -17,10 +18,42 @@ exports.enroll = catchAsync(async (req, res) => {
   if (tutorial.status !== "published")
     throw new AppError("Tutorial not published", 400);
 
+  const activePlanId = await getActiveStudentPlanId(user_id);
+  const includedPlans = Array.isArray(tutorial.included_plans)
+    ? tutorial.included_plans
+    : [];
+  const coveredBySubscription =
+    activePlanId && includedPlans.includes(activePlanId);
+
   const id = uuidv4();
 
   const enroll = async (trx) => {
-    if (Number(tutorial.price) > 0) {
+    if (coveredBySubscription) {
+      const usage = await trx("plan_usage_metrics")
+        .where({
+          plan_id: activePlanId,
+          item_type: "tutorial",
+          item_id: tutorialId,
+        })
+        .first();
+
+      if (usage) {
+        await trx("plan_usage_metrics")
+          .where({
+            plan_id: activePlanId,
+            item_type: "tutorial",
+            item_id: tutorialId,
+          })
+          .update({ usage_count: usage.usage_count + 1 });
+      } else {
+        await trx("plan_usage_metrics").insert({
+          plan_id: activePlanId,
+          item_type: "tutorial",
+          item_id: tutorialId,
+          usage_count: 1,
+        });
+      }
+    } else if (Number(tutorial.price) > 0) {
       const payment = await trx("payments")
         .where({ user_id, item_type: "tutorial", item_id: tutorialId })
         .first();

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -2,8 +2,13 @@ const request = require('supertest');
 const express = require('express');
 const errorHandler = require('../src/middleware/errorHandler');
 
-jest.mock('../src/config/database');
+jest.mock('../src/config/database', () => jest.fn());
 const db = require('../src/config/database');
+
+jest.mock('../src/modules/plans/subscription.helper', () => ({
+  getActiveStudentPlanId: jest.fn(),
+}));
+const { getActiveStudentPlanId } = require('../src/modules/plans/subscription.helper');
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
@@ -23,6 +28,7 @@ app.use(errorHandler);
 describe('POST /api/users/tutorials/enrollments/:id', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getActiveStudentPlanId.mockResolvedValue(null);
   });
 
   it('enrolls in a free tutorial', async () => {
@@ -46,7 +52,9 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
         };
     });
 
-    const res = await request(app).post('/api/users/tutorials/enrollments/t1');
+    const res = await request(app).post(
+      '/api/users/tutorials/enrollments/123e4567-e89b-12d3-a456-426614174000',
+    );
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Enrolled successfully');
   });
@@ -76,7 +84,9 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
         };
     });
 
-    const res = await request(app).post('/api/users/tutorials/enrollments/t2');
+    const res = await request(app).post(
+      '/api/users/tutorials/enrollments/123e4567-e89b-12d3-a456-426614174001',
+    );
     expect(res.status).toBe(402);
     expect(res.body.message).toBe('Payment required');
   });
@@ -107,9 +117,50 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
         };
     });
 
-    const res = await request(app).post('/api/users/tutorials/enrollments/t3');
+    const res = await request(app).post(
+      '/api/users/tutorials/enrollments/123e4567-e89b-12d3-a456-426614174002',
+    );
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Enrolled successfully');
+  });
+
+  it('enrolls in paid tutorial covered by subscription', async () => {
+    const planInsert = jest.fn(() => Promise.resolve());
+
+    db.mockImplementation((table) => {
+      if (table === 'tutorials')
+        return {
+          where: () => ({
+            first: () =>
+              Promise.resolve({
+                id: 't4',
+                price: 100,
+                moderation_status: 'Approved',
+                status: 'published',
+                included_plans: ['plan1'],
+              }),
+          }),
+        };
+      if (table === 'tutorial_enrollments')
+        return {
+          where: () => ({ first: () => Promise.resolve(null) }),
+          insert: jest.fn(() => Promise.resolve()),
+        };
+      if (table === 'plan_usage_metrics')
+        return {
+          where: () => ({ first: () => Promise.resolve(null), update: jest.fn() }),
+          insert: planInsert,
+        };
+    });
+
+    getActiveStudentPlanId.mockResolvedValue('plan1');
+
+    const res = await request(app).post(
+      '/api/users/tutorials/enrollments/123e4567-e89b-12d3-a456-426614174003',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Enrolled successfully');
+    expect(planInsert).toHaveBeenCalled();
   });
 });
 
@@ -152,7 +203,9 @@ describe('POST /api/users/tutorials/enrollments/:id/complete', () => {
         };
     });
 
-    const res = await request(app).post('/api/users/tutorials/enrollments/t1/complete');
+    const res = await request(app).post(
+      '/api/users/tutorials/enrollments/123e4567-e89b-12d3-a456-426614174000/complete',
+    );
     expect(res.status).toBe(200);
     expect(update).toHaveBeenCalledWith({ status: 'completed', progress: 100 });
   });
@@ -188,7 +241,7 @@ describe('POST /api/users/tutorials/enrollments/:id/complete', () => {
     });
 
     const res = await request(app).post(
-      '/api/users/tutorials/enrollments/t1/complete'
+      '/api/users/tutorials/enrollments/123e4567-e89b-12d3-a456-426614174000/complete',
     );
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
## Summary
- Check if a tutorial is covered by the student's active subscription plan before enforcing payment
- Log tutorial usage into `plan_usage_metrics` when access is granted via a plan
- Add tests covering enrollment via subscription

## Testing
- `npm test tests/tutorialEnrollmentRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc34aaa0f88328aa8905f528e2a72b