### PR TITLE
Set domain in Nginx SSL configuration

### DIFF
--- a/nginx/conf.d/ssl.conf
+++ b/nginx/conf.d/ssl.conf
@@ -1,11 +1,11 @@
 server {
     listen 443 ssl;
-    server_name $app_domain www.$app_domain;
+    server_name eduskillbridge.net www.eduskillbridge.net;
     # allow up to 100 MB uploads to avoid 413 errors
     client_max_body_size 100M;
 
-    ssl_certificate /etc/letsencrypt/live/$app_domain/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$app_domain/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/eduskillbridge.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/eduskillbridge.net/privkey.pem;
 
     include /etc/nginx/conf.d/common_locations.conf;
 }


### PR DESCRIPTION
## Summary
- specify eduskillbridge.net as server_name
- update LetsEncrypt certificate paths for domain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be71eaee508328b201ed9bcbb4fb3e