### PR TITLE
refactor: use shared buildUrl helper

### DIFF
--- a/frontend/src/components/PageLoader.js
+++ b/frontend/src/components/PageLoader.js
@@ -3,7 +3,7 @@ import Router from "next/router";
 import NProgress from "nprogress";
 import "nprogress/nprogress.css";
 import useAppConfigStore from "@/store/appConfigStore";
-import { API_BASE_URL } from "@/config/config";
+import { buildUrl } from "@/utils/url";
 
 // Configure NProgress to remove the spinner icon
 NProgress.configure({ showSpinner: false });
@@ -12,9 +12,7 @@ const PageLoader = () => {
   const [visible, setVisible] = useState(true);
   const settings = useAppConfigStore((s) => s.settings);
   const loaded = useAppConfigStore((s) => s.loaded);
-  const logoSrc = settings.logoUrl || settings.logo_url
-    ? `${API_BASE_URL}${settings.logoUrl || settings.logo_url}`
-    : null;
+  const logoSrc = buildUrl(settings.logoUrl || settings.logo_url);
 
   useEffect(() => {
     const handleStart = () => NProgress.start();

--- a/frontend/src/components/books/BookDetails.js
+++ b/frontend/src/components/books/BookDetails.js
@@ -8,6 +8,7 @@ import { useTranslation } from "next-i18next";
 import { formatCurrency } from "@/utils/currency";
 import { mapBookForCart } from "@/utils/bookMapping";
 import { API_BASE_URL } from "@/config/config";
+import { buildUrl } from "@/utils/url";
 
 export default function BookDetails({ book }) {
   const { t } = useTranslation(["website", "common"]);
@@ -38,6 +39,7 @@ export default function BookDetails({ book }) {
 
   let actionButtons = null;
   const downloadUrl = `${API_BASE_URL}/library/download/${book.id}`;
+  const coverUrl = book.cover_image_url || buildUrl(book.cover_image);
 
   if (book.is_paid) {
     if (book.user_has_access) {
@@ -89,9 +91,9 @@ export default function BookDetails({ book }) {
 
   return (
     <div className="flex flex-col md:flex-row gap-8 bg-gray-800/60 p-6 rounded-xl shadow-lg">
-      {book.cover_image_url && (
+      {coverUrl && (
         <Image
-          src={book.cover_image_url}
+          src={coverUrl}
           alt={book.title}
           width={400}
           height={600}

--- a/frontend/src/components/chat/ChatHeader.js
+++ b/frontend/src/components/chat/ChatHeader.js
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { FaVideo, FaWhatsapp, FaEnvelope } from "react-icons/fa";
-import { API_BASE_URL } from "@/config/config";
 import formatRelativeTime from "@/utils/relativeTime";
+import { buildUrl } from "@/utils/url";
 import dayjs from "dayjs";
 import ChatImage from "../shared/ChatImage";
 
@@ -10,8 +10,8 @@ const ChatHeader = ({ selectedChat, onStartVideoCall }) => {
 
   const getAvatarUrl = (url, fallback = "/images/default-avatar.png") => {
     if (!url) return fallback;
-    if (url.startsWith("http") || url.startsWith("blob:")) return url;
-    return `${API_BASE_URL}${url}`;
+    if (url.startsWith("blob:")) return url;
+    return buildUrl(url) || fallback;
   };
 
   if (!selectedChat) {

--- a/frontend/src/components/chat/ChatSidebar.js
+++ b/frontend/src/components/chat/ChatSidebar.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import ChatImage from "../shared/ChatImage";
-import { API_BASE_URL } from "@/config/config";
+import { buildUrl } from "@/utils/url";
 import {
   FaPlus,
   FaClock,
@@ -28,8 +28,8 @@ const ChatSidebar = ({
 
   const getAvatarUrl = (url) => {
     if (!url) return "/images/default-avatar.png";
-    if (url.startsWith("http") || url.startsWith("blob:")) return url;
-    return `${API_BASE_URL}${url}`;
+    if (url.startsWith("blob:")) return url;
+    return buildUrl(url) || "/images/default-avatar.png";
   };
 
   const isUserOnline = (user) =>

--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -5,8 +5,8 @@ import formatRelativeTime from "@/utils/relativeTime";
 import ChatHeader from "./ChatHeader";
 import MessageInput from "./MessageInput";
 import { FaCheck, FaCheckDouble, FaThumbtack, FaReply, FaTrash } from "react-icons/fa";
-import { API_BASE_URL } from "@/config/config";
 import { toast } from "react-toastify";
+import { buildUrl } from "@/utils/url";
 import useAuthStore from "@/store/auth/authStore";
 import {
   getConversation,
@@ -28,14 +28,14 @@ const ChatWindow = ({ selectedChat, refreshUsers }) => {
 
   const getAvatarUrl = (url) => {
     if (!url) return "/images/default-avatar.png";
-    if (url.startsWith("http") || url.startsWith("blob:")) return url;
-    return `${API_BASE_URL}${url}`;
+    if (url.startsWith("blob:")) return url;
+    return buildUrl(url) || "/images/default-avatar.png";
   };
 
   const getMediaUrl = (url) => {
     if (!url) return null;
-    if (url.startsWith("http") || url.startsWith("blob:") || url.startsWith("data:")) return url;
-    return `${API_BASE_URL}${url}`;
+    if (url.startsWith("blob:") || url.startsWith("data:")) return url;
+    return buildUrl(url);
   };
 
   const isImage = (path) => {

--- a/frontend/src/components/chat/MessageItem.js
+++ b/frontend/src/components/chat/MessageItem.js
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 import ChatImage from "../shared/ChatImage";
 import formatRelativeTime from "@/utils/relativeTime";
-import { API_BASE_URL } from "@/config/config";
+import { buildUrl } from "@/utils/url";
 import useAuthStore from "@/store/auth/authStore";
 import {
   FaPlay,
@@ -17,8 +17,8 @@ const MessageItem = ({ message, onReply, onDelete, onPin }) => {
 
   const getMediaUrl = (url) => {
     if (!url) return null;
-    if (url.startsWith("http") || url.startsWith("blob:") || url.startsWith("data:")) return url;
-    return `${API_BASE_URL}${url}`;
+    if (url.startsWith("blob:") || url.startsWith("data:")) return url;
+    return buildUrl(url);
   };
 
   const isImage = (path) => {

--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -21,6 +21,7 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import useAppConfigStore from "@/store/appConfigStore";
 import LinkText from "@/components/shared/LinkText";
+import { buildUrl } from "@/utils/url";
 
 export default function Header() {
   const user = useAuthStore((state) => state.user);
@@ -343,10 +344,9 @@ export default function Header() {
             {user?.avatar_url && (
               <img
                 src={
-                  user.avatar_url.startsWith("http") ||
                   user.avatar_url.startsWith("blob:")
                     ? user.avatar_url
-                    : `${process.env.NEXT_PUBLIC_API_BASE_URL}${user.avatar_url}`
+                    : buildUrl(user.avatar_url)
                 }
                 alt="User Avatar"
                 className="w-9 h-9 rounded-full border border-gray-300 shadow object-cover"

--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -5,8 +5,8 @@ import { ChevronDown, Plus } from 'lucide-react';
 import { useTranslation, i18n } from 'next-i18next';
 import { useState, useEffect } from 'react';
 import useAppConfigStore from '@/store/appConfigStore';
-import { API_BASE_URL } from '@/config/config';
 import logo from '@/shared/assets/images/login/logo.png';
+import { buildUrl } from '@/utils/url';
 import { clearCache } from '@/services/admin/cacheService';
 import { adminNavLinks } from './SidebarLinks/adminLinks';
 import { instructorNavLinks } from './SidebarLinks/instructorLinks';
@@ -54,7 +54,7 @@ export default function Sidebar({ role = 'admin' }) {
       <div>
         <div className="flex items-center gap-3 mb-8">
           <img
-            src={settings.logo_url ? `${API_BASE_URL}${settings.logo_url}` : logo.src || logo}
+            src={settings.logo_url ? buildUrl(settings.logo_url) : logo.src || logo}
             alt={`${settings.appName || 'SkillBridge'} Logo`}
             className="w-12 h-12 rounded-full object-contain shadow"
           />

--- a/frontend/src/components/groups/GroupForm.js
+++ b/frontend/src/components/groups/GroupForm.js
@@ -10,7 +10,7 @@ import { sendChatMessage } from '@/services/messageService';
 import { createNotification } from '@/services/notificationService';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
-import { API_BASE_URL } from '@/config/config';
+import { buildUrl } from '@/utils/url';
 
 export default function GroupForm() {
   const router = useRouter();
@@ -44,11 +44,8 @@ export default function GroupForm() {
       user.profile_image ||
       '';
     if (!url) return '/images/default-avatar.png';
-    if (url.startsWith('http') || url.startsWith('blob:') || url.startsWith('data:'))
-      return url;
-    const clean = url.startsWith('/') ? url : `/${url}`;
-    return `${API_BASE_URL}${clean}`;
-
+    if (url.startsWith('blob:') || url.startsWith('data:')) return url;
+    return buildUrl(url) || '/images/default-avatar.png';
   };
 
   useEffect(() => {

--- a/frontend/src/components/shared/LanguageSwitcher.js
+++ b/frontend/src/components/shared/LanguageSwitcher.js
@@ -1,7 +1,7 @@
 import useSWR from "swr";
 import { useTranslation } from "next-i18next";
 import api from "@/services/api/api";
-import { API_BASE_URL } from "@/config/config";
+import { buildUrl } from "@/utils/url";
 
 const fetcher = url => api.get(url).then(res => res.data.data);
 
@@ -34,7 +34,7 @@ export default function LanguageSwitcher({ changeLang }) {
               <img
                 src={
                   lang.icon_url
-                    ? `${API_BASE_URL}${lang.icon_url}`
+                    ? buildUrl(lang.icon_url)
                     : "/flags/default.png"
                 }
                 alt={`${lang.name} flag`}

--- a/frontend/src/components/tutorials/create/CurriculumStep.js
+++ b/frontend/src/components/tutorials/create/CurriculumStep.js
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 import { toast } from "react-toastify";
 import { FaPlus, FaTrash, FaPlay } from "react-icons/fa";
 import { uploadChapterVideo } from "@/services/admin/tutorialChapterService";
+import { buildUrl } from "@/utils/url";
 
 export default function CurriculumStep({ tutorialData, setTutorialData, onNext, onBack }) {
   const { t } = useTranslation("tutorials");
@@ -52,7 +53,7 @@ export default function CurriculumStep({ tutorialData, setTutorialData, onNext, 
         setUploadProgress(progress);
       });
       const serverPath = res.video_url;
-      const previewUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL}${serverPath}`;
+      const previewUrl = buildUrl(serverPath);
       handleChange(index, "video", previewUrl);
       handleChange(index, "videoUrl", serverPath);
       toast.success(t("create.curriculum.video_upload_success"));

--- a/frontend/src/components/website/sections/Footer.js
+++ b/frontend/src/components/website/sections/Footer.js
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import GoogleAd from "@/components/shared/GoogleAd";
-import { API_BASE_URL } from "@/config/config";
 import useAppConfigStore from "@/store/appConfigStore";
 import {
   FaFacebook, FaTwitter, FaLinkedin, FaInstagram, FaYoutube,

--- a/frontend/src/components/website/sections/Hero.js
+++ b/frontend/src/components/website/sections/Hero.js
@@ -23,8 +23,8 @@ import AdMediaModal from "@/components/website/AdMediaModal";
 import SidebarMenu from "@/components/shared/SidebarMenu";
 import Chatbot from "@/components/shared/Chatbot";
 import useAppConfigStore from "@/store/appConfigStore";
-import { API_BASE_URL } from "@/config/config";
 import { fetchAds, recordAdView, recordAdClick } from "@/services/adsService";
+import { buildUrl } from "@/utils/url";
 import { searchAll } from "@/services/searchService";
 import { useTranslation } from "next-i18next";
 import useAuthStore from "@/store/auth/authStore";
@@ -61,14 +61,8 @@ const Hero = () => {
       setHeroBg("");
       return;
     }
-    let base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-    if (!base.startsWith("http") && typeof window !== "undefined") {
-      base = window.location.origin + base;
-    }
-    const normalizedBg = bg.startsWith("http")
-      ? bg
-      : `${base.replace(/\/$/, "")}${bg.startsWith("/") ? bg : `/${bg}`}`;
-    setHeroBg(normalizedBg);
+    const normalizedBg = buildUrl(bg);
+    setHeroBg(normalizedBg || "");
   }, [settings.home_bg_url]);
 
   // Always fetch latest configuration so hero background stays in sync

--- a/frontend/src/components/website/sections/InstructorBooking.js
+++ b/frontend/src/components/website/sections/InstructorBooking.js
@@ -17,9 +17,7 @@ import {
 } from "react-icons/fa6";
 import { FaSearch } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
-
-// Use a relative API base URL by default so deployments work on any domain
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+import { buildUrl } from "@/utils/url";
 
 const defaultCategories = ["All"];
 const sortOptions = ["Highest Rated", "Most Experienced"];
@@ -49,7 +47,7 @@ export default function InstructorBooking() {
           ...ins,
           name: ins.full_name,
           avatar: ins.avatar_url
-            ? `${API_BASE_URL}${ins.avatar_url}`
+            ? buildUrl(ins.avatar_url) || "/images/profile/user.png"
             : "/images/profile/user.png",
           rating: ins.rating || 5,
           tags: Array.isArray(ins.expertise) ? ins.expertise : [],

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -25,7 +25,6 @@ import { toast } from "react-toastify";
 
 import useAuthStore from "@/store/auth/authStore";
 import useAdminStore from "@/store/admin/adminStore";
-import { API_BASE_URL } from "@/config/config";
 import useCartStore from "@/store/cart/cartStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
@@ -33,6 +32,7 @@ import LinkText from "@/components/shared/LinkText";
 import useAppConfigStore from "@/store/appConfigStore";
 import api from "@/services/api/api";
 import { getCurrencies } from "@/services/currencyService";
+import { buildUrl } from "@/utils/url";
 
 const fetcher = (url) => api.get(url).then((res) => res.data.data);
 const currencyFetcher = () => getCurrencies();
@@ -198,8 +198,8 @@ const Navbar = () => {
 
   const getAvatarUrl = (avatar) => {
     if (!avatar) return "";
-    if (avatar.startsWith("http") || avatar.startsWith("blob:")) return avatar;
-    return `${API_BASE_URL}${avatar}`; // avatar starts with "/uploads/..."
+    if (avatar.startsWith("blob:")) return avatar;
+    return buildUrl(avatar) || "";
   };
 
   return (
@@ -217,7 +217,7 @@ const Navbar = () => {
         <Link href="/">
           <div className="w-14 h-14 rounded-full border-4 border-gray-800 flex items-center justify-center shadow-lg bg-gray-800 cursor-pointer overflow-hidden">
             <img
-              src={appSettings.logo_url ? `${API_BASE_URL}${appSettings.logo_url}` : logo.src || logo}
+              src={appSettings.logo_url ? buildUrl(appSettings.logo_url) : logo.src || logo}
               alt={`${appSettings.appName || 'SkillBridge'} Logo`}
               width={45}
               height={45}
@@ -386,7 +386,7 @@ const Navbar = () => {
           <img
             src={
               currentLang?.icon_url
-                ? `${API_BASE_URL}${currentLang.icon_url}`
+                ? buildUrl(currentLang.icon_url)
                 : "/flags/default.png"
             }
             alt={currentLang ? currentLang.name : 'language'}

--- a/frontend/src/components/website/sections/StudyCategories.js
+++ b/frontend/src/components/website/sections/StudyCategories.js
@@ -3,7 +3,7 @@ import { useTranslation } from "next-i18next";
 import { motion, AnimatePresence } from "framer-motion";
 import { FaChevronDown, FaFilter } from "react-icons/fa";
 import { fetchCategoryTree } from "@/services/instructor/categoryService";
-import { API_BASE_URL } from "@/config/config";
+import { buildUrl } from "@/utils/url";
 
 const renderTree = (nodes, level = 1) => {
   return (nodes || []).map((node) => (
@@ -96,7 +96,7 @@ export default function StudyCategories() {
               <div className="p-6">
                 {cat.image_url && (
                   <img
-                    src={`${API_BASE_URL}${cat.image_url}`}
+                    src={buildUrl(cat.image_url)}
                     alt={cat.name}
                     className="w-16 h-16 rounded-full mx-auto mb-2 object-cover"
                   />


### PR DESCRIPTION
## Summary
- use shared buildUrl for avatar and media URLs across components
- remove ad-hoc API_BASE_URL concatenation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2576d99588328a3bd8380d2b002f2