### PR TITLE
Ensure instructor filter for online classes

### DIFF
--- a/frontend/src/components/instructors/OnlineClassList.js
+++ b/frontend/src/components/instructors/OnlineClassList.js
@@ -30,13 +30,16 @@ export default function OnlineClassList() {
     load();
   }, []);
 
+  // The backend should already scope results to the logged-in instructor.
+  // This client-side filter is a safeguard to exclude any unexpected records
+  // and avoids defaulting to true when instructor data is missing.
   const myClasses = classes.filter((cls) => {
     if (cls.instructor_id && user?.id) return cls.instructor_id === user.id;
     if (cls.instructor && (user?.full_name || user?.name)) {
       const name = user.full_name || user.name;
       return cls.instructor === name;
     }
-    return true;
+    return false;
   });
 
   const filteredClasses = myClasses


### PR DESCRIPTION
## Summary
- Strictly filter instructor classes by matching `instructor_id` or instructor name
- Document assumption that backend already scopes classes to the logged-in instructor

## Testing
- `npm test` (failed: see logs for details)
- `npm run lint` (failed: 56 errors, 271 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c5b0e553e883289b170303d39a25d8