### PR TITLE
Ensure CSRF token on admin identity upload

### DIFF
--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -65,10 +65,15 @@ export const uploadAdminIdentity = async (file) => {
   const formData = new FormData();
   formData.append("identity", file); // this must match multer field name
 
+  const headers = { "Content-Type": "multipart/form-data" };
+
+  // Acquire a CSRF token (sets cookie if needed) and include it if present
+  const csrfToken = await ensureCsrfToken();
+  if (csrfToken) headers["x-csrf-token"] = csrfToken;
+
   const res = await api.post("/users/admin/profile/identity", formData, {
-    headers: {
-      "Content-Type": "multipart/form-data",
-    },
+    headers,
+    withCredentials: true, // rely on default cookie-based auth
   });
 
   return res.data;


### PR DESCRIPTION
## Summary
- fetch CSRF token before `uploadAdminIdentity`
- attach token to `x-csrf-token` header and keep multipart form data

## Testing
- `npm test src/tests/__tests__/CacheManager.test.tsx` *(fails: _cacheService.clearCache.mockReset is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c4396124e88328b11245c07e1e220b