### PR TITLE
fix: use explicit path for frontend env in Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,7 @@ COPY package.json package-lock.json ./
 RUN npm ci && npm cache clean --force
 COPY .env.production .env.production
 COPY . .
-RUN set -a && . .env.production && npm run build
+RUN set -a && . ./.env.production && npm run build
 
 # Production stage
 FROM node:18-alpine AS production


### PR DESCRIPTION
## Summary
- source `.env.production` with a relative path in the frontend Dockerfile to avoid "not found" errors

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js')*
- `docker build -t skillbridge-frontend-test -f frontend/Dockerfile frontend` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `set -a && . ./.env.production && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bec1a8c5988328b54079600f9386f5