### PR TITLE
Persist avatar URL after admin profile updates

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -215,6 +215,7 @@ useEffect(() => {
       setUser({ ...current, avatar_url: res.avatar_url });
       setFormData((prev) => ({
         ...prev,
+        avatar_url: res.avatar_url,
         avatarPreview: `${process.env.NEXT_PUBLIC_API_BASE_URL}${res.avatar_url}?v=${Date.now()}`,
       }));
       setShowCropper(false);
@@ -274,6 +275,7 @@ useEffect(() => {
         date_of_birth: formData.date_of_birth,
         job_title: formData.job_title,
         department: formData.department,
+        avatar_url: formData.avatar_url,
         social_links,
       });
 
@@ -291,6 +293,7 @@ useEffect(() => {
 
       setFormData((prev) => ({
         ...prev,
+        avatar_url: fresh.avatar_url,
         email: fresh.email || "",
         job_title: fresh.job_title || "",
         department: fresh.department || "",


### PR DESCRIPTION
## Summary
- store uploaded avatar URL in form state
- include avatar_url in admin profile update payload
- refresh formData avatar fields from server after submission

## Testing
- `pre-commit run --files frontend/src/pages/dashboard/admin/profile/edit.js` *(fails: 329 problems (56 errors, 273 warnings))*
- `npm test --prefix frontend` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e1cb91883289829c36867748a7c