### PR TITLE
Import env configuration into server

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -22,6 +22,7 @@ const { refreshCookieOptions } = require("./utils/cookie");
 const startJobs = require("./jobs");
 const { initSockets, state: socketState } = require("./sockets");
 const routes = require("./routes");
+const config = require("./config/env");
 
 // Ensure required environment secrets are present
 const requiredSecrets = [


### PR DESCRIPTION
## Summary
- import env configuration in backend server to access configured variables

## Testing
- `npm test` *(fails: tests/bookRoutes.test.js, tests/paymentCommission.test.js, tests/paymentInvoiceEmail.test.js, tests/tutorialRoutes.test.js, tests/paymentAmountValidation.test.js, tests/authSanitization.test.js, tests/studentPaymentRoutes.test.js, tests/tutorialUpdateTransaction.test.js, tests/bankPaymentRoutes.test.js, tests/blogRoutes.test.js, tests/libraryRoutes.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8b4d78448328acd376801fe2f385