### PR TITLE
feat: use localized dashboard titles

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1,4 +1,9 @@
 {
+  "titles": {
+    "student_dashboard": "لوحة تحكم الطالب",
+    "instructor_dashboard": "لوحة تحكم المدرس",
+    "admin_dashboard": "لوحة تحكم المدير"
+  },
   "welcome_admin": "مرحباً، أيها المشرف",
   "users": "المستخدمون",
   "settings": "الإعدادات (JSON)",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1,4 +1,9 @@
 {
+  "titles": {
+    "student_dashboard": "Studenten-Dashboard",
+    "instructor_dashboard": "Dozenten-Dashboard",
+    "admin_dashboard": "Admin-Dashboard"
+  },
   "welcome_admin": "Willkommen, Admin",
   "users": "Benutzer",
   "settings": "Einstellungen (JSON)",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1,4 +1,9 @@
 {
+  "titles": {
+    "student_dashboard": "Student Dashboard",
+    "instructor_dashboard": "Instructor Dashboard",
+    "admin_dashboard": "Admin Dashboard"
+  },
   "welcome_admin": "Welcome, Admin",
   "users": "Users",
   "settings": "Settings (JSON)",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1,4 +1,9 @@
 {
+  "titles": {
+    "student_dashboard": "Panel de Estudiante",
+    "instructor_dashboard": "Panel de Instructor",
+    "admin_dashboard": "Panel de Administrador"
+  },
   "welcome_admin": "Bienvenido, administrador",
   "users": "Usuarios",
   "settings": "Configuración (JSON)",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1,4 +1,9 @@
 {
+  "titles": {
+    "student_dashboard": "Tableau Étudiant",
+    "instructor_dashboard": "Tableau Instructeur",
+    "admin_dashboard": "Tableau Admin"
+  },
   "welcome_admin": "Bienvenue, Administrateur",
   "users": "Utilisateurs",
   "settings": "Paramètres (JSON)",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1,4 +1,9 @@
 {
+  "titles": {
+    "student_dashboard": "छात्र डैशबोर्ड",
+    "instructor_dashboard": "प्रशिक्षक डैशबोर्ड",
+    "admin_dashboard": "व्यवस्थापक डैशबोर्ड"
+  },
   "welcome_admin": "स्वागत है, व्यवस्थापक",
   "users": "उपयोगकर्ता",
   "settings": "सेटिंग्स (JSON)",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1,4 +1,9 @@
 {
+  "titles": {
+    "student_dashboard": "Dashboard studente",
+    "instructor_dashboard": "Dashboard istruttore",
+    "admin_dashboard": "Dashboard amministratore"
+  },
   "welcome_admin": "Benvenuto, amministratore",
   "users": "Utenti",
   "settings": "Impostazioni (JSON)",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1,4 +1,9 @@
 {
+  "titles": {
+    "student_dashboard": "学生仪表板",
+    "instructor_dashboard": "讲师仪表板",
+    "admin_dashboard": "管理仪表板"
+  },
   "welcome_admin": "管理员欢迎您",
   "users": "用户",
   "settings": "设置（JSON）",

--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -84,21 +84,22 @@ export default function Header() {
     localStorage.setItem("theme", newDark ? "dark" : "light");
   };
 
+  const routeTitleMap = {
+    "/dashboard/student": "titles.student_dashboard",
+    "/dashboard/instructor": "titles.instructor_dashboard",
+    "/dashboard/admin": "titles.admin_dashboard",
+    "/dashboard/admin/settings/languages": "languagesPage.title",
+    "/dashboard/admin/settings/languages/create": "languagesPage.create_title",
+    "/dashboard/admin/settings/languages/edit/[code]": "languagesPage.edit_title",
+  };
+
   const getPageTitle = () => {
     const { pathname, query } = router;
-    switch (pathname) {
-      case "/dashboard/admin/settings/languages":
-        return tDashboard("languagesPage.title");
-      case "/dashboard/admin/settings/languages/create":
-        return tDashboard("languagesPage.create_title");
-      case "/dashboard/admin/settings/languages/edit/[code]":
-        return tDashboard("languagesPage.edit_title", { code: query.code });
-      default: {
-        const slug = pathname.split("/").pop();
-        if (!slug || slug === "index") return t("dashboard");
-        return slug.replace(/-/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
-      }
+    const key = routeTitleMap[pathname];
+    if (key) {
+      return tDashboard(key, { code: query.code });
     }
+    return t("dashboard");
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- map dashboard routes to translation keys in header
- add localized dashboard titles to translations

## Testing
- `npm test --silent > /tmp/test.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_68bc3cccdec48328a169862cf7478f2b