### PR TITLE
chore: update API base URL to HTTPS

### DIFF
--- a/.env
+++ b/.env
@@ -21,4 +21,4 @@ SMTP_SECURE=false
 SMTP_USER=your_smtp_username
 SMTP_PASS=your_smtp_password
 
-NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api


### PR DESCRIPTION
## Summary
- point NEXT_PUBLIC_API_BASE_URL to the production HTTPS endpoint

## Testing
- `npm run build` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68be98a2033483289fd27d03c58c602a