### PR TITLE
Hash tokens in blacklist and add missing migration

### DIFF
--- a/backend/src/migrations/20250721200000_add_expires_at_to_blacklisted_tokens.js
+++ b/backend/src/migrations/20250721200000_add_expires_at_to_blacklisted_tokens.js
@@ -1,0 +1,29 @@
+/**
+ * Adds expires_at column to blacklisted_tokens if missing.
+ * @param { import('knex').Knex } knex
+ */
+exports.up = async function (knex) {
+  const hasTable = await knex.schema.hasTable('blacklisted_tokens');
+  if (!hasTable) return;
+  const hasColumn = await knex.schema.hasColumn('blacklisted_tokens', 'expires_at');
+  if (!hasColumn) {
+    await knex.schema.alterTable('blacklisted_tokens', (table) => {
+      table.timestamp('expires_at').notNullable().index();
+    });
+  }
+};
+
+/**
+ * Drops expires_at column from blacklisted_tokens if present.
+ * @param { import('knex').Knex } knex
+ */
+exports.down = async function (knex) {
+  const hasTable = await knex.schema.hasTable('blacklisted_tokens');
+  if (!hasTable) return;
+  const hasColumn = await knex.schema.hasColumn('blacklisted_tokens', 'expires_at');
+  if (hasColumn) {
+    await knex.schema.alterTable('blacklisted_tokens', (table) => {
+      table.dropColumn('expires_at');
+    });
+  }
+};

--- a/backend/src/services/tokenBlacklistService.js
+++ b/backend/src/services/tokenBlacklistService.js
@@ -3,6 +3,10 @@ const logger = require('../utils/logger.js');
 const jwt = require('jsonwebtoken');
 const crypto = require('crypto');
 
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
 /**
  * Inserts a token into the blacklist store.
  * @param {string} token
@@ -10,8 +14,6 @@ const crypto = require('crypto');
  */
 async function addToken(token) {
   if (!token) return;
-
-  const tokenHash = hashToken(token);
 
   let expiresAt = null;
   try {
@@ -25,7 +27,6 @@ async function addToken(token) {
 
   const tokenHash = hashToken(token);
   try {
-    const tokenHash = hashToken(token);
     await db('blacklisted_tokens')
       .insert({ token_hash: tokenHash, expires_at: expiresAt })
       .onConflict('token_hash')


### PR DESCRIPTION
## Summary
- Hash JWTs before storing or querying blacklist entries
- Add missing migration skeleton for `expires_at` on blacklisted tokens

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined], etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c4886d47ec8328bf7516adf02bb655