### PR TITLE
Fix nginx upstream hosts for production

### DIFF
--- a/docs/social-login-setup.md
+++ b/docs/social-login-setup.md
@@ -34,7 +34,7 @@ If the redirect URI does not exactly match what is configured on Google, the log
 
 If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, verify the frontend's `NEXT_PUBLIC_API_BASE_URL` points to your backend URL including the `/api` prefix. Without this variable the login and register buttons default to `/api/auth/*` which only works when the frontend and backend share the same host. Both buttons now append `?origin=` with the current site origin so the API can redirect back correctly even when `FRONTEND_URL` is not configured.
 
-If requests to `/api/*` still return a Next.js 404 page, confirm your reverse proxy forwards the `/api` path to the backend container. The provided `nginx/conf.d` configs use `location ^~ /api/` to proxy to `backend:5002` without rewriting the prefix. Restart nginx after updating the configuration.
+If requests to `/api/*` still return a Next.js 404 page, confirm your reverse proxy forwards the `/api` path to the backend server. The provided `nginx/conf.d` configs use `location ^~ /api/` to proxy to `127.0.0.1:5002` without rewriting the prefix. Restart nginx after updating the configuration.
 
 After editing the files you can verify that nginx picked up the change by running:
 

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -5,7 +5,10 @@ server_name $APP_DOMAIN www.$APP_DOMAIN;
   client_max_body_size 100M;
 
   location / {
-    proxy_pass http://frontend:3000;
+    # In production the frontend runs on the host network and is not
+    # accessible by the Docker service name.  Using localhost ensures nginx
+    # can always reach the Next.js app.
+    proxy_pass http://127.0.0.1:3000;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -19,7 +22,10 @@ server_name $APP_DOMAIN www.$APP_DOMAIN;
 
   # Forward Socket.IO traffic to backend and enable WebSocket upgrades
   location /socket.io/ {
-    proxy_pass http://backend:5002;
+    # The API server listens on the host network so we proxy to localhost
+    # rather than the Docker service name to avoid 502 errors when nginx runs
+    # outside the compose network.
+    proxy_pass http://127.0.0.1:5002;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
@@ -35,7 +41,7 @@ server_name $APP_DOMAIN www.$APP_DOMAIN;
 
   location ^~ /api/ {
     # forward API requests without rewriting the path
-    proxy_pass http://backend:5002;
+    proxy_pass http://127.0.0.1:5002;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/conf.d/ssl.conf
+++ b/nginx/conf.d/ssl.conf
@@ -8,7 +8,9 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/$APP_DOMAIN/privkey.pem;
 
     location / {
-        proxy_pass http://frontend:3000;
+        # When nginx runs on the host rather than in Docker we must proxy to
+        # localhost so requests reach the Next.js frontend.
+        proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -22,7 +24,9 @@ server {
 
     # Forward Socket.IO traffic to backend and enable WebSocket upgrades
     location /socket.io/ {
-        proxy_pass http://backend:5002;
+        # The API server is exposed on the host network.  Proxying to
+        # localhost avoids DNS lookup failures for the Docker service name.
+        proxy_pass http://127.0.0.1:5002;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -38,7 +42,7 @@ server {
 
     location ^~ /api/ {
         # forward API requests without rewriting the path
-        proxy_pass http://backend:5002;
+        proxy_pass http://127.0.0.1:5002;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- proxy nginx to localhost instead of Docker service names to avoid 502
- update social login docs for new proxy address

## Testing
- `npm --prefix backend test` *(fails: database configuration is missing and multiple Jest suites fail)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6ea4ac788328b24b5999211d4f97