### PR TITLE
Increase frontend healthcheck start period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,10 +75,10 @@ services:
       - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000"]
-      interval: 30s
+      interval: 10s
       timeout: 10s
-      retries: 3
-      start_period: 5s
+      retries: 5
+      start_period: 30s
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- extend frontend container healthcheck start period to 30s and tune interval/retries

## Testing
- `docker-compose config`
- `docker-compose up -d --build` *(fails: Error while fetching server API version: connection aborted/permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7cc3d24832885e63d133d0c6106