### PR TITLE
fix: guard student profile auth parsing

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -73,7 +73,14 @@ export default function StudentProfileEdit() {
 
   useEffect(() => {
     const local = localStorage.getItem("auth");
-    const parsed = JSON.parse(local)?.state;
+    let parsed;
+    if (local) {
+      try {
+        parsed = JSON.parse(local)?.state;
+      } catch (error) {
+        console.error("Failed to parse auth from localStorage", error);
+      }
+    }
     if (hasHydrated && !user && parsed?.user) {
       setUser(parsed.user);
     }


### PR DESCRIPTION
## Summary
- handle missing or invalid auth in student profile edit

## Testing
- `cd frontend && npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c4695106b08328a4d0abe14314c608