### PR TITLE
feat: send csrf token when uploading admin avatar

### DIFF
--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -36,17 +36,17 @@ export const updateAdminProfile = async (profileData) => {
  */
 
 export const uploadAdminAvatar = async (adminId, avatarFile) => {
+  // Obtain a CSRF token and include it in the upload request headers
+  const csrfToken = await ensureCsrfToken();
+
   const formData = new FormData();
   formData.append("avatar", avatarFile);
-  const headers = { "Content-Type": "multipart/form-data" };
-
-  // Ensure a CSRF token is present. If the cookie hasn't been set yet,
-  // trigger a lightweight GET request to acquire one before proceeding.
-  const csrfToken = await ensureCsrfToken();
-  if (csrfToken) headers["x-csrf-token"] = csrfToken;
 
   const res = await api.patch(`/users/admin/${adminId}/avatar`, formData, {
-    headers,
+    headers: {
+      "Content-Type": "multipart/form-data",
+      "x-csrf-token": csrfToken,
+    },
     withCredentials: true, // if using cookies
   });
   return res.data;


### PR DESCRIPTION
## Summary
- ensure `uploadAdminAvatar` obtains a CSRF token and adds it to the `x-csrf-token` header
- confirm axios instance sends cookies with `withCredentials: true`

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c4395bb748832899097d41fb64bf86