### PR TITLE
Handle unsupported caches before deletion

### DIFF
--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -49,7 +49,12 @@ export default function CacheManager({
 
   const handleClearCache = async () => {
     try {
-      await caches.delete(WARM_CACHE);
+      if ("caches" in window) {
+        await caches.delete(WARM_CACHE);
+      } else {
+        setStatus("error");
+        return;
+      }
       if (strategy === "B") {
         const registration = await navigator.serviceWorker.ready;
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });


### PR DESCRIPTION
## Summary
- guard cache deletion with a window.caches check
- mark the cache operation as error when the Cache API is unavailable

## Testing
- `npm test src/tests/__tests__/CacheManager.test.tsx` *(fails: Expected "dashboard.cache_cleared")*


------
https://chatgpt.com/codex/tasks/task_e_68c029d3ce7083288d29d90b0bc3dbe1