### PR TITLE
Sanitize popup announcements before display

### DIFF
--- a/frontend/src/components/common/PopupAnnouncement.js
+++ b/frontend/src/components/common/PopupAnnouncement.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import DOMPurify from "isomorphic-dompurify";
 import api from "@/services/api/api";
 import useAuthStore from "@/store/auth/authStore";
 
@@ -59,7 +60,9 @@ export default function PopupAnnouncement() {
     <div className={`fixed z-50 ${positionClass} transform`}> 
       <div className={`p-4 rounded shadow ${themeClass}`}> 
         {popup.title && <h3 className="font-bold mb-2">{popup.title}</h3>}
-        <div dangerouslySetInnerHTML={{ __html: popup.message }} />
+        <div
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(popup.message) }}
+        />
       </div>
     </div>
   );

--- a/frontend/src/tests/__tests__/PopupAnnouncementSanitization.test.js
+++ b/frontend/src/tests/__tests__/PopupAnnouncementSanitization.test.js
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import PopupAnnouncement from '../../components/common/PopupAnnouncement';
+import useAuthStore from '../../store/auth/authStore';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ pathname: '/' }),
+}));
+
+const mockGet = jest.fn();
+jest.mock('../../services/api/api', () => ({
+  get: (...args) => mockGet(...args),
+}));
+
+test('sanitizes popup message before rendering', async () => {
+  const dirty = '<p>Safe</p><img src=x onerror="alert(1)" /><script>alert(1)</script>';
+  mockGet.mockResolvedValue({ data: { data: [{ id: 1, message: dirty, once_per_session: false }] } });
+  useAuthStore.setState({ user: null });
+
+  render(<PopupAnnouncement />);
+  const paragraph = await screen.findByText('Safe');
+  const html = paragraph.parentElement.innerHTML;
+
+  expect(html).toContain('<p>Safe</p>');
+  expect(html).not.toContain('<script>');
+  expect(html).not.toContain('onerror');
+});


### PR DESCRIPTION
## Summary
- sanitize popup announcement message with DOMPurify
- add test verifying popup messages are sanitized

## Testing
- `npm test src/tests/__tests__/PopupAnnouncementSanitization.test.js`
- `npm test src/tests/__tests__/CacheManager.test.tsx` *(fails: TypeError: _cacheService.clearCache.mockReset is not a function)*
- `npm run lint` *(fails: 44 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c460cb6754832885ae4e136e667ff8