### PR TITLE
Mount Let's Encrypt certs into Nginx container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
       - backend
       - frontend


### PR DESCRIPTION
## Summary
- mount /etc/letsencrypt into the nginx service so deployed certs can be used

## Testing
- `certbot certonly --standalone -d eduskillbridge.net -d www.eduskillbridge.net --non-interactive --agree-tos -m admin@eduskillbridge.net`
- `ls /etc/letsencrypt/live`
- `docker-compose restart nginx`


------
https://chatgpt.com/codex/tasks/task_e_68bf945011948328a37aec3720150f31