### PR TITLE
Hash blacklisted tokens

### DIFF
--- a/backend/src/migrations/20250905000000_alter_blacklisted_tokens_hash.js
+++ b/backend/src/migrations/20250905000000_alter_blacklisted_tokens_hash.js
@@ -1,0 +1,35 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const hasTable = await knex.schema.hasTable('blacklisted_tokens');
+  if (!hasTable) return;
+  const hasColumn = await knex.schema.hasColumn('blacklisted_tokens', 'token');
+  if (hasColumn) {
+    await knex.schema.alterTable('blacklisted_tokens', (table) => {
+      table.renameColumn('token', 'token_hash');
+    });
+    await knex.schema.alterTable('blacklisted_tokens', (table) => {
+      table.string('token_hash', 64).notNullable().unique().alter();
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  const hasTable = await knex.schema.hasTable('blacklisted_tokens');
+  if (!hasTable) return;
+  const hasColumn = await knex.schema.hasColumn('blacklisted_tokens', 'token_hash');
+  if (hasColumn) {
+    await knex.schema.alterTable('blacklisted_tokens', (table) => {
+      table.renameColumn('token_hash', 'token');
+    });
+    await knex.schema.alterTable('blacklisted_tokens', (table) => {
+      table.string('token').notNullable().unique().alter();
+    });
+  }
+};

--- a/backend/src/services/tokenBlacklistService.js
+++ b/backend/src/services/tokenBlacklistService.js
@@ -1,15 +1,24 @@
 const db = require('../config/database');
 const logger = require('../utils/logger.js');
+const crypto = require('crypto');
 
 /**
  * Inserts a token into the blacklist store.
  * @param {string} token
  * @returns {Promise<void>}
  */
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
 async function addToken(token) {
   if (!token) return;
   try {
-    await db('blacklisted_tokens').insert({ token }).onConflict('token').ignore();
+    const tokenHash = hashToken(token);
+    await db('blacklisted_tokens')
+      .insert({ token_hash: tokenHash })
+      .onConflict('token_hash')
+      .ignore();
   } catch (err) {
     logger.error('Failed to add token to blacklist:', err);
     throw err;
@@ -23,7 +32,10 @@ async function addToken(token) {
  */
 async function isTokenBlacklisted(token) {
   if (!token) return false;
-  const record = await db('blacklisted_tokens').where({ token }).first();
+  const tokenHash = hashToken(token);
+  const record = await db('blacklisted_tokens')
+    .where({ token_hash: tokenHash })
+    .first();
   return !!record;
 }
 

--- a/backend/tests/tokenBlacklistService.test.js
+++ b/backend/tests/tokenBlacklistService.test.js
@@ -17,10 +17,19 @@ const mockLogger = {
 jest.mock('../src/utils/logger.js', () => mockLogger);
 
 const { addToken, isTokenBlacklisted } = require('../src/services/tokenBlacklistService');
+const crypto = require('crypto');
 
 describe('tokenBlacklistService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  test('addToken hashes token before storing', async () => {
+    mockIgnore.mockResolvedValueOnce();
+    await addToken('tok');
+    const hash = crypto.createHash('sha256').update('tok').digest('hex');
+    expect(mockInsert).toHaveBeenCalledWith({ token_hash: hash });
+    expect(mockOnConflict).toHaveBeenCalledWith('token_hash');
   });
 
   test('addToken logs and rethrows on failure', async () => {
@@ -39,5 +48,13 @@ describe('tokenBlacklistService', () => {
     mockFirst.mockRejectedValueOnce(err);
 
     await expect(isTokenBlacklisted('tok')).rejects.toThrow('query fail');
+  });
+
+  test('isTokenBlacklisted hashes token for lookup', async () => {
+    const hash = crypto.createHash('sha256').update('tok').digest('hex');
+    mockFirst.mockResolvedValueOnce({ token_hash: hash });
+    const result = await isTokenBlacklisted('tok');
+    expect(mockWhere).toHaveBeenCalledWith({ token_hash: hash });
+    expect(result).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- store a SHA-256 hash for blacklisted tokens instead of raw token
- adjust blacklist lookups to compare hashed tokens
- add migration renaming `token` column to `token_hash`
- test blacklisting uses hashed values

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*
- `npm test tests/tokenBlacklistService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c44caae77483288f9165c314e60173