### PR TITLE
Reset avatar input after selection

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -187,14 +187,19 @@ useEffect(() => {
 
   const handleAvatarSelect = (e) => {
     const file = e.target.files[0];
-    if (!file) return;
+    if (!file) {
+      e.target.value = '';
+      return;
+    }
     if (file.size > 10 * 1024 * 1024) {
       toast.error(t('avatar_max_size'));
+      e.target.value = '';
       return;
     }
     setTempFileName(file.name);
     setTempAvatar(URL.createObjectURL(file));
     setShowCropper(true);
+    e.target.value = '';
   };
 
   const handleCropUpload = async () => {


### PR DESCRIPTION
## Summary
- reset file input after processing selected avatar to allow re-selecting same file

## Testing
- `npm test` *(fails: _cacheService.clearCache.mockReset is not a function, Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js')*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e15b8488328af2477cb18c4b329