### PR TITLE
refactor cache manager to use shared service

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -8,6 +8,7 @@ import useAppConfigStore from '@/store/appConfigStore';
 import { API_BASE_URL } from '@/config/config';
 import logo from '@/shared/assets/images/login/logo.png';
 import { clearCache } from '@/services/admin/cacheService';
+import { toast } from 'react-toastify';
 import { adminNavLinks } from './SidebarLinks/adminLinks';
 import { instructorNavLinks } from './SidebarLinks/instructorLinks';
 import { studentNavLinks } from './SidebarLinks/studentLinks';
@@ -31,8 +32,10 @@ export default function Sidebar({ role = 'admin' }) {
   const handleClearCache = async () => {
     try {
       await clearCache();
+      toast.success(t('cache_cleared'));
     } catch (err) {
       console.error('Failed to clear cache', err);
+      toast.error(t('cache_clear_failed'));
     }
   };
 

--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
+import { clearCache as clearServerCache } from "@/services/admin/cacheService";
+import { toast } from "react-toastify";
+import { i18n } from "next-i18next";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -53,14 +56,13 @@ export default function CacheManager({
         const registration = await navigator.serviceWorker.ready;
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });
       }
-      try {
-        await fetch("/api/admin/cache/clear", { method: "POST" });
-      } catch (e) {
-        console.error(e);
-      }
+      await clearServerCache();
+      toast.success(i18n.t("dashboard.cache_cleared"));
       setStatus("idle");
     } catch (err) {
       console.error(err);
+      toast.error(i18n.t("dashboard.cache_clear_failed"));
+      setStatus("error");
     }
   };
 

--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -1,13 +1,3 @@
 import api from "@/services/api/api";
-import { toast } from "react-toastify";
-import { i18n } from "next-i18next";
 
-export const clearCache = async () => {
-  try {
-    await api.post("/cache/clear");
-    toast.success(i18n.t("dashboard.cache_cleared"));
-  } catch (err) {
-    toast.error(i18n.t("dashboard.cache_clear_failed"));
-    throw err;
-  }
-};
+export const clearCache = () => api.post("/admin/cache/clear");

--- a/frontend/src/tests/__tests__/CacheManager.test.tsx
+++ b/frontend/src/tests/__tests__/CacheManager.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import CacheManager from '@/components/pwa/CacheManager';
+import { clearCache as mockClearCache } from '../../services/admin/cacheService';
+import { toast } from 'react-toastify';
+
+jest.mock('../../services/admin/cacheService', () => ({
+  clearCache: jest.fn(),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('next-i18next', () => ({
+  i18n: { t: (key: string) => key },
+}));
+
+const setupEnvironment = () => {
+  Object.defineProperty(window, 'caches', {
+    value: { delete: jest.fn().mockResolvedValue(true) },
+    configurable: true,
+  });
+  Object.defineProperty(window.navigator, 'serviceWorker', {
+    value: { ready: Promise.resolve({}) },
+    configurable: true,
+  });
+};
+
+describe('CacheManager', () => {
+  beforeEach(() => {
+    setupEnvironment();
+    (mockClearCache as jest.Mock).mockReset();
+    (toast.success as jest.Mock).mockReset();
+    (toast.error as jest.Mock).mockReset();
+  });
+
+  it('shows success toast when cache cleared', async () => {
+    (mockClearCache as jest.Mock).mockResolvedValue({});
+    render(<CacheManager />);
+    const button = await screen.findByText('Clear Cache');
+    fireEvent.click(button);
+    await waitFor(() => expect(mockClearCache).toHaveBeenCalled());
+    expect(toast.success).toHaveBeenCalledWith('dashboard.cache_cleared');
+  });
+
+  it('shows error toast when clearing cache fails', async () => {
+    (mockClearCache as jest.Mock).mockRejectedValue(new Error('fail'));
+    render(<CacheManager />);
+    const button = await screen.findByText('Clear Cache');
+    fireEvent.click(button);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('dashboard.cache_clear_failed'));
+  });
+});


### PR DESCRIPTION
## Summary
- use shared admin cache service in CacheManager and show toast messages
- point cache service to secured `/admin/cache/clear` endpoint
- add unit tests for CacheManager

## Testing
- `npm test src/tests/__tests__/CacheManager.test.tsx`
- `npx eslint src/components/pwa/CacheManager.tsx src/services/admin/cacheService.js src/components/dashboard/Sidebar.js src/tests/__tests__/CacheManager.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bfea99e1a88328b1da7101704bd023