### PR TITLE
Restrict Nginx CORS to allowlisted origin

### DIFF
--- a/nginx/conf.d/common_locations.conf
+++ b/nginx/conf.d/common_locations.conf
@@ -1,3 +1,5 @@
+  set $allowed_origin https://$app_domain;
+
   location / {
     proxy_pass http://frontend:3000;
     proxy_http_version 1.1;
@@ -7,7 +9,9 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    add_header Access-Control-Allow-Origin $http_origin always;
+    if ($http_origin = $allowed_origin) {
+      add_header Access-Control-Allow-Origin $allowed_origin always;
+    }
     add_header Access-Control-Allow-Credentials true always;
   }
 
@@ -23,7 +27,9 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    add_header Access-Control-Allow-Origin $http_origin always;
+    if ($http_origin = $allowed_origin) {
+      add_header Access-Control-Allow-Origin $allowed_origin always;
+    }
     add_header Access-Control-Allow-Credentials true always;
   }
 
@@ -37,6 +43,8 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    add_header Access-Control-Allow-Origin $http_origin always;
+    if ($http_origin = $allowed_origin) {
+      add_header Access-Control-Allow-Origin $allowed_origin always;
+    }
     add_header Access-Control-Allow-Credentials true always;
   }


### PR DESCRIPTION
## Summary
- allow only the configured app domain as CORS origin
- ensure origin header is checked before adding Access-Control-Allow-Origin

## Testing
- `APP_DOMAIN=example.com nginx -t -c /tmp/nginx_test.conf`
- `APP_DOMAIN=example.com nginx -s reload -c /tmp/nginx_test.conf`


------
https://chatgpt.com/codex/tasks/task_e_68bd76eca5948328a614f0c08a5e3b47