### PR TITLE
docs: clarify API base URL usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,4 @@ APP_DOMAIN=yourdomain.com
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production
 
-NEXT_PUBLIC_API_BASE_URL=https://example.com/api
+NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ npm --prefix frontend install
        - `JWT_SECRET`, `REFRESH_TOKEN_SECRET`
        - `FRONTEND_URL`, `NEXT_PUBLIC_API_BASE_URL`
 
+         `NEXT_PUBLIC_API_BASE_URL` should point to the backend API. When running
+         with Docker Compose this should use the internal service URL
+         `http://backend:5002/api`. For public deployments update it to your
+         externally accessible domain, for example
+         `https://yourdomain.com/api`.
+
    - Copy the backend example file and adjust values as needed:
 
      ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -87,11 +87,15 @@ referenced in `nginx/conf.d/ssl.conf`.
    `NEXT_PUBLIC_API_BASE_URL` to your backend URL including the `/api` prefix.
    For example:
    
-  ```bash
-  # Point the frontend to your backend including the /api prefix
-  NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api
-  ```
-   
+ ```bash
+ # Point the frontend to your backend including the /api prefix
+ NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api
+ ```
+  In the Docker Compose setup the root `.env` uses
+  `NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api` so containers can communicate
+  over the internal network. Update this to the public URL, as shown above,
+  when deploying.
+
    Without this variable the frontend defaults to `/api` which may point to the
    wrong server when deployed.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,6 +74,12 @@ NEXT_PUBLIC_TRUSTED_ICON_HOSTS=yourdomain.com,cdn.yourdomain.com
 hosts for payment method icons. URLs outside this list will fall back to a
 default icon.
 
+The root `.env` file defaults `NEXT_PUBLIC_API_BASE_URL` to
+`http://backend:5002/api` so Docker services can reach the backend container
+internally. Update this value to your public domain (for example,
+`https://yourdomain.com/api`) when exposing the frontend outside of the Docker
+network.
+
 ## 3. Install dependencies (optional)
 
 For manual development outside of Docker:

--- a/docs/social-login-setup.md
+++ b/docs/social-login-setup.md
@@ -32,7 +32,7 @@ knex seed:run --specific=08_social_login_settings_seed.js
 If the redirect URI does not exactly match what is configured on Google, the login page will display **Error 400: redirect_uri_mismatch**.
 
 
-If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, verify the frontend's `NEXT_PUBLIC_API_BASE_URL` points to your backend URL including the `/api` prefix. Without this variable the login and register buttons default to `/api/auth/*` which only works when the frontend and backend share the same host. Both buttons now append `?origin=` with the current site origin so the API can redirect back correctly even when `FRONTEND_URL` is not configured.
+If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, verify the frontend's `NEXT_PUBLIC_API_BASE_URL` points to your backend URL including the `/api` prefix. When using Docker Compose the root `.env` sets this to `http://backend:5002/api`. For public deployments update it to your externally reachable domain such as `https://yourdomain.com/api`. Without this variable the login and register buttons default to `/api/auth/*` which only works when the frontend and backend share the same host. Both buttons now append `?origin=` with the current site origin so the API can redirect back correctly even when `FRONTEND_URL` is not configured.
 
 If requests to `/api/*` still return a Next.js 404 page, confirm your reverse proxy forwards the `/api` path to the backend container. The provided `nginx/conf.d` configs use `location ^~ /api/` to proxy to `backend:5002` without rewriting the prefix. Restart nginx after updating the configuration.
 


### PR DESCRIPTION
## Summary
- default NEXT_PUBLIC_API_BASE_URL to internal backend service for Docker Compose
- explain internal vs public API URLs in environment and deployment docs

## Testing
- `npm --prefix backend test` *(fails: 36 failed, 79 passed)*
- `npm --prefix backend test -- tests/adsRoutes.test.js`
- `npm --prefix frontend test -- src/tests/__tests__/tutorialService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd6cbc997c8328840cfba4368f6837