### PR TITLE
fail fast when redis is unavailable

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -102,9 +102,9 @@ const sessionOptions = {
   cookie: { ...refreshCookieOptions },
 };
 
+let redisClient;
 if (process.env.REDIS_URL) {
-  const redisClient = createClient({ url: process.env.REDIS_URL });
-  redisClient.connect().catch(console.error);
+  redisClient = createClient({ url: process.env.REDIS_URL });
   sessionOptions.store = new RedisStore({ client: redisClient });
 }
 
@@ -156,6 +156,15 @@ app.use(require("./middleware/errorHandler"));
 const PORT = process.env.PORT || 5002;
 
 async function startServer() {
+  if (redisClient) {
+    try {
+      await redisClient.connect();
+    } catch (err) {
+      logger.error("❌ Failed to connect to Redis:", err);
+      process.exit(1);
+    }
+  }
+
   try {
     await db.connectWithRetry();
     // Migrations are handled via the dedicated `npm run migrate` script.

--- a/backend/tests/redisConnectionExit.test.js
+++ b/backend/tests/redisConnectionExit.test.js
@@ -1,0 +1,77 @@
+const mockExpress = require('express');
+
+describe('Redis connection', () => {
+  let exitSpy;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    process.env.NODE_ENV = 'test';
+    process.env.REDIS_URL = 'redis://localhost:6379';
+    process.env.JWT_SECRET = 'jwt';
+    process.env.REFRESH_TOKEN_SECRET = 'refresh';
+    process.env.SESSION_SECRET = 'session';
+    process.env.TEST_DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    delete process.env.REDIS_URL;
+  });
+
+  it('exits the process if Redis connection fails', async () => {
+    const mockConnect = jest.fn().mockRejectedValue(new Error('Redis down'));
+
+    jest.mock('redis', () => ({
+      createClient: jest.fn(() => ({ connect: mockConnect })),
+    }));
+
+    jest.mock('connect-redis', () => ({
+      default: jest.fn().mockImplementation(function RedisStore() {
+        return { on: jest.fn() };
+      }),
+    }));
+
+    const mockLoggerError = jest.fn();
+    jest.mock('../src/utils/logger.js', () => ({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: mockLoggerError,
+    }));
+
+    jest.mock('../src/config/passport', () => ({
+      passport: {
+        initialize: () => (req, res, next) => next(),
+        session: () => (req, res, next) => next(),
+      },
+      initStrategies: jest.fn(),
+    }));
+
+    jest.mock('../src/config/database', () => ({
+      connectWithRetry: jest.fn(),
+      migrate: { list: jest.fn().mockResolvedValue([[], []]) },
+    }));
+
+    jest.mock('../src/routes', () => mockExpress.Router());
+    jest.mock('../src/jobs', () => jest.fn());
+    jest.mock('../src/sockets', () => ({
+      initSockets: jest.fn(),
+      state: { io: {}, rooms: {}, participants: {}, userSockets: {} },
+    }));
+
+    const { startServer } = require('../src/server');
+
+    await expect(startServer()).rejects.toThrow('exit');
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to connect to Redis'),
+      expect.any(Error)
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure Redis is connected during startup and exit on failure
- add test covering Redis connection failure

## Testing
- `npm test -- tests/redisConnectionExit.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be86770de48328b16253159a681784