### PR TITLE
fix: add cache import to server

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,6 +13,7 @@ const session = require("express-session");
 const RedisStore = require("connect-redis").default;
 const redisClient = require("./utils/redisClient");
 const socketStore = require("./utils/socketStore");
+const cache = require("./utils/cache");
 const rateLimit = require("express-rate-limit");
 const { passport, initStrategies } = require("./config/passport");
 const db = require("./config/database");


### PR DESCRIPTION
## Summary
- require cache utility in server to support global cache clearing

## Testing
- `NODE_ENV=test JWT_SECRET=a REFRESH_TOKEN_SECRET=a SESSION_SECRET=a TEST_DATABASE_URL=https://example.com node - <<'NODE'
const path=require('path');
const dbStub={connectWithRetry:async()=>{console.log('mock db connect');},migrate:{list:async()=>[[],[]]}};
require.cache[path.resolve('./src/config/database.js')]={id:path.resolve('./src/config/database.js'),filename:path.resolve('./src/config/database.js'),loaded:true,exports:dbStub};
const srv=require('./src/server');
srv.startServer().then(async()=>{console.log('server started');await srv.clearServerCache();console.log('cache cleared');srv.server.close(()=>console.log('server closed'));}).catch(err=>{console.error('error',err);process.exit(1);});
NODE`
- `npm test -- tests/cacheRoutes.test.js` (fails: expect(received).toEqual(expected))

------
https://chatgpt.com/codex/tasks/task_e_68c3f72c57cc8328ac984042e36dd6d3