### PR TITLE
feat: update PayPal server SDK

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "name": "backend",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "@paypal/checkout-server-sdk": "^1.0.3",
+        "@paypal/paypal-server-sdk": "^1.1.0",
         "bcrypt": "^6.0.0",
         "connect-redis": "^7.1.1",
         "cookie-parser": "^1.4.7",
@@ -67,6 +67,237 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apimatic/authentication-adapters": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@apimatic/authentication-adapters/-/authentication-adapters-0.5.12.tgz",
+      "integrity": "sha512-H0dVMsuiPRRS6qPSz42T8ktaOUBlvJgKSj5L+DKr4DwBEZaE6rZx4i5kuEdAUZ5oIuteupbGEx5hMJlPi6Y0XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apimatic/core-interfaces": "^0.2.12",
+        "@apimatic/http-headers": "^0.3.7",
+        "@apimatic/http-query": "^0.3.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/axios-client-adapter": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@apimatic/axios-client-adapter/-/axios-client-adapter-0.3.18.tgz",
+      "integrity": "sha512-4DX6PgMT3VyACsf+EA3IxPrJzE1Schnwm+EGoCDZ8oAt7WYf3nByH1nKbmRVLEw7TGp4ZNU9slUHmdiJZ7FM6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@apimatic/convert-to-stream": "^0.1.7",
+        "@apimatic/core-interfaces": "^0.2.12",
+        "@apimatic/file-wrapper": "^0.3.7",
+        "@apimatic/http-headers": "^0.3.7",
+        "@apimatic/http-query": "^0.3.7",
+        "@apimatic/json-bigint": "^1.2.0",
+        "@apimatic/proxy": "^0.1.2",
+        "axios": "^1.8.4",
+        "detect-browser": "^5.3.0",
+        "detect-node": "^2.1.0",
+        "form-data": "^4.0.1",
+        "lodash.flatmap": "^4.5.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/convert-to-stream": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@apimatic/convert-to-stream/-/convert-to-stream-0.1.7.tgz",
+      "integrity": "sha512-uOCSy8YV0umHI4422l6wXcY/CN/oplLgoitpOY+P52I8dSrkQK+P+8HCITLDW4ND1I5OvRfvb1OwvN4+1JdgvA==",
+      "license": "ISC",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/core": {
+      "version": "0.10.26",
+      "resolved": "https://registry.npmjs.org/@apimatic/core/-/core-0.10.26.tgz",
+      "integrity": "sha512-wml7KNNP3P8BXXI2bOXyuMugQpLZ1MpOl6EM40nSOCXmR4lTr1ssfoUi+LrK1n7o6JxLoYp9mGkMNHoR7n35Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@apimatic/convert-to-stream": "^0.1.7",
+        "@apimatic/core-interfaces": "^0.2.12",
+        "@apimatic/file-wrapper": "^0.3.7",
+        "@apimatic/http-headers": "^0.3.7",
+        "@apimatic/http-query": "^0.3.7",
+        "@apimatic/json-bigint": "^1.2.0",
+        "@apimatic/schema": "^0.7.20",
+        "detect-browser": "^5.3.0",
+        "detect-node": "^2.1.0",
+        "form-data": "^4.0.1",
+        "lodash.defaultsdeep": "^4.6.1",
+        "lodash.flatmap": "^4.5.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/core-interfaces": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@apimatic/core-interfaces/-/core-interfaces-0.2.12.tgz",
+      "integrity": "sha512-XdEbSEfLEUY6KvKWQVXGMMGQmt589Zj0MnssPZ7FdgWFCrqe4aNgYt2Fl/fOC9r64GZvd7o1T9m4HKFilXi4nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@apimatic/file-wrapper": "^0.3.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/file-wrapper": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@apimatic/file-wrapper/-/file-wrapper-0.3.7.tgz",
+      "integrity": "sha512-uJh2immpzZiZYOiG+Q9qtArg3bUk7lmx7eYFRI38wIOS2zlxQh90WkuJzaL2nvSmNsJ3p+yg5ePAyRpqoJmw7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/http-headers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@apimatic/http-headers/-/http-headers-0.3.7.tgz",
+      "integrity": "sha512-DxLmwDMnAT5sOiuYI7EIuQq2PAVhbV9ICDLSdICRFflklgfKQ9agVEyNRgYVhuXz1m7IDoqqjGb1hs6iMJJpEg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/http-query": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@apimatic/http-query/-/http-query-0.3.7.tgz",
+      "integrity": "sha512-HauS4Jsuve1tGy1pnAidjHNL/TFVLesOxL7QtOdZyb+s0EHiHF6Vhx/kNroJ4mH/yCN3OHcHcqMJlfg0V5ET9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apimatic/file-wrapper": "^0.3.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/json-bigint": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@apimatic/json-bigint/-/json-bigint-1.2.0.tgz",
+      "integrity": "sha512-+bmVzYMdZu0Ya5L+my4FXFUih54OvQA/qlZsFOYdOoostyUuB27UDrVWQs/WVCmS0ADdo5vTU0eeTrrBkHoySw==",
+      "license": "MIT"
+    },
+    "node_modules/@apimatic/oauth-adapters": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@apimatic/oauth-adapters/-/oauth-adapters-0.4.16.tgz",
+      "integrity": "sha512-rmFj32QRbRhCkhBf50Wz0VdVghw58FiJPIl9ICWhpbgP9MuBg7xnSpbdHBflqjGRFyS9rtOTJOzCQnUl76F3oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apimatic/core-interfaces": "^0.2.12",
+        "@apimatic/file-wrapper": "^0.3.7",
+        "@apimatic/http-headers": "^0.3.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/proxy": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/proxy/-/proxy-0.1.2.tgz",
+      "integrity": "sha512-Xo3PO69tos+ssAfjcBGxSxXu1jpdEwse+yYnWC8D8bCsuWKUVJh8TwWl01Zyw3s60FdikyGCGtiQ3LB2cBrbeg==",
+      "license": "ISC",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/proxy/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@apimatic/proxy/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apimatic/proxy/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@apimatic/proxy/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@apimatic/proxy/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@apimatic/schema": {
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/@apimatic/schema/-/schema-0.7.20.tgz",
+      "integrity": "sha512-kMU1LqCypb0AwY8nXLV0aBoyubHHAxD8htyeAMFLYqWmmt+1pUBe33hHIDMdkREkNm+AYpl2n6vHBC1kqgju1w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1511,26 +1742,20 @@
         "@noble/hashes": "^1.1.5"
       }
     },
-    "node_modules/@paypal/checkout-server-sdk": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@paypal/checkout-server-sdk/-/checkout-server-sdk-1.0.3.tgz",
-      "integrity": "sha512-UEdq8akEdMz0Vs4qoQFU2gMp8PpyE/HKyMwiZuK4vIWUKl8jfd1fWKjQN5cDFm9NkFUIp5U7h++rdMOVj9WMNA==",
-      "deprecated": "Package no longer supported. The author suggests using the @paypal/paypal-server-sdk package instead: https://www.npmjs.com/package/@paypal/paypal-server-sdk. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "SEE LICENSE IN https://github.com/paypal/Checkout-NodeJS-SDK/blob/master/LICENSE",
+    "node_modules/@paypal/paypal-server-sdk": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-server-sdk/-/paypal-server-sdk-1.1.0.tgz",
+      "integrity": "sha512-MaJQmSVpQb5nEeZWZDTtGRxeaHj6O51G9Olmm3zQ5E4XNgR4emAI08CKC2ZPhBldVoxAoBVjLyvKjGV5lC1n2Q==",
+      "license": "MIT",
       "dependencies": {
-        "@paypal/paypalhttp": "^1.0.1"
+        "@apimatic/authentication-adapters": "^0.5.4",
+        "@apimatic/axios-client-adapter": "^0.3.7",
+        "@apimatic/core": "^0.10.16",
+        "@apimatic/oauth-adapters": "^0.4.8",
+        "@apimatic/schema": "^0.7.14"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@paypal/paypalhttp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@paypal/paypalhttp/-/paypalhttp-1.0.1.tgz",
-      "integrity": "sha512-DC7AHxTT7drF6dUi3YaFdPVuT15sIkpD5H2eHmdtFgxM4UanS1o1ZDfMhR9mpxd8o+X6pz2r+EZVRRq+n1cssQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/@redis/bloom": {
@@ -2060,8 +2285,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2894,7 +3129,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -3204,7 +3438,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3237,6 +3470,12 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -3255,6 +3494,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -3539,7 +3784,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3893,6 +4137,26 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fontkit": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
@@ -3911,10 +4175,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "dev": true,
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3931,7 +4194,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3941,7 +4203,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -4278,7 +4539,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5784,6 +6044,18 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaultsdeep": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha512-/OcpcAGWlrZyoHGeHh3cAoa6nGdX6QYtmzNP84Jqol6UEQQ2gIaU3H+0eICcjcKGl0/XF8LWOujNn9lffsnaOg==",
       "license": "MIT"
     },
     "node_modules/lodash.get": {
@@ -7322,6 +7594,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -8668,6 +8946,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
     "node_modules/tmpl": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@paypal/checkout-server-sdk": "^1.0.3",
+    "@paypal/paypal-server-sdk": "^1.1.0",
     "bcrypt": "^6.0.0",
     "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.7",

--- a/backend/src/services/paypalService.js
+++ b/backend/src/services/paypalService.js
@@ -1,4 +1,4 @@
-const paypal = require('@paypal/checkout-server-sdk');
+const { Client, Environment, OrdersController, CheckoutPaymentIntent } = require('@paypal/paypal-server-sdk');
 const paymentMethodsService = require('../modules/paymentMethods/paymentMethods.service');
 
 let client;
@@ -9,18 +9,15 @@ async function getClient() {
   if (!settings?.client_id || !settings?.client_secret) {
     throw new Error('PayPal credentials are not configured');
   }
-  const mode = settings.mode === 'live' ? 'live' : 'sandbox';
   const environment =
-    mode === 'live'
-      ? new paypal.core.LiveEnvironment(
-          settings.client_id,
-          settings.client_secret
-        )
-      : new paypal.core.SandboxEnvironment(
-          settings.client_id,
-          settings.client_secret
-        );
-  client = new paypal.core.PayPalHttpClient(environment);
+    settings.mode === 'live' ? Environment.Production : Environment.Sandbox;
+  client = new Client({
+    environment,
+    clientCredentialsAuthCredentials: {
+      oAuthClientId: settings.client_id,
+      oAuthClientSecret: settings.client_secret,
+    },
+  });
   return client;
 }
 
@@ -29,34 +26,34 @@ exports.invalidateClient = () => {
 };
 
 exports.createOrder = async ({ amount, currency = 'USD', returnUrl, cancelUrl }) => {
-  const request = new paypal.orders.OrdersCreateRequest();
-  request.prefer('return=representation');
   const body = {
-    intent: 'CAPTURE',
-    purchase_units: [
+    intent: CheckoutPaymentIntent.Capture,
+    purchaseUnits: [
       {
         amount: {
-          currency_code: currency,
-          value: amount,
+          currencyCode: currency,
+          value: String(amount),
         },
       },
     ],
   };
   if (returnUrl || cancelUrl) {
-    body.application_context = {};
-    if (returnUrl) body.application_context.return_url = returnUrl;
-    if (cancelUrl) body.application_context.cancel_url = cancelUrl;
+    body.applicationContext = {};
+    if (returnUrl) body.applicationContext.returnUrl = returnUrl;
+    if (cancelUrl) body.applicationContext.cancelUrl = cancelUrl;
   }
-  request.requestBody(body);
   const cli = await getClient();
-  const response = await cli.execute(request);
-  return response.result;
+  const orders = new OrdersController(cli);
+  const { result } = await orders.createOrder({
+    body,
+    prefer: 'return=representation',
+  });
+  return result;
 };
 
 exports.captureOrder = async (orderId) => {
-  const request = new paypal.orders.OrdersCaptureRequest(orderId);
-  request.requestBody({});
   const cli = await getClient();
-  const response = await cli.execute(request);
-  return response.result;
+  const orders = new OrdersController(cli);
+  const { result } = await orders.captureOrder({ id: orderId, body: {} });
+  return result;
 };

--- a/backend/tests/paypalService.test.js
+++ b/backend/tests/paypalService.test.js
@@ -1,0 +1,62 @@
+const paymentMethodsService = require('../src/modules/paymentMethods/paymentMethods.service');
+const paypalService = require('../src/services/paypalService');
+
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getPayPalSettings: jest.fn(),
+}));
+
+const mockCreateOrder = jest.fn().mockResolvedValue({ result: { id: 'order123' } });
+const mockCaptureOrder = jest.fn().mockResolvedValue({ result: { id: 'capture123' } });
+
+jest.mock('@paypal/paypal-server-sdk', () => ({
+  OrdersController: jest.fn().mockImplementation(() => ({
+    createOrder: mockCreateOrder,
+    captureOrder: mockCaptureOrder,
+  })),
+  Client: jest.fn(),
+  Environment: { Sandbox: 'sandbox', Production: 'production' },
+  CheckoutPaymentIntent: { Capture: 'CAPTURE' },
+}));
+
+const { Client, Environment, CheckoutPaymentIntent } = require('@paypal/paypal-server-sdk');
+
+describe('paypalService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    paypalService.invalidateClient();
+    paymentMethodsService.getPayPalSettings.mockResolvedValue({
+      client_id: 'id',
+      client_secret: 'secret',
+      mode: 'sandbox',
+    });
+  });
+
+  it('creates an order', async () => {
+    const result = await paypalService.createOrder({ amount: 10, currency: 'USD' });
+    expect(result).toEqual({ id: 'order123' });
+    expect(Client).toHaveBeenCalledWith({
+      environment: Environment.Sandbox,
+      clientCredentialsAuthCredentials: {
+        oAuthClientId: 'id',
+        oAuthClientSecret: 'secret',
+      },
+    });
+    expect(mockCreateOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          intent: CheckoutPaymentIntent.Capture,
+          purchaseUnits: [
+            { amount: { currencyCode: 'USD', value: '10' } },
+          ],
+        }),
+        prefer: 'return=representation',
+      })
+    );
+  });
+
+  it('captures an order', async () => {
+    const capture = await paypalService.captureOrder('order123');
+    expect(capture).toEqual({ id: 'capture123' });
+    expect(mockCaptureOrder).toHaveBeenCalledWith({ id: 'order123', body: {} });
+  });
+});


### PR DESCRIPTION
## Summary
- migrate to `@paypal/paypal-server-sdk`
- adapt PayPal service for new client and controller APIs
- add regression tests for order create/capture flows

## Testing
- `npm test` *(fails: test database configuration is missing)*
- `npx jest tests/paypalService.test.js --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68bd7dc86f588328bee41430b1493aa4