### PR TITLE
test: update cache clearing tests

### DIFF
--- a/backend/tests/cacheRoutes.test.js
+++ b/backend/tests/cacheRoutes.test.js
@@ -1,8 +1,8 @@
 const request = require('supertest');
 const express = require('express');
 
-const mockClearServerCache = jest.fn();
-jest.mock('../src/utils/cache', () => mockClearServerCache);
+// Mock admin auth middleware to allow requests through
+jest.mock('../src/middleware/requireAdmin', () => [(_req, _res, next) => next()]);
 
 const cacheRoutes = require('../src/routes/cache.routes');
 
@@ -13,27 +13,24 @@ function createApp() {
 }
 
 describe('Cache routes', () => {
-  beforeEach(() => {
-    mockClearServerCache.mockReset();
+  afterEach(() => {
+    delete global.clearServerCache;
   });
 
-  it('returns success when cache is cleared', async () => {
-    mockClearServerCache.mockResolvedValue();
+  it('returns cleared status when cache is cleared', async () => {
+    global.clearServerCache = jest.fn().mockResolvedValue();
     const app = createApp();
     const res = await request(app).post('/api/cache/clear');
-    expect(mockClearServerCache).toHaveBeenCalled();
+    expect(global.clearServerCache).toHaveBeenCalled();
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      status: 'success',
-      message: 'Cache cleared',
-    });
+    expect(res.body).toEqual({ status: 'cleared' });
   });
 
   it('returns error when cache clearing fails', async () => {
-    mockClearServerCache.mockRejectedValue(new Error('fail'));
+    global.clearServerCache = jest.fn().mockRejectedValue(new Error('fail'));
     const app = createApp();
     const res = await request(app).post('/api/cache/clear');
-    expect(mockClearServerCache).toHaveBeenCalled();
+    expect(global.clearServerCache).toHaveBeenCalled();
     expect(res.status).toBe(500);
     expect(res.body).toEqual({
       status: 'error',

--- a/backend/tests/cacheUtil.test.js
+++ b/backend/tests/cacheUtil.test.js
@@ -1,20 +1,21 @@
-const mockFlushAll = jest.fn();
-const mockClearAll = jest.fn();
+const cache = require('../src/utils/cache');
 
-jest.mock('../src/utils/redisClient', () => ({ flushAll: mockFlushAll }));
-jest.mock('../src/utils/socketStore', () => ({ clearAll: mockClearAll }));
-
-const clearServerCache = require('../src/utils/cache');
-
-describe('clearServerCache', () => {
-  beforeEach(() => {
-    mockFlushAll.mockClear();
-    mockClearAll.mockClear();
+describe('cache utility', () => {
+  afterEach(async () => {
+    await cache.clear();
+    delete global.clearServerCache;
   });
 
-  it('flushes redis and clears memory caches', async () => {
-    await clearServerCache();
-    expect(mockFlushAll).toHaveBeenCalled();
-    expect(mockClearAll).toHaveBeenCalled();
+  it('clears stored values via clear()', async () => {
+    cache.set('foo', 'bar');
+    await cache.clear();
+    expect(cache.get('foo')).toBeUndefined();
+  });
+
+  it('clears store through global.clearServerCache', async () => {
+    cache.set('baz', 'qux');
+    global.clearServerCache = cache.clear;
+    await global.clearServerCache();
+    expect(cache.get('baz')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- align cache clearing route tests with admin auth and new response shape
- verify in-memory cache utilities and global clearServerCache hook

## Testing
- `cd backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68c029b225d48328812891f18a415d9b