### PR TITLE
Add CSRF token handling for admin avatar upload

### DIFF
--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -1,5 +1,6 @@
 // 📁 src/services/admin/adminService.js
 import api from "@/services/api/api";
+import { getCsrfToken } from "@/services/api/csrf";
 
 /**
  * 👤 Get current admin profile.
@@ -33,9 +34,13 @@ export const updateAdminProfile = async (profileData) => {
 export const uploadAdminAvatar = async (adminId, avatarFile) => {
   const formData = new FormData();
   formData.append("avatar", avatarFile);
+  const token = getCsrfToken();
 
   const res = await api.patch(`/users/admin/${adminId}/avatar`, formData, {
-    headers: { "Content-Type": "multipart/form-data" },
+    headers: {
+      "Content-Type": "multipart/form-data",
+      "x-csrf-token": token,
+    },
     withCredentials: true, // if using cookies
   });
   return res.data;


### PR DESCRIPTION
## Summary
- include CSRF token retrieval in admin avatar upload service
- send token in request headers alongside multipart form data

## Testing
- `npx jest --runInBand` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*
- `npm run lint` *(fails: 44 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c2766fad14832893387d016ebde355