### PR TITLE
feat: translate favorite tutorials in sidebar

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1065,6 +1065,7 @@
     "FAQs": "الأسئلة الشائعة",
     "Footer Settings": "إعدادات التذييل",
     "Go to Website": "الانتقال إلى الموقع",
+    "Favorite Tutorials": "الدروس المفضلة",
     "Help Center": "مركز المساعدة",
     "Instructors": "المدربون",
     "Language Config": "إعداد اللغة",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1079,6 +1079,7 @@
     "FAQs": "FAQs",
     "Footer Settings": "Footer Settings",
     "Go to Website": "Go to Website",
+    "Favorite Tutorials": "Lieblingstutorials",
     "Help Center": "Help Center",
     "Instructors": "Instructors",
     "Language Config": "Sprachkonfiguration",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1065,6 +1065,7 @@
     "FAQs": "FAQs",
     "Footer Settings": "Footer Settings",
     "Go to Website": "Go to Website",
+    "Favorite Tutorials": "Favorite Tutorials",
     "Help Center": "Help Center",
     "Instructors": "Instructors",
     "Language Config": "Language Config",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1065,6 +1065,7 @@
     "FAQs": "Preguntas frecuentes",
     "Footer Settings": "Configuración de pie de página",
     "Go to Website": "Ir al sitio web",
+    "Favorite Tutorials": "Tutoriales favoritos",
     "Help Center": "Centro de ayuda",
     "Instructors": "Instructores",
     "Language Config": "Configuración del lenguaje",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1045,6 +1045,7 @@
     "FAQs": "FAQs",
     "Footer Settings": "Paramètres du pied de page",
     "Go to Website": "Aller au site web",
+    "Favorite Tutorials": "Tutoriels favoris",
     "Help Center": "Centre d'aide",
     "Instructors": "Instructeurs",
     "Language Config": "Configuration de la langue",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1065,6 +1065,7 @@
     "FAQs": "पूछे जाने वाले प्रश्न",
     "Footer Settings": "फुटर सेटिंग्स",
     "Go to Website": "वेबसाइट पर जाएं",
+    "Favorite Tutorials": "पसंदीदा ट्यूटोरियल",
     "Help Center": "सहायता केंद्र",
     "Instructors": "प्रशिक्षक",
     "Language Config": "भाषा विन्यास",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1079,6 +1079,7 @@
     "FAQs": "FAQ",
     "Footer Settings": "Impostazioni del piè di pagina",
     "Go to Website": "Vai al sito web",
+    "Favorite Tutorials": "Tutorial preferiti",
     "Help Center": "Centro di aiuto",
     "Instructors": "Istruttori",
     "Language Config": "Configurazione del linguaggio",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1065,6 +1065,7 @@
     "FAQs": "常见问题解答",
     "Footer Settings": "页脚设置",
     "Go to Website": "访问网站",
+    "Favorite Tutorials": "收藏教程",
     "Help Center": "帮助中心",
     "Instructors": "讲师",
     "Language Config": "语言配置",


### PR DESCRIPTION
## Summary
- add `sidebar.Favorite Tutorials` translations for all locales
- keep sidebar labels localized for student navigation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc3cc9c254832880af2c94b2a65c98