### PR TITLE
Add frontend health route and update compose healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       # IMPORTANT: browsers can't call localhost on your server
       - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/src/pages/api/health.js
+++ b/frontend/src/pages/api/health.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ status: "ok" });
+}


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint to frontend
- update docker-compose frontend healthcheck to hit the new endpoint

## Testing
- `docker compose up --build -d` *(fails: command not found)*
- `npx jest src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: Cannot find module '../../services/instructor/subscriptionService')*


------
https://chatgpt.com/codex/tasks/task_e_68bde85bb0d483289e2143778eb85434