### PR TITLE
Configure Helmet CSP

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -48,7 +48,19 @@ const app = express();
 app.set('trust proxy', 1);
 const server = http.createServer(app);
 
-app.use(helmet());
+// Configure security headers
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+      },
+    },
+    crossOriginEmbedderPolicy: false,
+  })
+);
 
 // 🌐 Fix CORS (must be very early)
 const FRONTEND_ORIGINS = (process.env.FRONTEND_URL || "http://localhost:3000")


### PR DESCRIPTION
## Summary
- configure helmet with CSP allowing 'self' and 'unsafe-inline' for scripts and styles
- disable cross-origin-embedder-policy to prevent CSP violations

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined], invoice email tests failing, etc.)*
- `NODE_ENV=test node -e "const srv=require('./src/server'); srv.startServer().then(()=>console.log('server started'));"` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9e69d9348328ad881202856c5439