### PR TITLE
Trim whitespace from admin profile text inputs

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -165,10 +165,20 @@ function ProfileEditTemplate() {
   }, [hasHydrated, user]);
 
 
+  const trimValue = (val) => (typeof val === "string" ? val.trim() : val);
+
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+    setFormData((prev) => ({ ...prev, [name]: trimValue(value) }));
     if (errors[name]) setErrors((prev) => ({ ...prev, [name]: null }));
+  };
+
+  const handleSocialLinkChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      socialLinks: { ...prev.socialLinks, [name]: trimValue(value) },
+    }));
   };
 
   const onCropComplete = useCallback((_, area) => {
@@ -532,12 +542,7 @@ function ProfileEditTemplate() {
                       type="text"
                       name={name}
                       value={formData.socialLinks[name] || ""}
-                      onChange={(e) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          socialLinks: { ...prev.socialLinks, [name]: e.target.value.trim() },
-                        }))
-                      }
+                      onChange={handleSocialLinkChange}
                       placeholder={
                         name === 'website'
                           ? 'https://yourwebsite.com'


### PR DESCRIPTION
## Summary
- Trim and sanitize admin profile form inputs using a reusable helper
- Add dedicated handler for social link fields to reuse trimming logic

## Testing
- `npm test` *(fails: _cacheService.clearCache.mockReset is not a function, Cannot find module '../../services/instructor/subscriptionService'_)*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a33456ec83289968008c3323736a