### PR TITLE
Expand gender options for profiles

### DIFF
--- a/backend/src/modules/users/student/student.validator.js
+++ b/backend/src/modules/users/student/student.validator.js
@@ -4,7 +4,7 @@ const { z } = require("zod");
 const updateStudentProfileSchema = z.object({
   full_name: z.string().min(3, "Full name is required"),
   phone: z.string().min(8, "Phone number is required"),
-  gender: z.enum(["male", "female"]),
+  gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
   date_of_birth: z.string().refine((val) => !isNaN(Date.parse(val)), {
     message: "Invalid date of birth",
   }),

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -29,7 +29,7 @@ const studentProfileSchema = z.object({
     .refine((val) => isValidPhoneNumber(val), {
       message: "Invalid phone number",
     }),
-  gender: z.enum(["male", "female"]),
+  gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
   date_of_birth: z.string().refine(val => !isNaN(Date.parse(val)), {
     message: "Invalid date format",
   }),
@@ -514,6 +514,8 @@ export default function StudentProfileEdit() {
                       >
                         <option value="male">Male</option>
                         <option value="female">Female</option>
+                        <option value="other">Other</option>
+                        <option value="prefer-not-to-say">Prefer not to say</option>
                       </select>
                     </div>
 

--- a/frontend/src/utils/validation/adminProfileSchema.js
+++ b/frontend/src/utils/validation/adminProfileSchema.js
@@ -9,7 +9,7 @@ export const adminProfileSchema = z.object({
     .refine((val) => isValidPhoneNumber(val), {
       message: "Invalid phone number",
     }),
-  gender: z.enum(["male", "female"]),
+  gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
   date_of_birth: z.string().refine((val) => !isNaN(Date.parse(val)), {
     message: "Invalid date",
   }),


### PR DESCRIPTION
## Summary
- allow `other` and `prefer-not-to-say` as gender options in student profiles
- update student profile form to show the expanded gender list
- align admin profile validation with the extended gender enum

## Testing
- `npm test` (backend) *(failed: bookRoutes, paymentCommission, paymentInvoiceEmail, tutorialRoutes, studentPaymentRoutes, tutorialUpdateTransaction, seoConfigRoutes, authLoginRoutes, authRegisterRoutes, paymentInstallments and others)*
- `npm test` (frontend) *(failed: CacheManager test and others)*
- `npm run lint` (frontend) *(errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c4694f849c83288995363375ab1aac