### PR TITLE
refactor: separate avatar upload state

### DIFF
--- a/frontend/src/components/instructor/profile/AvatarUploader.js
+++ b/frontend/src/components/instructor/profile/AvatarUploader.js
@@ -1,6 +1,12 @@
 import { FaUserCircle, FaTrash, FaUpload, FaSpinner } from "react-icons/fa";
 
-export default function AvatarUploader({ avatarPreview, isSubmitting, t, onSelect, onRemove }) {
+export default function AvatarUploader({
+  avatarPreview,
+  isUploadingAvatar,
+  t,
+  onSelect,
+  onRemove,
+}) {
   return (
     <div className="bg-white p-6 rounded-lg shadow-md">
       <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
@@ -29,7 +35,7 @@ export default function AvatarUploader({ avatarPreview, isSubmitting, t, onSelec
         <label className="cursor-pointer">
           <input type="file" accept="image/*" onChange={onSelect} className="hidden" />
           <div className="px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700 transition-colors flex items-center gap-2">
-            {isSubmitting ? <FaSpinner className="animate-spin" /> : <FaUpload />}
+            {isUploadingAvatar ? <FaSpinner className="animate-spin" /> : <FaUpload />}
             {avatarPreview ? t('change_photo') : t('upload_photo')}
           </div>
         </label>

--- a/frontend/src/components/instructor/profile/DemoVideoUploader.js
+++ b/frontend/src/components/instructor/profile/DemoVideoUploader.js
@@ -1,6 +1,12 @@
 import { FaVideo, FaTrash, FaUpload, FaSpinner } from "react-icons/fa";
 
-export default function DemoVideoUploader({ demoPreview, isSubmitting, t, onSelect, onRemove }) {
+export default function DemoVideoUploader({
+  demoPreview,
+  isUploadingDemo,
+  t,
+  onSelect,
+  onRemove,
+}) {
   return (
     <div className="bg-white p-6 rounded-lg shadow-md">
       <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
@@ -26,7 +32,7 @@ export default function DemoVideoUploader({ demoPreview, isSubmitting, t, onSele
         <label className="cursor-pointer">
           <input type="file" accept="video/*" onChange={onSelect} className="hidden" />
           <div className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors flex items-center gap-2">
-            {isSubmitting ? <FaSpinner className="animate-spin" /> : <FaUpload />}
+            {isUploadingDemo ? <FaSpinner className="animate-spin" /> : <FaUpload />}
             {demoPreview ? t('change_video') : t('upload_video')}
           </div>
         </label>

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -70,6 +70,7 @@ function ProfileEditTemplate() {
   });
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
   const [expanded, setExpanded] = useState({ personal: true, social: true });
   const [showCropper, setShowCropper] = useState(false);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
@@ -203,7 +204,7 @@ useEffect(() => {
       toast.error(t("user_not_loaded"));
       return;
     }
-    setIsSubmitting(true);
+    setIsUploadingAvatar(true);
     try {
       const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
       const file = new File([blob], tempFileName || "avatar.jpg", {
@@ -225,7 +226,7 @@ useEffect(() => {
       const msg = error.response?.data?.message || t('avatar_upload_failed');
       toast.error(msg);
     } finally {
-      setIsSubmitting(false);
+      setIsUploadingAvatar(false);
     }
   };
 
@@ -372,7 +373,7 @@ useEffect(() => {
                   disabled={!user?.id}
                 />
                 <div className="px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700 transition-colors flex items-center gap-2">
-                  {isSubmitting ? (
+                  {isUploadingAvatar ? (
                     <FaSpinner className="animate-spin" />
                   ) : (
                     <FaUpload />
@@ -567,7 +568,7 @@ useEffect(() => {
                 onClick={handleCropUpload}
                 className="px-4 py-2 bg-yellow-600 text-white rounded flex items-center gap-2"
               >
-                {isSubmitting ? <FaSpinner className="animate-spin" /> : <FaCheck />}
+                {isUploadingAvatar ? <FaSpinner className="animate-spin" /> : <FaCheck />}
                 {t('upload')}
               </button>
             </div>

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -94,6 +94,8 @@ export default function InstructorProfileEdit() {
   });
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
+  const [isUploadingDemo, setIsUploadingDemo] = useState(false);
 
   const [showCropper, setShowCropper] = useState(false);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
@@ -225,7 +227,7 @@ export default function InstructorProfileEdit() {
     const file = e.target.files[0];
     if (!file) return;
     if (file.size > 3 * 1024 * 1024) return toast.error(t('demo_max_size'));
-    setIsSubmitting(true);
+    setIsUploadingDemo(true);
     try {
       const res = await uploadInstructorDemo(user.id, file);
       setFormData(prev => ({
@@ -235,7 +237,7 @@ export default function InstructorProfileEdit() {
     } catch (error) {
       toast.error(t('demo_upload_failed'));
     } finally {
-      setIsSubmitting(false);
+      setIsUploadingDemo(false);
     }
   };
 
@@ -254,7 +256,7 @@ export default function InstructorProfileEdit() {
 
   const handleCropUpload = async () => {
     if (!tempAvatar || !croppedAreaPixels) return;
-    setIsSubmitting(true);
+    setIsUploadingAvatar(true);
     try {
       const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
       const file = new File([blob], tempFileName || "avatar.jpg", { type: blob.type });
@@ -274,7 +276,7 @@ export default function InstructorProfileEdit() {
       const msg = error.response?.data?.message || t('avatar_upload_failed');
       toast.error(msg);
     } finally {
-      setIsSubmitting(false);
+      setIsUploadingAvatar(false);
     }
   };
 
@@ -383,14 +385,14 @@ export default function InstructorProfileEdit() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-10">
           <AvatarUploader
             avatarPreview={formData.avatarPreview}
-            isSubmitting={isSubmitting}
+            isUploadingAvatar={isUploadingAvatar}
             t={t}
             onSelect={handleAvatarSelect}
             onRemove={() => setFormData((prev) => ({ ...prev, avatarPreview: null }))}
           />
           <DemoVideoUploader
             demoPreview={formData.demoPreview}
-            isSubmitting={isSubmitting}
+            isUploadingDemo={isUploadingDemo}
             t={t}
             onSelect={handleDemoSelect}
             onRemove={() => setFormData((prev) => ({ ...prev, demoPreview: null }))}
@@ -815,7 +817,7 @@ export default function InstructorProfileEdit() {
                 onClick={handleCropUpload}
                 className="px-4 py-2 bg-yellow-600 text-white rounded flex items-center gap-2"
               >
-                {isSubmitting ? <FaSpinner className="animate-spin" /> : <FaCheck />}
+                {isUploadingAvatar ? <FaSpinner className="animate-spin" /> : <FaCheck />}
                 {t('upload')}
               </button>
             </div>

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -52,6 +52,8 @@ export default function StudentProfileEdit() {
   const refreshMessages = useMessageStore((s) => s.fetch);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
+  const [, setIsUploadingIdentity] = useState(false);
   const [expanded, setExpanded] = useState({
     avatar: true,
     identity: true,
@@ -189,7 +191,7 @@ export default function StudentProfileEdit() {
 
   const handleCropUpload = async () => {
     if (!tempAvatar || !croppedAreaPixels) return;
-    setIsSubmitting(true);
+    setIsUploadingAvatar(true);
     try {
       const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
       const file = new File([blob], tempFileName || "avatar.jpg", { type: blob.type });
@@ -210,7 +212,7 @@ export default function StudentProfileEdit() {
       const msg = error.response?.data?.message || t('avatar_upload_failed');
       toast.error(msg);
     } finally {
-      setIsSubmitting(false);
+      setIsUploadingAvatar(false);
     }
   };
 
@@ -235,7 +237,7 @@ export default function StudentProfileEdit() {
       return;
     }
     try {
-      setIsSubmitting(true);
+      setIsUploadingIdentity(true);
       await uploadStudentIdentity(user.id, file);
       setFormData(prev => ({
         ...prev,
@@ -246,7 +248,7 @@ export default function StudentProfileEdit() {
     } catch (err) {
       toast.error(t('id_upload_failed'));
     } finally {
-      setIsSubmitting(false);
+      setIsUploadingIdentity(false);
     }
   };
 
@@ -741,7 +743,7 @@ export default function StudentProfileEdit() {
                 onClick={handleCropUpload}
                 className="px-4 py-2 bg-yellow-600 text-white rounded flex items-center gap-2"
               >
-                {isSubmitting ? <FaSpinner className="animate-spin" /> : <FaCheck />}
+                {isUploadingAvatar ? <FaSpinner className="animate-spin" /> : <FaCheck />}
                 Upload
               </button>
             </div>


### PR DESCRIPTION
## Summary
- add `isUploadingAvatar` state to instructor, student, and admin profile editors
- reserve `isSubmitting` for form submission only
- update avatar and demo video upload components to use dedicated flags

## Testing
- `npx jest src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: Cannot find module '../../services/instructor/subscriptionService')*
- `npx jest src/tests/__tests__/CacheManager.test.tsx` *(fails: TypeError: _cacheService.clearCache.mockReset is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e0dd4a0832881b096642b5796f0