### PR TITLE
chore: set API base URL to https

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,4 +1,4 @@
 # Production environment variables
 APP_DOMAIN=eduskillbridge.net
-NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
 NEXT_PUBLIC_SOCKET_URL=https://${APP_DOMAIN}


### PR DESCRIPTION
## Summary
- use explicit `https://eduskillbridge.net/api` for `NEXT_PUBLIC_API_BASE_URL` in production

## Testing
- `npm test` (backend) *(fails: Route.post() requires a callback function but got a [object Undefined])*
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68be98899a348328a60b5fc2bb93ab3c