### PR TITLE
feat: add coinbase payment support

### DIFF
--- a/backend/src/modules/payments/coinbase.controller.js
+++ b/backend/src/modules/payments/coinbase.controller.js
@@ -1,0 +1,141 @@
+const logger = require('../../utils/logger.js');
+const catchAsync = require('../../utils/catchAsync');
+const AppError = require('../../utils/AppError');
+const { sendSuccess } = require('../../utils/response');
+const paymentsService = require('./payments.service');
+const { STATUS } = paymentsService;
+const paymentConfigService = require('../paymentConfig/paymentConfig.service');
+const paymentMethodsService = require('../paymentMethods/paymentMethods.service');
+const coinbaseService = require('../../services/coinbaseService');
+const { v4: uuidv4 } = require('uuid');
+const { grantAccess } = require('./paymentAccess');
+const plansService = require('../plans/plans.service');
+
+const DEFAULT_PLATFORM_CUT = {
+  class: 15,
+  book: 10,
+  tutorial: 20,
+};
+
+const ALLOWED_ITEM_TYPES = ['class', 'book', 'tutorial', 'plan'];
+const SUPPORTED_FIAT = [
+  'USD','EUR','GBP','JPY','CNY','SAR','AED','KWD','INR','CAD','AUD','CHF','QAR','EGP','TRY','KRW','SGD','RUB',
+];
+
+exports.initiateCoinbasePayment = catchAsync(async (req, res) => {
+  const { item_type, item_id, amount, currency } = req.body;
+  const user_id = req.user?.id;
+  if (!user_id || !item_type || !item_id || amount === undefined) {
+    throw new AppError('Missing required fields', 400);
+  }
+  if (!ALLOWED_ITEM_TYPES.includes(item_type)) {
+    throw new AppError('Invalid item type', 400);
+  }
+  const numericAmount = Number(amount);
+  if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+    throw new AppError('Amount must be a positive number', 400);
+  }
+  const currencyCode = currency || 'USD';
+  if (!SUPPORTED_FIAT.includes(currencyCode)) {
+    throw new AppError('Unsupported currency', 400);
+  }
+
+  if (item_type === 'plan') {
+    const plan = await plansService.getPlanById(item_id);
+    if (!plan) throw new AppError('Plan not found', 404);
+    const prices = [Number(plan.price_monthly), Number(plan.price_yearly)];
+    const matched = prices.find((p) => Math.abs(numericAmount - p) < 0.01);
+    if (!matched) {
+      throw new AppError('Payment amount does not match plan price', 400);
+    }
+  }
+
+  const method = await paymentMethodsService.getByType('coinbase');
+  if (!method) {
+    throw new AppError('Coinbase payment method not configured', 400);
+  }
+  const settings = method.settings || {};
+  if (!settings.api_key) {
+    throw new AppError('Coinbase payment method missing API key', 500);
+  }
+
+  let platform_fee = 0;
+  let instructor_amount = numericAmount;
+  try {
+    const cfg = await paymentConfigService.getSettings();
+    const cut = cfg?.platformCut?.[item_type] ?? DEFAULT_PLATFORM_CUT[item_type] ?? 0;
+    platform_fee = (numericAmount * cut) / 100;
+    instructor_amount = numericAmount - platform_fee;
+  } catch (err) {
+    logger.error('Failed to load payment settings:', err);
+  }
+
+  const paymentId = uuidv4();
+
+  const params = {
+    name: 'Course Purchase',
+    description: 'Access to Prime Content',
+    pricing_type: 'fixed_price',
+    local_price: { amount: numericAmount, currency: currencyCode },
+    metadata: { payment_id: paymentId },
+  };
+  if (process.env.FRONTEND_URL) {
+    params.redirect_url = `${process.env.FRONTEND_URL}/payments/success`;
+    params.cancel_url = `${process.env.FRONTEND_URL}/payments/error`;
+  }
+
+  const charge = await coinbaseService.createCharge(settings.api_key, params);
+
+  const chargeData = charge?.data || charge;
+
+  const paymentData = {
+    id: paymentId,
+    user_id,
+    method_id: method.id,
+    item_type,
+    item_id,
+    amount: numericAmount,
+    currency: currencyCode,
+    status: STATUS.PENDING_PAYMENT,
+    reference_id: chargeData.id?.toString() || null,
+    receipt_url: chargeData.hosted_url,
+    platform_fee,
+    instructor_amount,
+  };
+  const payment = await paymentsService.create(paymentData);
+
+  sendSuccess(res, { hosted_url: chargeData.hosted_url, payment }, 'Coinbase payment initiated');
+});
+
+exports.handleWebhook = catchAsync(async (req, res) => {
+  const signature = req.get('X-CC-Webhook-Signature');
+  const payload = JSON.stringify(req.body || {});
+  const event = req.body?.event;
+  const paymentId = event?.data?.metadata?.payment_id;
+  if (!paymentId) return res.status(400).end();
+
+  const payment = await paymentsService.getById(paymentId);
+  if (!payment) return res.status(404).end();
+  const method = await paymentMethodsService.getById(payment.method_id);
+  const secret = method?.settings?.webhook_secret;
+  if (!coinbaseService.verifyWebhook(payload, signature, secret)) {
+    return res.status(400).end();
+  }
+
+  let statusUpdate = {};
+  const type = event?.type;
+  const chargeId = event?.data?.id;
+  if (type === 'charge:confirmed') {
+    statusUpdate = { status: STATUS.PAID, reference_id: chargeId, paid_at: new Date() };
+  } else if (type === 'charge:failed') {
+    statusUpdate = { status: STATUS.REJECTED, reference_id: chargeId };
+  }
+  if (Object.keys(statusUpdate).length) {
+    const updated = await paymentsService.update(paymentId, statusUpdate);
+    if (updated.status === STATUS.PAID) {
+      await grantAccess(updated);
+    }
+  }
+  res.json({ ok: true });
+});
+

--- a/backend/src/modules/payments/coinbase.routes.js
+++ b/backend/src/modules/payments/coinbase.routes.js
@@ -1,0 +1,10 @@
+const router = require('express').Router();
+const controller = require('./coinbase.controller');
+const { verifyToken, isStudent } = require('../../middleware/auth/authMiddleware');
+
+router.post('/webhook', controller.handleWebhook);
+router.post('/initiate', verifyToken, isStudent, controller.initiateCoinbasePayment);
+// Alias support for '/create'
+router.post('/create', verifyToken, isStudent, controller.initiateCoinbasePayment);
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -40,6 +40,7 @@ router.use(
 router.use('/api/payments/student', require('../modules/payments/student.routes'));
 router.use('/api/payments/bank', require('../modules/payments/bank.routes'));
 router.use('/api/payments/crypto', require('../modules/payments/crypto.routes'));
+router.use('/api/payments/coinbase', require('../modules/payments/coinbase.routes'));
 // Alias for NOWPayments crypto gateway
 router.use(
   '/api/payments/nowpayments',

--- a/backend/src/services/coinbaseService.js
+++ b/backend/src/services/coinbaseService.js
@@ -1,0 +1,53 @@
+const crypto = require('crypto');
+
+// Use native fetch if available, otherwise fallback to node-fetch
+const fetchFn =
+  typeof fetch === 'function'
+    ? fetch
+    : (...args) => import('node-fetch').then(({ default: f }) => f(...args));
+
+const BASE_URL = 'https://api.commerce.coinbase.com';
+
+/**
+ * Create a Coinbase Commerce charge.
+ * @param {string} apiKey - Coinbase Commerce API key.
+ * @param {object} params - Charge parameters.
+ * @returns {Promise<object>} Charge response.
+ */
+exports.createCharge = async (apiKey, params) => {
+  const res = await fetchFn(`${BASE_URL}/charges`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CC-Api-Key': apiKey,
+      'X-CC-Version': '2018-03-22',
+    },
+    body: JSON.stringify(params),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Coinbase createCharge failed: ${text}`);
+  }
+  return res.json();
+};
+
+/**
+ * Verify Coinbase Commerce webhook signature.
+ * @param {string} payload - Raw JSON string received.
+ * @param {string} signature - Signature from 'X-CC-Webhook-Signature' header.
+ * @param {string} secret - Shared webhook secret.
+ * @returns {boolean} True if signature matches, otherwise false.
+ */
+exports.verifyWebhook = (payload, signature, secret) => {
+  if (!signature || !secret) return false;
+  try {
+    const hmac = crypto
+      .createHmac('sha256', secret)
+      .update(payload)
+      .digest('hex');
+    return hmac === signature;
+  } catch (_) {
+    return false;
+  }
+};
+

--- a/backend/tests/coinbasePaymentRoutes.test.js
+++ b/backend/tests/coinbasePaymentRoutes.test.js
@@ -1,0 +1,85 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/modules/payments/payments.service', () => ({
+  getById: jest.fn(),
+  update: jest.fn(),
+  STATUS: { PAID: 'paid', REJECTED: 'rejected' },
+}));
+
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getById: jest.fn(),
+}));
+
+jest.mock('../src/services/coinbaseService', () => ({
+  verifyWebhook: jest.fn(),
+}));
+
+jest.mock('../src/modules/payments/paymentAccess', () => ({
+  grantAccess: jest.fn(),
+}));
+
+const paymentsService = require('../src/modules/payments/payments.service');
+const methodsService = require('../src/modules/paymentMethods/paymentMethods.service');
+const coinbaseService = require('../src/services/coinbaseService');
+const { grantAccess } = require('../src/modules/payments/paymentAccess');
+const routes = require('../src/modules/payments/coinbase.routes');
+const { STATUS } = require('../src/modules/payments/payments.service');
+
+const app = express();
+app.use(express.json());
+app.use('/api/payments/coinbase', routes);
+const errorHandler = require('../src/middleware/errorHandler');
+app.use(errorHandler);
+
+describe('POST /api/payments/coinbase/webhook', () => {
+  it('marks payment as paid when charge confirmed', async () => {
+    const payload = {
+      event: {
+        type: 'charge:confirmed',
+        data: { id: 'ch_1', metadata: { payment_id: 'p1' } },
+      },
+    };
+    coinbaseService.verifyWebhook.mockReturnValue(true);
+    paymentsService.getById.mockResolvedValue({ id: 'p1', method_id: 'm1' });
+    methodsService.getById.mockResolvedValue({ id: 'm1', settings: { webhook_secret: 'whsec' } });
+    paymentsService.update.mockResolvedValue({ id: 'p1', status: STATUS.PAID });
+
+    const res = await request(app)
+      .post('/api/payments/coinbase/webhook')
+      .set('X-CC-Webhook-Signature', 'sig')
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(paymentsService.update).toHaveBeenCalledWith(
+      'p1',
+      expect.objectContaining({ status: STATUS.PAID, reference_id: 'ch_1' })
+    );
+    expect(grantAccess).toHaveBeenCalled();
+  });
+
+  it('marks payment as rejected when charge failed', async () => {
+    const payload = {
+      event: {
+        type: 'charge:failed',
+        data: { id: 'ch_2', metadata: { payment_id: 'p2' } },
+      },
+    };
+    coinbaseService.verifyWebhook.mockReturnValue(true);
+    paymentsService.getById.mockResolvedValue({ id: 'p2', method_id: 'm1' });
+    methodsService.getById.mockResolvedValue({ id: 'm1', settings: { webhook_secret: 'whsec' } });
+    paymentsService.update.mockResolvedValue({ id: 'p2', status: STATUS.REJECTED });
+
+    const res = await request(app)
+      .post('/api/payments/coinbase/webhook')
+      .set('X-CC-Webhook-Signature', 'sig')
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(paymentsService.update).toHaveBeenCalledWith(
+      'p2',
+      expect.objectContaining({ status: STATUS.REJECTED, reference_id: 'ch_2' })
+    );
+  });
+});
+

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -6,7 +6,7 @@ import { fetchTutorialDetails } from '@/services/tutorialService';
 import { fetchBook } from '@/services/bookService';
 import { fetchPlanDetails } from '@/services/public/planService';
 import { validateCode } from '@/services/couponService';
-import { initiateBankPayment, initiateCryptoPayment, initiatePayPalPayment } from '@/services/paymentService';
+import { initiateBankPayment, initiateCoinbasePayment, initiateCryptoPayment, initiatePayPalPayment } from '@/services/paymentService';
 import { createPayment, fetchPayment } from '@/services/student/paymentService';
 import { subscribeToPlan } from '@/services/subscriptionService';
 import useCartStore from '@/store/cart/cartStore';
@@ -260,7 +260,11 @@ export async function handleCryptoPayment({
     };
     if (itemType === 'plan') payload.interval = interval;
     if (couponId) payload.coupon_id = couponId;
-    const data = await initiateCryptoPayment(payload);
+    const initFn =
+      getMethodIdentifier(method).toLowerCase() === 'coinbase'
+        ? initiateCoinbasePayment
+        : initiateCryptoPayment;
+    const data = await initFn(payload);
     if (data?.invoice_url) {
       window.location.href = data.invoice_url;
     } else {

--- a/frontend/src/services/paymentService.js
+++ b/frontend/src/services/paymentService.js
@@ -13,6 +13,12 @@ export const initiateCryptoPayment = async (payload) => {
   return data?.data ?? data;
 };
 
+// Initiate Coinbase payment
+export const initiateCoinbasePayment = async (payload) => {
+  const { data } = await api.post("/payments/coinbase/initiate", payload);
+  return data?.data ?? data;
+};
+
 // Initiate PayPal payment
 export const initiatePayPalPayment = async (payload) => {
   const { data } = await api.post("/payments/paypal/create", payload);

--- a/frontend/src/shared/api/payments.js
+++ b/frontend/src/shared/api/payments.js
@@ -1,18 +1,11 @@
-export const processCoinbasePayment = async (amount, currency) => {
+export const processCoinbasePayment = async (payload) => {
     try {
-        const response = await fetch('https://api.commerce.coinbase.com/charges', {
+        const response = await fetch('/api/payments/coinbase/initiate', {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
-                'X-CC-Api-Key': process.env.NEXT_PUBLIC_COINBASE_API_KEY, // Use Environment Variable
-                'X-CC-Version': '2018-03-22'
+                'Content-Type': 'application/json'
             },
-            body: JSON.stringify({
-                name: "Course Purchase",
-                description: "Access to Prime Content",
-                pricing_type: "fixed_price",
-                local_price: { amount: amount, currency: currency }
-            })
+            body: JSON.stringify(payload)
         });
 
         const data = await response.json();


### PR DESCRIPTION
## Summary
- add Coinbase Commerce service to create charges and verify webhooks
- expose new payment controller, routes, and frontend helpers for Coinbase
- test webhook status handling for Coinbase payments

## Testing
- `npm test` *(fails: test database configuration is missing)*


------
https://chatgpt.com/codex/tasks/task_e_68bd7dc741108328833a2a713fe4d0ae