### PR TITLE
chore: remove duplicate redis client require

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -20,7 +20,6 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
 const verificationService = require("../../verify/verify.service");
-const redisClient = require("../../../utils/redisClient");
 const {
   REFRESH_TOKEN_EXPIRES_IN,
   REFRESH_TOKEN_MAX_AGE,


### PR DESCRIPTION
## Summary
- remove redundant redis client import in auth service

## Testing
- `npm test` (fails: Test Suites: 18 failed, 2 skipped, 111 passed, 129 of 131 total)


------
https://chatgpt.com/codex/tasks/task_e_68c41886b0048328934ce8c284a1353a