### PR TITLE
Wait for healthy backend and frontend before starting nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,8 +97,10 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
     depends_on:
-      - backend
-      - frontend
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- Ensure nginx waits for the backend and frontend to pass their health checks before starting
- Keep backend and frontend health checks in place

## Testing
- `npm test` (backend) *(fails: 36 failed, 79 passed)*
- `CI=true npm test --silent` (frontend) *(passes shown, no summary)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cb941648328885387b75cd14f42