### PR TITLE
chore: ignore backend env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 # Local environment variables
 /.env
 /.env.production
+backend/.env
+backend/.env.production
 dist/
 coverage/
 .vscode/


### PR DESCRIPTION
## Summary
- ignore `backend/.env` and `backend/.env.production`
- verify no backend env files are tracked

## Testing
- `npm test --prefix backend` *(fails: Route.post() requires a callback function but got a [object Undefined])*

------
https://chatgpt.com/codex/tasks/task_e_68bfc1a284748328b5a762d8da4770ec