### PR TITLE
test: refine cache tests

### DIFF
--- a/backend/tests/cacheRoutes.test.js
+++ b/backend/tests/cacheRoutes.test.js
@@ -1,8 +1,7 @@
 const request = require('supertest');
 const express = require('express');
 
-const mockClearServerCache = jest.fn();
-jest.mock('../src/utils/cache', () => mockClearServerCache);
+jest.mock('../src/middleware/requireAdmin', () => (_req, _res, next) => next());
 
 const cacheRoutes = require('../src/routes/cache.routes');
 
@@ -13,27 +12,24 @@ function createApp() {
 }
 
 describe('Cache routes', () => {
-  beforeEach(() => {
-    mockClearServerCache.mockReset();
+  afterEach(() => {
+    delete global.clearServerCache;
   });
 
   it('returns success when cache is cleared', async () => {
-    mockClearServerCache.mockResolvedValue();
+    global.clearServerCache = jest.fn().mockResolvedValue();
     const app = createApp();
     const res = await request(app).post('/api/cache/clear');
-    expect(mockClearServerCache).toHaveBeenCalled();
+    expect(global.clearServerCache).toHaveBeenCalled();
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      status: 'success',
-      message: 'Cache cleared',
-    });
+    expect(res.body).toEqual({ status: 'cleared' });
   });
 
   it('returns error when cache clearing fails', async () => {
-    mockClearServerCache.mockRejectedValue(new Error('fail'));
+    global.clearServerCache = jest.fn().mockRejectedValue(new Error('fail'));
     const app = createApp();
     const res = await request(app).post('/api/cache/clear');
-    expect(mockClearServerCache).toHaveBeenCalled();
+    expect(global.clearServerCache).toHaveBeenCalled();
     expect(res.status).toBe(500);
     expect(res.body).toEqual({
       status: 'error',

--- a/backend/tests/cacheUtil.test.js
+++ b/backend/tests/cacheUtil.test.js
@@ -1,20 +1,25 @@
-const mockFlushAll = jest.fn();
-const mockClearAll = jest.fn();
+const cache = require('../src/utils/cache');
 
-jest.mock('../src/utils/redisClient', () => ({ flushAll: mockFlushAll }));
-jest.mock('../src/utils/socketStore', () => ({ clearAll: mockClearAll }));
-
-const clearServerCache = require('../src/utils/cache');
-
-describe('clearServerCache', () => {
-  beforeEach(() => {
-    mockFlushAll.mockClear();
-    mockClearAll.mockClear();
+describe('cache utility', () => {
+  afterEach(async () => {
+    await cache.clear();
   });
 
-  it('flushes redis and clears memory caches', async () => {
-    await clearServerCache();
-    expect(mockFlushAll).toHaveBeenCalled();
-    expect(mockClearAll).toHaveBeenCalled();
+  it('stores and retrieves values', () => {
+    cache.set('foo', 'bar');
+    expect(cache.get('foo')).toBe('bar');
+  });
+
+  it('deletes values', () => {
+    cache.set('foo', 'bar');
+    cache.del('foo');
+    expect(cache.get('foo')).toBeUndefined();
+  });
+
+  it('clears all values', async () => {
+    cache.set('foo', 'bar');
+    await cache.clear();
+    expect(cache.get('foo')).toBeUndefined();
   });
 });
+


### PR DESCRIPTION
## Summary
- mock `requireAdmin` and invoke global `clearServerCache` in cache route tests
- verify Map-based cache util operations

## Testing
- `cd backend && npm test -- tests/cacheRoutes.test.js tests/cacheUtil.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c029a2968c8328b23b757cc1b2db54