### PR TITLE
fix test mocks and subscription credit

### DIFF
--- a/backend/src/modules/books/__tests__/book.controller.test.js
+++ b/backend/src/modules/books/__tests__/book.controller.test.js
@@ -9,6 +9,29 @@ jest.mock('../book.service', () => ({
   clearBookTags: jest.fn(),
 }));
 
+jest.mock('../book.utils', () => ({
+  processTags: jest.fn(() => []),
+}));
+
+jest.mock('../../notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+jest.mock('../../messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+jest.mock('../../services/mailService', () => ({
+  sendMail: jest.fn(),
+}));
+jest.mock('../../services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+jest.mock('../../users/user.model', () => ({
+  findAdmins: jest.fn(),
+  findInstructors: jest.fn(),
+  findStudents: jest.fn(),
+  findContactInfo: jest.fn(),
+}));
+
 const controller = require('../book.controller');
 const service = require('../book.service');
 

--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -3,6 +3,8 @@ const QueryBuilder = require('knex/lib/query/querybuilder');
 const fs = require('fs');
 const path = require('path');
 
+jest.setTimeout(30000);
+
 QueryBuilder.prototype.whereILike = function (column, value) {
   return this.whereRaw(`LOWER(${column}) LIKE LOWER(?)`, [value]);
 };
@@ -25,6 +27,16 @@ jest.mock('../../plans/subscription.helper', () => ({
 }));
 jest.mock('../../payments/helpers/planRevenue', () => ({
   calculateInstructorAmount: jest.fn().mockResolvedValue(0),
+}));
+
+jest.mock('../../payments/payments.service', () => ({
+  STATUS: { PAID: 'paid', AWAITING_APPROVAL: 'awaiting_approval' },
+  create: jest.fn(async (data) => ({ id: 'pay-' + Math.random(), ...data, status: 'awaiting_approval' })),
+  approveBankPayment: jest.fn(async (id, data) => ({ id, ...data, status: 'paid' })),
+}));
+
+jest.mock('../../payments/paymentAccess', () => ({
+  grantAccess: jest.fn(() => Promise.resolve()),
 }));
 
 const db = require('../../../config/database');

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -74,6 +74,8 @@ exports.enroll = catchAsync(async (req, res) => {
         source: "subscription",
         amount: 0,
       });
+
+      await creditInstructorSubscription("class", classId, activePlanId, trx);
     } else if (Number(cls.price) > 0) {
       const payment = await trx("payments")
         .where({

--- a/backend/src/modules/community/public/__tests__/public.routes.test.js
+++ b/backend/src/modules/community/public/__tests__/public.routes.test.js
@@ -55,7 +55,7 @@ describe('community public routes', () => {
       .field('title', 't')
       .field('content', 'c')
       .field('tags', JSON.stringify(['tag1']))
-      .attach('image', Buffer.from('img'), 'a.png');
+      .attach('files', Buffer.from('img'), 'a.png');
     expect(res.statusCode).toBe(200);
     expect(service.createDiscussion).toHaveBeenCalled();
     expect(res.body.data).toEqual(disc);

--- a/backend/src/modules/library/__tests__/library.routes.test.js
+++ b/backend/src/modules/library/__tests__/library.routes.test.js
@@ -7,7 +7,7 @@ jest.mock('../library.service', () => ({
 }));
 const service = require('../library.service');
 
-jest.mock('../../middleware/auth/authMiddleware', () => ({
+jest.mock('../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => { req.user = { id: 's1', plan_id: 'plan1' }; next(); },
   isStudent: (_req, _res, next) => next(),
 }));

--- a/backend/src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js
+++ b/backend/src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js
@@ -79,7 +79,7 @@ describe('Tutorial assignment routes', () => {
   test('get assignments by tutorial', async () => {
     const list = [{ id: '1' }];
     service.getByTutorial.mockResolvedValue(list);
-    const res = await request(app).get('/api/users/tutorials/assignments/tut1');
+    const res = await request(app).get('/api/users/tutorials/assignments/123e4567-e89b-12d3-a456-426614174000');
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toEqual(list);
   });
@@ -99,7 +99,7 @@ describe('Tutorial assignment routes', () => {
       due_date: '2024-01-01',
     });
     const res = await request(app)
-      .post('/api/users/tutorials/assignments/t1')
+      .post('/api/users/tutorials/assignments/123e4567-e89b-12d3-a456-426614174000')
       .send({ title: 'New', due_date: '2024-01-01' });
     expect(res.statusCode).toBe(200);
     expect(service.createAssignment).toHaveBeenCalled();
@@ -110,7 +110,7 @@ describe('Tutorial assignment routes', () => {
 
   test('create assignment fails with invalid date', async () => {
     const res = await request(app)
-      .post('/api/users/tutorials/assignments/t1')
+      .post('/api/users/tutorials/assignments/123e4567-e89b-12d3-a456-426614174000')
       .send({ title: 'New', due_date: 'not-a-date' });
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toBe('Validation error');
@@ -119,7 +119,7 @@ describe('Tutorial assignment routes', () => {
 
   test('create assignment fails with missing title', async () => {
     const res = await request(app)
-      .post('/api/users/tutorials/assignments/t1')
+      .post('/api/users/tutorials/assignments/123e4567-e89b-12d3-a456-426614174000')
       .send({ due_date: '2024-01-01' });
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toBe('Validation error');
@@ -150,7 +150,7 @@ describe('Tutorial assignment routes', () => {
       .mockResolvedValueOnce({ instructor_id: 'other-user' })
       .mockResolvedValueOnce(null);
     const res = await request(app)
-      .post('/api/users/tutorials/assignments/t1')
+      .post('/api/users/tutorials/assignments/123e4567-e89b-12d3-a456-426614174000')
       .send({ title: 'New', due_date: '2024-01-01T00:00:00.000Z' });
     expect([403, 404]).toContain(res.statusCode);
     expect(service.createAssignment).not.toHaveBeenCalled();

--- a/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
+++ b/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
@@ -40,7 +40,7 @@ describe("generate certificate route", () => {
     service.isUserCompletedTutorial.mockResolvedValue(false);
 
     const res = await request(app).post(
-      "/api/users/tutorials/certificate/t1/certificate/generate",
+      "/api/users/tutorials/certificate/123e4567-e89b-12d3-a456-426614174000/certificate/generate",
     );
 
     expect(res.statusCode).toBe(403);
@@ -52,7 +52,7 @@ describe("generate certificate route", () => {
     service.issueCertificate.mockResolvedValue({ id: "cert1" });
 
     const res = await request(app).post(
-      "/api/users/tutorials/certificate/t1/certificate/generate",
+      "/api/users/tutorials/certificate/123e4567-e89b-12d3-a456-426614174000/certificate/generate",
     );
 
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
## Summary
- correct auth middleware mock paths and attach field names in community and library tests
- validate tutorial endpoints using UUIDs
- credit instructor subscription on class enrollments
- add supporting test mocks

## Testing
- `npm test src/modules/library/__tests__/library.routes.test.js src/modules/community/public/__tests__/public.routes.test.js src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js src/modules/books/__tests__/book.controller.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bd8e144ef48328ac82cae13390c4ab