### PR TITLE
Add Helmet middleware for security headers

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "express-rate-limit": "^7.5.0",
         "express-session": "^1.17.3",
         "fluent-ffmpeg": "^2.1.3",
+        "helmet": "^7.2.0",
         "joi": "^17.13.0",
         "json2csv": "^6.0.0-alpha.2",
         "jsonwebtoken": "^9.0.2",
@@ -4314,6 +4315,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "express-rate-limit": "^7.5.0",
     "express-session": "^1.17.3",
     "fluent-ffmpeg": "^2.1.3",
+    "helmet": "^7.2.0",
     "joi": "^17.13.0",
     "json2csv": "^6.0.0-alpha.2",
     "jsonwebtoken": "^9.0.2",

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,6 +4,7 @@ const logger = require('./utils/logger.js');
 const express = require("express");
 const http = require("http");
 const cors = require("cors");
+const helmet = require("helmet");
 const morgan = require("morgan");
 const cookieParser = require("cookie-parser");
 const session = require("express-session");
@@ -42,6 +43,8 @@ if (missingSecrets.length) {
 
 const app = express();
 const server = http.createServer(app);
+
+app.use(helmet());
 
 // 🌐 Fix CORS (must be very early)
 let FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";


### PR DESCRIPTION
## Summary
- import and configure Helmet on Express server
- add Helmet to dependencies

## Testing
- `npm test` *(fails: Route.post requires a callback function; process.exit called)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8c30455c83288d71e49a2c2bb895