### PR TITLE
Send verification OTP after registration

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -24,7 +24,7 @@ exports.register = catchAsync(async (req, res, next) => {
       }
     }
     const { user } = await authService.registerUser(req.body);
-    res.status(201).json({ message: "Registration successful", user });
+    res.status(201).json({ message: "Registration successful. A verification email has been sent.", user });
   } catch (err) {
     logger.error("🔥 Registration error caught:");
     logger.error("Name:", err.name);

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -20,7 +20,6 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
 const verificationService = require("../../verify/verify.service");
-const redisClient = require("../../../utils/redisClient");
 const {
   REFRESH_TOKEN_EXPIRES_IN,
   REFRESH_TOKEN_MAX_AGE,
@@ -156,6 +155,12 @@ exports.registerUser = async (data) => {
   } catch (err) {
     logger.error("Error sending registration emails:", err.message);
   }
+  // Queue verification email OTP sending without delaying response
+  setImmediate(() => {
+    verificationService
+      .sendOtp(newUser.id, "email")
+      .catch((err) => logger.error("Error sending verification OTP:", err));
+  });
   const safeUser = sanitizeUserUtil(newUser);
   return { user: { ...safeUser, roles, permissions } };
 };


### PR DESCRIPTION
## Summary
- Queue email OTP dispatch after user registration to avoid delaying API response
- Inform clients that a verification email has been sent upon registration

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*

------
https://chatgpt.com/codex/tasks/task_e_68c41880c5b48328bea30f31665b3606