### PR TITLE
feat: add media uploader hook

### DIFF
--- a/frontend/src/hooks/useMediaUploader.js
+++ b/frontend/src/hooks/useMediaUploader.js
@@ -1,0 +1,134 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+const DEFAULT_MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+const DEFAULT_MAX_VIDEO_SIZE = 100 * 1024 * 1024; // 100MB
+
+/**
+ * Hook to handle image and video uploads with progress tracking.
+ * Accepts optional translation function `t`, error handler `onError`,
+ * callbacks for when media is selected, and an optional `uploadFn` for
+ * performing the actual upload.
+ */
+export default function useMediaUploader({
+  t,
+  onError,
+  onImageSelect,
+  onVideoSelect,
+  uploadFn,
+  maxImageSize = DEFAULT_MAX_IMAGE_SIZE,
+  maxVideoSize = DEFAULT_MAX_VIDEO_SIZE,
+} = {}) {
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [imageUploading, setImageUploading] = useState(false);
+  const [videoUploading, setVideoUploading] = useState(false);
+  const videoIntervalRef = useRef(null);
+  const videoUrlRef = useRef(null);
+
+  const handleImageUpload = useCallback(
+    (e) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      if (file.size > maxImageSize) {
+        onError?.(t ? t('image_size_exceeded') : 'Image size exceeded');
+        return;
+      }
+
+      setImageUploading(true);
+      setUploadProgress(0);
+
+      if (uploadFn) {
+        uploadFn(file, 'image', setUploadProgress)
+          .then((url) => {
+            onImageSelect?.(file, url);
+          })
+          .catch(() => {
+            onError?.(t ? t('upload_failed') : 'Upload failed');
+          })
+          .finally(() => {
+            setImageUploading(false);
+          });
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onprogress = (event) => {
+        if (event.lengthComputable) {
+          const percent = Math.round((event.loaded / event.total) * 100);
+          setUploadProgress(percent);
+        }
+      };
+      reader.onloadend = () => {
+        onImageSelect?.(file, reader.result);
+        setImageUploading(false);
+      };
+      reader.onerror = () => {
+        onError?.(t ? t('image_preview_failed') : 'Failed to load image preview.');
+        setImageUploading(false);
+      };
+      reader.readAsDataURL(file);
+    },
+    [maxImageSize, onError, onImageSelect, t, uploadFn]
+  );
+
+  const handleVideoUpload = useCallback(
+    (e) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      if (file.size > maxVideoSize) {
+        onError?.(t ? t('video_size_exceeded') : 'Video size exceeded');
+        return;
+      }
+
+      setVideoUploading(true);
+      setUploadProgress(0);
+
+      if (uploadFn) {
+        uploadFn(file, 'video', setUploadProgress)
+          .then((url) => {
+            onVideoSelect?.(file, url);
+          })
+          .catch(() => {
+            onError?.(t ? t('upload_failed') : 'Upload failed');
+          })
+          .finally(() => {
+            setVideoUploading(false);
+          });
+        return;
+      }
+
+      if (videoIntervalRef.current) clearInterval(videoIntervalRef.current);
+      videoIntervalRef.current = setInterval(() => {
+        setUploadProgress((prev) => {
+          if (prev >= 100) {
+            if (videoIntervalRef.current) clearInterval(videoIntervalRef.current);
+            videoUrlRef.current = URL.createObjectURL(file);
+            onVideoSelect?.(file, videoUrlRef.current);
+            setVideoUploading(false);
+            return 100;
+          }
+          return prev + 10;
+        });
+      }, 300);
+    },
+    [maxVideoSize, onError, onVideoSelect, t, uploadFn]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (videoIntervalRef.current) clearInterval(videoIntervalRef.current);
+      if (videoUrlRef.current) URL.revokeObjectURL(videoUrlRef.current);
+    };
+  }, []);
+
+  return {
+    uploadProgress,
+    imageUploading,
+    videoUploading,
+    handleImageUpload,
+    handleVideoUpload,
+    setUploadProgress,
+  };
+}
+

--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -8,7 +8,7 @@
 // Notifications and translations are also integrated.
 // ─────────────────────────────────────────────────────
 
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { toast } from 'react-toastify';
@@ -30,6 +30,7 @@ import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
 import FloatingInput from '@/components/shared/FloatingInput';
 import { toDateTimeISO } from '@/utils/date';
+import useMediaUploader from '@/hooks/useMediaUploader';
 
 const ReactQuill = dynamic(() => import('react-quill'), {
   ssr: false,
@@ -67,16 +68,28 @@ function CreateOnlineClass() {
     lessons: [],
     lessonCount: ''
   });
-  const [uploadProgress, setUploadProgress] = useState(0);
-  const [imageUploading, setImageUploading] = useState(false);
-  const [videoUploading, setVideoUploading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [categories, setCategories] = useState([]);
   const [plans, setPlans] = useState([]);
   const [allTags, setAllTags] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
   const [tagInput, setTagInput] = useState('');
-  const videoIntervalRef = useRef(null);
+
+  const {
+    uploadProgress,
+    imageUploading,
+    videoUploading,
+    handleImageUpload,
+    handleVideoUpload,
+    setUploadProgress,
+  } = useMediaUploader({
+    t,
+    onError: (msg) => toast.error(msg),
+    onImageSelect: (file, preview) =>
+      setFormData((prev) => ({ ...prev, image: file, imagePreview: preview })),
+    onVideoSelect: (file, preview) =>
+      setFormData((prev) => ({ ...prev, demoVideo: file, demoPreview: preview })),
+  });
 
   const filteredTagSuggestions = useMemo(
     () =>
@@ -102,12 +115,6 @@ function CreateOnlineClass() {
   }, []);
 
   useEffect(() => {
-    return () => {
-      if (videoIntervalRef.current) clearInterval(videoIntervalRef.current);
-    };
-  }, []);
-
-  useEffect(() => {
     if (user?.full_name) {
       setFormData((prev) => ({ ...prev, instructor: user.full_name }));
     }
@@ -121,71 +128,6 @@ function CreateOnlineClass() {
     }));
   };
 
-  const handleImageUpload = (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-
-    if (file.size > 5 * 1024 * 1024) {
-      toast.error(t('image_size_exceeded'));
-      return;
-    }
-
-    setImageUploading(true);
-    setUploadProgress(0);
-
-    const reader = new FileReader();
-    reader.onprogress = (event) => {
-      if (event.lengthComputable) {
-        const percent = Math.round((event.loaded / event.total) * 100);
-        setUploadProgress(percent);
-      }
-    };
-    reader.onloadend = () => {
-      setFormData((prev) => ({
-        ...prev,
-        image: file,
-        imagePreview: reader.result
-      }));
-      setImageUploading(false);
-    };
-    reader.onerror = () => {
-      toast.error(t('image_preview_failed'));
-      setImageUploading(false);
-    };
-    reader.readAsDataURL(file);
-  };
-
-  const handleVideoUpload = (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-
-    if (file.size > 100 * 1024 * 1024) {
-      toast.error(t('video_size_exceeded'));
-      return;
-    }
-
-    setVideoUploading(true);
-    setUploadProgress(0);
-
-    // Simulate upload progress (replace with actual upload logic)
-    if (videoIntervalRef.current) clearInterval(videoIntervalRef.current);
-    videoIntervalRef.current = setInterval(() => {
-      setUploadProgress((prev) => {
-        if (prev >= 100) {
-          if (videoIntervalRef.current) clearInterval(videoIntervalRef.current);
-          videoIntervalRef.current = null;
-          setVideoUploading(false);
-          setFormData((prev) => ({
-            ...prev,
-            demoVideo: file,
-            demoPreview: URL.createObjectURL(file),
-          }));
-          return 100;
-        }
-        return prev + 10;
-      });
-    }, 300);
-  };
 
   const addTag = (tag) => {
     if (tag && !selectedTags.includes(tag)) {

--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -18,6 +18,7 @@ import useScheduleStore from '@/store/schedule/scheduleStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import { toDateTimeISO } from '@/utils/date';
 import FloatingInput from '@/components/shared/FloatingInput';
+import useMediaUploader from '@/hooks/useMediaUploader';
 
 const ReactQuill = dynamic(() => import('react-quill'), {
   ssr: false,
@@ -52,14 +53,26 @@ function CreateOnlineClass() {
     lessons: [],
     lessonCount: ''
   });
-  const [uploadProgress, setUploadProgress] = useState(0);
-  const [imageUploading, setImageUploading] = useState(false);
-  const [videoUploading, setVideoUploading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [categories, setCategories] = useState([]);
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
   const [tagInput, setTagInput] = useState('');
+
+  const {
+    uploadProgress,
+    imageUploading,
+    videoUploading,
+    handleImageUpload,
+    handleVideoUpload,
+    setUploadProgress,
+  } = useMediaUploader({
+    onError: (msg) => toast.error(msg),
+    onImageSelect: (file, preview) =>
+      setFormData((prev) => ({ ...prev, image: file, imagePreview: preview })),
+    onVideoSelect: (file, preview) =>
+      setFormData((prev) => ({ ...prev, demoVideo: file, demoPreview: preview })),
+  });
 
   useEffect(() => {
     fetchAllCategories({ status: 'active', limit: 100 })
@@ -102,69 +115,6 @@ function CreateOnlineClass() {
     }));
   };
 
-  const handleImageUpload = (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-
-    if (file.size > 5 * 1024 * 1024) {
-      toast.error('Image must be less than 5MB');
-      return;
-    }
-
-    setImageUploading(true);
-    setUploadProgress(0);
-
-    const reader = new FileReader();
-    reader.onprogress = (event) => {
-      if (event.lengthComputable) {
-        const percent = Math.round((event.loaded / event.total) * 100);
-        setUploadProgress(percent);
-      }
-    };
-    reader.onloadend = () => {
-      setFormData((prev) => ({
-        ...prev,
-        image: file,
-        imagePreview: reader.result
-      }));
-      setImageUploading(false);
-    };
-    reader.onerror = () => {
-      toast.error('Failed to load image preview.');
-      setImageUploading(false);
-    };
-    reader.readAsDataURL(file);
-  };
-
-  const handleVideoUpload = (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-
-    if (file.size > 100 * 1024 * 1024) {
-      toast.error('Video must be less than 100MB');
-      return;
-    }
-
-    setVideoUploading(true);
-    setUploadProgress(0);
-
-    // Simulate upload progress (replace with actual upload logic)
-    const interval = setInterval(() => {
-      setUploadProgress(prev => {
-        if (prev >= 100) {
-          clearInterval(interval);
-          setVideoUploading(false);
-          setFormData(prev => ({
-            ...prev,
-            demoVideo: file,
-            demoPreview: URL.createObjectURL(file)
-          }));
-          return 100;
-        }
-        return prev + 10;
-      });
-    }, 300);
-  };
 
   const addTag = (tag) => {
     if (tag && !selectedTags.includes(tag)) {


### PR DESCRIPTION
## Summary
- add `useMediaUploader` hook for image and video uploads with progress and optional server callback
- use `useMediaUploader` in admin and instructor online class creation pages

## Testing
- `npm test -- --silent` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b0ea9bcc8328bb7715bc6ccb5d9a