### PR TITLE
Add default app domain to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@ DATABASE_URL=postgres://postgres:postgres@db:5432/eduSkillbridge
 JWT_SECRET=your_jwt_secret_here
 REFRESH_TOKEN_SECRET=your_refresh_token_secret_here
 FRONTEND_URL=https://example.com
+APP_DOMAIN=yourdomain.com
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production
-APP_DOMAIN=yourdomain.com
 
 NEXT_PUBLIC_API_BASE_URL=https://example.com/api


### PR DESCRIPTION
## Summary
- move APP_DOMAIN into the global section of `.env.example`

## Testing
- `npm test` (fails: many suites failed)


------
https://chatgpt.com/codex/tasks/task_e_68bc7e0f0f1883289de524a50ab0f34c