### PR TITLE
Check plan feature before returning ad analytics

### DIFF
--- a/backend/src/modules/ads/ads.controller.js
+++ b/backend/src/modules/ads/ads.controller.js
@@ -576,10 +576,20 @@ exports.getAdAnalytics = catchAsync(async (req, res) => {
     throw new AppError("Forbidden", 403);
   }
 
-  const canShowAnalytics =
-    req.user.plan?.showAnalytics || req.user.subscription?.showAnalytics;
-  if (!isAdmin && !canShowAnalytics) {
-    throw new AppError("Analytics not available for your current plan", 403);
+  if (!isAdmin) {
+    const planId =
+      req.user.plan_id || req.user.plan?.id || req.user.subscription?.plan_id;
+    const plan = planId ? await planService.getPlanById(planId) : null;
+    if (!plan) {
+      throw new AppError("Plan not found", 403);
+    }
+    const features = parsePlanFeatures(plan);
+    if (!features["ads_show_analytics"]) {
+      throw new AppError(
+        "Analytics not available for your current plan",
+        403
+      );
+    }
   }
 
   const data = await service.getAdAnalytics(req.params.id);

--- a/backend/tests/adsRoutes.test.js
+++ b/backend/tests/adsRoutes.test.js
@@ -450,6 +450,11 @@ describe('GET /api/ads/:id/analytics', () => {
   it('returns ad analytics when user has access', async () => {
     const analytics = { views: 5, ctr: 1, clicks: 2, unique_viewers: 3 };
     service.getAdAnalytics = jest.fn().mockResolvedValue(analytics);
+    planService.getPlanById.mockResolvedValue({
+      features: [
+        { feature_key: 'ads_show_analytics', value: true },
+      ],
+    });
     const res = await request(app).get('/api/ads/1/analytics');
     expect(res.status).toBe(200);
     expect(service.getAdAnalytics).toHaveBeenCalledWith('1');
@@ -471,9 +476,14 @@ describe('GET /api/ads/:id/analytics', () => {
         roles: ['instructor'],
         email: 'inst@example.com',
         full_name: 'Instructor One',
-        plan: { showAnalytics: false },
+        plan_id: 'plan1',
       };
       next();
+    });
+    planService.getPlanById.mockResolvedValue({
+      features: [
+        { feature_key: 'ads_show_analytics', value: false },
+      ],
     });
     const res = await request(app).get('/api/ads/1/analytics');
     expect(res.status).toBe(403);


### PR DESCRIPTION
## Summary
- load requesting user's plan before returning ad analytics
- block analytics when `ads_show_analytics` plan feature is disabled
- update ad analytics route tests for plan feature checks

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*

------
https://chatgpt.com/codex/tasks/task_e_68bc7844d990832881c45b5a869c2812