### PR TITLE
refactor: centralize admin cache clear

### DIFF
--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
+import { clearCache as clearCacheApi } from "@/services/admin/cacheService";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -46,7 +47,7 @@ export default function CacheManager({
     }
   };
 
-  const clearCache = async () => {
+  const handleClearCache = async () => {
     try {
       await caches.delete(WARM_CACHE);
       if (strategy === "B") {
@@ -54,7 +55,7 @@ export default function CacheManager({
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });
       }
       try {
-        await fetch("/api/admin/cache/clear", { method: "POST" });
+        await clearCacheApi();
       } catch (e) {
         console.error(e);
       }
@@ -74,7 +75,7 @@ export default function CacheManager({
         {status === "success" && "Cached"}
         {status === "error" && "Retry"}
       </Button>
-      <Button className="bg-gray-200 text-gray-800" onClick={clearCache} type="button">
+      <Button className="bg-gray-200 text-gray-800" onClick={handleClearCache} type="button">
         Clear Cache
       </Button>
     </div>

--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -4,7 +4,7 @@ import { i18n } from "next-i18next";
 
 export const clearCache = async () => {
   try {
-    await api.post("/cache/clear");
+    await api.post("/admin/cache/clear");
     toast.success(i18n.t("dashboard.cache_cleared"));
   } catch (err) {
     toast.error(i18n.t("dashboard.cache_clear_failed"));

--- a/frontend/src/utils/cache.js
+++ b/frontend/src/utils/cache.js
@@ -1,10 +1,8 @@
+import { clearCache as clearCacheService } from "@/services/admin/cacheService";
+
 export async function clearCache() {
   try {
-    const res = await fetch('/api/admin/cache/clear', {
-      method: 'POST',
-      credentials: 'include',
-    });
-    if (!res.ok) throw new Error('Failed to clear cache');
+    await clearCacheService();
     return true;
   } catch (err) {
     console.error('Failed to clear cache', err);


### PR DESCRIPTION
## Summary
- update cache service to call `/admin/cache/clear`
- use cacheService in utilities and PWA cache manager instead of fetch

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, etc.)*
- `npx eslint src/services/admin/cacheService.js src/utils/cache.js src/components/pwa/CacheManager.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfea93389c83288fead450e8fec7c4