### PR TITLE
feat: add cache clearing utility

### DIFF
--- a/backend/src/routes/cache.routes.js
+++ b/backend/src/routes/cache.routes.js
@@ -3,9 +3,10 @@ const router = express.Router();
 
 router.post('/clear', async (_req, res) => {
   try {
-    if (global.clearServerCache) {
-      await global.clearServerCache();
+    if (!global.clearServerCache) {
+      throw new Error('Cache clear function not available');
     }
+    await global.clearServerCache();
     res.status(200).json({ status: 'cleared' });
   } catch (err) {
     console.error('Failed to clear cache', err);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -23,6 +23,7 @@ const startJobs = require("./jobs");
 const { initSockets, state: socketState } = require("./sockets");
 const routes = require("./routes");
 const config = require("./config/env");
+const cache = require("./utils/cache");
 
 // Ensure required environment secrets are present
 const requiredSecrets = [
@@ -47,6 +48,7 @@ if (missingSecrets.length) {
 const app = express();
 app.set('trust proxy', 1);
 const server = http.createServer(app);
+global.clearServerCache = cache.clear;
 
 // Configure security headers
 app.use(

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -1,0 +1,16 @@
+const store = new Map();
+
+module.exports = {
+  get(key) {
+    return store.get(key);
+  },
+  set(key, value) {
+    store.set(key, value);
+  },
+  del(key) {
+    store.delete(key);
+  },
+  async clear() {
+    store.clear();
+  },
+};


### PR DESCRIPTION
## Summary
- add simple in-memory cache utility with clear function
- expose cache clearing on server via `global.clearServerCache`
- ensure cache clearing route errors when unavailable

## Testing
- `npm test` *(fails: Route.post requires a callback function; various tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bfea8db92c83289ce1b23c4403cdd2