### PR TITLE
chore(frontend): expand tailwind content paths

### DIFF
--- a/frontend/tailwind.config.mjs
+++ b/frontend/tailwind.config.mjs
@@ -1,10 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 const config = {
-  content: [
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./app/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- simplify Tailwind's `content` glob to scan all files under `src`

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bf9e695b9c83288fda41f4690033ae