### PR TITLE
Wrap student checkout in db transaction

### DIFF
--- a/backend/src/modules/payments/payments.service.js
+++ b/backend/src/modules/payments/payments.service.js
@@ -10,15 +10,21 @@ const STATUS = {
 
 exports.STATUS = STATUS;
 
-exports.create = async (data, schedules = []) => {
-  return db.transaction(async (trx) => {
-    const [row] = await trx("payments").insert(data).returning("*");
+exports.create = async (data, schedules = [], trx) => {
+  const run = async (transaction) => {
+    const [row] = await transaction("payments").insert(data).returning("*");
     if (schedules.length) {
       const records = schedules.map((s) => ({ ...s, payment_id: row.id }));
-      await trx("payment_schedules").insert(records);
+      await transaction("payment_schedules").insert(records);
     }
     return row;
-  });
+  };
+
+  if (trx) {
+    return run(trx);
+  }
+
+  return db.transaction(run);
 };
 
 exports.getAll = async (status, methodType) => {

--- a/backend/src/modules/users/student/student.class.js
+++ b/backend/src/modules/users/student/student.class.js
@@ -62,49 +62,55 @@ class Student {
         ? paymentsService.STATUS.AWAITING_APPROVAL
         : paymentsService.STATUS.PENDING_PAYMENT;
 
-    const results = [];
-    const processedIds = [];
+    return db.transaction(async (trx) => {
+      const results = [];
+      const processedIds = [];
 
-    for (const item of cartItems) {
-      if (item.item_type !== "class") {
-        throw new Error("Invalid cart item type");
+      for (const item of cartItems) {
+        if (item.item_type !== "class") {
+          throw new Error("Invalid cart item type");
+        }
+
+        const cls = await trx("online_classes").where({ id: item.id }).first();
+        if (!cls) {
+          throw new Error("Class not found");
+        }
+
+        const [enrollment] = await trx("class_enrollments")
+          .insert({
+            id: uuidv4(),
+            user_id: this.userId,
+            class_id: item.id,
+            status: "enrolled",
+          })
+          .returning("*");
+
+        const payment = await paymentsService.create(
+          {
+            user_id: this.userId,
+            method_id: paymentMethodId,
+            item_type: item.item_type,
+            item_id: item.id,
+            amount: item.price || 0,
+            status: item.price > 0 ? status : paymentsService.STATUS.PAID,
+          },
+          [],
+          trx
+        );
+
+        processedIds.push(item.id);
+        results.push({ enrollment, payment });
       }
 
-      const cls = await db("online_classes").where({ id: item.id }).first();
-      if (!cls) {
-        throw new Error("Class not found");
+      if (processedIds.length) {
+        await trx("cart_items")
+          .where({ user_id: this.userId })
+          .whereIn("item_id", processedIds)
+          .del();
       }
 
-      const [enrollment] = await db("class_enrollments")
-        .insert({
-          id: uuidv4(),
-          user_id: this.userId,
-          class_id: item.id,
-          status: "enrolled",
-        })
-        .returning("*");
-
-      const payment = await paymentsService.create({
-        user_id: this.userId,
-        method_id: paymentMethodId,
-        item_type: item.item_type,
-        item_id: item.id,
-        amount: item.price || 0,
-        status: item.price > 0 ? status : paymentsService.STATUS.PAID,
-      });
-
-      processedIds.push(item.id);
-      results.push({ enrollment, payment });
-    }
-
-    if (processedIds.length) {
-      await db("cart_items")
-        .where({ user_id: this.userId })
-        .whereIn("item_id", processedIds)
-        .del();
-    }
-
-    return results;
+      return results;
+    });
   }
 }
 

--- a/backend/tests/studentCheckoutTransaction.test.js
+++ b/backend/tests/studentCheckoutTransaction.test.js
@@ -1,0 +1,135 @@
+jest.mock('../src/config/database', () => {
+  const commitSpy = jest.fn();
+  const rollbackSpy = jest.fn();
+
+  const data = {
+    online_classes: [{ id: 'c1' }],
+    class_enrollments: [],
+    cart_items: [{ user_id: 'u1', item_id: 'c1' }],
+    payments: [],
+  };
+
+  return {
+    __data: data,
+    __commit: commitSpy,
+    __rollback: rollbackSpy,
+    transaction: jest.fn(async (cb) => {
+      const local = JSON.parse(JSON.stringify(data));
+
+      const query = (table) => {
+        if (table === 'online_classes') {
+          return {
+            where(cond) {
+              this._cond = cond;
+              return this;
+            },
+            first() {
+              return Promise.resolve(
+                local.online_classes.find((r) => r.id === this._cond.id)
+              );
+            },
+          };
+        }
+        if (table === 'class_enrollments') {
+          return {
+            insert(rec) {
+              local.class_enrollments.push(rec);
+              return {
+                returning: async () => [rec],
+              };
+            },
+          };
+        }
+        if (table === 'cart_items') {
+          return {
+            where(cond) {
+              this._cond = cond;
+              return this;
+            },
+            whereIn(_field, values) {
+              this._values = values;
+              return this;
+            },
+            del() {
+              local.cart_items = local.cart_items.filter(
+                (c) => !(c.user_id === this._cond.user_id && this._values.includes(c.item_id))
+              );
+              return Promise.resolve();
+            },
+          };
+        }
+        if (table === 'payments') {
+          return {
+            insert(rec) {
+              local.payments.push(rec);
+              return {
+                returning: async () => [rec],
+              };
+            },
+          };
+        }
+        return {};
+      };
+
+      const trx = (table) => query(table);
+
+      try {
+        const res = await cb(trx);
+        Object.assign(data, local);
+        commitSpy();
+        return res;
+      } catch (err) {
+        rollbackSpy();
+        throw err;
+      }
+    }),
+  };
+});
+
+jest.mock('../src/modules/cart/cart.service', () => ({
+  list: jest.fn(),
+}));
+
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getById: jest.fn(),
+}));
+
+jest.mock('../src/modules/payments/payments.service', () => ({
+  create: jest.fn(),
+  STATUS: { AWAITING_APPROVAL: 'awaiting_approval', PENDING_PAYMENT: 'pending_payment', PAID: 'paid' },
+}));
+
+const Student = require('../src/modules/users/student/student.class');
+const cartService = require('../src/modules/cart/cart.service');
+const paymentMethodsService = require('../src/modules/paymentMethods/paymentMethods.service');
+const paymentsService = require('../src/modules/payments/payments.service');
+const db = require('../src/config/database');
+
+describe('Student checkout transaction', () => {
+  beforeEach(() => {
+    cartService.list.mockResolvedValue([
+      { id: 'c1', item_type: 'class', price: 50 },
+    ]);
+    paymentMethodsService.getById.mockResolvedValue({ type: 'card' });
+    paymentsService.create.mockReset();
+    db.transaction.mockClear();
+    db.__commit.mockClear();
+    db.__rollback.mockClear();
+    db.__data.class_enrollments = [];
+    db.__data.cart_items = [{ user_id: 'u1', item_id: 'c1' }];
+    db.__data.payments = [];
+  });
+
+  it('rolls back when payment creation fails', async () => {
+    paymentsService.create.mockRejectedValue(new Error('fail'));
+    const student = new Student('u1');
+    await expect(student.checkout('pm1')).rejects.toThrow('fail');
+
+    expect(db.__rollback).toHaveBeenCalled();
+    expect(db.__commit).not.toHaveBeenCalled();
+    expect(db.__data.class_enrollments).toHaveLength(0);
+    expect(db.__data.cart_items).toHaveLength(1);
+    expect(db.__data.payments).toHaveLength(0);
+  });
+});
+


### PR DESCRIPTION
## Summary
- use a single `db.transaction` during student checkout to enroll, create payment records, and remove cart items atomically
- allow `paymentsService.create` to reuse an existing transaction
- add a rollback-focused integration test for checkout failures

## Testing
- `npm test` *(fails: Test Suites: 36 failed, 1 skipped, 79 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8c1eb3108328bce2831548597493