### PR TITLE
refactor auth hydration into reusable hook

### DIFF
--- a/frontend/src/hooks/useHydratedUser.js
+++ b/frontend/src/hooks/useHydratedUser.js
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import useAuthStore from "@/store/auth/authStore";
+
+export default function useHydratedUser() {
+  const user = useAuthStore((s) => s.user);
+  const hasHydrated = useAuthStore((s) => s.hasHydrated);
+
+  useEffect(() => {
+    if (user && hasHydrated) return;
+
+    try {
+      const raw = localStorage.getItem("auth");
+      if (!raw) {
+        if (!hasHydrated) {
+          useAuthStore.setState({ hasHydrated: true });
+        }
+        return;
+      }
+      const parsed = JSON.parse(raw)?.state;
+      if (parsed?.user) {
+        useAuthStore.setState({
+          user: parsed.user,
+          accessToken: parsed.accessToken,
+          hasHydrated: true,
+        });
+      } else if (!hasHydrated) {
+        useAuthStore.setState({ hasHydrated: true });
+      }
+    } catch (err) {
+      console.error("Failed to parse auth from localStorage", err);
+      localStorage.removeItem("auth");
+      useAuthStore.setState({ hasHydrated: true });
+    }
+  }, [user, hasHydrated]);
+
+  return { user, hasHydrated };
+}
+

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -10,6 +10,7 @@ import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
 import "@/styles/globals.css";
 import "@/services/api/tokenInterceptor";
 import useAuthStore from "@/store/auth/authStore";
+import useHydratedUser from "@/hooks/useHydratedUser";
 import useAppConfigStore from "@/store/appConfigStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
@@ -74,20 +75,7 @@ function MyApp({ Component, pageProps, router }) {
   const currentLang = langs?.find((l) => l.code === i18n.language);
   const user = useAuthStore((s) => s.user);
   const [gaId, setGaId] = useState(null);
-
-  useEffect(() => {
-    const local = localStorage.getItem("auth");
-    if (local) {
-      const parsed = JSON.parse(local)?.state;
-      if (parsed?.user) {
-        useAuthStore.setState({
-          user: parsed.user,
-          accessToken: parsed.accessToken,
-          hasHydrated: true, // ✅ manually set hydration flag
-        });
-      }
-    }
-  }, []);
+  useHydratedUser();
 
   useEffect(() => {
     if (router.pathname.startsWith('/auth')) return;

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -23,6 +23,7 @@ import {
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useAuthStore from "@/store/auth/authStore";
 import useMessageStore from "@/store/messages/messageStore";
+import useHydratedUser from "@/hooks/useHydratedUser";
 import {
   getAdminProfile,
   updateAdminProfile,
@@ -52,7 +53,8 @@ const profileSchema = z.object({
 function ProfileEditTemplate() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'adminProfilePage' });
-  const { user, hasHydrated, setUser } = useAuthStore();
+  const { user, hasHydrated } = useHydratedUser();
+  const setUser = useAuthStore((s) => s.setUser);
   const [loadingProfile, setLoadingProfile] = useState(true);
   const [formData, setFormData] = useState({
     full_name: "",
@@ -77,21 +79,6 @@ function ProfileEditTemplate() {
   const [tempFileName, setTempFileName] = useState("");
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const fetchMessages = useMessageStore((state) => state.fetch);
-
-useEffect(() => {
-  const local = localStorage.getItem("auth");
-  let parsed;
-  if (local) {
-    try {
-      parsed = JSON.parse(local)?.state;
-    } catch (error) {
-      console.error("Failed to parse auth from localStorage", error);
-    }
-  }
-  if (hasHydrated && !user && parsed?.user) {
-    setUser(parsed.user);
-  }
-}, [hasHydrated]);
 
   useEffect(() => {
     if (!hasHydrated) return;

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -25,6 +25,7 @@ import {
 } from "@/services/instructor/instructorService";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
+import useHydratedUser from "@/hooks/useHydratedUser";
 import {
   FaUpload,
   FaTrash,
@@ -95,7 +96,7 @@ const socialPlatforms = [
 export default function InstructorProfileEdit() {
   const router = useRouter();
   const { t } = useTranslation('dashboard', { keyPrefix: 'instructorProfilePage' });
-  const { user, hasHydrated } = useAuthStore();
+  const { user, hasHydrated } = useHydratedUser();
   const fetchNotifications = useNotificationStore((state) => state.fetch);
 
   const [formData, setFormData] = useState({

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -16,6 +16,7 @@ import useMessageStore from "@/store/messages/messageStore";
 import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
 import logger from "@/utils/logger";
+import useHydratedUser from "@/hooks/useHydratedUser";
 import {
   FaUpload, FaTrash, FaFilePdf, FaSpinner,
   FaUserCircle, FaIdCard, FaLinkedin, FaGithub,
@@ -42,9 +43,11 @@ const studentProfileSchema = z.object({
 
 export default function StudentProfileEdit() {
   const router = useRouter();
-  const { user, logout, hasHydrated, setUser } = useAuthStore();
+  const logout = useAuthStore((s) => s.logout);
+  const setUser = useAuthStore((s) => s.setUser);
   const refreshNotifications = useNotificationStore((s) => s.fetch);
   const refreshMessages = useMessageStore((s) => s.fetch);
+  const { user, hasHydrated } = useHydratedUser();
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [expanded, setExpanded] = useState({
@@ -70,14 +73,6 @@ export default function StudentProfileEdit() {
   });
   const [errors, setErrors] = useState({});
 
-
-  useEffect(() => {
-    const local = localStorage.getItem("auth");
-    const parsed = JSON.parse(local)?.state;
-    if (hasHydrated && !user && parsed?.user) {
-      setUser(parsed.user);
-    }
-  }, [hasHydrated]);
 
   useEffect(() => {
     if (!user) {


### PR DESCRIPTION
## Summary
- add `useHydratedUser` hook to centralize auth hydration from localStorage
- replace per-page hydration logic in admin, student, and instructor profiles with the new hook
- wire the hook into `_app.js` for consistent store initialization

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js, StudentTutorialsPage.test.js)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4694d6e6483288f2d9dd43478bd22