### PR TITLE
refactor: use cache service for warm cache clearing

### DIFF
--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
+import { clearCache } from "@/services/admin/cacheService";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -46,18 +47,14 @@ export default function CacheManager({
     }
   };
 
-  const clearCache = async () => {
+  const handleClearCache = async () => {
     try {
       await caches.delete(WARM_CACHE);
       if (strategy === "B") {
         const registration = await navigator.serviceWorker.ready;
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });
       }
-      try {
-        await fetch("/api/admin/cache/clear", { method: "POST" });
-      } catch (e) {
-        console.error(e);
-      }
+      await clearCache();
       setStatus("idle");
     } catch (err) {
       console.error(err);
@@ -74,7 +71,7 @@ export default function CacheManager({
         {status === "success" && "Cached"}
         {status === "error" && "Retry"}
       </Button>
-      <Button className="bg-gray-200 text-gray-800" onClick={clearCache} type="button">
+      <Button className="bg-gray-200 text-gray-800" onClick={handleClearCache} type="button">
         Clear Cache
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- replace inline fetch with `clearCache` service in PWA cache manager
- simplify cache clearing logic and preserve status reset

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfea7fad5c8328a49396a0454bd141