### PR TITLE
Remove duplicate Clear Cache link from admin sidebar

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -107,8 +107,7 @@ export const adminNavLinks = [
           { label: 'certificate_templates', href: '/dashboard/admin/settings/certificates', icon: LayoutTemplate },
           { label: 'third_parties_config', href: '/dashboard/admin/settings/thirdParty', icon: Brain }
         ]
-      },
-      { label: 'clear_cache', href: '/dashboard/admin/cache', icon: RefreshCcw }
+      }
     ]
   }
 ];


### PR DESCRIPTION
## Summary
- remove duplicate `clear_cache` entry from admin sidebar links

## Testing
- `node -e "const {adminNavLinks}=require('./src/components/dashboard/SidebarLinks/adminLinks.js');const count=adminNavLinks.flatMap(s=>s.items).filter(i=>i.label==='clear_cache').length;console.log('clear_cache count:',count);"`
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' in InstructorSettingsPage.test.js)*


------
https://chatgpt.com/codex/tasks/task_e_68bfea98feec832895abf9a2a9b543a9