### PR TITLE
Fix failing test mocks and upload field

### DIFF
--- a/backend/src/modules/books/__tests__/book.controller.test.js
+++ b/backend/src/modules/books/__tests__/book.controller.test.js
@@ -8,17 +8,6 @@ jest.mock('../book.service', () => ({
   getBookById: jest.fn(),
   clearBookTags: jest.fn(),
 }));
-jest.mock('../book.utils', () => ({ processTags: jest.fn() }));
-jest.mock('../../notifications/notifications.service', () => ({
-  createNotification: jest.fn(),
-}));
-jest.mock('../../messages/messages.service', () => ({
-  createMessage: jest.fn(),
-}));
-jest.mock('../../../services/mailService', () => ({ sendMail: jest.fn() }));
-jest.mock('../../../services/smsService', () => ({ sendSMS: jest.fn() }));
-jest.mock('../../users/user.model', () => ({ findAdmins: jest.fn(() => []) }));
-
 jest.mock('../book.utils', () => ({
   processTags: jest.fn(() => []),
 }));
@@ -29,10 +18,10 @@ jest.mock('../../notifications/notifications.service', () => ({
 jest.mock('../../messages/messages.service', () => ({
   createMessage: jest.fn(),
 }));
-jest.mock('../../services/mailService', () => ({
+jest.mock('../../../services/mailService', () => ({
   sendMail: jest.fn(),
 }));
-jest.mock('../../services/smsService', () => ({
+jest.mock('../../../services/smsService', () => ({
   sendSMS: jest.fn(),
 }));
 jest.mock('../../users/user.model', () => ({

--- a/backend/src/modules/community/public/__tests__/public.routes.test.js
+++ b/backend/src/modules/community/public/__tests__/public.routes.test.js
@@ -55,7 +55,7 @@ describe('community public routes', () => {
       .field('title', 't')
       .field('content', 'c')
       .field('tags', JSON.stringify(['tag1']))
-      .attach('files', Buffer.from('img'), 'a.png');
+      .attach('image', Buffer.from('img'), 'a.png');
     expect(res.statusCode).toBe(200);
     expect(service.createDiscussion).toHaveBeenCalled();
     expect(res.body.data).toEqual(disc);


### PR DESCRIPTION
## Summary
- Correct mail and SMS service mock paths in book controller tests
- Use correct multipart field name in community discussion route tests

## Testing
- `npm test` (fails: test database configuration is missing)
- `npx jest src/modules/books/__tests__/book.controller.test.js src/modules/community/public/__tests__/public.routes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdb5784d9483288ccf70895328c53a