### PR TITLE
Fix admin profile update and avatar upload syntax

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -115,20 +115,22 @@ exports.updateProfile = async (req, res) => {
         user_id: userId,
         ...profileData,
         created_at: new Date(),
-
       });
+    }
 
     // 3. Replace social links
     await trx("user_social_links").where({ user_id: userId }).del();
 
     for (const link of social_links) {
-      if (link.url?.trim()) {
+      if (link.url?.trim() && allowedPlatforms.includes(link.platform)) {
         await trx("user_social_links").insert({
           user_id: userId,
-          ...profileData,
+          platform: link.platform,
+          url: link.url,
           created_at: new Date(),
         });
       }
+    }
     await trx.commit();
     res.json({ message: "Admin profile updated and marked as complete." });
   } catch (error) {
@@ -198,7 +200,6 @@ exports.updateAvatar = async (req, res) => {
       return res.status(400).json({ message: "No image uploaded" });
     }
 
-  try {
     const filePath = `/uploads/admin/avatars/${req.file.filename}`;
 
     await db("users")


### PR DESCRIPTION
## Summary
- resolve syntax error and validate social link updates in admin profile flow
- simplify admin avatar upload handling and ensure file cleanup on errors

## Testing
- `pre-commit run --files backend/src/modules/users/admin/admin.controller.js` *(fails: 44 errors, 271 warnings)*
- `npm test --prefix backend` *(fails: 18 suites failed, 2 skipped, 110 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b828450c8328a13f78b5a933ee84