### PR TITLE
Prevent state updates after unmount in admin profile edit

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -86,38 +86,44 @@ function ProfileEditTemplate() {
   const fetchMessages = useMessageStore((state) => state.fetch);
 
   useEffect(() => {
+    let isMounted = true;
+
     if (!hasHydrated) return;
     if (!user) {
-      setLoadingProfile(false);
+      if (isMounted) setLoadingProfile(false);
       return;
     }
     const role = user.role?.toLowerCase();
     if (role !== "admin" && role !== "superadmin") {
-      setLoadingProfile(false);
+      if (isMounted) setLoadingProfile(false);
       return;
     }
 
     // Pre-fill with existing user info while fetching latest data
-    setFormData((prev) => ({
-      ...prev,
-      full_name: user.full_name || "",
-      email: user.email || "",
-      phone: user.phone || "",
-      gender: user.gender || "male",
-      date_of_birth: user.date_of_birth?.split("T")[0] || "",
-      avatar_url: user.avatar_url,
-      avatarPreview: user.avatar_url
-        ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${user.avatar_url}`
-        : null,
-      job_title: user.job_title || "",
-      department: user.department || "",
-    }));
+    if (isMounted) {
+      setFormData((prev) => ({
+        ...prev,
+        full_name: user.full_name || "",
+        email: user.email || "",
+        phone: user.phone || "",
+        gender: user.gender || "male",
+        date_of_birth: user.date_of_birth?.split("T")[0] || "",
+        avatar_url: user.avatar_url,
+        avatarPreview: user.avatar_url
+          ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${user.avatar_url}`
+          : null,
+        job_title: user.job_title || "",
+        department: user.department || "",
+      }));
+    }
 
     const loadProfile = async () => {
       try {
+        if (!isMounted) return;
         setLoadingProfile(true);
 
         const res = await getAdminProfile();
+        if (!isMounted) return;
         const {
           full_name,
           email,
@@ -137,6 +143,7 @@ function ProfileEditTemplate() {
           }
         });
 
+        if (!isMounted) return;
         setFormData((prev) => ({
           ...prev,
           full_name,
@@ -153,15 +160,18 @@ function ProfileEditTemplate() {
           socialLinks: socialMap,
         }));
       } catch (err) {
-        toast.error(t('load_profile_failed'));
+        if (isMounted) toast.error(t('load_profile_failed'));
         console.error("Profile load error:", err);
       } finally {
-        setLoadingProfile(false);
-
+        if (isMounted) setLoadingProfile(false);
       }
     };
 
     loadProfile();
+
+    return () => {
+      isMounted = false;
+    };
   }, [hasHydrated, user]);
 
 


### PR DESCRIPTION
## Summary
- guard admin profile edit async calls with a mounted flag to prevent state updates after unmount

## Testing
- `npm test` *(fails: TypeError _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService')*
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a327276c8328a40a9d50ec20ba9f