### PR TITLE
Add avatar deletion loading state for admin profile page

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -75,6 +75,7 @@ function ProfileEditTemplate() {
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
+  const [isRemovingAvatar, setIsRemovingAvatar] = useState(false);
   const [expanded, setExpanded] = useState({ personal: true, social: true });
   const [showCropper, setShowCropper] = useState(false);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
@@ -251,7 +252,7 @@ function ProfileEditTemplate() {
       toast.error(t("user_not_loaded"));
       return;
     }
-    setIsSubmitting(true);
+    setIsRemovingAvatar(true);
     try {
       await deleteAdminAvatar(user.id);
       const { setUser } = useAuthStore.getState();
@@ -264,7 +265,7 @@ function ProfileEditTemplate() {
       const msg = error.response?.data?.message || t("avatar_remove_failed");
       toast.error(msg);
     } finally {
-      setIsSubmitting(false);
+      setIsRemovingAvatar(false);
     }
   };
 
@@ -376,9 +377,18 @@ function ProfileEditTemplate() {
                   />
                   <button
                     onClick={handleAvatarRemove}
-                    className="absolute -top-2 -right-2 p-1 bg-red-600 text-white rounded-full hover:bg-red-700 transition-colors"
+                    disabled={isRemovingAvatar}
+                    className={`absolute -top-2 -right-2 p-1 rounded-full text-white transition-colors ${
+                      isRemovingAvatar
+                        ? 'bg-red-400 cursor-not-allowed'
+                        : 'bg-red-600 hover:bg-red-700'
+                    }`}
                   >
-                    <FaTrash size={14} />
+                    {isRemovingAvatar ? (
+                      <FaSpinner className="animate-spin" size={14} />
+                    ) : (
+                      <FaTrash size={14} />
+                    )}
                   </button>
                 </div>
               ) : (


### PR DESCRIPTION
## Summary
- add `isRemovingAvatar` state to track avatar deletion progress
- use `isRemovingAvatar` in `handleAvatarRemove`
- disable avatar delete button and show spinner while removing

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a318d84c8328b11d9e6da33be90f