### PR TITLE
fix: import redis client

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -23,6 +23,7 @@ const {
   REFRESH_TOKEN_EXPIRES_IN,
   REFRESH_TOKEN_MAX_AGE,
 } = require("../../../config/tokens");
+const redisClient = require("../../../utils/redisClient");
 
 // ─────────────────────────────────────────────────────────────
 // 🔧 Config Constants


### PR DESCRIPTION
## Summary
- fix login crash by importing redis client in auth service

## Testing
- `npm test` *(fails: 18 failed, 2 skipped, 111 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f4dcc3c883288d43fdd93e6d67fb