### PR TITLE
refactor: avoid reusing transaction after commit in admin controller

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -131,8 +131,23 @@ exports.updateProfile = async (req, res) => {
         });
       }
     }
+
     await trx.commit();
-    // 4. Return the freshly updated profile details
+  } catch (error) {
+    await trx.rollback();
+    if (error.code === "23505") {
+      if (error.constraint === "users_email_unique") {
+        return res.status(409).json({ message: "Email already in use" });
+      }
+      if (error.constraint === "users_phone_unique") {
+        return res.status(409).json({ message: "Phone number already in use" });
+      }
+    }
+    return handleControllerError(res, error, "Unable to update profile", { userId });
+  }
+
+  try {
+    // 4. Return the freshly updated profile details using a new db connection
     const [user] = await db("users")
       .where({ id: userId })
       .select(
@@ -150,15 +165,13 @@ exports.updateProfile = async (req, res) => {
         "updated_at"
       );
 
-    const [adminProfile] = await trx("admin_profiles")
+    const [adminProfile] = await db("admin_profiles")
       .where({ user_id: userId })
       .select("job_title", "department", "identity_doc_url", "created_at", "updated_at");
 
-    const socialLinks = await trx("user_social_links")
+    const socialLinks = await db("user_social_links")
       .where({ user_id: userId })
       .select("platform", "url");
-
-    await trx.commit();
 
     return res.json({
       ...user,
@@ -166,16 +179,7 @@ exports.updateProfile = async (req, res) => {
       social_links: socialLinks,
     });
   } catch (error) {
-    await trx.rollback();
-    if (error.code === "23505") {
-      if (error.constraint === "users_email_unique") {
-        return res.status(409).json({ message: "Email already in use" });
-      }
-      if (error.constraint === "users_phone_unique") {
-        return res.status(409).json({ message: "Phone number already in use" });
-      }
-    }
-    handleControllerError(res, error, "Unable to update profile", { userId });
+    return handleControllerError(res, error, "Unable to update profile", { userId });
   }
 };
 


### PR DESCRIPTION
## Summary
- prevent reuse of committed transaction when updating admin profile
- fetch updated profile using a new database connection

## Testing
- `cd backend && npm test` *(fails: 22 failed, 2 skipped, 117 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e1a3d388328acf7b7eabc7fb33c