### PR TITLE
Add translation for missing payment methods message

### DIFF
--- a/frontend/public/locales/ar/common.json
+++ b/frontend/public/locales/ar/common.json
@@ -104,5 +104,6 @@
   "swift_code": "SWIFT Code",
   "branch_address": "Branch Address",
   "payment_reference_optional": "Reference / Notes (optional)",
-  "payment_receipt_optional": "Payment Receipt (optional)"
+  "payment_receipt_optional": "Payment Receipt (optional)",
+  "no_payment_methods_plan": "لا توجد طرق دفع متاحة لهذه الخطة"
 }

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -99,5 +99,6 @@
   "swift_code": "SWIFT Code",
   "branch_address": "Branch Address",
   "payment_reference_optional": "Reference / Notes (optional)",
-  "payment_receipt_optional": "Payment Receipt (optional)"
+  "payment_receipt_optional": "Payment Receipt (optional)",
+  "no_payment_methods_plan": "Für diesen Plan sind keine Zahlungsmethoden verfügbar"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -106,5 +106,6 @@
   "swift_code": "SWIFT Code",
   "branch_address": "Branch Address",
   "payment_reference_optional": "Reference / Notes (optional)",
-  "payment_receipt_optional": "Payment Receipt (optional)"
+  "payment_receipt_optional": "Payment Receipt (optional)",
+  "no_payment_methods_plan": "No payment methods available for this plan"
 }

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -96,5 +96,6 @@
   "swift_code": "SWIFT Code",
   "branch_address": "Branch Address",
   "payment_reference_optional": "Reference / Notes (optional)",
-  "payment_receipt_optional": "Payment Receipt (optional)"
+  "payment_receipt_optional": "Payment Receipt (optional)",
+  "no_payment_methods_plan": "No hay métodos de pago disponibles para este plan"
 }

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -104,5 +104,6 @@
   "swift_code": "SWIFT Code",
   "branch_address": "Branch Address",
   "payment_reference_optional": "Reference / Notes (optional)",
-  "payment_receipt_optional": "Payment Receipt (optional)"
+  "payment_receipt_optional": "Payment Receipt (optional)",
+  "no_payment_methods_plan": "Aucune méthode de paiement disponible pour ce plan"
 }

--- a/frontend/public/locales/hi/common.json
+++ b/frontend/public/locales/hi/common.json
@@ -104,5 +104,6 @@
   "swift_code": "SWIFT Code",
   "branch_address": "Branch Address",
   "payment_reference_optional": "Reference / Notes (optional)",
-  "payment_receipt_optional": "Payment Receipt (optional)"
+  "payment_receipt_optional": "Payment Receipt (optional)",
+  "no_payment_methods_plan": "इस योजना के लिए कोई भुगतान विधि उपलब्ध नहीं है"
 }

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -106,5 +106,6 @@
   "swift_code": "SWIFT Code",
   "branch_address": "Branch Address",
   "payment_reference_optional": "Reference / Notes (optional)",
-  "payment_receipt_optional": "Payment Receipt (optional)"
+  "payment_receipt_optional": "Payment Receipt (optional)",
+  "no_payment_methods_plan": "Nessun metodo di pagamento disponibile per questo piano"
 }

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -104,5 +104,6 @@
   "swift_code": "SWIFT Code",
   "branch_address": "Branch Address",
   "payment_reference_optional": "Reference / Notes (optional)",
-  "payment_receipt_optional": "Payment Receipt (optional)"
+  "payment_receipt_optional": "Payment Receipt (optional)",
+  "no_payment_methods_plan": "此计划没有可用的付款方式"
 }

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -550,7 +550,7 @@ export default function CheckoutPage() {
       setPaymentStatus('processing');
       const eligible = filterEligibleMethods(methods, itemType);
       if (eligible.length === 0) {
-        toast.error('No payment methods available for this plan');
+        toast.error(t('no_payment_methods_plan'));
         setPaymentStatus('idle');
         return;
       }
@@ -830,7 +830,7 @@ export default function CheckoutPage() {
             </div>
           ) : noPaymentMethods ? (
             <div className="text-center">
-              <p className="text-red-400 mb-4">No payment methods available for this plan</p>
+              <p className="text-red-400 mb-4">{t('no_payment_methods_plan')}</p>
               <button
                 disabled
                 className="px-6 py-2 bg-yellow-500 text-gray-900 font-bold rounded opacity-50 cursor-not-allowed"


### PR DESCRIPTION
## Summary
- add `no_payment_methods_plan` translation to all locales
- use translation for missing payment method toast and message in checkout page

## Testing
- `npm run lint --prefix frontend` *(fails: jsx-a11y, react/display-name, no-console)*
- `npm test --prefix frontend src/tests/__tests__/filterEligibleMethods.test.js` *(fails: expect(...).toEqual)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8c0c3a1c8328a4b4d1095fd59c32