### PR TITLE
Simplify Nginx default server_name

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-server_name $app_domain www.$app_domain _;
+server_name _;
   # allow up to 100 MB uploads to avoid 413 errors
   client_max_body_size 100M;
 


### PR DESCRIPTION
## Summary
- use fallback server_name `_` in default Nginx config

## Testing
- `npm test` (backend) *(fails: Test Suites: 17 failed, 2 skipped, 100 passed)*
- `npm test -- src/tests/__tests__/bookService.test.js` *(pass)*
- `docker compose restart nginx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be669e9ba483289686bf57f9d07619