### PR TITLE
feat: add cache clearing toasts

### DIFF
--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
 import { clearCache } from "@/services/admin/cacheService";
+import { toast } from "react-toastify";
+import { i18n } from "next-i18next";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -56,9 +58,11 @@ export default function CacheManager({
       }
       await clearCache();
       setStatus("idle");
+      toast.success(i18n.t("dashboard.cache_cleared"));
     } catch (err) {
       console.error(err);
       setStatus("error");
+      toast.error(i18n.t("dashboard.cache_clear_failed"));
     }
   };
 

--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -1,11 +1,5 @@
 import api from "@/services/api/api";
 
 export const clearCache = async () => {
-  try {
-    await api.post("/admin/cache/clear");
-    toast.success(i18n.t("dashboard.cache_cleared"));
-  } catch (err) {
-    toast.error(i18n.t("dashboard.cache_clear_failed"));
-    throw err;
-  }
+  await api.post("/admin/cache/clear");
 };


### PR DESCRIPTION
## Summary
- invoke success/error toasts for cache clearing in the PWA cache manager
- simplify admin cache service to only call API

## Testing
- `cd frontend && npm test -- src/tests/__tests__/CacheManager.test.tsx`
- `cd frontend && npm run lint` *(fails: React component warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c029c8b9308328a55183aaeed814f3