### PR TITLE
refactor: centralize logging and silence debug output

### DIFF
--- a/frontend/src/components/admin/categories/CategoryForm.js
+++ b/frontend/src/components/admin/categories/CategoryForm.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import logger from "@/utils/logger";
 
 export default function CategoryForm({ categories }) {
   const [formData, setFormData] = useState({
@@ -13,7 +14,7 @@ export default function CategoryForm({ categories }) {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    console.log("Submitting category:", formData);
+    logger.log("Submitting category:", formData);
     alert("Category submitted (mock)");
   };
 

--- a/frontend/src/components/admin/online-classes/forms/CreateClassForm.js
+++ b/frontend/src/components/admin/online-classes/forms/CreateClassForm.js
@@ -1,5 +1,6 @@
 // src/components/forms/CreateClassForm.js
 import { useState } from 'react';
+import logger from '@/utils/logger';
 
 export default function CreateClassForm() {
   const [step, setStep] = useState(1);
@@ -50,7 +51,7 @@ export default function CreateClassForm() {
 
   const handleSubmit = () => {
     setSubmitted(true);
-    console.log('Submitting:', formData);
+    logger.log('Submitting:', formData);
     setTimeout(() => {
       window.location.href = '/dashboard/admin/online-classes';
     }, 2500);

--- a/frontend/src/components/admin/users/UserCardGrid.js
+++ b/frontend/src/components/admin/users/UserCardGrid.js
@@ -1,5 +1,6 @@
 import React from "react";
 import UserCard from "./UserCard";
+import logger from "@/utils/logger";
 
 /**
  * UserCardGrid
@@ -18,7 +19,7 @@ export default function UserCardGrid({
   onSelectUser,
 }) {
   if (!Array.isArray(users)) {
-    console.warn("⚠️ `users` is not an array:", users);
+    logger.warn("⚠️ `users` is not an array:", users);
     return <div className="text-red-500">Invalid users data</div>;
   }
 
@@ -34,7 +35,7 @@ export default function UserCardGrid({
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       {users.map((user, idx) => {
         if (!user?.id) {
-          console.warn(`⚠️ User at index ${idx} has no ID`, user);
+          logger.warn(`⚠️ User at index ${idx} has no ID`, user);
           return null;
         }
 

--- a/frontend/src/components/groups/InviteUserModal.js
+++ b/frontend/src/components/groups/InviteUserModal.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import logger from '@/utils/logger';
 
 export default function InviteUserModal({ groupId, onClose }) {
   const [email, setEmail] = useState('');
@@ -6,7 +7,7 @@ export default function InviteUserModal({ groupId, onClose }) {
 
   const handleSend = () => {
     // Mock invite send (replace with real logic later)
-    console.log(`📨 Invite sent to ${email} for group ${groupId}`);
+    logger.log(`📨 Invite sent to ${email} for group ${groupId}`);
     setSent(true);
     setTimeout(onClose, 1000); // auto close after 1s
   };

--- a/frontend/src/components/instructors/CreateClassForm.js
+++ b/frontend/src/components/instructors/CreateClassForm.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import logger from '@/utils/logger';
 
 export default function CreateClassForm({ onSubmit }) {
   const [step, setStep] = useState(1);
@@ -44,7 +45,7 @@ export default function CreateClassForm({ onSubmit }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (onSubmit) onSubmit(formData);
-    console.log('Create class data', formData);
+    logger.log('Create class data', formData);
   };
 
   return (

--- a/frontend/src/components/profile/steps/FinalReview.js
+++ b/frontend/src/components/profile/steps/FinalReview.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { FaArrowLeft, FaCheckCircle, FaUpload, FaExclamationTriangle, FaPlayCircle, FaTrash } from "react-icons/fa";
+import logger from "@/utils/logger";
 
 const FinalReview = ({ formData, prevStep }) => {
   const [isAgreed, setIsAgreed] = useState(false);
@@ -56,7 +57,7 @@ const FinalReview = ({ formData, prevStep }) => {
     }
 
     // 🔹 Send to Admin for Approval
-    console.log("🚀 Submitting Profile for Review:", formData);
+    logger.log("🚀 Submitting Profile for Review:", formData);
 
     // ✅ Mark as Submitted
     setSubmitted(true);

--- a/frontend/src/components/shared/SidebarMenu.js
+++ b/frontend/src/components/shared/SidebarMenu.js
@@ -9,6 +9,7 @@ import {
   FaBullhorn, FaTachometerAlt
 } from "react-icons/fa";
 import useAuthStore from "@/store/auth/authStore";
+import logger from "@/utils/logger";
 
 const SidebarMenu = ({ isOpen, onClose, showAds }) => {
   const sidebarRef = useRef(null);
@@ -16,10 +17,7 @@ const SidebarMenu = ({ isOpen, onClose, showAds }) => {
   const { user } = useAuthStore();
   const { t } = useTranslation("common");
   const userRole = user?.role?.toLowerCase();
-
-  if (process.env.NODE_ENV === "development") {
-    console.log("🔍 SidebarMenu Loaded | Role:", userRole, "| User:", user);
-  }
+  logger.log("🔍 SidebarMenu Loaded | Role:", userRole, "| User:", user);
 
   const [hydrated, setHydrated] = useState(false);
 

--- a/frontend/src/components/video-call/LiveTranscription.js
+++ b/frontend/src/components/video-call/LiveTranscription.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { FaMicrophone, FaMicrophoneSlash } from "react-icons/fa";
+import logger from "@/utils/logger";
 
 const defaultLanguage =
   typeof window !== "undefined"
@@ -27,7 +28,7 @@ const LiveTranscription = ({ isEnabled = true, language = defaultLanguage, onTra
   // ✅ Initialize Speech Recognition
   useEffect(() => {
     if (!window.SpeechRecognition && !window.webkitSpeechRecognition) {
-      console.warn("Speech Recognition API is not supported in this browser.");
+      logger.warn("Speech Recognition API is not supported in this browser.");
       return;
     }
 

--- a/frontend/src/components/video-call/TranscriptionManager.js
+++ b/frontend/src/components/video-call/TranscriptionManager.js
@@ -1,5 +1,6 @@
 // components/video-call/TranscriptionManager.js
 import { useEffect, useRef, useState } from "react";
+import logger from "@/utils/logger";
 
 const defaultLanguage =
   typeof window !== "undefined"
@@ -18,7 +19,7 @@ const TranscriptionManager = ({ currentSpeaker = "Unknown" }) => {
       window.SpeechRecognition || window.webkitSpeechRecognition;
 
     if (!SpeechRecognition) {
-      console.warn("Speech Recognition API not supported");
+      logger.warn("Speech Recognition API not supported");
       return;
     }
 
@@ -46,7 +47,7 @@ const TranscriptionManager = ({ currentSpeaker = "Unknown" }) => {
       }
     };
 
-    recognition.onerror = (e) => console.error("Transcription error:", e.error);
+    recognition.onerror = (e) => logger.error("Transcription error:", e.error);
 
     recognitionRef.current = recognition;
     recognition.start();

--- a/frontend/src/components/video-call/VideoCallScreen.js
+++ b/frontend/src/components/video-call/VideoCallScreen.js
@@ -7,6 +7,7 @@ import {
   FaChalkboardTeacher,
   FaUserShield,
 } from "react-icons/fa";
+import logger from "@/utils/logger";
 
 import VideoGrid from "./VideoGrid";
 import ParticipantList from "./ParticipantList";
@@ -79,7 +80,7 @@ const VideoCallScreen = ({ chatId, userRole = roles.PARTICIPANT }) => {
     if (!document.fullscreenElement) {
       document.documentElement
         .requestFullscreen()
-        .catch(() => console.warn("Fullscreen not supported"));
+        .catch(() => logger.warn("Fullscreen not supported"));
     }
   }, []);
 

--- a/frontend/src/hooks/useVideoCall.js
+++ b/frontend/src/hooks/useVideoCall.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { io } from "socket.io-client";
 import Peer from "simple-peer";
+import logger from "@/utils/logger";
 
 export default function useVideoCall(roomId, userName = "User", role = "participant") {
   const [peers, setPeers] = useState([]);
@@ -70,7 +71,7 @@ export default function useVideoCall(roomId, userName = "User", role = "particip
           setPeers((prev) => prev.filter((p) => p.peerID !== id));
         });
       } catch (err) {
-        console.error("Failed to get media", err);
+        logger.error("Failed to get media", err);
         setError(err);
       }
     };
@@ -118,8 +119,8 @@ export default function useVideoCall(roomId, userName = "User", role = "particip
         signal,
       });
     });
-    peer.on("error", (err) => console.error("Peer error", err));
-    peer.on("close", () => console.warn("Peer connection closed"));
+    peer.on("error", (err) => logger.error("Peer error", err));
+    peer.on("close", () => logger.warn("Peer connection closed"));
     return peer;
   };
 
@@ -133,8 +134,8 @@ export default function useVideoCall(roomId, userName = "User", role = "particip
     peer.on("signal", (signal) => {
       socketRef.current.emit("returning-signal", { signal, callerID });
     });
-    peer.on("error", (err) => console.error("Peer error", err));
-    peer.on("close", () => console.warn("Peer connection closed"));
+    peer.on("error", (err) => logger.error("Peer error", err));
+    peer.on("close", () => logger.warn("Peer connection closed"));
     peer.signal(incomingSignal);
     return peer;
   };
@@ -173,7 +174,7 @@ export default function useVideoCall(roomId, userName = "User", role = "particip
       oldTrack.stop();
       setSelectedAudioInput(deviceId);
     } catch (err) {
-      console.error("Failed to switch microphone", err);
+      logger.error("Failed to switch microphone", err);
     }
   };
 
@@ -182,7 +183,7 @@ export default function useVideoCall(roomId, userName = "User", role = "particip
     document.querySelectorAll("video").forEach((video) => {
       if (typeof video.sinkId !== "undefined") {
         video.setSinkId(deviceId).catch((e) => {
-          console.warn("Failed to set output device", e);
+          logger.warn("Failed to set output device", e);
           setError(e);
         });
       }

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -20,6 +20,7 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
+import logger from "@/utils/logger";
 
 // ─────────────────────
 // 🔐 Validation schema
@@ -81,9 +82,7 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
   // ─────────────────────────────
   const onSubmit = async (data) => {
   try {
-    if (process.env.NODE_ENV !== "production") {
-      console.log("➡️ login onSubmit invoked");
-    }
+    logger.log("➡️ login onSubmit invoked");
     let cfg = recaptchaCfg;
     if (!cfg && cfgLoading) {
       cfg = await fetchSocialLoginConfig().catch(() => null);
@@ -115,9 +114,7 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
       router.push(targetPath);
     }, 500);
   } catch (err) {
-    if (process.env.NODE_ENV !== "production") {
-      console.error("❌ login onSubmit error", { message: err?.message });
-    }
+    logger.error("❌ login onSubmit error", { message: err?.message });
     let msg =
       err?.response?.data?.message ||
       err?.response?.data?.error ||

--- a/frontend/src/pages/dashboard/admin/currency/languages/create.js
+++ b/frontend/src/pages/dashboard/admin/currency/languages/create.js
@@ -3,6 +3,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState } from "react";
 import { useRouter } from "next/router";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
+import logger from "@/utils/logger";
 
 export default function CreateLanguagePage() {
   const router = useRouter();
@@ -27,7 +28,7 @@ export default function CreateLanguagePage() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    console.log("Language submitted:", form);
+    logger.log("Language submitted:", form);
     router.push("/dashboard/admin/settings/languages");
   };
 

--- a/frontend/src/pages/dashboard/admin/profile/change-password.js
+++ b/frontend/src/pages/dashboard/admin/profile/change-password.js
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { FaLock, FaEye, FaEyeSlash, FaCheckCircle, FaExclamationTriangle, FaArrowLeft } from "react-icons/fa";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer"; // ✅ Import Footer
+import logger from "@/utils/logger";
 
 const ChangePasswordPage = ({ prevStep }) => {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -35,7 +36,7 @@ const ChangePasswordPage = ({ prevStep }) => {
     }
 
     // 🔹 Success! (Mock: Send update request to backend)
-    console.log("🚀 Password updated successfully!");
+    logger.log("🚀 Password updated successfully!");
     setSuccess(true);
 
     // 🔹 Clear input fields

--- a/frontend/src/pages/dashboard/admin/users/index.js
+++ b/frontend/src/pages/dashboard/admin/users/index.js
@@ -9,6 +9,7 @@ import { fetchAllUsers } from "@/services/admin/userService";
 import useAuthStore from "@/store/auth/authStore";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import { toast } from "react-toastify";
+import logger from "@/utils/logger";
 
 function UsersPage() {
   const { t } = useTranslation("dashboard");
@@ -36,7 +37,7 @@ function UsersPage() {
     const loadUsers = async () => {
       try {
         const data = await fetchAllUsers(); // ✅ No token needed (cookie session)
-        console.log("✅ API returned users:", data);
+        logger.log("✅ API returned users:", data);
 
         const formatted = (data ?? []).map((u) => ({
           ...u,
@@ -52,7 +53,7 @@ function UsersPage() {
         setUsers(formatted);
       } catch (err) {
         toast.error("Error fetching users");
-        console.error("❌ Error loading users:", err);
+        logger.error("❌ Error loading users:", err);
       } finally {
         setLoading(false);
       }

--- a/frontend/src/pages/dashboard/instructor/profile/change-password.js
+++ b/frontend/src/pages/dashboard/instructor/profile/change-password.js
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { FaLock, FaEye, FaEyeSlash, FaCheckCircle, FaExclamationTriangle, FaArrowLeft } from "react-icons/fa";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer"; // ✅ Import Footer
+import logger from "@/utils/logger";
 
 const ChangePasswordPage = ({ prevStep }) => {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -35,7 +36,7 @@ const ChangePasswordPage = ({ prevStep }) => {
     }
 
     // 🔹 Success! (Mock: Send update request to backend)
-    console.log("🚀 Password updated successfully!");
+    logger.log("🚀 Password updated successfully!");
     setSuccess(true);
 
     // 🔹 Clear input fields

--- a/frontend/src/pages/dashboard/instructor/profile/steps/FinalReview.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/FinalReview.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { FaArrowLeft, FaCheckCircle, FaUpload, FaExclamationTriangle, FaPlayCircle, FaTrash } from "react-icons/fa";
+import logger from "@/utils/logger";
 
 const FinalReview = ({ formData = {}, prevStep = () => {} }) => {
   const [isAgreed, setIsAgreed] = useState(false);
@@ -56,7 +57,7 @@ const FinalReview = ({ formData = {}, prevStep = () => {} }) => {
     }
 
     // 🔹 Send to Admin for Approval
-    console.log("🚀 Submitting Profile for Review:", formData);
+    logger.log("🚀 Submitting Profile for Review:", formData);
 
     // ✅ Mark as Submitted
     setSubmitted(true);

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -14,6 +14,7 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
+import logger from "@/utils/logger";
 import {
   FaUpload, FaTrash, FaFilePdf, FaSpinner,
   FaUserCircle, FaIdCard, FaLinkedin, FaGithub,
@@ -223,7 +224,7 @@ export default function StudentProfileEdit() {
     if (!validateForm()) return;
     try {
       setIsSubmitting(true);
-      console.log("[StudentProfileEdit] Submitting form", formData);
+      logger.log("[StudentProfileEdit] Submitting form", formData);
 
       const social_links = Object.entries(formData.socialLinks || {})
         .filter(([, url]) => url.trim() !== "")
@@ -239,7 +240,7 @@ export default function StudentProfileEdit() {
         learning_goals: formData.learning_goals,
         social_links,
       };
-      console.log("[StudentProfileEdit] Payload", payload);
+      logger.log("[StudentProfileEdit] Payload", payload);
 
       await toast.promise(updateStudentProfile(payload), {
         pending: "Saving profile...",
@@ -256,7 +257,7 @@ export default function StudentProfileEdit() {
       });
 
       const fresh = await getStudentProfile();
-      console.log("[StudentProfileEdit] Updated profile", fresh);
+      logger.log("[StudentProfileEdit] Updated profile", fresh);
 
       setUser({
         ...user,
@@ -281,7 +282,7 @@ export default function StudentProfileEdit() {
         refreshNotifications?.();
         refreshMessages?.();
       } catch (err) {
-        console.error("[StudentProfileEdit] notification error", err);
+        logger.error("[StudentProfileEdit] notification error", err);
       }
 
 
@@ -289,7 +290,7 @@ export default function StudentProfileEdit() {
 
 
     } catch (err) {
-      console.error("[StudentProfileEdit] update error", err);
+      logger.error("[StudentProfileEdit] update error", err);
       const msg = err.response?.data?.message || err.message || "Failed to update profile";
       toast.error(msg);
       if (err.response?.status === 401) {

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -4,6 +4,7 @@ import * as authService from "@/services/auth/authService";
 import { getFullProfile } from "@/services/profile/profileService";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import logger from "@/utils/logger";
 
 const useAuthStore = create(
   persist(
@@ -19,9 +20,7 @@ const useAuthStore = create(
       isAuthenticated: () => !!get().accessToken && !!get().user,
 
       login: async (credentials) => {
-        if (process.env.NODE_ENV !== "production") {
-          console.log("🔑 authStore.login invoked");
-        }
+        logger.log("🔑 authStore.login invoked");
         const { accessToken, user } = await authService.loginUser(credentials);
         if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
           user.avatar_url = null;
@@ -47,9 +46,7 @@ const useAuthStore = create(
           fetchNotifications?.();
           return user;
         } catch (err) {
-          if (process.env.NODE_ENV !== "production") {
-            console.error("❌ loginWithToken error", { message: err?.message });
-          }
+          logger.error("❌ loginWithToken error", { message: err?.message });
           set({ accessToken: null, user: null });
         }
       },
@@ -64,9 +61,7 @@ const useAuthStore = create(
           set({ user: fresh });
           return fresh;
         } catch (err) {
-          if (process.env.NODE_ENV !== "production") {
-            console.error("❌ refreshUser error", { message: err?.message });
-          }
+          logger.error("❌ refreshUser error", { message: err?.message });
         }
       },
 
@@ -94,9 +89,7 @@ const useAuthStore = create(
       name: "auth",
       onRehydrateStorage: () => {
         return (state) => {
-          if (process.env.NODE_ENV !== "production") {
-            console.log("🔥 Zustand hydrated");
-          }
+          logger.log("🔥 Zustand hydrated");
           set({ hasHydrated: true });
         };
       },

--- a/frontend/src/utils/community/moderation.js
+++ b/frontend/src/utils/community/moderation.js
@@ -2,10 +2,12 @@ export const markAsResolved = (discussion) => {
   return { ...discussion, status: "resolved" };
 };
 
+import logger from "@/utils/logger";
+
 export const warnUser = (userId, reason) => {
-  console.warn(`Warned user ${userId} for reason: ${reason}`);
+  logger.warn(`Warned user ${userId} for reason: ${reason}`);
 };
 
 export const lockDiscussion = (discussionId) => {
-  console.warn(`Discussion ${discussionId} locked`);
+  logger.warn(`Discussion ${discussionId} locked`);
 };

--- a/frontend/src/utils/logger.js
+++ b/frontend/src/utils/logger.js
@@ -1,18 +1,23 @@
-const isProd = process.env.NODE_ENV === "production";
+const levels = ["log", "warn", "error"];
+const envLevel = process.env.NEXT_PUBLIC_LOG_LEVEL || (process.env.NODE_ENV === "production" ? "error" : "log");
+const levelIndex = levels.indexOf(envLevel);
+const currentLevel = levelIndex === -1 ? (process.env.NODE_ENV === "production" ? 2 : 0) : levelIndex;
 
 const logger = {
   log: (...args) => {
-    if (!isProd) {
+    if (currentLevel <= 0) {
       console.log(...args);
     }
   },
   warn: (...args) => {
-    if (!isProd) {
+    if (currentLevel <= 1) {
       console.warn(...args);
     }
   },
   error: (...args) => {
-    console.error(...args);
+    if (currentLevel <= 2) {
+      console.error(...args);
+    }
   },
 };
 


### PR DESCRIPTION
## Summary
- add configurable logger that filters messages by `NEXT_PUBLIC_LOG_LEVEL`
- replace stray `console.log`/`console.warn` calls with centralized logger
- remove development-only logs across auth, admin, and video call modules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5ed8f66883288ba418d15991bea6