### PR TITLE
Include CSRF header when uploading admin avatar

### DIFF
--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -45,7 +45,7 @@ export const uploadAdminAvatar = async (adminId, avatarFile) => {
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
 
   const res = await api.patch(`/users/admin/${adminId}/avatar`, formData, {
-    headers: csrfToken ? { "x-csrf-token": csrfToken } : undefined,
+    headers,
     withCredentials: true, // if using cookies
   });
   return res.data;


### PR DESCRIPTION
## Summary
- merge CSRF token into existing headers for avatar uploads
- ensure avatar upload requests send both Content-Type and CSRF headers with credentials

## Testing
- `npm test src/tests/__tests__/bookService.test.js`
- `npm run lint`
- manual avatar upload request verifying headers

------
https://chatgpt.com/codex/tasks/task_e_68c2a06890588328be0a39dbe3c458d3