### PR TITLE
fix: validate SMTP port before creating transporter

### DIFF
--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -22,7 +22,18 @@ async function createTransporter() {
   const cfg = (await emailConfigService.getSettings()) || {};
 
   const host = (cfg.smtpHost || process.env.SMTP_HOST || "").trim();
-  const port = parseInt(cfg.smtpPort || process.env.SMTP_PORT, 10);
+  const rawPort = cfg.smtpPort || process.env.SMTP_PORT;
+  const defaultPort = 587;
+  let port = Number.parseInt(rawPort, 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    if (rawPort) {
+      logger.error(`Invalid SMTP port "${rawPort}". Falling back to ${defaultPort}.`);
+    }
+    port = defaultPort;
+  }
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid SMTP port: ${port}`);
+  }
   const user = (cfg.username || process.env.SMTP_USER || "").trim();
   const pass = (cfg.password || process.env.SMTP_PASS || "").trim();
 


### PR DESCRIPTION
## Summary
- default SMTP port to 587 when no valid port provided
- log and guard against invalid SMTP port values

## Testing
- `npm test` *(fails: tests/paymentCommission.test.js, tests/paymentInvoiceEmail.test.js, tests/tutorialRoutes.test.js, tests/paymentAmountValidation.test.js, tests/tutorialUpdateTransaction.test.js, tests/studentPaymentRoutes.test.js, tests/seoConfigRoutes.test.js, tests/paymentInstallments.test.js, tests/cryptoPaymentRoutes.test.js, tests/bankPaymentRoutes.test.js, tests/blogRoutes.test.js, tests/libraryRoutes.test.js, tests/redisConnectionExit.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8b4ecac88328b8dbaf409faf3836