### PR TITLE
Proxy Next.js static files through Nginx

### DIFF
--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -20,6 +20,15 @@
     add_header Access-Control-Allow-Credentials true always;
   }
 
+  location /_next/static/ {
+    proxy_pass http://frontend:3000/_next/static/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   # Forward Socket.IO traffic to backend and enable WebSocket upgrades
   location /socket.io/ {
     proxy_pass http://backend:5002;


### PR DESCRIPTION
## Summary
- proxy Next.js static assets via `/ _next/static/`

## Testing
- `nginx -t -c nginx/nginx.conf` *(fails: command not found)*
- `sudo service nginx reload` *(fails: nginx: unrecognized service)*

------
https://chatgpt.com/codex/tasks/task_e_68be9fc1be0c832880b397b19b94ca36