### PR TITLE
Add default app domain to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,6 @@ REFRESH_TOKEN_SECRET=your_refresh_token_secret_here
 FRONTEND_URL=https://example.com
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production
+APP_DOMAIN=yourdomain.com
 
 NEXT_PUBLIC_API_BASE_URL=https://example.com/api


### PR DESCRIPTION
## Summary
- provide `APP_DOMAIN` in example env file so deployments include the variable by default

## Testing
- `cd backend && npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*
- `cd frontend && npm test` *(fails: Expected ';', '}' or <eof>)*

------
https://chatgpt.com/codex/tasks/task_e_68bc76006f3483288dad4ad96be2727a