### PR TITLE
chore: mount common nginx locations conf

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/conf.d/common_locations.conf:/etc/nginx/conf.d/common_locations.conf:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
     depends_on:
       backend:


### PR DESCRIPTION
## Summary
- expose common nginx locations configuration in the compose stack

## Testing
- `docker-compose config`
- `docker-compose up -d --build nginx` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68be7f124dd88328b5a78a20eedeb127