### PR TITLE
Refactor admin profile update transaction

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -131,8 +131,19 @@ exports.updateProfile = async (req, res) => {
         });
       }
     }
+
+    // 4. Fetch related profile details within the transaction
+    const [adminProfile] = await trx("admin_profiles")
+      .where({ user_id: userId })
+      .select("job_title", "department", "identity_doc_url", "created_at", "updated_at");
+
+    const socialLinks = await trx("user_social_links")
+      .where({ user_id: userId })
+      .select("platform", "url");
+
     await trx.commit();
-    // 4. Return the freshly updated profile details
+
+    // Post-commit: fetch core user details using standard connection
     const [user] = await db("users")
       .where({ id: userId })
       .select(
@@ -149,16 +160,6 @@ exports.updateProfile = async (req, res) => {
         "created_at",
         "updated_at"
       );
-
-    const [adminProfile] = await trx("admin_profiles")
-      .where({ user_id: userId })
-      .select("job_title", "department", "identity_doc_url", "created_at", "updated_at");
-
-    const socialLinks = await trx("user_social_links")
-      .where({ user_id: userId })
-      .select("platform", "url");
-
-    await trx.commit();
 
     return res.json({
       ...user,


### PR DESCRIPTION
## Summary
- remove premature transaction commit when updating admin profiles
- fetch admin profile and social links within the transaction and commit once
- retrieve user details after commit using standard DB connection

## Testing
- `npm test` *(fails: Test Suites: 21 failed, 2 skipped, 118 passed, 139 of 141 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e122fcc83288756c12ad55e9fc9