### PR TITLE
Connect certificate pages to API

### DIFF
--- a/frontend/src/pages/dashboard/admin/certificates/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/certificates/edit/[id].js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
+import { getCertificate, updateCertificate } from "@/services/admin/certificateService";
 
 export default function AdminEditCertificatePage() {
   const router = useRouter();
@@ -10,36 +11,49 @@ export default function AdminEditCertificatePage() {
 
   const [certificate, setCertificate] = useState(null);
   const [saving, setSaving] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    if (id) {
-      // TODO: Replace with real fetch from backend
-      setCertificate({
-        id,
-        studentName: "Sara Ali",
-        className: "React & Next.js Bootcamp",
-        issueDate: "2025-05-30T10:00:00Z",
-        status: "Pending",
-      });
-    }
+    const load = async () => {
+      if (!id) return;
+      setLoading(true);
+      setError('');
+      try {
+        const data = await getCertificate(id);
+        setCertificate(data);
+      } catch (err) {
+        console.error('Failed to load certificate', err);
+        setError('Failed to load certificate');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [id]);
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!certificate.studentName.trim() || !certificate.className.trim()) {
       alert("⚠️ Please fill in all fields.");
       return;
     }
 
     setSaving(true);
-
-    setTimeout(() => {
-      setSaving(false);
-      alert("✅ Certificate updated successfully (mock)!");
+    setError('');
+    try {
+      await updateCertificate(id, certificate);
       router.push(`/dashboard/admin/certificates/view/${id}`);
-    }, 1000);
+    } catch (err) {
+      console.error('Update failed', err);
+      setError('Failed to save certificate');
+    } finally {
+      setSaving(false);
+    }
   };
 
-  if (!certificate) return <div className="text-center p-10 text-gray-500">Loading certificate...</div>;
+  if (loading) return <div className="text-center p-10 text-gray-500">Loading certificate...</div>;
+  if (error) return <div className="text-center p-10 text-red-500">{error}</div>;
+  if (!certificate) return null;
 
   return (
     <AdminLayout>

--- a/frontend/src/pages/dashboard/admin/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/certificates/index.js
@@ -8,7 +8,12 @@ import { FaSearch, FaSync, FaEye, FaDownload, FaCheckCircle, FaTimesCircle } fro
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
-import { fetchAllCertificates } from "@/services/admin/certificateService";
+import {
+  fetchAllCertificates,
+  approveCertificate,
+  rejectCertificate,
+  downloadCertificate,
+} from "@/services/admin/certificateService";
 
 export default function AdminCertificatesPage() {
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'adminCertificatesPage' });
@@ -19,15 +24,22 @@ export default function AdminCertificatesPage() {
   const [page, setPage] = useState(1);
   const limit = 10;
   const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     const load = async () => {
+      setLoading(true);
+      setError('');
       try {
         const data = await fetchAllCertificates(page, limit);
         setCertificates(data);
         setHasMore(data.length === limit);
       } catch (err) {
         console.error('Failed to load certificates', err);
+        setError('Failed to load certificates');
+      } finally {
+        setLoading(false);
       }
     };
     load();
@@ -42,10 +54,50 @@ export default function AdminCertificatesPage() {
     return matchesSearch && matchesStatus;
   });
 
+  const handleDownload = async (cert) => {
+    try {
+      const blob = await downloadCertificate(cert.id);
+      const url = window.URL.createObjectURL(new Blob([blob]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `certificate-${cert.id}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch (err) {
+      alert('Download failed');
+    }
+  };
+
+  const handleApprove = async (id) => {
+    try {
+      await approveCertificate(id);
+      setCertificates((prev) =>
+        prev.map((c) => (c.id === id ? { ...c, status: 'Issued' } : c))
+      );
+    } catch (err) {
+      alert('Approve failed');
+    }
+  };
+
+  const handleReject = async (id) => {
+    try {
+      await rejectCertificate(id);
+      setCertificates((prev) =>
+        prev.map((c) => (c.id === id ? { ...c, status: 'Revoked' } : c))
+      );
+    } catch (err) {
+      alert('Reject failed');
+    }
+  };
+
   return (
     <AdminLayout>
-      <div className="min-h-screen px-6 py-10 bg-white text-gray-900" dir={i18n.dir()}> 
+      <div className="min-h-screen px-6 py-10 bg-white text-gray-900" dir={i18n.dir()}>
         <h1 className="text-2xl font-bold text-yellow-500 mb-6">🎓 {t('title')}</h1>
+
+        {loading && <p className="text-center">Loading...</p>}
+        {error && <p className="text-center text-red-500">{error}</p>}
 
         {/* Filters */}
         <div className="flex flex-wrap gap-4 mb-6">
@@ -111,7 +163,7 @@ export default function AdminCertificatesPage() {
                     </Link>
                     {c.status && c.status === 'Issued' && (
                       <button
-                        onClick={() => alert('🚀 Downloading certificate (mock)!')}
+                        onClick={() => handleDownload(c)}
                         className="text-green-600 hover:text-green-800"
                       >
                         <FaDownload />
@@ -120,13 +172,13 @@ export default function AdminCertificatesPage() {
                     {c.status && c.status === 'Pending' && (
                       <>
                         <button
-                          onClick={() => alert('✅ Approving certificate (mock)!')}
+                          onClick={() => handleApprove(c.id)}
                           className="text-green-600 hover:text-green-800"
                         >
                           <FaCheckCircle />
                         </button>
                         <button
-                          onClick={() => alert('❌ Rejecting certificate (mock)!')}
+                          onClick={() => handleReject(c.id)}
                           className="text-red-500 hover:text-red-700"
                         >
                           <FaTimesCircle />

--- a/frontend/src/pages/dashboard/admin/certificates/issue-manual.js
+++ b/frontend/src/pages/dashboard/admin/certificates/issue-manual.js
@@ -3,6 +3,7 @@ import { useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
 import { useRouter } from "next/router";
+import { issueCertificate } from "@/services/admin/certificateService";
 
 export default function ManualCertificateIssuePage() {
   const router = useRouter();
@@ -12,20 +13,25 @@ export default function ManualCertificateIssuePage() {
   const [issueDate, setIssueDate] = useState(new Date().toISOString().slice(0, 16)); // default to now
   const [status, setStatus] = useState("Issued");
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!studentName.trim() || !className.trim()) {
       alert("⚠️ Please fill in all required fields.");
       return;
     }
 
     setSaving(true);
-
-    setTimeout(() => {
-      setSaving(false);
-      alert("✅ Certificate issued successfully (mock)!");
+    setError('');
+    try {
+      await issueCertificate({ studentName, className, issueDate, status });
       router.push("/dashboard/admin/certificates");
-    }, 1000);
+    } catch (err) {
+      console.error('Issue certificate failed', err);
+      setError('Failed to issue certificate');
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -35,6 +41,7 @@ export default function ManualCertificateIssuePage() {
           <h1 className="text-3xl font-bold text-yellow-500 mb-8">🎓 Issue Certificate Manually</h1>
 
           <div className="space-y-6 bg-gray-100 p-6 rounded-xl shadow-md">
+            {error && <p className="text-red-500 text-center">{error}</p>}
             {/* Student Name */}
             <div>
               <label className="block mb-2 font-semibold">Student Name</label>

--- a/frontend/src/pages/dashboard/admin/certificates/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/certificates/view/[id].js
@@ -3,49 +3,75 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaDownload, FaCheckCircle, FaTimesCircle } from "react-icons/fa";
+import {
+  getCertificate,
+  approveCertificate,
+  rejectCertificate,
+  downloadCertificate,
+} from "@/services/admin/certificateService";
 
 export default function ViewCertificatePage() {
   const router = useRouter();
   const { id } = router.query;
 
   const [certificate, setCertificate] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    if (id) {
-      // TODO: Replace with real fetch from API later
-      setCertificate({
-        id,
-        studentName: "Sara Ali",
-        className: "React & Next.js Bootcamp",
-        issueDate: "2025-05-30T10:00:00Z",
-        status: "Pending",
-        certificateUrl: "https://via.placeholder.com/600x400.png?text=Certificate+Preview",
-      });
-    }
+    const load = async () => {
+      if (!id) return;
+      setLoading(true);
+      setError('');
+      try {
+        const data = await getCertificate(id);
+        setCertificate(data);
+      } catch (err) {
+        console.error('Failed to load certificate', err);
+        setError('Failed to load certificate');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [id]);
 
-  if (!certificate) {
-    return <div className="text-center text-gray-600 p-10">Loading certificate...</div>;
-  }
+  if (loading) return <div className="text-center text-gray-600 p-10">Loading certificate...</div>;
+  if (error) return <div className="text-center text-red-500 p-10">{error}</div>;
+  if (!certificate) return null;
 
-  const handleApprove = () => {
-    alert("✅ Certificate Approved Successfully (mock)!");
-    // TODO: Send approve request to backend
-    router.push("/dashboard/admin/certificates");
-  };
-
-  const handleReject = () => {
-    if (confirm("❌ Are you sure you want to reject this certificate?")) {
-      alert("Certificate Rejected (mock).");
-      // TODO: Send reject request to backend
+  const handleApprove = async () => {
+    try {
+      await approveCertificate(id);
       router.push("/dashboard/admin/certificates");
+    } catch {
+      alert('Failed to approve');
     }
   };
 
-  const handleDownload = () => {
-    alert("🚀 Downloading certificate (mock)!");
-    // TODO: Open/download certificate PDF from backend
-    window.open(certificate.certificateUrl, "_blank");
+  const handleReject = async () => {
+    if (!confirm("❌ Are you sure you want to reject this certificate?")) return;
+    try {
+      await rejectCertificate(id);
+      router.push("/dashboard/admin/certificates");
+    } catch {
+      alert('Failed to reject');
+    }
+  };
+
+  const handleDownload = async () => {
+    try {
+      const blob = await downloadCertificate(id);
+      const url = window.URL.createObjectURL(new Blob([blob]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `certificate-${id}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch {
+      alert('Download failed');
+    }
   };
 
   return (

--- a/frontend/src/pages/dashboard/instructor/certificates/create.js
+++ b/frontend/src/pages/dashboard/instructor/certificates/create.js
@@ -2,6 +2,10 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
+import {
+  fetchClassStudents,
+  issueCertificate,
+} from "@/services/instructor/certificateService";
 
 export default function IssueCertificatePage() {
   const router = useRouter();
@@ -12,43 +16,55 @@ export default function IssueCertificatePage() {
   const [studentName, setStudentName] = useState("");
   const [courseTitle, setCourseTitle] = useState("");
   const [issueDate, setIssueDate] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    if (classId) {
-      // Mock: Fetch enrolled students + class details
-      setStudents([
-        { id: "s1", name: "Ahmed Mohamed" },
-        { id: "s2", name: "Sara Ali" },
-      ]);
-      setCourseTitle("React & Next.js Bootcamp");
-      setIssueDate(new Date().toISOString().slice(0, 10));
-    }
+    const load = async () => {
+      if (!classId) return;
+      setLoading(true);
+      setError('');
+      try {
+        const data = await fetchClassStudents(classId);
+        setStudents(data?.students || []);
+        setCourseTitle(data?.classTitle || "");
+        setIssueDate(new Date().toISOString().slice(0, 10));
+      } catch (err) {
+        console.error('Failed to load class info', err);
+        setError('Failed to load class info');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [classId]);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!selectedStudent || !studentName) {
       alert("⚠️ Please select a student and ensure the name is filled.");
       return;
     }
 
-    const newCertificate = {
-      studentId: selectedStudent,
-      studentName,
-      courseTitle,
-      instructorName: "Ayman Khalid", // Ideally from auth context
-      issueDate,
-      status: "Issued",
-    };
-
-    console.log("🎓 Issued Certificate:", newCertificate);
-
-    alert("✅ Certificate issued successfully!");
-
-    // Redirect to certificate list
-    router.push(`/dashboard/instructor/certificates`);
+    setSaving(true);
+    setError('');
+    try {
+      await issueCertificate({
+        classId,
+        studentId: selectedStudent,
+        studentName,
+        issueDate,
+      });
+      router.push(`/dashboard/instructor/certificates`);
+    } catch (err) {
+      console.error('Issue failed', err);
+      setError('Failed to issue certificate');
+    } finally {
+      setSaving(false);
+    }
   };
 
-  if (!classId) return <div className="text-white p-10">Loading class info...</div>;
+  if (!classId || loading) return <div className="text-white p-10">Loading class info...</div>;
 
   return (
     <InstructorLayout>
@@ -56,6 +72,7 @@ export default function IssueCertificatePage() {
         <h1 className="text-2xl font-bold text-yellow-500 mb-8">🎓 Issue Certificate</h1>
 
         <div className="space-y-6 max-w-xl">
+          {error && <p className="text-red-500">{error}</p>}
           <select
             value={selectedStudent}
             onChange={(e) => {
@@ -98,9 +115,10 @@ export default function IssueCertificatePage() {
 
           <button
             onClick={handleSubmit}
-            className="w-full py-3 bg-green-500 hover:bg-green-600 text-white font-bold rounded-full mt-6"
+            disabled={saving}
+            className="w-full py-3 bg-green-500 hover:bg-green-600 text-white font-bold rounded-full mt-6 disabled:opacity-50"
           >
-            📤 Issue Certificate
+            {saving ? 'Issuing...' : '📤 Issue Certificate'}
           </button>
         </div>
       </div>

--- a/frontend/src/pages/dashboard/instructor/certificates/index.js
+++ b/frontend/src/pages/dashboard/instructor/certificates/index.js
@@ -3,34 +3,40 @@ import { useEffect, useState } from "react";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import Link from "next/link";
 import { FaEye, FaTrashAlt } from "react-icons/fa";
+import {
+  fetchCertificates,
+  deleteCertificate,
+} from "@/services/instructor/certificateService";
 
 export default function InstructorCertificatesPage() {
   const [certificates, setCertificates] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    // Mock certificates
-    setCertificates([
-      {
-        id: "c1",
-        studentName: "Ahmed Mohamed",
-        courseTitle: "React & Next.js Bootcamp",
-        issueDate: "2025-05-01",
-        status: "Issued",
-      },
-      {
-        id: "c2",
-        studentName: "Sara Ali",
-        courseTitle: "UI/UX Design Basics",
-        issueDate: "2025-05-03",
-        status: "Issued",
-      },
-    ]);
+    const load = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const data = await fetchCertificates();
+        setCertificates(data);
+      } catch (err) {
+        console.error('Failed to load certificates', err);
+        setError('Failed to load certificates');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, []);
 
-  const handleDelete = (id) => {
-    if (confirm("Are you sure you want to delete this certificate?")) {
+  const handleDelete = async (id) => {
+    if (!confirm("Are you sure you want to delete this certificate?")) return;
+    try {
+      await deleteCertificate(id);
       setCertificates((prev) => prev.filter((c) => c.id !== id));
-      alert("🗑️ Certificate deleted (mock)!");
+    } catch (err) {
+      alert('Delete failed');
     }
   };
 
@@ -39,7 +45,9 @@ export default function InstructorCertificatesPage() {
       <div className="min-h-screen px-6 py-10 bg-white text-gray-900">
         <h1 className="text-2xl font-bold text-yellow-500 mb-8">🎓 My Issued Certificates</h1>
 
-        {certificates.length === 0 ? (
+        {loading && <p className="text-center">Loading...</p>}
+        {error && <p className="text-center text-red-500">{error}</p>}
+        {!loading && certificates.length === 0 ? (
           <p className="text-center text-gray-500">No certificates issued yet.</p>
         ) : (
           <div className="overflow-x-auto">

--- a/frontend/src/pages/dashboard/instructor/certificates/preview/[id].js
+++ b/frontend/src/pages/dashboard/instructor/certificates/preview/[id].js
@@ -3,30 +3,37 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import QRCode from "react-qr-code";
-import { NotebookTabs } from "lucide-react";
+import { getCertificate } from "@/services/instructor/certificateService";
 
 export default function CertificatePreviewPage() {
   const router = useRouter();
   const { id } = router.query;
 
   const [certificate, setCertificate] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    if (id) {
-      // Mock data fetch
-      setCertificate({
-        id,
-        studentName: "Ahmed Mohamed",
-        courseTitle: "React & Next.js Bootcamp",
-        issueDate: "2025-05-01",
-        instructorName: "Ayman Khalid",
-        platformName: "SkillBridge Academy",
-        grade: "95%", // Optional grade
-      });
-    }
+    const load = async () => {
+      if (!id) return;
+      setLoading(true);
+      setError('');
+      try {
+        const data = await getCertificate(id);
+        setCertificate(data);
+      } catch (err) {
+        console.error('Failed to load certificate', err);
+        setError('Failed to load certificate');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [id]);
 
-  if (!certificate) return <div className="text-gray-700 p-10">Loading certificate...</div>;
+  if (loading) return <div className="text-gray-700 p-10">Loading certificate...</div>;
+  if (error) return <div className="text-red-500 p-10">{error}</div>;
+  if (!certificate) return null;
 
   return (
     <InstructorLayout>

--- a/frontend/src/pages/dashboard/student/certificates/index.js
+++ b/frontend/src/pages/dashboard/student/certificates/index.js
@@ -3,55 +3,46 @@ import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import Link from "next/link";
 import { FaDownload, FaEye, FaShareAlt } from "react-icons/fa";
-import jsPDF from "jspdf";
-import html2canvas from "html2canvas";
-import QRCode from "react-qr-code";
+import {
+  fetchCertificates,
+  downloadCertificate,
+} from "@/services/student/certificateService";
 
 export default function StudentCertificatesPage() {
     const [certificates, setCertificates] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
 
     useEffect(() => {
-        setCertificates([
-            {
-                id: "cert1",
-                courseTitle: "React & Next.js Bootcamp",
-                InstrucorName: "Ayman Khan",
-                studentName: "Sara Ali",
-                issueDate: "2025-05-01",
-                serialNumber: "CERT-00001",
-                status: "Issued",
-                grade: "95%", // ✅ Added Grade
-            },
-        ]);
+        const load = async () => {
+            setLoading(true);
+            setError('');
+            try {
+                const data = await fetchCertificates();
+                setCertificates(data);
+            } catch (err) {
+                console.error('Failed to load certificates', err);
+                setError('Failed to load certificates');
+            } finally {
+                setLoading(false);
+            }
+        };
+        load();
     }, []);
 
     const handleDownloadCertificate = async (cert) => {
-        const certDiv = document.getElementById(`certificate-${cert.id}`);
-        if (!certDiv) {
-            alert("❌ Certificate not ready!");
-            return;
+        try {
+            const blob = await downloadCertificate(cert.id);
+            const url = window.URL.createObjectURL(new Blob([blob]));
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `certificate-${cert.id}.pdf`;
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+        } catch (err) {
+            alert('Download failed');
         }
-
-        const clone = certDiv.cloneNode(true);
-        clone.style.position = "fixed";
-        clone.style.top = "-9999px";
-        clone.style.left = "-9999px";
-        clone.style.display = "block";
-        document.body.appendChild(clone);
-
-        const canvas = await html2canvas(clone, { scale: 3 });
-        const imgData = canvas.toDataURL("image/png");
-
-        const pdf = new jsPDF({
-            orientation: "landscape",
-            unit: "px",
-            format: [canvas.width, canvas.height],
-        });
-
-        pdf.addImage(imgData, "PNG", 0, 0, canvas.width, canvas.height);
-        pdf.save(`${cert.courseTitle.replace(/\s+/g, "_")}_Certificate.pdf`);
-
-        document.body.removeChild(clone);
     };
 
     const handleShareCertificate = (cert) => {
@@ -74,7 +65,9 @@ export default function StudentCertificatesPage() {
             <div className="min-h-screen bg-white px-6 py-10 text-gray-900">
                 <h1 className="text-2xl font-bold text-yellow-500 mb-8">🎓 My Certificates</h1>
 
-                {certificates.length === 0 ? (
+                {loading && <p className="text-center">Loading...</p>}
+                {error && <p className="text-center text-red-500">{error}</p>}
+                {!loading && certificates.length === 0 ? (
                     <p className="text-center text-gray-500">No certificates earned yet.</p>
                 ) : (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -106,100 +99,6 @@ export default function StudentCertificatesPage() {
                                         </>
                                     )}
                                 </div>
-
-                                {/* Hidden Certificate Layout */}
-                                {cert.status === "Issued" && (
-                                    <div
-                                        id={`certificate-${cert.id}`}
-                                        className="hidden w-[1200px] h-[850px] p-12 rounded-2xl shadow-2xl flex flex-col justify-center items-center text-center relative overflow-hidden"
-                                        style={{
-                                            fontFamily: "Georgia, serif",
-                                            backgroundImage: "url('/images/paper-texture.png')",
-                                            backgroundSize: "cover",
-                                            backgroundColor: "white",
-                                            position: "relative",
-                                            border: "14px solid #FFD700", // 🟡 Solid Yellow (Gold)
-                                            borderImageSlice: 1,
-                                            borderWidth: "14px",
-                                            borderImageSource: "linear-gradient(45deg, #FFD700, #FFB800)",
-                                            boxShadow: "0 0 20px 4px #FFD700",
-                                            color: "#333",
-                                        }}
-                                    >
-
-                                        {/* Top Logo */}
-                                        <div className="w-full flex justify-center mb-6">
-                                            <img src="/images/certificate/logo.png" alt="Platform Logo" className="w-32" />
-                                        </div>
-
-                                        {/* Presented By */}
-                                        <p className="text-sm uppercase tracking-widest text-gray-500">Presented by SkillBridge</p>
-
-                                        {/* Certificate Title */}
-                                        <h1 className="text-6xl font-extrabold text-yellow-600 mt-3 mb-6" style={{ fontFamily: "'Great Vibes', cursive" }}>
-                                            Certificate of Completion
-                                        </h1>
-
-                                        {/* Recipient */}
-                                        <p className="text-lg text-gray-600">This is proudly awarded to</p>
-                                        <h2 className="text-5xl font-extrabold text-gray-900 mt-3 mb-6">{cert.studentName}</h2>
-
-                                        {/* Course Title */}
-                                        <p className="text-lg text-gray-600">for successfully completing</p>
-                                        <h3 className="text-2xl font-semibold text-gray-700 mt-2 mb-6">{cert.courseTitle}</h3>
-
-                                        {/* Grade */}
-                                        <p className="text-lg text-gray-600 mt-4">
-                                            Final Grade: <span className="font-bold text-green-600 text-2xl">{cert.grade}</span>
-                                        </p>
-
-
-                                        {/* Issue Date */}
-                                        <p className="text-sm text-gray-500 mb-8">Issued on {new Date(cert.issueDate).toLocaleDateString()}</p>
-
-                                        {/* Serial Number */}
-                                        <div
-                                            style={{
-                                                position: "absolute",
-                                                top: "24px",
-                                                right: "40px",
-                                                backgroundColor: "#fff",
-                                                padding: "6px 14px",
-                                                borderRadius: "10px",
-                                                border: "1px solid #FFD700",
-                                                fontSize: "12px",
-                                                fontWeight: "bold",
-                                                boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
-                                            }}
-                                        >
-                                            Serial: {cert.serialNumber}
-                                        </div>
-
-                                        {/* Bottom Section */}
-                                        <div className="absolute bottom-10 w-full flex justify-between items-center px-20">
-                                            {/* Instructor */}
-                                            <div className="text-center">
-                                                <p className="text-sm text-gray-600 mt-1">Instructor</p>
-                                                <h2 className="text-2xl font-semibold">{cert.InstrucorName}</h2> 
-                                                <img src="/images/certificate/instructor-signature.png" alt="Instructor Signature" className="w-28 mx-auto mb-1" />
-                                            </div>
-
-                                            {/* QR Code */}
-                                            <div className="text-center">
-                                                <QRCode value={`https://yourplatform.com/certificate/verify/${cert.id}`} size={80} bgColor="#FFFFFF" fgColor="#222222" />
-                                                <p className="text-[10px] text-gray-500 mt-1">Scan to Verify</p>
-                                            </div>
-
-                                            {/* Platform Official */}
-                                            <div className="text-center">
-                                                <p className="text-2xl italic font-bold text-gray-700">SkillBridge</p>
-                                                <p className="text-sm text-gray-500">Platform Official</p>
-                                            </div>
-                                        </div>
-
-                                    </div>
-
-                                )}
                             </div>
                         ))}
                     </div>

--- a/frontend/src/pages/dashboard/student/certificates/view/[id].js
+++ b/frontend/src/pages/dashboard/student/certificates/view/[id].js
@@ -3,6 +3,12 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import { FaCheckCircle, FaTimesCircle, FaDownload } from "react-icons/fa";
+import {
+  getCertificate,
+  issueCertificate,
+  revokeCertificate,
+  downloadCertificate,
+} from "@/services/student/certificateService";
 
 export default function AdminCertificateViewPage() {
   const router = useRouter();
@@ -10,36 +16,65 @@ export default function AdminCertificateViewPage() {
 
   const [certificate, setCertificate] = useState(null);
   const [status, setStatus] = useState("Pending");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    if (id) {
-      // Mock loading certificate
-      setCertificate({
-        id,
-        studentName: "Sara Ali",
-        className: "React & Next.js Bootcamp",
-        issueDate: "2025-05-30T10:00:00Z",
-        status: "Pending", // or 'Issued'
-      });
-      setStatus("Pending");
-    }
+    const load = async () => {
+      if (!id) return;
+      setLoading(true);
+      setError('');
+      try {
+        const data = await getCertificate(id);
+        setCertificate(data);
+        setStatus(data?.status || 'Pending');
+      } catch (err) {
+        console.error('Failed to load certificate', err);
+        setError('Failed to load certificate');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [id]);
 
-  const handleIssueCertificate = () => {
-    setStatus("Issued");
-    alert("✅ Certificate Issued Successfully!");
-    // TODO: Save update to backend
-  };
-
-  const handleRevokeCertificate = () => {
-    if (confirm("⚠️ Are you sure you want to revoke this certificate?")) {
-      setStatus("Revoked");
-      alert("❌ Certificate Revoked.");
-      // TODO: Save update to backend
+  const handleIssueCertificate = async () => {
+    try {
+      await issueCertificate(id);
+      setStatus('Issued');
+    } catch (err) {
+      alert('Issue failed');
     }
   };
 
-  if (!certificate) return <div className="text-center mt-32 text-gray-700">Loading Certificate...</div>;
+  const handleRevokeCertificate = async () => {
+    if (!confirm("⚠️ Are you sure you want to revoke this certificate?")) return;
+    try {
+      await revokeCertificate(id);
+      setStatus('Revoked');
+    } catch (err) {
+      alert('Revoke failed');
+    }
+  };
+
+  const handleDownload = async () => {
+    try {
+      const blob = await downloadCertificate(id);
+      const url = window.URL.createObjectURL(new Blob([blob]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `certificate-${id}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch (err) {
+      alert('Download failed');
+    }
+  };
+
+  if (loading) return <div className="text-center mt-32 text-gray-700">Loading Certificate...</div>;
+  if (error) return <div className="text-center mt-32 text-red-500">{error}</div>;
+  if (!certificate) return null;
 
   return (
     <StudentLayout>
@@ -89,7 +124,7 @@ export default function AdminCertificateViewPage() {
             {status === "Issued" && (
               <div className="pt-4 flex gap-4">
                 <button
-                  onClick={() => alert('🚀 Download will start soon (mock)!')}
+                  onClick={handleDownload}
                   className="w-full py-3 bg-blue-500 hover:bg-blue-600 text-white font-bold rounded-lg flex items-center justify-center gap-2"
                 >
                   <FaDownload /> Download Certificate

--- a/frontend/src/services/admin/certificateService.js
+++ b/frontend/src/services/admin/certificateService.js
@@ -12,3 +12,41 @@ export const fetchAllCertificates = async (page = 1, limit = 10) => {
   });
   return data?.data ?? [];
 };
+
+/** Fetch single certificate details */
+export const getCertificate = async (id) => {
+  const { data } = await api.get(`/certificates/admin/${id}`);
+  return data?.data;
+};
+
+/** Approve certificate */
+export const approveCertificate = async (id) => {
+  const { data } = await api.patch(`/certificates/admin/${id}/approve`);
+  return data?.data;
+};
+
+/** Reject certificate */
+export const rejectCertificate = async (id) => {
+  const { data } = await api.patch(`/certificates/admin/${id}/reject`);
+  return data?.data;
+};
+
+/** Issue certificate manually */
+export const issueCertificate = async (payload) => {
+  const { data } = await api.post("/certificates/admin", payload);
+  return data?.data;
+};
+
+/** Update certificate */
+export const updateCertificate = async (id, payload) => {
+  const { data } = await api.put(`/certificates/admin/${id}`, payload);
+  return data?.data;
+};
+
+/** Download certificate */
+export const downloadCertificate = async (id) => {
+  const res = await api.get(`/certificates/admin/${id}/download`, {
+    responseType: "blob",
+  });
+  return res.data;
+};

--- a/frontend/src/services/instructor/certificateService.js
+++ b/frontend/src/services/instructor/certificateService.js
@@ -1,0 +1,35 @@
+// ─────────────────────────────────────────────────────────
+// Instructor Certificates API helpers
+// ─────────────────────────────────────────────────────────
+import api from "@/services/api/api";
+
+export const fetchCertificates = async () => {
+  const { data } = await api.get("/certificates/instructor");
+  return data?.data ?? [];
+};
+
+export const getCertificate = async (id) => {
+  const { data } = await api.get(`/certificates/instructor/${id}`);
+  return data?.data;
+};
+
+export const deleteCertificate = async (id) => {
+  await api.delete(`/certificates/instructor/${id}`);
+};
+
+export const issueCertificate = async (payload) => {
+  const { data } = await api.post("/certificates/instructor", payload);
+  return data?.data;
+};
+
+export const downloadCertificate = async (id) => {
+  const res = await api.get(`/certificates/instructor/${id}/download`, {
+    responseType: "blob",
+  });
+  return res.data;
+};
+
+export const fetchClassStudents = async (classId) => {
+  const { data } = await api.get(`/classes/${classId}/students`);
+  return data?.data;
+};

--- a/frontend/src/services/student/certificateService.js
+++ b/frontend/src/services/student/certificateService.js
@@ -1,0 +1,31 @@
+// ─────────────────────────────────────────────────────────
+// Student Certificates API helpers
+// ─────────────────────────────────────────────────────────
+import api from "@/services/api/api";
+
+export const fetchCertificates = async () => {
+  const { data } = await api.get("/certificates/student");
+  return data?.data ?? [];
+};
+
+export const getCertificate = async (id) => {
+  const { data } = await api.get(`/certificates/student/${id}`);
+  return data?.data;
+};
+
+export const downloadCertificate = async (id) => {
+  const res = await api.get(`/certificates/student/${id}/download`, {
+    responseType: "blob",
+  });
+  return res.data;
+};
+
+export const issueCertificate = async (id) => {
+  const { data } = await api.patch(`/certificates/student/${id}/issue`);
+  return data?.data;
+};
+
+export const revokeCertificate = async (id) => {
+  const { data } = await api.patch(`/certificates/student/${id}/revoke`);
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- Replace certificate mocks with API-driven data and action handlers
- Add admin/student/instructor certificate services for fetching, issuing, approving and downloading certificates
- Introduce loading and error states across certificate dashboards

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc53caa4388328871df419a9422c77