### PR TITLE
Add health check endpoint for backend

### DIFF
--- a/backend/src/routes/health.routes.js
+++ b/backend/src/routes/health.routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (_req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -100,6 +100,7 @@ router.use('/api/library', require('../modules/library/library.routes'));
 router.use('/api/search', require('../modules/search/search.routes'));
 router.use('/api/install', require('../modules/install/install.routes'));
 
+router.use('/api/health', require('./health.routes'));
 router.use('/api/users/classes/lessons', require('./lesson.routes'));
 router.use('/api/video-calls', require('./videoCalls.routes'));
 


### PR DESCRIPTION
## Summary
- add `/api/health` Express route returning `{ status: 'ok' }`
- register health route in main router

## Testing
- `npm test` *(fails: database configuration is missing)*
- `docker-compose --env-file .env.example build backend` *(fails: Connection refused, Docker daemon unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6ccd434c832887663cadeab840aa