### PR TITLE
Add curl installation to frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,7 @@ FROM node:18
 
 # Set working directory
 WORKDIR /app
+RUN apt-get update && apt-get install -y curl
 
 # Copy package.json and lock file
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Summary
- install curl in frontend Dockerfile after setting workdir

## Testing
- `docker compose build frontend` (fails: docker: 'compose' is not a docker command)

------
https://chatgpt.com/codex/tasks/task_e_68bc83400e8c8328b07abee0864e3dc3