### PR TITLE
Handle nested social link validation errors

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -278,7 +278,8 @@ function ProfileEditTemplate() {
       if (err instanceof z.ZodError) {
         const newErrors = {};
         err.errors.forEach((error) => {
-          newErrors[error.path[0]] = t(error.message);
+          const key = error.path.join(".");
+          newErrors[key] = t(error.message);
         });
         setErrors(newErrors);
         if (err.errors?.length) {
@@ -532,12 +533,13 @@ function ProfileEditTemplate() {
                       type="text"
                       name={name}
                       value={formData.socialLinks[name] || ""}
-                      onChange={(e) =>
+                      onChange={(e) => {
                         setFormData((prev) => ({
                           ...prev,
                           socialLinks: { ...prev.socialLinks, [name]: e.target.value.trim() },
-                        }))
-                      }
+                        }));
+                        setErrors((prev) => ({ ...prev, [`socialLinks.${name}`]: null }));
+                      }}
                       placeholder={
                         name === 'website'
                           ? 'https://yourwebsite.com'
@@ -545,6 +547,11 @@ function ProfileEditTemplate() {
                       }
                       className="w-full px-3 py-2 border border-gray-300 rounded-md"
                     />
+                    {errors[`socialLinks.${name}`] && (
+                      <p className="text-red-500 text-sm mt-1">
+                        {errors[`socialLinks.${name}`]}
+                      </p>
+                    )}
                   </div>
                 ))}
               </div>

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -214,7 +214,10 @@ export default function InstructorProfileEdit() {
       return true;
     } catch (err) {
       const errs = {};
-      err.errors.forEach(e => { errs[e.path[0]] = t(e.message); });
+      err.errors.forEach(error => {
+        const key = error.path.join(".");
+        errs[key] = t(error.message);
+      });
       setErrors(errs);
       if (err.errors?.length) {
         toast.error(t(err.errors[0].message));
@@ -760,12 +763,13 @@ export default function InstructorProfileEdit() {
                     type="text"
                     name={name}
                     value={formData.socialLinks[name] || ""}
-                    onChange={(e) =>
+                    onChange={(e) => {
                       setFormData((prev) => ({
                         ...prev,
                         socialLinks: { ...prev.socialLinks, [name]: e.target.value },
-                      }))
-                    }
+                      }));
+                      setErrors((prev) => ({ ...prev, [`socialLinks.${name}`]: null }));
+                    }}
                     placeholder={
                       name === 'website'
                         ? 'https://yourwebsite.com'
@@ -773,6 +777,11 @@ export default function InstructorProfileEdit() {
                     }
                     className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-yellow-500 focus:border-yellow-500"
                   />
+                  {errors[`socialLinks.${name}`] && (
+                    <p className="text-red-500 text-sm mt-1">
+                      {errors[`socialLinks.${name}`]}
+                    </p>
+                  )}
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -159,6 +159,7 @@ export default function StudentProfileEdit() {
       ...prev,
       socialLinks: { ...prev.socialLinks, [name]: value.trim() }
     }));
+    setErrors(prev => ({ ...prev, [`socialLinks.${name}`]: null }));
   };
 
   const onCropComplete = useCallback((_, area) => {
@@ -266,8 +267,9 @@ export default function StudentProfileEdit() {
       return true;
     } catch (err) {
       const errs = {};
-      err.errors.forEach((e) => {
-        errs[e.path[0]] = t(e.message);
+      err.errors.forEach((error) => {
+        const key = error.path.join(".");
+        errs[key] = t(error.message);
       });
       setErrors(errs);
       if (err.errors?.length) {
@@ -651,7 +653,7 @@ export default function StudentProfileEdit() {
                       <FaLinkedin className="w-4 h-4 mr-2 text-blue-700" />
                       {t('linkedin_label')}
                     </label>
-                    <input
+                  <input
                       type="text"
                       name="linkedin"
                       value={formData.socialLinks.linkedin || ""}
@@ -659,6 +661,11 @@ export default function StudentProfileEdit() {
                       placeholder={t('linkedin_placeholder')}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500"
                     />
+                    {errors['socialLinks.linkedin'] && (
+                      <p className="text-red-500 text-sm mt-1">
+                        {errors['socialLinks.linkedin']}
+                      </p>
+                    )}
                   </div>
 
                   <div>
@@ -666,7 +673,7 @@ export default function StudentProfileEdit() {
                       <FaGithub className="w-4 h-4 mr-2 text-gray-800" />
                       {t('github_label')}
                     </label>
-                    <input
+                  <input
                       type="text"
                       name="github"
                       value={formData.socialLinks.github || ""}
@@ -674,6 +681,11 @@ export default function StudentProfileEdit() {
                       placeholder={t('github_placeholder')}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500"
                     />
+                    {errors['socialLinks.github'] && (
+                      <p className="text-red-500 text-sm mt-1">
+                        {errors['socialLinks.github']}
+                      </p>
+                    )}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Use joined error paths in profile forms to capture nested validation errors
- Show per-platform validation feedback in Social Links sections and clear errors on change

## Testing
- `npm test` *(fails: _cacheService.clearCache.mockReset is not a function, Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js'_)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5a31404548328bd8a7f98660bb99e