### PR TITLE
Remove test command from backend Docker build stage

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,7 +5,6 @@ RUN apk add --no-cache curl
 COPY package*.json ./
 RUN npm ci && npm cache clean --force
 COPY . .
-RUN npm test
 
 # Production stage
 FROM node:18-alpine


### PR DESCRIPTION
## Summary
- Avoid running tests during backend image build by removing `RUN npm test`

## Testing
- `cd backend && npm test` *(fails: 17 failed, 2 skipped, 103 passed, 120 of 122 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7a9f0c0083289581974b126605f8