### PR TITLE
Start nginx without waiting for healthy dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,9 +102,9 @@ services:
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
     depends_on:
       backend:
-        condition: service_healthy
+        condition: service_started
       frontend:
-        condition: service_healthy
+        condition: service_started
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- Ensure nginx starts even if backend or frontend health checks fail by switching `depends_on` conditions to `service_started`

## Testing
- `npm test` in `backend`
- `npm test src/tests/__tests__/Navbar.test.js` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68be71ee62148328a938cda909f96e07