### PR TITLE
Add nginx reverse proxy service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,21 @@ services:
     depends_on:
       - backend
 
+  nginx:
+    image: nginx:alpine
+    restart: always
+    env_file:
+      - ./.env
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+    depends_on:
+      - backend
+      - frontend
+
 volumes:
   postgres_data:
   pgadmin_data:


### PR DESCRIPTION
## Summary
- introduce nginx service acting as reverse proxy
- mount nginx configuration and expose HTTP/HTTPS ports

## Testing
- `docker-compose config | grep -A5 'nginx:'`


------
https://chatgpt.com/codex/tasks/task_e_68bc760579f08328809a0d8e543e5662