### PR TITLE
Load secrets from root env and document required variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,17 @@
+# Environment variables for docker-compose
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=eduSkillbridge
+
+PGADMIN_DEFAULT_EMAIL=admin@skillbridge.com
+PGADMIN_DEFAULT_PASSWORD=admin123
+
+PORT=5002
+DATABASE_URL=postgres://postgres:postgres@db:5432/eduSkillbridge
+JWT_SECRET=SkillBr1dge-!Secure.JWT-Key!
+REFRESH_TOKEN_SECRET=SkillBr1dge-!Refresh.JWT-Key!
+FRONTEND_URL=https://eduskillbridge.net
+MAX_BLOG_IMAGE_BYTES=10485760
+NODE_ENV=production
+
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api

--- a/README.md
+++ b/README.md
@@ -15,18 +15,28 @@ Alternatively, launch the backend and open [`/install`](http://localhost:5002/in
 
 ## Quick start
 
-1. Copy the example environment file and adjust values as needed:
+1. Configure environment variables:
 
-   ```bash
-    cp backend/.env.example backend/.env
-    # edit backend/.env and set your secrets
-    # FRONTEND_URL defaults to http://localhost:3000
-    # set it to your frontend's domain if different and omit any trailing slash
-    # When using docker-compose make sure the value does
-    # not include an extra "FRONTEND_URL=" prefix.
-    # Optionally set ADMIN_INITIAL_PASSWORD and SUPERADMIN_INITIAL_PASSWORD
-    # to control the seeded admin credentials
-    ```
+   - Edit the `.env` file in the project root. Docker Compose loads
+     sensitive values from here, including:
+
+       - `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`
+       - `PGADMIN_DEFAULT_EMAIL`, `PGADMIN_DEFAULT_PASSWORD`
+       - `JWT_SECRET`, `REFRESH_TOKEN_SECRET`
+       - `FRONTEND_URL`, `NEXT_PUBLIC_API_BASE_URL`
+
+   - Copy the backend example file and adjust values as needed:
+
+     ```bash
+     cp backend/.env.example backend/.env
+     # edit backend/.env and set your secrets
+     # FRONTEND_URL defaults to http://localhost:3000
+     # set it to your frontend's domain if different and omit any trailing slash
+     # When using docker-compose make sure the value does
+     # not include an extra "FRONTEND_URL=" prefix.
+     # Optionally set ADMIN_INITIAL_PASSWORD and SUPERADMIN_INITIAL_PASSWORD
+     # to control the seeded admin credentials
+     ```
 
 2. Initialize the database (run migrations and seeds):
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,8 @@ DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge
 TEST_DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge_test
 # Production database connection. Store the actual value securely outside version control.
 PRODUCTION_DATABASE_URL=
+# Secrets used to sign JSON Web Tokens. Make sure these match the values
+# in the project root `.env` when running via docker-compose.
 JWT_SECRET=your_jwt_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret
 MAX_BLOG_IMAGE_BYTES=10485760

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,12 @@ services:
   db:
     image: postgres:14
     restart: always
+    env_file:
+      - ./.env
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: eduSkillbridge
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "5432:5432"
     volumes:
@@ -16,9 +18,11 @@ services:
   pgadmin:
     image: dpage/pgadmin4
     restart: always
+    env_file:
+      - ./.env
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@skillbridge.com
-      PGADMIN_DEFAULT_PASSWORD: admin123
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
     ports:
       - "5050:80"
     depends_on:
@@ -29,16 +33,18 @@ services:
   backend:
     build: ./backend
     restart: always
+    env_file:
+      - ./.env
     ports:
       - "5002:5002"
     environment:
-      - PORT=5002
-      - DATABASE_URL=postgres://postgres:postgres@db:5432/eduSkillbridge
-      - JWT_SECRET=SkillBr1dge-!Secure.JWT-Key!
-      - REFRESH_TOKEN_SECRET=SkillBr1dge-!Refresh.JWT-Key!
-      - FRONTEND_URL=https://eduskillbridge.net
-      - MAX_BLOG_IMAGE_BYTES=10485760
-      - NODE_ENV=production
+      - PORT=${PORT}
+      - DATABASE_URL=${DATABASE_URL}
+      - JWT_SECRET=${JWT_SECRET}
+      - REFRESH_TOKEN_SECRET=${REFRESH_TOKEN_SECRET}
+      - FRONTEND_URL=${FRONTEND_URL}
+      - MAX_BLOG_IMAGE_BYTES=${MAX_BLOG_IMAGE_BYTES}
+      - NODE_ENV=${NODE_ENV}
     depends_on:
       - db
     volumes:
@@ -48,9 +54,11 @@ services:
     build: ./frontend
     ports:
       - "3000:3000"
+    env_file:
+      - ./.env
     environment:
       # IMPORTANT: browsers can't call localhost on your server
-      - NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+      - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
     depends_on:
       - backend
 


### PR DESCRIPTION
## Summary
- add root `.env` with JWT and other secrets
- use env vars in docker-compose and load from env file
- document required variables in backend example and README

## Testing
- `npm --prefix backend test` *(fails: Route.post requires callback function...)*

------
https://chatgpt.com/codex/tasks/task_e_68bc53c729888328950eef6d0bf7ea4d