### PR TITLE
Use NetworkFirst for scripts and styles

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-globals */
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
 
-const CACHE_VERSION = 'V1';
+const CACHE_VERSION = 'V2';
 const WARM_CACHE = `SKILLBRIDGE-WARM-${CACHE_VERSION}`;
 const HTML_CACHE = `SKILLBRIDGE-HTML-${CACHE_VERSION}`;
 const ASSET_CACHE = `SKILLBRIDGE-ASSETS-${CACHE_VERSION}`;
@@ -72,7 +72,7 @@ workbox.routing.setCatchHandler(async ({ event }) => {
 
 workbox.routing.registerRoute(
   ({ request }) => request.destination === 'script' || request.destination === 'style',
-  new workbox.strategies.StaleWhileRevalidate({
+  new workbox.strategies.NetworkFirst({
     cacheName: ASSET_CACHE,
   })
 );


### PR DESCRIPTION
## Summary
- use NetworkFirst strategy for scripts and styles in service worker
- bump CACHE_VERSION to V2

## Testing
- `CI=true npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' in InstructorSettingsPage.test.js)*
- `npm run lint`
- `npm run build` *(terminated: long-running build)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9e5aa63483288b024f4198f2593b