### PR TITLE
Enforce group plan limits

### DIFF
--- a/backend/src/modules/groups/__tests__/planLimits.test.js
+++ b/backend/src/modules/groups/__tests__/planLimits.test.js
@@ -1,0 +1,72 @@
+jest.mock('../../../config/database', () => ({}));
+jest.mock('../groups.service', () => ({
+  findByName: jest.fn(),
+  createGroup: jest.fn(),
+  addMember: jest.fn(),
+  syncGroupTags: jest.fn(),
+  getGroupById: jest.fn(),
+  requestJoin: jest.fn(),
+  listAdminIds: jest.fn(),
+  getMemberRole: jest.fn(),
+  countUserGroups: jest.fn(),
+}));
+jest.mock('../../plans/plans.service', () => ({
+  getPlanById: jest.fn(),
+}));
+jest.mock('../../notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+jest.mock('../../messages/messages.service', () => ({
+  createMessage: jest.fn(),
+  sendEmail: jest.fn(),
+}));
+jest.mock('../../../services/mailService', () => ({ sendMail: jest.fn() }));
+jest.mock('../../../services/whatsappService', () => ({ sendWhatsApp: jest.fn() }));
+jest.mock('../../../utils/frontend', () => ({ frontendBase: 'http://test' }));
+
+const controller = require('../groups.controller');
+const service = require('../groups.service');
+const planService = require('../../plans/plans.service');
+const AppError = require('../../../utils/AppError');
+
+describe('group plan limits', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('createGroup fails when plan disallows creation', async () => {
+    planService.getPlanById.mockResolvedValue({
+      features: [{ feature_key: 'groups_create', value: 'false' }],
+    });
+    const req = { user: { id: 'u1', plan_id: 1 }, body: { name: 'Test' } };
+    const res = {};
+    await new Promise((resolve) => {
+      controller.createGroup(req, res, (err) => {
+        expect(err).toBeInstanceOf(AppError);
+        expect(err.message).toMatch(/upgrade plan/i);
+        resolve();
+      });
+    });
+    expect(service.createGroup).not.toHaveBeenCalled();
+  });
+
+  test('joinGroup fails when join limit reached', async () => {
+    planService.getPlanById.mockResolvedValue({
+      features: [{ feature_key: 'groups_join_limit', value: '1' }],
+    });
+    service.getGroupById.mockResolvedValue({ requires_approval: false, name: 'G' });
+    service.getMemberRole.mockResolvedValue(null);
+    service.countUserGroups.mockResolvedValue(1);
+    const req = { params: { id: 'g2' }, user: { id: 'u1', plan_id: 1 } };
+    const res = {};
+    await new Promise((resolve) => {
+      controller.joinGroup(req, res, (err) => {
+        expect(err).toBeInstanceOf(AppError);
+        expect(err.message).toMatch(/upgrade plan/i);
+        resolve();
+      });
+    });
+    expect(service.addMember).not.toHaveBeenCalled();
+  });
+});
+

--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -11,8 +11,38 @@ const mailService = require("../../services/mailService");
 const whatsappService = require("../../services/whatsappService");
 const { frontendBase } = require("../../utils/frontend");
 const db = require("../../config/database");
+const planService = require("../plans/plans.service");
+
+const parsePlanFeatures = (plan = {}) => {
+  const result = {};
+  if (!plan || !Array.isArray(plan.features)) return result;
+  plan.features.forEach((f) => {
+    let val = f.value;
+    if (typeof val === "string") {
+      try {
+        val = JSON.parse(val);
+      } catch {
+        if (val === "true") val = true;
+        else if (val === "false") val = false;
+        else if (!isNaN(val)) val = Number(val);
+      }
+    }
+    result[f.feature_key] = val;
+  });
+  return result;
+};
 
 exports.createGroup = catchAsync(async (req, res) => {
+  const planId =
+    req.user.plan_id ||
+    req.user.plan?.id ||
+    req.user.subscription?.plan_id;
+  const plan = planId ? await planService.getPlanById(planId) : null;
+  const features = parsePlanFeatures(plan);
+  if (!features["groups_create"]) {
+    throw new AppError("Upgrade plan to create more groups", 403);
+  }
+
   const {
     name,
     description,
@@ -224,6 +254,26 @@ exports.joinGroup = catchAsync(async (req, res) => {
   const groupId = req.params.id;
   const group = await service.getGroupById(groupId);
   if (!group) throw new AppError("Group not found", 404);
+
+  const existingRole = await service.getMemberRole(groupId, req.user.id);
+  if (!existingRole) {
+    const planId =
+      req.user.plan_id ||
+      req.user.plan?.id ||
+      req.user.subscription?.plan_id;
+    const plan = planId ? await planService.getPlanById(planId) : null;
+    const features = parsePlanFeatures(plan);
+    const joinLimit = features["groups_join_limit"];
+    if (joinLimit && joinLimit !== "unlimited") {
+      const limitNum = Number(joinLimit);
+      if (!isNaN(limitNum)) {
+        const count = await service.countUserGroups(req.user.id);
+        if (count >= limitNum) {
+          throw new AppError("Upgrade plan to join more groups", 403);
+        }
+      }
+    }
+  }
 
   if (group.requires_approval) {
     const reqRow = await service.requestJoin(groupId, req.user.id);

--- a/backend/src/modules/groups/groups.service.js
+++ b/backend/src/modules/groups/groups.service.js
@@ -132,6 +132,15 @@ exports.cancelJoinRequest = async (groupId, userId) => {
   return row;
 };
 
+// Count total groups a user is a member of
+exports.countUserGroups = async (userId) => {
+  const row = await db("group_members")
+    .where({ user_id: userId })
+    .count("id as count")
+    .first();
+  return Number(row?.count || 0);
+};
+
 exports.getUserGroups = async (userId) => {
   const lastMessageSub = db.raw(
     `(


### PR DESCRIPTION
## Summary
- enforce plan-based restrictions for group creation and joining
- add membership counting helper for groups
- cover plan limit checks with unit tests

## Testing
- `npm test` *(fails: Route.post requires a callback function but got a [object Undefined])*
- `npx jest src/modules/groups/__tests__/planLimits.test.js --runTestsByPath`

------
https://chatgpt.com/codex/tasks/task_e_68bc4b570a58832896560e6c0fbd71f4