### PR TITLE
chore: rate limit auth registration

### DIFF
--- a/backend/src/modules/auth/routes/auth.routes.js
+++ b/backend/src/modules/auth/routes/auth.routes.js
@@ -19,7 +19,12 @@ router.use((req, res, next) => {
  * @desc    Register a new user
  * @access  Public
  */
-router.post("/register", validate(authValidation.registerSchema), authController.register);
+router.post(
+  "/register",
+  limitAuthRequests,
+  validate(authValidation.registerSchema),
+  authController.register
+);
 
 /**
  * @route   POST /auth/login


### PR DESCRIPTION
## Summary
- add rate limiter to `/register` route to throttle signup bursts

## Testing
- `npm test` *(fails: Test Suites: 21 failed, 2 skipped, 114 passed, 135 of 137 total)*
- `NODE_ENV=test node - <<'NODE'...`

------
https://chatgpt.com/codex/tasks/task_e_68c44cbc0abc8328a16a948ef359a0a3