### PR TITLE
Handle disabled installer with helpful 410 response

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -187,6 +187,17 @@ app.use((req, res, next) => {
   next();
 });
 
+app.use("/install", (req, res, next) => {
+  if (!config.ENABLE_INSTALL) {
+    return res
+      .status(410)
+      .send(
+        "The web installer has been disabled. See https://github.com/eduskillbridge/SkillBridge/blob/main/docs/installation.md for setup instructions."
+      );
+  }
+  return next();
+});
+
 if (config.ENABLE_INSTALL) {
   const installerPath = path.join(__dirname, "../../install");
   app.use(


### PR DESCRIPTION
## Summary
- return 410 Gone with installation guidance when the web installer is disabled

## Testing
- `npm test --prefix backend` *(fails: 20 failed, 114 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4383810b08328be01919fbce00b24