### PR TITLE
Handle invalid auth parse in profile edit

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -75,7 +75,14 @@ function ProfileEditTemplate() {
 
 useEffect(() => {
   const local = localStorage.getItem("auth");
-  const parsed = JSON.parse(local)?.state;
+  let parsed;
+  if (local) {
+    try {
+      parsed = JSON.parse(local)?.state;
+    } catch (error) {
+      console.error("Failed to parse auth from localStorage", error);
+    }
+  }
   if (hasHydrated && !user && parsed?.user) {
     setUser(parsed.user);
   }


### PR DESCRIPTION
## Summary
- guard admin profile auth parsing with try/catch to avoid crashes on malformed localStorage

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*
- `npm run lint` *(fails: 315 problems, 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a0716ce88328a42cd203dff42e4f