### PR TITLE
feat: add accessible label to payment icon fallback

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -68,7 +68,7 @@ function isTrustedIcon(url) {
 
 export function TrustedIcon({ src, alt }) {
   const [error, setError] = useState(false);
-  if (!src || error) return <FaMoneyCheckAlt />;
+  if (!src || error) return <FaMoneyCheckAlt aria-label={alt} role="img" />;
   return (
     <img
       src={src}

--- a/frontend/src/tests/__tests__/resolveIconElement.test.js
+++ b/frontend/src/tests/__tests__/resolveIconElement.test.js
@@ -1,4 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { TrustedIcon } from '@/pages/payments/checkout';
+
 describe('resolveIconElement', () => {
+  it('passes alt text to fallback icon', () => {
+    render(<TrustedIcon alt="Custom" />);
+    expect(screen.getByLabelText('Custom')).toBeInTheDocument();
+  });
+
   const loadModule = async () => {
     jest.resetModules();
     const mod = await import('@/pages/payments/checkout');


### PR DESCRIPTION
## Summary
- add aria-label to TrustedIcon fallback icon for screen reader support
- test that fallback icon exposes provided alt text

## Testing
- `npm test -- src/tests/__tests__/resolveIconElement.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c0e4e148328a2a4b0f99c9f0cb9