### PR TITLE
Use production npm ci in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y curl
 COPY package.json package-lock.json ./
 
 # Install dependencies
-RUN npm install
+RUN npm ci --only=production
 
 # Copy rest of the app
 COPY . .


### PR DESCRIPTION
## Summary
- use `npm ci --only=production` when building frontend image

## Testing
- `npm test src/tests/__tests__/InstructorSettingsPage.test.js` (fails: Cannot find module '../../services/instructor/subscriptionService')
- `docker build -t skillbridge-frontend .` (fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)
- `npm ci --only=production` (simulated) followed by `npm ls eslint`

------
https://chatgpt.com/codex/tasks/task_e_68bd6cb8789c8328a9533d02d834ed68