### PR TITLE
feat(auth): add transactional registration

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -111,70 +111,95 @@ exports.registerUser = async (data) => {
 
   const hashed = await bcrypt.hash(data.password, SALT_ROUNDS);
 
-  const [newUser] = await userModel.insertUser({
-    full_name: data.full_name,
-    email: data.email,
-    phone: data.phone,
-    password_hash: hashed,
-    role: data.role || "Student",
-    status: "pending",
-    is_email_verified: false,
-    is_phone_verified: false,
-    profile_complete: false,
-    created_at: new Date(),
-    updated_at: new Date(),
-  });
+  const admins = await userModel.findAdmins();
+  let newUser;
+  try {
+    await db.transaction(async (trx) => {
+      [newUser] = await userModel.insertUser(
+        {
+          full_name: data.full_name,
+          email: data.email,
+          phone: data.phone,
+          password_hash: hashed,
+          role: data.role || "Student",
+          status: "pending",
+          is_email_verified: false,
+          is_phone_verified: false,
+          profile_complete: false,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        trx,
+      );
 
-  const roleName = data.role || "Student";
-  const roleRow = await db("roles").where({ name: roleName }).first();
-  if (roleRow) {
-    await db("user_roles").insert({ user_id: newUser.id, role_id: roleRow.id });
+      const roleName = data.role || "Student";
+      const roleRow = await trx("roles").where({ name: roleName }).first();
+      if (roleRow) {
+        await trx("user_roles").insert({
+          user_id: newUser.id,
+          role_id: roleRow.id,
+        });
+      }
+
+      const welcomeMessage =
+        newUser.role && newUser.role.toLowerCase() === "instructor"
+          ? "Thank you for joining our platform! Your account is under review. Please complete your profile while we review your account."
+          : "Welcome to SkillBridge!";
+
+      await notificationService.createNotification(
+        {
+          user_id: newUser.id,
+          type: "welcome",
+          message: welcomeMessage,
+        },
+        trx,
+      );
+
+      const firstAdmin = admins[0];
+      if (firstAdmin) {
+        await messageService.createMessage(
+          {
+            sender_id: firstAdmin.id,
+            receiver_id: newUser.id,
+            message: welcomeMessage,
+          },
+          trx,
+        );
+      }
+
+      await Promise.all(
+        admins.map((admin) =>
+          notificationService.createNotification(
+            {
+              user_id: admin.id,
+              type: "new_user",
+              message: `New user ${newUser.full_name} (${newUser.role}) just registered`,
+            },
+            trx,
+          ),
+        ),
+      );
+
+      await Promise.all(
+        admins.map((admin) =>
+          messageService.createMessage(
+            {
+              sender_id: newUser.id,
+              receiver_id: admin.id,
+              message: `New user ${newUser.full_name} (${newUser.role}) just registered`,
+            },
+            trx,
+          ),
+        ),
+      );
+    });
+  } catch (err) {
+    logger.error("Failed to register user", err);
+    throw err;
   }
 
   const roles = await userModel.getUserRoles(newUser.id);
   const permissions = await userModel.getUserPermissions(newUser.id);
-
-  const welcomeMessage =
-    newUser.role && newUser.role.toLowerCase() === "instructor"
-      ?
-        "Thank you for joining our platform! Your account is under review. Please complete your profile while we review your account."
-      : "Welcome to SkillBridge!";
-
-  await notificationService.createNotification({
-    user_id: newUser.id,
-    type: "welcome",
-    message: welcomeMessage,
-  });
-
-  const admins = await userModel.findAdmins();
-  const firstAdmin = admins[0];
-  if (firstAdmin) {
-    await messageService.createMessage({
-      sender_id: firstAdmin.id,
-      receiver_id: newUser.id,
-      message: welcomeMessage,
-    });
-  }
-  await Promise.all(
-    admins.map((admin) =>
-      notificationService.createNotification({
-        user_id: admin.id,
-        type: "new_user",
-        message: `New user ${newUser.full_name} (${newUser.role}) just registered`,
-
-      })
-    )
-  );
-  await Promise.all(
-    admins.map((admin) =>
-      messageService.createMessage({
-        sender_id: newUser.id,
-        receiver_id: admin.id,
-        message: `New user ${newUser.full_name} (${newUser.role}) just registered`,
-
-      })
-    )
-  );
 
   // Send emails
   try {
@@ -184,18 +209,20 @@ exports.registerUser = async (data) => {
         sendNewUserAdminEmail(admin.email, {
           full_name: newUser.full_name,
           email: newUser.email,
-        })
-      )
+        }),
+      ),
     );
   } catch (err) {
     logger.error("Error sending registration emails:", err.message);
   }
+
   // Queue verification email OTP sending without delaying response
   setImmediate(() => {
     verificationService
       .sendOtp(newUser.id, "email")
       .catch((err) => logger.error("Error sending verification OTP:", err));
   });
+
   const safeUser = sanitizeUserUtil(newUser);
   return { user: { ...safeUser, roles, permissions } };
 };

--- a/backend/src/modules/notifications/notifications.service.js
+++ b/backend/src/modules/notifications/notifications.service.js
@@ -1,7 +1,11 @@
 const db = require("../../config/database");
 
-exports.createNotification = async ({ user_id, type, message }) => {
-  const [row] = await db("notifications")
+exports.createNotification = async (
+  { user_id, type, message },
+  trx = null,
+) => {
+  const query = trx || db;
+  const [row] = await query("notifications")
     .insert({ user_id, type, message, created_at: new Date() })
     .returning("*");
   return row;

--- a/backend/src/modules/users/user.model.js
+++ b/backend/src/modules/users/user.model.js
@@ -128,8 +128,8 @@ exports.findStudents = () => {
  * - Expects pre-validated user object
  * - Returns full inserted row
  */
-exports.insertUser = (data) => {
-  return db("users").insert(data).returning("*");
+exports.insertUser = (data, trx = db) => {
+  return trx("users").insert(data).returning("*");
 };
 
 /**

--- a/backend/tests/authSanitization.test.js
+++ b/backend/tests/authSanitization.test.js
@@ -23,6 +23,7 @@ jest.mock('../src/config/database', () => {
     }
     return {};
   });
+  mockDb.transaction = jest.fn(async (cb) => cb(mockDb));
   mockDb.fn = { now: jest.fn() };
   return mockDb;
 });
@@ -34,6 +35,7 @@ jest.mock('../src/modules/users/user.model', () => ({
   insertUser: jest.fn(),
   updateUser: jest.fn(),
   getUserRoles: jest.fn(),
+  getUserPermissions: jest.fn(),
   findAdmins: jest.fn(),
   findById: jest.fn(),
 }));
@@ -68,6 +70,7 @@ process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
 const authService = require('../src/modules/auth/services/auth.service');
 const authMiddleware = require('../src/middleware/auth/authMiddleware');
 const userModel = require('../src/modules/users/user.model');
+const db = require('../src/config/database');
 
 describe('Sensitive data sanitization', () => {
   beforeEach(() => {
@@ -92,6 +95,7 @@ describe('Sensitive data sanitization', () => {
     userModel.findByPhone.mockResolvedValue(null);
     userModel.insertUser.mockResolvedValue([mockUser]);
     userModel.getUserRoles.mockResolvedValue([]);
+    userModel.getUserPermissions.mockResolvedValue([]);
     userModel.findAdmins.mockResolvedValue([]);
 
     const result = await authService.registerUser({
@@ -102,6 +106,7 @@ describe('Sensitive data sanitization', () => {
     });
 
     expect(result.user.password_hash).toBeUndefined();
+    expect(db.transaction).toHaveBeenCalled();
   });
 
   it('loginUser does not return password_hash', async () => {
@@ -115,6 +120,7 @@ describe('Sensitive data sanitization', () => {
     userModel.findByEmail.mockResolvedValue({ ...mockUser });
     userModel.updateUser.mockResolvedValue([mockUser]);
     userModel.getUserRoles.mockResolvedValue([]);
+    userModel.getUserPermissions.mockResolvedValue([]);
 
     const issueSpy = jest
       .spyOn(authService, 'issueRefreshToken')


### PR DESCRIPTION
## Summary
- ensure user registration and related actions run within a DB transaction
- support optional transactions for notification creation
- expand user insert helper and tests accordingly

## Testing
- `npm test` *(fails: 21 failed, 2 skipped, 114 passed, 135 total)*
- `npm test tests/authSanitization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c44ca404588328b7d6b8c6a285c745