### PR TITLE
feat: add plan feature enforcement

### DIFF
--- a/backend/src/modules/ads/ads.utils.js
+++ b/backend/src/modules/ads/ads.utils.js
@@ -1,23 +1,4 @@
-const parsePlanFeatures = (plan = {}) => {
-  const result = {};
-  if (!plan || !Array.isArray(plan.features)) return result;
-
-  plan.features.forEach((f) => {
-    let val = f.value;
-    if (typeof val === 'string') {
-      try {
-        val = JSON.parse(val);
-      } catch {
-        if (val === 'true') val = true;
-        else if (val === 'false') val = false;
-        else if (!isNaN(val)) val = Number(val);
-      }
-    }
-    result[f.feature_key] = val;
-  });
-
-  return result;
-};
+const { parsePlanFeatures } = require("../../utils/planFeatures");
 
 // Safely calculate click-through rate as a percentage.
 // Returns 0 if views is not a positive number to avoid division errors.

--- a/backend/src/modules/classes/__tests__/class.controller.test.js
+++ b/backend/src/modules/classes/__tests__/class.controller.test.js
@@ -49,6 +49,8 @@ jest.mock('../../users/user.model', () => ({
 jest.mock('../../plans/instructor.helper', () => ({
   getActiveInstructorPlan: jest.fn(() => Promise.resolve({}))
 }));
+jest.mock('../../plans/plans.service', () => ({ getPlanById: jest.fn() }));
+const planService = require('../../plans/plans.service');
 
 const controller = require('../class.controller');
 const service = require('../class.service');
@@ -56,6 +58,9 @@ const service = require('../class.service');
 describe('class.controller createClass', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    planService.getPlanById.mockResolvedValue({
+      features: [{ feature_key: 'classes_create', value: 'true' }],
+    });
   });
 
   test('instructor cannot create class for another instructor', async () => {

--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -64,6 +64,8 @@ jest.mock('../../plans/instructor.helper', () => ({
   getActiveInstructorPlan: jest.fn(),
 }));
 const { getActiveInstructorPlan } = require('../../plans/instructor.helper');
+jest.mock('../../plans/plans.service', () => ({ getPlanById: jest.fn() }));
+const planService = require('../../plans/plans.service');
 
 const app = express();
 app.use(express.json());
@@ -76,6 +78,10 @@ describe('Class routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getActiveInstructorPlan.mockResolvedValue({ id: 'plan1', max_courses: 10 });
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      features: [{ feature_key: 'classes_create', value: 'true' }],
+    });
     service.countPublishedClasses.mockResolvedValue(0);
     service.getClassById.mockResolvedValue({ id: '1', status: 'draft', instructor_id: 'test-user', title: 'Old' });
   });
@@ -185,6 +191,18 @@ describe('Class routes', () => {
     const res = await request(app).post('/classes/instructor').send(data);
     expect(res.statusCode).toBe(200);
     expect(service.createClass).toHaveBeenCalled();
+  });
+
+  test('instructor cannot create class when feature disabled', async () => {
+    planService.getPlanById.mockResolvedValueOnce({
+      id: 'plan1',
+      features: [{ feature_key: 'classes_create', value: 'false' }],
+    });
+    const res = await request(app)
+      .post('/classes/instructor')
+      .send({ title: 'Nope' });
+    expect(res.statusCode).toBe(403);
+    expect(service.createClass).not.toHaveBeenCalled();
   });
 
   test('instructor can update class without plan', async () => {

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -8,7 +8,9 @@ const notificationService = require("../notifications/notifications.service");
 const messageService = require("../messages/messages.service");
 const userModel = require("../users/user.model");
 const { getActiveInstructorPlan } = require("../plans/instructor.helper");
+const planService = require("../plans/plans.service");
 const AppError = require("../../utils/AppError");
+const { parsePlanFeatures } = require("../../utils/planFeatures");
 
 const slugify = require("slugify");
 const db = require("../../config/database");
@@ -67,6 +69,11 @@ exports.createClass = catchAsync(async (req, res) => {
     const plan = await getActiveInstructorPlan(req.user.id);
     if (!plan) {
       throw new AppError("Active plan required", 403);
+    }
+    const fullPlan = await planService.getPlanById(plan.id);
+    const features = parsePlanFeatures(fullPlan);
+    if (!features["classes_create"]) {
+      throw new AppError("Class creation not allowed for your plan", 403);
     }
     if (data.status === "published" && plan.max_courses) {
       const count = await service.countPublishedClasses(req.user.id);

--- a/backend/src/modules/community/public/__tests__/public.routes.test.js
+++ b/backend/src/modules/community/public/__tests__/public.routes.test.js
@@ -25,16 +25,27 @@ jest.mock('../../../../utils/email', () => ({
 }));
 
 jest.mock('../../../../middleware/auth/authMiddleware', () => ({
-  verifyToken: (req, _res, next) => { req.user = { id: 'u1', full_name: 'Test User' }; next(); },
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'u1', full_name: 'Test User', plan_id: 'plan1' };
+    next();
+  },
 }));
 
 const routes = require('../public.routes');
+jest.mock('../../../plans/plans.service', () => ({ getPlanById: jest.fn() }));
+const planService = require('../../../plans/plans.service');
 const app = express();
 app.use(express.json());
 app.use('/community', routes);
 
 describe('community public routes', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      features: [{ feature_key: 'community_post', value: 'true' }],
+    });
+  });
 
   test('create discussion', async () => {
     const disc = { id: 'd1', title: 't', content: 'c', tags: ['tag1'] };
@@ -48,5 +59,19 @@ describe('community public routes', () => {
     expect(res.statusCode).toBe(200);
     expect(service.createDiscussion).toHaveBeenCalled();
     expect(res.body.data).toEqual(disc);
+  });
+
+  test('blocks discussion when feature disabled', async () => {
+    planService.getPlanById.mockResolvedValueOnce({
+      id: 'plan1',
+      features: [{ feature_key: 'community_post', value: 'false' }],
+    });
+    const res = await request(app)
+      .post('/community/discussions')
+      .field('title', 't')
+      .field('content', 'c')
+      .field('tags', JSON.stringify(['tag1']));
+    expect(res.statusCode).toBe(403);
+    expect(service.createDiscussion).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/community/public/public.controller.js
+++ b/backend/src/modules/community/public/public.controller.js
@@ -2,6 +2,8 @@ const catchAsync = require("../../../utils/catchAsync");
 const AppError = require("../../../utils/AppError");
 const { sendSuccess } = require("../../../utils/response");
 const service = require("./public.service");
+const planService = require("../../plans/plans.service");
+const { parsePlanFeatures } = require("../../../utils/planFeatures");
 
 exports.listDiscussions = catchAsync(async (_req, res) => {
   const list = await service.listDiscussions();
@@ -23,6 +25,14 @@ exports.createDiscussion = catchAsync(async (req, res) => {
   const { title, content } = req.body || {};
   let { tags } = req.body || {};
   if (!title || !content) throw new AppError("Missing fields", 400);
+
+  const planId =
+    req.user.plan_id || req.user.plan?.id || req.user.subscription?.plan_id;
+  const plan = planId ? await planService.getPlanById(planId) : null;
+  const features = parsePlanFeatures(plan);
+  if (!features["community_post"]) {
+    throw new AppError("Community posting not allowed for your plan", 403);
+  }
 
   if (typeof tags === "string") {
     try { tags = JSON.parse(tags); } catch { tags = tags.split(',').map((t) => t.trim()).filter(Boolean); }
@@ -70,6 +80,14 @@ exports.listReplies = catchAsync(async (req, res) => {
 exports.createReply = catchAsync(async (req, res) => {
   const { content } = req.body || {};
   if (!content) throw new AppError('Missing fields', 400);
+
+  const planId =
+    req.user.plan_id || req.user.plan?.id || req.user.subscription?.plan_id;
+  const plan = planId ? await planService.getPlanById(planId) : null;
+  const features = parsePlanFeatures(plan);
+  if (!features["community_post"]) {
+    throw new AppError("Community posting not allowed for your plan", 403);
+  }
 
   const file = req.files?.file?.[0];
   const audio = req.files?.audio?.[0];

--- a/backend/src/modules/library/__tests__/library.routes.test.js
+++ b/backend/src/modules/library/__tests__/library.routes.test.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../library.service', () => ({
+  listForStudent: jest.fn(),
+  getBookForDownload: jest.fn(),
+}));
+const service = require('../library.service');
+
+jest.mock('../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => { req.user = { id: 's1', plan_id: 'plan1' }; next(); },
+  isStudent: (_req, _res, next) => next(),
+}));
+
+jest.mock('../../plans/plans.service', () => ({ getPlanById: jest.fn() }));
+const planService = require('../../plans/plans.service');
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => true),
+  createReadStream: jest.fn(() => ({ pipe: jest.fn() })),
+}));
+
+const routes = require('../library.routes');
+const app = express();
+app.use('/library', routes);
+
+describe('library routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      features: [{ feature_key: 'tutorials_download', value: 'true' }],
+    });
+    service.getBookForDownload.mockResolvedValue({ pdf_url: '/file.pdf', title: 'Book' });
+  });
+
+  test('blocks download when feature disabled', async () => {
+    planService.getPlanById.mockResolvedValueOnce({
+      id: 'plan1',
+      features: [{ feature_key: 'tutorials_download', value: 'false' }],
+    });
+    const res = await request(app).get('/library/download/1');
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/backend/src/modules/library/library.controller.js
+++ b/backend/src/modules/library/library.controller.js
@@ -3,6 +3,8 @@ const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const path = require("path");
 const fs = require("fs");
+const planService = require("../plans/plans.service");
+const { parsePlanFeatures } = require("../../utils/planFeatures");
 
 exports.listLibrary = catchAsync(async (req, res) => {
   const items = await service.listForStudent(req.user.id);
@@ -10,6 +12,13 @@ exports.listLibrary = catchAsync(async (req, res) => {
 });
 
 exports.downloadBook = catchAsync(async (req, res) => {
+  const planId =
+    req.user.plan_id || req.user.plan?.id || req.user.subscription?.plan_id;
+  const plan = planId ? await planService.getPlanById(planId) : null;
+  const features = parsePlanFeatures(plan);
+  if (!features["tutorials_download"]) {
+    return res.status(403).json({ message: "Access denied" });
+  }
   const { bookId } = req.params;
   const book = await service.getBookForDownload(req.user.id, bookId);
   if (!book) {

--- a/backend/src/seeds/09_plans_seed.js
+++ b/backend/src/seeds/09_plans_seed.js
@@ -144,6 +144,27 @@ exports.seed = async function (knex) {
     },
     {
       id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.basic,
+      feature_key: 'classes_create',
+      value: 'false',
+      description: 'Cannot create classes'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.basic,
+      feature_key: 'tutorials_download',
+      value: 'false',
+      description: 'Cannot download tutorials'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.basic,
+      feature_key: 'community_post',
+      value: 'false',
+      description: 'Cannot post in community'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.regular,
       feature_key: 'commission_rate',
       value: '0.2',
@@ -165,6 +186,27 @@ exports.seed = async function (knex) {
     },
     {
       id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.regular,
+      feature_key: 'classes_create',
+      value: 'false',
+      description: 'Cannot create classes'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.regular,
+      feature_key: 'tutorials_download',
+      value: 'true',
+      description: 'Can download tutorials'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.regular,
+      feature_key: 'community_post',
+      value: 'true',
+      description: 'Can post in community'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.prime,
       feature_key: 'commission_rate',
       value: '0.1',
@@ -183,6 +225,27 @@ exports.seed = async function (knex) {
       feature_key: 'groups_join_limit',
       value: 'unlimited',
       description: 'Join unlimited groups'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'classes_create',
+      value: 'false',
+      description: 'Cannot create classes'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'tutorials_download',
+      value: 'true',
+      description: 'Can download tutorials'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids.prime,
+      feature_key: 'community_post',
+      value: 'true',
+      description: 'Can post in community'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -218,6 +281,27 @@ exports.seed = async function (knex) {
       feature_key: 'groups_join_limit',
       value: '3',
       description: 'Join up to 3 groups'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids['instructor-basic'],
+      feature_key: 'classes_create',
+      value: 'true',
+      description: 'Can create classes'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids['instructor-basic'],
+      feature_key: 'tutorials_download',
+      value: 'true',
+      description: 'Can download tutorials'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids['instructor-basic'],
+      feature_key: 'community_post',
+      value: 'true',
+      description: 'Can post in community'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -260,6 +344,27 @@ exports.seed = async function (knex) {
       feature_key: 'groups_join_limit',
       value: 'unlimited',
       description: 'Join unlimited groups'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids['instructor-pro'],
+      feature_key: 'classes_create',
+      value: 'true',
+      description: 'Can create classes'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids['instructor-pro'],
+      feature_key: 'tutorials_download',
+      value: 'true',
+      description: 'Can download tutorials'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids['instructor-pro'],
+      feature_key: 'community_post',
+      value: 'true',
+      description: 'Can post in community'
     }
   ]);
 };

--- a/backend/src/utils/planFeatures.js
+++ b/backend/src/utils/planFeatures.js
@@ -1,0 +1,22 @@
+const parsePlanFeatures = (plan = {}) => {
+  const result = {};
+  if (!plan || !Array.isArray(plan.features)) return result;
+
+  plan.features.forEach((f) => {
+    let val = f.value;
+    if (typeof val === 'string') {
+      try {
+        val = JSON.parse(val);
+      } catch {
+        if (val === 'true') val = true;
+        else if (val === 'false') val = false;
+        else if (!isNaN(val)) val = Number(val);
+      }
+    }
+    result[f.feature_key] = val;
+  });
+
+  return result;
+};
+
+module.exports = { parsePlanFeatures };


### PR DESCRIPTION
## Summary
- seed plans with classes, tutorials, and community feature flags
- enforce plan feature checks for class creation, tutorial downloads, and community posts
- add integration tests for feature restrictions

## Testing
- `npm test` *(fails: Route.post requires a callback and multiple process.exit issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4b55fb788328ad75b2c8fae411d9