### PR TITLE
Add service health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,11 @@ services:
       - FRONTEND_URL=${FRONTEND_URL}
       - MAX_BLOG_IMAGE_BYTES=${MAX_BLOG_IMAGE_BYTES}
       - NODE_ENV=${NODE_ENV}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5002/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     depends_on:
       - db
     volumes:
@@ -59,8 +64,14 @@ services:
     environment:
       # IMPORTANT: browsers can't call localhost on your server
       - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- add curl-based healthchecks for backend and frontend services
- ensure frontend waits for a healthy backend before starting

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc760c177c8328828dac4b4ec314e5