### PR TITLE
refactor: centralize admin profile upsert

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -7,6 +7,7 @@ const db = require("../../../config/database");
 const bcrypt = require("bcrypt");
 const notificationService = require("../../notifications/notifications.service");
 const messageService = require("../../messages/messages.service");
+const adminService = require("./admin.service");
 const handleControllerError = require("../../../utils/handleControllerError");
 
 
@@ -87,23 +88,7 @@ exports.updateProfile = async (req, res) => {
     });
 
     // 2. Upsert admin profile
-    const profileData = {
-      job_title,
-      department,
-      updated_at: new Date(),
-    };
-
-    const existing = await db("admin_profiles").where({ user_id: userId }).first();
-
-    if (existing) {
-      await db("admin_profiles").where({ user_id: userId }).update(profileData);
-    } else {
-      await db("admin_profiles").insert({
-        user_id: userId,
-        ...profileData,
-        created_at: new Date(),
-      });
-    }
+    await adminService.upsertAdminProfile(db, userId, { job_title, department });
 
     // 3. Replace social links
     await db("user_social_links").where({ user_id: userId }).del();
@@ -176,6 +161,7 @@ exports.updateAvatar = async (req, res) => {
     return res.status(400).json({ message: "No image uploaded" });
   }
 
+  try {
     const filePath = `/uploads/admin/avatars/${req.file.filename}`;
 
     await db("users")

--- a/backend/src/modules/users/admin/admin.service.js
+++ b/backend/src/modules/users/admin/admin.service.js
@@ -1,6 +1,7 @@
 // 📁 src/modules/users/admin/admin.service.js
 
 const db = require("../../../config/database");
+const logger = require("../../../utils/logger.js");
 
 /**
  * Fetch admin profile data by user_id
@@ -11,28 +12,42 @@ exports.getAdminProfile = (userId) => {
 };
 
 /**
- * Create or update admin profile details
+ * Helper to create or update an admin profile
+ * @param {object} dbConn - Knex instance
+ * @param {string} userId
+ * @param {object} profileData
+ */
+exports.upsertAdminProfile = async (dbConn, userId, profileData) => {
+  try {
+    const existing = await dbConn("admin_profiles").where({ user_id: userId }).first();
+
+    const data = {
+      ...profileData,
+      updated_at: new Date(),
+    };
+
+    if (existing) {
+      await dbConn("admin_profiles").where({ user_id: userId }).update(data);
+    } else {
+      await dbConn("admin_profiles").insert({
+        user_id: userId,
+        ...data,
+        created_at: new Date(),
+      });
+    }
+  } catch (error) {
+    logger.error("Failed to upsert admin profile", error.message);
+    throw error;
+  }
+};
+
+/**
+ * Create or update admin profile details using default db connection
  * @param {string} userId
  * @param {object} data - { gender, date_of_birth, avatar_url, identity_doc_url, etc. }
  */
-exports.updateAdminProfile = async (userId, data) => {
-  const exists = await db("admin_profiles").where({ user_id: userId }).first();
-
-  const profileData = {
-    ...data,
-    updated_at: new Date(),
-  };
-
-  if (exists) {
-    await db("admin_profiles").where({ user_id: userId }).update(profileData);
-  } else {
-    await db("admin_profiles").insert({
-      user_id: userId,
-      ...profileData,
-      created_at: new Date(),
-    });
-  }
-};
+exports.updateAdminProfile = (userId, data) =>
+  exports.upsertAdminProfile(db, userId, data);
 
 // ---------------------------------------------------------------------------
 // 📊 Dashboard statistics for the main admin dashboard


### PR DESCRIPTION
## Summary
- add reusable `upsertAdminProfile` helper in admin service
- refactor admin profile controller to call helper for upsert and log errors

## Testing
- `npm test` (fails: Test Suites: 17 failed, 2 skipped, 108 passed, 125 of 127 total)

------
https://chatgpt.com/codex/tasks/task_e_68c2a0766af08328bf7c615a936a096c