### PR TITLE
Ensure nginx waits for healthy backend and frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,8 +97,10 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
     depends_on:
-      - backend
-      - frontend
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- update nginx depends_on to require healthy backend and frontend services before startup

## Testing
- `docker-compose config`
- `docker-compose down` *(fails: Error while fetching server API version: Connection refused)*
- `docker-compose up -d` *(fails: Error while fetching server API version: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cc67b7c832882eaa6c1386c93ae