### PR TITLE
docs: add installer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,28 @@ The script validates prerequisites, copies example env files, builds and starts 
 
 > **Note:** Always review the script before piping it into `bash` to verify it comes from a trusted source.
 
-Alternatively, launch the backend and open [`/install`](http://localhost:5002/install) to use a simple web-based installer that checks prerequisites and runs the setup scripts after entering configuration values. This route is disabled by default; set `ENABLE_INSTALL=true` in the backend environment to expose it.
+Alternatively, you can enable the web-based installer at [`/install`](http://localhost:5002/install); see the [Installer](#installer) section for details.
+
+## Installer
+
+Set `ENABLE_INSTALL=true` and `INSTALL_API_ENABLED=true` to expose the installation UI at `/install` and the API endpoints under `/api/install/*`. These variables must be set for the installer routes to work.
+
+### Example usage
+
+With docker-compose:
+
+```bash
+ENABLE_INSTALL=true INSTALL_API_ENABLED=true docker-compose up
+```
+
+Starting the backend directly:
+
+```bash
+cd backend
+ENABLE_INSTALL=true INSTALL_API_ENABLED=true npm start
+```
+
+Then visit `http://localhost:5002/install` and follow the prompts.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- document how to enable the web-based installer
- add docker-compose and npm start examples for installer

## Testing
- `npm test --prefix backend tests/installRoute.test.js` *(fails: TypeError: Cannot read properties of null (reading 'close'))*
- `npm test --prefix frontend src/tests/__tests__/TutorialsSection.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c438367dd8832894bc8db0f04657a0