### PR TITLE
docs: require migrations before server start

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -136,9 +136,10 @@ const PORT = process.env.PORT || 5002;
 
 async function startServer() {
   try {
-    const [, pending] = await db.migrate.list({
-      directory: path.join(__dirname, "migrations"),
-    });
+    // Migrations are handled via the dedicated `npm run migrate` script.
+    // Only warn here if the database is behind so the server can still start.
+    const migrationDir = path.join(__dirname, "migrations");
+    const [, pending] = await db.migrate.list({ directory: migrationDir });
     if (pending.length) {
       logger.warn(
         `⚠️ Pending migrations detected. Run \"npm run migrate\" before starting the server.`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -98,6 +98,18 @@ referenced in `nginx/conf.d/ssl.conf`.
 After updating these files, rebuild the Docker images or restart the server so
 that the environment changes take effect.
 
+## Run database migrations
+
+Before starting the backend server or after pulling updates, apply any pending
+database migrations:
+
+```bash
+npm --prefix backend run migrate
+```
+
+Running migrations separately keeps `startServer()` lightweight and ensures the
+database schema matches the application's expectations.
+
 ## Preserve uploaded media
 
 The admin panel lets you upload a logo and favicon under


### PR DESCRIPTION
## Summary
- warn if pending migrations when starting server
- document running migrations before deployment

## Testing
- `npm --prefix backend test` *(fails: process.exit called - database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7e14af008328bac67d792a622986