### PR TITLE
chore: add otp attempt helpers

### DIFF
--- a/backend/src/modules/verify/verify.service.js
+++ b/backend/src/modules/verify/verify.service.js
@@ -6,11 +6,18 @@ const userModel = require("../users/user.model");
 const { sendOtpEmail } = require("../../utils/email");
 const smsService = require("../../services/smsService");
 const AppError = require("../../utils/AppError");
+const redisClient = require("../../utils/redisClient");
+const logger = require("../../utils/logger.js");
 const crypto = require("crypto");
 const bcrypt = require("bcrypt");
 const { OTP_LENGTH } = require("../auth/constants");
 
 const SALT_ROUNDS = 12;
+const OTP_ATTEMPT_PREFIX = "otpAttempt:";
+
+function getAttemptKey(userId, type) {
+  return `${OTP_ATTEMPT_PREFIX}${userId}:${type}`;
+}
 const generateCode = () => {
   const max = Math.pow(10, OTP_LENGTH);
   return crypto.randomInt(0, max).toString().padStart(OTP_LENGTH, "0");


### PR DESCRIPTION
## Summary
- import Redis client and logger for OTP verification
- add helper for generating OTP attempt keys

## Testing
- `npm test` *(fails: 21 failed, 2 skipped, 114 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c44c9ee1008328b4056ee381300d7c