### PR TITLE
Enable Passport sessions for persistent logins

### DIFF
--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -10,6 +10,15 @@ const GitHubStrategy = require('passport-github2').Strategy;
 const socialAuthService = require('../modules/auth/services/socialAuth.service');
 const socialLoginConfigService = require('../modules/socialLoginConfig/socialLoginConfig.service');
 
+// Basic session support for Passport
+passport.serializeUser((user, done) => {
+  done(null, user);
+});
+
+passport.deserializeUser((user, done) => {
+  done(null, user);
+});
+
 let initialized = false;
 
 async function initStrategies() {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -109,6 +109,7 @@ if (process.env.REDIS_URL) {
 app.use(session(sessionOptions));
 
 app.use(passport.initialize());
+app.use(passport.session());
 
 
 


### PR DESCRIPTION
## Summary
- Enable Passport session management in server setup
- Add serialize/deserialize handlers for Passport sessions

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined]; development database configuration is missing)*
- `npm start` *(fails: development database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cd1dd78832887d6471dcd41ff92