### PR TITLE
feat: add default country to phone validation

### DIFF
--- a/backend/src/modules/auth/validators/auth.validator.js
+++ b/backend/src/modules/auth/validators/auth.validator.js
@@ -3,6 +3,9 @@ const { z } = require("zod");
 const { PASSWORD_REGEX, OTP_LENGTH } = require("../constants");
 const { isValidPhoneNumber } = require("libphonenumber-js");
 
+// Default country used for phone number validation
+const DEFAULT_COUNTRY = "US";
+
 /**
  * @desc Validation for user registration
  */
@@ -11,7 +14,7 @@ exports.registerSchema = z.object({
   email: z.string().email("Invalid email address"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val), {
+    .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
       message: "Invalid phone number",
     }),
   password: z

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -35,6 +35,9 @@ import getCroppedImg from "@/utils/cropImage";
 import { toSocialLinksArray } from "@/utils/socialLinks";
 import { allowedPlatforms } from "@/utils/socialPlatforms";
 
+// Default country for phone validation
+const DEFAULT_COUNTRY = "US";
+
 // Add service imports as needed, e.g., getProfile, updateProfile, uploadAvatar, etc.
 
 export const profileSchema = z.object({
@@ -42,7 +45,7 @@ export const profileSchema = z.object({
   email: z.string().email("invalid_email_address"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val), {
+    .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
       message: "invalid_phone_number",
     }),
   job_title: z.string().min(2),

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -44,12 +44,14 @@ import ExpertiseList from "@/components/instructor/profile/ExpertiseList";
 import CertificatesSection from "@/components/instructor/profile/CertificatesSection";
 import SocialLinksSection from "@/components/instructor/profile/SocialLinksSection";
 
+// Default country for phone validation
+const DEFAULT_COUNTRY = "US";
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
 export const instructorProfileSchema = z.object({
   full_name: z.string().min(3, "full_name_min"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val), {
+    .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
       message: "invalid_phone_number",
     }),
   gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -28,9 +28,12 @@ import {
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
 
+// Default country for phone validation
+const DEFAULT_COUNTRY = "US";
+
 export const studentProfileSchema = z.object({
   full_name: z.string().min(3, "full_name_min"),
-  phone: z.string().refine((val) => isValidPhoneNumber(val), {
+  phone: z.string().refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
     message: "invalid_phone_number",
   }),
   gender: z.enum(['male', 'female']),

--- a/frontend/src/utils/auth/validationSchemas.js
+++ b/frontend/src/utils/auth/validationSchemas.js
@@ -1,6 +1,9 @@
 // 📁 src/utils/validationSchemas.js
 import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
+
+// Default country for phone validation
+const DEFAULT_COUNTRY = "US";
 // These helpers generate validation schemas using i18n translations
 // 🔐 Login Schema
 export const loginSchema = (t) =>
@@ -20,7 +23,7 @@ export const registerSchema = (t) =>
       email: z.string().email(t("invalid_email_address")),
       phone: z
         .string()
-        .refine((val) => isValidPhoneNumber(val), {
+        .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
           message: t("invalid_phone_number"),
         }),
 

--- a/frontend/src/utils/validation/adminProfileSchema.js
+++ b/frontend/src/utils/validation/adminProfileSchema.js
@@ -2,11 +2,14 @@
 import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
 
+// Default country for phone validation
+const DEFAULT_COUNTRY = "US";
+
 export const adminProfileSchema = z.object({
   full_name: z.string().min(3, "Full name is required"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val), {
+    .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
       message: "Invalid phone number",
     }),
   gender: z.enum(["male", "female"]),


### PR DESCRIPTION
## Summary
- add `DEFAULT_COUNTRY` constant for phone validation
- use default country in frontend profile schemas and auth validators

## Testing
- `npm test tests/authRegisterRoutes.test.js`
- `npm test src/tests/__tests__/profileSchemaSocialLinks.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5a314b8a0832892d5cb3a3ce46de1