### PR TITLE
refactor: rely on auth store for 401 handling

### DIFF
--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -74,11 +74,10 @@ api.interceptors.response.use(
 
     if (error.response?.status === 401 && !originalRequest._retry && !isAuthRoute) {
       logger.warn("\u26A0\uFE0F Received 401 for", originalRequest?.url);
-      const refreshCookie = getCookie("refreshToken");
       const hasAuthState = !!authStore.accessToken || !!authStore.user;
 
-      if (!refreshCookie && !hasAuthState) {
-        logger.warn("\u26A0\uFE0F No refresh cookie or auth state; redirecting to login");
+      if (!hasAuthState) {
+        logger.warn("\u26A0\uFE0F No auth state; redirecting to login");
         authStore.logout(true);
         if (typeof window !== "undefined") {
           Router.push("/auth/login");


### PR DESCRIPTION
## Summary
- remove refresh cookie checks in token interceptor
- depend solely on in-memory auth state for 401 redirects

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*
- `npm run lint` *(fails: 44 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c44cac90148328b2eb74f2fd33fd80