### PR TITLE
fix: allow string ids and fallback test db

### DIFF
--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -3,10 +3,21 @@ const knex = require('knex');
 const knexfile = require('../../knexfile.js');
 
 const environment = process.env.NODE_ENV || 'development';
-const config = knexfile[environment];
+let config = knexfile[environment];
 
+// In test environments the database connection details may be omitted.
+// Fallback to an in-memory SQLite database so modules can require the DB
+// without throwing configuration errors.
 if (!config || !config.connection) {
-  throw new Error(`${environment} database configuration is missing`);
+  if (environment === 'test') {
+    config = {
+      client: 'sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    };
+  } else {
+    throw new Error(`${environment} database configuration is missing`);
+  }
 }
 
 const db = knex({ ...config, pool: { min: 2, max: 10 } });

--- a/backend/src/modules/messages/messages.validator.js
+++ b/backend/src/modules/messages/messages.validator.js
@@ -1,7 +1,10 @@
 const { z } = require("zod");
 
+// Keep the `id` parameter as a string so downstream services receive it in
+// its original form. Allow any non-empty string since some routes (like
+// video call IDs) use alphanumeric identifiers.
 const idParams = z.object({
-  id: z.coerce.number().int(),
+  id: z.string().trim().min(1),
 });
 
 exports.idParam = {


### PR DESCRIPTION
## Summary
- fallback to in-memory SQLite when test DB config is missing
- treat message route IDs as non-empty strings to support alphanumeric values

## Testing
- `npm test`
- `npm test -- tests/messageRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf8a0265f08328a4a33bf4f0daa1e5