### PR TITLE
Ensure admin profile exists before identity upload

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -207,12 +207,25 @@ exports.uploadIdentityDoc = async (req, res) => {
 
     const filePath = `/uploads/admin/identity/${req.file.filename}`;
 
-    await db("admin_profiles")
+    const existingProfile = await db("admin_profiles")
       .where({ user_id: req.user.id })
-      .update({
+      .first();
+
+    if (existingProfile) {
+      await db("admin_profiles")
+        .where({ user_id: req.user.id })
+        .update({
+          identity_doc_url: filePath,
+          updated_at: new Date(),
+        });
+    } else {
+      await db("admin_profiles").insert({
+        user_id: req.user.id,
         identity_doc_url: filePath,
+        created_at: new Date(),
         updated_at: new Date(),
       });
+    }
 
     res.status(200).json({
       message: "Identity document uploaded successfully",


### PR DESCRIPTION
## Summary
- Verify admin profile exists when uploading identity documents
- Insert profile if missing before updating identity document URL

## Testing
- `npm test` *(fails: Test Suites: 19 failed, 2 skipped, 106 passed, 125 of 127 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a06fe11883288b8895b996f8c853