### PR TITLE
docs: document database url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ PGADMIN_DEFAULT_EMAIL=admin@example.com
 PGADMIN_DEFAULT_PASSWORD=change_me
 
 PORT=5002
-DATABASE_URL=postgres://user:password@db:5432/eduSkillbridge
+# The credentials in DATABASE_URL must mirror POSTGRES_USER and POSTGRES_PASSWORD above
+DATABASE_URL=postgres://postgres:change_me@db:5432/eduSkillbridge
 
 JWT_SECRET=your_jwt_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret


### PR DESCRIPTION
## Summary
- set default DATABASE_URL to match POSTGRES_USER and POSTGRES_PASSWORD
- note that DATABASE_URL credentials must mirror POSTGRES_USER and POSTGRES_PASSWORD

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test` *(fails to complete: process produced extensive output without final summary)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8b580da883289c6940ba4b51366e