### PR TITLE
Replace assignment mocks with API calls

### DIFF
--- a/frontend/src/pages/dashboard/admin/assignments/approve/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/approve/[id].js
@@ -3,29 +3,51 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaCheckCircle } from 'react-icons/fa';
+import {
+  fetchAssignmentById,
+  approveAssignment,
+} from '@/services/admin/assignmentService';
 
 export default function ApproveAssignmentPage() {
   const router = useRouter();
   const { id } = router.query;
   const [assignment, setAssignment] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [actionLoading, setActionLoading] = useState(false);
 
   useEffect(() => {
-    // Mock fetch assignment by ID
-    setAssignment({
-      id,
-      title: 'React State Management',
-      instructor: 'Ayman Khalid',
-      className: 'React & Next.js Bootcamp',
-      dueDate: '2025-05-30T23:59:00Z',
-    });
+    if (!id) return;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchAssignmentById(id);
+        setAssignment(data);
+      } catch (err) {
+        setError('Failed to load assignment.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [id]);
 
-  const handleApprove = () => {
-    alert('✅ Assignment approved successfully!');
-    router.push('/dashboard/admin/assignments/success');
+  const handleApprove = async () => {
+    setActionLoading(true);
+    try {
+      await approveAssignment(id);
+      alert('✅ Assignment approved successfully!');
+      router.push('/dashboard/admin/assignments/success');
+    } catch (err) {
+      alert('Failed to approve assignment.');
+    } finally {
+      setActionLoading(false);
+    }
   };
 
-  if (!assignment) return <div className="text-center mt-32 text-gray-700">Loading...</div>;
+  if (loading) return <div className="text-center mt-32 text-gray-700">Loading...</div>;
+  if (error) return <div className="text-center mt-32 text-red-500">{error}</div>;
 
   return (
     <AdminLayout>
@@ -37,13 +59,14 @@ export default function ApproveAssignmentPage() {
             <div>
               <h2 className="text-2xl font-semibold mb-2">{assignment.title}</h2>
               <p><strong>Instructor:</strong> {assignment.instructor}</p>
-              <p><strong>Class:</strong> {assignment.class}</p>
+              <p><strong>Class:</strong> {assignment.className}</p>
               <p><strong>Due Date:</strong> {new Date(assignment.dueDate).toLocaleString()}</p>
             </div>
 
             <button
               onClick={handleApprove}
-              className="w-full py-4 bg-green-500 hover:bg-green-600 text-white font-bold rounded-lg flex items-center justify-center gap-2"
+              disabled={actionLoading}
+              className="w-full py-4 bg-green-500 hover:bg-green-600 text-white font-bold rounded-lg flex items-center justify-center gap-2 disabled:opacity-50"
             >
               <FaCheckCircle /> Confirm Approve
             </button>

--- a/frontend/src/pages/dashboard/admin/assignments/reject/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/reject/[id].js
@@ -3,6 +3,10 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaTimesCircle } from 'react-icons/fa';
+import {
+  fetchAssignmentById,
+  rejectAssignment,
+} from '@/services/admin/assignmentService';
 
 export default function RejectAssignmentPage() {
   const router = useRouter();
@@ -10,29 +14,46 @@ export default function RejectAssignmentPage() {
 
   const [assignment, setAssignment] = useState(null);
   const [reason, setReason] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [actionLoading, setActionLoading] = useState(false);
 
   useEffect(() => {
-    // Mock assignment fetch
-    setAssignment({
-      id,
-      title: 'React Basics',
-      instructor: 'Ayman Khalid',
-      className: 'React Bootcamp',
-    });
+    if (!id) return;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchAssignmentById(id);
+        setAssignment(data);
+      } catch (err) {
+        setError('Failed to load assignment.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [id]);
 
-  const handleReject = () => {
+  const handleReject = async () => {
     if (!reason.trim()) {
       alert('⚠️ Please provide a reason for rejection.');
       return;
     }
-
-    // TODO: Save rejection reason and update status
-    alert(`❌ Assignment "${assignment.title}" rejected successfully with reason: ${reason}`);
-    router.push('/dashboard/admin/assignments');
+    setActionLoading(true);
+    try {
+      await rejectAssignment(id, reason);
+      alert(`❌ Assignment "${assignment.title}" rejected successfully with reason: ${reason}`);
+      router.push('/dashboard/admin/assignments');
+    } catch (err) {
+      alert('Failed to reject assignment.');
+    } finally {
+      setActionLoading(false);
+    }
   };
 
-  if (!assignment) return <div className="text-center mt-32 text-gray-700">Loading...</div>;
+  if (loading) return <div className="text-center mt-32 text-gray-700">Loading...</div>;
+  if (error) return <div className="text-center mt-32 text-red-500">{error}</div>;
 
   return (
     <AdminLayout>
@@ -55,7 +76,8 @@ export default function RejectAssignmentPage() {
             <div className="flex gap-4">
               <button
                 onClick={handleReject}
-                className="w-full py-3 bg-red-500 hover:bg-red-600 text-white font-bold rounded flex items-center justify-center gap-2"
+                disabled={actionLoading}
+                className="w-full py-3 bg-red-500 hover:bg-red-600 text-white font-bold rounded flex items-center justify-center gap-2 disabled:opacity-50"
               >
                 <FaTimesCircle /> Reject Assignment
               </button>

--- a/frontend/src/pages/dashboard/admin/assignments/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/view/[id].js
@@ -3,6 +3,11 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaCheckCircle, FaTimesCircle } from 'react-icons/fa';
+import {
+  fetchAssignmentById,
+  approveAssignment,
+  rejectAssignment,
+} from '@/services/admin/assignmentService';
 
 export default function AdminAssignmentReviewPage() {
   const router = useRouter();
@@ -11,46 +16,60 @@ export default function AdminAssignmentReviewPage() {
   const [assignment, setAssignment] = useState(null);
   const [actionNote, setActionNote] = useState('');
   const [status, setStatus] = useState('Pending');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [actionLoading, setActionLoading] = useState(false);
 
   useEffect(() => {
-    // Mock fetch assignment
-    setAssignment({
-      id,
-      title: 'React State Management',
-      instructor: 'Ayman Khalid',
-      className: 'React & Next.js Bootcamp',
-      type: 'mcq',
-      allowLate: true,
-      dueDate: '2025-05-30T23:59:00Z',
-      gradingRubric: 'Focus on correct hook usage, clear logic, and no unnecessary re-renders.',
-      questions: [
-        {
-          question: 'Which hook is used to manage component state?',
-          options: ['useEffect', 'useState', 'useContext', 'useMemo'],
-          correct: 1,
-          points: 2
-        }
-      ]
-    });
+    if (!id) return;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchAssignmentById(id);
+        setAssignment(data);
+        setStatus(data?.status || 'Pending');
+      } catch (err) {
+        setError('Failed to load assignment.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [id]);
 
-  const handleApprove = () => {
-    setStatus('Approved');
-    alert('✅ Assignment Approved Successfully!');
-    // TODO: Save the action in backend later
+  const handleApprove = async () => {
+    setActionLoading(true);
+    try {
+      await approveAssignment(id, actionNote);
+      setStatus('Approved');
+      alert('✅ Assignment Approved Successfully!');
+    } catch (err) {
+      alert('Failed to approve assignment.');
+    } finally {
+      setActionLoading(false);
+    }
   };
 
-  const handleReject = () => {
+  const handleReject = async () => {
     if (!actionNote.trim()) {
       alert('⚠️ Please provide a reason for rejection.');
       return;
     }
-    setStatus('Rejected');
-    alert('❌ Assignment Rejected and Instructor Notified.');
-    // TODO: Save the action in backend later
+    setActionLoading(true);
+    try {
+      await rejectAssignment(id, actionNote);
+      setStatus('Rejected');
+      alert('❌ Assignment Rejected and Instructor Notified.');
+    } catch (err) {
+      alert('Failed to reject assignment.');
+    } finally {
+      setActionLoading(false);
+    }
   };
 
-  if (!assignment) return <div className="text-center mt-32 text-gray-700">Loading...</div>;
+  if (loading) return <div className="text-center mt-32 text-gray-700">Loading...</div>;
+  if (error) return <div className="text-center mt-32 text-red-500">{error}</div>;
 
   return (
     <AdminLayout>
@@ -126,14 +145,16 @@ export default function AdminAssignmentReviewPage() {
                 <div className="flex gap-4">
                   <button
                     onClick={handleApprove}
-                    className="w-full py-3 bg-green-500 hover:bg-green-600 text-white font-bold rounded-lg flex items-center justify-center gap-2"
+                    disabled={actionLoading}
+                    className="w-full py-3 bg-green-500 hover:bg-green-600 text-white font-bold rounded-lg flex items-center justify-center gap-2 disabled:opacity-50"
                   >
                     <FaCheckCircle /> Approve
                   </button>
 
                   <button
                     onClick={handleReject}
-                    className="w-full py-3 bg-red-500 hover:bg-red-600 text-white font-bold rounded-lg flex items-center justify-center gap-2"
+                    disabled={actionLoading}
+                    className="w-full py-3 bg-red-500 hover:bg-red-600 text-white font-bold rounded-lg flex items-center justify-center gap-2 disabled:opacity-50"
                   >
                     <FaTimesCircle /> Reject
                   </button>

--- a/frontend/src/services/admin/assignmentService.js
+++ b/frontend/src/services/admin/assignmentService.js
@@ -4,3 +4,38 @@ export const fetchAllAssignments = async () => {
   const { data } = await api.get("/users/classes/assignments/admin");
   return data?.data ?? [];
 };
+
+export const fetchAssignmentById = async (id) => {
+  const { data } = await api.get(`/users/classes/assignments/admin/${id}`);
+  const a = data?.data;
+  if (!a) return null;
+  return {
+    id: a.id,
+    title: a.title,
+    instructor: a.instructor,
+    className: a.class_title,
+    type: a.type,
+    allowLate: a.allow_late,
+    dueDate: a.due_date,
+    gradingRubric: a.grading_rubric,
+    questions: a.questions || [],
+    status: a.status,
+  };
+};
+
+export const approveAssignment = async (id, note) => {
+  const payload = note ? { note } : {};
+  const { data } = await api.patch(
+    `/users/classes/assignments/admin/${id}/approve`,
+    payload
+  );
+  return data?.data;
+};
+
+export const rejectAssignment = async (id, reason) => {
+  const { data } = await api.patch(
+    `/users/classes/assignments/admin/${id}/reject`,
+    { reason }
+  );
+  return data?.data;
+};


### PR DESCRIPTION
## Summary
- replace assignment mocks with backend API calls
- persist approve and reject actions
- add loading and error states to assignment pages

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ed9f17083288b1dae9e81b71dfe