### PR TITLE
Clean up old avatars after update

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -240,11 +240,20 @@ exports.updateAvatar = async (req, res) => {
       return res.status(400).json({ message: "No image uploaded" });
     }
 
+    const { avatar_url: oldAvatar } = await db("users")
+      .where({ id: req.params.id })
+      .first("avatar_url");
+
     const filePath = `/uploads/admin/avatars/${req.file.filename}`;
 
     await db("users")
       .where({ id: req.params.id })
       .update({ avatar_url: filePath, updated_at: new Date() });
+
+    if (oldAvatar) {
+      const oldPath = path.join(__dirname, "../../../../", oldAvatar);
+      fs.unlink(oldPath, (err) => err && logger.error("Failed to remove old avatar:", err));
+    }
 
     res.json({ message: "Avatar updated", avatar_url: filePath });
   } catch (error) {

--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -222,9 +222,18 @@ exports.updateAvatar = async (req, res) => {
             return res.status(403).json({ error: "Unauthorized" });
         }
 
+        const { avatar_url: oldAvatar } = await db("users")
+            .where({ id: req.user.id })
+            .first("avatar_url");
+
         const avatarUrl = `/uploads/avatars/instructor/${req.file.filename}`;
 
         await db("users").where({ id: req.user.id }).update({ avatar_url: avatarUrl });
+
+        if (oldAvatar) {
+            const oldPath = path.join(__dirname, "../../../../", oldAvatar);
+            fs.unlink(oldPath, (error) => error && logger.error("Failed to remove old avatar:", error));
+        }
 
         res.json({ avatar_url: avatarUrl });
     } catch (err) {

--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -1,5 +1,6 @@
 const logger = require('../../../utils/logger.js');
 const fs = require("fs");
+const path = require("path");
 /**
  * Student controller
  */
@@ -177,10 +178,21 @@ exports.updateAvatar = async (req, res) => {
     if (!req.file) {
       return res.status(400).json({ message: "No avatar uploaded" });
     }
+
+    const { avatar_url: oldAvatar } = await db("users")
+      .where({ id: req.user.id })
+      .first("avatar_url");
+
     const avatarUrl = `/uploads/avatars/student/${req.file.filename}`;
     await db("users")
       .where({ id: req.user.id })
       .update({ avatar_url: avatarUrl });
+
+    if (oldAvatar) {
+      const oldPath = path.join(__dirname, "../../../../", oldAvatar);
+      fs.unlink(oldPath, (err) => err && logger.error("Failed to remove old avatar:", err));
+    }
+
     res.json({ avatar_url: avatarUrl });
   } catch (error) {
     if (req.file) {

--- a/backend/tests/adminAvatarController.test.js
+++ b/backend/tests/adminAvatarController.test.js
@@ -1,14 +1,22 @@
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  unlink: jest.fn((path, cb) => cb && cb(null)),
+}));
+
 jest.mock('../src/config/database', () => {
   const update = jest.fn();
-  const where = jest.fn(() => ({ update }));
+  const first = jest.fn().mockResolvedValue({ avatar_url: '/uploads/admin/avatars/old.png' });
+  const where = jest.fn(() => ({ first, update }));
   const db = jest.fn(() => ({ where }));
   db.update = update;
   db.where = where;
+  db.first = first;
   return db;
 });
 
 const controller = require('../src/modules/users/admin/admin.controller');
 const mockDb = require('../src/config/database');
+const fs = require('fs');
 
 describe('admin controller updateAvatar', () => {
   beforeEach(() => {
@@ -31,10 +39,13 @@ describe('admin controller updateAvatar', () => {
     expect(res.status).not.toHaveBeenCalled();
     expect(mockDb).toHaveBeenCalledWith('users');
     expect(mockDb.where).toHaveBeenCalledWith({ id: '1' });
+    expect(mockDb.where).toHaveBeenCalledTimes(2);
+    expect(mockDb.first).toHaveBeenCalledWith('avatar_url');
     expect(mockDb.update).toHaveBeenCalledWith({
       avatar_url: '/uploads/admin/avatars/avatar.png',
       updated_at: expect.any(Date),
     });
+    expect(fs.unlink.mock.calls[0][0]).toContain('/uploads/admin/avatars/old.png');
     expect(res.json).toHaveBeenCalledWith({
       message: 'Avatar updated',
       avatar_url: '/uploads/admin/avatars/avatar.png',


### PR DESCRIPTION
## Summary
- retrieve current avatar before updating
- remove previous avatar file after saving new one
- log avatar cleanup failures without failing requests

## Testing
- `npm test` *(fails: Route.post requires a callback function but got a [object Undefined])*
- `npx jest tests/adminAvatarController.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c52e0b05108328b9eec8f042c26df3