### PR TITLE
Remove duplicate admin cache route registration

### DIFF
--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -108,10 +108,8 @@ router.use('/api/search', require('../modules/search/search.routes'));
 if (process.env.INSTALL_API_ENABLED === 'true') {
   router.use('/api/install', require('../modules/install/install.routes'));
 }
-router.use('/api/admin/cache', require('./cache.routes'));
 router.use('/api/users/classes/lessons', require('./lesson.routes'));
 router.use('/api/video-calls', require('./videoCalls.routes'));
-router.use('/api/admin/cache', require('./cache.routes'));
 
 router.get('/', (_req, res) => res.send('🚀 SkillBridge API is live.'));
 


### PR DESCRIPTION
## Summary
- remove duplicate `/api/admin/cache` route registrations so it's defined only once

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test` *(fails: Test Suites: 17 failed, 2 skipped, 101 passed, 118 of 120 total)*

------
https://chatgpt.com/codex/tasks/task_e_68be7e1114908328be3147917532c886