### PR TITLE
Clarify SMTP configuration and security

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,9 @@ JWT_SECRET=your_jwt_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret
 MAX_BLOG_IMAGE_BYTES=10485760
 CLOUDINARY_API_KEY=your_key
+# SMTP configuration
+# Port 587 uses STARTTLS; keep SMTP_SECURE=false for this port.
+# For TLS-over-SSL use port 465 and set SMTP_SECURE=true.
 SMTP_HOST=smtp.mailtrap.io
 SMTP_PORT=587
 SMTP_SECURE=false

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -31,8 +31,9 @@ async function createTransporter() {
     port,
     secure:
       cfg.encryption === "SSL" ||
-      cfg.encryption === "TLS" ||
-      process.env.SMTP_SECURE === "true",
+      process.env.SMTP_SECURE === "true" ||
+      port === 465,
+    requireTLS: cfg.encryption === "TLS",
     auth: {
       user,
       pass,


### PR DESCRIPTION
## Summary
- Document SMTP port and secure settings in backend environment example
- Derive Nodemailer `secure` flag from port or explicit settings

## Testing
- `npm test` *(fails: test database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd76eac11c8328b0aae287c2a0e8f1