### PR TITLE
feat: add retry logic for database startup

### DIFF
--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -7,19 +7,37 @@ const environment = process.env.NODE_ENV || 'development';
 const config = knexfile[environment];
 
 if (!config || !config.connection) {
-  logger.error(`${environment} database configuration is missing`);
-  process.exit(1);
+  throw new Error(`${environment} database configuration is missing`);
 }
 
 const db = knex({ ...config, pool: { min: 2, max: 10 } });
 
-if (environment !== 'test') {
-  db.raw('SELECT 1')
-    .then(() => logger.log('✅ PostgreSQL Database Connected'))
-    .catch((err) => {
-      logger.error('❌ Database Connection Error:', err);
-      process.exit(1);
-    });
+/**
+ * Attempt to verify a database connection with retries.
+ * @param {number} maxAttempts Maximum connection attempts
+ */
+async function connectWithRetry(maxAttempts = 5) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await db.raw('SELECT 1');
+      logger.log('✅ PostgreSQL Database Connected');
+      return;
+    } catch (err) {
+      logger.error(`❌ Database connection attempt ${attempt} failed:`, err);
+      if (attempt === maxAttempts) {
+        logger.error(
+          `❌ Database connection failed after ${maxAttempts} attempts`,
+          err
+        );
+        throw err;
+      }
+      const delay = Math.pow(2, attempt - 1) * 1000;
+      logger.warn(`Retrying in ${delay}ms...`);
+      await new Promise((res) => setTimeout(res, delay));
+    }
+  }
 }
+
+db.connectWithRetry = connectWithRetry;
 
 module.exports = db;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -145,6 +145,7 @@ const PORT = process.env.PORT || 5002;
 
 async function startServer() {
   try {
+    await db.connectWithRetry();
     // Migrations are handled via the dedicated `npm run migrate` script.
     // Only warn here if the database is behind so the server can still start.
     const migrationDir = path.join(__dirname, "migrations");


### PR DESCRIPTION
## Summary
- add exponential backoff retry for PostgreSQL connection
- start server only after database connection succeeds

## Testing
- `npm test` *(fails: Test Suites: 36 failed, 1 skipped, 79 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cc7500483288d8cbce5c5da0292