### PR TITLE
refactor: centralize allowed origin mapping

### DIFF
--- a/nginx/conf.d/common_locations.conf
+++ b/nginx/conf.d/common_locations.conf
@@ -1,8 +1,3 @@
-  set $allowed_origin "";
-  if ($app_domain != "") {
-    set $allowed_origin https://$app_domain;
-  }
-
   location / {
     proxy_pass http://frontend:3000;
     proxy_http_version 1.1;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,10 +3,16 @@ events {}
 
 http {
     map $APP_DOMAIN $app_domain {
-        "" _;
+        "" "";
         default $APP_DOMAIN;
     }
 
+    map $app_domain $allowed_origin {
+        "" "";
+        default https://$app_domain;
+    }
+
     # Load virtual hosts from the conf.d directory
-    include /etc/nginx/conf.d/*.conf;
+    include conf.d/default.conf;
+    include conf.d/ssl.conf;
 }


### PR DESCRIPTION
## Summary
- compute `allowed_origin` using a `map` in the main nginx.conf
- remove per-file `set` directives from common location snippets
- explicitly include server configs to avoid HTTP-level inclusion

## Testing
- `docker-compose config`
- `docker-compose up -d nginx` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_68be86cb2e8883288631a3b5c91a4542