### PR TITLE
feat: allow admins to delete avatars

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -256,6 +256,40 @@ exports.updateAvatar = async (req, res) => {
   }
 };
 
+// Remove avatar and clear avatar_url
+exports.deleteAvatar = async (req, res) => {
+  try {
+    if (String(req.params.id) !== String(req.user.id)) {
+      return res.status(403).json({ message: "Forbidden" });
+    }
+
+    const user = await db("users").where({ id: req.params.id }).first("avatar_url");
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    if (user.avatar_url) {
+      const filePath = path.join(
+        __dirname,
+        "../../../../",
+        user.avatar_url.replace(/^\//, "")
+      );
+      fs.unlink(filePath, (err) => {
+        if (err) logger.error(err);
+      });
+    }
+
+    await db("users")
+      .where({ id: req.params.id })
+      .update({ avatar_url: null, updated_at: new Date() });
+
+    res.json({ message: "Avatar removed" });
+  } catch (error) {
+    logger.error(error);
+    res.status(500).json({ message: "Failed to remove avatar" });
+  }
+};
+
 /**
  * @desc Upload identity document (image/pdf)
  * @route POST /api/users/admin/profile/identity

--- a/backend/src/modules/users/admin/admin.routes.js
+++ b/backend/src/modules/users/admin/admin.routes.js
@@ -51,6 +51,9 @@ router.patch(
   controller.updateAvatar
 );
 
+// 🗑 Remove avatar
+router.delete("/:id/avatar", controller.deleteAvatar);
+
 
 
 // ─────────────────────────────────────────────

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -27,6 +27,7 @@ import {
   getAdminProfile,
   updateAdminProfile,
   uploadAdminAvatar,
+  deleteAdminAvatar,
 } from "@/services/admin/adminService";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
@@ -239,6 +240,28 @@ useEffect(() => {
     setCrop({ x: 0, y: 0 });
   };
 
+  const handleAvatarRemove = async () => {
+    if (!user?.id) {
+      toast.error(t("user_not_loaded"));
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await deleteAdminAvatar(user.id);
+      const { setUser } = useAuthStore.getState();
+      const current = useAuthStore.getState().user;
+      setUser({ ...current, avatar_url: null });
+      setFormData((prev) => ({ ...prev, avatarPreview: null, avatar_url: null }));
+      toast.success(t("avatar_remove_success"));
+    } catch (error) {
+      console.error("Avatar delete error:", error.response);
+      const msg = error.response?.data?.message || t("avatar_remove_failed");
+      toast.error(msg);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
 
   const validateForm = () => {
     try {
@@ -344,9 +367,7 @@ useEffect(() => {
                     className="w-32 h-32 rounded-full object-cover border-2 border-yellow-200"
                   />
                   <button
-                    onClick={() =>
-                      setFormData((prev) => ({ ...prev, avatarPreview: null }))
-                    }
+                    onClick={handleAvatarRemove}
                     className="absolute -top-2 -right-2 p-1 bg-red-600 text-white rounded-full hover:bg-red-700 transition-colors"
                   >
                     <FaTrash size={14} />

--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -49,12 +49,21 @@ export const uploadAdminAvatar = async (adminId, avatarFile) => {
   });
   return res.data;
 };
-
-
+/**
+ * 🗑 Remove admin avatar image.
+ *
+ * @param {string} adminId - Admin UUID
+ * @returns {Promise<Object>} Result message
+ */
+export const deleteAdminAvatar = async (adminId) => {
+  await ensureCsrfToken();
+  const res = await api.delete(`/users/admin/${adminId}/avatar`);
+  return res.data;
+};
 
 /**
  * 🪪 Upload admin identity file (e.g., ID card).
- * 
+ *
  * @param {File} identityFile - ID image file
  * @returns {Promise<Object>} Upload result
  */


### PR DESCRIPTION
## Summary
- allow admins to delete their avatar via new frontend handler and service
- add DELETE `/users/admin/:id/avatar` backend route and controller to remove file and clear db

## Testing
- `npm test` (backend) *(fails: Test Suites: 22 failed, 2 skipped, 117 passed, 139 of 141 total)*
- `npm test` (frontend) *(command terminated; logs show many test outputs without summary)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e231b9883288dad188518ca91e2