### PR TITLE
refactor: move logger require to top in error handler

### DIFF
--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,5 +1,6 @@
 // 📁 src/middleware/errorHandler.js
 const multer = require('multer');
+const logger = require("../utils/logger");
 
 module.exports = (err, req, res, next) => {
   // The CORS middleware defined in `src/server.js` already sets
@@ -26,7 +27,6 @@ module.exports = (err, req, res, next) => {
     message = 'Payload too large';
   }
 
-  const logger = require("../utils/logger");
   logger.error(`❌ ${status} - ${message}`);
   res.status(status).json({ message });
 };


### PR DESCRIPTION
## Summary
- move logger import to top-level in error handler middleware

## Testing
- `JWT_SECRET=secret REFRESH_TOKEN_SECRET=secret SESSION_SECRET=secret DATABASE_URL=postgres://localhost:5432/test TEST_DATABASE_URL=postgres://localhost:5432/test PORT=5000 npm test` *(fails: Route.post requires callback...)*
- `node -e "const express=require('express');const app=express();const errorHandler=require('./src/middleware/errorHandler');app.get('/error',(req,res,next)=>next(new Error('boom')));app.use(errorHandler);const server=app.listen(3001,()=>{require('http').get('http://localhost:3001/error', res=>{res.resume();res.on('end',()=>{server.close();});});});"`

------
https://chatgpt.com/codex/tasks/task_e_68bc8c2889408328845343038d01b09c