### PR TITLE
Ensure Nginx waits for healthy upstream services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,8 +97,10 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
     depends_on:
-      - backend
-      - frontend
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- Make nginx service depend on healthy backend and frontend containers

## Testing
- `docker compose config`
- `docker compose down` *(fails: Cannot connect to the Docker daemon)*
- `docker compose up -d --build` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cdb95d48328a184a240802f1fc7