### PR TITLE
Use setUser hook for auth updates and track avatar URLs

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -26,6 +26,7 @@ import { buildUrl } from "@/utils/url";
 export default function Header() {
   const user = useAuthStore((state) => state.user);
   const logout = useAuthStore((state) => state.logout);
+  const setUser = useAuthStore((state) => state.setUser);
   const userRole = user?.role?.toLowerCase();
   const { t } = useTranslation("common");
   const { t: tDashboard } = useTranslation("dashboard");
@@ -187,7 +188,6 @@ export default function Header() {
                 const res = await toggleInstructorStatus(newStatus);
                 const updated = res?.is_online ?? newStatus;
                 setAvailable(updated);
-                const setUser = useAuthStore.getState().setUser;
                 setUser({ ...user, is_online: updated });
                 toast.success(
                   updated

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -210,11 +210,10 @@ useEffect(() => {
         type: blob.type,
       });
       const res = await uploadAdminAvatar(user.id, file);
-      const { setUser } = useAuthStore.getState();
-      const current = useAuthStore.getState().user;
-      setUser({ ...current, avatar_url: res.avatar_url });
+      setUser({ ...user, avatar_url: res.avatar_url });
       setFormData((prev) => ({
         ...prev,
+        avatar_url: res.avatar_url,
         avatarPreview: `${process.env.NEXT_PUBLIC_API_BASE_URL}${res.avatar_url}?v=${Date.now()}`,
       }));
       setShowCropper(false);

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -74,7 +74,7 @@ export const instructorProfileSchema = z.object({
 export default function InstructorProfileEdit() {
   const router = useRouter();
   const { t } = useTranslation('dashboard', { keyPrefix: 'instructorProfilePage' });
-  const { user, hasHydrated } = useAuthStore();
+  const { user, hasHydrated, setUser } = useAuthStore();
   const fetchNotifications = useNotificationStore((state) => state.fetch);
 
   const [formData, setFormData] = useState({
@@ -89,6 +89,7 @@ export default function InstructorProfileEdit() {
     bio: "",
     socialLinks: {},
     certificates: [],
+    avatar_url: null,
     avatarPreview: null,
     demoPreview: null,
   });
@@ -181,6 +182,7 @@ export default function InstructorProfileEdit() {
           bio: instructor?.bio || "",
           socialLinks: socialMap,
           certificates: certificates || [],
+          avatar_url,
           avatarPreview: avatar_url
             ? `${BASE_URL}${avatar_url}`
             : null,
@@ -259,11 +261,10 @@ export default function InstructorProfileEdit() {
       const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
       const file = new File([blob], tempFileName || "avatar.jpg", { type: blob.type });
       const res = await uploadInstructorAvatar(user.id, file);
-      const { setUser } = useAuthStore.getState();
-      const current = useAuthStore.getState().user;
-      setUser({ ...current, avatar_url: res.avatar_url });
+      setUser({ ...user, avatar_url: res.avatar_url });
       setFormData((prev) => ({
         ...prev,
+        avatar_url: res.avatar_url,
         avatarPreview: `${BASE_URL}${res.avatar_url}?v=${Date.now()}`,
       }));
       setShowCropper(false);
@@ -305,8 +306,7 @@ export default function InstructorProfileEdit() {
       const fresh = await getInstructorProfile();
 
       // Update the auth store with the returned user data
-      const update = useAuthStore.getState().setUser;
-      update({
+      setUser({
         ...user,
         full_name: fresh.full_name,
         phone: fresh.phone,
@@ -507,7 +507,6 @@ export default function InstructorProfileEdit() {
                     const res = await toggleInstructorStatus(newStatus);
                     const updated = res?.is_online ?? newStatus;
                     setAvailable(updated);
-                    const setUser = useAuthStore.getState().setUser;
                     setUser({ ...user, is_online: updated });
                   } catch (err) {
                     toast.error(t('availability_update_failed'));

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -195,7 +195,7 @@ export default function StudentProfileEdit() {
       const file = new File([blob], tempFileName || "avatar.jpg", { type: blob.type });
       const res = await uploadStudentAvatar(user.id, file);
       const avatar_url = res.avatar_url;
-      useAuthStore.getState().setUser({ ...user, avatar_url });
+      setUser({ ...user, avatar_url });
       setFormData(prev => ({
         ...prev,
         avatar_url,


### PR DESCRIPTION
## Summary
- replace remaining `useAuthStore.getState().setUser` calls with `setUser` from `useAuthStore`
- persist uploaded avatar URLs in form data alongside previews

## Testing
- `npm test src/tests/__tests__/CardPaymentForm.test.js`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e0ffcb88328a3039ed08edd57ee