### PR TITLE
refactor: scope cache headers

### DIFF
--- a/backend/src/modules/auth/routes/auth.routes.js
+++ b/backend/src/modules/auth/routes/auth.routes.js
@@ -8,6 +8,12 @@ const validate = require("../../../middleware/validate");
 const authValidation = require("../validators/auth.validator");
 const { limitAuthRequests } = require("../../../middleware/rateLimiter");
 
+// Prevent caching of sensitive auth responses
+router.use((req, res, next) => {
+  res.set("Cache-Control", "no-store");
+  next();
+});
+
 /**
  * @route   POST /auth/register
  * @desc    Register a new user

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -62,12 +62,6 @@ const ALLOWED_ORIGINS = Array.from(
     ...FRONTEND_URL.split(",").map((o) => o.trim().replace(/\/$/, "")),
   ])
 );
-
-app.disable("etag");
-app.use((req, res, next) => {
-  res.set("Cache-Control", "no-store");
-  next();
-});
 // 🌐 CORS must run before body parsing so even 4xx responses include the header
 app.use(
   cors({
@@ -135,7 +129,12 @@ app.use(passport.session());
 
 // Restrict direct PDF access from the uploads folder
 const uploadsPath = path.join(__dirname, "../uploads");
-const serveUploads = express.static(uploadsPath);
+const serveUploads = express.static(uploadsPath, {
+  maxAge: "1h",
+  setHeaders: (res) => {
+    res.setHeader("Cache-Control", "public, max-age=3600");
+  },
+});
 const blockPdfMiddleware = (req, res, next) => {
   if (req.path.toLowerCase().endsWith(".pdf")) {
     return res.status(403).json({ message: "Direct PDF access is forbidden" });
@@ -151,7 +150,10 @@ app.use((req, res, next) => {
 
 if (process.env.ENABLE_INSTALL === "true") {
   const installerPath = path.join(__dirname, "../../install");
-  app.use("/install", express.static(installerPath));
+  app.use(
+    "/install",
+    express.static(installerPath, { maxAge: "1h" })
+  );
 }
 
 // ─── Routes ───


### PR DESCRIPTION
## Summary
- limit no-store caching to auth endpoints
- add cache headers for static asset routes
- remove blanket no-store middleware from server setup

## Testing
- `npm test` *(fails: Test Suites: 17 failed, 2 skipped, 103 passed, 120 of 122 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7a94fd008328b6a961e81ef02e05