### PR TITLE
refactor: delegate cache clear toasts to callers

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -2,7 +2,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { ChevronDown, Plus } from 'lucide-react';
-import { useTranslation } from 'next-i18next';
+import { useTranslation, i18n } from 'next-i18next';
 import { useState, useEffect } from 'react';
 import useAppConfigStore from '@/store/appConfigStore';
 import { API_BASE_URL } from '@/config/config';
@@ -32,10 +32,10 @@ export default function Sidebar({ role = 'admin' }) {
   const handleClearCache = async () => {
     try {
       await clearCache();
-      toast.success(t('cache_cleared'));
+      toast.success(i18n.t('dashboard.cache_cleared'));
     } catch (err) {
       console.error('Failed to clear cache', err);
-      toast.error(t('cache_clear_failed'));
+      toast.error(i18n.t('dashboard.cache_clear_failed'));
     }
   };
 

--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
 import { clearCache } from "@/services/admin/cacheService";
+import { toast } from "react-toastify";
+import { i18n } from "next-i18next";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -55,9 +57,11 @@ export default function CacheManager({
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });
       }
       await clearCache();
+      toast.success(i18n.t("dashboard.cache_cleared"));
       setStatus("idle");
     } catch (err) {
       console.error(err);
+      toast.error(i18n.t("dashboard.cache_clear_failed"));
       setStatus("error");
     }
   };

--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -1,11 +1,6 @@
 import api from "@/services/api/api";
 
 export const clearCache = async () => {
-  try {
-    await api.post("/admin/cache/clear");
-    toast.success(i18n.t("dashboard.cache_cleared"));
-  } catch (err) {
-    toast.error(i18n.t("dashboard.cache_clear_failed"));
-    throw err;
-  }
+  const response = await api.post("/admin/cache/clear");
+  return response;
 };


### PR DESCRIPTION
## Summary
- remove toast handling from cache clearing service and return API response
- handle cache clear success/error toasts in Sidebar and CacheManager

## Testing
- `npm test` (frontend) *(fails: Cannot find module '../../services/instructor/subscriptionService')*
- `npm test` (backend) *(fails: TypeError: Cannot read properties of null (reading 'close'))*

------
https://chatgpt.com/codex/tasks/task_e_68c029d25e5c8328b117138f71b21334