### PR TITLE
Fix down migration for blacklisted token hash

### DIFF
--- a/backend/src/migrations/20250905000000_alter_blacklisted_tokens_hash.js
+++ b/backend/src/migrations/20250905000000_alter_blacklisted_tokens_hash.js
@@ -27,8 +27,7 @@ exports.down = async function (knex) {
   const hasColumn = await knex.schema.hasColumn('blacklisted_tokens', 'token_hash');
   if (hasColumn) {
     await knex.schema.alterTable('blacklisted_tokens', (table) => {
-      table.dropUnique('token_hash');
-      table.dropUnique('token_hash', 'blacklisted_tokens_token_unique');
+      table.dropUnique('token_hash', 'blacklisted_tokens_token_hash_unique');
       table.renameColumn('token_hash', 'token');
     });
     await knex.schema.alterTable('blacklisted_tokens', (table) => {


### PR DESCRIPTION
## Summary
- remove redundant dropUnique call in `alter_blacklisted_tokens_hash` down migration
- rename dropUnique constraint for clarity

## Testing
- `DATABASE_URL=postgres://root:root@localhost/postgres npx knex migrate:latest`
- `DATABASE_URL=postgres://root:root@localhost/postgres npx knex migrate:rollback`


------
https://chatgpt.com/codex/tasks/task_e_68c50888a428832893811bb2b1efe03e