### PR TITLE
use prepared headers for admin avatar uploads

### DIFF
--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -45,7 +45,7 @@ export const uploadAdminAvatar = async (adminId, avatarFile) => {
   if (csrfToken) headers["x-csrf-token"] = csrfToken;
 
   const res = await api.patch(`/users/admin/${adminId}/avatar`, formData, {
-    headers: csrfToken ? { "x-csrf-token": csrfToken } : undefined,
+    headers,
     withCredentials: true, // if using cookies
   });
   return res.data;


### PR DESCRIPTION
## Summary
- ensure admin avatar uploads always send prepared headers including content type and optional CSRF token

## Testing
- `npm test` (fails: CacheManager.test.tsx, InstructorSettingsPage.test.js, ...)
- `npm run lint` (fails: 44 errors)


------
https://chatgpt.com/codex/tasks/task_e_68c2a063bb6c832888086263080815e5