### PR TITLE
build: pass API base URL to frontend at build time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,10 @@ services:
       - app-network
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
     ports:
       - "3000:3000"
     env_file:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci && npm cache clean --force
 COPY . .
-RUN npm run build
+ARG NEXT_PUBLIC_API_BASE_URL
+RUN NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL npm run build
 
 # Production stage
 FROM node:18-alpine AS production


### PR DESCRIPTION
## Summary
- pass NEXT_PUBLIC_API_BASE_URL as a build-time argument in the frontend Dockerfile
- supply the build arg from docker-compose so the frontend image is built with the correct API base URL

## Testing
- `docker-compose --env-file .env.example build frontend` *(fails: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused')))*

------
https://chatgpt.com/codex/tasks/task_e_68bde85e683c8328985cc022954df22c