### PR TITLE
Preserve query params during checkout redirect

### DIFF
--- a/frontend/src/pages/checkout/index.js
+++ b/frontend/src/pages/checkout/index.js
@@ -5,7 +5,7 @@ export default function CheckoutRedirect() {
   const router = useRouter();
 
   useEffect(() => {
-    router.replace('/payments/checkout' + window.location.search);
+    router.replace({ pathname: '/payments/checkout', query: router.query });
   }, [router]);
 
   return <p>Redirecting…</p>;

--- a/frontend/src/tests/__tests__/checkoutRedirect.test.js
+++ b/frontend/src/tests/__tests__/checkoutRedirect.test.js
@@ -1,0 +1,25 @@
+import { render, waitFor } from '@testing-library/react';
+import CheckoutRedirect from '../../pages/checkout';
+
+const replace = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: { foo: 'bar', baz: '1' },
+    replace,
+  }),
+}));
+
+afterEach(() => {
+  replace.mockClear();
+});
+
+test('redirects to payments/checkout preserving query parameters', async () => {
+  render(<CheckoutRedirect />);
+  await waitFor(() =>
+    expect(replace).toHaveBeenCalledWith({
+      pathname: '/payments/checkout',
+      query: { foo: 'bar', baz: '1' },
+    }),
+  );
+});


### PR DESCRIPTION
## Summary
- Replace checkout redirect to use object-based router.replace preserving query parameters
- Add unit test ensuring query params persist during redirect

## Testing
- `npm test` *(fails: filterEligibleMethods, InstructorSettingsPage)*
- `npm run lint` *(fails: missing display names)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8c21796c83289b622eb14d9bac2f