### PR TITLE
Gracefully handle login side-effect failures

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -283,10 +283,14 @@ exports.loginUser = async ({ email, password, ip }) => {
   }
 
   // Mark user as online on successful login
-  await userModel.updateUser(user.id, {
-    is_online: true,
-    updated_at: new Date(),
-  });
+  try {
+    await userModel.updateUser(user.id, {
+      is_online: true,
+      updated_at: new Date(),
+    });
+  } catch (err) {
+    logger.error("Failed to update user online status", err);
+  }
   user.is_online = true;
 
   const roles = await userModel.getUserRoles(user.id);
@@ -299,11 +303,15 @@ exports.loginUser = async ({ email, password, ip }) => {
   });
   const refreshToken = await issueRefreshToken(user.id, tokenRoles);
 
-  await notificationService.createNotification({
-    user_id: user.id,
-    type: "login",
-    message: "You have logged in successfully",
-  });
+  try {
+    await notificationService.createNotification({
+      user_id: user.id,
+      type: "login",
+      message: "You have logged in successfully",
+    });
+  } catch (err) {
+    logger.error("Failed to create login notification", err);
+  }
   const safeUser = sanitizeUserUtil(user);
   return { accessToken, refreshToken, user: { ...safeUser, roles, permissions } };
 };

--- a/backend/tests/authLoginErrorHandling.test.js
+++ b/backend/tests/authLoginErrorHandling.test.js
@@ -1,0 +1,119 @@
+jest.mock('../src/config/database', () => {
+  const mockDb = jest.fn((table) => {
+    if (table === 'refresh_tokens') {
+      return { insert: jest.fn().mockResolvedValue() };
+    }
+    return {};
+  });
+  mockDb.transaction = jest.fn(async (cb) => cb(mockDb));
+  mockDb.fn = { now: jest.fn() };
+  return mockDb;
+});
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findByEmail: jest.fn(),
+  updateUser: jest.fn(),
+  getUserRoles: jest.fn(),
+  getUserPermissions: jest.fn(),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/utils/email', () => ({
+  sendOtpEmail: jest.fn(),
+  sendPasswordChangeEmail: jest.fn(),
+  sendWelcomeEmail: jest.fn(),
+  sendNewUserAdminEmail: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn().mockResolvedValue('hashedpw'),
+  compare: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../src/utils/logger.js', () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+}));
+
+process.env.JWT_SECRET = 'testsecret';
+process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
+
+const authService = require('../src/modules/auth/services/auth.service');
+const userModel = require('../src/modules/users/user.model');
+const notificationService = require('../src/modules/notifications/notifications.service');
+const logger = require('../src/utils/logger.js');
+
+describe('loginUser error handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.JWT_SECRET = 'testsecret';
+    process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
+  });
+
+  it('returns tokens even if updateUser fails', async () => {
+    const mockUser = {
+      id: 1,
+      email: 'test@example.com',
+      password_hash: 'hashedpw',
+      role: 'Student',
+      status: 'active',
+    };
+    userModel.findByEmail.mockResolvedValue({ ...mockUser });
+    userModel.updateUser.mockRejectedValue(new Error('db fail'));
+    userModel.getUserRoles.mockResolvedValue([]);
+    userModel.getUserPermissions.mockResolvedValue([]);
+
+    const res = await authService.loginUser({
+      email: 'test@example.com',
+      password: 'pass',
+    });
+
+    expect(res.accessToken).toBeTruthy();
+    expect(res.refreshToken).toBeTruthy();
+    expect(res.user.id).toBe(1);
+    expect(res.user.password_hash).toBeUndefined();
+    expect(res.user.is_online).toBe(true);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('returns tokens even if notification creation fails', async () => {
+    const mockUser = {
+      id: 1,
+      email: 'test@example.com',
+      password_hash: 'hashedpw',
+      role: 'Student',
+      status: 'active',
+    };
+    userModel.findByEmail.mockResolvedValue({ ...mockUser });
+    userModel.updateUser.mockResolvedValue({});
+    userModel.getUserRoles.mockResolvedValue([]);
+    userModel.getUserPermissions.mockResolvedValue([]);
+    notificationService.createNotification.mockRejectedValue(
+      new Error('notify fail'),
+    );
+
+    const res = await authService.loginUser({
+      email: 'test@example.com',
+      password: 'pass',
+    });
+
+    expect(res.accessToken).toBeTruthy();
+    expect(res.refreshToken).toBeTruthy();
+    expect(res.user.id).toBe(1);
+    expect(res.user.password_hash).toBeUndefined();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Prevent login failures when updating online status or creating notifications fails
- Test login resilience when updateUser and notification creation throw errors

## Testing
- `npm test tests/authLoginErrorHandling.test.js`
- `npm test tests/authSanitization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c460da93108328be756323da1e1d99