### PR TITLE
docs: clarify install script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
 
 ## Automated Installation
 
+Ensure `bash`, `curl`, `docker` and `docker compose` are installed on your system.
+
 ```bash
-curl -s https://example.com/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/eduskillbridge/SkillBridge/main/install.sh | bash
 ```
 
-The script checks prerequisites, copies example env files, builds containers and can seed the database for development setups when `SEED_DB=true`.
+The script validates prerequisites, copies example env files, builds and starts the Docker containers, and can seed the database for development setups when `SEED_DB=true`. After it completes, the app is available at `http://localhost:3000`.
 
+> **Note:** Always review the script before piping it into `bash` to verify it comes from a trusted source.
 
 Alternatively, launch the backend and open [`/install`](http://localhost:5002/install) to use a simple web-based installer that checks prerequisites and runs the setup scripts after entering configuration values.
 


### PR DESCRIPTION
## Summary
- document prerequisites for the `install.sh` helper
- link to hosted install script
- warn users to verify installer authenticity before running

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68bc53cc51cc83289c3e47d87e64acf9