### PR TITLE
chore: run backend container as non-root

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,10 +10,13 @@ RUN npm test
 # Production stage
 FROM node:18-alpine
 WORKDIR /app
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl && \
+    (id -u node 2>/dev/null || adduser -S node)
 COPY package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/knexfile.js ./knexfile.js
+RUN chown -R node:node /app
 EXPOSE 5002
+USER node
 CMD ["node", "src/server.js"]


### PR DESCRIPTION
## Summary
- create `node` user in backend image
- switch to unprivileged `node` user at runtime
- chown application files for the node user

## Testing
- `npm test` *(fails: 17 failed, 103 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7a9f0c248328979198597bec96a6