### PR TITLE
Expose API base URL at build time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,26 +64,29 @@ services:
     networks:
       - app-network
 
-  frontend:
-    build: ./frontend
-    ports:
-      - "3000:3000"
-    env_file:
-      - ./.env
-    environment:
-      # IMPORTANT: browsers can't call localhost on your server
-      - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 5s
-    depends_on:
-      backend:
-        condition: service_healthy
-    networks:
-      - app-network
+    frontend:
+      build:
+        context: ./frontend
+        args:
+          NEXT_PUBLIC_API_BASE_URL: https://eduskillbridge.net/api
+      ports:
+        - "3000:3000"
+      env_file:
+        - ./.env
+      environment:
+        # IMPORTANT: browsers can't call localhost on your server
+        - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+      healthcheck:
+        test: ["CMD", "curl", "-f", "http://localhost:3000"]
+        interval: 30s
+        timeout: 10s
+        retries: 3
+        start_period: 5s
+      depends_on:
+        backend:
+          condition: service_healthy
+      networks:
+        - app-network
 
   nginx:
     image: nginx:alpine

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,11 @@
 # Build stage
 FROM node:18 AS builder
+ARG NEXT_PUBLIC_API_BASE_URL
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci && npm cache clean --force
 COPY . .
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
 RUN npm run build
 
 # Production stage


### PR DESCRIPTION
## Summary
- allow configuring frontend build with NEXT_PUBLIC_API_BASE_URL
- pass API base URL through docker-compose build args

## Testing
- `npm test` *(fails: Cannot find module ../../services/instructor/subscriptionService)*
- `docker compose build frontend` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7f630e88328a5b32e97ac723f34