### PR TITLE
test: update cache route tests

### DIFF
--- a/backend/src/routes/cache.routes.js
+++ b/backend/src/routes/cache.routes.js
@@ -9,7 +9,7 @@ router.post('/clear', requireAdmin, async (_req, res) => {
       throw new Error('Cache clear function not available');
     }
     await global.clearServerCache();
-    res.status(200).json({ status: 'cleared' });
+    res.status(200).json({ status: 'success', message: 'Cache cleared' });
   } catch (err) {
     console.error('Failed to clear cache', err);
     res

--- a/backend/tests/cacheRoutes.test.js
+++ b/backend/tests/cacheRoutes.test.js
@@ -3,24 +3,26 @@ const express = require('express');
 
 const mockClearServerCache = jest.fn();
 jest.mock('../src/utils/cache', () => mockClearServerCache);
+jest.mock('../src/middleware/requireAdmin', () => (_req, _res, next) => next());
 
 const cacheRoutes = require('../src/routes/cache.routes');
 
 function createApp() {
   const app = express();
-  app.use('/api/cache', cacheRoutes);
+  app.use('/api/admin/cache', cacheRoutes);
   return app;
 }
 
 describe('Cache routes', () => {
   beforeEach(() => {
     mockClearServerCache.mockReset();
+    global.clearServerCache = mockClearServerCache;
   });
 
   it('returns success when cache is cleared', async () => {
     mockClearServerCache.mockResolvedValue();
     const app = createApp();
-    const res = await request(app).post('/api/cache/clear');
+    const res = await request(app).post('/api/admin/cache/clear');
     expect(mockClearServerCache).toHaveBeenCalled();
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
@@ -32,7 +34,7 @@ describe('Cache routes', () => {
   it('returns error when cache clearing fails', async () => {
     mockClearServerCache.mockRejectedValue(new Error('fail'));
     const app = createApp();
-    const res = await request(app).post('/api/cache/clear');
+    const res = await request(app).post('/api/admin/cache/clear');
     expect(mockClearServerCache).toHaveBeenCalled();
     expect(res.status).toBe(500);
     expect(res.body).toEqual({


### PR DESCRIPTION
## Summary
- mount cache router at `/api/admin/cache` and bypass admin middleware
- ensure cache clearing returns `{status:'success', message:'Cache cleared'}`

## Testing
- `npm test -- --runTestsByPath tests/cacheRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c029cff7ac8328aa1b1214fcbe6d7c