### PR TITLE
chore: ignore node modules and note install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Alternatively, launch the backend and open [`/install`](http://localhost:5002/in
 
 ## Quick start
 
+Install the project dependencies:
+
+```bash
+npm --prefix backend install
+npm --prefix frontend install
+```
+
 1. Configure environment variables:
 
    - Edit the `.env` file in the project root. Docker Compose loads

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,14 @@
 
 This folder contains the Express.js API for SkillBridge. Run `npm test` to execute the Jest suite.
 
+## Setup
+
+Install the backend dependencies:
+
+```bash
+npm install
+```
+
 The `/api/system-errors` route reads the latest lines from `logs/error.log` and is used by the admin alerts page. Only authenticated admins can access it.
 
 ### Bank transfer receipts

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules/
 /.pnp
 .pnp.*
 .yarn/*


### PR DESCRIPTION
## Summary
- remove node_modules from backend and frontend
- add node_modules ignore entries and README install instructions

## Testing
- `npm --prefix backend test` *(fails: Route.post requires a callback)*
- `npm --prefix frontend test` *(fails: Syntax Error in checkoutPaymentFlow.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6601f85c83289fefd1015a5e28d6