### PR TITLE
Pass IP to failed login attempt tracking for missing users

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -192,7 +192,7 @@ exports.loginUser = async ({ email, password, ip }) => {
   if (!user) {
     // Perform a dummy hash to mitigate timing attacks when the user is missing
     await bcrypt.hash(password, SALT_ROUNDS);
-    recordFailedAttempt(email);
+    recordFailedAttempt(email, ip);
     throw new AppError("Invalid credentials", 401);
   }
 


### PR DESCRIPTION
## Summary
- record failed login attempts per IP when user is not found during authentication

## Testing
- `npm test` (fails: e.g., Identifier 'redisClient' has already been declared)


------
https://chatgpt.com/codex/tasks/task_e_68c4189181448328965be4562eea9107