### PR TITLE
Copy production env vars during build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci && npm cache clean --force
 COPY . .
+COPY .env.production .env
+ENV $(cat .env | xargs)
 RUN npm run build
 
 # Production stage


### PR DESCRIPTION
## Summary
- load production env vars during frontend Docker build

## Testing
- `npm test`
- `docker compose build frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be9fc2c6788328a2c57433824dc6a3