### PR TITLE
feat: add global cache clearing function

### DIFF
--- a/backend/src/routes/cache.routes.js
+++ b/backend/src/routes/cache.routes.js
@@ -3,9 +3,12 @@ const router = express.Router();
 
 router.post('/clear', async (_req, res) => {
   try {
-    if (global.clearServerCache) {
-      await global.clearServerCache();
+    if (typeof global.clearServerCache !== 'function') {
+      return res
+        .status(500)
+        .json({ status: 'error', message: 'Cache clearing function not defined' });
     }
+    await global.clearServerCache();
     res.status(200).json({ status: 'cleared' });
   } catch (err) {
     console.error('Failed to clear cache', err);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -24,6 +24,17 @@ const { initSockets, state: socketState } = require("./sockets");
 const routes = require("./routes");
 const config = require("./config/env");
 
+// Expose a global cache-clearing utility so other modules (like routes) can
+// programmatically flush any server-side caches. This clears both our
+// socket store (in-memory or Redis-backed) and any Redis data if a client is
+// configured.
+global.clearServerCache = async () => {
+  if (redisClient) {
+    await redisClient.flushAll();
+  }
+  await socketStore.clearAll();
+};
+
 // Ensure required environment secrets are present
 const requiredSecrets = [
   "JWT_SECRET",


### PR DESCRIPTION
## Summary
- expose global `clearServerCache` that flushes Redis and socket store caches
- ensure cache route errors if cache clearing function isn't defined

## Testing
- `npm test` *(fails: Test Suites: 16 failed, 2 skipped, 104 passed, 120 of 122 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bfea94bfe08328986c7c0d4330617a