### PR TITLE
Use shared APP_DOMAIN for frontend and nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
     ports:
       - "3000:3000"
     env_file:
+      - ./.env
       - ./frontend/.env.production
     healthcheck:
       test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:3000/api/health"]

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,4 +1,5 @@
 # Production environment variables
-APP_DOMAIN=eduskillbridge.net
-NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+# APP_DOMAIN is supplied via the root .env file so that nginx and
+# the frontend container share the same domain value.
+NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api
 NEXT_PUBLIC_SOCKET_URL=https://${APP_DOMAIN}


### PR DESCRIPTION
## Summary
- load root `.env` in the frontend service so nginx and Next.js see the same `APP_DOMAIN`
- derive production URLs from `APP_DOMAIN` in `frontend/.env.production`

## Testing
- `npm test` (frontend) *(fails: Cannot find module '../../services/instructor/subscriptionService')*
- `npm test` (backend) *(fails: Route.post() requires a callback function)*
- `docker-compose logs frontend nginx` *(fails: ModuleNotFoundError: No module named 'distutils')*
- `dockerd` *(fails: failed to mount overlay: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f4fcfbc8328b296aa81169e171c