### PR TITLE
refactor: simplify avatar removal state update

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -254,9 +254,7 @@ function ProfileEditTemplate() {
     setIsSubmitting(true);
     try {
       await deleteAdminAvatar(user.id);
-      const { setUser } = useAuthStore.getState();
-      const current = useAuthStore.getState().user;
-      setUser({ ...current, avatar_url: null });
+      setUser({ ...user, avatar_url: null });
       setFormData((prev) => ({ ...prev, avatarPreview: null, avatar_url: null }));
       toast.success(t("avatar_remove_success"));
     } catch (error) {


### PR DESCRIPTION
## Summary
- remove redundant auth store calls when deleting admin avatar

## Testing
- `npm test` *(fails: TypeError: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService')*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a31ef6c083289eab26670e041256