### PR TITLE
Use token blacklist service during password reset

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -19,6 +19,7 @@ const AppError = require("../../../utils/AppError");
 const notificationService = require("../../notifications/notifications.service");
 const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
+const { addToken } = require("../../../services/tokenBlacklistService");
 const verificationService = require("../../verify/verify.service");
 const { 
   REFRESH_TOKEN_EXPIRES_IN,
@@ -519,7 +520,7 @@ exports.resetPassword = async ({ email, code, new_password, accessToken }) => {
   // Optionally blacklist the provided access token
   if (accessToken) {
     try {
-      await addTokenToBlacklist(accessToken);
+      await addToken(accessToken);
     } catch (err) {
       logger.error("Failed to blacklist access token", err);
     }

--- a/backend/tests/authResetPasswordService.test.js
+++ b/backend/tests/authResetPasswordService.test.js
@@ -49,6 +49,7 @@ jest.mock('../src/modules/notifications/notifications.service', () => ({
 jest.mock('../src/modules/messages/messages.service', () => ({
   createMessage: jest.fn(),
 }));
+jest.mock('../src/services/tokenBlacklistService', () => ({ addToken: jest.fn(), }));
 
 jest.mock('../src/modules/auth/utils/sanitizeUser', () => jest.fn((u) => u));
 
@@ -64,6 +65,7 @@ const notificationService = require('../src/modules/notifications/notifications.
 const messageService = require('../src/modules/messages/messages.service');
 const bcrypt = require('bcrypt');
 const db = require('../src/config/database');
+const { addToken } = require('../src/services/tokenBlacklistService');
 
 describe('resetPassword service', () => {
   beforeEach(() => {
@@ -97,5 +99,25 @@ describe('resetPassword service', () => {
     // Ensure refresh tokens were revoked
     expect(refreshTokensTable.where).toHaveBeenCalledWith({ user_id: 1 });
     expect(refreshTokensWhere.del).toHaveBeenCalled();
+      expect(addToken).not.toHaveBeenCalled();
+  });
+  it('blacklists provided access token', async () => {
+    userModel.findByEmail.mockResolvedValue({
+      id: 1,
+      email: 'test@example.com',
+      password_hash: 'old_hash',
+    });
+
+    bcrypt.compare.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    bcrypt.hash.mockResolvedValue('new_hash');
+
+    await authService.resetPassword({
+      email: 'test@example.com',
+      code: '123456',
+      new_password: 'NewPass1!',
+      accessToken: 'token123',
+    });
+
+    expect(addToken).toHaveBeenCalledWith('token123');
   });
 });


### PR DESCRIPTION
## Summary
- Add token blacklist service import and blacklist access tokens during password reset
- Test password reset blacklists provided access tokens

## Testing
- `npm test tests/authResetPasswordService.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c44ca9c48883288879c5bb60eff6ee