### PR TITLE
chore: consolidate PostCSS config

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -2,6 +2,7 @@
 const config = {
   plugins: {
     tailwindcss: {},
+    autoprefixer: {},
   },
 };
 


### PR DESCRIPTION
## Summary
- use a single ESM-based PostCSS configuration with autoprefixer
- remove duplicate CommonJS PostCSS config

## Testing
- `npm test`
- `npm run build` *(fails: build generation was interrupted while producing static pages)*

------
https://chatgpt.com/codex/tasks/task_e_68bc53c8b4c08328bd0ec4a17f325492