### PR TITLE
feat: improve docker healthchecks

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -90,7 +90,12 @@ const defaultBodyLimit = "10mb";
 app.use(express.json({ limit: defaultBodyLimit }));
 app.use(express.urlencoded({ extended: true, limit: defaultBodyLimit }));
 app.use(cookieParser());
-app.use(morgan("dev"));
+app.use(
+  morgan("dev", {
+    skip: (req) =>
+      process.env.NODE_ENV === "production" && req.url === "/api/health",
+  })
+);
 
 if (!process.env.SESSION_SECRET) {
   throw new Error("SESSION_SECRET is required");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,9 +52,9 @@ services:
       - MAX_BLOG_IMAGE_BYTES=${MAX_BLOG_IMAGE_BYTES}
       - NODE_ENV=${NODE_ENV}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5002/api/health"]
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:5002/api/health"]
       interval: 30s
-      timeout: 10s
+      timeout: 30s
       retries: 3
       start_period: 30s
     depends_on:
@@ -72,9 +72,9 @@ services:
     env_file:
       - ./frontend/.env.production
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:3000/api/health"]
       interval: 30s
-      timeout: 10s
+      timeout: 30s
       retries: 3
       start_period: 30s
     depends_on:


### PR DESCRIPTION
## Summary
- quiet docker health checks and extend timeout
- skip backend health check logging in production

## Testing
- `npm test` (backend) *(fails: Route.post requires a callback function but got undefined, plus numerous failing tests)*
- `npm test` (frontend) *(tests run with many React warnings; final summary not captured)*

------
https://chatgpt.com/codex/tasks/task_e_68bec1a29198832888ef2284deba6ebc