### PR TITLE
Add localized validation messages for profile job fields

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -589,6 +589,8 @@
     "invalid_phone_number": "رقم هاتف غير صالح",
     "invalid_email_address": "عنوان البريد الإلكتروني غير صالح",
     "invalid_date": "تنسيق التاريخ غير صالح",
+    "job_title_min": "يجب أن يكون المسمى الوظيفي مكونًا من حرفين على الأقل",
+    "department_min": "يجب أن يكون القسم مكونًا من حرفين على الأقل",
     "url_invalid": "يجب أن يكون رابطاً صالحاً"
   },
   "adminCertificatesPage": {

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -603,6 +603,8 @@
     "invalid_phone_number": "Ungültige Telefonnummer",
     "invalid_email_address": "Invalid email address",
     "invalid_date": "Invalid date format",
+    "job_title_min": "Die Berufsbezeichnung muss mindestens 2 Zeichen enthalten",
+    "department_min": "Die Abteilung muss mindestens 2 Zeichen enthalten",
     "url_invalid": "Must be a valid URL"
   },
   "adminCertificatesPage": {

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -607,6 +607,8 @@
     "invalid_phone_number": "Invalid phone number",
     "invalid_email_address": "Invalid email address",
     "invalid_date": "Invalid date format",
+    "job_title_min": "Job title must be at least 2 characters",
+    "department_min": "Department must be at least 2 characters",
     "url_invalid": "Must be a valid URL"
   },
   "adminCertificatesPage": {

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -589,6 +589,8 @@
     "invalid_phone_number": "Número de teléfono no válido",
     "invalid_email_address": "Dirección de correo electrónico no válida",
     "invalid_date": "Formato de fecha no válido",
+    "job_title_min": "El título del puesto debe tener al menos 2 caracteres",
+    "department_min": "El departamento debe tener al menos 2 caracteres",
     "url_invalid": "Debe ser una URL válida"
   },
   "adminCertificatesPage": {

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -589,6 +589,8 @@
     "invalid_phone_number": "Numéro de téléphone invalide",
     "invalid_email_address": "Adresse e-mail invalide",
     "invalid_date": "Format de date invalide",
+    "job_title_min": "L'intitulé du poste doit comporter au moins 2 caractères",
+    "department_min": "Le département doit comporter au moins 2 caractères",
     "url_invalid": "Doit être une URL valide"
   },
   "adminCertificatesPage": {

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -589,6 +589,8 @@
     "invalid_phone_number": "अमान्य फोन नंबर",
     "invalid_email_address": "अमान्य ईमेल पता",
     "invalid_date": "अमान्य दिनांक प्रारूप",
+    "job_title_min": "पद का नाम कम से कम 2 अक्षरों का होना चाहिए",
+    "department_min": "विभाग का नाम कम से कम 2 अक्षरों का होना चाहिए",
     "url_invalid": "एक वैध URL होना चाहिए"
   },
   "adminCertificatesPage": {

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -603,6 +603,8 @@
     "invalid_phone_number": "Numero di telefono non valido",
     "invalid_email_address": "Indirizzo e -mail non valido",
     "invalid_date": "Formato della data non valido",
+    "job_title_min": "Il titolo di lavoro deve contenere almeno 2 caratteri",
+    "department_min": "Il dipartimento deve contenere almeno 2 caratteri",
     "url_invalid": "Deve essere un URL valido"
   },
   "adminCertificatesPage": {

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -589,6 +589,8 @@
     "invalid_phone_number": "无效的电话号码",
     "invalid_email_address": "无效的电子邮件地址",
     "invalid_date": "无效的日期格式",
+    "job_title_min": "职位名称至少需要2个字符",
+    "department_min": "部门名称至少需要2个字符",
     "url_invalid": "必须是有效的URL"
   },
   "adminCertificatesPage": {

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -45,8 +45,8 @@ export const profileSchema = z.object({
     .refine((val) => isValidPhoneNumber(val), {
       message: "invalid_phone_number",
     }),
-  job_title: z.string().min(2),
-  department: z.string().min(2),
+  job_title: z.string().min(2, 'job_title_min'),
+  department: z.string().min(2, 'department_min'),
   gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
   date_of_birth: z.string().refine((val) => !isNaN(Date.parse(val)), { message: "invalid_date" }),
   // Social links validated as URLs; allow empty strings so optional fields don't fail validation


### PR DESCRIPTION
## Summary
- reference job title and department length errors by translation keys
- add corresponding `job_title_min` and `department_min` messages to all dashboard locales

## Testing
- `npm test` *(fails: _CacheManager.test.tsx_, _InstructorSettingsPage.test.js_)*
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a331a6a883289610f8184dca87ac