### PR TITLE
ci: add workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint
+        run: npm run lint --if-present
+      - name: Build
+        run: npm run build --if-present
+      - name: Run tests
+        run: npm test -- --coverage
+      - name: Upload coverage
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: coverage
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint
+        run: npm run lint --if-present
+      - name: Build
+        run: npm run build --if-present
+      - name: Run tests
+        run: npm test -- --coverage
+      - name: Upload coverage
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: coverage


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to test backend and frontend with linting and optional build/coverage steps

## Testing
- `npm test --prefix backend` *(fails: Route.post requires a callback function)*
- `npm run lint --prefix backend --if-present`
- `npm run lint --prefix frontend` *(aborted)*
- `npm test --prefix frontend` *(partial run, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc53ce88e88328adf0150d25728965