### PR TITLE
chore: remove old admin avatar file

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -240,10 +240,26 @@ exports.updateAvatar = async (req, res) => {
       return res.status(400).json({ message: "No image uploaded" });
     }
 
+    const userId = req.params.id;
+
+    // Fetch existing avatar to remove old file if present
+    const [user] = await db("users")
+      .where({ id: userId })
+      .select("avatar_url");
+
+    if (user && user.avatar_url) {
+      const oldPath = path.join(__dirname, "../../../../", user.avatar_url);
+      try {
+        if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
+      } catch (err) {
+        logger.error(err);
+      }
+    }
+
     const filePath = `/uploads/admin/avatars/${req.file.filename}`;
 
     await db("users")
-      .where({ id: req.params.id })
+      .where({ id: userId })
       .update({ avatar_url: filePath, updated_at: new Date() });
 
     res.json({ message: "Avatar updated", avatar_url: filePath });


### PR DESCRIPTION
## Summary
- remove existing admin avatar file before saving new upload

## Testing
- `pre-commit run --files backend/src/modules/users/admin/admin.controller.js` *(fails: Interrupted - KeyboardInterrupt)*
- `npm test --prefix backend` *(fails: 23 failed, 2 skipped, 116 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e13bbf88328a60edddf5baad7db