### PR TITLE
chore: remove duplicate admin service import

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -10,7 +10,6 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const adminService = require("./admin.service");
 const handleControllerError = require("../../../utils/handleControllerError");
-const adminService = require("./admin.service");
 
 // Allowed social platforms for links
 const allowedPlatforms = [


### PR DESCRIPTION
## Summary
- remove extra `adminService` import in `admin.controller.js`

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test` *(fails: 21 failed, 2 skipped, 107 passed)*
- `npm start` *(fails: development database configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c2accdb90c8328ba57b0d36da0ef8e