### PR TITLE
refactor: centralize cache clearing utility

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -7,8 +7,7 @@ import { useState, useEffect } from 'react';
 import useAppConfigStore from '@/store/appConfigStore';
 import { API_BASE_URL } from '@/config/config';
 import logo from '@/shared/assets/images/login/logo.png';
-import { clearCache } from '@/services/admin/cacheService';
-import { toast } from 'react-toastify';
+import { clearCache } from '@/utils/cache';
 import { adminNavLinks } from './SidebarLinks/adminLinks';
 import { instructorNavLinks } from './SidebarLinks/instructorLinks';
 import { studentNavLinks } from './SidebarLinks/studentLinks';
@@ -29,14 +28,8 @@ export default function Sidebar({ role = 'admin' }) {
     fetchAppConfig();
   }, [fetchAppConfig]);
 
-  const handleClearCache = async () => {
-    try {
-      await clearCache();
-      toast.success(t('cache_cleared'));
-    } catch (err) {
-      console.error('Failed to clear cache', err);
-      toast.error(t('cache_clear_failed'));
-    }
+  const handleClearCache = () => {
+    clearCache();
   };
 
   const navMap = {

--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 import { CACHE_VERSION } from "@/config/pwa";
-import { clearCache } from "@/services/admin/cacheService";
+import { clearCache } from "@/utils/cache";
 
 // List of URLs to warm up in cache. Replace with actual routes as needed.
 const pwaWarmList: string[] = [];
@@ -54,8 +54,8 @@ export default function CacheManager({
         const registration = await navigator.serviceWorker.ready;
         registration.active?.postMessage({ type: "CLEAR_WARM_CACHE" });
       }
-      await clearCache();
-      setStatus("idle");
+      const success = await clearCache();
+      setStatus(success ? "idle" : "error");
     } catch (err) {
       console.error(err);
       setStatus("error");

--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -1,11 +1,3 @@
 import api from "@/services/api/api";
 
-export const clearCache = async () => {
-  try {
-    await api.post("/admin/cache/clear");
-    toast.success(i18n.t("dashboard.cache_cleared"));
-  } catch (err) {
-    toast.error(i18n.t("dashboard.cache_clear_failed"));
-    throw err;
-  }
-};
+export const clearCache = () => api.post("/admin/cache/clear");

--- a/frontend/src/utils/cache.js
+++ b/frontend/src/utils/cache.js
@@ -1,11 +1,15 @@
+import { toast } from "react-toastify";
+import { i18n } from "next-i18next";
 import { clearCache as clearCacheService } from "@/services/admin/cacheService";
 
 export async function clearCache() {
   try {
     await clearCacheService();
+    toast.success(i18n.t("dashboard.cache_cleared"));
     return true;
   } catch (err) {
-    console.error('Failed to clear cache', err);
+    console.error("Failed to clear cache", err);
+    toast.error(i18n.t("dashboard.cache_clear_failed"));
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- move cache clear toast handling into utility
- simplify cacheService to bare API call
- use new cache util in Sidebar and CacheManager

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService')*


------
https://chatgpt.com/codex/tasks/task_e_68c029b658148328bdc13f6b767631ab