### PR TITLE
feat(frontend): add production API base URL

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,2 @@
+# Production frontend environment variables
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.local.example
+!.env.production
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- allow committing the frontend production env file
- add NEXT_PUBLIC_API_BASE_URL for production build

## Testing
- `npm test src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: Cannot find module '../../services/instructor/subscriptionService')*
- `docker build -t skillbridge-frontend-test ./frontend` *(fails: cannot connect to Docker daemon / iptables permission)*


------
https://chatgpt.com/codex/tasks/task_e_68bf945e92948328b07e8deb8391355a