### PR TITLE
feat: add i18n for student dashboard

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1874,5 +1874,52 @@
     "purchase_failed": "Purchase failed",
     "price": "Price",
     "none_available": "No ad slots available"
+  },
+  "studentDashboardHome": {
+    "welcome_back": "👋 Welcome back, {{name}}!",
+    "enrolled_classes": "You're enrolled in {{count}} classes. Keep up the good work!",
+    "learning_progress": "📈 Learning Progress",
+    "upcoming_events": "📅 Upcoming Events",
+    "no_upcoming_events": "No upcoming events",
+    "current_classes": "📘 Current Classes",
+    "progress": "Progress",
+    "next_session": "Next session",
+    "view_class": "View Class",
+    "no_classes": "You are not enrolled in any classes.",
+    "class_number": "Class {{num}}"
+  },
+  "studentPaymentsPage": {
+    "title": "💳 Payment History",
+    "total_paid": "Total Paid",
+    "pending_payments": "Pending Payments",
+    "total_classes": "Total Classes",
+    "class": "Class",
+    "amount": "Amount",
+    "method": "Method",
+    "date": "Date",
+    "status": "Status",
+    "action": "Action",
+    "invoice": "Invoice",
+    "i_paid": "I Paid",
+    "awaiting_approval": "Awaiting Approval",
+    "download": "Download",
+    "payment_issues": "For any payment issues, contact <a>support@skillbridge.com</a>",
+    "confirm_bank_payment": "Confirm Bank Payment",
+    "reference_placeholder": "Transaction reference",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "invoice_not_found": "Invoice not found",
+    "invoice_failed": "❌ Failed to generate invoice. Please try again.",
+    "confirm_payment_failed": "Failed to confirm payment",
+    "status_labels": {
+      "awaiting_approval": "Awaiting Approval",
+      "paid": "Paid",
+      "pending_payment": "Pending Payment"
+    }
+  },
+  "studentSchedulePage": {
+    "title": "My Booked Lessons",
+    "failed_live_session": "Failed to join live session",
+    "event_alert": "📚 {{subject}}\\n👨‍🏫 Instructor: {{instructor}}"
   }
 }

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1880,5 +1880,52 @@
     "settings_updated": "Social login settings updated",
     "provider_settings_saved": "{{name}} settings saved",
     "provider_settings_updated": "{{name}} settings updated"
+  },
+  "studentDashboardHome": {
+    "welcome_back": "👋 Welcome back, {{name}}!",
+    "enrolled_classes": "You're enrolled in {{count}} classes. Keep up the good work!",
+    "learning_progress": "📈 Learning Progress",
+    "upcoming_events": "📅 Upcoming Events",
+    "no_upcoming_events": "No upcoming events",
+    "current_classes": "📘 Current Classes",
+    "progress": "Progress",
+    "next_session": "Next session",
+    "view_class": "View Class",
+    "no_classes": "You are not enrolled in any classes.",
+    "class_number": "Class {{num}}"
+  },
+  "studentPaymentsPage": {
+    "title": "💳 Payment History",
+    "total_paid": "Total Paid",
+    "pending_payments": "Pending Payments",
+    "total_classes": "Total Classes",
+    "class": "Class",
+    "amount": "Amount",
+    "method": "Method",
+    "date": "Date",
+    "status": "Status",
+    "action": "Action",
+    "invoice": "Invoice",
+    "i_paid": "I Paid",
+    "awaiting_approval": "Awaiting Approval",
+    "download": "Download",
+    "payment_issues": "For any payment issues, contact <a>support@skillbridge.com</a>",
+    "confirm_bank_payment": "Confirm Bank Payment",
+    "reference_placeholder": "Transaction reference",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "invoice_not_found": "Invoice not found",
+    "invoice_failed": "❌ Failed to generate invoice. Please try again.",
+    "confirm_payment_failed": "Failed to confirm payment",
+    "status_labels": {
+      "awaiting_approval": "Awaiting Approval",
+      "paid": "Paid",
+      "pending_payment": "Pending Payment"
+    }
+  },
+  "studentSchedulePage": {
+    "title": "My Booked Lessons",
+    "failed_live_session": "Failed to join live session",
+    "event_alert": "📚 {{subject}}\\n👨‍🏫 Instructor: {{instructor}}"
   }
 }

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1937,5 +1937,52 @@
     "purchase_failed": "Purchase failed",
     "price": "Price",
     "none_available": "No ad slots available"
+  },
+  "studentDashboardHome": {
+    "welcome_back": "👋 Welcome back, {{name}}!",
+    "enrolled_classes": "You're enrolled in {{count}} classes. Keep up the good work!",
+    "learning_progress": "📈 Learning Progress",
+    "upcoming_events": "📅 Upcoming Events",
+    "no_upcoming_events": "No upcoming events",
+    "current_classes": "📘 Current Classes",
+    "progress": "Progress",
+    "next_session": "Next session",
+    "view_class": "View Class",
+    "no_classes": "You are not enrolled in any classes.",
+    "class_number": "Class {{num}}"
+  },
+  "studentPaymentsPage": {
+    "title": "💳 Payment History",
+    "total_paid": "Total Paid",
+    "pending_payments": "Pending Payments",
+    "total_classes": "Total Classes",
+    "class": "Class",
+    "amount": "Amount",
+    "method": "Method",
+    "date": "Date",
+    "status": "Status",
+    "action": "Action",
+    "invoice": "Invoice",
+    "i_paid": "I Paid",
+    "awaiting_approval": "Awaiting Approval",
+    "download": "Download",
+    "payment_issues": "For any payment issues, contact <a>support@skillbridge.com</a>",
+    "confirm_bank_payment": "Confirm Bank Payment",
+    "reference_placeholder": "Transaction reference",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "invoice_not_found": "Invoice not found",
+    "invoice_failed": "❌ Failed to generate invoice. Please try again.",
+    "confirm_payment_failed": "Failed to confirm payment",
+    "status_labels": {
+      "awaiting_approval": "Awaiting Approval",
+      "paid": "Paid",
+      "pending_payment": "Pending Payment"
+    }
+  },
+  "studentSchedulePage": {
+    "title": "My Booked Lessons",
+    "failed_live_session": "Failed to join live session",
+    "event_alert": "📚 {{subject}}\\n👨‍🏫 Instructor: {{instructor}}"
   }
 }

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1866,5 +1866,52 @@
     "settings_updated": "Social login settings updated",
     "provider_settings_saved": "{{name}} settings saved",
     "provider_settings_updated": "{{name}} settings updated"
+  },
+  "studentDashboardHome": {
+    "welcome_back": "👋 Welcome back, {{name}}!",
+    "enrolled_classes": "You're enrolled in {{count}} classes. Keep up the good work!",
+    "learning_progress": "📈 Learning Progress",
+    "upcoming_events": "📅 Upcoming Events",
+    "no_upcoming_events": "No upcoming events",
+    "current_classes": "📘 Current Classes",
+    "progress": "Progress",
+    "next_session": "Next session",
+    "view_class": "View Class",
+    "no_classes": "You are not enrolled in any classes.",
+    "class_number": "Class {{num}}"
+  },
+  "studentPaymentsPage": {
+    "title": "💳 Payment History",
+    "total_paid": "Total Paid",
+    "pending_payments": "Pending Payments",
+    "total_classes": "Total Classes",
+    "class": "Class",
+    "amount": "Amount",
+    "method": "Method",
+    "date": "Date",
+    "status": "Status",
+    "action": "Action",
+    "invoice": "Invoice",
+    "i_paid": "I Paid",
+    "awaiting_approval": "Awaiting Approval",
+    "download": "Download",
+    "payment_issues": "For any payment issues, contact <a>support@skillbridge.com</a>",
+    "confirm_bank_payment": "Confirm Bank Payment",
+    "reference_placeholder": "Transaction reference",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "invoice_not_found": "Invoice not found",
+    "invoice_failed": "❌ Failed to generate invoice. Please try again.",
+    "confirm_payment_failed": "Failed to confirm payment",
+    "status_labels": {
+      "awaiting_approval": "Awaiting Approval",
+      "paid": "Paid",
+      "pending_payment": "Pending Payment"
+    }
+  },
+  "studentSchedulePage": {
+    "title": "My Booked Lessons",
+    "failed_live_session": "Failed to join live session",
+    "event_alert": "📚 {{subject}}\\n👨‍🏫 Instructor: {{instructor}}"
   }
 }

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1917,5 +1917,52 @@
     "purchase_failed": "Purchase failed",
     "price": "Price",
     "none_available": "No ad slots available"
+  },
+  "studentDashboardHome": {
+    "welcome_back": "👋 Welcome back, {{name}}!",
+    "enrolled_classes": "You're enrolled in {{count}} classes. Keep up the good work!",
+    "learning_progress": "📈 Learning Progress",
+    "upcoming_events": "📅 Upcoming Events",
+    "no_upcoming_events": "No upcoming events",
+    "current_classes": "📘 Current Classes",
+    "progress": "Progress",
+    "next_session": "Next session",
+    "view_class": "View Class",
+    "no_classes": "You are not enrolled in any classes.",
+    "class_number": "Class {{num}}"
+  },
+  "studentPaymentsPage": {
+    "title": "💳 Payment History",
+    "total_paid": "Total Paid",
+    "pending_payments": "Pending Payments",
+    "total_classes": "Total Classes",
+    "class": "Class",
+    "amount": "Amount",
+    "method": "Method",
+    "date": "Date",
+    "status": "Status",
+    "action": "Action",
+    "invoice": "Invoice",
+    "i_paid": "I Paid",
+    "awaiting_approval": "Awaiting Approval",
+    "download": "Download",
+    "payment_issues": "For any payment issues, contact <a>support@skillbridge.com</a>",
+    "confirm_bank_payment": "Confirm Bank Payment",
+    "reference_placeholder": "Transaction reference",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "invoice_not_found": "Invoice not found",
+    "invoice_failed": "❌ Failed to generate invoice. Please try again.",
+    "confirm_payment_failed": "Failed to confirm payment",
+    "status_labels": {
+      "awaiting_approval": "Awaiting Approval",
+      "paid": "Paid",
+      "pending_payment": "Pending Payment"
+    }
+  },
+  "studentSchedulePage": {
+    "title": "My Booked Lessons",
+    "failed_live_session": "Failed to join live session",
+    "event_alert": "📚 {{subject}}\\n👨‍🏫 Instructor: {{instructor}}"
   }
 }

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1866,5 +1866,52 @@
     "settings_updated": "Social login settings updated",
     "provider_settings_saved": "{{name}} settings saved",
     "provider_settings_updated": "{{name}} settings updated"
+  },
+  "studentDashboardHome": {
+    "welcome_back": "👋 Welcome back, {{name}}!",
+    "enrolled_classes": "You're enrolled in {{count}} classes. Keep up the good work!",
+    "learning_progress": "📈 Learning Progress",
+    "upcoming_events": "📅 Upcoming Events",
+    "no_upcoming_events": "No upcoming events",
+    "current_classes": "📘 Current Classes",
+    "progress": "Progress",
+    "next_session": "Next session",
+    "view_class": "View Class",
+    "no_classes": "You are not enrolled in any classes.",
+    "class_number": "Class {{num}}"
+  },
+  "studentPaymentsPage": {
+    "title": "💳 Payment History",
+    "total_paid": "Total Paid",
+    "pending_payments": "Pending Payments",
+    "total_classes": "Total Classes",
+    "class": "Class",
+    "amount": "Amount",
+    "method": "Method",
+    "date": "Date",
+    "status": "Status",
+    "action": "Action",
+    "invoice": "Invoice",
+    "i_paid": "I Paid",
+    "awaiting_approval": "Awaiting Approval",
+    "download": "Download",
+    "payment_issues": "For any payment issues, contact <a>support@skillbridge.com</a>",
+    "confirm_bank_payment": "Confirm Bank Payment",
+    "reference_placeholder": "Transaction reference",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "invoice_not_found": "Invoice not found",
+    "invoice_failed": "❌ Failed to generate invoice. Please try again.",
+    "confirm_payment_failed": "Failed to confirm payment",
+    "status_labels": {
+      "awaiting_approval": "Awaiting Approval",
+      "paid": "Paid",
+      "pending_payment": "Pending Payment"
+    }
+  },
+  "studentSchedulePage": {
+    "title": "My Booked Lessons",
+    "failed_live_session": "Failed to join live session",
+    "event_alert": "📚 {{subject}}\\n👨‍🏫 Instructor: {{instructor}}"
   }
 }

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1880,5 +1880,52 @@
     "settings_updated": "Social login settings updated",
     "provider_settings_saved": "{{name}} settings saved",
     "provider_settings_updated": "{{name}} settings updated"
+  },
+  "studentDashboardHome": {
+    "welcome_back": "👋 Welcome back, {{name}}!",
+    "enrolled_classes": "You're enrolled in {{count}} classes. Keep up the good work!",
+    "learning_progress": "📈 Learning Progress",
+    "upcoming_events": "📅 Upcoming Events",
+    "no_upcoming_events": "No upcoming events",
+    "current_classes": "📘 Current Classes",
+    "progress": "Progress",
+    "next_session": "Next session",
+    "view_class": "View Class",
+    "no_classes": "You are not enrolled in any classes.",
+    "class_number": "Class {{num}}"
+  },
+  "studentPaymentsPage": {
+    "title": "💳 Payment History",
+    "total_paid": "Total Paid",
+    "pending_payments": "Pending Payments",
+    "total_classes": "Total Classes",
+    "class": "Class",
+    "amount": "Amount",
+    "method": "Method",
+    "date": "Date",
+    "status": "Status",
+    "action": "Action",
+    "invoice": "Invoice",
+    "i_paid": "I Paid",
+    "awaiting_approval": "Awaiting Approval",
+    "download": "Download",
+    "payment_issues": "For any payment issues, contact <a>support@skillbridge.com</a>",
+    "confirm_bank_payment": "Confirm Bank Payment",
+    "reference_placeholder": "Transaction reference",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "invoice_not_found": "Invoice not found",
+    "invoice_failed": "❌ Failed to generate invoice. Please try again.",
+    "confirm_payment_failed": "Failed to confirm payment",
+    "status_labels": {
+      "awaiting_approval": "Awaiting Approval",
+      "paid": "Paid",
+      "pending_payment": "Pending Payment"
+    }
+  },
+  "studentSchedulePage": {
+    "title": "My Booked Lessons",
+    "failed_live_session": "Failed to join live session",
+    "event_alert": "📚 {{subject}}\\n👨‍🏫 Instructor: {{instructor}}"
   }
 }

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1837,5 +1837,52 @@
     "settings_updated": "Social login settings updated",
     "provider_settings_saved": "{{name}} settings saved",
     "provider_settings_updated": "{{name}} settings updated"
+  },
+  "studentDashboardHome": {
+    "welcome_back": "👋 Welcome back, {{name}}!",
+    "enrolled_classes": "You're enrolled in {{count}} classes. Keep up the good work!",
+    "learning_progress": "📈 Learning Progress",
+    "upcoming_events": "📅 Upcoming Events",
+    "no_upcoming_events": "No upcoming events",
+    "current_classes": "📘 Current Classes",
+    "progress": "Progress",
+    "next_session": "Next session",
+    "view_class": "View Class",
+    "no_classes": "You are not enrolled in any classes.",
+    "class_number": "Class {{num}}"
+  },
+  "studentPaymentsPage": {
+    "title": "💳 Payment History",
+    "total_paid": "Total Paid",
+    "pending_payments": "Pending Payments",
+    "total_classes": "Total Classes",
+    "class": "Class",
+    "amount": "Amount",
+    "method": "Method",
+    "date": "Date",
+    "status": "Status",
+    "action": "Action",
+    "invoice": "Invoice",
+    "i_paid": "I Paid",
+    "awaiting_approval": "Awaiting Approval",
+    "download": "Download",
+    "payment_issues": "For any payment issues, contact <a>support@skillbridge.com</a>",
+    "confirm_bank_payment": "Confirm Bank Payment",
+    "reference_placeholder": "Transaction reference",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "invoice_not_found": "Invoice not found",
+    "invoice_failed": "❌ Failed to generate invoice. Please try again.",
+    "confirm_payment_failed": "Failed to confirm payment",
+    "status_labels": {
+      "awaiting_approval": "Awaiting Approval",
+      "paid": "Paid",
+      "pending_payment": "Pending Payment"
+    }
+  },
+  "studentSchedulePage": {
+    "title": "My Booked Lessons",
+    "failed_live_session": "Failed to join live session",
+    "event_alert": "📚 {{subject}}\\n👨‍🏫 Instructor: {{instructor}}"
   }
 }

--- a/frontend/src/pages/dashboard/student/index.js
+++ b/frontend/src/pages/dashboard/student/index.js
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../next-i18next.config.js";
 import {
   LineChart,
   Line,
@@ -14,6 +17,9 @@ import { fetchMyEnrolledClasses } from "@/services/classService";
 import { getStudentProfile } from "@/services/student/studentService";
 
 function StudentDashboardHome() {
+  const { t, i18n } = useTranslation("dashboard", {
+    keyPrefix: "studentDashboardHome",
+  });
   const [hasMounted, setHasMounted] = useState(false);
   const [studentName, setStudentName] = useState("");
   const [classes, setClasses] = useState([]);
@@ -41,11 +47,11 @@ function StudentDashboardHome() {
 
         const progressChart = formatted.map((cls, index) => ({
           date: cls.nextSession
-            ? new Date(cls.nextSession).toLocaleDateString("en-US", {
+            ? new Date(cls.nextSession).toLocaleDateString(i18n.language, {
                 month: "short",
                 day: "numeric",
               })
-            : `Class ${index + 1}`,
+            : t("class_number", { num: index + 1 }),
           progress: cls.progress,
         }));
         setProgressData(progressChart);
@@ -55,7 +61,7 @@ function StudentDashboardHome() {
     };
 
     load();
-  }, []);
+  }, [t, i18n.language]);
 
   if (!hasMounted) return null;
 
@@ -63,16 +69,20 @@ function StudentDashboardHome() {
     <StudentLayout>
       <div className="p-6 space-y-6 text-gray-800">
         <div className="bg-yellow-100 p-4 rounded-lg shadow">
-          <h1 className="text-2xl font-bold mb-1">👋 Welcome back, {studentName}!</h1>
+          <h1 className="text-2xl font-bold mb-1">
+            {t("welcome_back", { name: studentName })}
+          </h1>
           <p className="text-sm text-gray-700">
-            You&apos;re enrolled in {classes.length} classes. Keep up the good work!
+            {t("enrolled_classes", { count: classes.length })}
           </p>
         </div>
 
         {/* Progress Chart */}
         {progressData.length > 0 && (
           <section className="bg-white border border-gray-200 p-4 rounded-lg shadow">
-            <h2 className="text-lg font-semibold mb-3">📈 Learning Progress</h2>
+            <h2 className="text-lg font-semibold mb-3">
+              {t("learning_progress")}
+            </h2>
             <ResponsiveContainer width="100%" height={200}>
               <LineChart
                 data={progressData}
@@ -96,7 +106,9 @@ function StudentDashboardHome() {
 
         {/* Upcoming Events */}
         <section>
-          <h2 className="text-lg font-semibold mb-3">📅 Upcoming Events</h2>
+          <h2 className="text-lg font-semibold mb-3">
+            {t("upcoming_events")}
+          </h2>
           <div className="bg-white p-4 rounded-lg shadow max-h-48 overflow-y-auto divide-y">
             {classes.length > 0 ? (
               classes.map((cls) => (
@@ -105,14 +117,18 @@ function StudentDashboardHome() {
                 </div>
               ))
             ) : (
-              <div className="py-2 text-sm text-gray-600">No upcoming events</div>
+              <div className="py-2 text-sm text-gray-600">
+                {t("no_upcoming_events")}
+              </div>
             )}
           </div>
         </section>
 
         {/* Classes Progress */}
         <section>
-          <h2 className="text-lg font-semibold mb-3">📘 Current Classes</h2>
+          <h2 className="text-lg font-semibold mb-3">
+            {t("current_classes")}
+          </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {classes.map((cls) => (
               <div
@@ -127,23 +143,21 @@ function StudentDashboardHome() {
                   ></div>
                 </div>
                 <p className="text-sm text-gray-600">
-                  Progress: {cls.progress}%
+                  {t("progress")}: {cls.progress}%
                 </p>
                 <p className="text-sm text-gray-600">
-                  Next session: {cls.nextSession}
+                  {t("next_session")}: {cls.nextSession}
                 </p>
                 <a
                   href={`/dashboard/student/classes/${cls.id}`}
                   className="inline-block mt-2 text-sm text-blue-600 hover:underline"
                 >
-                  View Class
+                  {t("view_class")}
                 </a>
               </div>
             ))}
             {classes.length === 0 && (
-              <p className="text-sm text-gray-600">
-                You are not enrolled in any classes.
-              </p>
+              <p className="text-sm text-gray-600">{t("no_classes")}</p>
             )}
           </div>
         </section>
@@ -158,4 +172,12 @@ const ProtectedStudentDashboardHome = withAuthProtection(
 );
 
 export default ProtectedStudentDashboardHome;
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
+}
 

--- a/frontend/src/pages/dashboard/student/payments/index.js
+++ b/frontend/src/pages/dashboard/student/payments/index.js
@@ -4,8 +4,14 @@ import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
 import { FaCreditCard, FaClock, FaCheckCircle, FaFileInvoice } from "react-icons/fa";
 import { fetchMyPayments, confirmPayment, uploadReceipt } from "@/services/student/paymentService";
+import { useTranslation, Trans } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 
 export default function StudentPaymentsPage() {
+  const { t } = useTranslation("dashboard", {
+    keyPrefix: "studentPaymentsPage",
+  });
   const [payments, setPayments] = useState([]);
   const [selectedPayment, setSelectedPayment] = useState(null);
   const [reference, setReference] = useState("");
@@ -56,13 +62,13 @@ export default function StudentPaymentsPage() {
       setReceipt(null);
     } catch (err) {
       console.error("Failed to confirm payment", err);
-      alert("Failed to confirm payment");
+      alert(t("confirm_payment_failed"));
     }
   };
 
   const downloadInvoicePDF = async (id) => {
     const element = document.getElementById(`invoice-${id}`);
-    if (!element) return alert("Invoice not found");
+    if (!element) return alert(t("invoice_not_found"));
   
     try {
       const canvas = await html2canvas(element, {
@@ -81,7 +87,7 @@ export default function StudentPaymentsPage() {
       pdf.save(`invoice-${id}.pdf`);
     } catch (err) {
       console.error("Failed to generate PDF:", err);
-      alert("❌ Failed to generate invoice. Please try again.");
+      alert(t("invoice_failed"));
     }
   };
   
@@ -89,27 +95,27 @@ export default function StudentPaymentsPage() {
   return (
     <StudentLayout>
       <div className="p-6 max-w-6xl mx-auto space-y-6 text-gray-800">
-        <h1 className="text-3xl font-bold text-yellow-500">💳 Payment History</h1>
+        <h1 className="text-3xl font-bold text-yellow-500">{t("title")}</h1>
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <div className="bg-white p-4 rounded-xl shadow flex items-center gap-4">
             <FaCheckCircle className="text-2xl text-green-500" />
             <div>
-              <p className="text-sm text-gray-500">Total Paid</p>
+              <p className="text-sm text-gray-500">{t("total_paid")}</p>
               <h2 className="text-xl font-semibold">${totalPaid}</h2>
             </div>
           </div>
           <div className="bg-white p-4 rounded-xl shadow flex items-center gap-4">
             <FaClock className="text-2xl text-yellow-500" />
             <div>
-              <p className="text-sm text-gray-500">Pending Payments</p>
+              <p className="text-sm text-gray-500">{t("pending_payments")}</p>
               <h2 className="text-xl font-semibold">{pending}</h2>
             </div>
           </div>
           <div className="bg-white p-4 rounded-xl shadow flex items-center gap-4">
             <FaCreditCard className="text-2xl text-blue-500" />
             <div>
-              <p className="text-sm text-gray-500">Total Classes</p>
+              <p className="text-sm text-gray-500">{t("total_classes")}</p>
               <h2 className="text-xl font-semibold">{payments.length}</h2>
             </div>
           </div>
@@ -119,13 +125,13 @@ export default function StudentPaymentsPage() {
           <table className="w-full table-auto text-sm">
             <thead>
               <tr className="bg-gray-100 text-left">
-                <th className="p-3">Class</th>
-                <th className="p-3">Amount</th>
-                <th className="p-3">Method</th>
-                <th className="p-3">Date</th>
-                <th className="p-3">Status</th>
-                <th className="p-3">Action</th>
-                <th className="p-3">Invoice</th>
+                <th className="p-3">{t("class")}</th>
+                <th className="p-3">{t("amount")}</th>
+                <th className="p-3">{t("method")}</th>
+                <th className="p-3">{t("date")}</th>
+                <th className="p-3">{t("status")}</th>
+                <th className="p-3">{t("action")}</th>
+                <th className="p-3">{t("invoice")}</th>
               </tr>
             </thead>
             <tbody>
@@ -134,7 +140,9 @@ export default function StudentPaymentsPage() {
                   <td className="p-3 font-medium">{p.class_title || p.item_id}</td>
                   <td className="p-3">${p.amount}</td>
                   <td className="p-3">{p.method_name || "-"}</td>
-                  <td className="p-3">{p.paid_at ? new Date(p.paid_at).toLocaleDateString() : "-"}</td>
+                  <td className="p-3">
+                    {p.paid_at ? new Date(p.paid_at).toLocaleDateString() : "-"}
+                  </td>
                   <td
                     className={`p-3 font-medium ${
                       p.status === "awaiting_approval"
@@ -144,12 +152,7 @@ export default function StudentPaymentsPage() {
                         : "text-yellow-600"
                     }`}
                   >
-                    {p.status
-                      ? p.status
-                          .split("_")
-                          .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-                          .join(" ")
-                      : ""}
+                    {t(`status_labels.${p.status}`)}
                   </td>
                   <td className="p-3">
                     {p.status === "pending_payment" ? (
@@ -157,10 +160,12 @@ export default function StudentPaymentsPage() {
                         onClick={() => setSelectedPayment(p)}
                         className="text-blue-600 hover:underline"
                       >
-                        I Paid
+                        {t("i_paid")}
                       </button>
                     ) : (
-                      <span className="text-gray-500">Awaiting Approval</span>
+                      <span className="text-gray-500">
+                        {t("awaiting_approval")}
+                      </span>
                     )}
                   </td>
                   <td className="p-3">
@@ -168,7 +173,7 @@ export default function StudentPaymentsPage() {
                       onClick={() => downloadInvoicePDF(p.id)}
                       className="text-blue-600 hover:underline flex items-center gap-1 text-xs"
                     >
-                      <FaFileInvoice /> Download
+                      <FaFileInvoice /> {t("download")}
                     </button>
                     <div id={`invoice-${p.id}`} className="hidden">
                       <div className="p-4 w-[600px] bg-white text-black">
@@ -189,19 +194,32 @@ export default function StudentPaymentsPage() {
         </div>
 
         <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 rounded-md text-sm text-yellow-800">
-          For any payment issues, contact <a href="mailto:support@skillbridge.com" className="underline font-medium">support@skillbridge.com</a>
+          <Trans
+            t={t}
+            i18nKey="payment_issues"
+            components={{
+              a: (
+                <a
+                  href="mailto:support@skillbridge.com"
+                  className="underline font-medium"
+                />
+              ),
+            }}
+          />
         </div>
 
         {selectedPayment && (
           <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
             <div className="bg-white p-6 rounded shadow max-w-sm w-full">
-              <h2 className="text-lg font-semibold mb-4">Confirm Bank Payment</h2>
+              <h2 className="text-lg font-semibold mb-4">
+                {t("confirm_bank_payment")}
+              </h2>
               <form onSubmit={handleConfirm} className="space-y-3">
                 <input
                   type="text"
                   value={reference}
                   onChange={(e) => setReference(e.target.value)}
-                  placeholder="Transaction reference"
+                  placeholder={t("reference_placeholder")}
                   className="w-full border rounded p-2"
                   required
                 />
@@ -216,13 +234,13 @@ export default function StudentPaymentsPage() {
                     onClick={() => setSelectedPayment(null)}
                     className="px-3 py-1 rounded bg-gray-200"
                   >
-                    Cancel
+                    {t("cancel")}
                   </button>
                   <button
                     type="submit"
                     className="px-3 py-1 rounded bg-yellow-500 text-white"
                   >
-                    Submit
+                    {t("submit")}
                   </button>
                 </div>
               </form>
@@ -232,4 +250,12 @@ export default function StudentPaymentsPage() {
       </div>
     </StudentLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }

--- a/frontend/src/pages/dashboard/student/schedule.js
+++ b/frontend/src/pages/dashboard/student/schedule.js
@@ -3,8 +3,14 @@ import StudentLayout from "@/components/layouts/StudentLayout";
 import CalendarView from "@/components/shared/CalendarView";
 import { fetchStudentBookings } from "@/services/student/bookingService";
 import { getLessonRoomLink } from "@/services/lessonService";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../next-i18next.config.js";
 
 export default function StudentSchedule() {
+  const { t } = useTranslation("dashboard", {
+    keyPrefix: "studentSchedulePage",
+  });
   const [events, setEvents] = useState([]);
 
   useEffect(() => {
@@ -34,7 +40,7 @@ export default function StudentSchedule() {
   return (
     <StudentLayout>
       <CalendarView
-        title="My Booked Lessons"
+        title={t("title")}
         events={events}
         onEventClick={async (info) => {
           const id = info.event.id || "";
@@ -48,14 +54,27 @@ export default function StudentSchedule() {
                 const url = await getLessonRoomLink(lessonId);
                 window.open(url, "_blank");
               } catch (err) {
-                alert("Failed to join live session");
+                alert(t("failed_live_session"));
               }
               return;
             }
           }
-          alert(`📚 ${info.event.extendedProps.subject}\n👨‍🏫 Instructor: ${info.event.extendedProps.instructor}`);
+          alert(
+            t("event_alert", {
+              subject: info.event.extendedProps.subject,
+              instructor: info.event.extendedProps.instructor,
+            })
+          );
         }}
       />
     </StudentLayout>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- localize student dashboard home and schedule pages
- convert student payments page to use i18n
- add dashboard translations for all locales

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3cccb53c8328a9f6988fbc719812