### PR TITLE
Handle avatar crop errors in admin profile edit

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -581,6 +581,7 @@
     "load_profile_failed": "فشل تحميل الملف الشخصي",
     "avatar_max_size": "الحجم الأقصى 10 MB",
     "avatar_upload_failed": "فشل رفع الصورة الشخصية",
+    "avatar_crop_failed": "فشل قص الصورة الرمزية",
     "profile_update_success": "تم تحديث الملف الشخصي بنجاح!",
     "profile_update_failed": "فشل تحديث الملف الشخصي",
     "full_name_min": "يجب أن يكون الاسم الكامل 3 أحرف على الأقل",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -558,6 +558,7 @@
     "certificate_remove_failed": "Failed to remove certificate",
     "avatar_max_size": "Max size 10 MB",
     "avatar_upload_failed": "Failed to upload avatar",
+    "avatar_crop_failed": "Avatar-Zuschnitt fehlgeschlagen",
     "profile_update_success": "Profile updated successfully!",
     "profile_update_failed": "Failed to update profile",
     "demo_max_size": "Max size 10 MB",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -599,6 +599,7 @@
     "load_profile_failed": "Failed to load profile",
     "avatar_max_size": "Max size 10 MB",
     "avatar_upload_failed": "Failed to upload avatar",
+    "avatar_crop_failed": "Failed to crop avatar",
     "profile_update_success": "Profile updated successfully!",
     "profile_update_failed": "Failed to update profile",
     "full_name_min": "Full name must be at least 3 characters",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -581,6 +581,7 @@
     "load_profile_failed": "No se pudo cargar perfil",
     "avatar_max_size": "Tamaño máximo de 10 MB",
     "avatar_upload_failed": "No se pudo subir avatar",
+    "avatar_crop_failed": "No se pudo recortar el avatar",
     "profile_update_success": "Perfil actualizado con éxito!",
     "profile_update_failed": "No se pudo actualizar el perfil",
     "full_name_min": "El nombre completo debe ser al menos 3 caracteres",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -581,6 +581,7 @@
     "load_profile_failed": "Échec du chargement du profil",
     "avatar_max_size": "Taille maximale 10 Mo",
     "avatar_upload_failed": "Échec du téléversement de l'avatar",
+    "avatar_crop_failed": "Échec du recadrage de l'avatar",
     "profile_update_success": "Profil mis à jour avec succès !",
     "profile_update_failed": "Échec de la mise à jour du profil",
     "full_name_min": "Le nom complet doit comporter au moins 3 caractères",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -581,6 +581,7 @@
     "load_profile_failed": "प्रोफ़ाइल लोड करने में विफल",
     "avatar_max_size": "अधिकतम आकार 10 एमबी",
     "avatar_upload_failed": "अवतार अपलोड करने में विफल",
+    "avatar_crop_failed": "अवतार क्रॉप विफल हुआ",
     "profile_update_success": "प्रोफ़ाइल सफलतापूर्वक अपडेट किया गया!",
     "profile_update_failed": "प्रोफ़ाइल अपडेट करने में विफल",
     "full_name_min": "पूरा नाम कम से कम 3 अक्षर होना चाहिए",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -595,6 +595,7 @@
     "load_profile_failed": "Impossibile caricare il profilo",
     "avatar_max_size": "Dimensione massima 10 MB",
     "avatar_upload_failed": "Impossibile caricare Avatar",
+    "avatar_crop_failed": "Ritaglio avatar non riuscito",
     "profile_update_success": "Profilo aggiornato correttamente!",
     "profile_update_failed": "Impossibile aggiornare il profilo",
     "full_name_min": "Il nome completo deve essere almeno 3 caratteri",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -581,6 +581,7 @@
     "load_profile_failed": "无法加载配置文件",
     "avatar_max_size": "最大尺寸10MB",
     "avatar_upload_failed": "无法上传头像",
+    "avatar_crop_failed": "头像裁剪失败",
     "profile_update_success": "个人资料成功更新了！",
     "profile_update_failed": "无法更新个人资料",
     "full_name_min": "全名必须至少为3个字符",

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -204,8 +204,16 @@ useEffect(() => {
       return;
     }
     setIsSubmitting(true);
+    let blob;
     try {
-      const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
+      blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
+    } catch (error) {
+      console.error('Avatar crop error:', error);
+      toast.error(t('avatar_crop_failed'));
+      setIsSubmitting(false);
+      return;
+    }
+    try {
       const file = new File([blob], tempFileName || "avatar.jpg", {
         type: blob.type,
       });


### PR DESCRIPTION
## Summary
- handle avatar cropping failures gracefully during admin avatar upload
- add `avatar_crop_failed` locale strings across languages

## Testing
- `npm test` (fails: _cacheService.clearCache.mockReset is not a function, Cannot find module '../../services/instructor/subscriptionService')
- `npm run lint` (fails: 329 problems including react/display-name, no-img-element)


------
https://chatgpt.com/codex/tasks/task_e_68c52e16a1ec8328a04b88c69aa6c514