### PR TITLE
Ensure token blacklist errors are surfaced

### DIFF
--- a/backend/src/services/tokenBlacklistService.js
+++ b/backend/src/services/tokenBlacklistService.js
@@ -1,4 +1,5 @@
 const db = require('../config/database');
+const logger = require('../utils/logger.js');
 
 /**
  * Inserts a token into the blacklist store.
@@ -10,7 +11,8 @@ async function addToken(token) {
   try {
     await db('blacklisted_tokens').insert({ token }).onConflict('token').ignore();
   } catch (err) {
-    // log or ignore
+    logger.error('Failed to add token to blacklist:', err);
+    throw err;
   }
 }
 

--- a/backend/tests/tokenBlacklistService.test.js
+++ b/backend/tests/tokenBlacklistService.test.js
@@ -1,0 +1,43 @@
+const mockIgnore = jest.fn();
+const mockOnConflict = jest.fn(() => ({ ignore: mockIgnore }));
+const mockInsert = jest.fn(() => ({ onConflict: mockOnConflict }));
+const mockFirst = jest.fn();
+const mockWhere = jest.fn(() => ({ first: mockFirst }));
+const mockDb = jest.fn(() => ({ insert: mockInsert, where: mockWhere }));
+
+jest.mock('../src/config/database.js', () => mockDb);
+
+const mockLogger = {
+  log: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+jest.mock('../src/utils/logger.js', () => mockLogger);
+
+const { addToken, isTokenBlacklisted } = require('../src/services/tokenBlacklistService');
+
+describe('tokenBlacklistService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('addToken logs and rethrows on failure', async () => {
+    const err = new Error('db fail');
+    mockIgnore.mockRejectedValueOnce(err);
+
+    await expect(addToken('tok')).rejects.toThrow('db fail');
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Failed to add token to blacklist:',
+      err
+    );
+  });
+
+  test('isTokenBlacklisted propagates database errors', async () => {
+    const err = new Error('query fail');
+    mockFirst.mockRejectedValueOnce(err);
+
+    await expect(isTokenBlacklisted('tok')).rejects.toThrow('query fail');
+  });
+});


### PR DESCRIPTION
## Summary
- log and rethrow database failures in `tokenBlacklistService`
- add tests verifying token blacklist service surfaces errors

## Testing
- `npm test tests/tokenBlacklistService.test.js`
- `pre-commit run --files src/services/tokenBlacklistService.js tests/tokenBlacklistService.test.js` *(fails: Component definition is missing display name, Unexpected console statement)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ca7898688328b5e2369e50714ec8