### PR TITLE
Validate avatar file type before upload

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -580,6 +580,7 @@
     "upload": "رفع",
     "load_profile_failed": "فشل تحميل الملف الشخصي",
     "avatar_max_size": "الحجم الأقصى 10 MB",
+    "avatar_invalid_type": "نوع ملف غير صالح. يرجى تحميل صورة.",
     "avatar_upload_failed": "فشل رفع الصورة الشخصية",
     "avatar_crop_failed": "فشل قص الصورة الرمزية",
     "profile_update_success": "تم تحديث الملف الشخصي بنجاح!",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -595,6 +595,7 @@
     "upload": "Upload",
     "load_profile_failed": "Failed to load profile",
     "avatar_max_size": "Max size 10 MB",
+    "avatar_invalid_type": "Ungültiger Dateityp. Bitte ein Bild hochladen.",
     "avatar_upload_failed": "Failed to upload avatar",
     "profile_update_success": "Profile updated successfully!",
     "profile_update_failed": "Failed to update profile",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -598,6 +598,7 @@
     "upload": "Upload",
     "load_profile_failed": "Failed to load profile",
     "avatar_max_size": "Max size 10 MB",
+    "avatar_invalid_type": "Invalid file type. Please upload an image.",
     "avatar_upload_failed": "Failed to upload avatar",
     "avatar_crop_failed": "Failed to crop avatar",
     "profile_update_success": "Profile updated successfully!",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -580,6 +580,7 @@
     "upload": "Subir",
     "load_profile_failed": "No se pudo cargar perfil",
     "avatar_max_size": "Tamaño máximo de 10 MB",
+    "avatar_invalid_type": "Tipo de archivo no válido. Por favor, sube una imagen.",
     "avatar_upload_failed": "No se pudo subir avatar",
     "avatar_crop_failed": "No se pudo recortar el avatar",
     "profile_update_success": "Perfil actualizado con éxito!",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -580,6 +580,7 @@
     "upload": "Téléverser",
     "load_profile_failed": "Échec du chargement du profil",
     "avatar_max_size": "Taille maximale 10 Mo",
+    "avatar_invalid_type": "Type de fichier invalide. Veuillez télécharger une image.",
     "avatar_upload_failed": "Échec du téléversement de l'avatar",
     "avatar_crop_failed": "Échec du recadrage de l'avatar",
     "profile_update_success": "Profil mis à jour avec succès !",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -580,6 +580,7 @@
     "upload": "अपलोड करना",
     "load_profile_failed": "प्रोफ़ाइल लोड करने में विफल",
     "avatar_max_size": "अधिकतम आकार 10 एमबी",
+    "avatar_invalid_type": "अमान्य फ़ाइल प्रकार। कृपया एक छवि अपलोड करें।",
     "avatar_upload_failed": "अवतार अपलोड करने में विफल",
     "avatar_crop_failed": "अवतार क्रॉप विफल हुआ",
     "profile_update_success": "प्रोफ़ाइल सफलतापूर्वक अपडेट किया गया!",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -594,6 +594,7 @@
     "upload": "Caricamento",
     "load_profile_failed": "Impossibile caricare il profilo",
     "avatar_max_size": "Dimensione massima 10 MB",
+    "avatar_invalid_type": "Tipo di file non valido. Carica un'immagine.",
     "avatar_upload_failed": "Impossibile caricare Avatar",
     "avatar_crop_failed": "Ritaglio avatar non riuscito",
     "profile_update_success": "Profilo aggiornato correttamente!",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -580,6 +580,7 @@
     "upload": "上传",
     "load_profile_failed": "无法加载配置文件",
     "avatar_max_size": "最大尺寸10MB",
+    "avatar_invalid_type": "文件类型无效。请上传图片。",
     "avatar_upload_failed": "无法上传头像",
     "avatar_crop_failed": "头像裁剪失败",
     "profile_update_success": "个人资料成功更新了！",

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -187,6 +187,11 @@ function ProfileEditTemplate() {
       e.target.value = '';
       return;
     }
+    if (!file.type.startsWith('image/')) {
+      toast.error(t('avatar_invalid_type'));
+      e.target.value = '';
+      return;
+    }
     if (file.size > 10 * 1024 * 1024) {
       toast.error(t('avatar_max_size'));
       e.target.value = '';


### PR DESCRIPTION
## Summary
- validate that selected avatar files are images before cropping/uploading
- add localized `avatar_invalid_type` string across locales

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a32b8fd48328a877271f909636dc