### PR TITLE
chore: avoid port 80 conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     env_file:
       - ./.env
     ports:
-      - "80:80"
+      - "8080:80"
       - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro


### PR DESCRIPTION
## Summary
- change nginx port mapping to avoid host port 80 conflicts

## Testing
- `docker compose up -d` *(fails: command not found)*
- `npm test tests/paymentCommission.test.js` *(fails: Route.post requires callback function)*

------
https://chatgpt.com/codex/tasks/task_e_68be7e0f912483288acc2b8113438a85