### PR TITLE
Fix duplicate avatar_url in admin profile update payload

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -295,7 +295,6 @@ function ProfileEditTemplate() {
         avatar_url: formData.avatar_url,
         job_title: formData.job_title,
         department: formData.department,
-        avatar_url: formData.avatar_url,
         social_links,
       });
 


### PR DESCRIPTION
## Summary
- remove redundant `avatar_url` field from admin profile update payload

## Testing
- `pre-commit run --files frontend/src/pages/dashboard/admin/profile/edit.js` *(fails: 327 problems)*
- `npm test src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c57ebb4a84832896b90101d6b16560