### PR TITLE
Ensure CSRF cookie domain defaults to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ SESSION_SECRET=your_session_secret
 REDIS_URL=redis://redis:6379
 FRONTEND_URL=https://example.com
 APP_DOMAIN=example.com
+COOKIE_DOMAIN=.example.com
 MAX_BLOG_IMAGE_BYTES=10485760
 # Set to 'production' when deploying
 NODE_ENV=development

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -10,6 +10,7 @@ REDIS_URL=redis://redis:6379
 FRONTEND_URL=https://example.com
 REDIS_URL=redis://redis:6379
 APP_DOMAIN=example.com
+COOKIE_DOMAIN=.example.com
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production
 

--- a/backend/src/utils/cookie.js
+++ b/backend/src/utils/cookie.js
@@ -10,6 +10,12 @@
 
 const { REFRESH_TOKEN_MAX_AGE } = require("../config/tokens");
 
+// Use the provided cookie domain or fall back to the production domain so
+// browsers store the csrfToken cookie when deployed.
+const COOKIE_DOMAIN =
+  process.env.COOKIE_DOMAIN ||
+  (process.env.NODE_ENV === "production" ? ".eduskillbridge.net" : undefined);
+
 const refreshCookieOptions = {
   httpOnly: true,
   secure: process.env.NODE_ENV === 'production',
@@ -26,9 +32,9 @@ const csrfCookieOptions = {
   sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
 };
 
-if (process.env.COOKIE_DOMAIN) {
-  refreshCookieOptions.domain = process.env.COOKIE_DOMAIN;
-  csrfCookieOptions.domain = process.env.COOKIE_DOMAIN;
+if (COOKIE_DOMAIN) {
+  refreshCookieOptions.domain = COOKIE_DOMAIN;
+  csrfCookieOptions.domain = COOKIE_DOMAIN;
 }
 
 module.exports = { refreshCookieOptions, csrfCookieOptions };


### PR DESCRIPTION
## Summary
- Default CSRF and refresh cookies to the `COOKIE_DOMAIN` or `.eduskillbridge.net` so browsers persist tokens across subdomains.
- Document `COOKIE_DOMAIN` in `.env` examples for production configuration.

## Testing
- ⚠️ `pre-commit run --files backend/src/utils/cookie.js .env.example backend/.env.production.example` (command not found)
- ⚠️ `npm test --prefix backend --silent 2>&1 | tail -n 20` (fails: 20 failed, 2 skipped, 114 passed, 134/136 total)


------
https://chatgpt.com/codex/tasks/task_e_68c4395eb84483289782c72191659726