### PR TITLE
refactor: clear cache action

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -83,7 +83,7 @@ export const adminNavLinks = [
   {
     title: 'settings',
     items: [
-      { label: 'clear_cache', href: '/dashboard/admin/cache', icon: RefreshCcw },
+      { label: 'clear_cache', icon: RefreshCcw, action: 'clearCache' },
       {
         label: 'settings',
         href: '#',
@@ -107,8 +107,7 @@ export const adminNavLinks = [
           { label: 'certificate_templates', href: '/dashboard/admin/settings/certificates', icon: LayoutTemplate },
           { label: 'third_parties_config', href: '/dashboard/admin/settings/thirdParty', icon: Brain }
         ]
-      },
-      { label: 'clear_cache', href: '/dashboard/admin/cache', icon: RefreshCcw }
+      }
     ]
   }
 ];


### PR DESCRIPTION
## Summary
- remove duplicate clear cache link in admin sidebar
- convert remaining clear cache link to use action so Sidebar renders button

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bfea9109bc83289f0cbd6fc585c056