### PR TITLE
fix: remove duplicate dynamic import

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -30,7 +30,6 @@ import {
   uploadAdminAvatar,
   deleteAdminAvatar,
 } from "@/services/admin/adminService";
-import dynamic from "next/dynamic";
 const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 import { toSocialLinksArray } from "@/utils/socialLinks";


### PR DESCRIPTION
## Summary
- remove redundant `next/dynamic` import from admin profile editor

## Testing
- `npm test`
- `npm run lint` *(fails: 56 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c585ac9fec83288aca8bac88d7f75b