### PR TITLE
Sanitize admin class description

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -10,6 +10,7 @@ import { safeEncodeURI } from "@/utils/url";
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
+import DOMPurify from 'isomorphic-dompurify';
 
 function AdminClassDetailPage() {
   const { id } = useRouter().query;
@@ -202,7 +203,10 @@ function AdminClassDetailPage() {
           {/* Description */}
           <div className="pt-4">
             <h3 className="text-lg font-semibold text-gray-700 mb-3 pb-2 border-b border-gray-100">{t('description_label')}</h3>
-            <div className="prose max-w-none text-gray-600" dangerouslySetInnerHTML={{__html: details?.description}} />
+            <div
+              className="prose max-w-none text-gray-600"
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(details?.description || "") }}
+            />
           </div>
 
           {/* Actions */}

--- a/frontend/src/tests/__tests__/AdminClassDetailSanitization.test.js
+++ b/frontend/src/tests/__tests__/AdminClassDetailSanitization.test.js
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { id: '1' } }),
+}));
+
+jest.mock('../../hooks/withAuthProtection', () => (Component) => Component);
+
+jest.mock('../../components/layouts/AdminLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key, i18n: { dir: () => 'ltr' } }),
+}));
+
+const mockFetch = jest.fn();
+jest.mock('../../services/admin/classService', () => ({
+  fetchAdminClassById: (...args) => mockFetch(...args),
+}));
+
+import AdminClassDetailPage from '@/pages/dashboard/admin/online-classes/[id]';
+
+test('sanitizes class description before rendering', async () => {
+  const dirty = '<p>Safe</p><script>alert("x")</script><img src=x onerror=alert(1) />';
+  mockFetch.mockResolvedValue({ description: dirty });
+
+  render(<AdminClassDetailPage />);
+  const paragraph = await screen.findByText('Safe');
+  const html = paragraph.closest('.prose').innerHTML;
+
+  expect(html).toContain('<p>Safe</p>');
+  expect(html).not.toContain('<script>');
+  expect(html).not.toContain('onerror');
+});


### PR DESCRIPTION
## Summary
- import DOMPurify on admin class detail page and sanitize description
- add unit test ensuring class description neutralizes XSS payloads

## Testing
- `npm test src/tests/__tests__/AdminClassDetailSanitization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be86cc63e88328bdb97c11e432b433