### PR TITLE
fix: update frontend healthcheck path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       - ./.env
       - ./frontend/.env.production
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:3000/api/health"]
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:3000"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
## Summary
- use root path for frontend healthcheck to avoid API rewrite

## Testing
- `docker-compose build` *(fails: No module named 'distutils')*
- `docker-compose up -d` *(fails: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_68bf8e89afa88328ba825c9cd11c97ba