### PR TITLE
refactor: simplify cache manager status handling

### DIFF
--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -20,6 +20,8 @@ export default function CacheManager({
 }: CacheManagerProps) {
   const [status, setStatus] = useState<Status>("idle");
   const [ready, setReady] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [clearing, setClearing] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -30,6 +32,7 @@ export default function CacheManager({
 
   const warmCache = async () => {
     setStatus("caching");
+    setMessage(null);
     try {
       if (strategy === "A") {
         await Promise.all(warmList.map((url) => fetch(url)));
@@ -41,13 +44,17 @@ export default function CacheManager({
         });
       }
       setStatus("success");
+      setMessage("Cache warmed");
     } catch (err) {
       console.error(err);
       setStatus("error");
+      setMessage("Failed to warm cache");
     }
   };
 
   const handleClearCache = async () => {
+    setClearing(true);
+    setMessage(null);
     try {
       await caches.delete(WARM_CACHE);
       if (strategy === "B") {
@@ -56,25 +63,37 @@ export default function CacheManager({
       }
       await clearCache();
       setStatus("idle");
+      setMessage("Cache cleared");
     } catch (err) {
       console.error(err);
       setStatus("error");
+      setMessage("Failed to clear cache");
+    } finally {
+      setClearing(false);
     }
   };
 
   if (!ready) return null;
 
   return (
-    <div className="space-x-2">
-      <Button onClick={warmCache} disabled={status === "caching"}>
-        {status === "caching" && "Caching…"}
-        {status === "idle" && "Warm Cache"}
-        {status === "success" && "Cached"}
-        {status === "error" && "Retry"}
-      </Button>
-      <Button className="bg-gray-200 text-gray-800" onClick={handleClearCache} type="button">
-        Clear Cache
-      </Button>
+    <div>
+      <div className="space-x-2">
+        <Button onClick={warmCache} disabled={status === "caching"}>
+          {status === "caching" && "Caching…"}
+          {status === "idle" && "Warm Cache"}
+          {status === "success" && "Cached"}
+          {status === "error" && "Retry"}
+        </Button>
+        <Button
+          className="bg-gray-200 text-gray-800"
+          onClick={handleClearCache}
+          type="button"
+          disabled={clearing}
+        >
+          {clearing ? "Clearing…" : "Clear Cache"}
+        </Button>
+      </div>
+      {message && <p className="text-sm text-gray-600 mt-2">{message}</p>}
     </div>
   );
 }

--- a/frontend/src/tests/__tests__/CacheManager.test.tsx
+++ b/frontend/src/tests/__tests__/CacheManager.test.tsx
@@ -1,17 +1,9 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import CacheManager from '@/components/pwa/CacheManager';
 import { clearCache as mockClearCache } from '../../services/admin/cacheService';
-import { toast } from 'react-toastify';
 
 jest.mock('../../services/admin/cacheService', () => ({
   clearCache: jest.fn(),
-}));
-
-jest.mock('react-toastify', () => ({
-  toast: {
-    success: jest.fn(),
-    error: jest.fn(),
-  },
 }));
 
 jest.mock('next-i18next', () => ({
@@ -33,24 +25,22 @@ describe('CacheManager', () => {
   beforeEach(() => {
     setupEnvironment();
     (mockClearCache as jest.Mock).mockReset();
-    (toast.success as jest.Mock).mockReset();
-    (toast.error as jest.Mock).mockReset();
   });
 
-  it('shows success toast when cache cleared', async () => {
+  it('shows message when cache cleared', async () => {
     (mockClearCache as jest.Mock).mockResolvedValue({});
     render(<CacheManager />);
     const button = await screen.findByText('Clear Cache');
     fireEvent.click(button);
     await waitFor(() => expect(mockClearCache).toHaveBeenCalled());
-    expect(toast.success).toHaveBeenCalledWith('dashboard.cache_cleared');
+    await screen.findByText('Cache cleared');
   });
 
-  it('shows error toast when clearing cache fails', async () => {
+  it('shows error message when clearing cache fails', async () => {
     (mockClearCache as jest.Mock).mockRejectedValue(new Error('fail'));
     render(<CacheManager />);
     const button = await screen.findByText('Clear Cache');
     fireEvent.click(button);
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('dashboard.cache_clear_failed'));
+    await screen.findByText('Failed to clear cache');
   });
 });


### PR DESCRIPTION
## Summary
- show cache warm/clear status via inline message
- disable clear cache button while operation runs
- adjust tests to expect inline status instead of toast

## Testing
- `npx eslint src/components/pwa/CacheManager.tsx src/tests/__tests__/CacheManager.test.tsx`
- `npm test src/tests/__tests__/CacheManager.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c029a4064c8328806c85b6a831b78f