### PR TITLE
chore: simplify nginx dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,10 +102,8 @@ services:
       - ./nginx/conf.d/common_locations.conf:/etc/nginx/conf.d/common_locations.conf:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
     depends_on:
-      backend:
-        condition: service_started
-      frontend:
-        condition: service_started
+      - backend
+      - frontend
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- simplify nginx depends_on to remove service start conditions

## Testing
- `docker compose up -d --build` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68be8324ef508328a5caac985e2a1b35