### PR TITLE
feat: enforce tutorial plan limits

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -15,6 +15,9 @@ const { sendTutorialApprovedEmail, sendTutorialRejectedEmail } = require(
 
 const catchAsync = require("../../../utils/catchAsync");
 const { v4: uuidv4 } = require("uuid");
+const { getActiveInstructorPlan } = require("../../plans/instructor.helper");
+const planService = require("../../plans/plans.service");
+const { parsePlanFeatures } = require("../../../utils/planFeatures");
 
 
 const { sendSuccess } = require("../../../utils/response");
@@ -73,6 +76,25 @@ exports.createTutorial = catchAsync(async (req, res) => {
     instructor_id = bodyInstructorId;
   } else {
     instructor_id = req.user.id;
+  }
+
+  if (req.user.role === "instructor") {
+    const plan = await getActiveInstructorPlan(instructor_id);
+    if (!plan) {
+      throw new AppError("Active plan required", 403);
+    }
+    const fullPlan = await planService.getPlanById(plan.id);
+    const features = parsePlanFeatures(fullPlan);
+    if (!features["tutorials_create"]) {
+      throw new AppError("Tutorial creation not allowed for your plan", 403);
+    }
+    const max = features["tutorials_max_count"];
+    if (status === "published" && max) {
+      const count = await service.countPublishedTutorials(instructor_id);
+      if (count >= max) {
+        throw new AppError("Tutorial limit reached for your plan", 403);
+      }
+    }
   }
 
   const id = uuidv4();
@@ -205,11 +227,32 @@ exports.togglePublishStatus = catchAsync(async (req, res) => {
   if (req.user.role === "instructor") {
     await assertInstructorOwnsTutorial(req.user.id, tutorialId);
   }
-  const updated = await service.togglePublishStatus(tutorialId);
-  if (!updated) {
-    throw new AppError("Tutorial not found", 404);
+  const existing = await service.getTutorialById(tutorialId);
+  if (!existing) throw new AppError("Tutorial not found", 404);
+  if (existing.status !== "published") {
+    const plan = await getActiveInstructorPlan(existing.instructor_id);
+    if (!plan) {
+      throw new AppError("Active plan required", 403);
+    }
+    const fullPlan = await planService.getPlanById(plan.id);
+    const features = parsePlanFeatures(fullPlan);
+    if (!features["tutorials_create"]) {
+      throw new AppError(
+        "Tutorial publishing not allowed for your plan",
+        403
+      );
+    }
+    const max = features["tutorials_max_count"];
+    if (max) {
+      const count = await service.countPublishedTutorials(
+        existing.instructor_id
+      );
+      if (count >= max) {
+        throw new AppError("Tutorial limit reached for your plan", 403);
+      }
+    }
   }
-
+  const updated = await service.togglePublishStatus(tutorialId);
   const tut = await service.getTutorialById(tutorialId);
   if (
     req.user.role !== "instructor" &&

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -13,6 +13,14 @@ exports.createTutorial = async (data, trx = db) => {
   return tutorial;
 };
 
+exports.countPublishedTutorials = async (instructorId) => {
+  const row = await db("tutorials")
+    .where({ instructor_id: instructorId, status: "published" })
+    .count("id as count")
+    .first();
+  return parseInt(row.count, 10) || 0;
+};
+
 const { parsePagination } = require("../../../utils/pagination");
 
 exports.getAllTutorials = async (filters = {}) => {

--- a/backend/tests/tutorialCreate.test.js
+++ b/backend/tests/tutorialCreate.test.js
@@ -12,9 +12,10 @@ jest.mock('../src/config/database', () => {
 });
 
 jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({
-  createTutorial: jest.fn(),
+  createTutorialWithRelations: jest.fn(),
   addTutorialTags: jest.fn(),
   getTutorialTags: jest.fn(),
+  countPublishedTutorials: jest.fn(),
 }));
 
 jest.mock('../src/modules/users/tutorials/chapters/tutorialChapter.service', () => ({
@@ -47,22 +48,40 @@ jest.mock('../src/utils/email', () => ({
   sendTutorialRejectedEmail: jest.fn(),
 }));
 
+jest.mock('../src/modules/plans/instructor.helper', () => ({
+  getActiveInstructorPlan: jest.fn(),
+}));
+
+jest.mock('../src/modules/plans/plans.service', () => ({
+  getPlanById: jest.fn(),
+}));
+
 const controller = require('../src/modules/users/tutorials/tutorial.controller');
 const service = require('../src/modules/users/tutorials/tutorial.service');
 const userModel = require('../src/modules/users/user.model');
 const db = require('../src/config/database');
+const { getActiveInstructorPlan } = require('../src/modules/plans/instructor.helper');
+const planService = require('../src/modules/plans/plans.service');
 
 
 describe('createTutorial', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     userModel.findAdmins.mockResolvedValue([]);
+    getActiveInstructorPlan.mockResolvedValue({ id: 'plan1' });
+    planService.getPlanById.mockResolvedValue({
+      id: 'plan1',
+      features: [
+        { feature_key: 'tutorials_create', value: 'true' },
+        { feature_key: 'tutorials_max_count', value: '10' },
+      ],
+    });
   });
 
   it('allows admin to create tutorial for another instructor', async () => {
     const instructorId = '11111111-1111-1111-1111-111111111111';
     userModel.findById.mockResolvedValue({ id: instructorId, full_name: 'Other Instructor', email: 'other@example.com' });
-    service.createTutorial.mockResolvedValue({ id: 'tut1' });
+    service.createTutorialWithRelations.mockResolvedValue({ id: 'tut1' });
 
     const req = {
       body: {
@@ -79,8 +98,8 @@ describe('createTutorial', () => {
     await controller.createTutorial(req, res, jest.fn());
     await new Promise((resolve) => setImmediate(resolve));
     expect(userModel.findById).toHaveBeenCalledWith(instructorId);
-    expect(service.createTutorial).toHaveBeenCalled();
-    const data = service.createTutorial.mock.calls[0][0];
+    expect(service.createTutorialWithRelations).toHaveBeenCalled();
+    const data = service.createTutorialWithRelations.mock.calls[0][0];
     expect(data.instructor_id).toBe(instructorId);
   });
 
@@ -88,7 +107,7 @@ describe('createTutorial', () => {
     const otherId = '11111111-1111-1111-1111-111111111112';
     const myId = '22222222-2222-2222-2222-222222222222';
     userModel.findById.mockResolvedValue({ id: myId, full_name: 'Me', email: 'me@example.com' });
-    service.createTutorial.mockResolvedValue({ id: 'tut1' });
+    service.createTutorialWithRelations.mockResolvedValue({ id: 'tut1' });
 
     const req = {
       body: {
@@ -104,12 +123,12 @@ describe('createTutorial', () => {
 
     await controller.createTutorial(req, res, jest.fn());
     await new Promise((resolve) => setImmediate(resolve));
-    const data = service.createTutorial.mock.calls[0][0];
+    const data = service.createTutorialWithRelations.mock.calls[0][0];
     expect(data.instructor_id).toBe(myId);
   });
 
   it('sets is_paid to false when price is 0', async () => {
-    service.createTutorial.mockResolvedValue({ id: 'tutFree' });
+    service.createTutorialWithRelations.mockResolvedValue({ id: 'tutFree' });
 
     const req = {
       body: {
@@ -125,12 +144,12 @@ describe('createTutorial', () => {
 
     await controller.createTutorial(req, res, jest.fn());
     await new Promise((resolve) => setImmediate(resolve));
-    const data = service.createTutorial.mock.calls[0][0];
+    const data = service.createTutorialWithRelations.mock.calls[0][0];
     expect(data.is_paid).toBe(false);
   });
 
   it('sets is_paid to true when price is greater than 0', async () => {
-    service.createTutorial.mockResolvedValue({ id: 'tutPaid' });
+    service.createTutorialWithRelations.mockResolvedValue({ id: 'tutPaid' });
 
     const req = {
       body: {
@@ -146,7 +165,7 @@ describe('createTutorial', () => {
 
     await controller.createTutorial(req, res, jest.fn());
     await new Promise((resolve) => setImmediate(resolve));
-    const data = service.createTutorial.mock.calls[0][0];
+    const data = service.createTutorialWithRelations.mock.calls[0][0];
     expect(data.is_paid).toBe(true);
   });
 
@@ -171,7 +190,7 @@ describe('createTutorial', () => {
 
     expect(whereRaw).toHaveBeenCalledWith('LOWER(title) = ?', 'my unique');
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(service.createTutorial).not.toHaveBeenCalled();
+    expect(service.createTutorialWithRelations).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/tests/tutorialRoutes.test.js
+++ b/backend/tests/tutorialRoutes.test.js
@@ -20,6 +20,7 @@ jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({
   getAssignmentCount: jest.fn(),
   recordTutorialView: jest.fn(),
   getTutorialViewCount: jest.fn(),
+  countPublishedTutorials: jest.fn(),
 }));
 
 jest.mock('../src/modules/users/tutorials/certificate/certificate.service', () => ({


### PR DESCRIPTION
## Summary
- enforce active plan permissions for tutorial creation and publishing
- add published tutorial count helper
- update tests for plan feature mocks

## Testing
- `npm test` *(fails: Jest worker child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68bc783e4d208328a0458e9a86fb8c7f