### PR TITLE
feat: decouple migrations from server startup

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "test": "NODE_ENV=test jest",
-    "migrate": "knex migrate:latest --knexfile knexfile.js",
+    "migrate": "node src/migrate.js",
     "seed": "knex seed:run --knexfile knexfile.js"
   },
   "keywords": [],

--- a/backend/src/migrate.js
+++ b/backend/src/migrate.js
@@ -1,0 +1,18 @@
+const path = require('path');
+const db = require('./config/database');
+const logger = require('./utils/logger.js');
+
+async function migrate() {
+  try {
+    await db.migrate.latest({ directory: path.join(__dirname, 'migrations') });
+    logger.log('✅ Database migrations up to date');
+    process.exit(0);
+  } catch (err) {
+    logger.error('❌ Migration failed:', err.message);
+    process.exit(1);
+  } finally {
+    await db.destroy();
+  }
+}
+
+migrate();

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -130,8 +130,16 @@ const PORT = process.env.PORT || 5002;
 
 async function startServer() {
   try {
-    await db.migrate.latest({ directory: path.join(__dirname, "migrations") });
-    logger.log("✅ Database migrations up to date");
+    const [, pending] = await db.migrate.list({
+      directory: path.join(__dirname, "migrations"),
+    });
+    if (pending.length) {
+      logger.warn(
+        `⚠️ Pending migrations detected. Run \"npm run migrate\" before starting the server.`
+      );
+    } else {
+      logger.log("✅ Database migrations up to date");
+    }
     await initStrategies();
     server.listen(PORT, "0.0.0.0", () => {
       logger.log(`✅ Server running on port ${PORT}`);

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,8 +89,10 @@ cd ..
 Run migrations and seed data:
 
 ```bash
-npx knex migrate:latest --knexfile backend/knexfile.js
-npx knex seed:run --knexfile backend/knexfile.js
+cd backend
+npm run migrate
+npm run seed
+cd ..
 ```
 
 ## 5. Launch the stack
@@ -140,17 +142,17 @@ To deploy SkillBridge for real users on a remote host:
 3. **Adjust Nginx for your domain.**
    - Set the `APP_DOMAIN` environment variable so Nginx and the backend use your domain.
    - Obtain TLS certificates (e.g. via Let's Encrypt's certbot) and ensure the paths in `ssl.conf` match the certificate locations.
-4. **Build and start the containers** in detached mode:
+4. **Run database migrations and seeds** before starting the containers:
+
+   ```bash
+   docker-compose run --rm backend npm run migrate
+   docker-compose run --rm backend npm run seed
+   ```
+
+5. **Build and start the containers** in detached mode:
 
    ```bash
    docker-compose up -d --build
-   ```
-
-5. **Run database migrations and seeds** inside the running backend container:
-
-   ```bash
-   docker-compose exec backend npx knex migrate:latest
-   docker-compose exec backend npx knex seed:run
    ```
 
 6. **Verify the deployment** by visiting `https://<your-domain>` in a browser. The API will be available at `https://<your-domain>/api`.


### PR DESCRIPTION
## Summary
- add standalone migration script and npm task
- warn at server startup when database migrations are pending
- document running migrations prior to deployment

## Testing
- `npm --prefix backend run migrate` (fails: development database configuration is missing)
- `npm --prefix backend test` (fails: 37 failed, 1 skipped, 76 passed, 113 of 114 total)


------
https://chatgpt.com/codex/tasks/task_e_68bc760b4efc83289c2e734b85f504ad