### PR TITLE
docs(frontend): document frontend setup and resources

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,39 +1,39 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# SkillBridge Frontend
 
-## Getting Started
+The SkillBridge frontend delivers the user experience for browsing courses, booking classes, and managing the administrative dashboard. Built with Next.js and Tailwind CSS, the application uses the pages router and organizes code under `src/` into directories for reusable `components`, route `pages`, API `services`, global state `store`, and shared utilities.
 
-First, run the development server:
+## Setup
+
+From the `frontend` directory install dependencies:
+
+```bash
+npm install
+```
+
+## Development Server
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result when running locally.
+## Linting
 
-You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
+```bash
+npm run lint
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Testing
 
-## Learn More
+```bash
+npm test
+```
 
-To learn more about Next.js, take a look at the following resources:
+## Production Build
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+npm run build
+npm start
+```
 
 ## Admin alerts page
 
@@ -42,3 +42,11 @@ Visit `/admin/alerts` while logged in as an admin to monitor recent warnings and
 ### Bank transfer receipts
 
 The invoice page allows students selecting bank transfer to upload payment proof. Files are sent to the backend `POST /api/payments/student/receipts` endpoint.
+
+## Resources
+
+- [Next.js Documentation](https://nextjs.org/docs) – learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) – an interactive Next.js tutorial.
+- [Next.js GitHub repository](https://github.com/vercel/next.js).
+- [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying).
+- [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) – easiest way to deploy a Next.js app.


### PR DESCRIPTION
## Summary
- describe SkillBridge frontend structure and features
- list exact commands for setup, linting, testing, and production builds
- move Next.js learning links into a dedicated Resources section

## Testing
- `npm --prefix frontend run lint` *(fails: 42 errors, 308 warnings)*
- `npm --prefix frontend test` *(terminated after partial execution due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68bc53ccd0488328ad3fdda01228ba9d