### PR TITLE
refactor: rely on cache service toasts in sidebar

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -8,7 +8,6 @@ import useAppConfigStore from '@/store/appConfigStore';
 import { API_BASE_URL } from '@/config/config';
 import logo from '@/shared/assets/images/login/logo.png';
 import { clearCache } from '@/services/admin/cacheService';
-import { toast } from 'react-toastify';
 import { adminNavLinks } from './SidebarLinks/adminLinks';
 import { instructorNavLinks } from './SidebarLinks/instructorLinks';
 import { studentNavLinks } from './SidebarLinks/studentLinks';
@@ -32,10 +31,8 @@ export default function Sidebar({ role = 'admin' }) {
   const handleClearCache = async () => {
     try {
       await clearCache();
-      toast.success(t('cache_cleared'));
     } catch (err) {
       console.error('Failed to clear cache', err);
-      toast.error(t('cache_clear_failed'));
     }
   };
 


### PR DESCRIPTION
## Summary
- remove Sidebar toast notifications for cache clearing and defer to cache service

## Testing
- `npm test`
- `npm run lint` (fails: Component definition is missing display name and other warnings)

------
https://chatgpt.com/codex/tasks/task_e_68c029a4db2c8328bb51ea03b373f670