### PR TITLE
Proxy uploads through Next.js to backend

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -99,6 +99,10 @@ const nextConfig = {
         source: '/api/:path*',
         destination: `${apiBase}/:path*`,
       },
+      {
+        source: '/uploads/:path*',
+        destination: `${apiBase}/uploads/:path*`,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary
- add rewrite rule so `/uploads/*` proxies to the API server

## Testing
- `npx jest src/tests/__tests__/bookService.test.js`
- `NEXT_TELEMETRY_DISABLED=1 npm run build`
- `curl -i http://localhost:3000/uploads/example.jpg`


------
https://chatgpt.com/codex/tasks/task_e_68c257796d0c83289eedccde8404fa6d