### PR TITLE
Remove duplicate Helmet middleware

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -7,7 +7,6 @@ const cors = require("cors");
 const helmet = require("helmet");
 const morgan = require("morgan");
 const cookieParser = require("cookie-parser");
-const helmet = require("helmet");
 const session = require("express-session");
 const RedisStore = require("connect-redis").default;
 const { createClient } = require("redis");
@@ -64,7 +63,6 @@ const ALLOWED_ORIGINS = Array.from(
 );
 
 app.disable("etag");
-app.use(helmet());
 app.use((req, res, next) => {
   res.set("Cache-Control", "no-store");
   next();


### PR DESCRIPTION
## Summary
- Remove duplicate `helmet` require in the server setup
- Ensure Helmet middleware is registered once

## Testing
- `npm test` *(fails: Route.post() requires a callback function, multiple suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bca186d31883288f25bc62a1ed2a47