### PR TITLE
Fix tests for library and tutorials; credit subscription enrollments

### DIFF
--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -376,7 +376,9 @@ exports.checkout = async (studentId) => {
         instructor_amount,
       };
 
-      const payment = await paymentsService.create(paymentData);
+      // Use the existing transaction to avoid nesting and potential
+      // database locks during tests.
+      const payment = await paymentsService.create(paymentData, [], trx);
       if (payment.status === PAYMENT_STATUS.PAID) {
         await libraryService.recordPurchase(studentId, b.id, b.price);
       }

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -74,6 +74,10 @@ exports.enroll = catchAsync(async (req, res) => {
         source: "subscription",
         amount: 0,
       });
+
+      // Credit the instructor for subscription-based enrollments so that
+      // instructors are compensated when a class is taken via a plan.
+      await creditInstructorSubscription("class", classId, activePlanId, trx);
     } else if (Number(cls.price) > 0) {
       const payment = await trx("payments")
         .where({

--- a/backend/src/modules/community/public/__tests__/public.routes.test.js
+++ b/backend/src/modules/community/public/__tests__/public.routes.test.js
@@ -55,7 +55,7 @@ describe('community public routes', () => {
       .field('title', 't')
       .field('content', 'c')
       .field('tags', JSON.stringify(['tag1']))
-      .attach('image', Buffer.from('img'), 'a.png');
+      .attach('files', Buffer.from('img'), 'a.png');
     expect(res.statusCode).toBe(200);
     expect(service.createDiscussion).toHaveBeenCalled();
     expect(res.body.data).toEqual(disc);

--- a/backend/src/modules/library/__tests__/library.routes.test.js
+++ b/backend/src/modules/library/__tests__/library.routes.test.js
@@ -7,7 +7,7 @@ jest.mock('../library.service', () => ({
 }));
 const service = require('../library.service');
 
-jest.mock('../../middleware/auth/authMiddleware', () => ({
+jest.mock('../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => { req.user = { id: 's1', plan_id: 'plan1' }; next(); },
   isStudent: (_req, _res, next) => next(),
 }));

--- a/backend/src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js
+++ b/backend/src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js
@@ -20,8 +20,10 @@ jest.mock('../tutorialAssignment.service', () => ({
 }));
 const service = require('../tutorialAssignment.service');
 
+const TUTORIAL_ID = '123e4567-e89b-12d3-a456-426614174000';
+
 jest.mock('../../tutorial.service', () => ({
-  getTutorialById: jest.fn(() => Promise.resolve({ id: 't1', title: 'Tutorial' })),
+  getTutorialById: jest.fn(() => Promise.resolve({ id: TUTORIAL_ID, title: 'Tutorial' })),
 }));
 
 jest.mock('../../enrollments/tutorialEnrollment.service', () => ({
@@ -79,7 +81,7 @@ describe('Tutorial assignment routes', () => {
   test('get assignments by tutorial', async () => {
     const list = [{ id: '1' }];
     service.getByTutorial.mockResolvedValue(list);
-    const res = await request(app).get('/api/users/tutorials/assignments/tut1');
+    const res = await request(app).get(`/api/users/tutorials/assignments/${TUTORIAL_ID}`);
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toEqual(list);
   });
@@ -99,7 +101,7 @@ describe('Tutorial assignment routes', () => {
       due_date: '2024-01-01',
     });
     const res = await request(app)
-      .post('/api/users/tutorials/assignments/t1')
+      .post(`/api/users/tutorials/assignments/${TUTORIAL_ID}`)
       .send({ title: 'New', due_date: '2024-01-01' });
     expect(res.statusCode).toBe(200);
     expect(service.createAssignment).toHaveBeenCalled();
@@ -110,7 +112,7 @@ describe('Tutorial assignment routes', () => {
 
   test('create assignment fails with invalid date', async () => {
     const res = await request(app)
-      .post('/api/users/tutorials/assignments/t1')
+      .post(`/api/users/tutorials/assignments/${TUTORIAL_ID}`)
       .send({ title: 'New', due_date: 'not-a-date' });
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toBe('Validation error');
@@ -119,7 +121,7 @@ describe('Tutorial assignment routes', () => {
 
   test('create assignment fails with missing title', async () => {
     const res = await request(app)
-      .post('/api/users/tutorials/assignments/t1')
+      .post(`/api/users/tutorials/assignments/${TUTORIAL_ID}`)
       .send({ due_date: '2024-01-01' });
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toBe('Validation error');
@@ -150,7 +152,7 @@ describe('Tutorial assignment routes', () => {
       .mockResolvedValueOnce({ instructor_id: 'other-user' })
       .mockResolvedValueOnce(null);
     const res = await request(app)
-      .post('/api/users/tutorials/assignments/t1')
+      .post(`/api/users/tutorials/assignments/${TUTORIAL_ID}`)
       .send({ title: 'New', due_date: '2024-01-01T00:00:00.000Z' });
     expect([403, 404]).toContain(res.statusCode);
     expect(service.createAssignment).not.toHaveBeenCalled();

--- a/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
+++ b/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
@@ -1,10 +1,12 @@
 const request = require("supertest");
 const express = require("express");
 
+const TUTORIAL_ID = '123e4567-e89b-12d3-a456-426614174001';
+
 jest.mock("../../../../../config/database", () => {
   const db = jest.fn(() => db);
   db.where = jest.fn(() => db);
-  db.first = jest.fn(() => Promise.resolve({ id: "t1", title: "Tut" }));
+  db.first = jest.fn(() => Promise.resolve({ id: TUTORIAL_ID, title: "Tut" }));
   return db;
 });
 
@@ -40,7 +42,7 @@ describe("generate certificate route", () => {
     service.isUserCompletedTutorial.mockResolvedValue(false);
 
     const res = await request(app).post(
-      "/api/users/tutorials/certificate/t1/certificate/generate",
+      `/api/users/tutorials/certificate/${TUTORIAL_ID}/certificate/generate`,
     );
 
     expect(res.statusCode).toBe(403);
@@ -52,7 +54,7 @@ describe("generate certificate route", () => {
     service.issueCertificate.mockResolvedValue({ id: "cert1" });
 
     const res = await request(app).post(
-      "/api/users/tutorials/certificate/t1/certificate/generate",
+      `/api/users/tutorials/certificate/${TUTORIAL_ID}/certificate/generate`,
     );
 
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
## Summary
- credit instructors when students enroll via subscription
- fix failing tests by using correct auth path, file fields, and valid UUIDs
- avoid deadlocks in book checkout by reusing transaction

## Testing
- `npx jest src/modules/library/__tests__/library.routes.test.js src/modules/community/public/__tests__/public.routes.test.js src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js src/modules/users/tutorials/assignments/__tests__/tutorialAssignment.routes.test.js src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68bd8e144ef48328ac82cae13390c4ab