### PR TITLE
chore: set production domain env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,35 @@
+# Example environment variables for docker-compose development
+# Copy this file to `.env` and replace placeholder values with your own.
+
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=change_me
+POSTGRES_DB=eduSkillbridge
+
+PGADMIN_DEFAULT_EMAIL=admin@example.com
+PGADMIN_DEFAULT_PASSWORD=change_me
+
+PORT=5002
+# The credentials in DATABASE_URL must mirror POSTGRES_USER and POSTGRES_PASSWORD above
+DATABASE_URL=postgres://postgres:change_me@db:5432/eduSkillbridge
+
+JWT_SECRET=your_jwt_secret
+REFRESH_TOKEN_SECRET=your_refresh_token_secret
+SESSION_SECRET=your_session_secret
+REDIS_URL=redis://redis:6379
+FRONTEND_URL=https://eduskillbridge.net
+APP_DOMAIN=eduskillbridge.net
+MAX_BLOG_IMAGE_BYTES=10485760
+# Set to 'production' when deploying
+NODE_ENV=development
+
+# SMTP configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password
+
+# The frontend uses this URL for browser requests.
+# Replace it with your public API endpoint before deploying.
+NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
+

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api


### PR DESCRIPTION
## Summary
- configure production domain variables in backend .env
- point frontend API base URL to eduskillbridge domain

## Testing
- `docker compose up -d --build` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bf944c83e083288caa52c868bb68b1