### PR TITLE
Ensure CSRF token on admin profile update

### DIFF
--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -20,7 +20,11 @@ export const getAdminProfile = async () => {
  * admin-specific details, and social links
  */
 export const updateAdminProfile = async (profileData) => {
-  const res = await api.put("/users/admin/profile", profileData);
+  const headers = {};
+  const csrfToken = await ensureCsrfToken();
+  if (csrfToken) headers["x-csrf-token"] = csrfToken;
+
+  const res = await api.put("/users/admin/profile", profileData, { headers });
   return res.data;
 };
 


### PR DESCRIPTION
## Summary
- ensure CSRF token and apply x-csrf-token header when updating admin profile

## Testing
- `npm test -- src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: _cacheService.clearCache.mockReset is not a function)*


------
https://chatgpt.com/codex/tasks/task_e_68c52e225c948328ab29ada4e0121c34