### PR TITLE
Fix video upload limit enforcement

### DIFF
--- a/backend/src/middleware/videoUploadMiddleware.js
+++ b/backend/src/middleware/videoUploadMiddleware.js
@@ -45,9 +45,7 @@ const fileFilter = (req, file, cb) => {
 const uploadVideo = multer({
   storage,
   fileFilter,
-  limits: {
-    limits: { fileSize: 100 * 1024 * 1024 } // 100MB
-  },
+  limits: { fileSize: 100 * 1024 * 1024 }, // 100MB
 });
 
 module.exports = uploadVideo;

--- a/backend/tests/videoUploadMiddleware.test.js
+++ b/backend/tests/videoUploadMiddleware.test.js
@@ -1,0 +1,39 @@
+const request = require("supertest");
+const express = require("express");
+const path = require("path");
+const fs = require("fs");
+
+// Increase timeout for handling large buffers
+jest.setTimeout(20000);
+
+const uploadVideo = require("../src/middleware/videoUploadMiddleware");
+
+const app = express();
+app.post("/upload", (req, res) => {
+  // Mock authenticated user for filename generation
+  req.user = { id: "test" };
+  uploadVideo.single("video")(req, res, (err) => {
+    if (err) {
+      return res.status(400).send(err.code);
+    }
+    res.status(200).send("ok");
+  });
+});
+
+afterAll(() => {
+  // Clean up any partially uploaded files
+  const dir = path.join(__dirname, "../src/uploads/demo-videos");
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("videoUploadMiddleware", () => {
+  it("rejects uploads larger than 100MB", async () => {
+    const largeBuffer = Buffer.alloc(101 * 1024 * 1024); // 101MB
+    const res = await request(app)
+      .post("/upload")
+      .attach("video", largeBuffer, { filename: "large.mp4", contentType: "video/mp4" });
+
+    expect(res.status).toBe(400);
+    expect(res.text).toBe("LIMIT_FILE_SIZE");
+  });
+});


### PR DESCRIPTION
## Summary
- correct multer config to enforce 100 MB upload limit
- add test to reject videos larger than the limit

## Testing
- `npm test` *(fails: paymentCommission.test.js, bookRoutes.test.js, paymentInvoiceEmail.test.js, tutorialRoutes.test.js, messageRoutes.test.js, paymentAmountValidation.test.js, paymentInstallments.test.js, bankPaymentRoutes.test.js, cryptoPaymentRoutes.test.js, blogRoutes.test.js, libraryRoutes.test.js, socialLoginConfigService.test.js, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be66ad590083289f2096b7eadf91db