### PR TITLE
Expose server cache clearing and test redis/socket flush

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,7 +13,6 @@ const session = require("express-session");
 const RedisStore = require("connect-redis").default;
 const redisClient = require("./utils/redisClient");
 const socketStore = require("./utils/socketStore");
-const clearServerCache = require("./utils/cache");
 const rateLimit = require("express-rate-limit");
 const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");
@@ -27,15 +26,16 @@ const config = require("./config/env");
 const cache = require("./utils/cache");
 
 // Expose a global cache-clearing utility so other modules (like routes) can
-// programmatically flush any server-side caches. This clears both our
-// socket store (in-memory or Redis-backed) and any Redis data if a client is
-// configured.
-global.clearServerCache = async () => {
+// programmatically flush any server-side caches. This clears our socket store,
+// any Redis data, and the in-memory cache.
+async function clearServerCache() {
   if (redisClient) {
     await redisClient.flushAll();
   }
   await socketStore.clearAll();
-};
+  await cache.clear();
+}
+global.clearServerCache = clearServerCache;
 
 // Ensure required environment secrets are present
 const requiredSecrets = [
@@ -60,7 +60,6 @@ if (missingSecrets.length) {
 const app = express();
 app.set('trust proxy', 1);
 const server = http.createServer(app);
-global.clearServerCache = cache.clear;
 
 // Configure security headers
 app.use(
@@ -252,6 +251,7 @@ module.exports = {
   app,
   server,
   startServer,
+  clearServerCache,
   get io() {
     return socketState.io;
   },

--- a/backend/tests/cacheUtil.test.js
+++ b/backend/tests/cacheUtil.test.js
@@ -1,10 +1,16 @@
 const mockFlushAll = jest.fn();
 const mockClearAll = jest.fn();
 
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'jwt';
+process.env.REFRESH_TOKEN_SECRET = 'refresh';
+process.env.SESSION_SECRET = 'session';
+process.env.TEST_DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
 jest.mock('../src/utils/redisClient', () => ({ flushAll: mockFlushAll }));
 jest.mock('../src/utils/socketStore', () => ({ clearAll: mockClearAll }));
 
-const clearServerCache = require('../src/utils/cache');
+const { clearServerCache } = require('../src/server');
 
 describe('clearServerCache', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- export `clearServerCache` from `server.js` so it flushes Redis, socket store, and in-memory cache
- update cache utility test to import from the server and verify `flushAll` and `clearAll` mocks are called

## Testing
- `npm test -- tests/cacheUtil.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c029d07d788328873adad735956975