### PR TITLE
Import allowedPlatforms in admin profile editor

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -31,6 +31,7 @@ import {
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
 import { toSocialLinksArray } from "@/utils/socialLinks";
+import { allowedPlatforms } from "@/utils/socialPlatforms";
 
 // Add service imports as needed, e.g., getProfile, updateProfile, uploadAvatar, etc.
 


### PR DESCRIPTION
## Summary
- import `allowedPlatforms` constant to admin profile edit page to support social link filtering

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68c515cebcd08328bf45849cb4354d11