### PR TITLE
Fix avatar cropping before upload

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -205,6 +205,7 @@ function ProfileEditTemplate() {
     }
     setIsUploadingAvatar(true);
     try {
+      const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
       const file = new File([blob], tempFileName || "avatar.jpg", {
         type: blob.type,
       });


### PR DESCRIPTION
## Summary
- obtain cropped image blob before constructing upload file in admin profile edit page

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c57eac13bc8328bbcf62f4f3c69607