### PR TITLE
Add global rate limiter to backend server

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,6 +10,7 @@ const cookieParser = require("cookie-parser");
 const session = require("express-session");
 const RedisStore = require("connect-redis").default;
 const { createClient } = require("redis");
+const rateLimit = require("express-rate-limit");
 const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");
 const csrf = require("./middleware/csrf");
@@ -107,6 +108,13 @@ if (process.env.REDIS_URL) {
 }
 
 app.use(session(sessionOptions));
+
+// Apply rate limiting to all requests
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+app.use(limiter);
 
 app.use(passport.initialize());
 


### PR DESCRIPTION
## Summary
- import express-rate-limit and add a global limiter (100 requests/15min)

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined], and multiple suite failures)*
- `NODE_ENV=test JWT_SECRET=a REFRESH_TOKEN_SECRET=b PORT=5002 SESSION_SECRET=secret TEST_DATABASE_URL=postgres://localhost/test node - <<'NODE' >/tmp/ratelog.log
const request=require('supertest');
const {app}=require('./src/server');
(async()=>{
 for(let i=1;i<=101;i++){
   const res=await request(app).get('/');
   if(i>=99){
     console.log('Request',i,'status',res.status);
   }
 }
})();
NODE
 tail -n 20 /tmp/ratelog.log`

------
https://chatgpt.com/codex/tasks/task_e_68bd6cd5d95483288588c08f692df199