### PR TITLE
Secure install API with admin authentication

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -1,9 +1,17 @@
 const { execFile } = require('child_process');
 const path = require('path');
 
-exports.checkPrereqs = (req, res) => {
-  const script = path.join(__dirname, '../../../../scripts/check_prereqs.sh');
-  execFile(script, (error, stdout, stderr) => {
+const allowedScripts = {
+  prereqs: path.join(__dirname, '../../../../scripts/check_prereqs.sh'),
+  install: path.join(__dirname, '../../../../install.sh'),
+};
+
+const executeScript = (res, scriptKey) => {
+  const script = allowedScripts[scriptKey];
+  if (!script) {
+    return res.status(400).json({ ok: false, output: 'Invalid script' });
+  }
+  execFile(script, { shell: false }, (error, stdout, stderr) => {
     const output = stdout + stderr;
     if (error) {
       return res.status(500).json({ ok: false, output });
@@ -12,13 +20,5 @@ exports.checkPrereqs = (req, res) => {
   });
 };
 
-exports.runInstall = (req, res) => {
-  const script = path.join(__dirname, '../../../../install.sh');
-  execFile(script, (error, stdout, stderr) => {
-    const output = stdout + stderr;
-    if (error) {
-      return res.status(500).json({ ok: false, output });
-    }
-    res.json({ ok: true, output });
-  });
-};
+exports.checkPrereqs = (req, res) => executeScript(res, 'prereqs');
+exports.runInstall = (req, res) => executeScript(res, 'install');

--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -1,5 +1,8 @@
 const router = require('express').Router();
 const controller = require('./install.controller');
+const { verifyToken, isAdmin } = require('../../middleware/auth/authMiddleware');
+const validate = require('../../middleware/validate');
+const { z } = require('zod');
 
 // Guard installation endpoints behind an environment flag.
 // This prevents the install API from being accessible in production
@@ -11,7 +14,11 @@ router.use((req, res, next) => {
   return res.status(403).json({ message: 'Installation via API is disabled.' });
 });
 
-router.get('/prereqs', controller.checkPrereqs);
-router.post('/run', controller.runInstall);
+// Require authenticated administrator for all install endpoints
+router.use(verifyToken, isAdmin);
+
+const emptySchema = z.object({}).strict();
+router.get('/prereqs', validate({ query: emptySchema }), controller.checkPrereqs);
+router.post('/run', validate({ body: emptySchema }), controller.runInstall);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- protect install endpoints with admin auth and strict request validation
- whitelist install scripts to prevent arbitrary execution

## Testing
- `npm test` *(fails: tests/paymentInstallments.test.js and others)*

------
https://chatgpt.com/codex/tasks/task_e_68be7e12250483288edff95309e8697f