### PR TITLE
Import Redis client in auth service

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -19,6 +19,7 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
 const verificationService = require("../../verify/verify.service");
+const redisClient = require("../../../utils/redisClient");
 const {
   REFRESH_TOKEN_EXPIRES_IN,
   REFRESH_TOKEN_MAX_AGE,


### PR DESCRIPTION
## Summary
- import `redisClient` into auth service so login attempt tracking can use Redis when `REDIS_URL` is provided

## Testing
- `REDIS_URL=redis://localhost:6379 npm test -- --runInBand`
- `REDIS_URL=redis://localhost:6379 npm test tests/bookRoutes.test.js -- --runInBand` *(fails: creates a book, updates a book)*


------
https://chatgpt.com/codex/tasks/task_e_68c3f72977bc8328b4a4528817d3e4c1