### PR TITLE
feat: validate social links urls

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -33,7 +33,7 @@ import getCroppedImg from "@/utils/cropImage";
 
 // Add service imports as needed, e.g., getProfile, updateProfile, uploadAvatar, etc.
 
-const profileSchema = z.object({
+export const profileSchema = z.object({
   full_name: z.string().min(3, "full_name_min"),
   email: z.string().email("invalid_email_address"),
   phone: z
@@ -45,8 +45,8 @@ const profileSchema = z.object({
   department: z.string().min(2),
   gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
   date_of_birth: z.string().refine((val) => !isNaN(Date.parse(val)), { message: "invalid_date" }),
-  // Social links are optional strings without URL validation
-  socialLinks: z.record(z.string()).optional(),
+  // Social links validated as URLs
+  socialLinks: z.record(z.string().url("invalid_url")).optional(),
 });
 
 function ProfileEditTemplate() {

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -54,7 +54,7 @@ import { MdOutlineWorkOutline } from "react-icons/md";
 import { RiDeleteBin6Line } from "react-icons/ri";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-const instructorProfileSchema = z.object({
+export const instructorProfileSchema = z.object({
   full_name: z.string().min(3, "full_name_min"),
   phone: z
     .string()
@@ -76,7 +76,7 @@ const instructorProfileSchema = z.object({
       message: "bio_max_words",
     }),
   socialLinks: z
-    .record(z.string())
+    .record(z.string().url("invalid_url"))
     .optional(),
 });
 

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
+import { useTranslation } from "next-i18next";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import {
   getStudentProfile,
@@ -22,7 +23,7 @@ import {
   FaChevronDown, FaChevronUp, FaTimesCircle, FaGraduationCap
 } from "react-icons/fa";
 
-const studentProfileSchema = z.object({
+export const studentProfileSchema = z.object({
   full_name: z.string().min(3, "Full name must be at least 3 characters"),
   phone: z
     .string()
@@ -36,12 +37,13 @@ const studentProfileSchema = z.object({
   education_level: z.string().min(2, "Education level is required"),
   topics: z.array(z.string()).optional(),
   learning_goals: z.string().optional(),
-  // Social links are optional strings without strict URL validation
-  socialLinks: z.record(z.string()).optional(),
+  // Social links validated as URLs
+  socialLinks: z.record(z.string().url("invalid_url")).optional(),
 });
 
 export default function StudentProfileEdit() {
   const router = useRouter();
+  const { t } = useTranslation('dashboard', { keyPrefix: 'studentProfilePage' });
   const { user, logout, hasHydrated, setUser } = useAuthStore();
   const refreshNotifications = useNotificationStore((s) => s.fetch);
   const refreshMessages = useMessageStore((s) => s.fetch);
@@ -211,13 +213,17 @@ export default function StudentProfileEdit() {
         ...formData,
         socialLinks: Object.keys(sanitizedLinks).length ? sanitizedLinks : undefined,
       });
+      setErrors({});
       return true;
     } catch (err) {
       const errs = {};
       err.errors.forEach((e) => {
-        errs[e.path[0]] = e.message;
+        errs[e.path[0]] = t(e.message);
       });
       setErrors(errs);
+      if (err.errors?.length) {
+        toast.error(t(err.errors[0].message));
+      }
       return false;
     }
   };

--- a/frontend/src/tests/__tests__/profileSchemaSocialLinks.test.js
+++ b/frontend/src/tests/__tests__/profileSchemaSocialLinks.test.js
@@ -1,0 +1,57 @@
+import { ZodError } from 'zod';
+import { profileSchema as adminProfileSchema } from '@/pages/dashboard/admin/profile/edit';
+import { instructorProfileSchema } from '@/pages/dashboard/instructor/profile/edit';
+import { studentProfileSchema } from '@/pages/dashboard/student/profile/edit';
+
+describe('profile schema socialLinks URL validation', () => {
+  const common = {
+    full_name: 'John Doe',
+    phone: '+14155552671',
+    gender: 'male',
+    date_of_birth: '1990-01-01',
+  };
+
+  test('admin profile rejects invalid URL', () => {
+    const data = {
+      ...common,
+      email: 'admin@example.com',
+      job_title: 'Manager',
+      department: 'IT',
+      socialLinks: { twitter: 'not-a-url' },
+    };
+    expect(() => adminProfileSchema.parse(data)).toThrow(ZodError);
+    try {
+      adminProfileSchema.parse(data);
+    } catch (err) {
+      expect(err.errors[0].message).toBe('invalid_url');
+    }
+  });
+
+  test('instructor profile rejects invalid URL', () => {
+    const data = {
+      ...common,
+      experience: 1,
+      socialLinks: { twitter: 'invalid-url' },
+    };
+    expect(() => instructorProfileSchema.parse(data)).toThrow(ZodError);
+    try {
+      instructorProfileSchema.parse(data);
+    } catch (err) {
+      expect(err.errors[0].message).toBe('invalid_url');
+    }
+  });
+
+  test('student profile rejects invalid URL', () => {
+    const data = {
+      ...common,
+      education_level: 'High School',
+      socialLinks: { twitter: 'bad' },
+    };
+    expect(() => studentProfileSchema.parse(data)).toThrow(ZodError);
+    try {
+      studentProfileSchema.parse(data);
+    } catch (err) {
+      expect(err.errors[0].message).toBe('invalid_url');
+    }
+  });
+});

--- a/frontend/src/utils/validation/adminProfileSchema.js
+++ b/frontend/src/utils/validation/adminProfileSchema.js
@@ -17,6 +17,6 @@ export const adminProfileSchema = z.object({
   job_title: z.string().min(2, "Job title is required"),
   department: z.string().min(2, "Department is required"),
   socialLinks: z
-    .record(z.string().url("Must be a valid URL"))
+    .record(z.string().url("invalid_url"))
     .optional(), // optional dictionary { platform: url }
 });


### PR DESCRIPTION
## Summary
- require valid URLs for admin, instructor, and student profile social links
- expose schemas for testing and translate invalid URL errors
- add unit test covering invalid social link inputs

## Testing
- `npm test src/tests/__tests__/profileSchemaSocialLinks.test.js`
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined]; paymentCommission.test.js and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c4696b310c8328958ba1394b237bf7