### PR TITLE
Include avatar URL in admin profile updates

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -88,16 +88,19 @@ exports.updateProfile = async (req, res) => {
   const trx = await db.transaction();
   try {
     // 1. Update core user fields
-    await trx("users").where({ id: userId }).update({
+    const userUpdate = {
       email,
       full_name,
       phone,
       gender,
       date_of_birth,
-      avatar_url,
       profile_complete: true,
       updated_at: new Date(),
-    });
+    };
+    if (avatar_url !== undefined) {
+      userUpdate.avatar_url = avatar_url;
+    }
+    await trx("users").where({ id: userId }).update(userUpdate);
 
     // 2. Upsert admin profile
     const profileData = {

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -215,6 +215,7 @@ useEffect(() => {
       setUser({ ...current, avatar_url: res.avatar_url });
       setFormData((prev) => ({
         ...prev,
+        avatar_url: res.avatar_url,
         avatarPreview: `${process.env.NEXT_PUBLIC_API_BASE_URL}${res.avatar_url}?v=${Date.now()}`,
       }));
       setShowCropper(false);
@@ -272,6 +273,7 @@ useEffect(() => {
         phone: formData.phone,
         gender: formData.gender,
         date_of_birth: formData.date_of_birth,
+        avatar_url: formData.avatar_url,
         job_title: formData.job_title,
         department: formData.department,
         social_links,


### PR DESCRIPTION
## Summary
- store avatar URL in admin profile form after cropping upload
- send avatar URL when saving admin profile
- avoid overwriting avatar URL on backend when none provided

## Testing
- `npm test` (backend) *(fails: Test Suites: 22 failed, 2 skipped, 117 passed)*
- `npm test` (frontend) *(fails: CacheManager tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e1f8e5083289cd7eed2bbb5d2ae