### PR TITLE
Ensure logger creates directories recursively

### DIFF
--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -6,7 +6,7 @@ const LOG_DIR = path.join(__dirname, "../../logs");
 const LOG_FILE = path.join(LOG_DIR, "error.log");
 
 if (!fs.existsSync(LOG_DIR)) {
-  fs.mkdirSync(LOG_DIR);
+  fs.mkdirSync(LOG_DIR, { recursive: true });
 }
 const logStream = fs.createWriteStream(LOG_FILE, { flags: "a" });
 


### PR DESCRIPTION
## Summary
- Ensure `logger` creates its `logs` directory recursively

## Testing
- `npm test` *(fails: 17 failed, 103 passed)*
- `JWT_SECRET=1 REFRESH_TOKEN_SECRET=1 SESSION_SECRET=1 DATABASE_URL=postgres://localhost:5432/db node -e "global.config=require('./src/config/env'); require('./src/server');"` *(fails: database connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8b5734c8832882b4db5d4cd54a15