### PR TITLE
refactor: improve cache clear handling

### DIFF
--- a/backend/src/routes/cache.routes.js
+++ b/backend/src/routes/cache.routes.js
@@ -1,15 +1,21 @@
 const express = require('express');
 const requireAdmin = require('../middleware/requireAdmin');
 const router = express.Router();
-const clearServerCache = require('../utils/cache');
 
 router.post('/clear', requireAdmin, async (_req, res) => {
   try {
     if (!global.clearServerCache) {
-      throw new Error('Cache clear function not available');
+      return res
+        .status(503)
+        .json({
+          status: 'error',
+          message: 'Cache clear function not available',
+        });
     }
     await global.clearServerCache();
-    res.status(200).json({ status: 'cleared' });
+    res
+      .status(200)
+      .json({ status: 'success', message: 'Cache cleared' });
   } catch (err) {
     console.error('Failed to clear cache', err);
     res

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,7 +13,6 @@ const session = require("express-session");
 const RedisStore = require("connect-redis").default;
 const redisClient = require("./utils/redisClient");
 const socketStore = require("./utils/socketStore");
-const clearServerCache = require("./utils/cache");
 const rateLimit = require("express-rate-limit");
 const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");


### PR DESCRIPTION
## Summary
- return descriptive success or error objects from cache clearing route
- send HTTP 503 when no cache clearing function is defined
- remove unused cache clearing imports

## Testing
- `npm test` *(fails: Test Suites: 18 failed, 2 skipped, 104 passed, 122 of 124 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c029c47a9c83288aff5bb29522ae81