### PR TITLE
Prevent hydration mismatch on admin profile edit page

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -174,6 +174,12 @@ function ProfileEditTemplate() {
     setCroppedAreaPixels(area);
   }, []);
 
+  const isClientReady =
+    typeof window !== "undefined" && hasHydrated && i18n.isInitialized;
+  if (!isClientReady) {
+    return null;
+  }
+
   const handleAvatarSelect = (e) => {
     const file = e.target.files[0];
     if (!file) {


### PR DESCRIPTION
## Summary
- avoid hydration errors by rendering profile edit page only when store and translations are ready

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' ...)*
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c57ebd913483289a3cb470132c0aac