### PR TITLE
feat: hide OTP code in sendOtp response

### DIFF
--- a/backend/src/modules/verify/verify.service.js
+++ b/backend/src/modules/verify/verify.service.js
@@ -46,7 +46,7 @@ exports.sendOtp = async (userId, type) => {
     }
   }
 
-  return { code };
+  return { alreadyVerified: false };
 };
 
 exports.verifyOtp = async (userId, type, code) => {


### PR DESCRIPTION
## Summary
- stop returning OTP code from `sendOtp` service
- only expose verification status flags

## Testing
- `npm test` *(fails: 21 failed, 108 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c418935ce08328bd1156e89ddb86c9