### PR TITLE
chore: centralize dotenv initialization

### DIFF
--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -1,5 +1,3 @@
-require('dotenv').config();
-
 const baseConfig = {
   client: 'pg',
   migrations: {

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -1,5 +1,4 @@
 const logger = require('../utils/logger.js');
-require('dotenv').config();
 const knex = require('knex');
 const knexfile = require('../../knexfile.js');
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,3 +1,5 @@
+require("dotenv").config();
+
 const logger = require('./utils/logger.js');
 // ─── SkillBridge Backend – Main Server Entry Point ───
 
@@ -19,7 +21,6 @@ const { refreshCookieOptions } = require("./utils/cookie");
 const startJobs = require("./jobs");
 const { initSockets, state: socketState } = require("./sockets");
 const routes = require("./routes");
-require("dotenv").config();
 
 // Ensure required environment secrets are present
 const requiredSecrets = [


### PR DESCRIPTION
## Summary
- Load environment variables once at server startup
- Remove redundant dotenv calls from database and Knex configs

## Testing
- `npm test` *(fails: Test Suites: 30 failed, 1 skipped, 91 passed, 121 of 122 total)*


------
https://chatgpt.com/codex/tasks/task_e_68bf7b39b53c83289ce82702943c8369