### PR TITLE
fix: avoid null avatar overwrites

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -88,16 +88,24 @@ exports.updateProfile = async (req, res) => {
   const trx = await db.transaction();
   try {
     // 1. Update core user fields
-    await trx("users").where({ id: userId }).update({
+    const updateData = {
       email,
       full_name,
       phone,
       gender,
       date_of_birth,
-      avatar_url,
       profile_complete: true,
       updated_at: new Date(),
-    });
+    };
+
+    // Only include avatar_url if it's provided in the request body. This prevents
+    // unintentionally setting the column to NULL when the client does not send a
+    // value, preserving the existing database value instead.
+    if (avatar_url !== undefined && avatar_url !== null) {
+      updateData.avatar_url = avatar_url;
+    }
+
+    await trx("users").where({ id: userId }).update(updateData);
 
     // 2. Upsert admin profile
     const profileData = {


### PR DESCRIPTION
## Summary
- prevent unintended avatar URL removal during admin profile updates

## Testing
- `npm test` *(fails: 22 failed, 117 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e1bc4bc83288ba4f3f0f40b50cb