### PR TITLE
chore: add root dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Exclude version control
+.git
+.gitignore
+
+# Node dependencies
+**/node_modules
+
+# Logs
+**/logs
+**/*.log
+npm-debug.log
+
+# Build outputs
+frontend/.next
+backend/uploads
+
+# Environment files
+.env
+*.env
+
+# Docker compose and other local files
+docker-compose.yml


### PR DESCRIPTION
## Summary
- add repository-level `.dockerignore` to drop node_modules, logs, env files and other build artifacts

## Testing
- `npm --prefix backend test` *(fails: Route.post callback undefined and missing DB config)*
- `npm --prefix frontend test` *(fails: TypeError userModel.getUserPermissions not a function)*
- `docker-compose build backend frontend` *(fails: Docker daemon unavailable: Connection aborted, FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cb782548328b5f0d35fb441b319