### PR TITLE
feat: add cache clearing utility and tests

### DIFF
--- a/backend/src/routes/cache.routes.js
+++ b/backend/src/routes/cache.routes.js
@@ -1,15 +1,18 @@
 const express = require('express');
 const router = express.Router();
+const clearServerCache = require('../utils/cache');
 
 router.post('/clear', async (_req, res) => {
   try {
-    if (global.clearServerCache) {
-      await global.clearServerCache();
-    }
-    res.status(200).json({ status: 'cleared' });
+    await clearServerCache();
+    res
+      .status(200)
+      .json({ status: 'success', message: 'Cache cleared' });
   } catch (err) {
     console.error('Failed to clear cache', err);
-    res.status(500).json({ status: 'error', message: 'Failed to clear cache' });
+    res
+      .status(500)
+      .json({ status: 'error', message: 'Failed to clear cache' });
   }
 });
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,6 +13,7 @@ const session = require("express-session");
 const RedisStore = require("connect-redis").default;
 const redisClient = require("./utils/redisClient");
 const socketStore = require("./utils/socketStore");
+const clearServerCache = require("./utils/cache");
 const rateLimit = require("express-rate-limit");
 const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");
@@ -23,6 +24,8 @@ const startJobs = require("./jobs");
 const { initSockets, state: socketState } = require("./sockets");
 const routes = require("./routes");
 const config = require("./config/env");
+
+global.clearServerCache = clearServerCache;
 
 // Ensure required environment secrets are present
 const requiredSecrets = [

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -1,0 +1,14 @@
+const redisClient = require('./redisClient');
+const socketStore = require('./socketStore');
+
+async function clearServerCache() {
+  if (redisClient) {
+    await redisClient.flushAll();
+  }
+
+  if (socketStore && typeof socketStore.clearAll === 'function') {
+    await socketStore.clearAll();
+  }
+}
+
+module.exports = clearServerCache;

--- a/backend/tests/cacheRoutes.test.js
+++ b/backend/tests/cacheRoutes.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+
+const mockClearServerCache = jest.fn();
+jest.mock('../src/utils/cache', () => mockClearServerCache);
+
+const cacheRoutes = require('../src/routes/cache.routes');
+
+function createApp() {
+  const app = express();
+  app.use('/api/cache', cacheRoutes);
+  return app;
+}
+
+describe('Cache routes', () => {
+  beforeEach(() => {
+    mockClearServerCache.mockReset();
+  });
+
+  it('returns success when cache is cleared', async () => {
+    mockClearServerCache.mockResolvedValue();
+    const app = createApp();
+    const res = await request(app).post('/api/cache/clear');
+    expect(mockClearServerCache).toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      status: 'success',
+      message: 'Cache cleared',
+    });
+  });
+
+  it('returns error when cache clearing fails', async () => {
+    mockClearServerCache.mockRejectedValue(new Error('fail'));
+    const app = createApp();
+    const res = await request(app).post('/api/cache/clear');
+    expect(mockClearServerCache).toHaveBeenCalled();
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({
+      status: 'error',
+      message: 'Failed to clear cache',
+    });
+  });
+});

--- a/backend/tests/cacheUtil.test.js
+++ b/backend/tests/cacheUtil.test.js
@@ -1,0 +1,20 @@
+const mockFlushAll = jest.fn();
+const mockClearAll = jest.fn();
+
+jest.mock('../src/utils/redisClient', () => ({ flushAll: mockFlushAll }));
+jest.mock('../src/utils/socketStore', () => ({ clearAll: mockClearAll }));
+
+const clearServerCache = require('../src/utils/cache');
+
+describe('clearServerCache', () => {
+  beforeEach(() => {
+    mockFlushAll.mockClear();
+    mockClearAll.mockClear();
+  });
+
+  it('flushes redis and clears memory caches', async () => {
+    await clearServerCache();
+    expect(mockFlushAll).toHaveBeenCalled();
+    expect(mockClearAll).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `clearServerCache` util to flush Redis and in-memory caches
- expose `clearServerCache` globally during server startup
- update cache route to use the utility and return JSON status
- add unit tests for cache clearing and route responses

## Testing
- `npm test -- tests/cacheUtil.test.js tests/cacheRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfea96f3988328b224d7c1ccca844c