### PR TITLE
Add instructor invoice routes and UI

### DIFF
--- a/backend/src/modules/invoices/instructor.routes.js
+++ b/backend/src/modules/invoices/instructor.routes.js
@@ -1,0 +1,12 @@
+const router = require("express").Router();
+const controller = require("./invoices.controller");
+const { verifyToken, isInstructor } = require("../../middleware/auth/authMiddleware");
+
+router.use(verifyToken, isInstructor);
+
+router.get("/", controller.getMyInvoices);
+router.get("/payment/:paymentId", controller.getMyInvoiceByPaymentId);
+router.get("/:id/download", controller.downloadInvoice);
+router.get("/:id", controller.getMyInvoice);
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -52,6 +52,7 @@ router.use(
 router.use('/api/payments/admin', require('../modules/payments/payments.routes'));
 router.use('/api/invoices/admin', require('../modules/invoices/invoices.routes'));
 router.use('/api/invoices/student', require('../modules/invoices/student.routes'));
+router.use('/api/invoices/instructor', require('../modules/invoices/instructor.routes'));
 router.use(
   '/api/admin/payments/bank',
   require('../modules/payments/bank.admin.routes')

--- a/frontend/src/pages/dashboard/instructor/settings/index.js
+++ b/frontend/src/pages/dashboard/instructor/settings/index.js
@@ -10,9 +10,28 @@ export default function InstructorSettingsPage() {
   const fetchSubscription = useSubscriptionStore((state) => state.fetch);
   const [upgrading, setUpgrading] = useState(false);
   const [canceling, setCanceling] = useState(false);
+  const [invoices, setInvoices] = useState([]);
+  const [loadingInvoices, setLoadingInvoices] = useState(true);
+  const [invoiceError, setInvoiceError] = useState(null);
+
+  const loadInvoices = async () => {
+    setLoadingInvoices(true);
+    setInvoiceError(null);
+    try {
+      const { data } = await api.get("/invoices/instructor");
+      setInvoices(data?.data || []);
+    } catch (err) {
+      console.error("Failed to fetch invoices", err);
+      setInvoiceError(err);
+      setInvoices([]);
+    } finally {
+      setLoadingInvoices(false);
+    }
+  };
 
   useEffect(() => {
     fetchSubscription();
+    loadInvoices();
   }, [fetchSubscription]);
 
   const handleUpgrade = async () => {
@@ -88,6 +107,37 @@ export default function InstructorSettingsPage() {
           ) : (
             <p>No active subscription.</p>
           )}
+
+          <div>
+            <h3 className="font-medium">Invoices</h3>
+            {loadingInvoices ? (
+              <p>Loading invoices...</p>
+            ) : invoiceError ? (
+              <div>
+                <p className="text-red-600">Failed to load invoices.</p>
+                <button onClick={loadInvoices} className="text-blue-600 underline">
+                  Retry
+                </button>
+              </div>
+            ) : invoices.length ? (
+              <ul className="list-disc list-inside space-y-1">
+                {invoices.map((inv) => (
+                  <li key={inv.id}>
+                    <a
+                      href={inv.pdf_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 underline"
+                    >
+                      Invoice {inv.id}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>No invoices found.</p>
+            )}
+          </div>
         </div>
       </div>
     </InstructorLayout>


### PR DESCRIPTION
## Summary
- add instructor invoice routes protected for instructors
- mount instructor invoice API route
- show instructor invoices in dashboard settings

## Testing
- `cd backend && npm test` (fails: database configuration is missing)
- `cd frontend && npm test` (fails: syntax error in tests)


------
https://chatgpt.com/codex/tasks/task_e_68bc7849455c83289d275a78f7087494