### PR TITLE
chore: install curl in backend container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,7 @@ FROM node:18-alpine
 
 # Set working directory inside the container
 WORKDIR /app
+RUN apk add --no-cache curl
 
 # Copy package.json and package-lock.json first (better build caching)
 COPY package*.json ./


### PR DESCRIPTION
## Summary
- install curl in backend Docker image

## Testing
- `docker compose build backend` *(fails: 'compose' is not a docker command')*


------
https://chatgpt.com/codex/tasks/task_e_68bc8340f42c83288347c5037e065571