### PR TITLE
Handle multer errors for admin avatar uploads

### DIFF
--- a/backend/src/modules/users/admin/admin.routes.js
+++ b/backend/src/modules/users/admin/admin.routes.js
@@ -28,7 +28,28 @@ router.use(verifyToken, isAdmin);
 // ─────────────────────────────────────────────
 // 📤 Avatar Upload (FormData: avatar)
 // ─────────────────────────────────────────────
-router.patch("/:id/avatar", upload.single("avatar"), controller.updateAvatar);
+router.patch(
+  "/:id/avatar",
+  (req, res, next) => {
+    upload.single("avatar")(req, res, (err) => {
+      if (err) {
+        logger.error("Multer upload error:", err.message);
+        let message = err.message;
+        if (err.code === "LIMIT_FILE_SIZE") {
+          message = "Avatar file too large. Max 10MB allowed.";
+        } else if (err.message === "Invalid file type for this field") {
+          message = "Invalid avatar file type. Only image files are allowed.";
+        }
+        return res.status(400).json({ message });
+      }
+      if (process.env.NODE_ENV !== "production") {
+        logger.debug("Avatar upload request received");
+      }
+      next();
+    });
+  },
+  controller.updateAvatar
+);
 
 
 


### PR DESCRIPTION
## Summary
- wrap admin avatar upload with multer error handling
- send 400 responses for invalid file type or oversized avatar uploads

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined], etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c297bf498083288347ec57ee86eeb3