### PR TITLE
fix: import allowed platforms in admin profile edit

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -31,6 +31,7 @@ import {
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
 import { toSocialLinksArray } from "@/utils/socialLinks";
+import { allowedPlatforms } from "@/utils/socialPlatforms";
 
 // Add service imports as needed, e.g., getProfile, updateProfile, uploadAvatar, etc.
 


### PR DESCRIPTION
## Summary
- import allowedPlatforms in admin profile edit page to resolve runtime error

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js'; TypeError: _cacheService.clearCache.mockReset is not a function)*
- `npm run dev` *(checked http://localhost:3000/dashboard/admin/profile/edit returns 200)*

------
https://chatgpt.com/codex/tasks/task_e_68c515da9a9083289c8e33542f289108