### PR TITLE
Default to SMTP port 587 when unspecified

### DIFF
--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -22,7 +22,11 @@ async function createTransporter() {
   const cfg = (await emailConfigService.getSettings()) || {};
 
   const host = (cfg.smtpHost || process.env.SMTP_HOST || "").trim();
-  const port = parseInt(cfg.smtpPort || process.env.SMTP_PORT, 10);
+  const rawPort = cfg.smtpPort || process.env.SMTP_PORT;
+  const port = parseInt(rawPort, 10) || 587;
+  if (port === 587 && rawPort !== "587") {
+    logger.warn("SMTP port not specified or invalid; defaulting to 587");
+  }
   const user = (cfg.username || process.env.SMTP_USER || "").trim();
   const pass = (cfg.password || process.env.SMTP_PASS || "").trim();
 


### PR DESCRIPTION
## Summary
- Use port 587 as a fallback in `createTransporter`
- Warn when SMTP port is missing or invalid

## Testing
- `npm test` *(fails: Route.post() requires a callback function...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8b5a88bc83289fcaa429f0f0fd9b