### PR TITLE
chore: trust proxy for secure cookies

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -42,6 +42,7 @@ if (missingSecrets.length) {
 // ─── Express and HTTP Setup ───
 
 const app = express();
+app.set('trust proxy', 1);
 const server = http.createServer(app);
 
 app.use(helmet());


### PR DESCRIPTION
## Summary
- trust the first proxy hop so Express can send secure cookies when behind Nginx

## Testing
- `npm test` (fails: Route.post() requires a callback function but got a [object Undefined])
- `docker compose build backend` (fails: command not found: docker)
- `curl -i http://localhost:8080/`

------
https://chatgpt.com/codex/tasks/task_e_68bd6cd0808083289601402f86252527