### PR TITLE
Allow frontend Docker build without .env.production

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,7 @@ ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL \
     APP_DOMAIN=$APP_DOMAIN
 
 # Source optional production env file if present before building.
-RUN if [ -f .env.production ]; then set -a && . .env.production; fi && npm run build
+RUN if [ -f .env.production ]; then set -a && . .env.production; fi; npm run build
 
 # Production stage
 FROM node:18-alpine AS production


### PR DESCRIPTION
## Summary
- ensure Dockerfile build step runs `npm run build` even when `.env.production` is absent by separating commands with `;`

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService')*
- `docker build -t skillbridge-frontend-test frontend` *(fails: docker not installed/daemon can't start)*
- `npm run build --prefix frontend` *(compiles but exited while generating static pages)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f499e988328b5af21375320595a