### PR TITLE
refactor: remove react-hot-toast and use react-toastify

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,7 +62,6 @@
         "react-easy-crop": "^5.4.1",
         "react-google-recaptcha-v3": "^1.11.0",
         "react-hook-form": "^7.56.4",
-        "react-hot-toast": "^2.5.2",
         "react-i18next": "^15.4.1",
         "react-icons": "^5.4.0",
         "react-markdown": "^10.0.0",
@@ -7765,15 +7764,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/goober": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
-      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -13099,23 +13089,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
-      }
-    },
-    "node_modules/react-hot-toast": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
-      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.3",
-        "goober": "^2.1.16"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
       }
     },
     "node_modules/react-i18next": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,6 @@
     "react-easy-crop": "^5.4.1",
     "react-google-recaptcha-v3": "^1.11.0",
     "react-hook-form": "^7.56.4",
-    "react-hot-toast": "^2.5.2",
     "react-i18next": "^15.4.1",
     "react-icons": "^5.4.0",
     "react-markdown": "^10.0.0",

--- a/frontend/src/components/admin/roles/PermissionAssignment.js
+++ b/frontend/src/components/admin/roles/PermissionAssignment.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { CheckCircle, CheckSquare, PlusCircle } from "lucide-react";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
 import {
   fetchAllPermissions,

--- a/frontend/src/components/admin/roles/RoleManagement.js
+++ b/frontend/src/components/admin/roles/RoleManagement.js
@@ -4,7 +4,7 @@ import useAuthStore from "@/store/auth/authStore";
 import PermissionAssignment from "./PermissionAssignment";
 import AddRoleModal from "./AddRoleModal";
 import EditRoleModal from "./EditRoleModal";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import {
   fetchAllRoles,
   fetchRoleById,

--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
 import Image from "next/image";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import useCartStore from "@/store/cart/cartStore";
 import useAuthStore from "@/store/auth/authStore";
 import { useTranslation } from "next-i18next";

--- a/frontend/src/components/books/BookForm.js
+++ b/frontend/src/components/books/BookForm.js
@@ -5,7 +5,7 @@ import { fetchBookTags, createBookTag } from "@/services/bookTagService";
 import { getLanguages } from "@/services/languageService";
 import debounce from "lodash/debounce";
 import { MAX_IMAGE_SIZE, MAX_IMAGE_SIZE_MB } from "@/utils/constants";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 
 export default function BookForm({
   onSubmit,

--- a/frontend/src/components/books/BookReviewForm.js
+++ b/frontend/src/components/books/BookReviewForm.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { createReview } from "@/services/bookReviewService";
 import useAuthStore from "@/store/auth/authStore";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 
 export default function BookReviewForm({ bookId, onSubmitted }) {

--- a/frontend/src/components/books/FilterSidebar.js
+++ b/frontend/src/components/books/FilterSidebar.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { FaTimesCircle } from "react-icons/fa";
 import { fetchBookCategories } from "@/services/bookCategoryService";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import {
   BOOK_PRICE_RANGE_DEFAULT,

--- a/frontend/src/components/chat/GroupChat.js
+++ b/frontend/src/components/chat/GroupChat.js
@@ -4,7 +4,7 @@ import MessageList from "./MessageList";
 import TypingIndicator from "./TypingIndicator";
 import ChatHeader from "./ChatHeader";
 import groupService from "@/services/groupService";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 
 
 export default function GroupChat({ group, groupId: idProp, groupName: nameProp }) {

--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import useAuthStore from '@/store/auth/authStore';
 import { X, Mail, Smartphone, Image as ImageIcon, Tag, Users } from 'lucide-react';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 import groupService from '@/services/groupService';
 import { fetchAllCategories } from '@/services/instructor/categoryService';
 import userService from '@/services/profile/userService';

--- a/frontend/src/components/groups/GroupMembersList.js
+++ b/frontend/src/components/groups/GroupMembersList.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import groupService from "@/services/groupService";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import { FaUserSlash, FaVolumeMute, FaUserShield, FaBan } from "react-icons/fa";
 
 export default function GroupMembersList({

--- a/frontend/src/components/groups/JoinRequestCard.js
+++ b/frontend/src/components/groups/JoinRequestCard.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import groupService from '@/services/groupService';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 
 export default function JoinRequestCard({ groupId, onCountChange }) {
   const [requests, setRequests] = useState([]);

--- a/frontend/src/components/tutorials/create/CurriculumStep.js
+++ b/frontend/src/components/tutorials/create/CurriculumStep.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "next-i18next";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import { FaPlus, FaTrash, FaPlay } from "react-icons/fa";
 import { uploadChapterVideo } from "@/services/admin/tutorialChapterService";
 

--- a/frontend/src/components/tutorials/detail/TutorialPlayer.js
+++ b/frontend/src/components/tutorials/detail/TutorialPlayer.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import { useRouter } from "next/router";
 import {
   Play,

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -3,8 +3,7 @@ import { appWithTranslation, useTranslation } from "next-i18next";
 import useSWR from "swr";
 import nextI18NextConfig from "../../next-i18next.config.js";
 import { motion, AnimatePresence } from "framer-motion";
-import { Toaster, toast } from "react-hot-toast";
-import { ToastContainer } from "react-toastify";
+import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import "react-quill/dist/quill.snow.css";       // ✅ Rich text editor
 import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
@@ -229,17 +228,6 @@ function MyApp({ Component, pageProps, router }) {
               />
             )}
 
-            {/* Global Toast Message Containers */}
-            <Toaster
-              position="top-center"
-              toastOptions={{
-                duration: 3000,
-                style: {
-                  background: "#333",
-                  color: "#fff",
-                },
-              }}
-            />
             {/* Display React Toastify notifications centered at the top */}
             <ToastContainer position="top-center" autoClose={3000} />
           </motion.div>

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import BookForm from "@/components/books/BookForm";

--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -10,7 +10,7 @@ import { fetchBookTags } from "@/services/bookTagService";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { FiPlus, FiSearch, FiTrash2, FiChevronLeft, FiChevronRight, FiFilter, FiX, FiEdit, FiEye } from "react-icons/fi";
 import { Switch } from '@headlessui/react';

--- a/frontend/src/pages/dashboard/admin/books/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/view/[id].js
@@ -13,7 +13,7 @@ import {
   FiImage,
 } from "react-icons/fi";
 import Link from "next/link";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -20,7 +20,7 @@ import {
   FaFolderOpen,
 } from 'react-icons/fa';
 import groupService from '@/services/groupService';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 
 // ...imports (same as before)...
 

--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -12,7 +12,7 @@ import {
   FaRegSquare,
 } from 'react-icons/fa';
 import groupService from '@/services/groupService';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 import ConfirmModal from '@/components/common/ConfirmModal';
 
 const imagePool = [

--- a/frontend/src/pages/dashboard/admin/permissions/index.js
+++ b/frontend/src/pages/dashboard/admin/permissions/index.js
@@ -3,7 +3,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import useAuthStore from "@/store/auth/authStore";
 import { PlusCircle, Trash2 } from "lucide-react";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -11,7 +11,7 @@ import { fetchBookTags } from "@/services/bookTagService";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { FiPlus, FiSearch, FiTrash2, FiChevronLeft, FiChevronRight, FiFilter, FiX, FiEdit, FiEye } from "react-icons/fi";
 // Switch removed as status is no longer a simple toggle

--- a/frontend/src/pages/dashboard/instructor/community/ask.js
+++ b/frontend/src/pages/dashboard/instructor/community/ask.js
@@ -3,7 +3,7 @@ import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { FaPaperPlane } from "react-icons/fa";
 import { useRouter } from "next/router";
 import { createDiscussion, searchTags } from "@/services/communityService";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 
 export default function AskQuestionPage() {
   const [title, setTitle] = useState("");

--- a/frontend/src/pages/dashboard/instructor/community/index.js
+++ b/frontend/src/pages/dashboard/instructor/community/index.js
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import Link from "next/link";
 import { FaSearch, FaPlus, FaTags } from "react-icons/fa";
-import toast, { Toaster } from "react-hot-toast";
+import { toast } from "react-toastify";
 import { fetchDiscussions, searchTags } from "@/services/communityService";
 import useAuthStore from "@/store/auth/authStore";
 
@@ -59,7 +59,6 @@ export default function InstructorCommunityPage() {
 
   return (
     <InstructorLayout title="Community">
-      <Toaster position="top-center" />
       <div className="p-6 max-w-5xl mx-auto">
         {/* Header + CTA */}
         <div className="flex justify-between items-center mb-6">

--- a/frontend/src/pages/dashboard/instructor/groups/[id].js
+++ b/frontend/src/pages/dashboard/instructor/groups/[id].js
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import Link from "next/link";
 import GroupChat from "@/components/chat/GroupChat";
 import GroupMembersList from "@/components/groups/GroupMembersList";

--- a/frontend/src/pages/dashboard/instructor/groups/explore.js
+++ b/frontend/src/pages/dashboard/instructor/groups/explore.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Search } from 'lucide-react';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 import groupService from '@/services/groupService';
 
 export default function ExploreGroupsPage() {

--- a/frontend/src/pages/dashboard/instructor/groups/my-groups.js
+++ b/frontend/src/pages/dashboard/instructor/groups/my-groups.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 import groupService from '@/services/groupService';
 import useAuthStore from '@/store/auth/authStore';
 

--- a/frontend/src/pages/dashboard/student/books.js
+++ b/frontend/src/pages/dashboard/student/books.js
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import Image from "next/image";
 import { FiDownload, FiEye, FiHeart } from "react-icons/fi";
 import { useTranslation } from "next-i18next";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import useLibraryStore from "@/store/libraryStore";
 import useBookWishlistStore from "@/store/books/wishlistStore";
 import { API_BASE_URL } from "@/config/config";

--- a/frontend/src/pages/dashboard/student/community/ask.js
+++ b/frontend/src/pages/dashboard/student/community/ask.js
@@ -3,7 +3,7 @@ import StudentLayout from "@/components/layouts/StudentLayout";
 import { FaPaperPlane } from "react-icons/fa";
 import { useRouter } from "next/router";
 import { createDiscussion, searchTags } from "@/services/communityService";
-import toast, { Toaster } from "react-hot-toast";
+import { toast } from "react-toastify";
 
 export default function AskQuestionPage() {
   const [title, setTitle] = useState("");
@@ -65,7 +65,6 @@ export default function AskQuestionPage() {
 
   return (
     <StudentLayout title="Ask a Question">
-      <Toaster position="top-center" />
       <div className="p-6 max-w-3xl mx-auto">
         <h1 className="text-2xl font-bold mb-6">📝 Ask a New Question</h1>
 

--- a/frontend/src/pages/dashboard/student/community/index.js
+++ b/frontend/src/pages/dashboard/student/community/index.js
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import Link from "next/link";
 import { FaSearch, FaPlus, FaTags } from "react-icons/fa";
-import toast, { Toaster } from "react-hot-toast";
+import { toast } from "react-toastify";
 import { fetchDiscussions } from "@/services/communityService";
 import useAuthStore from "@/store/auth/authStore";
 
@@ -61,7 +61,6 @@ export default function StudentCommunityPage() {
 
   return (
     <StudentLayout title="Community">
-      <Toaster position="top-center" />
       <div className="p-6 max-w-5xl mx-auto">
         {/* Header + CTA */}
         <div className="flex justify-between items-center mb-6">

--- a/frontend/src/pages/dashboard/student/community/my-questions.js
+++ b/frontend/src/pages/dashboard/student/community/my-questions.js
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { FaEye } from "react-icons/fa";
 import { fetchDiscussions } from "@/services/communityService";
 import useAuthStore from "@/store/auth/authStore";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 
 export default function MyQuestionsPage() {
   const { user } = useAuthStore();

--- a/frontend/src/pages/dashboard/student/community/questions/[id].js
+++ b/frontend/src/pages/dashboard/student/community/questions/[id].js
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import { FaReply, FaUserCircle } from "react-icons/fa";
 import { fetchDiscussionById, fetchReplies, createReply } from "@/services/communityService";
-import toast, { Toaster } from "react-hot-toast";
+import { toast } from "react-toastify";
 
 export default function QuestionDetailPage() {
   const router = useRouter();
@@ -59,7 +59,6 @@ export default function QuestionDetailPage() {
 
   return (
     <StudentLayout title={question.title}>
-      <Toaster position="top-center" />
       <div className="p-6 max-w-4xl mx-auto space-y-8">
         {/* Question */}
         <div className="bg-white border border-gray-200 p-6 rounded-lg shadow">

--- a/frontend/src/pages/dashboard/student/groups/[id].js
+++ b/frontend/src/pages/dashboard/student/groups/[id].js
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import StudentLayout from '@/components/layouts/StudentLayout';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 import Link from 'next/link';
 import GroupChat from '@/components/chat/GroupChat';
 import GroupMembersList from '@/components/groups/GroupMembersList';

--- a/frontend/src/pages/dashboard/student/groups/explore.js
+++ b/frontend/src/pages/dashboard/student/groups/explore.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Search } from 'lucide-react';
 import StudentLayout from '@/components/layouts/StudentLayout';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 import groupService from '@/services/groupService';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';

--- a/frontend/src/pages/dashboard/student/groups/my-groups.js
+++ b/frontend/src/pages/dashboard/student/groups/my-groups.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import StudentLayout from '@/components/layouts/StudentLayout';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 import groupService from '@/services/groupService';
 
 export default function MyGroupsPage() {

--- a/frontend/src/pages/dashboard/student/groups/requests.js
+++ b/frontend/src/pages/dashboard/student/groups/requests.js
@@ -2,7 +2,7 @@ import StudentLayout from '@/components/layouts/StudentLayout';
 import { Clock } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import groupService from '@/services/groupService';
-import { toast } from 'react-hot-toast';
+import { toast } from 'react-toastify';
 
 export default function JoinRequestsPage() {
   const [requests, setRequests] = useState([]);

--- a/frontend/src/pages/marketplace/books/index.js
+++ b/frontend/src/pages/marketplace/books/index.js
@@ -9,8 +9,8 @@ import BookFilterSidebar from "@/components/books/FilterSidebar";
 import { fetchBooks } from "@/services/bookService";
 import useBookWishlistStore from "@/store/books/wishlistStore";
 import useCartStore from "@/store/cart/cartStore";
-// Use global react-hot-toast setup from _app.js
-import { toast } from "react-hot-toast";
+// Use global react-toastify setup from _app.js
+import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../next-i18next.config.js";

--- a/frontend/src/pages/tutorials/[id].js
+++ b/frontend/src/pages/tutorials/[id].js
@@ -12,7 +12,7 @@ import ChapterList from "@/components/tutorials/detail/ChapterList";
 import dynamic from "next/dynamic";
 import TutorialSkeleton from "@/components/tutorials/detail/TutorialSkeleton";
 import CourseProgress from "@/components/classes/CourseProgress";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
 import useCartStore from "@/store/cart/cartStore";
 import useTutorialProgress from "@/hooks/useTutorialProgress";

--- a/frontend/src/tests/__tests__/BookDetails.test.js
+++ b/frontend/src/tests/__tests__/BookDetails.test.js
@@ -12,7 +12,7 @@ jest.mock('next/router', () => ({
   useRouter: () => ({ push: jest.fn() }),
 }));
 
-jest.mock('react-hot-toast', () => ({
+jest.mock('react-toastify', () => ({
   toast: { info: jest.fn(), error: jest.fn(), success: jest.fn() },
 }));
 

--- a/frontend/src/tests/__tests__/TutorialDetailAddToCart.test.js
+++ b/frontend/src/tests/__tests__/TutorialDetailAddToCart.test.js
@@ -30,9 +30,9 @@ jest.mock('../../components/tutorials/detail/RelatedTutorials', () => createMock
 jest.mock('../../components/classes/CourseProgress', () => createMock('CourseProgress'));
 jest.mock('../../components/tutorials/detail/TutorialSkeleton', () => createMock('TutorialSkeleton'));
 
-jest.mock('react-hot-toast', () => ({
+jest.mock('react-toastify', () => ({
   __esModule: true,
-  default: { success: jest.fn(), error: jest.fn() },
+  toast: { success: jest.fn(), error: jest.fn() },
 }));
 
 jest.mock('next/link', () => ({
@@ -81,7 +81,7 @@ describe('TutorialDetail add to cart', () => {
     const button = await screen.findByRole('button', { name: /add to cart/i });
     fireEvent.click(button);
     await waitFor(() => expect(addItem).not.toHaveBeenCalled());
-    const toast = require('react-hot-toast').default;
+    const { toast } = require('react-toastify');
     expect(toast.error).toHaveBeenCalledWith('Already in cart');
   });
 });

--- a/frontend/src/tests/__tests__/TutorialPageNoChapters.test.js
+++ b/frontend/src/tests/__tests__/TutorialPageNoChapters.test.js
@@ -29,9 +29,8 @@ jest.mock('../../components/tutorials/detail/RelatedTutorials', () => createMock
 jest.mock('../../components/classes/CourseProgress', () => createMock('CourseProgress'));
 jest.mock('../../components/tutorials/detail/TutorialSkeleton', () => createMock('TutorialSkeleton'));
 
-jest.mock('react-hot-toast', () => ({
-  success: jest.fn(),
-  error: jest.fn(),
+jest.mock('react-toastify', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
 }));
 
 jest.mock('next/link', () => ({

--- a/frontend/src/tests/__tests__/bookForm.test.js
+++ b/frontend/src/tests/__tests__/bookForm.test.js
@@ -14,7 +14,7 @@ jest.mock('next-i18next', () => ({
   useTranslation: () => ({ t: (key) => key }),
 }));
 
-jest.mock('react-hot-toast', () => ({
+jest.mock('react-toastify', () => ({
   toast: { error: jest.fn() },
 }));
 
@@ -29,7 +29,7 @@ describe('BookForm', () => {
 
     render(<BookForm onSubmit={jest.fn()} categories={[]} />);
 
-    const { toast } = require('react-hot-toast');
+    const { toast } = require('react-toastify');
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to load languages'));
   });
 
@@ -45,7 +45,7 @@ describe('BookForm', () => {
     fireEvent.change(input, { target: { value: 'test' } });
 
     await waitFor(() => expect(fetchBookTags).toHaveBeenCalled());
-    const { toast } = require('react-hot-toast');
+    const { toast } = require('react-toastify');
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to fetch tags'));
   });
 });

--- a/frontend/src/tests/__tests__/shareFallback.test.js
+++ b/frontend/src/tests/__tests__/shareFallback.test.js
@@ -1,5 +1,5 @@
 import { handleShare } from '@/pages/tutorials/[id]';
-import toast from 'react-hot-toast';
+import { toast } from 'react-toastify';
 
 describe('handleShare fallback', () => {
   it('copies link to clipboard when navigator.share is unavailable', async () => {


### PR DESCRIPTION
## Summary
- remove react-hot-toast in favor of react-toastify
- update app and components to use ToastContainer and toast from react-toastify
- drop react-hot-toast dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e64ec2483288dd385631e637eb1