### PR TITLE
docs: document install API flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,6 @@ SMTP_PASS=your_smtp_password
 # Replace it with your public API endpoint before deploying.
 NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
 
+# Expose protected installation endpoints (requires admin auth)
+INSTALL_API_ENABLED=false
+

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ The script validates prerequisites, copies example env files, builds and starts 
 
 Alternatively, launch the backend and open [`/install`](http://localhost:5002/install) to use a simple web-based installer that checks prerequisites and runs the setup scripts after entering configuration values. This route is disabled by default; set `ENABLE_INSTALL=true` in the backend environment to expose it.
 
+For scripted deployments, installation endpoints are also available under `/api/install`. They remain disabled unless `INSTALL_API_ENABLED=true` is set in your `.env`. These routes require an authenticated administrator. Example:
+
+```
+# backend/.env
+INSTALL_API_ENABLED=true
+```
+
 ## Quick start
 
 Install the project dependencies:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,6 +60,17 @@ NEXT_PUBLIC_BOOK_PRICE_RANGE_DEFAULT=100
 NEXT_PUBLIC_BOOK_PRICE_RANGE_MAX=500
 ```
 
+### Installation API
+
+The backend exposes protected setup endpoints at `/api/install` for automated deployments. They are disabled by default and can be enabled by adding `INSTALL_API_ENABLED=true` to `backend/.env`:
+
+```
+# backend/.env
+INSTALL_API_ENABLED=true
+```
+
+All `/api/install` requests must be authenticated with an administrator token.
+
 ### Initial admin passwords
 
 Set `ADMIN_INITIAL_PASSWORD` and `SUPERADMIN_INITIAL_PASSWORD` in


### PR DESCRIPTION
## Summary
- expose INSTALL_API_ENABLED in example env file
- describe enabling /api/install endpoints and required admin auth

## Testing
- `pre-commit run --files .env.example README.md docs/installation.md` *(failed: frontend lint errors)*
- `npm test` *(backend, failing tests)*
- `CI=true npm test` *(frontend, process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68c438da59f88328bb46ebb613e12784