### PR TITLE
Hash tokens in blacklist service

### DIFF
--- a/backend/src/services/tokenBlacklistService.js
+++ b/backend/src/services/tokenBlacklistService.js
@@ -1,16 +1,17 @@
 const db = require('../config/database');
 const logger = require('../utils/logger.js');
 const jwt = require('jsonwebtoken');
+const crypto = require('crypto');
+
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
 
 /**
  * Inserts a token into the blacklist store.
  * @param {string} token
  * @returns {Promise<void>}
  */
-function hashToken(token) {
-  return crypto.createHash('sha256').update(token).digest('hex');
-}
-
 async function addToken(token) {
   if (!token) return;
 
@@ -25,9 +26,10 @@ async function addToken(token) {
   }
 
   try {
+    const tokenHash = hashToken(token);
     await db('blacklisted_tokens')
-      .insert({ token, expires_at: expiresAt })
-      .onConflict('token')
+      .insert({ token_hash: tokenHash, expires_at: expiresAt })
+      .onConflict('token_hash')
       .ignore();
   } catch (err) {
     logger.error('Failed to add token to blacklist:', err);
@@ -42,8 +44,9 @@ async function addToken(token) {
  */
 async function isTokenBlacklisted(token) {
   if (!token) return false;
+  const tokenHash = hashToken(token);
   const record = await db('blacklisted_tokens')
-    .where({ token })
+    .where({ token_hash: tokenHash })
     .andWhere('expires_at', '>', db.fn.now())
     .first();
   return !!record;

--- a/backend/tests/tokenBlacklistService.test.js
+++ b/backend/tests/tokenBlacklistService.test.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const mockIgnore = jest.fn();
 const mockOnConflict = jest.fn(() => ({ ignore: mockIgnore }));
 const mockInsert = jest.fn(() => ({ onConflict: mockOnConflict }));
@@ -31,7 +32,7 @@ describe('tokenBlacklistService', () => {
     mockIgnore.mockResolvedValueOnce();
     await addToken('tok');
     const hash = crypto.createHash('sha256').update('tok').digest('hex');
-    expect(mockInsert).toHaveBeenCalledWith({ token_hash: hash });
+    expect(mockInsert).toHaveBeenCalledWith({ token_hash: hash, expires_at: null });
     expect(mockOnConflict).toHaveBeenCalledWith('token_hash');
   });
 


### PR DESCRIPTION
## Summary
- hash JWTs before storing in blacklisted_tokens
- query blacklist by hashed token
- adjust token blacklist tests for hashed storage

## Testing
- `npm test` *(fails: Test Suites: 23 failed, 2 skipped, 115 passed, 138 of 140 total)*
- `npm test tests/tokenBlacklistService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c48a2694b88328bc002bb9ac1a1341