### PR TITLE
chore: configure API base URL for production

### DIFF
--- a/backend/.env.production
+++ b/backend/.env.production
@@ -17,3 +17,5 @@ SMTP_PORT=587
 SMTP_SECURE=false
 SMTP_USER=your_smtp_username
 SMTP_PASS=your_smtp_password
+
+NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api


### PR DESCRIPTION
## Summary
- set `NEXT_PUBLIC_API_BASE_URL` in backend production env

## Testing
- `docker compose build frontend && docker compose up -d` *(fails: command not found: docker)*
- `cd backend && npm test` *(fails: 16 failed, 104 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8e8896448328ab3b22d22a012924