### PR TITLE
Ensure critical env vars are defined

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,18 @@ Install the backend dependencies:
 npm install
 ```
 
+### Required environment variables
+
+The server will fail to start unless the following variables are defined:
+
+- `JWT_SECRET` – signing key for access tokens
+- `REFRESH_TOKEN_SECRET` – signing key for refresh tokens
+- `DATABASE_URL` – PostgreSQL connection string (use `TEST_DATABASE_URL` when running tests)
+- `PORT` – port for the HTTP server
+- `SESSION_SECRET` – session cookie signing secret
+
+Provide these variables via a `.env` file or the hosting environment.
+
 The `/api/system-errors` route reads the latest lines from `logs/error.log` and is used by the admin alerts page. Only authenticated admins can access it.
 
 ### Bank transfer receipts

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -20,7 +20,13 @@ const routes = require("./routes");
 require("dotenv").config();
 
 // Ensure required environment secrets are present
-const requiredSecrets = ["JWT_SECRET", "REFRESH_TOKEN_SECRET"];
+const requiredSecrets = [
+  "JWT_SECRET",
+  "REFRESH_TOKEN_SECRET",
+  process.env.NODE_ENV === "test" ? "TEST_DATABASE_URL" : "DATABASE_URL",
+  "PORT",
+  "SESSION_SECRET",
+].filter(Boolean);
 const missingSecrets = requiredSecrets.filter((key) => !process.env[key]);
 if (missingSecrets.length) {
   throw new Error(


### PR DESCRIPTION
## Summary
- fail fast if core environment variables (JWT and refresh secrets, database URL, server port, session secret) are missing
- document mandatory env vars in backend README

## Testing
- `cd backend && JWT_SECRET=foo REFRESH_TOKEN_SECRET=bar DATABASE_URL=postgres://localhost:5432/test PORT=5000 SESSION_SECRET=baz TEST_DATABASE_URL=postgres://localhost:5432/test npm test` *(fails: Test Suites: 24 failed, 2 skipped, 88 passed, 112 total)*


------
https://chatgpt.com/codex/tasks/task_e_68bc76076108832883984bb1a7e3ec48