### PR TITLE
chore: make server port optional

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -25,7 +25,6 @@ require("dotenv").config();
 const requiredSecrets = [
   "JWT_SECRET",
   "REFRESH_TOKEN_SECRET",
-  "PORT",
   "SESSION_SECRET",
 ];
 const dbKey =


### PR DESCRIPTION
## Summary
- remove `PORT` from required env vars in server
- server falls back to default port when `PORT` is unset

## Testing
- `npm test` *(fails: 17 failed, 2 skipped, 100 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be66b141f883289c5ec03dc0b7aae5