### PR TITLE
chore: enforce https for frontend env variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 APP_DOMAIN=eduskillbridge.net
 FRONTEND_URL=https://eduskillbridge.net
+
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+NEXT_PUBLIC_SOCKET_URL=https://eduskillbridge.net


### PR DESCRIPTION
## Summary
- ensure public API and socket URLs use `https://eduskillbridge.net`

## Testing
- `docker-compose up --build -d frontend` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_68bf9a156a148328bbd9737e3505bddf