### PR TITLE
Quote CSV fields in AdminClassesTable export

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -72,17 +72,30 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
   );
 
   const exportCSV = () => {
-    const headers = ["Title", "Instructor", "Start Date", "End Date", "Category", "Publish Status"];
-    const rows = classList.map(cls => [
+    const headers = [
+      "Title",
+      "Instructor",
+      "Start Date",
+      "End Date",
+      "Category",
+      "Publish Status",
+    ];
+    const rows = classList.map((cls) => [
       cls.title,
       cls.instructor,
       cls.start_date,
       cls.end_date,
       cls.category,
-      cls.publishStatus
+      cls.publishStatus,
     ]);
-    const csvContent = [headers, ...rows].map(e => e.join(",")).join("\n");
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const escapeCell = (cell) =>
+      `"${String(cell ?? "").replace(/"/g, '""')}"`;
+    const csvContent = [headers, ...rows]
+      .map((row) => row.map(escapeCell).join(","))
+      .join("\n");
+    const blob = new Blob([csvContent], {
+      type: "text/csv;charset=utf-8;",
+    });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;


### PR DESCRIPTION
## Summary
- ensure CSV export wraps each field in quotes and escapes embedded quotes for reliability

## Testing
- `python - <<'PY' ...` (CSV quoting demo)
- `CI=true npx jest src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: Cannot find module 'subscriptionService'; _cacheService.clearCache.mockReset is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b0e2418883288069d27fa52370c7