### PR TITLE
Refine installer UI with branding and progress

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -1,34 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>SkillBridge Installer</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-</head>
-<body>
-  <h1>SkillBridge Installation</h1>
-  <section id="step1">
-    <h2>Step 1: Prerequisite Check</h2>
-    <button id="checkBtn">Recheck</button>
-    <pre id="prereqOutput"></pre>
-  </section>
-  <section id="step2" style="display: none;">
-    <h2>Step 2: Configuration</h2>
-    <form id="configForm">
-      <label>
-        Admin Email
-        <input type="email" name="adminEmail" required />
-      </label>
-      <br />
-      <label>
-        Admin Password
-        <input type="password" name="adminPassword" required />
-      </label>
-      <br />
-      <button type="submit">Run Install</button>
-    </form>
-    <pre id="installOutput"></pre>
-  </section>
-  <script src="install.js" defer></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SkillBridge Installer</title>
+    <link rel="icon" type="image/svg+xml" href="logo.svg" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-50 min-h-screen flex items-center justify-center">
+    <div class="max-w-md w-full bg-white shadow rounded p-6">
+      <img src="logo.svg" alt="SkillBridge" class="h-12 mx-auto mb-4" />
+      <h1 class="text-2xl font-bold text-center mb-6">SkillBridge Installation</h1>
+
+      <div class="mb-4">
+        <div class="w-full bg-gray-200 rounded-full h-2">
+          <div id="progressBar" class="bg-blue-600 h-2 rounded-full" style="width: 0%"></div>
+        </div>
+      </div>
+
+      <div id="errorBox" class="text-red-600 mb-4 hidden"></div>
+
+      <section id="step1">
+        <h2 class="text-xl font-semibold mb-2">Step 1: Prerequisite Check</h2>
+        <button id="checkBtn" class="px-4 py-2 bg-blue-600 text-white rounded">Recheck</button>
+        <pre id="prereqOutput" class="bg-gray-100 p-2 mt-2 rounded"></pre>
+      </section>
+
+      <section id="step2" class="mt-6 hidden">
+        <h2 class="text-xl font-semibold mb-2">Step 2: Configuration</h2>
+        <form id="configForm" class="space-y-4">
+          <label class="block">
+            <span class="block mb-1">Admin Email</span>
+            <input type="email" name="adminEmail" required class="w-full border rounded p-2" />
+          </label>
+          <label class="block">
+            <span class="block mb-1">Admin Password</span>
+            <input type="password" name="adminPassword" required class="w-full border rounded p-2" />
+          </label>
+          <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">Run Install</button>
+        </form>
+        <pre id="installOutput" class="bg-gray-100 p-2 mt-2 rounded"></pre>
+      </section>
+    </div>
+    <script src="install.js" defer></script>
+  </body>
 </html>

--- a/install/install.js
+++ b/install/install.js
@@ -1,17 +1,37 @@
+const progressBar = document.getElementById('progressBar');
+const errorBox = document.getElementById('errorBox');
+
+function setProgress(p) {
+  progressBar.style.width = `${p}%`;
+}
+
+function showError(msg) {
+  errorBox.textContent = msg;
+  errorBox.classList.remove('hidden');
+}
+
+function clearError() {
+  errorBox.textContent = '';
+  errorBox.classList.add('hidden');
+}
+
 async function checkPrereqs() {
   const output = document.getElementById('prereqOutput');
   output.textContent = 'Checking...';
+  clearError();
+  setProgress(10);
   try {
     const res = await fetch('/api/install/prereqs');
     const data = await res.json();
     output.textContent = data.output || JSON.stringify(data, null, 2);
     if (data.ok) {
-      document.getElementById('step2').style.display = 'block';
+      document.getElementById('step2').classList.remove('hidden');
+      setProgress(50);
     } else {
-      document.getElementById('step2').style.display = 'none';
+      document.getElementById('step2').classList.add('hidden');
     }
   } catch (err) {
-    output.textContent = 'Error: ' + err.message;
+    showError(`Prerequisite check failed: ${err.message}`);
   }
 }
 
@@ -24,6 +44,8 @@ form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const out = document.getElementById('installOutput');
   out.textContent = 'Running install...';
+  clearError();
+  setProgress(75);
   const payload = {
     adminEmail: form.adminEmail.value,
     adminPassword: form.adminPassword.value,
@@ -36,7 +58,8 @@ form.addEventListener('submit', async (e) => {
     });
     const data = await res.json();
     out.textContent = data.output || JSON.stringify(data, null, 2);
+    setProgress(100);
   } catch (err) {
-    out.textContent = 'Error: ' + err.message;
+    showError(`Install failed: ${err.message}`);
   }
 });

--- a/install/logo.svg
+++ b/install/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+  <rect width="100" height="20" fill="#1e40af"/>
+  <text x="50" y="14" font-size="12" text-anchor="middle" fill="white" font-family="Arial, sans-serif">SkillBridge</text>
+</svg>


### PR DESCRIPTION
## Summary
- restyle installer with Tailwind, logo branding, progress bar and error area
- add progress tracking and error reporting in install script

## Testing
- `pre-commit run --files install/index.html install/install.js install/logo.svg` (fails: 315 problems, 44 errors)
- `npm test --prefix frontend` (fails: CacheManager and other tests)
- `npm test --prefix backend` (fails: multiple test suites)


------
https://chatgpt.com/codex/tasks/task_e_68c438d3fd988328821a395fe0145cd3