### PR TITLE
Require Redis for session persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ JWT_SECRET=your_jwt_secret_here
 REFRESH_TOKEN_SECRET=your_refresh_token_secret_here
 SESSION_SECRET=your_session_secret_here
 FRONTEND_URL=https://example.com
+REDIS_URL=redis://redis:6379
 APP_DOMAIN=yourdomain.com
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -43,11 +43,16 @@ npm --prefix frontend install
      including:
 
        - `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`
-       - `PGADMIN_DEFAULT_EMAIL`, `PGADMIN_DEFAULT_PASSWORD`
-       - `JWT_SECRET`, `REFRESH_TOKEN_SECRET`
-       - `FRONTEND_URL`
+      - `PGADMIN_DEFAULT_EMAIL`, `PGADMIN_DEFAULT_PASSWORD`
+      - `JWT_SECRET`, `REFRESH_TOKEN_SECRET`
+      - `FRONTEND_URL`
+      - `REDIS_URL`
 
-     The frontend now reads its production settings from
+    A Redis instance (or compatible session store) is required in production
+    to persist user sessions. Set `REDIS_URL` to your store's connection
+    string.
+
+    The frontend now reads its production settings from
      `frontend/.env.production`. When deploying, remove or override the root
      `.env` and set `NEXT_PUBLIC_API_BASE_URL` in
      `frontend/.env.production` so the build uses your public HTTPS domain (for
@@ -60,6 +65,7 @@ npm --prefix frontend install
      cp backend/.env.example backend/.env
      # edit backend/.env and set your secrets
      # FRONTEND_URL defaults to http://localhost:3000
+     # REDIS_URL should point to your Redis instance for session persistence
      # set it to your frontend's domain if different and omit any trailing slash
      # When using docker-compose make sure the value does
      # not include an extra "FRONTEND_URL=" prefix.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,8 @@ DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge
 TEST_DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge_test
 # Production database connection. Store the actual value securely outside version control.
 PRODUCTION_DATABASE_URL=
+# Redis connection for session storage
+REDIS_URL=redis://localhost:6379
 # Secrets used to sign JSON Web Tokens. Make sure these match the values
 # in the project root `.env` when running via docker-compose.
 JWT_SECRET=your_jwt_secret

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -7,6 +7,7 @@ JWT_SECRET=change_me
 REFRESH_TOKEN_SECRET=change_me
 SESSION_SECRET=change_me
 FRONTEND_URL=https://example.com
+REDIS_URL=redis://redis:6379
 APP_DOMAIN=example.com
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -106,6 +106,10 @@ let redisClient;
 if (process.env.REDIS_URL) {
   redisClient = createClient({ url: process.env.REDIS_URL });
   sessionOptions.store = new RedisStore({ client: redisClient });
+} else if (process.env.NODE_ENV === "production") {
+  const msg = "REDIS_URL is required in production for session persistence";
+  logger.error(`❌ ${msg}`);
+  throw new Error(msg);
 }
 
 app.use(session(sessionOptions));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,16 @@ services:
     networks:
       - app-network
 
+  redis:
+    image: redis:7
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - app-network
+
   pgadmin:
     image: dpage/pgadmin4
     restart: always
@@ -51,6 +61,7 @@ services:
       - FRONTEND_URL=${FRONTEND_URL}
       - MAX_BLOG_IMAGE_BYTES=${MAX_BLOG_IMAGE_BYTES}
       - NODE_ENV=${NODE_ENV}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5002/api/health"]
       interval: 30s
@@ -59,6 +70,7 @@ services:
       start_period: 30s
     depends_on:
       - db
+      - redis
     volumes:
       - ./backend/uploads:/app/uploads
     networks:
@@ -105,6 +117,7 @@ services:
 volumes:
   postgres_data:
   pgadmin_data:
+  redis_data:
 
 networks:
   app-network:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,7 @@ This document explains how to set up SkillBridge for local development and for h
 - [Node.js](https://nodejs.org/) 18 or later
 - [Docker](https://www.docker.com/) and Docker Compose
 - Git
+- Redis or another session store for production deployments
 
 ## 1. Clone the repository
 
@@ -34,6 +35,10 @@ without HTTPS, also set:
 COOKIE_SECURE=false
 COOKIE_SAMESITE=None
 ```
+
+A Redis instance (or compatible store) is required to persist sessions in
+production. Set `REDIS_URL` in `backend/.env` to point to your Redis server
+(for example `redis://localhost:6379`).
 
 The book filter's price range uses configurable defaults:
 
@@ -116,6 +121,7 @@ The containers expose the following URLs:
 - Backend API: `http://localhost:5002/api`
 - PostgreSQL: `localhost:5432`
 - pgAdmin: `http://localhost:5050`
+- Redis: `localhost:6379`
 
 Once running, open the frontend URL in your browser and create an account or log
 in.


### PR DESCRIPTION
## Summary
- enforce REDIS_URL in production to avoid in-memory sessions
- document need for Redis and provide sample configuration
- add a Redis service to docker-compose and wire backend to it

## Testing
- `npm --prefix backend test` *(fails: 17 failed, 103 passed)*
- `npm --prefix frontend test` *(fails: see log)*

------
https://chatgpt.com/codex/tasks/task_e_68bec1b5db208328b0fb2e42ec789f9d