### PR TITLE
Remove manual multipart header for admin avatar upload

### DIFF
--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -37,12 +37,10 @@ export const updateAdminProfile = async (profileData) => {
 export const uploadAdminAvatar = async (adminId, avatarFile) => {
   const formData = new FormData();
   formData.append("avatar", avatarFile);
-  const headers = { "Content-Type": "multipart/form-data" };
   const csrfToken = getCsrfToken();
-  if (csrfToken) headers["x-csrf-token"] = csrfToken;
 
   const res = await api.patch(`/users/admin/${adminId}/avatar`, formData, {
-    headers,
+    headers: csrfToken ? { "x-csrf-token": csrfToken } : undefined,
     withCredentials: true, // if using cookies
   });
   return res.data;


### PR DESCRIPTION
## Summary
- remove hardcoded `Content-Type` so axios can set multipart boundary for admin avatar uploads

## Testing
- `npm test --silent | tail -n 20`
- `npm run lint` *(fails: Component definition is missing display name)*
- `node -e "const axios=require('axios'); const fd=new FormData(); fd.append('avatar', new Blob(['hello'], {type:'text/plain'}), 'avatar.txt'); axios.patch('https://httpbin.org/anything', fd).then(res=>console.log(res.status, res.data.files, res.data.headers['Content-Type'])).catch(console.error);"`

------
https://chatgpt.com/codex/tasks/task_e_68c297ce89a08328a520c8b00ff7b68f