### PR TITLE
feat: add API health endpoint

### DIFF
--- a/backend/src/routes/health.routes.js
+++ b/backend/src/routes/health.routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (_req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 
+router.use('/api/health', require('./health.routes'));
 router.use('/api/auth', require('../modules/auth/routes/auth.routes'));
 router.use('/api/users', require('../modules/users/user.routes'));
 router.use('/api/verify', require('../modules/verify/verify.routes'));


### PR DESCRIPTION
## Summary
- add simple `/api/health` route returning `{ status: "ok" }`
- register health route before other API routes

## Testing
- `npm test` *(fails: Route.post() requires a callback; database configuration is missing; etc.)*
- `curl http://localhost:5002/api/health`


------
https://chatgpt.com/codex/tasks/task_e_68bd6cc328108328927d4db40164e87e