### PR TITLE
Enable SSL ports and SSL config in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,11 +92,11 @@ services:
       - ./.env
     ports:
       - "80:80"
-      # - "443:443"
+      - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
-      # - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
+      - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- expose nginx on port 443
- mount ssl.conf for nginx

## Testing
- `scripts/deploy_server.sh eduskillbridge.net` *(fails: Neither certbot nor acme.sh is installed.)*
- `nginx -s reload` *(fails: command not found)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd8dfb17483288c3e30461a1358af