### PR TITLE
feat: remove frontend mocks and call real APIs

### DIFF
--- a/frontend/src/components/admin/categories/CategoryList.js
+++ b/frontend/src/components/admin/categories/CategoryList.js
@@ -1,13 +1,26 @@
+import { useEffect, useState } from "react";
 import CategoryItem from "./CategoryItem";
 import Link from "next/link";
-
-const mockCategories = [
-  { id: 1, name: "Programming", slug: "programming" },
-  { id: 2, name: "Design", slug: "design" },
-  { id: 3, name: "Marketing", slug: "marketing" },
-];
+import { fetchBookCategories } from "@/services/bookCategoryService";
 
 export default function CategoryList() {
+  const [categories, setCategories] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    fetchBookCategories()
+      .then((data) => {
+        if (isMounted) setCategories(data);
+      })
+      .catch(() => isMounted && setError("Failed to load categories"))
+      .finally(() => isMounted && setLoading(false));
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
@@ -20,8 +33,12 @@ export default function CategoryList() {
       </div>
 
       <div className="border rounded-md overflow-hidden">
-        {mockCategories.length > 0 ? (
-          mockCategories.map(cat => (
+        {loading ? (
+          <p className="p-4">Loading...</p>
+        ) : error ? (
+          <p className="p-4 text-red-500">{error}</p>
+        ) : categories.length > 0 ? (
+          categories.map((cat) => (
             <CategoryItem key={cat.id} category={cat} />
           ))
         ) : (

--- a/frontend/src/components/chat/GroupMemberList.js
+++ b/frontend/src/components/chat/GroupMemberList.js
@@ -1,26 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ChatImage from '../shared/ChatImage';
-
-const mockMembers = [
-  {
-    id: 1,
-    name: 'Sarah Johnson',
-    avatar: 'https://i.pravatar.cc/150?img=1',
-    role: 'admin',
-  },
-  {
-    id: 2,
-    name: 'Ali Mansour',
-    avatar: 'https://i.pravatar.cc/150?img=2',
-    role: 'member',
-  },
-  {
-    id: 3,
-    name: 'Lina Farah',
-    avatar: 'https://i.pravatar.cc/150?img=3',
-    role: 'pending',
-  },
-];
+import groupService from '@/services/groupService';
 
 const roleStyles = {
   admin: 'bg-green-100 text-green-700',
@@ -28,7 +8,29 @@ const roleStyles = {
   pending: 'bg-yellow-100 text-yellow-700',
 };
 
-export default function GroupMembersList({ members = mockMembers }) {
+export default function GroupMembersList({ groupId }) {
+  const [members, setMembers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!groupId) return;
+    let isMounted = true;
+    groupService
+      .getGroupMembers(groupId)
+      .then((data) => {
+        if (isMounted) setMembers(data);
+      })
+      .catch(() => isMounted && setError('Failed to load members'))
+      .finally(() => isMounted && setLoading(false));
+    return () => {
+      isMounted = false;
+    };
+  }, [groupId]);
+
+  if (loading) return <p className="text-sm text-gray-500">Loading...</p>;
+  if (error) return <p className="text-sm text-red-500">{error}</p>;
+
   return (
     <div className="space-y-3">
       {members.map((member) => (
@@ -54,7 +56,6 @@ export default function GroupMembersList({ members = mockMembers }) {
             </div>
           </div>
 
-          {/* Optional actions for admin */}
           {member.role === 'pending' && (
             <div className="flex gap-2">
               <button className="text-xs text-green-600 hover:underline">Approve</button>

--- a/frontend/src/components/chat/PendingJoinRequests.js
+++ b/frontend/src/components/chat/PendingJoinRequests.js
@@ -1,23 +1,26 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import ChatImage from '../shared/ChatImage';
+import groupService from '@/services/groupService';
 
-const mockPendingRequests = [
-  {
-    id: 'u1',
-    name: 'Omar Saleh',
-    avatar: 'https://i.pravatar.cc/150?img=4',
-    requestedAt: '2h ago',
-  },
-  {
-    id: 'u2',
-    name: 'Leila Hassan',
-    avatar: 'https://i.pravatar.cc/150?img=5',
-    requestedAt: '5h ago',
-  },
-];
+export default function PendingJoinRequests({ groupId, onApprove, onReject }) {
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-export default function PendingJoinRequests({ onApprove, onReject }) {
-  const [requests, setRequests] = useState(mockPendingRequests);
+  useEffect(() => {
+    if (!groupId) return;
+    let isMounted = true;
+    groupService
+      .getJoinRequestsForGroup(groupId)
+      .then((data) => {
+        if (isMounted) setRequests(data);
+      })
+      .catch(() => isMounted && setError('Failed to load requests'))
+      .finally(() => isMounted && setLoading(false));
+    return () => {
+      isMounted = false;
+    };
+  }, [groupId]);
 
   const handleApprove = (id) => {
     setRequests((prev) => prev.filter((r) => r.id !== id));
@@ -32,7 +35,11 @@ export default function PendingJoinRequests({ onApprove, onReject }) {
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-semibold">🕓 Pending Join Requests</h3>
-      {requests.length === 0 ? (
+      {loading ? (
+        <p className="text-sm text-gray-500">Loading...</p>
+      ) : error ? (
+        <p className="text-sm text-red-500">{error}</p>
+      ) : requests.length === 0 ? (
         <p className="text-sm text-gray-500">No pending requests.</p>
       ) : (
         requests.map((user) => (

--- a/frontend/src/components/shared/DynamicAds.js
+++ b/frontend/src/components/shared/DynamicAds.js
@@ -1,22 +1,64 @@
 import { useState, useEffect } from "react";
-import mockAds from "@/mocks/ads.json";
+import { fetchAds } from "@/services/adsService";
 
 const DynamicAds = () => {
+  const [ads, setAds] = useState([]);
   const [currentAd, setCurrentAd] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentAd((prev) => (prev + 1) % mockAds.length);
-    }, 5000);
-    return () => clearInterval(interval);
+    let isMounted = true;
+    const loadAds = async () => {
+      try {
+        const { data } = await fetchAds();
+        if (isMounted) setAds(data);
+      } catch (err) {
+        if (isMounted) setError("Failed to load ads");
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+    loadAds();
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
+  useEffect(() => {
+    if (!ads.length) return;
+    const interval = setInterval(() => {
+      setCurrentAd((prev) => (prev + 1) % ads.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [ads]);
+
+  if (loading) return <div className="text-center">Loading ads...</div>;
+  if (error) return <div className="text-center text-red-500">{error}</div>;
+  if (!ads.length) return null;
+
+  const ad = ads[currentAd];
   return (
     <div className="border p-4 rounded-lg shadow-md text-center">
-      <img src={mockAds[currentAd].image} alt={mockAds[currentAd].title} className="w-full h-40 object-cover rounded" />
-      <h2 className="text-lg font-bold mt-2">{mockAds[currentAd].title}</h2>
-      <p className="text-gray-600">{mockAds[currentAd].description}</p>
-      <a href={mockAds[currentAd].link} className="mt-2 inline-block bg-blue-500 text-white px-4 py-2 rounded">Learn More</a>
+      {ad.image && (
+        <img
+          src={ad.image}
+          alt={ad.title}
+          className="w-full h-40 object-cover rounded"
+        />
+      )}
+      <h2 className="text-lg font-bold mt-2">{ad.title}</h2>
+      {ad.description && (
+        <p className="text-gray-600">{ad.description}</p>
+      )}
+      {ad.link && (
+        <a
+          href={ad.link}
+          className="mt-2 inline-block bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          Learn More
+        </a>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/shared/SearchFilters.js
+++ b/frontend/src/components/shared/SearchFilters.js
@@ -1,5 +1,14 @@
 const SearchFilters = ({ selected, onChange }) => {
-    const categories = ["all", "course", "instructor", "community", "nft"];
+    const categories = [
+      "all",
+      "classes",
+      "tutorials",
+      "books",
+      "instructors",
+      "offers",
+      "community",
+      "blog",
+    ];
   
     return (
       <div className="flex gap-3 my-4">

--- a/frontend/src/hooks/useLastSeen.js
+++ b/frontend/src/hooks/useLastSeen.js
@@ -1,28 +1,42 @@
 import { useState, useEffect } from "react";
-import mockUsers from "@/mocks/sampleUsers.json"; // ✅ Import mock data
+import api from "@/services/api/api";
 
 const useLastSeen = (userId) => {
   const [lastSeen, setLastSeen] = useState(null);
   const [isOnline, setIsOnline] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    // Simulate fetching user data (Replace with API Call)
-    const user = mockUsers.find((user) => user.id === userId);
-    if (user) {
-      const online =
-        user.isOnline !== undefined ? user.isOnline : user.status === "online";
-      setIsOnline(online);
-      if (online) {
-        setLastSeen("Online");
-      } else if (user.lastSeen) {
-        setLastSeen(`Last seen ${user.lastSeen}`);
-      } else {
-        setLastSeen("Offline");
+    if (!userId) return;
+    let isMounted = true;
+    const fetchStatus = async () => {
+      try {
+        const { data } = await api.get(`/users/usersmanagement/${userId}`);
+        if (!isMounted) return;
+        const user = data?.data || data;
+        const online = user?.is_online ?? false;
+        setIsOnline(!!online);
+        if (online) {
+          setLastSeen("Online");
+        } else if (user?.last_seen) {
+          setLastSeen(`Last seen ${user.last_seen}`);
+        } else {
+          setLastSeen("Offline");
+        }
+      } catch (err) {
+        if (isMounted) setError("Failed to fetch status");
+      } finally {
+        if (isMounted) setLoading(false);
       }
-    }
+    };
+    fetchStatus();
+    return () => {
+      isMounted = false;
+    };
   }, [userId]);
 
-  return { lastSeen, isOnline };
+  return { lastSeen, isOnline, loading, error };
 };
 
 export default useLastSeen;

--- a/frontend/src/pages/api/search/suggestions.js
+++ b/frontend/src/pages/api/search/suggestions.js
@@ -1,11 +1,21 @@
-import data from '@/mocks/searchResults.json';
+import axios from 'axios';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   const { q = '' } = req.query;
-  const query = q.toLowerCase();
-  const suggestions = data
-    .filter((item) => item.title.toLowerCase().includes(query))
-    .slice(0, 5)
-    .map((item) => item.title);
-  res.status(200).json(suggestions);
+  if (!q) {
+    return res.status(200).json([]);
+  }
+
+  try {
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000/api';
+    const { data } = await axios.get(`${base}/search`, { params: { q } });
+    const payload = data.data || data;
+    const suggestions = Object.values(payload)
+      .flat()
+      .map((item) => item.title || item.full_name)
+      .slice(0, 5);
+    res.status(200).json(suggestions);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch suggestions' });
+  }
 }

--- a/frontend/src/pages/search/index.js
+++ b/frontend/src/pages/search/index.js
@@ -3,13 +3,15 @@ import { useRouter } from "next/router";
 import SearchBar from "@/components/shared/SearchBar";
 import SearchFilters from "@/components/shared/SearchFilters";
 import SearchResults from "@/components/shared/SearchResults";
-import mockData from "@/mocks/searchResults.json";
+import { searchAll } from "@/services/searchService";
 
 const SearchPage = () => {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
-  const [filteredResults, setFilteredResults] = useState(mockData);
+  const [results, setResults] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState("all");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (router.query.q) {
@@ -19,22 +21,52 @@ const SearchPage = () => {
 
   useEffect(() => {
     if (searchQuery) {
-      router.replace({ pathname: '/search', query: { q: searchQuery } }, undefined, { shallow: true });
+      router.replace(
+        { pathname: "/search", query: { q: searchQuery } },
+        undefined,
+        { shallow: true }
+      );
     }
   }, [searchQuery]);
 
   useEffect(() => {
-    let results = mockData;
-    if (searchQuery) {
-      results = results.filter((item) =>
-        item.title.toLowerCase().includes(searchQuery.toLowerCase())
-      );
+    if (!searchQuery) {
+      setResults([]);
+      return;
     }
-    if (selectedCategory !== "all") {
-      results = results.filter((item) => item.type === selectedCategory);
-    }
-    setFilteredResults(results);
-  }, [searchQuery, selectedCategory]);
+
+    let isMounted = true;
+    setLoading(true);
+    setError(null);
+    searchAll(searchQuery)
+      .then((data) => {
+        if (!isMounted) return;
+        const flat = [];
+        Object.entries(data || {}).forEach(([type, arr]) => {
+          (arr || []).forEach((item) =>
+            flat.push({
+              id: item.id,
+              title: item.title || item.full_name,
+              description: item.description || item.excerpt || "",
+              image: item.cover || item.image || item.avatar_url,
+              type,
+            })
+          );
+        });
+        setResults(flat);
+      })
+      .catch(() => isMounted && setError("Failed to fetch results"))
+      .finally(() => isMounted && setLoading(false));
+
+    return () => {
+      isMounted = false;
+    };
+  }, [searchQuery]);
+
+  const filteredResults =
+    selectedCategory === "all"
+      ? results
+      : results.filter((r) => r.type === selectedCategory);
 
   return (
     <div className="p-6">
@@ -42,10 +74,15 @@ const SearchPage = () => {
       <SearchBar
         value={searchQuery}
         onChange={setSearchQuery}
-        onKeyDown={(e) => e.key === 'Enter' && router.push(`/search?q=${encodeURIComponent(searchQuery)}`)}
+        onKeyDown={(e) =>
+          e.key === "Enter" &&
+          router.push(`/search?q=${encodeURIComponent(searchQuery)}`)
+        }
       />
       <SearchFilters selected={selectedCategory} onChange={setSelectedCategory} />
-      <SearchResults results={filteredResults} />
+      {loading && <p>Loading...</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      {!loading && !error && <SearchResults results={filteredResults} />}
     </div>
   );
 };

--- a/frontend/src/pages/support/ticket-status.js
+++ b/frontend/src/pages/support/ticket-status.js
@@ -1,34 +1,41 @@
+import { useEffect, useState } from "react";
 import PageHead from "@/components/common/PageHead";
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
-
-// Mocked ticket data (to be replaced with actual API integration)
-const mockTickets = [
-  {
-    id: "TCK-1001",
-    subject: "Refund not processed",
-    status: "Open",
-    createdAt: "2025-05-01",
-    lastUpdated: "2025-05-03",
-  },
-  {
-    id: "TCK-1002",
-    subject: "Unable to join live class",
-    status: "Resolved",
-    createdAt: "2025-04-28",
-    lastUpdated: "2025-04-30",
-  },
-];
+import { fetchMyTickets } from "@/services/supportService";
 
 export default function TicketStatusPage() {
+  const [tickets, setTickets] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    fetchMyTickets()
+      .then((data) => {
+        if (isMounted) setTickets(data);
+      })
+      .catch(() => isMounted && setError("Failed to load tickets"))
+      .finally(() => isMounted && setLoading(false));
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <div className="bg-gray-900 text-white min-h-screen">
       <PageHead title="My Support Tickets" />
       <Navbar />
       <main className="max-w-5xl mx-auto px-4 py-20">
-        <h1 className="text-3xl font-bold text-yellow-500 mb-8 text-center">My Support Tickets</h1>
+        <h1 className="text-3xl font-bold text-yellow-500 mb-8 text-center">
+          My Support Tickets
+        </h1>
 
-        {mockTickets.length === 0 ? (
+        {loading ? (
+          <p className="text-center text-gray-400">Loading...</p>
+        ) : error ? (
+          <p className="text-center text-red-500">{error}</p>
+        ) : tickets.length === 0 ? (
           <p className="text-center text-gray-400">No support tickets found.</p>
         ) : (
           <div className="overflow-x-auto border border-gray-700 rounded shadow-lg">
@@ -44,17 +51,23 @@ export default function TicketStatusPage() {
                 </tr>
               </thead>
               <tbody>
-                {mockTickets.map((ticket) => (
-                  <tr key={ticket.id} className="border-t border-gray-700 hover:bg-gray-700 transition">
+                {tickets.map((ticket) => (
+                  <tr
+                    key={ticket.id}
+                    className="border-t border-gray-700 hover:bg-gray-700 transition"
+                  >
                     <td className="px-4 py-3 font-mono">{ticket.id}</td>
                     <td className="px-4 py-3">{ticket.subject}</td>
                     <td className="px-4 py-3">
-                      <span className={`px-2 py-1 rounded text-sm font-semibold ${ticket.status === "Resolved"
-                          ? "bg-green-600 text-white"
-                          : ticket.status === "Open"
+                      <span
+                        className={`px-2 py-1 rounded text-sm font-semibold ${
+                          ticket.status === "resolved"
+                            ? "bg-green-600 text-white"
+                            : ticket.status === "open"
                             ? "bg-yellow-500 text-black"
                             : "bg-gray-600 text-white"
-                        }`}>
+                        }`}
+                      >
                         {ticket.status}
                       </span>
                     </td>
@@ -69,7 +82,6 @@ export default function TicketStatusPage() {
                       </a>
                     </td>
                   </tr>
-
                 ))}
               </tbody>
             </table>

--- a/frontend/src/services/cartService.js
+++ b/frontend/src/services/cartService.js
@@ -1,16 +1,13 @@
 import api from "@/services/api/api";
-import mockCart from "@/mocks/sampleCart.json"; // Import mock data
-
-const MOCK_MODE = false;
 
 export const getCartItems = async () => {
-  if (MOCK_MODE) {
-    return new Promise((resolve) => {
-      setTimeout(() => resolve(mockCart), 500);
-    });
+  try {
+    const res = await api.get("/cart");
+    return res.data?.data ?? res.data;
+  } catch (error) {
+    console.error("Error fetching cart items:", error);
+    return [];
   }
-  const res = await api.get('/cart');
-  return res.data?.data ?? res.data;
 };
 
 export const addToCart = async (item) => {


### PR DESCRIPTION
## Summary
- replace mock cart items, ads, search results, ticket lists and chat data with real API calls
- add loading and error states for dynamic ads, search, support tickets and chat lists
- expand search filters to backend-supported categories

## Testing
- `npm test src/tests/__tests__/Navbar.test.js`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc66112ae483289004c15996586cd3