### PR TITLE
feat: add formatClass helper

### DIFF
--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -33,13 +33,19 @@ const formatEnrolledClass = (cls) => {
   };
 };
 
+export const formatClass = (cls) => {
+  const base = formatBaseClass(cls);
+  return {
+    ...base,
+    scheduleStatus: computeScheduleStatus(base.start_date, base.end_date),
+    trending: Boolean(cls.trending),
+  };
+};
+
 export const fetchPublishedClasses = async () => {
   const res = await api.get("/users/classes");
   const list = extractData(res);
-  const formatted = list.map((cls) => ({
-    ...formatClass(cls),
-    trending: Boolean(cls.trending),
-  }));
+  const formatted = list.map(formatClass);
   return { ...res.data, data: formatted };
 };
 


### PR DESCRIPTION
## Summary
- add reusable formatClass function for user classes
- use formatClass in published and detail fetchers

## Testing
- `npm run lint` *(fails: Component definition is missing display name)*
- `npm test -- --silent` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b0e01a748328994ba28aab986760