### PR TITLE
Fix admin avatar upload CSRF token usage

### DIFF
--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -37,19 +37,12 @@ export const updateAdminProfile = async (profileData) => {
 export const uploadAdminAvatar = async (adminId, avatarFile) => {
   const formData = new FormData();
   formData.append("avatar", avatarFile);
-  const token = getCsrfToken();
-
   const headers = { "Content-Type": "multipart/form-data" };
-  const token = getCsrfToken();
-  if (token) headers["x-csrf-token"] = token;
-
   const csrfToken = getCsrfToken();
+  if (csrfToken) headers["x-csrf-token"] = csrfToken;
 
   const res = await api.patch(`/users/admin/${adminId}/avatar`, formData, {
-    headers: {
-      "Content-Type": "multipart/form-data",
-      "x-csrf-token": csrfToken,
-    },
+    headers,
     withCredentials: true, // if using cookies
   });
   return res.data;


### PR DESCRIPTION
## Summary
- streamline CSRF token retrieval for admin avatar uploads

## Testing
- `npx jest src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: TypeError and missing module)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c288d347808328b627d886d8a902da