### PR TITLE
fix: refresh admin profile after update

### DIFF
--- a/frontend/src/store/admin/adminStore.js
+++ b/frontend/src/store/admin/adminStore.js
@@ -31,7 +31,16 @@ const useAdminStore = create(
         set({ isLoading: true, error: null });
         try {
           const data = await updateAdminProfile(profileData);
-          set({ profile: data, isLoading: false });
+
+          if (data && data.message) {
+            const profile = await getAdminProfile();
+            set({ profile, isLoading: false });
+          } else {
+            set((state) => ({
+              profile: { ...state.profile, ...data },
+              isLoading: false,
+            }));
+          }
           return true;
         } catch (err) {
           set({ error: err.message, isLoading: false });


### PR DESCRIPTION
## Summary
- avoid overwriting admin profile with update response
- merge updated fields or re-fetch full profile after updating

## Testing
- `npm test src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: mockReset not a function; missing module)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a06201008328a6035c7f1f2fda81