### PR TITLE
Use server-side redirect on home page

### DIFF
--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,10 +1,12 @@
-import { useEffect } from "react";
-import { useRouter } from "next/router";
-
 export default function Home() {
-  const router = useRouter();
+  return null;
+}
 
-  useEffect(() => { router.push("/auth/login"); }, [router]);
-
-  return null; // Empty page, as it redirects automatically
+export function getServerSideProps() {
+  return {
+    redirect: {
+      destination: "/auth/login",
+      permanent: false,
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- redirect home page to login using Next.js server-side props

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js')*
- `npm run lint` *(fails: Component definition is missing display name, unexpected console statement)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9e6a83a48328acca2bb6779b459e