### PR TITLE
Reset avatar crop state on selection

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -192,8 +192,14 @@ useEffect(() => {
       toast.error(t('avatar_max_size'));
       return;
     }
+    if (tempAvatar) {
+      URL.revokeObjectURL(tempAvatar);
+    }
     setTempFileName(file.name);
     setTempAvatar(URL.createObjectURL(file));
+    setCroppedAreaPixels(null);
+    setCrop({ x: 0, y: 0 });
+    setZoom(1);
     setShowCropper(true);
   };
 


### PR DESCRIPTION
## Summary
- revoke previous avatar preview URL when selecting a new avatar
- reset crop, zoom, and crop area when a new avatar is selected

## Testing
- `npm test` (fails: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService')
- `npm run lint` (fails: 56 errors, 273 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c52e1478e08328bcf75e709e52454c