### PR TITLE
Wrap admin avatar update in try/catch

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -175,7 +175,7 @@ exports.updateAvatar = async (req, res) => {
   if (!req.file) {
     return res.status(400).json({ message: "No image uploaded" });
   }
-
+  try {
     const filePath = `/uploads/admin/avatars/${req.file.filename}`;
 
     await db("users")


### PR DESCRIPTION
## Summary
- guard admin avatar update with try/catch

## Testing
- `npm test` (fails: Test Suites: 17 failed, 2 skipped, 108 passed, 125 of 127 total)


------
https://chatgpt.com/codex/tasks/task_e_68c2a0606a988328bebc69e982c7de26