### PR TITLE
feat: decouple prod env from frontend build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,7 @@ ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL \
     APP_DOMAIN=$APP_DOMAIN
 
 # Source optional production env file if present before building.
-RUN if [ -f .env.production ]; then set -a && . .env.production; fi && npm run build
+RUN if [ -f .env.production ]; then set -a && . .env.production; fi; npm run build
 
 # Production stage
 FROM node:18-alpine AS production


### PR DESCRIPTION
## Summary
- decouple optional `.env.production` sourcing from the frontend build step to ensure builds succeed even without the file

## Testing
- `npm test src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: Cannot find module '../../services/instructor/subscriptionService')*
- `docker build -t skillbridge-frontend-test frontend` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f42c874832895a512b345250f1b