### PR TITLE
Delay socket.io initialization until server start

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -156,13 +156,6 @@ if (process.env.ENABLE_INSTALL === "true") {
 
 // ─── Routes ───
 app.use(routes);
-
-// Initialize sockets
-initSockets(server, ALLOWED_ORIGINS);
-const { io, rooms, participants, userSockets } = socketState;
-global.io = io;
-global.userSockets = userSockets;
-
 app.use(require("./middleware/errorHandler"));
 const PORT = process.env.PORT || 5002;
 
@@ -190,8 +183,19 @@ async function startServer() {
       logger.log("✅ Database migrations up to date");
     }
     await initStrategies();
-    server.listen(PORT, "0.0.0.0", () => {
-      logger.log(`✅ Server running on port ${PORT}`);
+    await new Promise((resolve, reject) => {
+      server.listen(PORT, "0.0.0.0", (err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        logger.log(`✅ Server running on port ${PORT}`);
+        initSockets(server, ALLOWED_ORIGINS);
+        const { io, userSockets } = socketState;
+        global.io = io;
+        global.userSockets = userSockets;
+        resolve();
+      });
     });
     startJobs();
   } catch (err) {
@@ -204,4 +208,17 @@ if (process.env.NODE_ENV !== "test") {
   startServer();
 }
 
-module.exports = { app, server, io, rooms, participants, startServer };
+module.exports = {
+  app,
+  server,
+  startServer,
+  get io() {
+    return socketState.io;
+  },
+  get rooms() {
+    return socketState.rooms;
+  },
+  get participants() {
+    return socketState.participants;
+  },
+};


### PR DESCRIPTION
## Summary
- Initialize sockets only after HTTP server starts
- Export socket state via getters so `io` is accessible after startup

## Testing
- `npm test` *(fails: 18 failed, 102 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7a93ec1c8328861129eef97c0e1b