### PR TITLE
fix: ensure CSRF cookie before admin avatar upload

### DIFF
--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -36,8 +36,8 @@ export const updateAdminProfile = async (profileData) => {
  */
 
 export const uploadAdminAvatar = async (adminId, avatarFile) => {
-  // Obtain a CSRF token and include it in the upload request headers
-  const csrfToken = await ensureCsrfToken();
+  // Ensure a CSRF cookie exists so Axios can automatically attach the token
+  await ensureCsrfToken();
 
   const formData = new FormData();
   formData.append("avatar", avatarFile);
@@ -45,9 +45,7 @@ export const uploadAdminAvatar = async (adminId, avatarFile) => {
   const res = await api.patch(`/users/admin/${adminId}/avatar`, formData, {
     headers: {
       "Content-Type": "multipart/form-data",
-      "x-csrf-token": csrfToken,
     },
-    withCredentials: true, // if using cookies
   });
   return res.data;
 };


### PR DESCRIPTION
## Summary
- rely on existing CSRF cookie so Axios attaches header automatically when uploading admin avatars

## Testing
- `CI=true npx jest src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService')*


------
https://chatgpt.com/codex/tasks/task_e_68c528aa26b883288954c2ae5e645bfc