### PR TITLE
build(frontend): load .env.production during build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,7 @@ ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL \
     APP_DOMAIN=$APP_DOMAIN
 
 # Source optional production env file if present before building.
-RUN if [ -f .env.production ]; then set -a && . .env.production; fi && npm run build
+RUN set -a && [ -f .env.production ] && . .env.production; npm run build
 
 # Production stage
 FROM node:18-alpine AS production


### PR DESCRIPTION
## Summary
- Load `.env.production` if present during frontend build

## Testing
- `docker build -f frontend/Dockerfile ./frontend` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f4ef17883288703b08f283fa129