### PR TITLE
fix: gate admin profile edit behind client hydration

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
+import dynamic from "next/dynamic";
 import {
   FaSpinner,
   FaChevronDown,
@@ -210,10 +211,11 @@ function ProfileEditTemplate() {
       });
       const res = await uploadAdminAvatar(user.id, file);
       setUser({ ...user, avatar_url: res.avatar_url });
+      const cacheBust = Date.now();
       setFormData((prev) => ({
         ...prev,
         avatar_url: res.avatar_url,
-        avatarPreview: `${process.env.NEXT_PUBLIC_API_BASE_URL}${res.avatar_url}?v=${Date.now()}`,
+        avatarPreview: `${process.env.NEXT_PUBLIC_API_BASE_URL}${res.avatar_url}?v=${cacheBust}`,
       }));
       setShowCropper(false);
       URL.revokeObjectURL(tempAvatar);
@@ -610,7 +612,14 @@ const ProtectedProfileEdit = withAuthProtection(ProfileEditTemplate, [
 
 ProtectedProfileEdit.getLayout = ProfileEditTemplate.getLayout;
 
-export default ProtectedProfileEdit;
+const ProtectedProfileEditPage = dynamic(
+  () => Promise.resolve(ProtectedProfileEdit),
+  { ssr: false }
+);
+
+ProtectedProfileEditPage.getLayout = ProfileEditTemplate.getLayout;
+
+export default ProtectedProfileEditPage;
 
 export async function getStaticProps({ locale }) {
   return {


### PR DESCRIPTION
## Summary
- dynamically load admin profile edit page on client to avoid hydration mismatch
- defer avatar preview cache busting until after hydration

## Testing
- `npm test` (fails: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService')
- `npm run lint` (fails: Component definition is missing display name)


------
https://chatgpt.com/codex/tasks/task_e_68c57eb50c44832887b37e4a3b6ab32b