### PR TITLE
Revoke identity preview URLs

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -127,6 +127,14 @@ export default function StudentProfileEdit() {
     loadProfile();
   }, [user, router]);
 
+  useEffect(() => {
+    return () => {
+      if (formData.identityPreview) {
+        URL.revokeObjectURL(formData.identityPreview);
+      }
+    };
+  }, [formData.identityPreview]);
+
   const toggleSection = (section) => setExpanded(prev => ({ ...prev, [section]: !prev[section] }));
 
   const handleInputChange = (e) => {
@@ -184,11 +192,16 @@ export default function StudentProfileEdit() {
     try {
       setIsSubmitting(true);
       await uploadStudentIdentity(user.id, file);
-      setFormData(prev => ({
-        ...prev,
-        identityFile: file,
-        identityPreview: URL.createObjectURL(file)
-      }));
+      setFormData(prev => {
+        if (prev.identityPreview) {
+          URL.revokeObjectURL(prev.identityPreview);
+        }
+        return {
+          ...prev,
+          identityFile: file,
+          identityPreview: URL.createObjectURL(file)
+        };
+      });
       toast.success("Identity document uploaded successfully!");
     } catch (err) {
       toast.error("Failed to upload identity document");
@@ -198,7 +211,12 @@ export default function StudentProfileEdit() {
   };
 
   const removeIdentity = () => {
-    setFormData(prev => ({ ...prev, identityFile: null, identityPreview: null }));
+    setFormData(prev => {
+      if (prev.identityPreview) {
+        URL.revokeObjectURL(prev.identityPreview);
+      }
+      return { ...prev, identityFile: null, identityPreview: null };
+    });
   };
 
   const validateForm = () => {


### PR DESCRIPTION
## Summary
- prevent memory leaks by revoking previous identity preview URLs before creating new ones
- revoke identity preview URL on removal and component unmount

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c46968db208328915dc1cad663b303