### PR TITLE
feat: route next static assets

### DIFF
--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -20,6 +20,26 @@
     add_header Access-Control-Allow-Credentials true always;
   }
 
+  # Serve Next.js static assets directly from the frontend service
+  location ^~ /_next/static/ {
+    proxy_pass http://frontend:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # Ensure a single Access-Control-Allow-Origin header
+    proxy_hide_header Access-Control-Allow-Origin;
+    if ($allowed_origin != "") {
+      if ($http_origin = $allowed_origin) {
+        add_header Access-Control-Allow-Origin $allowed_origin always;
+      }
+    }
+    add_header Access-Control-Allow-Credentials true always;
+    expires 1y;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+
   # Forward Socket.IO traffic to backend and enable WebSocket upgrades
   location /socket.io/ {
     proxy_pass http://backend:5002;


### PR DESCRIPTION
## Summary
- proxy Next.js static assets through dedicated Nginx location

## Testing
- `docker compose run --rm nginx nginx -t` *(fails: command not found)*
- `nginx -t -c /tmp/nginx-test.conf` *(fails: "if" directive is not allowed here)*

------
https://chatgpt.com/codex/tasks/task_e_68be9fae73b08328807f3e8d09554e3d