### PR TITLE
refactor: centralize nginx location blocks

### DIFF
--- a/nginx/conf.d/common_locations.conf
+++ b/nginx/conf.d/common_locations.conf
@@ -1,0 +1,42 @@
+  location / {
+    proxy_pass http://frontend:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # Ensure a single Access-Control-Allow-Origin header
+    proxy_hide_header Access-Control-Allow-Origin;
+    add_header Access-Control-Allow-Origin $http_origin always;
+    add_header Access-Control-Allow-Credentials true always;
+  }
+
+  # Forward Socket.IO traffic to backend and enable WebSocket upgrades
+  location /socket.io/ {
+    proxy_pass http://backend:5002;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # Ensure a single Access-Control-Allow-Origin header
+    proxy_hide_header Access-Control-Allow-Origin;
+    add_header Access-Control-Allow-Origin $http_origin always;
+    add_header Access-Control-Allow-Credentials true always;
+  }
+
+  location ^~ /api/ {
+    # forward API requests without rewriting the path
+    proxy_pass http://backend:5002;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # Ensure a single Access-Control-Allow-Origin header
+    proxy_hide_header Access-Control-Allow-Origin;
+    add_header Access-Control-Allow-Origin $http_origin always;
+    add_header Access-Control-Allow-Credentials true always;
+  }

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,49 +1,8 @@
 server {
   listen 80;
-server_name $APP_DOMAIN www.$APP_DOMAIN;
+  server_name $APP_DOMAIN www.$APP_DOMAIN;
   # allow up to 100 MB uploads to avoid 413 errors
   client_max_body_size 100M;
 
-  location / {
-    proxy_pass http://frontend:3000;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    # Ensure a single Access-Control-Allow-Origin header
-    proxy_hide_header Access-Control-Allow-Origin;
-    add_header Access-Control-Allow-Origin $http_origin always;
-    add_header Access-Control-Allow-Credentials true always;
-  }
-
-  # Forward Socket.IO traffic to backend and enable WebSocket upgrades
-  location /socket.io/ {
-    proxy_pass http://backend:5002;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    # Ensure a single Access-Control-Allow-Origin header
-    proxy_hide_header Access-Control-Allow-Origin;
-    add_header Access-Control-Allow-Origin $http_origin always;
-    add_header Access-Control-Allow-Credentials true always;
-  }
-
-  location ^~ /api/ {
-    # forward API requests without rewriting the path
-    proxy_pass http://backend:5002;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    # Ensure a single Access-Control-Allow-Origin header
-    proxy_hide_header Access-Control-Allow-Origin;
-    add_header Access-Control-Allow-Origin $http_origin always;
-    add_header Access-Control-Allow-Credentials true always;
-  }
+  include /etc/nginx/conf.d/common_locations.conf;
 }

--- a/nginx/conf.d/ssl.conf
+++ b/nginx/conf.d/ssl.conf
@@ -7,46 +7,5 @@ server {
     ssl_certificate /etc/letsencrypt/live/$APP_DOMAIN/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/$APP_DOMAIN/privkey.pem;
 
-    location / {
-        proxy_pass http://frontend:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        # Ensure a single Access-Control-Allow-Origin header
-        proxy_hide_header Access-Control-Allow-Origin;
-        add_header Access-Control-Allow-Origin $http_origin always;
-        add_header Access-Control-Allow-Credentials true always;
-    }
-
-    # Forward Socket.IO traffic to backend and enable WebSocket upgrades
-    location /socket.io/ {
-        proxy_pass http://backend:5002;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        # Ensure a single Access-Control-Allow-Origin header
-        proxy_hide_header Access-Control-Allow-Origin;
-        add_header Access-Control-Allow-Origin $http_origin always;
-        add_header Access-Control-Allow-Credentials true always;
-    }
-
-    location ^~ /api/ {
-        # forward API requests without rewriting the path
-        proxy_pass http://backend:5002;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        # Ensure a single Access-Control-Allow-Origin header
-        proxy_hide_header Access-Control-Allow-Origin;
-        add_header Access-Control-Allow-Origin $http_origin always;
-        add_header Access-Control-Allow-Credentials true always;
-    }
+    include /etc/nginx/conf.d/common_locations.conf;
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,6 +2,6 @@ env APP_DOMAIN;
 events {}
 
 http {
-    # Load virtual hosts from the conf.d directory
-    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/conf.d/default.conf;
+    include /etc/nginx/conf.d/ssl.conf;
 }


### PR DESCRIPTION
## Summary
- consolidate duplicated Nginx location directives into `common_locations.conf`
- reference shared include from both HTTP and SSL server blocks
- load only the desired server configs in `nginx.conf`

## Testing
- `nginx -t`
- `nginx -s reload`


------
https://chatgpt.com/codex/tasks/task_e_68bd6cba5a288328af4e28182990ec6b