### PR TITLE
Handle disallowed CORS origins without throwing

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -76,7 +76,9 @@ app.use(
       if (!origin || ALLOWED_ORIGINS.includes(origin)) {
         callback(null, origin);
       } else {
-        callback(new Error("Not allowed by CORS"));
+        // Deny the request without throwing so Express can return 403
+        logger.warn(`CORS blocked origin: ${origin}`);
+        callback(null, false);
       }
     },
     credentials: true,


### PR DESCRIPTION
## Summary
- Avoid throwing an error for disallowed CORS origins; callback with `false`
- Log any blocked CORS origins for audit purposes

## Testing
- `npm test` *(fails: 18 failed, 2 skipped, 100 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be7e1219288328a8c4116006a12df2