### PR TITLE
Use envsubst for Nginx server name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,10 @@ services:
       - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./nginx/templates:/etc/nginx/templates:ro
+      - ./nginx/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+    command: ["nginx", "-g", "daemon off;"]
     depends_on:
       - backend
       - frontend

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+SERVER_NAME="_"
+if [ -n "$APP_DOMAIN" ]; then
+  SERVER_NAME="$APP_DOMAIN www.$APP_DOMAIN"
+fi
+
+export SERVER_NAME APP_DOMAIN
+
+envsubst '$SERVER_NAME $APP_DOMAIN' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '$SERVER_NAME $APP_DOMAIN' < /etc/nginx/templates/ssl.conf.template > /etc/nginx/conf.d/ssl.conf
+
+exec "$@"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,3 @@
-env APP_DOMAIN;
 events {}
 
 http {

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -1,6 +1,6 @@
 server {
   listen 80;
-server_name $APP_DOMAIN www.$APP_DOMAIN;
+  server_name ${SERVER_NAME};
   # allow up to 100 MB uploads to avoid 413 errors
   client_max_body_size 100M;
 

--- a/nginx/templates/ssl.conf.template
+++ b/nginx/templates/ssl.conf.template
@@ -1,11 +1,11 @@
 server {
     listen 443 ssl;
-    server_name $APP_DOMAIN www.$APP_DOMAIN;
+    server_name ${SERVER_NAME};
     # allow up to 100 MB uploads to avoid 413 errors
     client_max_body_size 100M;
 
-    ssl_certificate /etc/letsencrypt/live/$APP_DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$APP_DOMAIN/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/${APP_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${APP_DOMAIN}/privkey.pem;
 
     location / {
         proxy_pass http://frontend:3000;


### PR DESCRIPTION
## Summary
- Replace `server_name` variables with envsubst-ready templates for both HTTP and HTTPS configs.
- Add entrypoint script to render Nginx configs from templates using `APP_DOMAIN`.
- Update docker-compose to use the entrypoint script and templates instead of static configs.

## Testing
- `APP_DOMAIN=example.com sh nginx/entrypoint.sh true`
- `nginx -t` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6ccfb1bc832880770454b25fe75b