### PR TITLE
Use plan commission rate for subscription revenue

### DIFF
--- a/backend/src/modules/payments/helpers/__tests__/planRevenue.test.js
+++ b/backend/src/modules/payments/helpers/__tests__/planRevenue.test.js
@@ -1,9 +1,10 @@
-jest.mock('../../../config/database', () => {
+jest.mock('../../../../config/database', () => {
   const db = jest.fn(() => db);
   db.where = jest.fn(() => db);
   db.first = jest.fn();
   db.insert = jest.fn(() => db);
   db.update = jest.fn(() => db);
+  db.select = jest.fn();
   return db;
 });
 
@@ -11,7 +12,7 @@ jest.mock('../platformFee', () => ({
   calculatePlatformFee: jest.fn(() => ({ instructor_amount: 80 })),
 }));
 
-const db = require('../../../config/database');
+const db = require('../../../../config/database');
 const { calculateInstructorAmount } = require('../planRevenue');
 const { calculatePlatformFee } = require('../platformFee');
 
@@ -20,27 +21,36 @@ describe('calculateInstructorAmount', () => {
     jest.clearAllMocks();
   });
 
-  it('applies commission rate to usage amount', async () => {
+  it('uses plan commission rate when available', async () => {
     db.first
       .mockResolvedValueOnce({ usage_count: 2 })
       .mockResolvedValueOnce({ price_monthly: 100 });
+    db.select.mockResolvedValueOnce([
+      { feature_key: 'commission_rate', value: '0.3' },
+    ]);
 
-    const amt = await calculateInstructorAmount(
-      'plan1',
-      'item1',
-      null,
-      'tutorial'
-    );
-    expect(amt).toBeCloseTo(40);
-    expect(db).toHaveBeenCalledWith('plan_usage_metrics');
-    expect(calculatePlatformFee).toHaveBeenCalledWith('tutorial', 100);
+    const amt = await calculateInstructorAmount('plan1', 'item1');
+    expect(amt).toBeCloseTo(35);
+    expect(calculatePlatformFee).not.toHaveBeenCalled();
+  });
+
+  it('handles different commission rates', async () => {
+    db.first
+      .mockResolvedValueOnce({ usage_count: 4 })
+      .mockResolvedValueOnce({ price_monthly: 200 });
+    db.select.mockResolvedValueOnce([
+      { feature_key: 'commission_rate', value: '0.1' },
+    ]);
+
+    const amt = await calculateInstructorAmount('plan2', 'item2');
+    expect(amt).toBeCloseTo(45);
   });
 
   it('returns 0 when plan not found', async () => {
     db.first
       .mockResolvedValueOnce({ usage_count: 1 })
       .mockResolvedValueOnce(null);
-    const amt = await calculateInstructorAmount('plan1', 'item1');
+    const amt = await calculateInstructorAmount('planX', 'itemX');
     expect(amt).toBe(0);
   });
 });

--- a/backend/src/modules/payments/helpers/planRevenue.js
+++ b/backend/src/modules/payments/helpers/planRevenue.js
@@ -1,5 +1,6 @@
 const db = require("../../../config/database");
 const { calculatePlatformFee } = require("./platformFee");
+const { parsePlanFeatures } = require("../../../utils/planFeatures");
 
 // Calculate instructor share for a subscription-covered enrollment
 // Uses plan usage metrics and the plan's commission rate to determine the
@@ -29,8 +30,20 @@ exports.calculateInstructorAmount = async (
 
     const plan = await query("plans").where({ id: planId }).first();
     if (!plan) return 0;
+
+    const featureRows = await query("plan_features")
+      .where({ plan_id: planId })
+      .select("feature_key", "value");
+    const features = parsePlanFeatures({ features: featureRows });
+
     const price = Number(plan.price_monthly || 0);
-    const { instructor_amount: net } = await calculatePlatformFee(itemType, price);
+    let net;
+    if (features.commission_rate != null) {
+      const commissionRate = Number(features.commission_rate);
+      net = price - price * commissionRate;
+    } else {
+      ({ instructor_amount: net } = await calculatePlatformFee(itemType, price));
+    }
     const amount = row.usage_count > 0 ? net / row.usage_count : 0;
 
     await query("plan_usage_metrics")


### PR DESCRIPTION
## Summary
- parse plan features in plan revenue helper
- apply plan-specific commission_rate when calculating instructor payout
- cover multiple commission rates in plan revenue tests

## Testing
- `npm test src/modules/payments/helpers/__tests__/planRevenue.test.js`
- `npm test` *(fails: Route.post() requires a callback function; process.exit called with "1" in src/config/database.js:11)*

------
https://chatgpt.com/codex/tasks/task_e_68bc78471fc48328a3dc250c37725d00