### PR TITLE
fix: streamline admin profile edit dynamic imports

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -30,7 +30,6 @@ import {
   uploadAdminAvatar,
   deleteAdminAvatar,
 } from "@/services/admin/adminService";
-import dynamic from "next/dynamic";
 const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 import { toSocialLinksArray } from "@/utils/socialLinks";
@@ -619,14 +618,7 @@ const ProtectedProfileEdit = withAuthProtection(ProfileEditTemplate, [
 
 ProtectedProfileEdit.getLayout = ProfileEditTemplate.getLayout;
 
-const ProtectedProfileEditPage = dynamic(
-  () => Promise.resolve(ProtectedProfileEdit),
-  { ssr: false }
-);
-
-ProtectedProfileEditPage.getLayout = ProfileEditTemplate.getLayout;
-
-export default ProtectedProfileEditPage;
+export default ProtectedProfileEdit;
 
 export async function getStaticProps({ locale }) {
   return {


### PR DESCRIPTION
## Summary
- remove redundant dynamic wrapper around admin profile edit page
- rely on withAuthProtection for client-side gating

## Testing
- `npm test`
- `npm run lint` *(fails: 56 errors, 271 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c585ac9fec83288aca8bac88d7f75b