### PR TITLE
feat: proxy install route

### DIFF
--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -78,6 +78,16 @@
     add_header Access-Control-Allow-Credentials true always;
   }
 
+  # Forward installer requests to the backend
+  location /install/ {
+    proxy_pass http://backend:5002;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   # Proxy uploaded files to the backend
   location ^~ /uploads/ {
     proxy_pass http://backend:5002;


### PR DESCRIPTION
## Summary
- proxy `/install/` path to the backend service

## Testing
- `pre-commit run --files nginx/snippets/common_locations.inc` *(fails: ESLint errors in unrelated files)*
- `nginx -t` *(fails: "if" directive not allowed in snippet)*
- `nginx -s reload` *(fails: "if" directive not allowed in snippet)*

------
https://chatgpt.com/codex/tasks/task_e_68c438ee2f84832895e30ca35cdc0c1e