### PR TITLE
chore: remove duplicate health route

### DIFF
--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -100,8 +100,6 @@ router.use('/api/book-reviews', require('../modules/bookReviews/bookReview.route
 router.use('/api/library', require('../modules/library/library.routes'));
 router.use('/api/search', require('../modules/search/search.routes'));
 router.use('/api/install', require('../modules/install/install.routes'));
-
-router.use('/api/health', require('./health.routes'));
 router.use('/api/users/classes/lessons', require('./lesson.routes'));
 router.use('/api/video-calls', require('./videoCalls.routes'));
 


### PR DESCRIPTION
## Summary
- remove duplicate /api/health route registration

## Testing
- `npm test` *(fails: test database configuration is missing and other failures)*
- `NODE_ENV=test TEST_DATABASE_URL=postgres://user:pass@localhost:5432/db JWT_SECRET=1 REFRESH_TOKEN_SECRET=1 PORT=5000 SESSION_SECRET=1 node -e "const request=require('supertest');const express=require('express');const routes=require('./src/routes');const app=express();app.use(routes);request(app).get('/api/health').then(res=>{console.log('status',res.status);console.log('body',res.text);}).catch(err=>{console.error('error',err);});"`


------
https://chatgpt.com/codex/tasks/task_e_68bd76eabd38832881f7bfe2ad589600