### PR TITLE
refactor online class status logic

### DIFF
--- a/frontend/src/components/website/sections/OnlineClasses.js
+++ b/frontend/src/components/website/sections/OnlineClasses.js
@@ -19,21 +19,12 @@ import {
   getMyClassWishlist,
   getMyLikedClasses,
 } from "@/services/classService";
+import { computeScheduleStatus } from "@/utils/classSchedule";
 import useAuthStore from "@/store/auth/authStore";
 import { toast } from "react-toastify";
 
 // Initial category options include the special "Trending" filter
 const initialCategories = ["All", "Trending"];
-
-const computeStatus = (start, end) => {
-  const now = new Date();
-  const s = start ? new Date(start) : null;
-  const e = end ? new Date(end) : null;
-  if (s && now < s) return "Upcoming";
-  if (s && (!e || now <= e) && now >= s) return "Live";
-  if (e && now > e) return "Completed";
-  return "Upcoming";
-};
 
 const OnlineClasses = () => {
   const [selectedCategory, setSelectedCategory] = useState("All");
@@ -56,7 +47,7 @@ const OnlineClasses = () => {
         const list = res?.data ?? [];
         const formatted = list.map((c) => ({
           ...c,
-          status: computeStatus(c.start_date, c.end_date),
+          status: computeScheduleStatus(c.start_date, c.end_date),
         }));
         setClasses(formatted);
         const cats = Array.from(
@@ -95,7 +86,7 @@ const OnlineClasses = () => {
       (selectedCategory === "All" ||
         (selectedCategory === "Trending" && classItem.trending) ||
         classItem.category === selectedCategory) &&
-      (showLiveClasses ? classItem.status === "Live" : true) &&
+      (showLiveClasses ? classItem.status === "Ongoing" : true) &&
       classItem.title?.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
@@ -210,7 +201,7 @@ const OnlineClasses = () => {
                   )}
                   <span
                     className={`px-3 py-1 text-xs font-bold rounded-full ${
-                      classItem.status === "Live"
+                      classItem.status === "Ongoing"
                         ? "bg-red-500 text-white animate-pulse"
                         : classItem.status === "Completed"
                         ? "bg-gray-600 text-white"
@@ -222,7 +213,7 @@ const OnlineClasses = () => {
                 </div>
 
                 {/* Icon */}
-                {classItem.status === "Live" ? (
+                {classItem.status === "Ongoing" ? (
                   <FaVideo className="text-red-400 text-5xl mb-4 mx-auto" />
                 ) : (
                   <FaBookOpen className="text-yellow-400 text-5xl mb-4 mx-auto" />
@@ -240,7 +231,7 @@ const OnlineClasses = () => {
                   className="mt-4 bg-yellow-500 text-gray-900 font-semibold px-5 py-2 rounded-lg hover:bg-yellow-600 transition w-full"
                   onClick={() => router.push(`/online-classes/${classItem.id}`)}
                 >
-                  {classItem.status === "Live" ? `🎥 ${t('join_live')}` : `📘 ${t('view_class')}`}
+                  {classItem.status === "Ongoing" ? `🎥 ${t('join_live')}` : `📘 ${t('view_class')}`}
                 </button>
               </motion.div>
             ))}


### PR DESCRIPTION
## Summary
- use shared `computeScheduleStatus` utility in OnlineClasses component
- remove local schedule-status function and adjust logic for 'Ongoing' classes

## Testing
- `npm test` *(fails: Cannot find module ../../services/instructor/subscriptionService, and _cacheService.clearCache.mockReset is not a function)*
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b0e73f188328a92c6bb775822264