### PR TITLE
chore: add no-redeclare ESLint rule and lint hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run lint
-        run: npm run lint --if-present
+        run: npm run lint
       - name: Build
         run: npm run build --if-present
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: frontend-lint
+        name: frontend lint
+        entry: npm run lint --prefix frontend
+        language: system
+        pass_filenames: false

--- a/frontend/eslint.config.local.mjs
+++ b/frontend/eslint.config.local.mjs
@@ -19,6 +19,7 @@ const eslintConfig = [
   {
     rules: {
       'no-console': noConsoleRule,
+      'no-redeclare': 'error',
     },
   },
 ];


### PR DESCRIPTION
## Summary
- enforce `no-redeclare` rule in frontend ESLint config
- run `npm run lint` for frontend job in CI
- add pre-commit hook to lint frontend before commits

## Testing
- `npm --prefix frontend run lint 2>&1 | tail -n 20`
- `npm --prefix frontend test src/tests/__tests__/CacheManager.test.tsx 2>&1 | tail -n 20` *(fails: _TypeError: _cacheService.clearCache.mockReset is not a function_)*

------
https://chatgpt.com/codex/tasks/task_e_68c2acce932c8328b7c993ead124b448