### PR TITLE
Revoke object URLs in admin class form

### DIFF
--- a/frontend/src/components/admin/online-classes/forms/CreateClassForm.js
+++ b/frontend/src/components/admin/online-classes/forms/CreateClassForm.js
@@ -1,5 +1,5 @@
 // src/components/forms/CreateClassForm.js
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import logger from '@/utils/logger';
 
 export default function CreateClassForm() {
@@ -45,6 +45,23 @@ export default function CreateClassForm() {
     const updated = formData.lessons.filter((_, i) => i !== index);
     setFormData({ ...formData, lessons: updated });
   };
+
+  const handleImageChange = (e) => {
+    const file = e.target.files[0];
+    if (formData.image) {
+      URL.revokeObjectURL(formData.image);
+    }
+    const imageUrl = file ? URL.createObjectURL(file) : '';
+    setFormData({ ...formData, image: imageUrl });
+  };
+
+  useEffect(() => {
+    return () => {
+      if (formData.image) {
+        URL.revokeObjectURL(formData.image);
+      }
+    };
+  }, [formData.image]);
 
   const next = () => setStep((prev) => prev + 1);
   const back = () => setStep((prev) => prev - 1);
@@ -102,11 +119,7 @@ export default function CreateClassForm() {
             <input
               type="file"
               accept="image/*"
-              onChange={(e) => {
-                const file = e.target.files[0];
-                const imageUrl = file ? URL.createObjectURL(file) : '';
-                setFormData({ ...formData, image: imageUrl });
-              }}
+              onChange={handleImageChange}
               className="w-full p-3 border border-gray-300 rounded-lg"
             />
             {formData.image && (


### PR DESCRIPTION
## Summary
- revoke previous preview URL when selecting a new class image
- clean up image preview URL on component unmount

## Testing
- `npm test src/tests/__tests__/bookService.test.js`
- `npm test src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: _cacheService.clearCache.mockReset is not a function)*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b0e4250c8328a491007ce6d2dd60