### PR TITLE
refactor: expose socket state without globals

### DIFF
--- a/backend/src/middleware/auth/verifyHostRole.js
+++ b/backend/src/middleware/auth/verifyHostRole.js
@@ -1,10 +1,11 @@
 const logger = require('../../utils/logger.js');
 const db = require("../../config/database");
+const socketState = require("../../sockets").state;
 
 module.exports = async function verifyHostRole(req, res, next) {
   const { roomId } = req.params;
   try {
-    const socketId = global.userSockets?.[req.user.id];
+    const socketId = socketState.userSockets?.[req.user.id];
     if (!socketId)
       return res.status(403).json({ message: "Not allowed" });
     const participant = await db("video_call_participants")

--- a/backend/src/modules/groups/groups.controller.js
+++ b/backend/src/modules/groups/groups.controller.js
@@ -13,6 +13,7 @@ const { frontendBase } = require("../../utils/frontend");
 const db = require("../../config/database");
 const planService = require("../plans/plans.service");
 const { parsePlanFeatures } = require("../../utils/planFeatures");
+const socketState = require("../../sockets").state;
 
 exports.createGroup = catchAsync(async (req, res) => {
   const planId =
@@ -431,9 +432,9 @@ exports.startVideoCall = catchAsync(async (req, res) => {
       });
 
       try {
-        if (global.io && global.userSockets?.[uid]) {
-          global.io
-            .to(global.userSockets[uid])
+        if (socketState.io && socketState.userSockets?.[uid]) {
+          socketState.io
+            .to(socketState.userSockets[uid])
             .emit("incoming-call", {
               chatId: id,
               roomId,

--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -4,6 +4,7 @@ const { v4: uuidv4 } = require("uuid");
 const mailService = require("../../services/mailService");
 const whatsappService = require("../../services/whatsappService");
 const AppError = require("../../utils/AppError");
+const socketState = require("../../sockets").state;
 
 const MESSAGE_RETENTION_MS =
   parseInt(process.env.MESSAGE_RETENTION_HOURS || "24", 10) *
@@ -21,8 +22,8 @@ exports.createMessage = async (
       .insert({ sender_id, receiver_id, message, booking_id, type })
       .returning("*");
     try {
-      if (emit && global.io && global.userSockets?.[receiver_id]) {
-        global.io.to(global.userSockets[receiver_id]).emit("message-created");
+      if (emit && socketState.io && socketState.userSockets?.[receiver_id]) {
+        socketState.io.to(socketState.userSockets[receiver_id]).emit("message-created");
       }
     } catch (err) {
       logger.error("Failed to emit message-created event", err.message);
@@ -104,8 +105,8 @@ exports.sendEmail = async ({ sender_id, receiver_id, subject, message }) =>
     }
 
     try {
-      if (global.io && global.userSockets?.[receiver_id]) {
-        global.io.to(global.userSockets[receiver_id]).emit("message-created");
+      if (socketState.io && socketState.userSockets?.[receiver_id]) {
+        socketState.io.to(socketState.userSockets[receiver_id]).emit("message-created");
       }
     } catch (err) {
       logger.error("Failed to emit message-created event", err.message);
@@ -137,8 +138,8 @@ exports.sendWhatsApp = async ({ sender_id, receiver_id, message }) =>
     }
 
     try {
-      if (global.io && global.userSockets?.[receiver_id]) {
-        global.io.to(global.userSockets[receiver_id]).emit("message-created");
+      if (socketState.io && socketState.userSockets?.[receiver_id]) {
+        socketState.io.to(socketState.userSockets[receiver_id]).emit("message-created");
       }
     } catch (err) {
       logger.error("Failed to emit message-created event", err.message);
@@ -185,22 +186,22 @@ exports.startVideoCall = async ({ sender_id, receiver_id }) => {
   });
 
   try {
-    if (global.io && global.userSockets?.[receiver_id]) {
+    if (socketState.io && socketState.userSockets?.[receiver_id]) {
       const caller = await db("users")
         .select("full_name")
         .where({ id: sender_id })
         .first();
 
-      global.io.to(global.userSockets[receiver_id]).emit("message-created");
+      socketState.io.to(socketState.userSockets[receiver_id]).emit("message-created");
 
       // Emit legacy event for compatibility
-      global.io
-        .to(global.userSockets[receiver_id])
+      socketState.io
+        .to(socketState.userSockets[receiver_id])
         .emit("video-call-invite", { callId: call.id, roomId });
 
       // Emit incoming-call event used by the frontend call overlay
-      global.io
-        .to(global.userSockets[receiver_id])
+      socketState.io
+        .to(socketState.userSockets[receiver_id])
         .emit("incoming-call", {
           chatId: sender_id,
           roomId,
@@ -224,9 +225,9 @@ exports.respondVideoCall = async ({ call_id, user_id, action }) => {
     .update({ status })
     .returning("*");
   try {
-    if (global.io && global.userSockets?.[call.caller_id]) {
-      global.io
-        .to(global.userSockets[call.caller_id])
+    if (socketState.io && socketState.userSockets?.[call.caller_id]) {
+      socketState.io
+        .to(socketState.userSockets[call.caller_id])
         .emit("video-call-response", { callId: call_id, status });
     }
   } catch (err) {
@@ -244,14 +245,14 @@ exports.endVideoCall = async ({ call_id, user_id }) => {
     .update({ status: "ended", ended_at: new Date() })
     .returning("*");
   try {
-    if (global.io) {
+    if (socketState.io) {
       const sockets = [];
-      if (global.userSockets?.[call.caller_id])
-        sockets.push(global.userSockets[call.caller_id]);
-      if (global.userSockets?.[call.receiver_id])
-        sockets.push(global.userSockets[call.receiver_id]);
+      if (socketState.userSockets?.[call.caller_id])
+        sockets.push(socketState.userSockets[call.caller_id]);
+      if (socketState.userSockets?.[call.receiver_id])
+        sockets.push(socketState.userSockets[call.receiver_id]);
       sockets.forEach((sid) =>
-        global.io.to(sid).emit("video-call-ended", { callId: call_id }),
+        socketState.io.to(sid).emit("video-call-ended", { callId: call_id }),
       );
     }
   } catch (err) {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -160,8 +160,8 @@ app.use(routes);
 // Initialize sockets
 initSockets(server, ALLOWED_ORIGINS);
 const { io, rooms, participants, userSockets } = socketState;
-global.io = io;
-global.userSockets = userSockets;
+app.locals.io = io;
+app.locals.userSockets = userSockets;
 
 app.use(require("./middleware/errorHandler"));
 const PORT = process.env.PORT || 5002;
@@ -204,4 +204,4 @@ if (process.env.NODE_ENV !== "test") {
   startServer();
 }
 
-module.exports = { app, server, io, rooms, participants, startServer };
+module.exports = { app, server, io, rooms, participants, userSockets, startServer };

--- a/backend/tests/video-calls/hostRole.test.js
+++ b/backend/tests/video-calls/hostRole.test.js
@@ -23,8 +23,8 @@ const verifyHostRole = require('../../src/middleware/auth/verifyHostRole');
 const app = express();
 app.use(express.json());
 const attachUser = (req, _res, next) => { req.user = { id: 'user1' }; next(); };
-
-global.userSockets = { user1: 'socket1' };
+const socketState = require('../../src/sockets').state;
+socketState.userSockets = { user1: 'socket1' };
 
 app.patch('/api/video-calls/:roomId/participants/:id', attachUser, verifyHostRole, (_req, res) => res.json({}));
 app.delete('/api/video-calls/:roomId/participants/:id', attachUser, verifyHostRole, (_req, res) => res.status(204).end());


### PR DESCRIPTION
## Summary
- avoid using global variables for Socket.IO by attaching `io` and `userSockets` to app locals
- import shared socket state in modules and tests

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined], plus multiple other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7a92100c8328a8810cb1f3911e37