### PR TITLE
refactor: remove toast calls from cache service

### DIFF
--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -1,11 +1,3 @@
 import api from "@/services/api/api";
 
-export const clearCache = async () => {
-  try {
-    await api.post("/admin/cache/clear");
-    toast.success(i18n.t("dashboard.cache_cleared"));
-  } catch (err) {
-    toast.error(i18n.t("dashboard.cache_clear_failed"));
-    throw err;
-  }
-};
+export const clearCache = () => api.post("/admin/cache/clear");

--- a/frontend/src/tests/__tests__/CacheManager.test.tsx
+++ b/frontend/src/tests/__tests__/CacheManager.test.tsx
@@ -1,17 +1,9 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import CacheManager from '@/components/pwa/CacheManager';
 import { clearCache as mockClearCache } from '../../services/admin/cacheService';
-import { toast } from 'react-toastify';
 
 jest.mock('../../services/admin/cacheService', () => ({
   clearCache: jest.fn(),
-}));
-
-jest.mock('react-toastify', () => ({
-  toast: {
-    success: jest.fn(),
-    error: jest.fn(),
-  },
 }));
 
 jest.mock('next-i18next', () => ({
@@ -33,24 +25,23 @@ describe('CacheManager', () => {
   beforeEach(() => {
     setupEnvironment();
     (mockClearCache as jest.Mock).mockReset();
-    (toast.success as jest.Mock).mockReset();
-    (toast.error as jest.Mock).mockReset();
   });
 
-  it('shows success toast when cache cleared', async () => {
+  it('invokes clearCache when button is clicked', async () => {
     (mockClearCache as jest.Mock).mockResolvedValue({});
     render(<CacheManager />);
     const button = await screen.findByText('Clear Cache');
     fireEvent.click(button);
     await waitFor(() => expect(mockClearCache).toHaveBeenCalled());
-    expect(toast.success).toHaveBeenCalledWith('dashboard.cache_cleared');
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument();
   });
 
-  it('shows error toast when clearing cache fails', async () => {
+  it('shows retry when clearing cache fails', async () => {
     (mockClearCache as jest.Mock).mockRejectedValue(new Error('fail'));
     render(<CacheManager />);
     const button = await screen.findByText('Clear Cache');
     fireEvent.click(button);
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('dashboard.cache_clear_failed'));
+    await waitFor(() => expect(mockClearCache).toHaveBeenCalled());
+    expect(await screen.findByText('Retry')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- strip toast notifications from cacheService so it only performs API requests
- keep cache clearing notifications in Sidebar
- update CacheManager tests for new behavior

## Testing
- `cd frontend && npm test -- CacheManager`


------
https://chatgpt.com/codex/tasks/task_e_68c029c86558832882bcc0666ac58bf1