### PR TITLE
Rename plan feature for library downloads

### DIFF
--- a/backend/src/modules/library/__tests__/library.routes.test.js
+++ b/backend/src/modules/library/__tests__/library.routes.test.js
@@ -29,7 +29,7 @@ describe('library routes', () => {
     jest.clearAllMocks();
     planService.getPlanById.mockResolvedValue({
       id: 'plan1',
-      features: [{ feature_key: 'tutorials_download', value: 'true' }],
+      features: [{ feature_key: 'books_download', value: 'true' }],
     });
     service.getBookForDownload.mockResolvedValue({ pdf_url: '/file.pdf', title: 'Book' });
   });
@@ -37,7 +37,7 @@ describe('library routes', () => {
   test('blocks download when feature disabled', async () => {
     planService.getPlanById.mockResolvedValueOnce({
       id: 'plan1',
-      features: [{ feature_key: 'tutorials_download', value: 'false' }],
+      features: [{ feature_key: 'books_download', value: 'false' }],
     });
     const res = await request(app).get('/library/download/1');
     expect(res.statusCode).toBe(403);

--- a/backend/src/modules/library/library.controller.js
+++ b/backend/src/modules/library/library.controller.js
@@ -16,7 +16,7 @@ exports.downloadBook = catchAsync(async (req, res) => {
     req.user.plan_id || req.user.plan?.id || req.user.subscription?.plan_id;
   const plan = planId ? await planService.getPlanById(planId) : null;
   const features = parsePlanFeatures(plan);
-  if (!features["tutorials_download"]) {
+  if (!features["books_download"]) {
     return res.status(403).json({ message: "Access denied" });
   }
   const { bookId } = req.params;

--- a/backend/src/seeds/09_plans_seed.js
+++ b/backend/src/seeds/09_plans_seed.js
@@ -152,9 +152,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.basic,
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'false',
-      description: 'Cannot download tutorials'
+      description: 'Cannot download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -194,9 +194,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.regular,
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'true',
-      description: 'Can download tutorials'
+      description: 'Can download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -236,9 +236,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids.prime,
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'true',
-      description: 'Can download tutorials'
+      description: 'Can download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -299,9 +299,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids['instructor-basic'],
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'true',
-      description: 'Can download tutorials'
+      description: 'Can download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),
@@ -369,9 +369,9 @@ exports.seed = async function (knex) {
     {
       id: knex.raw('uuid_generate_v4()'),
       plan_id: ids['instructor-pro'],
-      feature_key: 'tutorials_download',
+      feature_key: 'books_download',
       value: 'true',
-      description: 'Can download tutorials'
+      description: 'Can download books'
     },
     {
       id: knex.raw('uuid_generate_v4()'),


### PR DESCRIPTION
## Summary
- rename `tutorials_download` feature to `books_download`
- update plan seeds and library controller to use `books_download`
- adjust library route tests for new feature

## Testing
- `npm run migrate` *(fails: development database configuration is missing)*
- `npm run seed` *(fails: Unable to acquire a connection)*
- `npm test` *(fails: database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc78372c608328a026b5e000308d67