### PR TITLE
Fix unclosed CSS layer in global stylesheet

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -206,3 +206,5 @@ input:-webkit-autofill:focus {
     0 0 10px #fbbf24,
     0 0 5px #fbbf24;
 }
+
+}


### PR DESCRIPTION
## Summary
- close missing `@layer base` block in global Tailwind CSS file

## Testing
- `npm test`
- `npm run lint` *(fails: 44 errors, 271 warnings)*
- `npm run build` *(incomplete: process aborted while creating optimized build)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa4eb25e48328b7edaf20020385de