### PR TITLE
Sanitize JSON-LD schema in SeoTags

### DIFF
--- a/frontend/src/components/common/SeoTags.js
+++ b/frontend/src/components/common/SeoTags.js
@@ -40,6 +40,26 @@ export default function SeoTags() {
     ? `${settings.globalSEO?.noindexSitewide || meta.noindex ? 'noindex' : 'index'},${meta.nofollow ? 'nofollow' : 'follow'}`
     : null;
 
+  const allowedSchemaFields = ['@context', '@type', 'name', 'url', 'logo', 'sameAs'];
+  let sanitizedJsonSchema;
+  if (settings.jsonSchema) {
+    try {
+      const parsed = JSON.parse(settings.jsonSchema);
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        Object.keys(parsed).every((key) => allowedSchemaFields.includes(key))
+      ) {
+        sanitizedJsonSchema = JSON.stringify(parsed)
+          .replace(/</g, '\\u003c')
+          .replace(/>/g, '\\u003e')
+          .replace(/&/g, '\\u0026');
+      }
+    } catch {
+      // ignore invalid JSON
+    }
+  }
+
   return (
     <Head>
       {meta.title && <title>{meta.title}</title>}
@@ -64,8 +84,8 @@ export default function SeoTags() {
       {twitterImage && <meta name="twitter:image" content={twitterImage} />}
       {twitter.handle && <meta name="twitter:site" content={twitter.handle} />}
       {twitter.handle && <meta name="twitter:creator" content={twitter.handle} />}
-      {settings.jsonSchema && (
-        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: settings.jsonSchema }} />
+      {sanitizedJsonSchema && (
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: sanitizedJsonSchema }} />
       )}
     </Head>
   );

--- a/frontend/src/tests/__tests__/SeoTags.test.js
+++ b/frontend/src/tests/__tests__/SeoTags.test.js
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import SeoTags from '@/components/common/SeoTags';
+import useSEOConfigStore from '@/store/seoConfigStore';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ asPath: '/', locale: 'en', locales: ['en'], defaultLocale: 'en' }),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ i18n: { options: { locales: ['en'] } } }),
+}));
+
+beforeEach(() => {
+  useSEOConfigStore.persist?.clearStorage();
+  useSEOConfigStore.setState({
+    fetch: jest.fn(),
+    loaded: true,
+    settings: { metaTags: {}, openGraph: {}, twitter: {}, jsonSchema: '' },
+  }, true);
+});
+
+test('rejects malformed json schema input', () => {
+  useSEOConfigStore.setState((s) => ({
+    ...s,
+    settings: { ...s.settings, jsonSchema: '</script><script>alert(1)</script>' },
+  }));
+  const { container } = render(<SeoTags />);
+  expect(container.querySelector('script[type="application/ld+json"]')).toBeNull();
+});
+
+test('rejects schema with unexpected fields', () => {
+  useSEOConfigStore.setState((s) => ({
+    ...s,
+    settings: {
+      ...s.settings,
+      jsonSchema: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Organization',
+        name: 'SkillBridge',
+        url: 'https://example.com',
+        evil: 'true',
+      }),
+    },
+  }));
+  const { container } = render(<SeoTags />);
+  expect(container.querySelector('script[type="application/ld+json"]')).toBeNull();
+});
+


### PR DESCRIPTION
## Summary
- Parse and validate `settings.jsonSchema` before injection
- Escape and re-stringify JSON-LD content for safe `<script>` usage
- Add regression tests covering malformed and unexpected schema input

## Testing
- `npm test src/tests/__tests__/SeoTags.test.js`
- `npm test src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: Cannot find module '../../services/instructor/subscriptionService')*


------
https://chatgpt.com/codex/tasks/task_e_68be86d088588328a817749a537ee9d4