### PR TITLE
Add documentation index for guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,31 @@
+# SkillBridge Documentation
+
+## Setup
+- [Installation Guide](installation.md) — step-by-step setup instructions.
+- [Installation Guide (PDF)](installation.pdf) — downloadable PDF version.
+- [Deployment Guide](deployment.md) — how to deploy SkillBridge.
+- [Architecture Overview](architecture.md) — system components and data flow.
+- [Social Login Setup](social-login-setup.md) — configure OAuth providers.
+
+## Administration
+- [Alerts Management](admin-alerts.md) — configure system alerts.
+- [Ads Management](admin-ads-management.md) — manage platform advertisements.
+- [Category Management](admin-category-management.md) — organize course categories.
+- [Third-Party Integrations](admin-third-party-integrations.md) — connect external services.
+- [License Verification](license-verification.md) — verify instructor credentials.
+- [Messages Configuration](messages-config.md) — customize message templates.
+- [Coupon Management](coupon-management.md) — define promotional codes.
+- [Payment Icon Sources](payment-icon-sources.md) — references for payment icons.
+- [Subscription Plan Styles](subscription-plan-style.md) — style subscription options.
+
+## Workflows
+- [Book Workflow](book-workflow.md) — process for booking classes.
+- [Class Lifecycle Workflow](class-lifecycle-workflow.md) — lifecycle of a class.
+- [Class Plan Coverage](class-plan-coverage.md) — overview of plan coverage.
+- [Student Registration Guide](student-registration-guide.md) — steps for new student sign-up.
+- [Student Enrollment Workflow](student-enrollment-workflow.md) — enroll students into classes.
+
+## Reference
+- [API Documentation](api-docs.md) — REST API endpoints.
+- [Changelog](changelog.md) — record of notable changes.
+- [Release Checklist](release-checklist.md) — tasks before a release.


### PR DESCRIPTION
## Summary
- Document all guides in a new `docs/README.md`
- Link to setup, administration, workflow, and reference documentation including the new `installation.pdf`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd backend && npm test` *(fails: multiple failing tests)*
- `cd frontend && npm test` *(fails: syntax error in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6b91ec1883289640463177f2cfd0