### PR TITLE
Remove duplicate Clear Cache link

### DIFF
--- a/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
+++ b/frontend/src/components/dashboard/SidebarLinks/adminLinks.js
@@ -107,8 +107,7 @@ export const adminNavLinks = [
           { label: 'certificate_templates', href: '/dashboard/admin/settings/certificates', icon: LayoutTemplate },
           { label: 'third_parties_config', href: '/dashboard/admin/settings/thirdParty', icon: Brain }
         ]
-      },
-      { label: 'clear_cache', href: '/dashboard/admin/cache', icon: RefreshCcw }
+      }
     ]
   }
 ];


### PR DESCRIPTION
## Summary
- remove duplicate "Clear Cache" link from admin dashboard sidebar settings group

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfea7f09988328b0c6ae0483750259