### PR TITLE
feat: add admin cache management tools

### DIFF
--- a/backend/src/routes/cache.routes.js
+++ b/backend/src/routes/cache.routes.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+
+router.post('/clear', async (_req, res) => {
+  try {
+    if (global.clearServerCache) {
+      await global.clearServerCache();
+    }
+    res.status(200).json({ status: 'cleared' });
+  } catch (err) {
+    console.error('Failed to clear cache', err);
+    res.status(500).json({ status: 'error', message: 'Failed to clear cache' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -102,6 +102,7 @@ router.use('/api/book-reviews', require('../modules/bookReviews/bookReview.route
 router.use('/api/library', require('../modules/library/library.routes'));
 router.use('/api/search', require('../modules/search/search.routes'));
 router.use('/api/install', require('../modules/install/install.routes'));
+router.use('/api/admin/cache', require('./cache.routes'));
 router.use('/api/users/classes/lessons', require('./lesson.routes'));
 router.use('/api/video-calls', require('./videoCalls.routes'));
 

--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1150,6 +1150,7 @@
     "ads_manager": "مدير الإعلانات",
     "offers": "العروض",
     "support": "الدعم",
+    "clear_cache": "مسح ذاكرة التخزين المؤقت",
     "settings": "الإعدادات",
     "language_manager": "مدير اللغة",
     "language_config": "إعداد اللغة",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1164,6 +1164,7 @@
     "ads_manager": "Ads Manager",
     "offers": "Offers",
     "support": "Support",
+    "clear_cache": "Cache leeren",
     "settings": "Settings",
     "language_manager": "Sprachverwaltung",
     "language_config": "Sprachkonfiguration",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1168,6 +1168,7 @@
     "ads_manager": "Ads Manager",
     "offers": "Offers",
     "support": "Support",
+    "clear_cache": "Clear Cache",
     "settings": "Settings",
     "language_manager": "Language Manager",
     "language_config": "Language Config",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1150,6 +1150,7 @@
     "ads_manager": "Gerente de anuncios",
     "offers": "Oferta",
     "support": "Apoyo",
+    "clear_cache": "Limpiar caché",
     "settings": "Ajustes",
     "language_manager": "Administrador de idiomas",
     "language_config": "Configuración del lenguaje",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1150,6 +1150,7 @@
     "ads_manager": "Gestion des annonces",
     "offers": "Offres",
     "support": "Support",
+    "clear_cache": "Vider le cache",
     "settings": "Paramètres",
     "language_manager": "Gestion des langues",
     "language_config": "Configuration de la langue",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1150,6 +1150,7 @@
     "ads_manager": "विज्ञापन प्रबंधक",
     "offers": "ऑफर",
     "support": "सहायता",
+    "clear_cache": "कैश साफ़ करें",
     "settings": "सेटिंग्स",
     "language_manager": "भाषा प्रबंधक",
     "language_config": "भाषा विन्यास",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1164,6 +1164,7 @@
     "ads_manager": "Gestore annunci",
     "offers": "Offerte",
     "support": "Supporto",
+    "clear_cache": "Svuota cache",
     "settings": "Impostazioni",
     "language_manager": "Direttore linguistico",
     "language_config": "Configurazione del linguaggio",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1150,6 +1150,7 @@
     "ads_manager": "广告经理",
     "offers": "优惠",
     "support": "支持",
+    "clear_cache": "清除缓存",
     "settings": "设置",
     "language_manager": "语言经理",
     "language_config": "语言配置",

--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -34,7 +34,8 @@ import {
   BookMarked, // For Blogs
   HelpCircle, // For FAQs
   LifeBuoy,
-  BadgePercent
+  BadgePercent,
+  RefreshCcw
 } from 'lucide-react';
 
 export const adminNavLinks = [
@@ -105,7 +106,8 @@ export const adminNavLinks = [
           { label: 'certificate_templates', href: '/dashboard/admin/settings/certificates', icon: LayoutTemplate },
           { label: 'third_parties_config', href: '/dashboard/admin/settings/thirdParty', icon: Brain }
         ]
-      }
+      },
+      { label: 'clear_cache', href: '/dashboard/admin/cache', icon: RefreshCcw }
     ]
   }
 ];

--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -51,6 +51,11 @@ export default function CacheManager({
         const registration = await navigator.serviceWorker.ready;
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });
       }
+      try {
+        await fetch("/api/admin/cache/clear", { method: "POST" });
+      } catch (e) {
+        console.error(e);
+      }
       setStatus("idle");
     } catch (err) {
       console.error(err);

--- a/frontend/src/pages/dashboard/admin/cache.js
+++ b/frontend/src/pages/dashboard/admin/cache.js
@@ -1,0 +1,31 @@
+import AdminLayout from "@/components/layouts/AdminLayout";
+import CacheManager from "@/components/pwa/CacheManager";
+import withAuthProtection from "@/hooks/withAuthProtection";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../next-i18next.config.js";
+
+function AdminCachePage() {
+  const { t } = useTranslation("dashboard");
+
+  return (
+    <AdminLayout>
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-4">{t("clear_cache")}</h1>
+        <CacheManager />
+      </div>
+    </AdminLayout>
+  );
+}
+
+const ProtectedAdminCachePage = withAuthProtection(AdminCachePage, ["admin", "superadmin"]);
+
+export default ProtectedAdminCachePage;
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add admin dashboard page to clear PWA/server caches
- expose POST /api/admin/cache/clear endpoint and call from CacheManager
- link cache clearing page in admin sidebar and add translations

## Testing
- `npm test` (frontend)
- `npm test` (backend) *(fails: Exceeded timeout of 5000 ms for a hook)*

------
https://chatgpt.com/codex/tasks/task_e_68bd89d19bcc8328929f9c8056bdbafc