### PR TITLE
feat: add CSRF token endpoint

### DIFF
--- a/backend/src/routes/csrf.routes.js
+++ b/backend/src/routes/csrf.routes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+
+// Endpoint to trigger CSRF cookie generation
+router.get('/', (_req, res) => res.status(204).end());
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -6,6 +6,7 @@ const {
 } = require('../modules/install/install.routes');
 
 router.use('/api/health', require('./health.routes'));
+router.use('/api/csrf-token', require('./csrf.routes'));
 // grouped routers
 router.use(require('./auth'));
 router.use(require('./payments'));

--- a/backend/tests/csrfTokenRoute.test.js
+++ b/backend/tests/csrfTokenRoute.test.js
@@ -1,0 +1,27 @@
+const request = require('supertest');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const session = require('express-session');
+
+const csrf = require('../src/middleware/csrf');
+const csrfRoute = require('../src/routes/csrf.routes');
+
+function createApp() {
+  const app = express();
+  app.use(cookieParser());
+  app.use(session({ secret: 'test', resave: false, saveUninitialized: true }));
+  app.use(csrf);
+  app.use('/api/csrf-token', csrfRoute);
+  return app;
+}
+
+describe('GET /api/csrf-token', () => {
+  it('sets csrfToken cookie and returns 204', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/csrf-token');
+    expect(res.status).toBe(204);
+    expect(res.headers['set-cookie']).toEqual(
+      expect.arrayContaining([expect.stringContaining('csrfToken=')])
+    );
+  });
+});

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -20,6 +20,9 @@ random CSRF token. Clients must mirror this value in the `x-csrf-token` header
 on subsequent state‑changing requests (POST/PUT/PATCH/DELETE) to satisfy server
 CSRF validation.
 
+Clients can also fetch a fresh token at any time via `GET /api/csrf-token`,
+which sets a new `csrfToken` cookie and returns no content.
+
 ## Users
 
 `/api/users`


### PR DESCRIPTION
## Summary
- add `/api/csrf-token` route to expose CSRF cookie
- document token endpoint in API docs
- test new CSRF token route

## Testing
- `cd backend && npm test -- tests/csrfTokenRoute.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c48a23d45483289fe9231e47bc6596