### PR TITLE
Handle missing roomId in video call page

### DIFF
--- a/frontend/src/pages/video-call.js
+++ b/frontend/src/pages/video-call.js
@@ -4,6 +4,13 @@ import VideoCallScreen from "@/components/video-call/VideoCallScreen";
 const VideoCallPage = () => {
   const router = useRouter();
   const { roomId } = router.query; // use shared room identifier
+  if (!roomId) {
+    return (
+      <div className="bg-gray-900 min-h-screen flex items-center justify-center">
+        Loading...
+      </div>
+    );
+  }
 
   return (
     <div className="bg-gray-900 min-h-screen flex flex-col items-center justify-center">


### PR DESCRIPTION
## Summary
- Render a loading state when roomId is missing on the video call page
- Only render VideoCallScreen once the roomId is available

## Testing
- `npm test` *(fails: filterEligibleMethods.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8c3c9cd883289853ce1222f10637