### PR TITLE
Add stripe and coinbase payment method templates

### DIFF
--- a/backend/src/seeds/08_payment_methods_seed.js
+++ b/backend/src/seeds/08_payment_methods_seed.js
@@ -32,6 +32,28 @@ exports.seed = async function(knex) {
       is_default: false,
       created_at: now,
       updated_at: now
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      name: 'stripe',
+      type: 'stripe',
+      icon: 'stripe',
+      active: false,
+      settings: {},
+      is_default: false,
+      created_at: now,
+      updated_at: now
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
+      name: 'coinbase',
+      type: 'coinbase',
+      icon: 'coinbase',
+      active: false,
+      settings: {},
+      is_default: false,
+      created_at: now,
+      updated_at: now
     }
   ]);
 };


### PR DESCRIPTION
## Summary
- add inactive seed entries for stripe and coinbase with empty settings

## Testing
- `node -e "const {newDb}=require('pg-mem');const{v4:uuidv4}=require('uuid');const db=newDb();db.public.registerFunction({name:'uuid_generate_v4',returns:'uuid',implementation:uuidv4});const knex=db.adapters.createKnex();(async()=>{await knex.schema.createTable('payment_methods_config',t=>{t.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));t.string('name');t.string('type');t.string('icon');t.boolean('active').defaultTo(true);t.jsonb('settings').defaultTo('{}');t.boolean('is_default').defaultTo(false);t.timestamps(true,true);});await require('./backend/src/seeds/08_payment_methods_seed.js').seed(knex);const rows=await knex('payment_methods_config').select('name','type','active','settings');console.log(rows);})()"` *(passes)*
- `npm run seed` *(fails: Unable to acquire a connection)*
- `npm test` *(fails: test database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7dc856e483289c3f0677212dc8e7