### PR TITLE
chore: await message store fetch

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -335,8 +335,7 @@ function ProfileEditTemplate() {
       }));
 
       toast.success(t('profile_update_success'));
-      await fetchNotifications();
-      fetchMessages();
+      await Promise.all([fetchNotifications(), fetchMessages()]);
       router.push("/dashboard/admin/profile/steps/Verification");
     } catch (err) {
       toast.error(err.message || t('profile_update_failed'));


### PR DESCRIPTION
## Summary
- await message fetch after profile update by running notification and message refresh concurrently

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService'; TypeError: _cacheService.clearCache.mockReset is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a3289cbc8328a53fabf4c89658e5