### PR TITLE
feat: revoke temporary avatar URL on cleanup

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -165,6 +165,13 @@ function ProfileEditTemplate() {
   }, [hasHydrated, user]);
 
 
+  useEffect(() => {
+    return () => {
+      if (tempAvatar) URL.revokeObjectURL(tempAvatar);
+    };
+  }, [tempAvatar]);
+
+
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));


### PR DESCRIPTION
## Summary
- revoke temporary avatar Object URL when component unmounts

## Testing
- `npm test -- --silent` *(fails: _cacheService.clearCache.mockReset is not a function, Cannot find module '../../services/instructor/subscriptionService'_)*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a3217c6483288b80a1d909f7ef62