### PR TITLE
require csrf token for refresh endpoint

### DIFF
--- a/backend/src/middleware/csrf.js
+++ b/backend/src/middleware/csrf.js
@@ -16,12 +16,10 @@ const unsafeMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
 const exemptPaths = [
   '/api/auth/login',
   '/api/auth/register',
-  '/api/auth/refresh',
   '/api/auth/request-reset',
   '/api/auth/forgot-password',
   '/api/auth/verify-otp',
   '/api/auth/reset-password',
-  '/api/auth/refresh',
 ];
 
 module.exports = [

--- a/backend/tests/authRefreshRoutes.test.js
+++ b/backend/tests/authRefreshRoutes.test.js
@@ -54,11 +54,16 @@ describe('POST /api/auth/refresh', () => {
       refreshToken: 'newR',
     });
     authService.generateAccessToken.mockReturnValue('newA');
+    const tokenRes = await request(app).get('/api/auth/refresh');
+    const cookies = tokenRes.headers['set-cookie'];
+    const csrfCookie = cookies.find((c) => c.startsWith('csrfToken=')).split(';')[0];
+    const sessionCookie = cookies.find((c) => c.startsWith('connect.sid=')).split(';')[0];
+    const csrfToken = csrfCookie.split('=')[1];
 
     const refreshRes = await request(app)
       .post('/api/auth/refresh')
-      .set('Cookie', ['refreshToken=r', 'csrfToken=t'])
-      .set('x-csrf-token', 't');
+      .set('Cookie', [`refreshToken=r`, csrfCookie, sessionCookie])
+      .set('x-csrf-token', csrfToken);
 
     expect(refreshRes.status).toBe(200);
     expect(refreshRes.body.accessToken).toBe('newA');
@@ -73,12 +78,27 @@ describe('POST /api/auth/refresh', () => {
   it('rejects invalid refresh token', async () => {
     authService.rotateRefreshToken.mockRejectedValue(new Error('bad token'));
 
+    const tokenRes = await request(app).get('/api/auth/refresh');
+    const cookies = tokenRes.headers['set-cookie'];
+    const csrfCookie = cookies.find((c) => c.startsWith('csrfToken=')).split(';')[0];
+    const sessionCookie = cookies.find((c) => c.startsWith('connect.sid=')).split(';')[0];
+    const csrfToken = csrfCookie.split('=')[1];
+
     const res = await request(app)
       .post('/api/auth/refresh')
-      .set('Cookie', ['refreshToken=bad', 'csrfToken=t'])
-      .set('x-csrf-token', 't');
+      .set('Cookie', [`refreshToken=bad`, csrfCookie, sessionCookie])
+      .set('x-csrf-token', csrfToken);
 
     expect(res.status).toBe(401);
     expect(res.body.message).toMatch(/invalid or expired/i);
+  });
+
+  it('rejects request without CSRF token', async () => {
+    const res = await request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', ['refreshToken=r']);
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/csrf/i);
   });
 });


### PR DESCRIPTION
## Summary
- remove `/api/auth/refresh` from CSRF exempt list so refresh requests must include a token
- cover refresh route with CSRF-aware tests, including rejection without token

## Testing
- `npm test --prefix backend` *(fails: 21 failed, 2 skipped, 114 passed)*
- `npm test --prefix backend tests/authRefreshRoutes.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c44cbb36c883288e5efa7eaf29de68