### PR TITLE
Add installer fallback route

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -197,6 +197,11 @@ if (config.ENABLE_INSTALL) {
 
 // ─── Routes ───
 app.use(routes);
+if (!config.ENABLE_INSTALL) {
+  app.get('/install', (req, res) => {
+    res.status(403).send('Installer disabled – set ENABLE_INSTALL=true to enable');
+  });
+}
 app.use(require("./middleware/errorHandler"));
 const PORT = config.PORT;
 

--- a/backend/tests/installRoute.test.js
+++ b/backend/tests/installRoute.test.js
@@ -16,18 +16,19 @@ function getServer(enableInstall) {
 }
 
 describe('/install route', () => {
-  it('returns 404 when ENABLE_INSTALL is not set to true', async () => {
+  it('returns 403 with message when ENABLE_INSTALL is not set to true', async () => {
     const { app, io, server } = getServer();
     const res = await request(app).get('/install');
-    io.close();
+    io?.close && io.close();
     server.close();
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(403);
+    expect(res.text).toBe('Installer disabled – set ENABLE_INSTALL=true to enable');
   });
 
   it('serves installer when ENABLE_INSTALL is true', async () => {
     const { app, io, server } = getServer('true');
     const res = await request(app).get('/install/');
-    io.close();
+    io?.close && io.close();
     server.close();
     expect(res.status).toBe(200);
     expect(res.text).toContain('<!DOCTYPE html>');


### PR DESCRIPTION
## Summary
- return 403 text for GET /install when ENABLE_INSTALL is false
- adjust install route test for new behaviour

## Testing
- `pre-commit run --files backend/src/server.js backend/tests/installRoute.test.js` (fails: 315 problems in frontend lint)
- `npm test --prefix backend` (fails: 20 test suites failed)
- `npm test --prefix backend tests/installRoute.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c438442bc48328b370b321f07958a7