### PR TITLE
Move cache notifications to UI layer

### DIFF
--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
 import { clearCache } from "@/services/admin/cacheService";
+import { toast } from "react-toastify";
+import { i18n } from "next-i18next";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -56,9 +58,11 @@ export default function CacheManager({
       }
       await clearCache();
       setStatus("idle");
+      toast.success(i18n.t("dashboard:cache_cleared"));
     } catch (err) {
       console.error(err);
       setStatus("error");
+      toast.error(i18n.t("dashboard:cache_clear_failed"));
     }
   };
 

--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -3,9 +3,7 @@ import api from "@/services/api/api";
 export const clearCache = async () => {
   try {
     await api.post("/admin/cache/clear");
-    toast.success(i18n.t("dashboard.cache_cleared"));
   } catch (err) {
-    toast.error(i18n.t("dashboard.cache_clear_failed"));
     throw err;
   }
 };

--- a/frontend/src/tests/__tests__/CacheManager.test.tsx
+++ b/frontend/src/tests/__tests__/CacheManager.test.tsx
@@ -43,7 +43,9 @@ describe('CacheManager', () => {
     const button = await screen.findByText('Clear Cache');
     fireEvent.click(button);
     await waitFor(() => expect(mockClearCache).toHaveBeenCalled());
-    expect(toast.success).toHaveBeenCalledWith('dashboard.cache_cleared');
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith('dashboard:cache_cleared')
+    );
   });
 
   it('shows error toast when clearing cache fails', async () => {
@@ -51,6 +53,8 @@ describe('CacheManager', () => {
     render(<CacheManager />);
     const button = await screen.findByText('Clear Cache');
     fireEvent.click(button);
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('dashboard.cache_clear_failed'));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('dashboard:cache_clear_failed')
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Remove toast side-effects from cache service
- Show translated toast messages in CacheManager UI component
- Adapt CacheManager tests for new notification behavior

## Testing
- `npm test -- src/tests/__tests__/CacheManager.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c029c77c20832896935c1e3b285f5e