### PR TITLE
Track OTP verification attempts and enforce lockout

### DIFF
--- a/backend/src/modules/verify/verify.service.js
+++ b/backend/src/modules/verify/verify.service.js
@@ -9,6 +9,42 @@ const AppError = require("../../utils/AppError");
 const crypto = require("crypto");
 const bcrypt = require("bcrypt");
 const { OTP_LENGTH } = require("../auth/constants");
+const logger = require("../../utils/logger.js");
+const redisClient = require("../../utils/redisClient");
+
+const OTP_ATTEMPT_PREFIX = "otpAttempt:";
+const OTP_MAX_ATTEMPTS = 5;
+const OTP_LOCK_TIME = 15 * 60 * 1000; // 15 minutes
+
+function getAttemptKey(userId, type) {
+  return `${OTP_ATTEMPT_PREFIX}${userId}:${type}`;
+}
+
+async function recordFailedOtpAttempt(userId, type) {
+  if (!redisClient) return;
+  const key = getAttemptKey(userId, type);
+  let info = { count: 0, lockUntil: null };
+  try {
+    const data = await redisClient.get(key);
+    if (data) info = JSON.parse(data);
+    info.count += 1;
+    if (info.count >= OTP_MAX_ATTEMPTS) {
+      info.lockUntil = Date.now() + OTP_LOCK_TIME;
+    }
+    await redisClient.set(key, JSON.stringify(info), { PX: OTP_LOCK_TIME });
+  } catch (err) {
+    logger.error("Failed to record OTP attempt", err);
+  }
+}
+
+async function clearOtpAttempts(userId, type) {
+  if (!redisClient) return;
+  try {
+    await redisClient.del(getAttemptKey(userId, type));
+  } catch (err) {
+    logger.error("Failed to clear OTP attempts", err);
+  }
+}
 
 const SALT_ROUNDS = 12;
 const generateCode = () => {
@@ -86,22 +122,22 @@ exports.verifyOtp = async (userId, type, code) => {
     .orderBy("created_at", "desc")
     .first();
 
-  if (!record) throw new AppError("Invalid or expired OTP", 400);
+  if (!record) {
+    await recordFailedOtpAttempt(userId, type);
+    throw new AppError("Invalid or expired OTP", 400);
+  }
 
   const match = await bcrypt.compare(code, record.code);
-  if (!match) throw new Error("Invalid or expired OTP");
+  if (!match) {
+    await recordFailedOtpAttempt(userId, type);
+    throw new AppError("Invalid or expired OTP", 400);
+  }
 
   await db("verifications").where({ id: record.id }).update({ verified: true });
 
   await db("users").where({ id: userId }).update({ [updateField]: true });
 
-  if (redisClient) {
-    try {
-      await redisClient.del(getAttemptKey(userId, type));
-    } catch (err) {
-      logger.error("Failed to clear OTP attempts", err);
-    }
-  }
+  await clearOtpAttempts(userId, type);
 
   const userAfter = await db("users").where({ id: userId }).first();
   if (

--- a/backend/tests/verifyVerifyOtpService.test.js
+++ b/backend/tests/verifyVerifyOtpService.test.js
@@ -50,7 +50,8 @@ jest.mock('../src/config/database', () => {
   const verificationsQuery = {
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
-    first: jest.fn().mockResolvedValue(null),
+    orderBy: jest.fn().mockReturnThis(),
+    first: jest.fn(),
     update: jest.fn().mockResolvedValue(1),
   };
   const mockDb = jest.fn((table) => {
@@ -62,19 +63,44 @@ jest.mock('../src/config/database', () => {
     };
   });
   mockDb.raw = jest.fn();
+  mockDb.__usersQuery = usersQuery;
+  mockDb.__verificationsQuery = verificationsQuery;
   return mockDb;
 });
 
 const service = require('../src/modules/verify/verify.service');
 const redisClient = require('../src/utils/redisClient');
+const db = require('../src/config/database');
+const bcrypt = require('bcrypt');
 
-describe('verify.service.verifyOtp lockout', () => {
+describe('verify.service.verifyOtp', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     Object.keys(redisClient.__store).forEach((k) => delete redisClient.__store[k]);
+    db.__verificationsQuery.first.mockReset();
+  });
+
+  it('clears attempts on successful verification', async () => {
+    const hashed = await bcrypt.hash('123456', 12);
+    db.__verificationsQuery.first.mockResolvedValue({
+      id: 'v1',
+      user_id: 1,
+      type: 'email',
+      code: hashed,
+      expires_at: new Date(Date.now() + 60000),
+      verified: false,
+    });
+
+    const attemptKey = 'otpAttempt:1:email';
+    redisClient.__store[attemptKey] = JSON.stringify({ count: 1, lockUntil: null });
+
+    const result = await service.verifyOtp(1, 'email', '123456');
+    expect(result).toEqual({ alreadyVerified: false });
+    expect(redisClient.del).toHaveBeenCalledWith(attemptKey);
   });
 
   it('locks after too many invalid attempts', async () => {
+    db.__verificationsQuery.first.mockResolvedValue(null);
     for (let i = 0; i < 5; i++) {
       await expect(service.verifyOtp(1, 'email', '000000')).rejects.toThrow(
         'Invalid or expired OTP'


### PR DESCRIPTION
## Summary
- Add Redis-backed helpers in verify service for recording and clearing OTP attempts
- Increment OTP attempt counters on failure, lock after threshold, and clear on success
- Add unit tests for successful OTP verification and lockout scenario

## Testing
- `cd backend && npm test tests/verifyVerifyOtpService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c44cb6b75883288d0d14b638734bdd