### PR TITLE
fix: frontend healthcheck fails due to missing curl

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,7 @@ RUN npm run build
 # Production stage
 FROM node:18-alpine AS production
 WORKDIR /app
+RUN apk add --no-cache curl
 COPY package.json package-lock.json next.config.mjs next-i18next.config.js ./
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next


### PR DESCRIPTION
## Summary
- install curl in frontend image so Docker healthcheck works

## Testing
- `npm test src/tests/__tests__/bookService.test.js`
- `npm test tests/bookRoutes.test.js` *(fails: `${environment} database configuration is missing`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc0167a8c8328ba952000a2dd8392