### PR TITLE
Deduplicate dashboard clear_cache translations

### DIFF
--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1169,7 +1169,6 @@
     "ads_manager": "Ads Manager",
     "offers": "Offers",
     "support": "Support",
-    "clear_cache": "Clear Cache",
     "settings": "Settings",
     "language_manager": "Language Manager",
     "language_config": "Language Config",
@@ -1215,8 +1214,7 @@
     "offers_groups": "Offers & Groups",
     "payments_social": "Payments & Social",
     "payments": "Payments",
-    "my_reviews": "My Reviews",
-    "clear_cache": "Clear Cache"
+    "my_reviews": "My Reviews"
   },
   "emailConfigPage": {
     "title": "Email Configuration",


### PR DESCRIPTION
## Summary
- remove duplicate `clear_cache` keys in `dashboard` locale
- keep single `clear_cache` under `sidebar` alongside cache status messages

## Testing
- `npm run i18n:extract` *(fails: Missing script)*
- `npm run i18n:validate` *(fails: Missing script)*
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*
- `npm run lint` *(fails: 44 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c029d460388328a2032f76a1dfdf4c