### PR TITLE
Add included plans support for tutorials

### DIFF
--- a/backend/src/migrations/20250927000000_add_included_plans_to_tutorials.js
+++ b/backend/src/migrations/20250927000000_add_included_plans_to_tutorials.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('tutorials', function(table) {
+    table.jsonb('included_plans').notNullable().defaultTo('[]');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('tutorials', function(table) {
+    table.dropColumn('included_plans');
+  });
+};

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -46,6 +46,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     status = "draft",
     tags: rawTags,
     chapters: rawChapters,
+    included_plans = [],
     instructor_id: bodyInstructorId,
   } = req.body;
 
@@ -91,6 +92,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     instructor_id,
     status,
     moderation_status: status === "published" ? "Pending" : null,
+    included_plans,
     cover_image: thumbnailFile
       ? `/uploads/tutorials/${roleDir}/${thumbnailFile.filename}`
       : null,

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -7,7 +7,9 @@ const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
 
 exports.createTutorial = async (data, trx = db) => {
-  const [tutorial] = await trx("tutorials").insert(data).returning("*");
+  const insertData = { included_plans: [], ...data };
+  if (!insertData.included_plans) insertData.included_plans = [];
+  const [tutorial] = await trx("tutorials").insert(insertData).returning("*");
   return tutorial;
 };
 
@@ -198,7 +200,14 @@ exports.getTutorialsByInstructor = async (instructorId) => {
 };
 
 exports.updateTutorial = async (id, data) => {
-  const [updated] = await db("tutorials").where({ id }).update(data).returning("*");
+  const updateData = { ...data };
+  if (updateData.included_plans === undefined) {
+    delete updateData.included_plans;
+  }
+  const [updated] = await db("tutorials")
+    .where({ id })
+    .update(updateData)
+    .returning("*");
   return updated;
 };
 

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -39,6 +39,7 @@ exports.create = z.object({
       z.number().int().nonnegative()
     ).optional(),
     is_paid: z.preprocess(toBoolean, z.boolean().optional()),
+    included_plans: z.preprocess(parseJson, z.array(z.string()).optional()),
     tags: z.preprocess(parseJson, z.array(z.string()).optional()),
     chapters: z
       .preprocess(


### PR DESCRIPTION
## Summary
- allow tutorials to store included plan IDs
- accept `included_plans` array in tutorial validator
- persist and update `included_plans` on tutorial create/update

## Testing
- `npm test` *(fails: database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc34abe4688328b1317f87a7f33af1