### PR TITLE
Simplify payment method filtering

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -131,18 +131,10 @@ function isCryptoMethod(methodOrIdentifier) {
   );
 }
 
-export function filterEligibleMethods(methods, itemType) {
-  const active = Array.isArray(methods)
+export function filterEligibleMethods(methods) {
+  return Array.isArray(methods)
     ? methods.filter((m) => m.active !== false)
     : [];
-  // previously, plan subscriptions were restricted from using
-  // bank, PayPal and crypto payment methods. Plans now support
-  // all active payment methods, so no additional filtering is
-  // required when `itemType` is "plan".
-  if (itemType === 'plan') {
-    return active;
-  }
-  return active;
 }
 
 export function resolveCheckoutItem(query, cartItems) {
@@ -369,7 +361,7 @@ export default function CheckoutPage() {
     .toLowerCase();
 
   const filteredMethods = useMemo(() => {
-    const eligible = filterEligibleMethods(methods, itemType);
+    const eligible = filterEligibleMethods(methods);
     if (stripePromise) return eligible;
     return eligible.filter(
       (m) => getMethodIdentifier(m).toLowerCase() !== 'stripe'
@@ -470,7 +462,7 @@ export default function CheckoutPage() {
           if (!active) return;
           const methodsList = Array.isArray(data) ? data : [];
           setMethods(methodsList);
-          const eligibleMethods = filterEligibleMethods(methodsList, itemType);
+          const eligibleMethods = filterEligibleMethods(methodsList);
           if (eligibleMethods.length > 0) {
             const defaultMethod =
               eligibleMethods.find((m) => m.is_default) || eligibleMethods[0];
@@ -548,7 +540,7 @@ export default function CheckoutPage() {
     }
     if (itemType === 'plan' && !payment) {
       setPaymentStatus('processing');
-      const eligible = filterEligibleMethods(methods, itemType);
+      const eligible = filterEligibleMethods(methods);
       if (eligible.length === 0) {
         toast.error('No payment methods available for this plan');
         setPaymentStatus('idle');

--- a/frontend/src/tests/__tests__/filterEligibleMethods.test.js
+++ b/frontend/src/tests/__tests__/filterEligibleMethods.test.js
@@ -9,8 +9,8 @@ describe('filterEligibleMethods', () => {
     { id: 5, name: 'Inactive', type: 'stripe', active: false },
   ];
 
-  it('returns active methods for non-plan items', () => {
-    const result = filterEligibleMethods(methods, 'class');
+  it('returns only active methods', () => {
+    const result = filterEligibleMethods(methods);
     expect(result.map((m) => m.name)).toEqual([
       'Stripe',
       'PayPal',
@@ -19,29 +19,13 @@ describe('filterEligibleMethods', () => {
     ]);
   });
 
-
-  it('excludes PayPal and crypto for plan items', () => {
-
-    const result = filterEligibleMethods(methods, 'plan');
-    expect(result.map((m) => m.name)).toEqual(['Stripe', 'Bank']);
-  });
-
-  it('returns empty array when only PayPal and crypto methods for plan', () => {
-    const onlyIneligible = [
-      { id: 1, name: 'PayPal', type: null, active: true },
-      { id: 2, name: 'USDT', type: 'usdt', active: true },
-    ];
-    const result = filterEligibleMethods(onlyIneligible, 'plan');
-    expect(result.map((m) => m.name)).toEqual(['PayPal', 'Bank', 'USDT']);
-  });
-
-  it('handles methods with non-string identifiers', () => {
+  it('handles methods with non-string identifiers without throwing', () => {
     const weirdMethods = [
       { id: 6, name: 123, type: undefined, active: true },
       { id: 7, name: 'Some', type: 456, active: true },
     ];
-    expect(() => filterEligibleMethods(weirdMethods, 'class')).not.toThrow();
-    const result = filterEligibleMethods(weirdMethods, 'plan');
+    expect(() => filterEligibleMethods(weirdMethods)).not.toThrow();
+    const result = filterEligibleMethods(weirdMethods);
     expect(result.map((m) => m.id)).toEqual([6, 7]);
   });
 });


### PR DESCRIPTION
## Summary
- Remove plan-specific logic from payment method filtering
- Update payment method filter tests to match simplified behavior

## Testing
- `cd frontend && npm test src/tests/__tests__/filterEligibleMethods.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c1b895c8328ac3b3025c1a96ccc