### PR TITLE
feat: add admin cache clear endpoint and sidebar control

### DIFF
--- a/backend/src/routes/cache.routes.js
+++ b/backend/src/routes/cache.routes.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const { verifyToken, isAdmin } = require('../middleware/auth/authMiddleware');
+
+const router = express.Router();
+
+router.post('/clear', verifyToken, isAdmin, async (_req, res) => {
+  try {
+    if (global.cacheManager && typeof global.cacheManager.flush === 'function') {
+      await global.cacheManager.flush();
+    }
+    if (global.caches && typeof global.caches.keys === 'function') {
+      const keys = await global.caches.keys();
+      await Promise.all(keys.map((key) => global.caches.delete(key)));
+    }
+    if (global.redisClient && typeof global.redisClient.flushall === 'function') {
+      await global.redisClient.flushall();
+    }
+    return res.json({ message: 'Cache cleared' });
+  } catch (err) {
+    return res.status(500).json({ message: 'Failed to clear cache' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -60,6 +60,7 @@ router.use(
   '/api/admin/payments/bank',
   require('../modules/payments/bank.admin.routes')
 );
+router.use('/api/admin/cache', require('./cache.routes'));
 router.use('/api/payments/config', require('../modules/paymentConfig/paymentConfig.routes'));
 router.use('/api/messages/config', require('../modules/messagesConfig/messagesConfig.routes'));
 router.use('/api/social-login/config', require('../modules/socialLoginConfig/socialLoginConfig.routes'));

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1192,7 +1192,8 @@
     "offers_groups": "العروض والمجموعات",
     "payments_social": "المدفوعات والشبكات الاجتماعية",
     "payments": "المدفوعات",
-    "my_reviews": "تقييماتي"
+    "my_reviews": "تقييماتي",
+    "clear_cache": "مسح ذاكرة التخزين المؤقت"
   },
   "emailConfigPage": {
     "title": "تكوين البريد الإلكتروني",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1206,7 +1206,8 @@
     "offers_groups": "Offers & Groups",
     "payments_social": "Payments & Social",
     "payments": "Payments",
-    "my_reviews": "My Reviews"
+    "my_reviews": "My Reviews",
+    "clear_cache": "Cache löschen"
   },
   "emailConfigPage": {
     "title": "Email Configuration",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1210,7 +1210,8 @@
     "offers_groups": "Offers & Groups",
     "payments_social": "Payments & Social",
     "payments": "Payments",
-    "my_reviews": "My Reviews"
+    "my_reviews": "My Reviews",
+    "clear_cache": "Clear Cache"
   },
   "emailConfigPage": {
     "title": "Email Configuration",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1192,7 +1192,8 @@
     "offers_groups": "Ofertas y grupos",
     "payments_social": "Pagos y sociales",
     "payments": "Pagos",
-    "my_reviews": "Mis reseñas"
+    "my_reviews": "Mis reseñas",
+    "clear_cache": "Borrar caché"
   },
   "emailConfigPage": {
     "title": "Configuración de correo electrónico",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1192,7 +1192,8 @@
     "offers_groups": "Offres & Groupes",
     "payments_social": "Paiements & Réseaux",
     "payments": "Paiements",
-    "my_reviews": "Mes avis"
+    "my_reviews": "Mes avis",
+    "clear_cache": "Vider le cache"
   },
   "emailConfigPage": {
     "title": "Configuration des e-mails",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1192,7 +1192,8 @@
     "offers_groups": "प्रस्ताव और समूह",
     "payments_social": "भुगतान और सोशल",
     "payments": "भुगतान",
-    "my_reviews": "मेरी समीक्षाएँ"
+    "my_reviews": "मेरी समीक्षाएँ",
+    "clear_cache": "कैश साफ़ करें"
   },
   "emailConfigPage": {
     "title": "ईमेल विन्यास",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1206,7 +1206,8 @@
     "offers_groups": "Offerte e gruppi",
     "payments_social": "Pagamenti e social",
     "payments": "Pagamenti",
-    "my_reviews": "Le mie recensioni"
+    "my_reviews": "Le mie recensioni",
+    "clear_cache": "Cancella cache"
   },
   "emailConfigPage": {
     "title": "Configurazione e -mail",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1192,7 +1192,8 @@
     "offers_groups": "优惠和团体",
     "payments_social": "付款和社交",
     "payments": "付款",
-    "my_reviews": "我的评论"
+    "my_reviews": "我的评论",
+    "clear_cache": "清除缓存"
   },
   "emailConfigPage": {
     "title": "电子邮件配置",

--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -7,6 +7,8 @@ import { useState, useEffect } from 'react';
 import useAppConfigStore from '@/store/appConfigStore';
 import { API_BASE_URL } from '@/config/config';
 import logo from '@/shared/assets/images/login/logo.png';
+import { clearCache } from '@/utils/cache';
+import { toast } from 'react-toastify';
 
 import { adminNavLinks } from './SidebarLinks/adminLinks';
 import { instructorNavLinks } from './SidebarLinks/instructorLinks';
@@ -39,6 +41,15 @@ export default function Sidebar({ role = 'admin' }) {
 
   const toggleDropdown = (label) => {
     setActiveDropdown((prev) => (prev === label ? null : label));
+  };
+
+  const handleClearCache = async () => {
+    const success = await clearCache();
+    if (success) {
+      toast.success(t("sidebar.clear_cache"));
+    } else {
+      toast.error("Failed to clear cache");
+    }
   };
 
   return (
@@ -116,6 +127,15 @@ export default function Sidebar({ role = 'admin' }) {
           ))}
         </nav>
       </div>
+
+      {['admin','superadmin'].includes(role) && (
+        <button
+          onClick={handleClearCache}
+          className="flex items-center gap-3 px-4 py-2 text-sm font-medium rounded-lg transition-all duration-200 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
+        >
+          {t('sidebar.clear_cache')}
+        </button>
+      )}
 
       <div className="text-xs text-gray-400 dark:text-gray-500 text-center mt-8">
         &copy; {new Date().getFullYear()} {settings.appName || 'SkillBridge'}

--- a/frontend/src/utils/cache.js
+++ b/frontend/src/utils/cache.js
@@ -1,0 +1,13 @@
+export async function clearCache() {
+  try {
+    const res = await fetch('/api/admin/cache/clear', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!res.ok) throw new Error('Failed to clear cache');
+    return true;
+  } catch (err) {
+    console.error('Failed to clear cache', err);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/admin/cache/clear` endpoint to flush caches for admins
- expose `clearCache` util and add dashboard sidebar button for admins
- translate new `clear_cache` label across locales

## Testing
- `cd backend && npm test` *(fails: Cannot find module 'stripe'; test database configuration is missing)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd89c526c083288555845078a04cf8