### PR TITLE
Run migrations at backend startup and allow production DB URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ PGADMIN_DEFAULT_PASSWORD=change_me
 PORT=5002
 # The credentials in DATABASE_URL must mirror POSTGRES_USER and POSTGRES_PASSWORD above
 DATABASE_URL=postgres://postgres:change_me@db:5432/eduSkillbridge
+# Alternatively, provide PRODUCTION_DATABASE_URL for production deployments
+# PRODUCTION_DATABASE_URL=postgres://postgres:change_me@db:5432/eduSkillbridge
 
 JWT_SECRET=your_jwt_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,4 +18,4 @@ COPY --from=builder /app/knexfile.js ./knexfile.js
 RUN chown -R node:node /app
 EXPOSE 5002
 USER node
-CMD ["node", "src/server.js"]
+CMD ["sh", "-c", "npx knex migrate:latest && node src/server.js"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,7 +17,7 @@ any are missing:
 
 - `JWT_SECRET` – signing key for access tokens
 - `REFRESH_TOKEN_SECRET` – signing key for refresh tokens
-- `DATABASE_URL` – PostgreSQL connection string (use `TEST_DATABASE_URL` when running tests)
+- `DATABASE_URL` – PostgreSQL connection string (use `TEST_DATABASE_URL` when running tests). For production deployments, you may instead provide `PRODUCTION_DATABASE_URL`.
 - `PORT` – port for the HTTP server
 - `SESSION_SECRET` – session cookie signing secret
 

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -10,6 +10,7 @@ const EnvSchema = z.object({
   REFRESH_TOKEN_SECRET: z.string(),
   SESSION_SECRET: z.string(),
   DATABASE_URL: z.string().url().optional(),
+  PRODUCTION_DATABASE_URL: z.string().url().optional(),
   TEST_DATABASE_URL: z.string().url().optional(),
   REDIS_URL: z.string().url().optional(),
   FRONTEND_URL: z.string().default('http://localhost:3000'),
@@ -24,9 +25,15 @@ if (FRONTEND_URL.startsWith('FRONTEND_URL=')) {
   FRONTEND_URL = FRONTEND_URL.replace(/^FRONTEND_URL=/, '');
 }
 
-const DATABASE_URL = env.NODE_ENV === 'test' ? env.TEST_DATABASE_URL : env.DATABASE_URL;
+const DATABASE_URL =
+  env.NODE_ENV === 'test'
+    ? env.TEST_DATABASE_URL
+    : env.DATABASE_URL || env.PRODUCTION_DATABASE_URL;
 if (!DATABASE_URL) {
-  const key = env.NODE_ENV === 'test' ? 'TEST_DATABASE_URL' : 'DATABASE_URL';
+  const key =
+    env.NODE_ENV === 'test'
+      ? 'TEST_DATABASE_URL'
+      : 'DATABASE_URL or PRODUCTION_DATABASE_URL';
   throw new Error(`${key} is required`);
 }
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -41,8 +41,12 @@ const requiredSecrets = [
   "REFRESH_TOKEN_SECRET",
   "SESSION_SECRET",
 ];
-const dbKey =
-  process.env.NODE_ENV === "test" ? "TEST_DATABASE_URL" : "DATABASE_URL";
+let dbKey;
+if (process.env.NODE_ENV === "test") {
+  dbKey = "TEST_DATABASE_URL";
+} else {
+  dbKey = process.env.DATABASE_URL ? "DATABASE_URL" : "PRODUCTION_DATABASE_URL";
+}
 requiredSecrets.push(dbKey);
 const missingSecrets = requiredSecrets.filter((key) => !process.env[key]);
 if (missingSecrets.length) {


### PR DESCRIPTION
## Summary
- Run `knex migrate:latest` before starting the backend server
- Support `PRODUCTION_DATABASE_URL` as fallback database connection
- Document production database URL option

## Testing
- `TEST_DATABASE_URL=postgres://user:pass@localhost:5432/db npm test` *(fails: Test Suites: 17 failed, 2 skipped, 106 passed, 123 of 125 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c27671841c8328a3dbf1f35a871061