### PR TITLE
refactor: group auth and payment route wiring

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+
+// Authentication and user related routes
+router.use('/api/auth', require('../modules/auth/routes/auth.routes'));
+router.use('/api/users', require('../modules/users/user.routes'));
+router.use('/api/verify', require('../modules/verify/verify.routes'));
+router.use('/api/license', require('../modules/license/license.routes'));
+router.use('/api/certificates', require('../modules/users/tutorials/certificate/certificatePublic.routes'));
+router.use('/api/certificates/admin', require('../modules/users/tutorials/certificate/certificateAdmin.routes'));
+router.use('/api/certificate-templates', require('../modules/certificateTemplates/certificateTemplates.routes'));
+router.use('/api/roles', require('../modules/roles/roles.routes'));
+router.use('/api/plans', require('../modules/plans/plans.routes'));
+router.use('/api/user-subscriptions', require('../modules/subscriptions/subscriptions.routes'));
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -3,66 +3,16 @@ const router = express.Router();
 
 router.use('/api/health', require('./health.routes'));
 router.use('/api/cache', require('./cache.routes'));
-router.use('/api/auth', require('../modules/auth/routes/auth.routes'));
-router.use('/api/users', require('../modules/users/user.routes'));
-router.use('/api/verify', require('../modules/verify/verify.routes'));
-router.use('/api/license', require('../modules/license/license.routes'));
-router.use(
-  '/api/certificates',
-  require('../modules/users/tutorials/certificate/certificatePublic.routes')
-);
-router.use(
-  '/api/certificates/admin',
-  require('../modules/users/tutorials/certificate/certificateAdmin.routes')
-);
-router.use('/api/certificate-templates', require('../modules/certificateTemplates/certificateTemplates.routes'));
+// grouped routers
+router.use(require('./auth'));
+router.use(require('./payments'));
 router.use('/api/bookings/admin', require('../modules/bookings/bookings.routes'));
 router.use('/api/bookings/student', require('../modules/bookings/student.routes'));
 router.use('/api/bookings/instructor', require('../modules/bookings/instructor.routes'));
 router.use('/api/community/admin', require('../modules/community/admin/admin.routes'));
 router.use('/api/community', require('../modules/community/public/public.routes'));
 router.use('/api/related-questions', require('../modules/community/public/relatedQuestions.routes'));
-router.use('/api/roles', require('../modules/roles/roles.routes'));
-router.use('/api/plans', require('../modules/plans/plans.routes'));
-router.use(
-  '/api/user-subscriptions',
-  require('../modules/subscriptions/subscriptions.routes')
-);
-// Register admin routes before public routes to prevent public routes from catching
-// requests intended for admin endpoints such as "/api/payment-methods/admin".
-router.use(
-  '/api/payment-methods/admin',
-  require('../modules/paymentMethods/paymentMethods.routes')
-);
-router.use(
-  '/api/payment-methods',
-  require('../modules/paymentMethods/paymentMethods.public.routes')
-);
-router.use('/api/payments/student', require('../modules/payments/student.routes'));
-router.use('/api/payments/bank', require('../modules/payments/bank.routes'));
-router.use('/api/payments/crypto', require('../modules/payments/crypto.routes'));
-router.use('/api/payments/coinbase', require('../modules/payments/coinbase.routes'));
-// Alias for NOWPayments crypto gateway
-router.use(
-  '/api/payments/nowpayments',
-  require('../modules/payments/crypto.routes')
-);
-// PayPal order creation and callback
-router.use(
-  '/api/payments/paypal',
-  require('../modules/payments/paypal.routes')
-);
-router.use('/api/payments/stripe', require('../modules/payments/stripe.routes'));
-router.use('/api/payments/admin', require('../modules/payments/payments.routes'));
-router.use('/api/invoices/admin', require('../modules/invoices/invoices.routes'));
-router.use('/api/invoices/student', require('../modules/invoices/student.routes'));
-router.use('/api/invoices/instructor', require('../modules/invoices/instructor.routes'));
-router.use(
-  '/api/admin/payments/bank',
-  require('../modules/payments/bank.admin.routes')
-);
 router.use('/api/admin/cache', require('./cache.routes'));
-router.use('/api/payments/config', require('../modules/paymentConfig/paymentConfig.routes'));
 router.use('/api/messages/config', require('../modules/messagesConfig/messagesConfig.routes'));
 router.use('/api/social-login/config', require('../modules/socialLoginConfig/socialLoginConfig.routes'));
 router.use('/api/app-config', require('../modules/appConfig/appConfig.routes'));
@@ -76,7 +26,6 @@ router.use('/api/contact', require('../modules/contact/contact.routes'));
 router.use('/api/seo-config', require('../modules/seoConfig/seoConfig.routes'));
 router.use('/api/popup-announcements', require('../modules/popupAnnouncements/popupAnnouncements.routes'));
 router.use('/api/policies', require('../modules/policies/policies.routes'));
-router.use('/api/payouts', require('../modules/payouts/payouts.routes'));
 router.use('/api/ads', require('../modules/ads/ads.routes'));
 router.use('/api/coupons', require('../modules/coupons/coupons.routes'));
 router.use('/api/groups', require('../modules/groups/groups.routes'));

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const router = express.Router();
+
+// Payment related routes
+// Register admin payment-methods before public routes
+router.use('/api/payment-methods/admin', require('../modules/paymentMethods/paymentMethods.routes'));
+router.use('/api/payment-methods', require('../modules/paymentMethods/paymentMethods.public.routes'));
+router.use('/api/payments/student', require('../modules/payments/student.routes'));
+router.use('/api/payments/bank', require('../modules/payments/bank.routes'));
+router.use('/api/payments/crypto', require('../modules/payments/crypto.routes'));
+router.use('/api/payments/coinbase', require('../modules/payments/coinbase.routes'));
+// Alias for NOWPayments crypto gateway
+router.use('/api/payments/nowpayments', require('../modules/payments/crypto.routes'));
+// PayPal order creation and callback
+router.use('/api/payments/paypal', require('../modules/payments/paypal.routes'));
+router.use('/api/payments/stripe', require('../modules/payments/stripe.routes'));
+router.use('/api/payments/admin', require('../modules/payments/payments.routes'));
+router.use('/api/invoices/admin', require('../modules/invoices/invoices.routes'));
+router.use('/api/invoices/student', require('../modules/invoices/student.routes'));
+router.use('/api/invoices/instructor', require('../modules/invoices/instructor.routes'));
+router.use('/api/admin/payments/bank', require('../modules/payments/bank.admin.routes'));
+router.use('/api/payments/config', require('../modules/paymentConfig/paymentConfig.routes'));
+router.use('/api/payouts', require('../modules/payouts/payouts.routes'));
+
+module.exports = router;

--- a/backend/tests/authForgotPasswordRoutes.test.js
+++ b/backend/tests/authForgotPasswordRoutes.test.js
@@ -13,13 +13,24 @@ jest.mock('../src/modules/users/user.model', () => ({
   findByEmail: jest.fn(),
 }));
 
+// Mock unrelated routes used by grouped auth router
+jest.mock('../src/modules/users/user.routes', () => require('express').Router());
+jest.mock('../src/modules/verify/verify.routes', () => require('express').Router());
+jest.mock('../src/modules/license/license.routes', () => require('express').Router());
+jest.mock('../src/modules/users/tutorials/certificate/certificatePublic.routes', () => require('express').Router());
+jest.mock('../src/modules/users/tutorials/certificate/certificateAdmin.routes', () => require('express').Router());
+jest.mock('../src/modules/certificateTemplates/certificateTemplates.routes', () => require('express').Router());
+jest.mock('../src/modules/roles/roles.routes', () => require('express').Router());
+jest.mock('../src/modules/plans/plans.routes', () => require('express').Router());
+jest.mock('../src/modules/subscriptions/subscriptions.routes', () => require('express').Router());
+
 const service = require('../src/modules/auth/services/auth.service');
 const userModel = require('../src/modules/users/user.model');
-const routes = require('../src/modules/auth/routes/auth.routes');
+const routes = require('../src/routes/auth');
 
 const app = express();
 app.use(express.json());
-app.use('/api/auth', routes);
+app.use(routes);
 
 const errorHandler = require('../src/middleware/errorHandler');
 app.use(errorHandler);

--- a/backend/tests/authResetPasswordRoutes.test.js
+++ b/backend/tests/authResetPasswordRoutes.test.js
@@ -9,12 +9,23 @@ jest.mock('../src/modules/auth/services/auth.service', () => ({
   resetPassword: jest.fn(),
 }));
 
+// Mock unrelated routes used by grouped auth router
+jest.mock('../src/modules/users/user.routes', () => require('express').Router());
+jest.mock('../src/modules/verify/verify.routes', () => require('express').Router());
+jest.mock('../src/modules/license/license.routes', () => require('express').Router());
+jest.mock('../src/modules/users/tutorials/certificate/certificatePublic.routes', () => require('express').Router());
+jest.mock('../src/modules/users/tutorials/certificate/certificateAdmin.routes', () => require('express').Router());
+jest.mock('../src/modules/certificateTemplates/certificateTemplates.routes', () => require('express').Router());
+jest.mock('../src/modules/roles/roles.routes', () => require('express').Router());
+jest.mock('../src/modules/plans/plans.routes', () => require('express').Router());
+jest.mock('../src/modules/subscriptions/subscriptions.routes', () => require('express').Router());
+
 const service = require('../src/modules/auth/services/auth.service');
-const routes = require('../src/modules/auth/routes/auth.routes');
+const routes = require('../src/routes/auth');
 
 const app = express();
 app.use(express.json());
-app.use('/api/auth', routes);
+app.use(routes);
 
 const errorHandler = require('../src/middleware/errorHandler');
 app.use(errorHandler);

--- a/backend/tests/authVerificationRoutes.test.js
+++ b/backend/tests/authVerificationRoutes.test.js
@@ -10,12 +10,23 @@ jest.mock('../src/modules/auth/services/auth.service', () => ({
   confirmVerificationOtp: jest.fn(),
 }));
 
+// Mock unrelated routes used by the grouped auth router
+jest.mock('../src/modules/users/user.routes', () => require('express').Router());
+jest.mock('../src/modules/verify/verify.routes', () => require('express').Router());
+jest.mock('../src/modules/license/license.routes', () => require('express').Router());
+jest.mock('../src/modules/users/tutorials/certificate/certificatePublic.routes', () => require('express').Router());
+jest.mock('../src/modules/users/tutorials/certificate/certificateAdmin.routes', () => require('express').Router());
+jest.mock('../src/modules/certificateTemplates/certificateTemplates.routes', () => require('express').Router());
+jest.mock('../src/modules/roles/roles.routes', () => require('express').Router());
+jest.mock('../src/modules/plans/plans.routes', () => require('express').Router());
+jest.mock('../src/modules/subscriptions/subscriptions.routes', () => require('express').Router());
+
 const service = require('../src/modules/auth/services/auth.service');
-const routes = require('../src/modules/auth/routes/auth.routes');
+const routes = require('../src/routes/auth');
 
 const app = express();
 app.use(express.json());
-app.use('/api/auth', routes);
+app.use(routes);
 
 const errorHandler = require('../src/middleware/errorHandler');
 app.use(errorHandler);

--- a/backend/tests/authVerifyOtpRoutes.test.js
+++ b/backend/tests/authVerifyOtpRoutes.test.js
@@ -9,12 +9,23 @@ jest.mock('../src/modules/auth/services/auth.service', () => ({
   verifyOtp: jest.fn(),
 }));
 
+// Mock unrelated routes used by grouped auth router
+jest.mock('../src/modules/users/user.routes', () => require('express').Router());
+jest.mock('../src/modules/verify/verify.routes', () => require('express').Router());
+jest.mock('../src/modules/license/license.routes', () => require('express').Router());
+jest.mock('../src/modules/users/tutorials/certificate/certificatePublic.routes', () => require('express').Router());
+jest.mock('../src/modules/users/tutorials/certificate/certificateAdmin.routes', () => require('express').Router());
+jest.mock('../src/modules/certificateTemplates/certificateTemplates.routes', () => require('express').Router());
+jest.mock('../src/modules/roles/roles.routes', () => require('express').Router());
+jest.mock('../src/modules/plans/plans.routes', () => require('express').Router());
+jest.mock('../src/modules/subscriptions/subscriptions.routes', () => require('express').Router());
+
 const service = require('../src/modules/auth/services/auth.service');
-const routes = require('../src/modules/auth/routes/auth.routes');
+const routes = require('../src/routes/auth');
 
 const app = express();
 app.use(express.json());
-app.use('/api/auth', routes);
+app.use(routes);
 
 const errorHandler = require('../src/middleware/errorHandler');
 app.use(errorHandler);

--- a/backend/tests/paypalPaymentRoutes.test.js
+++ b/backend/tests/paypalPaymentRoutes.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 jest.mock('../src/modules/payments/payments.service', () => ({
   create: jest.fn(),
+  STATUS: { PENDING_PAYMENT: 'PENDING_PAYMENT', PAID: 'PAID', REJECTED: 'REJECTED' },
 }));
 
 jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
@@ -26,16 +27,32 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
   isStudent: (_req, _res, next) => next(),
 }));
 
+// Mock unrelated routes used by grouped payments router
+jest.mock('../src/modules/paymentMethods/paymentMethods.routes', () => require('express').Router());
+jest.mock('../src/modules/paymentMethods/paymentMethods.public.routes', () => require('express').Router());
+jest.mock('../src/modules/payments/student.routes', () => require('express').Router());
+jest.mock('../src/modules/payments/bank.routes', () => require('express').Router());
+jest.mock('../src/modules/payments/crypto.routes', () => require('express').Router());
+jest.mock('../src/modules/payments/coinbase.routes', () => require('express').Router());
+jest.mock('../src/modules/payments/stripe.routes', () => require('express').Router());
+jest.mock('../src/modules/payments/payments.routes', () => require('express').Router());
+jest.mock('../src/modules/invoices/invoices.routes', () => require('express').Router());
+jest.mock('../src/modules/invoices/student.routes', () => require('express').Router());
+jest.mock('../src/modules/invoices/instructor.routes', () => require('express').Router());
+jest.mock('../src/modules/payments/bank.admin.routes', () => require('express').Router());
+jest.mock('../src/modules/paymentConfig/paymentConfig.routes', () => require('express').Router());
+jest.mock('../src/modules/payouts/payouts.routes', () => require('express').Router());
+
 const paymentsService = require('../src/modules/payments/payments.service');
 const methodsService = require('../src/modules/paymentMethods/paymentMethods.service');
 const configService = require('../src/modules/paymentConfig/paymentConfig.service');
 const paypalService = require('../src/services/paypalService');
 const plansService = require('../src/modules/plans/plans.service');
-const routes = require('../src/modules/payments/paypal.routes');
+const routes = require('../src/routes/payments');
 
 const app = express();
 app.use(express.json());
-app.use('/api/payments/paypal', routes);
+app.use(routes);
 const errorHandler = require('../src/middleware/errorHandler');
 app.use(errorHandler);
 


### PR DESCRIPTION
## Summary
- add auth and payment sub-routers for cleaner registration
- simplify `routes/index.js` to use grouped routers
- adjust tests to import new sub-routers

## Testing
- `cd backend && npm test tests/authVerificationRoutes.test.js tests/authResetPasswordRoutes.test.js tests/authForgotPasswordRoutes.test.js tests/authVerifyOtpRoutes.test.js tests/paypalPaymentRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf7a9682e083289e7dcfdad9ae6da1