### PR TITLE
Set production API and domain URLs for frontend

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,3 @@
+APP_DOMAIN=eduskillbridge.net
 NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
 NEXT_PUBLIC_SOCKET_URL=https://eduskillbridge.net


### PR DESCRIPTION
## Summary
- define APP_DOMAIN, API base URL, and socket URL in `frontend/.env.production`

## Testing
- `docker compose build frontend` *(fails: docker: 'compose' is not a docker command)*
- `docker-compose build frontend` *(fails: Error while fetching server API version: FileNotFoundError / connection refused)*
- `docker-compose up -d frontend` *(fails: Error while fetching server API version: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_68bf99fed72883288dec72202007bdde