### PR TITLE
Fix admin avatar crop upload blob reference

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -205,6 +205,7 @@ function ProfileEditTemplate() {
     }
     setIsUploadingAvatar(true);
     try {
+      const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
       const file = new File([blob], tempFileName || "avatar.jpg", {
         type: blob.type,
       });


### PR DESCRIPTION
## Summary
- ensure cropped avatar blob is generated before creating upload File to avoid reference errors

## Testing
- `npm test src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: _cacheService.clearCache.mockReset is not a function; module not found)*
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c57ebc1adc8328b28e94c910cfcefc