### PR TITLE
feat: integrate GA via Next.js Script component

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -48,7 +48,24 @@ const app = express();
 app.set('trust proxy', 1);
 const server = http.createServer(app);
 
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: {
+        "script-src": [
+          "'self'",
+          "'unsafe-inline'",
+          "https://www.googletagmanager.com",
+        ],
+        "connect-src": [
+          "'self'",
+          "https://www.google-analytics.com",
+        ],
+      },
+    },
+  })
+);
 
 // 🌐 Fix CORS (must be very early)
 const FRONTEND_ORIGINS = (process.env.FRONTEND_URL || "http://localhost:3000")

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { appWithTranslation, useTranslation } from "next-i18next";
 import useSWR from "swr";
 import nextI18NextConfig from "../../next-i18next.config.js";
@@ -30,6 +30,7 @@ import SeoTags from "@/components/common/SeoTags";
 import PageLoader from "@/components/PageLoader";
 import PopupAnnouncement from "@/components/common/PopupAnnouncement";
 import { API_BASE_URL } from "@/config/config";
+import Script from "next/script";
 
 const langFetcher = () => getLanguages();
 
@@ -68,6 +69,7 @@ function MyApp({ Component, pageProps, router }) {
   const { data: langs } = useSWR("/languages", langFetcher);
   const currentLang = langs?.find((l) => l.code === i18n.language);
   const user = useAuthStore((s) => s.user);
+  const [gaId, setGaId] = useState(null);
 
   useEffect(() => {
     const local = localStorage.getItem("auth");
@@ -111,18 +113,7 @@ function MyApp({ Component, pageProps, router }) {
       })
       .then((cfg) => {
         if (cfg.enabled && cfg.measurementId) {
-          if (!document.querySelector(`script[data-ga-measurement-id="${cfg.measurementId}"]`)) {
-            const s = document.createElement('script');
-            s.async = true;
-            s.src = `https://www.googletagmanager.com/gtag/js?id=${cfg.measurementId}`;
-            s.dataset.gaMeasurementId = cfg.measurementId;
-            document.head.appendChild(s);
-
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){window.dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', cfg.measurementId);
-          }
+          setGaId(cfg.measurementId);
         }
       })
       .catch((err) => console.error('Failed to load Google Analytics', err));
@@ -193,6 +184,22 @@ function MyApp({ Component, pageProps, router }) {
     return (
       <>
         <PageLoader />
+        {gaId && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+              strategy="afterInteractive"
+            />
+            <Script id="ga-inline" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${gaId}');
+              `}
+            </Script>
+          </>
+        )}
         <AnimatePresence mode="wait">
           {/* Motion wrapper for route transition */}
           <motion.div


### PR DESCRIPTION
## Summary
- replace dynamic GA script injection with Next.js Script helper and inline init
- allow Google Analytics domains in Helmet CSP configuration

## Testing
- `npm test` (backend) *(fails: Test Suites: 16 failed, 2 skipped, 104 passed)*
- `npm test` (frontend) *(see console output; test run with many passes)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9e6b5a6c83289f2e2c17055452e5