### PR TITLE
docs: expand env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,11 @@ APP_DOMAIN=yourdomain.com
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production
 
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password
+
 NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
+

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,8 +1,18 @@
-# Example production environment variables
-# Provide actual secrets via deployment-time environment variables or a separate
-# .env.production file that is not committed to version control.
-
+# Example production environment variables for the backend
 PORT=5002
-DATABASE_URL=postgres://user:password@localhost:5432/skillbridge_prod
-TEST_DATABASE_URL=postgres://user:password@localhost:5432/skillbridge_test
-PRODUCTION_DATABASE_URL=postgres://user:password@localhost:5432/skillbridge_prod
+DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/DB_NAME
+TEST_DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/DB_NAME_TEST
+PRODUCTION_DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/DB_NAME
+JWT_SECRET=change_me
+REFRESH_TOKEN_SECRET=change_me
+SESSION_SECRET=change_me
+FRONTEND_URL=https://example.com
+APP_DOMAIN=example.com
+MAX_BLOG_IMAGE_BYTES=10485760
+NODE_ENV=production
+
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password


### PR DESCRIPTION
## Summary
- document SMTP settings in root `.env.example`
- expand backend `.env.production.example` with additional placeholders

## Testing
- `cd backend && npm test`
- `cd frontend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68bd6acf2ba4832895648a7eafefe010