### PR TITLE
Document hashed JWT tokens in blacklist

### DIFF
--- a/SkillBridge_DB_Schema_Overview.md
+++ b/SkillBridge_DB_Schema_Overview.md
@@ -35,10 +35,10 @@
 - **Columns**: `user_id`, `code_hash`, `expires_at`, `used`, `created_at`
 
 ### `blacklisted_tokens`
-- **Purpose**: Stores revoked JWTs to prevent reuse
+- **Purpose**: Stores SHA-256 hashes of revoked JWTs to prevent reuse
 - **Primary Key**: `id`
 - **Foreign Keys**: `—`
-- **Columns**: `token`, `expires_at`, `created_at`
+- **Columns**: `token_hash`, `expires_at`, `created_at`
 
 ### `student_profiles`
 - **Purpose**: Extra details for student accounts


### PR DESCRIPTION
## Summary
- note that `blacklisted_tokens` store revoked JWTs as SHA-256 hashes
- rename column reference from `token` to `token_hash`

## Testing
- `pre-commit run --files SkillBridge_DB_Schema_Overview.md` *(fails: 56 lint errors, 273 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c48a2be6fc832886d077b0ff8cc2b4