### PR TITLE
Ensure logger stream closes on process exit

### DIFF
--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -14,6 +14,15 @@ logStream.on("error", (err) => {
   console.error("Failed to write to log file:", err);
 });
 
+process.on("exit", () => logStream.end());
+
+const gracefulShutdown = () => {
+  logStream.end(() => process.exit(0));
+};
+
+process.on("SIGINT", gracefulShutdown);
+process.on("SIGTERM", gracefulShutdown);
+
 function append(type, args) {
   const line = `${new Date().toISOString()} [${type}] ${args.join(" ")}\n`;
   logStream.write(line, (err) => {


### PR DESCRIPTION
## Summary
- ensure log stream is closed when the process exits
- handle SIGINT and SIGTERM to gracefully shutdown logging

## Testing
- `npm test` *(fails: tests/bookRoutes.test.js, tests/paymentCommission.test.js, tests/paymentInvoiceEmail.test.js, tests/tutorialRoutes.test.js, tests/messageRoutes.test.js, tests/paymentAmountValidation.test.js, tests/tutorialUpdateTransaction.test.js, tests/paypalPaymentRoutes.test.js, tests/seoConfigRoutes.test.js, tests/paymentInstallments.test.js, tests/cryptoPaymentRoutes.test.js, tests/bankPaymentRoutes.test.js, tests/blogRoutes.test.js, tests/libraryRoutes.test.js, tests/socialLoginConfigService.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7aa0737c83288e31989a376ca4b8