### PR TITLE
feat(auth): revoke tokens on password reset

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -20,7 +20,7 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
 const verificationService = require("../../verify/verify.service");
-const redisClient = require("../../../utils/redisClient");
+const { addToken: addTokenToBlacklist } = require("../../../services/tokenBlacklistService");
 const {
   REFRESH_TOKEN_EXPIRES_IN,
   REFRESH_TOKEN_MAX_AGE,
@@ -390,10 +390,10 @@ exports.verifyOtp = async ({ email, code }) => {
 
 /**
  * Reset a user's password using a valid OTP code.
- * @param {{email:string, code:string, new_password:string}} data
+ * @param {{email:string, code:string, new_password:string, accessToken?:string}} data
  * @returns {Promise<void>}
  */
-exports.resetPassword = async ({ email, code, new_password }) => {
+exports.resetPassword = async ({ email, code, new_password, accessToken }) => {
   const user = await userModel.findByEmail(email);
   if (!user) throw new AppError("User not found", 404);
 
@@ -417,6 +417,18 @@ exports.resetPassword = async ({ email, code, new_password }) => {
   await db("users").where({ id: user.id }).update({ password_hash: hashed });
 
   await db("password_resets").where({ id: resetRecord.id }).update({ used: true });
+
+  // Revoke all refresh tokens for this user
+  await db("refresh_tokens").where({ user_id: user.id }).del();
+
+  // Optionally blacklist the provided access token
+  if (accessToken) {
+    try {
+      await addTokenToBlacklist(accessToken);
+    } catch (err) {
+      logger.error("Failed to blacklist access token", err);
+    }
+  }
 
   await sendPasswordChangeEmail(user.email);
 

--- a/backend/tests/authResetPasswordService.test.js
+++ b/backend/tests/authResetPasswordService.test.js
@@ -13,11 +13,23 @@ jest.mock('../src/config/database', () => {
     }),
   };
 
+  const refreshTokensWhere = { del: jest.fn().mockResolvedValue() };
+  const refreshTokensTable = {
+    where: jest.fn().mockReturnValue(refreshTokensWhere),
+  };
+
   const db = jest.fn((table) => {
     if (table === 'password_resets') return passwordResetsTable;
     if (table === 'users') return usersTable;
+    if (table === 'refresh_tokens') return refreshTokensTable;
     return {};
   });
+  db.__tables = {
+    passwordResetsTable,
+    usersTable,
+    refreshTokensTable,
+    refreshTokensWhere,
+  };
 
   return db;
 });
@@ -51,6 +63,7 @@ const { sendPasswordChangeEmail } = require('../src/utils/email');
 const notificationService = require('../src/modules/notifications/notifications.service');
 const messageService = require('../src/modules/messages/messages.service');
 const bcrypt = require('bcrypt');
+const db = require('../src/config/database');
 
 describe('resetPassword service', () => {
   beforeEach(() => {
@@ -80,5 +93,9 @@ describe('resetPassword service', () => {
       message: 'Your password was changed successfully',
     });
     expect(messageService.createMessage).not.toHaveBeenCalled();
+    const { refreshTokensTable, refreshTokensWhere } = db.__tables;
+    // Ensure refresh tokens were revoked
+    expect(refreshTokensTable.where).toHaveBeenCalledWith({ user_id: 1 });
+    expect(refreshTokensWhere.del).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- revoke all of a user's refresh tokens when resetting their password
- optionally blacklist current access token upon password reset
- cover resetPassword token revocation in tests

## Testing
- `npm test -- backend/tests/authResetPasswordService.test.js`
- `npm test` *(fails: bookRoutes, paymentCommission, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c41892a2548328958b38a97e0e2400