### PR TITLE
Allow empty social link URLs in profile schemas

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -47,8 +47,10 @@ export const profileSchema = z.object({
   department: z.string().min(2),
   gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
   date_of_birth: z.string().refine((val) => !isNaN(Date.parse(val)), { message: "invalid_date" }),
-  // Social links validated as URLs
-  socialLinks: z.record(z.string().url("invalid_url")).optional(),
+  // Social links validated as URLs; allow empty strings so optional fields don't fail validation
+  socialLinks: z
+    .record(z.string().url("invalid_url").or(z.literal("")))
+    .optional(),
 });
 
 function ProfileEditTemplate() {

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -67,7 +67,7 @@ export const instructorProfileSchema = z.object({
       message: "bio_max_words",
     }),
   socialLinks: z
-    .record(z.string().url("invalid_url"))
+    .record(z.string().url("invalid_url").or(z.literal("")))
     .optional(),
 });
 // Currency options will be loaded from the backend configuration

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -40,8 +40,10 @@ export const studentProfileSchema = z.object({
   education_level: z.string().min(2, "education_required"),
   topics: z.array(z.string()).optional(),
   learning_goals: z.string().optional(),
-  // Social links validated as URLs
-  socialLinks: z.record(z.string().url("invalid_url")).optional(),
+  // Social links validated as URLs but allow empty strings for optional entries
+  socialLinks: z
+    .record(z.string().url("invalid_url").or(z.literal("")))
+    .optional(),
 });
 
 export default function StudentProfileEdit() {

--- a/frontend/src/tests/tests/profileSchemaSocialLinks.test.js
+++ b/frontend/src/tests/tests/profileSchemaSocialLinks.test.js
@@ -1,0 +1,41 @@
+import { profileSchema as adminProfileSchema } from '@/pages/dashboard/admin/profile/edit';
+import { instructorProfileSchema } from '@/pages/dashboard/instructor/profile/edit';
+import { studentProfileSchema } from '@/pages/dashboard/student/profile/edit';
+
+describe('profile schema allows empty social link URLs', () => {
+  const common = {
+    full_name: 'John Doe',
+    phone: '+14155552671',
+    gender: 'male',
+    date_of_birth: '1990-01-01',
+  };
+
+  test('admin profile accepts empty social link', () => {
+    const data = {
+      ...common,
+      email: 'admin@example.com',
+      job_title: 'Manager',
+      department: 'IT',
+      socialLinks: { twitter: '' },
+    };
+    expect(() => adminProfileSchema.parse(data)).not.toThrow();
+  });
+
+  test('instructor profile accepts empty social link', () => {
+    const data = {
+      ...common,
+      experience: 1,
+      socialLinks: { twitter: '' },
+    };
+    expect(() => instructorProfileSchema.parse(data)).not.toThrow();
+  });
+
+  test('student profile accepts empty social link', () => {
+    const data = {
+      ...common,
+      education_level: 'High School',
+      socialLinks: { twitter: '' },
+    };
+    expect(() => studentProfileSchema.parse(data)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Permit empty strings in `socialLinks` for admin, instructor, and student profile schemas
- Add regression tests verifying empty social links validate successfully

## Testing
- `npm test profileSchemaSocialLinks.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c52e20ff5c83289ba09ca1728f8387