### PR TITLE
Improve admin classes sorting

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -30,6 +30,25 @@ import {
   FaList
 } from "react-icons/fa";
 
+export function compareValues(a, b, key) {
+  const valA = a[key];
+  const valB = b[key];
+
+  if (valA === valB) return 0;
+
+  const numA = typeof valA === 'number' ? valA : Date.parse(valA);
+  const numB = typeof valB === 'number' ? valB : Date.parse(valB);
+
+  if (!isNaN(numA) && !isNaN(numB)) {
+    return numA - numB;
+  }
+
+  if (typeof valA === 'string' && typeof valB === 'string') {
+    return valA.localeCompare(valB);
+  }
+
+  return 0;
+}
 
 export default function AdminClassesTable({ classes = [], loading = false }) {
   const [searchTerm, setSearchTerm] = useState("");
@@ -63,7 +82,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
     .filter((cls) =>
       filterApproval === "All" ? true : cls.approvalStatus === filterApproval
     )
-    .sort((a, b) => (a[sortKey] > b[sortKey] ? 1 : -1));
+    .sort((a, b) => compareValues(a, b, sortKey));
 
   const totalPages = Math.ceil(filteredClasses.length / itemsPerPage);
   const paginatedClasses = filteredClasses.slice(

--- a/frontend/src/tests/__tests__/AdminClassesTableSorting.test.js
+++ b/frontend/src/tests/__tests__/AdminClassesTableSorting.test.js
@@ -1,0 +1,28 @@
+import { compareValues } from "@/components/admin/online-classes/AdminClassesTable";
+
+describe("compareValues", () => {
+  const sample = [
+    { title: "B", start_date: "2024-05-02", price: 10 },
+    { title: "A", start_date: "2024-04-01", price: 20 },
+    { title: "C", start_date: "2024-05-01", price: 5 },
+  ];
+
+  test("sorts strings using localeCompare", () => {
+    const sorted = [...sample].sort((a, b) => compareValues(a, b, "title"));
+    expect(sorted.map((c) => c.title)).toEqual(["A", "B", "C"]);
+  });
+
+  test("sorts dates numerically", () => {
+    const sorted = [...sample].sort((a, b) => compareValues(a, b, "start_date"));
+    expect(sorted.map((c) => c.start_date)).toEqual([
+      "2024-04-01",
+      "2024-05-01",
+      "2024-05-02",
+    ]);
+  });
+
+  test("sorts numbers numerically", () => {
+    const sorted = [...sample].sort((a, b) => compareValues(a, b, "price"));
+    expect(sorted.map((c) => c.price)).toEqual([5, 10, 20]);
+  });
+});


### PR DESCRIPTION
## Summary
- add robust compareValues helper for sorting strings, dates, and numbers
- switch admin classes table to use generalized comparator
- cover compareValues with unit tests for string, date, and numeric sorting

## Testing
- `npm test -- AdminClassesTableSorting.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5b0e0e8588328b25a8f6cab3bca0a