### PR TITLE
chore: use https API base URL

### DIFF
--- a/.env
+++ b/.env
@@ -21,4 +21,4 @@ SMTP_SECURE=false
 SMTP_USER=your_smtp_username
 SMTP_PASS=your_smtp_password
 
-NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api


### PR DESCRIPTION
## Summary
- use `https://eduskillbridge.net/api` for `NEXT_PUBLIC_API_BASE_URL`

## Testing
- `npm run build`
- `curl -I https://eduskillbridge.net`
- `curl -I https://eduskillbridge.net/api/health`
- `curl -I https://eduskillbridge.net/_next/static/chunks/main-d387831b146d835d.js`


------
https://chatgpt.com/codex/tasks/task_e_68be98a7fe64832882e72fc7c2cee957