### PR TITLE
feat: guard install route with env flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The script validates prerequisites, copies example env files, builds and starts 
 
 > **Note:** Always review the script before piping it into `bash` to verify it comes from a trusted source.
 
-Alternatively, launch the backend and open [`/install`](http://localhost:5002/install) to use a simple web-based installer that checks prerequisites and runs the setup scripts after entering configuration values.
+Alternatively, launch the backend and open [`/install`](http://localhost:5002/install) to use a simple web-based installer that checks prerequisites and runs the setup scripts after entering configuration values. This route is disabled by default; set `ENABLE_INSTALL=true` in the backend environment to expose it.
 
 ## Quick start
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -140,8 +140,10 @@ app.use((req, res, next) => {
   next();
 });
 
-const installerPath = path.join(__dirname, "../../install");
-app.use("/install", express.static(installerPath));
+if (process.env.ENABLE_INSTALL === "true") {
+  const installerPath = path.join(__dirname, "../../install");
+  app.use("/install", express.static(installerPath));
+}
 
 // ─── Routes ───
 app.use(routes);

--- a/backend/tests/installRoute.test.js
+++ b/backend/tests/installRoute.test.js
@@ -1,0 +1,35 @@
+const request = require('supertest');
+
+function getServer(enableInstall) {
+  jest.resetModules();
+  process.env.NODE_ENV = 'test';
+  process.env.JWT_SECRET = 'test';
+  process.env.REFRESH_TOKEN_SECRET = 'test';
+  process.env.SESSION_SECRET = 'test';
+  process.env.TEST_DATABASE_URL = 'postgresql://localhost/testdb';
+  if (enableInstall === undefined) {
+    delete process.env.ENABLE_INSTALL;
+  } else {
+    process.env.ENABLE_INSTALL = enableInstall;
+  }
+  return require('../src/server');
+}
+
+describe('/install route', () => {
+  it('returns 404 when ENABLE_INSTALL is not set to true', async () => {
+    const { app, io, server } = getServer();
+    const res = await request(app).get('/install');
+    io.close();
+    server.close();
+    expect(res.status).toBe(404);
+  });
+
+  it('serves installer when ENABLE_INSTALL is true', async () => {
+    const { app, io, server } = getServer('true');
+    const res = await request(app).get('/install/');
+    io.close();
+    server.close();
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('<!DOCTYPE html>');
+  });
+});


### PR DESCRIPTION
## Summary
- gate `/install` static route behind `ENABLE_INSTALL` flag
- document `ENABLE_INSTALL` in README
- add tests for `/install` route behavior

## Testing
- `npm --prefix backend test installRoute.test.js -- --forceExit`


------
https://chatgpt.com/codex/tasks/task_e_68be8678184c8328bf6ec80be590399f