### PR TITLE
refactor: unify server cache clearing

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,7 +13,7 @@ const session = require("express-session");
 const RedisStore = require("connect-redis").default;
 const redisClient = require("./utils/redisClient");
 const socketStore = require("./utils/socketStore");
-const clearServerCache = require("./utils/cache");
+const cache = require("./utils/cache");
 const rateLimit = require("express-rate-limit");
 const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");
@@ -24,18 +24,19 @@ const startJobs = require("./jobs");
 const { initSockets, state: socketState } = require("./sockets");
 const routes = require("./routes");
 const config = require("./config/env");
-const cache = require("./utils/cache");
 
 // Expose a global cache-clearing utility so other modules (like routes) can
-// programmatically flush any server-side caches. This clears both our
-// socket store (in-memory or Redis-backed) and any Redis data if a client is
-// configured.
-global.clearServerCache = async () => {
+// programmatically flush any server-side caches. This clears Redis, the socket
+// store, and the in-memory cache.
+async function clearServerCache() {
   if (redisClient) {
     await redisClient.flushAll();
   }
   await socketStore.clearAll();
-};
+  await cache.clear();
+}
+
+global.clearServerCache = clearServerCache;
 
 // Ensure required environment secrets are present
 const requiredSecrets = [
@@ -60,7 +61,6 @@ if (missingSecrets.length) {
 const app = express();
 app.set('trust proxy', 1);
 const server = http.createServer(app);
-global.clearServerCache = cache.clear;
 
 // Configure security headers
 app.use(
@@ -252,6 +252,7 @@ module.exports = {
   app,
   server,
   startServer,
+  clearServerCache,
   get io() {
     return socketState.io;
   },


### PR DESCRIPTION
## Summary
- remove duplicate cache import and define single clearServerCache utility
- clear Redis, sockets, and in-memory cache via unified function and expose globally
- export clearServerCache for use by other modules

## Testing
- `npm test` *(fails: Route.post requires callback; TypeError: clearServerCache is not a function; and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c029acf31c8328a62cc511aed73109