### PR TITLE
refactor: externalize social login credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ APP_DOMAIN=yourdomain.com
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production
 
+# OAuth credentials for social logins
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_SECURE=false

--- a/backend/src/seeds/08_social_login_settings_seed.js
+++ b/backend/src/seeds/08_social_login_settings_seed.js
@@ -7,8 +7,8 @@ exports.seed = async function (knex) {
     providers: {
       google: {
         active: true,
-        clientId: '707378564878-smi89kqne0snc1usv9s1l465hs6lb9a0.apps.googleusercontent.com',
-        clientSecret: 'YOUR_GOOGLE_CLIENT_SECRET',
+        clientId: process.env.GOOGLE_CLIENT_ID || 'YOUR_GOOGLE_CLIENT_ID',
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET || 'YOUR_GOOGLE_CLIENT_SECRET',
         redirectUrl: `https://www.${APP_DOMAIN}/api/auth/google/callback`,
         label: 'Sign in with Google',
         icon: 'google'


### PR DESCRIPTION
## Summary
- load Google social login settings from environment variables instead of hard-coded values
- document Google OAuth variables in `.env.example`

## Testing
- `npm test` *(fails: tests such as `bookRoutes.test.js` and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bec1a73c908328ae35fd0d9afd0fdd