### PR TITLE
Add redis client to auth service

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -1,4 +1,5 @@
 const logger = require('../../../utils/logger.js');
+const redisClient = require("../../../utils/redisClient");
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 const { v4: uuidv4 } = require("uuid");


### PR DESCRIPTION
## Summary
- import redis client into auth service for tracking login attempts

## Testing
- `npm test` (fails: tests/bookRoutes.test.js, tests/paymentCommission.test.js, tests/paymentInvoiceEmail.test.js, tests/tutorialRoutes.test.js, tests/paymentAmountValidation.test.js, tests/authSanitization.test.js, tests/tutorialUpdateTransaction.test.js, tests/adminProfileRollback.test.js, tests/cryptoPaymentRoutes.test.js)


------
https://chatgpt.com/codex/tasks/task_e_68c3f7226524832887afc4d15a1d8d5a