### PR TITLE
refactor: centralize profile route mappings

### DIFF
--- a/frontend/src/components/auth/IncompleteAlertModal.js
+++ b/frontend/src/components/auth/IncompleteAlertModal.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import useAuthStore from "@/store/auth/authStore";
 import { useRouter } from "next/router";
+import profileRoutes from "@/constants/profileRoutes";
 
 export default function IncompleteAlertModal() {
   const { user } = useAuthStore();
@@ -31,12 +32,9 @@ export default function IncompleteAlertModal() {
         </p>
         <button
           onClick={() => {
-            const path = user.role === "Instructor"
-              ? "/dashboard/instructor/profile/edit"
-              : "/dashboard/student/profile/edit";
+            const path = profileRoutes[user.role?.toLowerCase()] || "/auth/login";
             router.push(path);
           }}
-
           className="bg-yellow-500 px-4 py-2 rounded text-gray-900 font-semibold"
         >
           Complete Now

--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -23,6 +23,8 @@ import useAppConfigStore from "@/store/appConfigStore";
 import LinkText from "@/components/shared/LinkText";
 import { buildUrl } from "@/utils/url";
 
+import profileRoutes from "@/constants/profileRoutes";
+
 export default function Header() {
   const user = useAuthStore((state) => state.user);
   const logout = useAuthStore((state) => state.logout);
@@ -58,10 +60,7 @@ export default function Header() {
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
   const router = useRouter();
 
-  const profileLink =
-    userRole === "superadmin" || userRole === "admin"
-      ? "/dashboard/admin/profile/edit"
-      : `/dashboard/${userRole}/profile/edit`;
+  const profileLink = profileRoutes[userRole] || `/dashboard/${userRole}/profile/edit`;
 
   const handleLogout = async () => {
     try {

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -34,6 +34,8 @@ import api from "@/services/api/api";
 import { getCurrencies } from "@/services/currencyService";
 import { buildUrl } from "@/utils/url";
 
+import profileRoutes from "@/constants/profileRoutes";
+
 const fetcher = (url) => api.get(url).then((res) => res.data.data);
 const currencyFetcher = () => getCurrencies();
 
@@ -118,13 +120,7 @@ const Navbar = () => {
 
   useEffect(() => {
     if (user && user.profile_complete === false) {
-      const profilePaths = {
-        admin: "/dashboard/admin/profile/edit",
-        instructor: "/dashboard/instructor/profile/edit",
-        student: "/dashboard/student/profile/edit",
-        superadmin: "/dashboard/admin/profile/edit",
-      };
-      const rolePath = profilePaths[userRole] || "/website";
+      const rolePath = profileRoutes[userRole] || "/website";
       if (router.pathname !== rolePath) {
         router.replace(rolePath);
         toast.info(t('please_complete_profile'));
@@ -191,10 +187,7 @@ const Navbar = () => {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const profileLink =
-    userRole === "superadmin" || userRole === "admin"
-      ? "/dashboard/admin/profile/edit"
-      : `/dashboard/${userRole}/profile/edit`;
+  const profileLink = profileRoutes[userRole] || `/dashboard/${userRole}/profile/edit`;
 
   const getAvatarUrl = (avatar) => {
     if (!avatar) return "";

--- a/frontend/src/constants/profileRoutes.js
+++ b/frontend/src/constants/profileRoutes.js
@@ -1,0 +1,11 @@
+const profileRoutes = {
+  admin: "/dashboard/admin/profile/edit",
+  superadmin: "/dashboard/admin/profile/edit",
+  instructor: "/dashboard/instructor/profile/edit",
+  student: "/dashboard/student/profile/edit",
+  employer: "/dashboard/employer/profile/edit",
+  mentor: "/dashboard/mentor/profile/edit",
+  school: "/dashboard/school/profile/edit",
+};
+
+export default profileRoutes;

--- a/frontend/src/hooks/RequireProfileCompletion.js
+++ b/frontend/src/hooks/RequireProfileCompletion.js
@@ -3,12 +3,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
-
-const roleRedirects = {
-  admin: "/dashboard/admin/profile/edit",
-  instructor: "/dashboard/instructor/profile/edit",
-  student: "/dashboard/student/profile/edit",
-};
+import profileRoutes from "@/constants/profileRoutes";
 
 export default function RequireProfileCompletion({ children }) {
   const { user } = useAuthStore();
@@ -17,7 +12,7 @@ export default function RequireProfileCompletion({ children }) {
 
   useEffect(() => {
     if (user && user.profile_complete === false) {
-      const targetPath = roleRedirects[userRole] || "/auth/login";
+      const targetPath = profileRoutes[userRole] || "/auth/login";
 
       // Avoid redirecting if already on the profile page
       if (router.pathname !== targetPath) {

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -27,6 +27,7 @@ import logger from "@/utils/logger";
 // ─────────────────────
 import { loginSchema as createLoginSchema } from "@/utils/auth/validationSchemas";
 import { isTokenExpired } from "@/utils/auth/tokenUtils";
+import profileRoutes from "@/constants/profileRoutes";
 
 function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading }) {
   const router = useRouter();
@@ -67,13 +68,7 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
     }
 
     if (user.profile_complete === false) {
-      const profilePaths = {
-        admin: "/dashboard/admin/profile/edit",
-        instructor: "/dashboard/instructor/profile/edit",
-        student: "/dashboard/student/profile/edit",
-        superadmin: "/dashboard/admin/profile/edit",
-      };
-      const rolePath = profilePaths[user.role?.toLowerCase()] || "/website";
+      const rolePath = profileRoutes[user.role?.toLowerCase()] || "/website";
       router.replace(rolePath);
     } else {
       router.replace("/website");
@@ -113,16 +108,9 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
     toast.success(t("login_successful"));
     fetchNotifications();
 
-    const profilePaths = {
-      admin: "/dashboard/admin/profile/edit",
-      instructor: "/dashboard/instructor/profile/edit",
-      student: "/dashboard/student/profile/edit",
-      superadmin: "/dashboard/admin/profile/edit",
-    };
-
     const targetPath =
       loggedInUser.profile_complete === false
-        ? profilePaths[loggedInUser.role?.toLowerCase()] || "/website"
+        ? profileRoutes[loggedInUser.role?.toLowerCase()] || "/website"
         : "/website";
 
     // 🚀 Redirect after a short delay so the toast is visible


### PR DESCRIPTION
## Summary
- add `profileRoutes` constant mapping roles to profile edit paths
- refactor login flow and navigation components to use centralized profile routes
- update profile completion checks to leverage shared profile route constants

## Testing
- `npm test` *(fails: _cacheService.clearCache.mockReset is not a function)*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a322877c83289d39a0ce85422303