### PR TITLE
Handle missing server cache clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ npm --prefix frontend install
 
 For detailed instructions see [docs/installation.md](docs/installation.md).
 See [docs/deployment.md](docs/deployment.md) for tips on configuring environment variables when hosting the app.
+When deploying, define a `global.clearServerCache` function on the backend so the admin **Clear Cache** button can purge server-side caches; otherwise `/api/cache/clear` will return a 503 status.
 For automated production setup run the installation wizard from the project root:
 
 ```bash

--- a/backend/src/routes/cache.routes.js
+++ b/backend/src/routes/cache.routes.js
@@ -3,13 +3,20 @@ const router = express.Router();
 
 router.post('/clear', async (_req, res) => {
   try {
-    if (global.clearServerCache) {
+    if (typeof global.clearServerCache === 'function') {
       await global.clearServerCache();
+      return res.status(200).json({ status: 'cleared' });
     }
-    res.status(200).json({ status: 'cleared' });
+
+    return res.status(503).json({
+      status: 'error',
+      message: 'Server cache clearing is not available',
+    });
   } catch (err) {
     console.error('Failed to clear cache', err);
-    res.status(500).json({ status: 'error', message: 'Failed to clear cache' });
+    res
+      .status(500)
+      .json({ status: 'error', message: 'Failed to clear cache' });
   }
 });
 

--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
+import { toast } from "react-toastify";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -54,9 +55,17 @@ export default function CacheManager({
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });
       }
       try {
-        await fetch("/api/admin/cache/clear", { method: "POST" });
+        const res = await fetch("/api/admin/cache/clear", { method: "POST" });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          const message = data.message || "Failed to clear server cache";
+          toast.error(message);
+        } else {
+          toast.success("Server cache cleared");
+        }
       } catch (e) {
         console.error(e);
+        toast.error("Failed to clear server cache");
       }
       setStatus("idle");
     } catch (err) {

--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -7,7 +7,9 @@ export const clearCache = async () => {
     await api.post("/cache/clear");
     toast.success(i18n.t("dashboard.cache_cleared"));
   } catch (err) {
-    toast.error(i18n.t("dashboard.cache_clear_failed"));
+    const message =
+      err?.response?.data?.message || i18n.t("dashboard.cache_clear_failed");
+    toast.error(message);
     throw err;
   }
 };


### PR DESCRIPTION
## Summary
- return 503 when no server-side cache clearing hook is registered
- bubble cache-clear errors to admin UI and PWA cache manager
- document global.clearServerCache requirement for deployments

## Testing
- `npm --prefix backend test` (fails: Route.post() requires a callback function...)
- `npm --prefix frontend test` (terminated due to long-running output)


------
https://chatgpt.com/codex/tasks/task_e_68bfea9b2fc48328a5b68ba4a8d8efd5