### PR TITLE
Remove duplicate REDIS_URL entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,6 @@ REFRESH_TOKEN_SECRET=your_refresh_token_secret_here
 SESSION_SECRET=your_session_secret_here
 REDIS_URL=redis://redis:6379
 FRONTEND_URL=https://example.com
-REDIS_URL=redis://redis:6379
 APP_DOMAIN=yourdomain.com
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production


### PR DESCRIPTION
## Summary
- remove duplicate `REDIS_URL` line from `.env.example`

## Testing
- `CI=true npm test` (backend) *(fails: 17 failed, 2 skipped)*
- `CI=true npx jest src/tests/__tests__/bookService.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bf7b344b0c832891aac5397ba2e6c2