### PR TITLE
refactor: use user id for otp attempt tracking

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -467,17 +467,17 @@ exports.verifyOtp = async ({ email, code }) => {
     .first();
 
   if (!record) {
-    await recordFailedOtpAttempt(identifier);
+    await recordFailedOtpAttempt(user.id);
     throw new AppError("Invalid or expired OTP", 400);
   }
 
   const match = await bcrypt.compare(code, record.code_hash);
   if (!match) {
-    await recordFailedOtpAttempt(identifier);
+    await recordFailedOtpAttempt(user.id);
     throw new AppError("Invalid or expired OTP", 400);
   }
 
-  await clearOtpAttempts(identifier);
+  await clearOtpAttempts(user.id);
   return true;
 };
 


### PR DESCRIPTION
## Summary
- use `user.id` directly for OTP verification

## Testing
- `npm test` *(fails: Identifier 'redisClient' has already been declared, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c45cefb8748328879f1271053fa2da