### PR TITLE
Add ad duration plan features for instructor plans

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -134,7 +134,7 @@ exports.createAd = catchAsync(async (req, res) => {
 
     const features = parsePlanFeatures(plan);
 
-    const maxDuration = Number(features["ads_max_ad_duration"] || 0);
+    const maxDuration = Number(features["ads_max_duration"] || 0);
     if (!end && maxDuration) {
       end = new Date(start.getTime() + maxDuration * 24 * 60 * 60 * 1000);
     } else if (end) {
@@ -425,7 +425,7 @@ exports.updateAd = catchAsync(async (req, res) => {
 
     const features = parsePlanFeatures(plan);
 
-    const maxDuration = Number(features["ads_max_ad_duration"] || 0);
+    const maxDuration = Number(features["ads_max_duration"] || 0);
     if (maxDuration && newStart && newEnd) {
       const diffDays = Math.ceil(
         (new Date(newEnd).getTime() - new Date(newStart).getTime()) /

--- a/backend/src/modules/plans/plans.service.js
+++ b/backend/src/modules/plans/plans.service.js
@@ -87,7 +87,9 @@ exports.getPlanFeatures = async (prefix) => {
 
   const transformKey = (key) => {
     if (prefix && key.startsWith(`${prefix}_`)) {
-      return toCamel(key.slice(prefix.length + 1));
+      const suffix = key.slice(prefix.length + 1);
+      if (prefix === "ads" && suffix === "max_duration") return "maxAdDuration";
+      return toCamel(suffix);
     }
     return toCamel(key);
   };

--- a/backend/src/seeds/09_plans_seed.js
+++ b/backend/src/seeds/09_plans_seed.js
@@ -201,6 +201,13 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids['instructor-basic'],
+      feature_key: 'ads_max_duration',
+      value: '7',
+      description: 'Ads can run up to 7 days'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids['instructor-basic'],
       feature_key: 'ads_show_analytics',
       value: 'false',
       description: 'No analytics access'
@@ -232,6 +239,13 @@ exports.seed = async function (knex) {
       feature_key: 'ads_max_ads',
       value: '10',
       description: 'Up to 10 active ads'
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      plan_id: ids['instructor-pro'],
+      feature_key: 'ads_max_duration',
+      value: '30',
+      description: 'Ads can run up to 30 days'
     },
     {
       id: knex.raw('uuid_generate_v4()'),


### PR DESCRIPTION
## Summary
- add ads_max_duration seed entries with plan-specific durations
- expose maxAdDuration via plan features service
- respect ads_max_duration in ads controller

## Testing
- `npm run seed`
- `node -e "const svc=require('./src/modules/plans/plans.service');svc.getPlanFeatures('ads').then(r=>{console.log(JSON.stringify(r,null,2));process.exit(0);});"`
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*

------
https://chatgpt.com/codex/tasks/task_e_68bc4b581bbc8328a6a2b545a71e8f38