### PR TITLE
Improve avatar upload error handling

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -201,7 +201,9 @@ useEffect(() => {
       URL.revokeObjectURL(tempAvatar);
       setTempAvatar(null);
     } catch (error) {
-      toast.error(t('avatar_upload_failed'));
+      console.error('Avatar upload error:', error.response);
+      const msg = error.response?.data?.message || t('avatar_upload_failed');
+      toast.error(msg);
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -323,7 +323,9 @@ export default function InstructorProfileEdit() {
       URL.revokeObjectURL(tempAvatar);
       setTempAvatar(null);
     } catch (error) {
-        toast.error(t('avatar_upload_failed'));
+      console.error('Avatar upload error:', error.response);
+      const msg = error.response?.data?.message || t('avatar_upload_failed');
+      toast.error(msg);
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -156,8 +156,10 @@ export default function StudentProfileEdit() {
         avatarPreview: `${process.env.NEXT_PUBLIC_API_BASE_URL}${avatar_url}?v=${Date.now()}`
       }));
       toast.success("Avatar uploaded successfully!");
-    } catch (err) {
-      toast.error("Failed to upload avatar");
+    } catch (error) {
+      console.error('Avatar upload error:', error.response);
+      const msg = error.response?.data?.message || 'Failed to upload avatar';
+      toast.error(msg);
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## Summary
- handle avatar upload errors using server-provided messages in admin profile editor
- apply same avatar upload error handling for instructor profile editor
- show API message when student avatar upload fails

## Testing
- `npm test src/tests/__tests__/CacheManager.test.tsx`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c297b9f9e88328980f59d036e7c739