### PR TITLE
feat: proxy install route

### DIFF
--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -87,3 +87,13 @@
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
+
+  # Forward installer requests to the backend
+  location ^~ /install/ {
+    proxy_pass http://backend:5002;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }


### PR DESCRIPTION
## Summary
- forward `/install/` requests to the backend in nginx

## Testing
- `nginx -t` *(fails: "if directive is not allowed here")*
- `npm test tests/installRoute.test.js` *(fails: Exceeded timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c438dbef088328b9dfa49c027775da