### PR TITLE
fix: simplify backend compose env configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,19 +49,8 @@ services:
     restart: always
     env_file:
       - ./.env
-      - ./backend/.env.production
     ports:
       - "5002:5002"
-    environment:
-      - PORT=${PORT}
-      - DATABASE_URL=${DATABASE_URL}
-      - JWT_SECRET=${JWT_SECRET}
-      - REFRESH_TOKEN_SECRET=${REFRESH_TOKEN_SECRET}
-      - SESSION_SECRET=${SESSION_SECRET}
-      - FRONTEND_URL=${FRONTEND_URL}
-      - MAX_BLOG_IMAGE_BYTES=${MAX_BLOG_IMAGE_BYTES}
-      - NODE_ENV=${NODE_ENV}
-      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:5002/api/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- remove list-style environment variables from backend in `docker-compose.yml`
- drop unused `backend/.env.production` reference

## Testing
- `docker-compose config`
- `npm test` *(fails: creates a book expect 200 received 400)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7b37cc988328bcf29bed7d17e515