### PR TITLE
Use Express csrf middleware tokens in auth routes

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -6,7 +6,6 @@ const AppError = require("../../../utils/AppError");
 const socialLoginConfigService = require("../../socialLoginConfig/socialLoginConfig.service");
 const recaptchaService = require("../../recaptcha/recaptcha.service");
 const authMiddleware = require("../../../middleware/auth/authMiddleware");
-const crypto = require("crypto");
 
 // 🔧 Cookie options used in login and logout
 const { refreshCookieOptions, csrfCookieOptions } = require("../../../utils/cookie");
@@ -67,11 +66,11 @@ exports.login = catchAsync(async (req, res) => {
       throw new AppError('Failed reCAPTCHA verification', 400);
     }
   }
-  const { accessToken, refreshToken, user } = await authService.loginUser({ ...req.body, ip: req.ip });
-  const csrfToken = crypto.randomBytes(64).toString("hex");
+  const { accessToken, refreshToken, user } =
+    await authService.loginUser({ ...req.body, ip: req.ip });
   res
     .cookie("refreshToken", refreshToken, refreshCookieOptions)
-    .cookie("csrfToken", csrfToken, csrfCookieOptions)
+    .cookie("csrfToken", req.csrfToken(), csrfCookieOptions)
     .json({ message: "Login successful", accessToken, user });
 });
 
@@ -101,10 +100,9 @@ exports.refreshToken = catchAsync(async (req, res) => {
     if (process.env.NODE_ENV !== "production") {
       logger.debug("\u2705 Refresh token rotated for user", decoded.id);
     }
-    const csrfToken = crypto.randomBytes(64).toString("hex");
     res
       .cookie("refreshToken", newRefreshToken, refreshCookieOptions)
-      .cookie("csrfToken", csrfToken, csrfCookieOptions)
+      .cookie("csrfToken", req.csrfToken(), csrfCookieOptions)
       .json({ message: "Token refreshed", accessToken });
   } catch (err) {
     logger.error("❌ Refresh token error:", err.message);


### PR DESCRIPTION
## Summary
- Drop manual CSRF token generation in auth login and refresh routes
- Use req.csrfToken() when sending CSRF cookie

## Testing
- `npm test` *(fails: 22 failed, 2 skipped, 113 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c44ca1ebec8328be1161a41f47ce91