### PR TITLE
feat: enforce required server env vars

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,7 +12,8 @@ npm install
 
 ### Required environment variables
 
-The server will fail to start unless the following variables are defined:
+The server validates these values at startup and exits with a clear error if
+any are missing:
 
 - `JWT_SECRET` – signing key for access tokens
 - `REFRESH_TOKEN_SECRET` – signing key for refresh tokens

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -23,15 +23,18 @@ require("dotenv").config();
 const requiredSecrets = [
   "JWT_SECRET",
   "REFRESH_TOKEN_SECRET",
-  process.env.NODE_ENV === "test" ? "TEST_DATABASE_URL" : "DATABASE_URL",
   "PORT",
   "SESSION_SECRET",
-].filter(Boolean);
+];
+const dbKey =
+  process.env.NODE_ENV === "test" ? "TEST_DATABASE_URL" : "DATABASE_URL";
+requiredSecrets.push(dbKey);
 const missingSecrets = requiredSecrets.filter((key) => !process.env[key]);
 if (missingSecrets.length) {
-  throw new Error(
-    `Missing required environment variables: ${missingSecrets.join(", ")}`
+  console.error(
+    `❌ Missing required environment variables: ${missingSecrets.join(", ")}`
   );
+  process.exit(1);
 }
 
 


### PR DESCRIPTION
## Summary
- validate critical server environment variables at startup
- document required backend environment variables

## Testing
- `npm test` *(fails: Route.post() requires a callback function and missing database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7e116f348328bcf5cd544563e77c