### PR TITLE
Default NODE_ENV to development in sample env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,8 @@ REDIS_URL=redis://redis:6379
 FRONTEND_URL=https://example.com
 APP_DOMAIN=example.com
 MAX_BLOG_IMAGE_BYTES=10485760
-NODE_ENV=production
+# Set to 'production' when deploying
+NODE_ENV=development
 
 # SMTP configuration
 SMTP_HOST=smtp.example.com


### PR DESCRIPTION
## Summary
- set `NODE_ENV` to `development` in `.env.example`
- document how to switch to production for deployment

## Testing
- `npm test 2>&1 | tail -n 20` (backend, fails: Test Suites: 17 failed)
- `CI=true npm test` (frontend) *(command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8b5977948328b4eb3262a5840f06