### PR TITLE
feat: expose nginx on port 80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     env_file:
       - ./.env
     ports:
-      - "8080:80"
+      - "80:80"
       - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro


### PR DESCRIPTION
## Summary
- expose nginx on standard port 80 in docker-compose configuration

## Testing
- `docker-compose up -d --build` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68bf94544f588328a2948d480fbaf539