### PR TITLE
Clarify video upload limit in middleware

### DIFF
--- a/backend/src/middleware/videoUploadMiddleware.js
+++ b/backend/src/middleware/videoUploadMiddleware.js
@@ -40,7 +40,7 @@ const fileFilter = (req, file, cb) => {
 
 // ───────────────────────────────────────────────
 // 🚀 Export Configured Multer Middleware
-// - Limits file size (e.g., 50MB)
+// - Limits file size to 100MB
 // ───────────────────────────────────────────────
 const uploadVideo = multer({
   storage,


### PR DESCRIPTION
## Summary
- update middleware comment to reflect 100MB video upload limit

## Testing
- `npm test` *(fails: Test Suites: 17 failed, 2 skipped, 101 passed, 118 of 120 total)*
- `docker build -t skillbridge-backend ./backend` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68be83259e8c83288d3dad8ab6d02f95