### PR TITLE
Remove manual auth rehydration

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -73,24 +73,11 @@ function MyApp({ Component, pageProps, router }) {
   );
   const currentLang = langs?.find((l) => l.code === i18n.language);
   const user = useAuthStore((s) => s.user);
+  const hasHydrated = useAuthStore((s) => s.hasHydrated);
   const [gaId, setGaId] = useState(null);
 
   useEffect(() => {
-    const local = localStorage.getItem("auth");
-    if (local) {
-      const parsed = JSON.parse(local)?.state;
-      if (parsed?.user) {
-        useAuthStore.setState({
-          user: parsed.user,
-          accessToken: parsed.accessToken,
-          hasHydrated: true, // ✅ manually set hydration flag
-        });
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    if (router.pathname.startsWith('/auth')) return;
+    if (!hasHydrated || router.pathname.startsWith('/auth')) return;
 
     const init = async () => {
       try {
@@ -103,7 +90,7 @@ function MyApp({ Component, pageProps, router }) {
       }
     };
     init();
-  }, [router.pathname]);
+  }, [router.pathname, hasHydrated]);
 
   useEffect(() => {
     if (!configLoaded) fetchConfig();

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -80,21 +80,6 @@ function ProfileEditTemplate() {
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const fetchMessages = useMessageStore((state) => state.fetch);
 
-useEffect(() => {
-  const local = localStorage.getItem("auth");
-  let parsed;
-  if (local) {
-    try {
-      parsed = JSON.parse(local)?.state;
-    } catch (error) {
-      console.error("Failed to parse auth from localStorage", error);
-    }
-  }
-  if (hasHydrated && !user && parsed?.user) {
-    setUser(parsed.user);
-  }
-}, [hasHydrated]);
-
   useEffect(() => {
     if (!hasHydrated) return;
     if (!user) {

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -81,23 +81,9 @@ export default function StudentProfileEdit() {
   const [tempAvatar, setTempAvatar] = useState(null);
   const [tempFileName, setTempFileName] = useState("");
 
-
   useEffect(() => {
-    const local = localStorage.getItem("auth");
-    let parsed;
-    if (local) {
-      try {
-        parsed = JSON.parse(local)?.state;
-      } catch (error) {
-        console.error("Failed to parse auth from localStorage", error);
-      }
-    }
-    if (hasHydrated && !user && parsed?.user) {
-      setUser(parsed.user);
-    }
-  }, [hasHydrated]);
+    if (!hasHydrated) return;
 
-  useEffect(() => {
     if (!user) {
       // No logged in user – stop loading to avoid endless spinner
       setIsLoading(false);
@@ -145,7 +131,7 @@ export default function StudentProfileEdit() {
     };
 
     loadProfile();
-  }, [user, router]);
+  }, [user, hasHydrated, router]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- Rely on Zustand's persisted auth rehydration by waiting for `hasHydrated`
- Remove manual `localStorage` parsing for auth in profile edit pages

## Testing
- `npm test`
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e0f1cb88328b3af2e0bde94663b