### PR TITLE
Record subscription-covered tutorial enrollments

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -5,6 +5,7 @@ const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
 const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
+const planRevenue = require("../../../payments/helpers/planRevenue");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -53,6 +54,21 @@ exports.enroll = catchAsync(async (req, res) => {
           usage_count: 1,
         });
       }
+
+      await planRevenue.calculateInstructorAmount(
+        activePlanId,
+        tutorialId,
+        trx,
+        "tutorial"
+      );
+
+      await trx("payments").insert({
+        user_id,
+        item_id: tutorialId,
+        item_type: "tutorial",
+        source: "subscription",
+        amount: 0,
+      });
     } else if (Number(tutorial.price) > 0) {
       const payment = await trx("payments")
         .where({ user_id, item_type: "tutorial", item_id: tutorialId })

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -10,6 +10,11 @@ jest.mock('../src/modules/plans/subscription.helper', () => ({
 }));
 const { getActiveStudentPlanId } = require('../src/modules/plans/subscription.helper');
 
+jest.mock('../src/modules/payments/helpers/planRevenue', () => ({
+  calculateInstructorAmount: jest.fn(),
+}));
+const planRevenue = require('../src/modules/payments/helpers/planRevenue');
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
     req.user = { id: 'user1' };
@@ -126,6 +131,7 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
 
   it('enrolls in paid tutorial covered by subscription', async () => {
     const planInsert = jest.fn(() => Promise.resolve());
+    const paymentInsert = jest.fn(() => Promise.resolve());
 
     db.mockImplementation((table) => {
       if (table === 'tutorials')
@@ -151,16 +157,32 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
           where: () => ({ first: () => Promise.resolve(null), update: jest.fn() }),
           insert: planInsert,
         };
+      if (table === 'payments')
+        return { insert: paymentInsert };
     });
 
     getActiveStudentPlanId.mockResolvedValue('plan1');
 
+    const tutorialId = '123e4567-e89b-12d3-a456-426614174003';
     const res = await request(app).post(
-      '/api/users/tutorials/enrollments/123e4567-e89b-12d3-a456-426614174003',
+      `/api/users/tutorials/enrollments/${tutorialId}`,
     );
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Enrolled successfully');
     expect(planInsert).toHaveBeenCalled();
+    expect(paymentInsert).toHaveBeenCalledWith({
+      user_id: 'user1',
+      item_id: tutorialId,
+      item_type: 'tutorial',
+      source: 'subscription',
+      amount: 0,
+    });
+    expect(planRevenue.calculateInstructorAmount).toHaveBeenCalledWith(
+      'plan1',
+      tutorialId,
+      expect.anything(),
+      'tutorial'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- record zero-amount subscription payments when enrolling in tutorials
- compute instructor revenue for subscription-covered tutorials
- test tutorial enrollment under subscription coverage

## Testing
- `npm test` *(fails: database configuration missing, but `tests/tutorialEnrollmentRoutes.test.js` passes before failure)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3ac035548328a8695d0ed628a39b