### PR TITLE
Log stack traces on server startup failure

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -156,7 +156,7 @@ async function startServer() {
     });
     startJobs();
   } catch (err) {
-    logger.error("❌ Failed to start server:", err.message);
+    logger.error("❌ Failed to start server:", err);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Log full error object when the server fails to start so stack traces appear in logs

## Testing
- `TEST_DATABASE_URL='postgres://localhost:5432/test' npm test` *(fails: Route.post() requires a callback function)*
- `JWT_SECRET=x REFRESH_TOKEN_SECRET=x PORT=5002 SESSION_SECRET=x DATABASE_URL='postgres://localhost:5432/test' node backend/src/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c26d26c8328a7f36133aaeb8ee3