### PR TITLE
feat: dynamically import cropper on admin profile

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -29,7 +29,8 @@ import {
   uploadAdminAvatar,
   deleteAdminAvatar,
 } from "@/services/admin/adminService";
-import Cropper from "react-easy-crop";
+import dynamic from "next/dynamic";
+const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 import { toSocialLinksArray } from "@/utils/socialLinks";
 import { allowedPlatforms } from "@/utils/socialPlatforms";


### PR DESCRIPTION
## Summary
- dynamically import `react-easy-crop` in admin profile editor to avoid SSR issues

## Testing
- `npm test` *(fails: _cacheManager.test.tsx_, _InstructorSettingsPage.test.js_)*
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c57eadc71c8328b9023959e52c9e50