### PR TITLE
Return full profile after student profile update

### DIFF
--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -104,7 +104,33 @@ exports.updateProfile = async (req, res) => {
     }
 
     await trx.commit();
-    res.json({ message: "Profile updated successfully" });
+
+    const [user] = await db("users")
+      .where({ id: userId })
+      .select(
+        "id",
+        "full_name",
+        "email",
+        "phone",
+        "gender",
+        "date_of_birth",
+        "avatar_url",
+        "is_email_verified",
+        "is_phone_verified",
+        "profile_complete",
+        "created_at",
+        "updated_at"
+      );
+
+    const [student] = await db("student_profiles")
+      .where({ user_id: userId })
+      .select("education_level", "topics", "learning_goals", "identity_doc_url");
+
+    const socialLinks = await db("user_social_links")
+      .where({ user_id: userId })
+      .select("platform", "url");
+
+    res.json({ ...user, student, social_links: socialLinks });
   } catch (err) {
     await trx.rollback();
     logger.error("Failed to update student profile", err.message);


### PR DESCRIPTION
## Summary
- After student profile update, fetch and return updated user, profile, and social links

## Testing
- `npm test` *(fails: Route.post requires callback; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c46963d5d88328b3481405eb82f061