### PR TITLE
refactor: centralize cache version

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-globals */
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
 
-const CACHE_VERSION = 'V1';
+import { CACHE_VERSION } from '../src/config/pwa.js';
 const WARM_CACHE = `SKILLBRIDGE-WARM-${CACHE_VERSION}`;
 const HTML_CACHE = `SKILLBRIDGE-HTML-${CACHE_VERSION}`;
 const ASSET_CACHE = `SKILLBRIDGE-ASSETS-${CACHE_VERSION}`;

--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
+import { CACHE_VERSION } from "@/config/pwa";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
+const WARM_CACHE = `SKILLBRIDGE-WARM-${CACHE_VERSION}`;
 
 type Status = "idle" | "caching" | "success" | "error";
 
@@ -46,7 +48,7 @@ export default function CacheManager({
 
   const clearCache = async () => {
     try {
-      await caches.delete("SKILLBRIDGE-WARM-V1");
+      await caches.delete(WARM_CACHE);
       if (strategy === "B") {
         const registration = await navigator.serviceWorker.ready;
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });

--- a/frontend/src/config/pwa.js
+++ b/frontend/src/config/pwa.js
@@ -1,0 +1,1 @@
+export const CACHE_VERSION = 'V1';


### PR DESCRIPTION
## Summary
- add shared `CACHE_VERSION` constant for PWA caches
- use shared constant in service worker and cache manager

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService')*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9e5961cc83289b3396eb075cf988