### PR TITLE
chore: remove bcryptjs and update license

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@paypal/checkout-server-sdk": "^1.0.3",
         "bcrypt": "^6.0.0",
-        "bcryptjs": "^2.4.3",
         "connect-redis": "^7.1.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -2264,12 +2263,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
-      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,12 +11,11 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "description": "",
   "dependencies": {
     "@paypal/checkout-server-sdk": "^1.0.3",
     "bcrypt": "^6.0.0",
-    "bcryptjs": "^2.4.3",
     "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- update backend license to MIT
- remove bcryptjs dependency and use bcrypt exclusively

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*

------
https://chatgpt.com/codex/tasks/task_e_68bc8c37fe9483289c16757660d3212d