### PR TITLE
refactor: remove inline redis url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,15 +53,14 @@ services:
     ports:
       - "5002:5002"
     environment:
-      - PORT=${PORT}
-      - DATABASE_URL=${DATABASE_URL}
-      - JWT_SECRET=${JWT_SECRET}
-      - REFRESH_TOKEN_SECRET=${REFRESH_TOKEN_SECRET}
-      - SESSION_SECRET=${SESSION_SECRET}
-      - FRONTEND_URL=${FRONTEND_URL}
-      - MAX_BLOG_IMAGE_BYTES=${MAX_BLOG_IMAGE_BYTES}
-      - NODE_ENV=${NODE_ENV}
-      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      PORT: ${PORT}
+      DATABASE_URL: ${DATABASE_URL}
+      JWT_SECRET: ${JWT_SECRET}
+      REFRESH_TOKEN_SECRET: ${REFRESH_TOKEN_SECRET}
+      SESSION_SECRET: ${SESSION_SECRET}
+      FRONTEND_URL: ${FRONTEND_URL}
+      MAX_BLOG_IMAGE_BYTES: ${MAX_BLOG_IMAGE_BYTES}
+      NODE_ENV: ${NODE_ENV}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:5002/api/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- remove inline REDIS_URL from backend service in docker-compose.yml
- switch backend service environment to key/value mapping to rely on env files

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7a8cbbbc8328844f9d8bf2c2a4a8