### PR TITLE
refactor: streamline cache clearing

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -144,15 +144,6 @@ export default function Sidebar({ role = 'admin' }) {
         </nav>
       </div>
 
-      {['admin','superadmin'].includes(role) && (
-        <button
-          onClick={handleClearCache}
-          className="flex items-center gap-3 px-4 py-2 text-sm font-medium rounded-lg transition-all duration-200 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
-        >
-          {t('sidebar.clear_cache')}
-        </button>
-      )}
-
       <div className="text-xs text-gray-400 dark:text-gray-500 text-center mt-8">
         &copy; {new Date().getFullYear()} {settings.appName || 'SkillBridge'}
       </div>

--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
 import { clearCache } from "@/services/admin/cacheService";
+import { toast } from "react-toastify";
+import { i18n } from "next-i18next";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -55,9 +57,11 @@ export default function CacheManager({
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });
       }
       await clearCache();
+      toast.success(i18n.t("dashboard.cache_cleared"));
       setStatus("idle");
     } catch (err) {
       console.error(err);
+      toast.error(i18n.t("dashboard.cache_clear_failed"));
       setStatus("error");
     }
   };

--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -1,11 +1,5 @@
 import api from "@/services/api/api";
 
 export const clearCache = async () => {
-  try {
-    await api.post("/admin/cache/clear");
-    toast.success(i18n.t("dashboard.cache_cleared"));
-  } catch (err) {
-    toast.error(i18n.t("dashboard.cache_clear_failed"));
-    throw err;
-  }
+  await api.post("/admin/cache/clear");
 };


### PR DESCRIPTION
## Summary
- remove redundant "Clear Cache" button, leaving sidebar nav action as sole trigger
- strip toast side effects from cache clearing service
- surface toast feedback in CacheManager's cache clearing handler

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c029d259088328a9b990ce730b166b