### PR TITLE
Use health-based dependencies for nginx service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,8 +109,10 @@ services:
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
     depends_on:
-      - backend
-      - frontend
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- wait for backend and frontend health before starting nginx

## Testing
- `docker-compose up -d` *(fails: Couldn't find env file: /workspace/Skillbridge/.env)*

------
https://chatgpt.com/codex/tasks/task_e_68bf945d266c8328a423794ec26e601b