### PR TITLE
Issue CSRF token cookies on login and refresh

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -6,6 +6,7 @@ const AppError = require("../../../utils/AppError");
 const socialLoginConfigService = require("../../socialLoginConfig/socialLoginConfig.service");
 const recaptchaService = require("../../recaptcha/recaptcha.service");
 const authMiddleware = require("../../../middleware/auth/authMiddleware");
+const crypto = require("crypto");
 
 // 🔧 Cookie options used in login and logout
 const { refreshCookieOptions, csrfCookieOptions } = require("../../../utils/cookie");
@@ -67,8 +68,10 @@ exports.login = catchAsync(async (req, res) => {
     }
   }
   const { accessToken, refreshToken, user } = await authService.loginUser({ ...req.body, ip: req.ip });
+  const csrfToken = crypto.randomBytes(64).toString("hex");
   res
     .cookie("refreshToken", refreshToken, refreshCookieOptions)
+    .cookie("csrfToken", csrfToken, csrfCookieOptions)
     .json({ message: "Login successful", accessToken, user });
 });
 
@@ -98,8 +101,10 @@ exports.refreshToken = catchAsync(async (req, res) => {
     if (process.env.NODE_ENV !== "production") {
       logger.debug("\u2705 Refresh token rotated for user", decoded.id);
     }
+    const csrfToken = crypto.randomBytes(64).toString("hex");
     res
       .cookie("refreshToken", newRefreshToken, refreshCookieOptions)
+      .cookie("csrfToken", csrfToken, csrfCookieOptions)
       .json({ message: "Token refreshed", accessToken });
   } catch (err) {
     logger.error("❌ Refresh token error:", err.message);

--- a/backend/tests/authRefreshRoutes.test.js
+++ b/backend/tests/authRefreshRoutes.test.js
@@ -63,5 +63,10 @@ describe('POST /api/auth/refresh', () => {
     expect(refreshRes.status).toBe(200);
     expect(refreshRes.body.accessToken).toBe('newA');
     expect(authService.rotateRefreshToken).toHaveBeenCalledWith('r');
+    expect(refreshRes.headers['set-cookie']).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('csrfToken='),
+      ])
+    );
   });
 });

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -15,6 +15,11 @@ The backend exposes a REST API under the `/api` prefix. Below is a brief outline
 - `POST /verify-otp` – verify the reset code
 - `POST /reset-password` – update the password
 
+`POST /login` and `POST /refresh` also issue a `csrfToken` cookie containing a
+random CSRF token. Clients must mirror this value in the `x-csrf-token` header
+on subsequent state‑changing requests (POST/PUT/PATCH/DELETE) to satisfy server
+CSRF validation.
+
 ## Users
 
 `/api/users`

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -1,6 +1,7 @@
 // 📁 src/services/auth/authService.js
 import api from "@/services/api/api";
 import logger from "@/utils/logger";
+import { ensureCsrfToken } from "@/services/api/csrf";
 
 /**
  * 🔐 Log in a user and retrieve access token and user info.
@@ -18,6 +19,8 @@ export const loginUser = async ({ email, password, recaptchaToken }) => {
       `${api.defaults.baseURL}/auth/login`
     );
     const res = await api.post("/auth/login", { email, password, recaptchaToken });
+    // Ensure the CSRF cookie from the backend is present for subsequent requests
+    await ensureCsrfToken();
     return res.data;
   } catch (err) {
     logger.error("❌ loginUser error", {
@@ -89,6 +92,7 @@ export const resetPassword = async ({ email, code, new_password }) => {
  */
 export const refreshAccessToken = async () => {
   const res = await api.post("/auth/refresh");
+  await ensureCsrfToken();
   return res.data;
 };
 


### PR DESCRIPTION
## Summary
- generate new CSRF token cookies during login and refresh token flows
- update frontend auth service to ensure CSRF cookie is present
- document CSRF token requirement in auth API docs
- extend refresh token test to assert CSRF cookie

## Testing
- `npm --prefix backend test` *(fails: multiple suites)*
- `npm --prefix frontend test` *(incomplete: produced partial output)*

------
https://chatgpt.com/codex/tasks/task_e_68c4187f03d4832888057f5eb7b697a6