### PR TITLE
Add plan configuration defaults and helpers

### DIFF
--- a/frontend/src/utils/plans/defaultPlanConfig.js
+++ b/frontend/src/utils/plans/defaultPlanConfig.js
@@ -1,0 +1,55 @@
+// utils/plans/defaultPlanConfig.js
+
+export const defaultPlanConfig = {
+  categories: {
+    onlineClasses: {
+      label: "Online Classes",
+      rules: ["canJoin", "canCreate"],
+    },
+    tutorials: {
+      label: "Tutorials",
+      rules: ["canViewPremium", "canDownload"],
+    },
+    community: {
+      label: "Community",
+      rules: ["canPost", "canReply"],
+    },
+    instructor: {
+      label: "Instructor",
+      rules: ["maxCourses", "adCredits"],
+    },
+  },
+  plans: {
+    Basic: {
+      canJoin: { onlineClasses: false },
+      canCreate: { onlineClasses: false },
+      canViewPremium: { tutorials: false },
+      canDownload: { tutorials: false },
+      canPost: { community: false },
+      canReply: { community: false },
+      maxCourses: { instructor: 1 },
+      adCredits: { instructor: 0 },
+    },
+    Regular: {
+      canJoin: { onlineClasses: true },
+      canCreate: { onlineClasses: false },
+      canViewPremium: { tutorials: true },
+      canDownload: { tutorials: false },
+      canPost: { community: true },
+      canReply: { community: true },
+      maxCourses: { instructor: 5 },
+      adCredits: { instructor: 100 },
+    },
+    Premium: {
+      canJoin: { onlineClasses: true },
+      canCreate: { onlineClasses: true },
+      canViewPremium: { tutorials: true },
+      canDownload: { tutorials: true },
+      canPost: { community: true },
+      canReply: { community: true },
+      maxCourses: { instructor: 20 },
+      adCredits: { instructor: 1000 },
+    },
+  },
+};
+

--- a/frontend/src/utils/plans/normalizePlanRules.js
+++ b/frontend/src/utils/plans/normalizePlanRules.js
@@ -1,0 +1,57 @@
+// utils/plans/normalizePlanRules.js
+
+// Convert flat plan rules to category grouped structure
+export function normalizePlanRules(planRules = {}) {
+  const grouped = {};
+  Object.entries(planRules).forEach(([ruleKey, mapping]) => {
+    const [categoryKey, value] = Object.entries(mapping || {})[0] || [];
+    if (!categoryKey) return;
+    if (!grouped[categoryKey]) grouped[categoryKey] = {};
+    grouped[categoryKey][ruleKey] = value;
+  });
+  return grouped;
+}
+
+// Convert category grouped rules back to flat structure
+export function denormalizePlanRules(groupedRules = {}) {
+  const flat = {};
+  Object.entries(groupedRules).forEach(([categoryKey, rules]) => {
+    Object.entries(rules || {}).forEach(([ruleKey, value]) => {
+      flat[ruleKey] = { [categoryKey]: value };
+    });
+  });
+  return flat;
+}
+
+// Infer rule type from a value
+export function inferRuleType(value) {
+  const type = typeof value;
+  if (type === "boolean") return "toggle";
+  if (type === "number") return "number";
+  return "unknown";
+}
+
+// Build rule definitions using categories and sample plan values
+export function buildRuleDefinitions(config) {
+  const { categories = {}, plans = {} } = config || {};
+  const samplePlan = Object.values(plans)[0] || {};
+  const definitions = {};
+
+  Object.entries(categories).forEach(([categoryKey, cat]) => {
+    definitions[categoryKey] = (cat.rules || []).map((ruleKey) => {
+      const sampleValue =
+        samplePlan[ruleKey] && samplePlan[ruleKey][categoryKey];
+      return {
+        key: ruleKey,
+        label: ruleKey
+          .replace(/([A-Z])/g, " $1")
+          .replace(/^./, (s) => s.toUpperCase()),
+        type: inferRuleType(sampleValue),
+        defaultValue: sampleValue,
+      };
+    });
+  });
+
+  return definitions;
+}
+

--- a/frontend/src/utils/plans/validatePlanConfig.js
+++ b/frontend/src/utils/plans/validatePlanConfig.js
@@ -1,0 +1,53 @@
+// utils/plans/validatePlanConfig.js
+
+export function validateRuleType(value) {
+  const t = typeof value;
+  return t === "boolean" || t === "number";
+}
+
+export function validateCategories(categories) {
+  if (!categories || typeof categories !== "object") {
+    throw new Error("Categories must be provided");
+  }
+  Object.entries(categories).forEach(([key, cat]) => {
+    if (!cat.label) {
+      throw new Error(`Category '${key}' is missing label`);
+    }
+    if (!Array.isArray(cat.rules)) {
+      throw new Error(`Category '${key}' rules must be an array`);
+    }
+  });
+  return true;
+}
+
+export function validatePlans(plans, categories) {
+  if (!plans || typeof plans !== "object") {
+    throw new Error("Plans must be provided");
+  }
+  Object.entries(plans).forEach(([planName, rules]) => {
+    Object.entries(rules || {}).forEach(([ruleKey, mapping]) => {
+      const [categoryKey, value] = Object.entries(mapping || {})[0] || [];
+      if (!categoryKey || !categories[categoryKey]) {
+        throw new Error(
+          `Rule '${ruleKey}' in plan '${planName}' references unknown category`
+        );
+      }
+      if (!validateRuleType(value)) {
+        throw new Error(
+          `Rule '${ruleKey}' in plan '${planName}' has invalid type`
+        );
+      }
+    });
+  });
+  return true;
+}
+
+export function validatePlanConfig(config) {
+  if (!config || typeof config !== "object") {
+    throw new Error("Config is required");
+  }
+  validateCategories(config.categories);
+  validatePlans(config.plans, config.categories);
+  return true;
+}
+


### PR DESCRIPTION
## Summary
- add default plan configuration matching existing sample
- add helpers to normalize and denormalize plan rules
- implement plan configuration validation utilities

## Testing
- `npm test -- src/tests/__tests__/bookService.test.js`
- `npx eslint src/utils/plans/defaultPlanConfig.js src/utils/plans/normalizePlanRules.js src/utils/plans/validatePlanConfig.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc4b58a0188328a657be33d6b3acf8