### PR TITLE
Protect cache clear endpoint with admin check

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Admins can build a nested list of course categories. CRUD endpoints live under `
 
 ## Cache management
 
-Admins can flush cached data from the dashboard. The **Clear Cache** button in the admin sidebar triggers `POST /api/cache/clear`, which purges Redis and other configured caches. Use this after deployments or major configuration changes to ensure fresh data.
+Admins can flush cached data from the dashboard. The **Clear Cache** button in the admin sidebar triggers `POST /api/admin/cache/clear`, which purges Redis and other configured caches. Use this after deployments or major configuration changes to ensure fresh data.
 
 ## Third-party integrations
 

--- a/backend/src/middleware/requireAdmin.js
+++ b/backend/src/middleware/requireAdmin.js
@@ -1,0 +1,4 @@
+const { verifyToken, isAdmin } = require('./auth/authMiddleware');
+
+// Combines token verification and admin role check
+module.exports = [verifyToken, isAdmin];

--- a/backend/src/routes/cache.routes.js
+++ b/backend/src/routes/cache.routes.js
@@ -1,7 +1,8 @@
 const express = require('express');
+const requireAdmin = require('../middleware/requireAdmin');
 const router = express.Router();
 
-router.post('/clear', async (_req, res) => {
+router.post('/clear', requireAdmin, async (_req, res) => {
   try {
     if (global.clearServerCache) {
       await global.clearServerCache();

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -2,7 +2,6 @@ const express = require('express');
 const router = express.Router();
 
 router.use('/api/health', require('./health.routes'));
-router.use('/api/cache', require('./cache.routes'));
 // grouped routers
 router.use(require('./auth'));
 router.use(require('./payments'));

--- a/backend/tests/cacheRoutes.test.js
+++ b/backend/tests/cacheRoutes.test.js
@@ -1,0 +1,27 @@
+const request = require('supertest');
+const express = require('express');
+
+// Mock auth middleware to simulate a logged-in non-admin user
+jest.mock('../src/middleware/auth/authMiddleware', () => {
+  const actual = jest.requireActual('../src/middleware/auth/authMiddleware');
+  return {
+    ...actual,
+    verifyToken: (req, _res, next) => {
+      req.user = { id: '1', roles: ['student'] };
+      next();
+    },
+  };
+});
+
+const routes = require('../src/routes/cache.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/admin/cache', routes);
+
+describe('POST /api/admin/cache/clear', () => {
+  it('returns 403 for non-admin users', async () => {
+    const res = await request(app).post('/api/admin/cache/clear');
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add `requireAdmin` middleware combining token verification and admin role check
- secure cache clearing route with `requireAdmin` and remove unprotected `/api/cache` mount
- update README and add test ensuring non-admin users receive 403

## Testing
- `npm test` *(fails: paymentCommission.test.js, bookRoutes.test.js, paymentInvoiceEmail.test.js, tutorialRoutes.test.js, paymentAmountValidation.test.js, studentPaymentRoutes.test.js, seoConfigRoutes.test.js, tutorialUpdateTransaction.test.js, paymentInstallments.test.js, bankPaymentRoutes.test.js, blogRoutes.test.js, libraryRoutes.test.js, socialLoginConfigService.test.js, installRoute.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bfea97f8d08328912051b214a13d7e