### PR TITLE
feat: add nonbinary gender options

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -29,7 +29,7 @@ const studentProfileSchema = z.object({
     .refine((val) => isValidPhoneNumber(val), {
       message: "Invalid phone number",
     }),
-  gender: z.enum(["male", "female"]),
+  gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
   date_of_birth: z.string().refine(val => !isNaN(Date.parse(val)), {
     message: "Invalid date format",
   }),
@@ -514,6 +514,8 @@ export default function StudentProfileEdit() {
                       >
                         <option value="male">Male</option>
                         <option value="female">Female</option>
+                        <option value="other">Other</option>
+                        <option value="prefer-not-to-say">Prefer not to say</option>
                       </select>
                     </div>
 


### PR DESCRIPTION
## Summary
- allow gender values "other" and "prefer-not-to-say" in student profile schema
- expose new gender choices in profile edit dropdown

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*
- `npm run lint` *(fails: 45 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c4696619c0832896d3df5af1009443