### PR TITLE
feat(nginx): handle optional app domain for CORS

### DIFF
--- a/nginx/conf.d/common_locations.conf
+++ b/nginx/conf.d/common_locations.conf
@@ -1,4 +1,7 @@
-  set $allowed_origin https://$app_domain;
+  set $allowed_origin "";
+  if ($app_domain != "") {
+    set $allowed_origin https://$app_domain;
+  }
 
   location / {
     proxy_pass http://frontend:3000;
@@ -9,8 +12,10 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($http_origin = $allowed_origin) {
-      add_header Access-Control-Allow-Origin $allowed_origin always;
+    if ($allowed_origin != "") {
+      if ($http_origin = $allowed_origin) {
+        add_header Access-Control-Allow-Origin $allowed_origin always;
+      }
     }
     add_header Access-Control-Allow-Credentials true always;
   }
@@ -27,8 +32,10 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($http_origin = $allowed_origin) {
-      add_header Access-Control-Allow-Origin $allowed_origin always;
+    if ($allowed_origin != "") {
+      if ($http_origin = $allowed_origin) {
+        add_header Access-Control-Allow-Origin $allowed_origin always;
+      }
     }
     add_header Access-Control-Allow-Credentials true always;
   }
@@ -43,8 +50,10 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($http_origin = $allowed_origin) {
-      add_header Access-Control-Allow-Origin $allowed_origin always;
+    if ($allowed_origin != "") {
+      if ($http_origin = $allowed_origin) {
+        add_header Access-Control-Allow-Origin $allowed_origin always;
+      }
     }
     add_header Access-Control-Allow-Credentials true always;
   }


### PR DESCRIPTION
## Summary
- Allow blank default for allowed origin and only set when APP_DOMAIN exists
- Guard CORS header injection by ensuring an allowed origin is defined

## Testing
- `nginx -t -c nginx/nginx.conf` *(fails: command not found: nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68be71ed4f248328b458d3835b43c8de