### PR TITLE
docs: warn against using internal API URL in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,5 +24,10 @@ SMTP_SECURE=false
 SMTP_USER=your_smtp_username
 SMTP_PASS=your_smtp_password
 
+# The frontend uses this URL for browser requests. The value below works for
+# docker-compose development where the API is reachable via the internal
+# hostname "backend". Replace it with your public HTTPS domain (e.g.
+# https://example.com/api) before building for production to avoid mixed
+# content errors.
 NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -13,6 +13,18 @@ try {
       `NEXT_PUBLIC_API_BASE_URL must be an absolute URL. Received: ${apiBase}`,
     );
   }
+
+  // Prevent shipping a build that points at an internal HTTP host which would
+  // cause browsers to block requests with mixed-content errors.
+  if (
+    process.env.NODE_ENV === 'production' &&
+    /^https?:\/\/(localhost|backend)(:\\d+)?/i.test(apiBase)
+  ) {
+    throw new Error(
+      `NEXT_PUBLIC_API_BASE_URL (${apiBase}) points to a non-public host. Set this to your public HTTPS domain in frontend/.env.production.`,
+    );
+  }
+
   ({ protocol, hostname, port } = new URL(apiBase));
 } catch (error) {
   console.warn(


### PR DESCRIPTION
## Summary
- document that NEXT_PUBLIC_API_BASE_URL must use a public HTTPS domain when deploying, not the internal `backend` host
- add build-time guard in Next.js config to prevent shipping a production build that points to an internal URL

## Testing
- `npm --prefix frontend test -- src/tests/__tests__/bookService.test.js`
- `npm --prefix backend test` *(fails: Route.post() requires a callback function but got a [object Undefined])*


------
https://chatgpt.com/codex/tasks/task_e_68bea29ef9dc832897368b5ca78e6989