### PR TITLE
feat: handle admin avatar removal state

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -75,6 +75,7 @@ function ProfileEditTemplate() {
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
+  const [isRemovingAvatar, setIsRemovingAvatar] = useState(false);
   const [expanded, setExpanded] = useState({ personal: true, social: true });
   const [showCropper, setShowCropper] = useState(false);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
@@ -251,12 +252,10 @@ function ProfileEditTemplate() {
       toast.error(t("user_not_loaded"));
       return;
     }
-    setIsSubmitting(true);
+    setIsRemovingAvatar(true);
     try {
       await deleteAdminAvatar(user.id);
-      const { setUser } = useAuthStore.getState();
-      const current = useAuthStore.getState().user;
-      setUser({ ...current, avatar_url: null });
+      setUser({ ...user, avatar_url: null });
       setFormData((prev) => ({ ...prev, avatarPreview: null, avatar_url: null }));
       toast.success(t("avatar_remove_success"));
     } catch (error) {
@@ -264,7 +263,7 @@ function ProfileEditTemplate() {
       const msg = error.response?.data?.message || t("avatar_remove_failed");
       toast.error(msg);
     } finally {
-      setIsSubmitting(false);
+      setIsRemovingAvatar(false);
     }
   };
 
@@ -376,9 +375,16 @@ function ProfileEditTemplate() {
                   />
                   <button
                     onClick={handleAvatarRemove}
-                    className="absolute -top-2 -right-2 p-1 bg-red-600 text-white rounded-full hover:bg-red-700 transition-colors"
+                    disabled={isRemovingAvatar}
+                    className={`absolute -top-2 -right-2 p-1 bg-red-600 text-white rounded-full transition-colors ${
+                      isRemovingAvatar ? 'opacity-50 cursor-not-allowed' : 'hover:bg-red-700'
+                    }`}
                   >
-                    <FaTrash size={14} />
+                    {isRemovingAvatar ? (
+                      <FaSpinner size={14} className="animate-spin" />
+                    ) : (
+                      <FaTrash size={14} />
+                    )}
                   </button>
                 </div>
               ) : (


### PR DESCRIPTION
## Summary
- track admin avatar deletion with dedicated `isRemovingAvatar` state
- use `setUser` hook to update store after avatar deletion
- disable avatar remove button with spinner during deletion

## Testing
- `npm test` *(fails: _CacheManager.test.tsx_, _InstructorSettingsPage.test.js_)*
- `npm run lint` *(fails: Component definition is missing display name, no-console)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a329933883289d8c9f6497099477