### PR TITLE
Validate social link platforms in admin profile schema

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -50,8 +50,18 @@ export const profileSchema = z.object({
   gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
   date_of_birth: z.string().refine((val) => !isNaN(Date.parse(val)), { message: "invalid_date" }),
   // Social links validated as URLs; allow empty strings so optional fields don't fail validation
+  // Additionally ensure provided keys correspond to allowed platforms
   socialLinks: z
     .record(z.string().url("invalid_url").or(z.literal("")))
+    .refine(
+      (links) =>
+        Object.keys(links).every((key) =>
+          allowedPlatforms.some((p) => p.name === key)
+        ),
+      {
+        message: "invalid_social_platform",
+      }
+    )
     .optional(),
 });
 


### PR DESCRIPTION
## Summary
- Ensure admin profile social link keys match allowed platforms

## Testing
- `npm test` (fails: _cacheService.clearCache.mockReset is not a function, Cannot find module '../../services/instructor/subscriptionService')
- `npm run lint` (fails: 56 errors, 271 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c5a32aeab88328b618eab1b3c1e69e