### PR TITLE
fix: remove duplicate redis client import

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -20,7 +20,6 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
 const verificationService = require("../../verify/verify.service");
-const redisClient = require("../../../utils/redisClient");
 const {
   REFRESH_TOKEN_EXPIRES_IN,
   REFRESH_TOKEN_MAX_AGE,


### PR DESCRIPTION
## Summary
- remove duplicate redisClient import in auth service

## Testing
- `node --check backend/src/modules/auth/services/auth.service.js`
- `cd backend && npm test` *(fails: Test Suites: 18 failed, 2 skipped, 111 passed, 129 of 131 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c41870412c8328a8621ac7539641d4