### PR TITLE
Define APP_DOMAIN and add Nginx server_name fallback

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,3 +1,4 @@
 # Production environment variables
+APP_DOMAIN=eduskillbridge.net
 NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api
 NEXT_PUBLIC_SOCKET_URL=https://${APP_DOMAIN}

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  server_name $app_domain www.$app_domain;
+server_name $app_domain www.$app_domain _;
   # allow up to 100 MB uploads to avoid 413 errors
   client_max_body_size 100M;
 


### PR DESCRIPTION
## Summary
- define APP_DOMAIN in frontend production env file
- add `_` fallback to Nginx server_name so config works when APP_DOMAIN unset

## Testing
- `cd backend && npm test tests/adsRoutes.test.js`
- `nginx -t -c /tmp/nginx-test.conf` *(fails: host not found in upstream "frontend")*
- `npm test` in frontend *(terminated: lengthy run)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7d39c1c83289f135b263b7014c6