### PR TITLE
secure media streaming path resolution

### DIFF
--- a/backend/src/modules/media/media.controller.js
+++ b/backend/src/modules/media/media.controller.js
@@ -4,10 +4,13 @@ const mime = require('mime-types');
 
 exports.stream = (req, res) => {
   const requested = req.params[0] || req.params.filename || '';
-  const safePath = path
-    .normalize(requested)
-    .replace(/^([\.]{2}[\/])+/, '');
-  const filePath = path.join(__dirname, '../../../uploads', safePath);
+  const uploadsDir = path.resolve(__dirname, '../../../uploads');
+  const filePath = path.resolve(uploadsDir, requested);
+  const relative = path.relative(uploadsDir, filePath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
   fs.stat(filePath, (err, stats) => {
     if (err || !stats.isFile()) {
       return res.status(404).json({ message: 'File not found' });

--- a/backend/tests/mediaRoutes.test.js
+++ b/backend/tests/mediaRoutes.test.js
@@ -1,0 +1,34 @@
+const request = require('supertest');
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const routes = require('../src/modules/media/media.routes');
+
+const app = express();
+app.use('/api/media', routes);
+
+describe('GET /api/media', () => {
+  const uploadsDir = path.resolve(__dirname, '../uploads');
+  const testFile = path.join(uploadsDir, 'test-file.txt');
+
+  beforeAll(() => {
+    fs.writeFileSync(testFile, 'hello');
+  });
+
+  afterAll(() => {
+    fs.unlinkSync(testFile);
+  });
+
+  it('serves files within uploads directory', async () => {
+    const res = await request(app).get('/api/media/test-file.txt');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('hello');
+  });
+
+  it('denies path traversal attempts', async () => {
+    const res = await request(app).get('/api/media/../package.json');
+    expect(res.status).toBe(403);
+  });
+});
+


### PR DESCRIPTION
## Summary
- guard media streaming with `path.resolve` and forbid paths outside `uploads`
- add unit tests verifying normal access and traversal rejection

## Testing
- `npm test tests/mediaRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2576d9c5883288ee69a8e2808f76f