### PR TITLE
feat: restrict install API

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -1,6 +1,16 @@
 const router = require('express').Router();
 const controller = require('./install.controller');
 
+// Guard installation endpoints behind an environment flag.
+// This prevents the install API from being accessible in production
+// and encourages using CLI scripts for deployment.
+router.use((req, res, next) => {
+  if (process.env.INSTALL_API_ENABLED === 'true') {
+    return next();
+  }
+  return res.status(403).json({ message: 'Installation via API is disabled.' });
+});
+
 router.get('/prereqs', controller.checkPrereqs);
 router.post('/run', controller.runInstall);
 

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -103,7 +103,11 @@ router.use('/api/instructor/books', require('../modules/books/instructorBook.rou
 router.use('/api/book-reviews', require('../modules/bookReviews/bookReview.routes'));
 router.use('/api/library', require('../modules/library/library.routes'));
 router.use('/api/search', require('../modules/search/search.routes'));
-router.use('/api/install', require('../modules/install/install.routes'));
+// Installation routes are disabled by default for security reasons.
+// They can be enabled explicitly via the INSTALL_API_ENABLED environment variable.
+if (process.env.INSTALL_API_ENABLED === 'true') {
+  router.use('/api/install', require('../modules/install/install.routes'));
+}
 router.use('/api/admin/cache', require('./cache.routes'));
 router.use('/api/users/classes/lessons', require('./lesson.routes'));
 router.use('/api/video-calls', require('./videoCalls.routes'));


### PR DESCRIPTION
## Summary
- guard install routes behind INSTALL_API_ENABLED flag
- conditionally register installation endpoints

## Testing
- `npm test` *(fails: Test Suites: 17 failed, 2 skipped, 100 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be66af1cc8832882a6f5424519a798