### PR TITLE
Ensure frontend build includes production env file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,8 @@ backend/uploads
 # Environment files
 .env
 *.env
+!frontend/.env.production
+!backend/.env.production
 
 # Docker compose and other local files
 docker-compose.yml

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,7 @@ FROM node:18 AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci && npm cache clean --force
+COPY .env.production .env.production
 COPY . .
 RUN set -a && . .env.production && npm run build
 


### PR DESCRIPTION
## Summary
- copy `.env.production` explicitly in frontend Dockerfile so build can source environment
- allow production env files through root `.dockerignore`

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68beb9a52b488328930833bddac399d8