### PR TITLE
refactor(auth): generic OTP error

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -428,7 +428,11 @@ exports.verifyOtp = async ({ email, code }) => {
   }
 
   const user = await userModel.findByEmail(email);
-  if (!user) throw new AppError("Invalid user", 400);
+  if (!user) {
+    // Return a generic error to avoid exposing whether the email exists
+    await recordFailedOtpAttempt(email);
+    throw new AppError("Invalid or expired OTP", 400);
+  }
 
   attempt = null;
   if (redisClient) {

--- a/backend/tests/authVerifyOtpService.test.js
+++ b/backend/tests/authVerifyOtpService.test.js
@@ -39,6 +39,20 @@ describe('verifyOtp retry counter', () => {
     jest.clearAllMocks();
   });
 
+  it('returns generic error when user is missing', async () => {
+    userModel.findByEmail.mockResolvedValue(null);
+    redisClient.get.mockResolvedValue(null);
+
+    await expect(
+      authService.verifyOtp({ email: 'missing@example.com', code: '123456' })
+    ).rejects.toMatchObject({
+      message: 'Invalid or expired OTP',
+      statusCode: 400,
+    });
+
+    expect(redisClient.set).toHaveBeenCalled();
+  });
+
   it('locks out after too many failed attempts', async () => {
     userModel.findByEmail.mockResolvedValue({ id: 1, email: 'test@example.com' });
     redisClient.get.mockResolvedValue(
@@ -55,6 +69,7 @@ describe('verifyOtp retry counter', () => {
   it('increments counter on failed attempt', async () => {
     userModel.findByEmail.mockResolvedValue({ id: 1, email: 'test@example.com' });
     redisClient.get
+      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(JSON.stringify({ count: 1, lockUntil: null }));
     passwordResetsTable.first.mockResolvedValue({ id: 2, code_hash: 'hash' });


### PR DESCRIPTION
## Summary
- hide user existence in verifyOtp by returning generic error
- test that OTP verification for non-existent emails uses generic error message

## Testing
- `npm test` *(fails: POST /api/books creates a book, PUT /api/books/:id updates a book, tests/paymentCommission.test.js, tests/paymentInvoiceEmail.test.js, tests/tutorialRoutes.test.js, tests/paymentAmountValidation.test.js, tests/seoConfigRoutes.test.js, tests/installApi.test.js, tests/cacheRoutes.test.js, tests/socialLoginConfigService.test.js, tests/verifyVerifyOtpService.test.js, tests/libraryRoutes.test.js, etc.)*
- `npm test -- tests/authVerifyOtpService.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c44cbdedfc832887e7ab3b13f3604c