### PR TITLE
Add frontend health endpoint and docker healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       # IMPORTANT: browsers can't call localhost on your server
       - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/src/pages/api/health.js
+++ b/frontend/src/pages/api/health.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ status: 'ok' });
+}


### PR DESCRIPTION
## Summary
- add simple /api/health endpoint in Next.js frontend
- update docker-compose to check /api/health for frontend health

## Testing
- `npm test` *(frontend: failing tests, sample failure in InstructorSettingsPage.test.js)*
- `npm test` *(backend: failing tests, sample failure in bookRoutes.test.js)*
- `node -e "const handler = require('./frontend/src/pages/api/health.js').default; const res={status:(c)=>({json:o=>console.log('status',c,'body',JSON.stringify(o))})}; handler({}, res);"`
- `docker compose build frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7f756348328992f54314b50e7c4