### PR TITLE
feat(auth): enforce stronger password policy

### DIFF
--- a/backend/src/modules/auth/constants.js
+++ b/backend/src/modules/auth/constants.js
@@ -1,4 +1,4 @@
 module.exports = {
   OTP_LENGTH: 6,
-  PASSWORD_REGEX: /^(?=.*[A-Z])(?=.*[^A-Za-z0-9]).{8,}$/,
+  PASSWORD_REGEX: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/,
 };

--- a/backend/src/modules/auth/validators/auth.validator.js
+++ b/backend/src/modules/auth/validators/auth.validator.js
@@ -13,7 +13,7 @@ exports.registerSchema = z.object({
     .string()
     .regex(
       PASSWORD_REGEX,
-      "Password must be at least 8 characters, include an uppercase letter and a special character"
+      "Password must be at least 8 characters and include uppercase, lowercase, number, and special character"
     ),
   role: z.enum(["Student", "Instructor", "Admin"]).optional(), // Optional for fallback logic
   recaptchaToken: z.string().optional(),
@@ -58,7 +58,7 @@ exports.resetPasswordSchema = z.object({
     .string()
     .regex(
       PASSWORD_REGEX,
-      "Password must be at least 8 characters, include an uppercase letter and a special character"
+      "Password must be at least 8 characters and include uppercase, lowercase, number, and special character"
     ),
 });
 


### PR DESCRIPTION
## Summary
- require lowercase and numeric characters in backend password regex
- clarify validation messages for registration and password reset

## Testing
- `npm test -- tests/authResetPasswordRoutes.test.js`
- `node -e "const {registerSchema}=require('./src/modules/auth/validators/auth.validator'); console.log(registerSchema.safeParse({full_name:'Test User', email:'user@example.com', phone:'123456789012', password:'Password1\!', role:'Student'}));"`


------
https://chatgpt.com/codex/tasks/task_e_68c41872072c83289155e61b855e00da