### PR TITLE
chore: exempt refresh token route from csrf

### DIFF
--- a/backend/src/middleware/csrf.js
+++ b/backend/src/middleware/csrf.js
@@ -20,6 +20,7 @@ const exemptPaths = [
   '/api/auth/forgot-password',
   '/api/auth/verify-otp',
   '/api/auth/reset-password',
+  '/api/auth/refresh',
 ];
 
 module.exports = [


### PR DESCRIPTION
## Summary
- prevent CSRF middleware from intercepting `/api/auth/refresh`

## Testing
- `npm test` *(fails: 17 failed, 106 passed)*
- `node -e ...` (POST /api/auth/refresh returns 200)


------
https://chatgpt.com/codex/tasks/task_e_68c2766eb0208328987be13b24530add