### PR TITLE
refactor: use cache service for cache clearing

### DIFF
--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
+import { clearCache as clearCacheApi } from "@/services/admin/cacheService";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -46,21 +47,18 @@ export default function CacheManager({
     }
   };
 
-  const clearCache = async () => {
+  const handleClearCache = async () => {
     try {
       await caches.delete(WARM_CACHE);
       if (strategy === "B") {
         const registration = await navigator.serviceWorker.ready;
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });
       }
-      try {
-        await fetch("/api/admin/cache/clear", { method: "POST" });
-      } catch (e) {
-        console.error(e);
-      }
+      await clearCacheApi();
       setStatus("idle");
     } catch (err) {
       console.error(err);
+      setStatus("error");
     }
   };
 
@@ -74,7 +72,7 @@ export default function CacheManager({
         {status === "success" && "Cached"}
         {status === "error" && "Retry"}
       </Button>
-      <Button className="bg-gray-200 text-gray-800" onClick={clearCache} type="button">
+      <Button className="bg-gray-200 text-gray-800" onClick={handleClearCache} type="button">
         Clear Cache
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- use shared cacheService to clear warm cache
- handle cache clear errors via status state

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js'; Error: fail in StudentTutorialsPage.test.js)*
- `npm run lint` *(fails: 44 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bfea8a64448328874dc0a342769c89