### PR TITLE
Enable bank payments for plan checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -138,11 +138,7 @@ export function filterEligibleMethods(methods, itemType) {
   if (itemType === 'plan') {
     return active.filter((m) => {
       const identifier = getMethodIdentifier(m).toLowerCase();
-      return (
-        identifier !== 'paypal' &&
-        identifier !== 'bank' &&
-        !isCryptoMethod(identifier)
-      );
+      return identifier !== 'paypal' && !isCryptoMethod(identifier);
     });
   }
   return active;

--- a/frontend/src/tests/__tests__/filterEligibleMethods.test.js
+++ b/frontend/src/tests/__tests__/filterEligibleMethods.test.js
@@ -19,15 +19,14 @@ describe('filterEligibleMethods', () => {
     ]);
   });
 
-  it('excludes PayPal, bank, and crypto for plan items', () => {
+  it('excludes PayPal and crypto for plan items, allowing bank', () => {
     const result = filterEligibleMethods(methods, 'plan');
-    expect(result.map((m) => m.name)).toEqual(['Stripe']);
+    expect(result.map((m) => m.name)).toEqual(['Stripe', 'Bank']);
   });
 
-  it('returns empty array when no eligible methods for plan', () => {
+  it('returns empty array when only PayPal and crypto methods for plan', () => {
     const onlyIneligible = [
       { id: 1, name: 'PayPal', type: null, active: true },
-      { id: 2, name: 'Bank', type: 'bank', active: true },
       { id: 3, name: 'USDT', type: 'usdt', active: true },
     ];
     const result = filterEligibleMethods(onlyIneligible, 'plan');

--- a/frontend/src/tests/__tests__/paymentHandlers.test.js
+++ b/frontend/src/tests/__tests__/paymentHandlers.test.js
@@ -46,17 +46,17 @@ beforeEach(() => {
   window.location = { href: '' };
 });
 
-test('bank payment redirects on success and handles errors', async () => {
+test('bank payment redirects on success and handles errors for plan', async () => {
   initiateBankPayment.mockResolvedValue({ id: 55 });
-  const args = baseArgs();
+  const args = { ...baseArgs(), itemType: 'plan' };
   await handleBankPayment(args);
   expect(initiateBankPayment).toHaveBeenCalled();
   expect(args.router.push).toHaveBeenCalledWith(
-    '/payments/success?itemType=class&itemId=1&payment_id=55'
+    '/payments/success?itemType=plan&itemId=1&payment_id=55'
   );
 
   initiateBankPayment.mockRejectedValue(new Error('fail'));
-  const errArgs = baseArgs();
+  const errArgs = { ...baseArgs(), itemType: 'plan' };
   await handleBankPayment(errArgs);
   expect(toast.error).toHaveBeenCalled();
   expect(errArgs.setPaymentStatus).toHaveBeenCalledWith('idle');


### PR DESCRIPTION
## Summary
- allow bank payments for plan checkout
- adjust eligible payment method tests
- ensure bank payment handler works for plans

## Testing
- `npx eslint src/pages/payments/checkout.js src/tests/__tests__/filterEligibleMethods.test.js src/tests/__tests__/paymentHandlers.test.js`
- `npm test -- src/tests/__tests__/filterEligibleMethods.test.js src/tests/__tests__/paymentHandlers.test.js`
- `npm test` *(fails: checkoutPaymentFlow.test.js syntax error; resolveIconElement.test.js assertion failure)*

------
https://chatgpt.com/codex/tasks/task_e_68bc783c0f508328b7ece7258595ef1d