### PR TITLE
Use csurf for CSRF protection

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "connect-redis": "^7.1.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "csurf": "^1.11.0",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
@@ -3347,6 +3348,94 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
+    },
+    "node_modules/csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "license": "MIT",
+      "dependencies": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "deprecated": "This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/csurf/node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "license": "ISC"
+    },
+    "node_modules/csurf/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -7908,6 +7997,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw==",
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -9030,6 +9125,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "csurf": "^1.11.0",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.0",

--- a/backend/src/middleware/csrf.js
+++ b/backend/src/middleware/csrf.js
@@ -1,27 +1,47 @@
-const csrf = (req, res, next) => {
-  if (process.env.NODE_ENV === 'test') return next();
+const csurf = require('csurf');
+const { csrfCookieOptions } = require('../utils/cookie');
 
-  const exempt = [
-    '/api/auth/login',
-    '/api/auth/register',
-    '/api/auth/request-reset',
-    '/api/auth/forgot-password',
-    '/api/auth/verify-otp',
-    '/api/auth/reset-password',
-  ];
+// Generate a CSRF token for every request but do not enforce validation yet.
+// This ensures req.csrfToken() is always available so we can expose the token
+// to clients via a cookie.
+const generateToken = csurf({
+  cookie: false,
+  ignoreMethods: ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE'],
+});
 
-  const unsafe = ['POST', 'PUT', 'PATCH', 'DELETE'];
-  const isAdTracking = /^\/api\/ads\/[^/]+\/(view|click)$/.test(req.path);
-  if (!unsafe.includes(req.method) || exempt.includes(req.path) || isAdTracking) {
-    return next();
-  }
+// Middleware that verifies the CSRF token for unsafe requests.
+const verifyToken = csurf({ cookie: false });
 
-  const tokenCookie = req.cookies?.csrfToken;
-  const tokenHeader = req.get('x-csrf-token');
-  if (!tokenCookie || !tokenHeader || tokenCookie !== tokenHeader) {
-    return res.status(403).json({ message: 'Invalid CSRF token' });
-  }
-  next();
-};
+const unsafeMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
+const exemptPaths = [
+  '/api/auth/login',
+  '/api/auth/register',
+  '/api/auth/request-reset',
+  '/api/auth/forgot-password',
+  '/api/auth/verify-otp',
+  '/api/auth/reset-password',
+];
 
-module.exports = csrf;
+module.exports = [
+  generateToken,
+  (req, res, next) => {
+    if (
+      process.env.NODE_ENV === 'test' ||
+      !unsafeMethods.includes(req.method) ||
+      exemptPaths.includes(req.path) ||
+      /^\/api\/ads\/[^/]+\/(view|click)$/.test(req.path)
+    ) {
+      return next();
+    }
+    return verifyToken(req, res, next);
+  },
+  (req, res, next) => {
+    try {
+      const token = req.csrfToken();
+      res.cookie('csrfToken', token, csrfCookieOptions);
+    } catch (e) {
+      // ignore if token generation failed
+    }
+    next();
+  },
+];

--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -66,10 +66,9 @@ exports.login = catchAsync(async (req, res) => {
       throw new AppError('Failed reCAPTCHA verification', 400);
     }
   }
-  const { accessToken, refreshToken, user, csrfToken } = await authService.loginUser(req.body);
+  const { accessToken, refreshToken, user } = await authService.loginUser(req.body);
   res
     .cookie("refreshToken", refreshToken, refreshCookieOptions)
-    .cookie("csrfToken", csrfToken, csrfCookieOptions)
     .json({ message: "Login successful", accessToken, user });
 });
 
@@ -93,13 +92,11 @@ exports.refreshToken = catchAsync(async (req, res) => {
       id: decoded.id,
       role: decoded.role,
     });
-    const csrfToken = authService.generateCsrfToken();
     if (process.env.NODE_ENV !== "production") {
       logger.debug("\u2705 Refresh token rotated for user", decoded.id);
     }
     res
       .cookie("refreshToken", newRefreshToken, refreshCookieOptions)
-      .cookie("csrfToken", csrfToken, csrfCookieOptions)
       .json({ message: "Token refreshed", accessToken });
   } catch (err) {
     logger.error("❌ Refresh token error:", err.message);

--- a/backend/src/modules/auth/controllers/socialAuth.controller.js
+++ b/backend/src/modules/auth/controllers/socialAuth.controller.js
@@ -1,8 +1,7 @@
 // Import the configured passport instance
 const { passport } = require('../../../config/passport');
-const { refreshCookieOptions, csrfCookieOptions } = require('../../../utils/cookie');
+const { refreshCookieOptions } = require('../../../utils/cookie');
 const { frontendBase, allowedOrigins } = require('../../../utils/frontend');
-const crypto = require('crypto');
 
 // Shared callback handler for social auth providers
 const handleCallback = (provider) => (req, res, next) => {
@@ -11,10 +10,7 @@ const handleCallback = (provider) => (req, res, next) => {
       return res.redirect(`${frontendBase}/auth/login?error=social`);
     }
     const { refreshToken } = result;
-    const csrfToken = crypto.randomBytes(24).toString('hex');
-    res
-      .cookie('refreshToken', refreshToken, refreshCookieOptions)
-      .cookie('csrfToken', csrfToken, csrfCookieOptions);
+    res.cookie('refreshToken', refreshToken, refreshCookieOptions);
     let origin = req.query.origin;
     if (!allowedOrigins.includes(origin)) {
       const headerOrigin = req.get('origin');

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -2,7 +2,6 @@ const logger = require('../../../utils/logger.js');
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 const { v4: uuidv4 } = require("uuid");
-const crypto = require("crypto");
 const userModel = require("../../users/user.model");
 const db = require("../../../config/database");
 const {
@@ -211,7 +210,6 @@ exports.loginUser = async ({ email, password }) => {
   const tokenRoles = roles.length ? roles : [user.role];
   const accessToken = generateAccessToken({ id: user.id, role: tokenRoles[0], roles: tokenRoles });
   const refreshToken = await issueRefreshToken(user.id, tokenRoles[0]);
-  const csrfToken = generateCsrfToken();
 
   await notificationService.createNotification({
     user_id: user.id,
@@ -219,7 +217,7 @@ exports.loginUser = async ({ email, password }) => {
     message: "You have logged in successfully",
   });
   const safeUser = sanitizeUserUtil(user);
-  return { accessToken, refreshToken, csrfToken, user: { ...safeUser, roles, permissions } };
+  return { accessToken, refreshToken, user: { ...safeUser, roles, permissions } };
 };
 
 /**
@@ -289,11 +287,6 @@ exports.revokeRefreshToken = async (jti) => {
   await db("refresh_tokens").where({ id: jti }).update({ revoked_at: new Date() });
 };
 
-function generateCsrfToken() {
-  return crypto.randomBytes(24).toString("hex");
-}
-
-exports.generateCsrfToken = generateCsrfToken;
 
 /**
  * Generate OTP for password reset and email it to the user.

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -90,7 +90,6 @@ app.use(express.json({ limit: defaultBodyLimit }));
 app.use(express.urlencoded({ extended: true, limit: defaultBodyLimit }));
 app.use(cookieParser());
 app.use(morgan("dev"));
-app.use(csrf);
 
 if (!process.env.SESSION_SECRET) {
   throw new Error("SESSION_SECRET is required");
@@ -109,6 +108,8 @@ if (process.env.REDIS_URL) {
 }
 
 app.use(session(sessionOptions));
+
+app.use(csrf);
 
 // Apply rate limiting to all requests
 const limiter = rateLimit({

--- a/backend/tests/authSocialRedirect.test.js
+++ b/backend/tests/authSocialRedirect.test.js
@@ -1,5 +1,8 @@
 const request = require('supertest');
 const express = require('express');
+const cookieParser = require('cookie-parser');
+const session = require('express-session');
+const csrf = require('../src/middleware/csrf');
 
 jest.mock('../src/config/passport', () => ({
   passport: { authenticate: jest.fn() },
@@ -14,6 +17,9 @@ const { passport } = require('../src/config/passport');
 const { googleCallback } = require('../src/modules/auth/controllers/socialAuth.controller');
 
 const app = express();
+app.use(cookieParser());
+app.use(session({ secret: 'test', resave: false, saveUninitialized: true }));
+app.use(csrf);
 app.get('/api/auth/google/callback', googleCallback);
 
 describe('social auth redirect', () => {


### PR DESCRIPTION
## Summary
- replace custom CSRF middleware with csurf
- expose session-based CSRF tokens in `csrfToken` cookie
- drop manual token generation from auth endpoints and social auth flow

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined], etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be66afbdcc8328bc5862e2966752a1