### PR TITLE
chore: secure install api

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -2,25 +2,16 @@ const { execFile } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
-// Whitelisted scripts that can be executed via the install API
+// Whitelisted scripts that can be executed via the install API. Paths are
+// resolved absolutely and must exist on disk to be executed.
 const SAFE_SCRIPTS = {
   prereqs: path.resolve(__dirname, '../../../../scripts/check_prereqs.sh'),
   install: path.resolve(__dirname, '../../../../install.sh'),
 };
 
-const isSafeScript = (key) => {
-  const filePath = SAFE_SCRIPTS[key];
-  return filePath && fs.existsSync(filePath);
-};
-
-const allowedScripts = {
-  prereqs: path.join(__dirname, '../../../../scripts/check_prereqs.sh'),
-  install: path.join(__dirname, '../../../../install.sh'),
-};
-
 const executeScript = (res, scriptKey) => {
-  const script = allowedScripts[scriptKey];
-  if (!script) {
+  const script = SAFE_SCRIPTS[scriptKey];
+  if (!script || !fs.existsSync(script)) {
     return res.status(400).json({ ok: false, output: 'Invalid script' });
   }
   execFile(script, { shell: false }, (error, stdout, stderr) => {

--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -4,19 +4,19 @@ const { verifyToken, isAdmin } = require('../../middleware/auth/authMiddleware')
 const validate = require('../../middleware/validate');
 const { z } = require('zod');
 
-// Guard installation endpoints behind an environment flag.
-// This prevents the install API from being accessible in production
-// and encourages using CLI scripts for deployment.
+// Guard installation endpoints behind an environment flag to prevent accidental
+// exposure in production deployments.
 router.use((req, res, next) => {
-  if (process.env.INSTALL_API_ENABLED === 'true') {
+  if (process.env.INSTALL_API_ENABLED?.toLowerCase() === 'true') {
     return next();
   }
   return res.status(403).json({ message: 'Installation via API is disabled.' });
 });
 
-// Require authenticated administrator for all install endpoints
+// Require an authenticated administrator for all install endpoints.
 router.use(verifyToken, isAdmin);
 
+// No input is accepted for these endpoints; validate empty payloads strictly.
 const emptySchema = z.object({}).strict();
 router.get('/prereqs', validate({ query: emptySchema }), controller.checkPrereqs);
 router.post('/run', validate({ body: emptySchema }), controller.runInstall);

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -104,8 +104,9 @@ router.use('/api/book-reviews', require('../modules/bookReviews/bookReview.route
 router.use('/api/library', require('../modules/library/library.routes'));
 router.use('/api/search', require('../modules/search/search.routes'));
 // Installation routes are disabled by default for security reasons.
-// They can be enabled explicitly via the INSTALL_API_ENABLED environment variable.
-if (process.env.INSTALL_API_ENABLED === 'true') {
+// They can be enabled explicitly via the INSTALL_API_ENABLED environment variable
+// set to the string "true" (case-insensitive).
+if (process.env.INSTALL_API_ENABLED?.toLowerCase() === 'true') {
   router.use('/api/install', require('../modules/install/install.routes'));
 }
 router.use('/api/users/classes/lessons', require('./lesson.routes'));


### PR DESCRIPTION
## Summary
- harden install API behind case-insensitive env flag
- enforce admin auth and empty payload validation on install endpoints
- whitelist install scripts and verify existence before execution

## Testing
- `npm test` *(fails: Route.post() requires a callback function, book route expected 200 received 400, invoice email dispatch, tutorial routes, payment commission, payment invoice, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be832751bc8328adb6102fe77ab5d8