### PR TITLE
Use dedicated books download feature key

### DIFF
--- a/backend/src/migrations/20250928010000_rename_tutorials_download_to_books_download.js
+++ b/backend/src/migrations/20250928010000_rename_tutorials_download_to_books_download.js
@@ -1,0 +1,11 @@
+exports.up = async function(knex) {
+  await knex('plan_features')
+    .where({ feature_key: 'tutorials_download' })
+    .update({ feature_key: 'books_download' });
+};
+
+exports.down = async function(knex) {
+  await knex('plan_features')
+    .where({ feature_key: 'books_download' })
+    .update({ feature_key: 'tutorials_download' });
+};

--- a/backend/src/modules/library/__tests__/library.routes.test.js
+++ b/backend/src/modules/library/__tests__/library.routes.test.js
@@ -29,7 +29,7 @@ describe('library routes', () => {
     jest.clearAllMocks();
     planService.getPlanById.mockResolvedValue({
       id: 'plan1',
-      features: [{ feature_key: 'tutorials_download', value: 'true' }],
+      features: [{ feature_key: 'books_download', value: 'true' }],
     });
     service.getBookForDownload.mockResolvedValue({ pdf_url: '/file.pdf', title: 'Book' });
   });
@@ -37,7 +37,7 @@ describe('library routes', () => {
   test('blocks download when feature disabled', async () => {
     planService.getPlanById.mockResolvedValueOnce({
       id: 'plan1',
-      features: [{ feature_key: 'tutorials_download', value: 'false' }],
+      features: [{ feature_key: 'books_download', value: 'false' }],
     });
     const res = await request(app).get('/library/download/1');
     expect(res.statusCode).toBe(403);

--- a/backend/src/modules/library/library.controller.js
+++ b/backend/src/modules/library/library.controller.js
@@ -16,7 +16,7 @@ exports.downloadBook = catchAsync(async (req, res) => {
     req.user.plan_id || req.user.plan?.id || req.user.subscription?.plan_id;
   const plan = planId ? await planService.getPlanById(planId) : null;
   const features = parsePlanFeatures(plan);
-  if (!features["tutorials_download"]) {
+  if (!features["books_download"]) {
     return res.status(403).json({ message: "Access denied" });
   }
   const { bookId } = req.params;

--- a/backend/src/seeds/09_plans_seed.js
+++ b/backend/src/seeds/09_plans_seed.js
@@ -152,9 +152,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.basic,
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'false',
-      description: 'Cannot download tutorials'
+      description: 'Cannot download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -194,9 +194,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.regular,
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'true',
-      description: 'Can download tutorials'
+      description: 'Can download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -236,9 +236,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.prime,
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'true',
-      description: 'Can download tutorials'
+      description: 'Can download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -299,9 +299,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids['instructor-basic'],
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'true',
-      description: 'Can download tutorials'
+      description: 'Can download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -369,9 +369,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids['instructor-pro'],
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'true',
-      description: 'Can download tutorials'
+      description: 'Can download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),

--- a/docs/book-workflow.md
+++ b/docs/book-workflow.md
@@ -93,7 +93,7 @@ Allow instructors to upload and sell PDF books, and allow students to browse, pu
 | Approve/reject | Admin only |
 | Purchase book | Student only |
 | View library | Student only |
-| Download book | Student only (if purchased) |
+| Download book | Student only (if purchased) and plan feature `books_download` enabled |
 | View earnings | Instructor |
 | Manage commission/settings | Admin |
 


### PR DESCRIPTION
## Summary
- switch library download check to `books_download`
- seed plans with new `books_download` feature and provide migration
- document book downloads requiring `books_download`

## Testing
- `cd backend && npm test` *(fails: Route.post requires a callback function but got undefined)*
- `cd frontend && npm test` *(fails: Syntax Error in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc783d30ac8328999630d5c1c21616