### PR TITLE
Use refs to manage upload intervals

### DIFF
--- a/frontend/src/components/profile/steps/FinalReview.js
+++ b/frontend/src/components/profile/steps/FinalReview.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaArrowLeft, FaCheckCircle, FaUpload, FaExclamationTriangle, FaPlayCircle, FaTrash } from "react-icons/fa";
 import logger from "@/utils/logger";
@@ -8,6 +8,15 @@ const FinalReview = ({ formData, prevStep }) => {
   const [demoVideo, setDemoVideo] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [submitted, setSubmitted] = useState(false);
+  const uploadIntervalRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (uploadIntervalRef.current) {
+        clearInterval(uploadIntervalRef.current);
+      }
+    };
+  }, []);
 
   // ✅ Handle Demo Video Upload with Progress Simulation
   const handleVideoUpload = (e) => {
@@ -29,12 +38,19 @@ const FinalReview = ({ formData, prevStep }) => {
     setDemoVideo(file.name);
     setUploadProgress(0);
 
+    if (uploadIntervalRef.current) {
+      clearInterval(uploadIntervalRef.current);
+    }
+
     // 🔹 Simulating Upload Progress
     let progress = 0;
-    const interval = setInterval(() => {
+    uploadIntervalRef.current = setInterval(() => {
       progress += 10;
       setUploadProgress(progress);
-      if (progress >= 100) clearInterval(interval);
+      if (progress >= 100) {
+        clearInterval(uploadIntervalRef.current);
+        uploadIntervalRef.current = null;
+      }
     }, 300);
   };
 
@@ -42,6 +58,10 @@ const FinalReview = ({ formData, prevStep }) => {
   const removeVideo = () => {
     setDemoVideo(null);
     setUploadProgress(0);
+    if (uploadIntervalRef.current) {
+      clearInterval(uploadIntervalRef.current);
+      uploadIntervalRef.current = null;
+    }
   };
 
   // ✅ Handle Submission

--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -1,6 +1,6 @@
 
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { toast } from 'react-toastify';
@@ -60,6 +60,7 @@ function CreateOnlineClass() {
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
   const [tagInput, setTagInput] = useState('');
+  const videoIntervalRef = useRef(null);
 
   useEffect(() => {
     fetchAllCategories({ status: 'active', limit: 100 })
@@ -93,6 +94,14 @@ function CreateOnlineClass() {
       setFormData((prev) => ({ ...prev, instructor: user.full_name }));
     }
   }, [user]);
+
+  useEffect(() => {
+    return () => {
+      if (videoIntervalRef.current) {
+        clearInterval(videoIntervalRef.current);
+      }
+    };
+  }, []);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -148,11 +157,18 @@ function CreateOnlineClass() {
     setVideoUploading(true);
     setUploadProgress(0);
 
+    if (videoIntervalRef.current) {
+      clearInterval(videoIntervalRef.current);
+    }
+
     // Simulate upload progress (replace with actual upload logic)
-    const interval = setInterval(() => {
+    videoIntervalRef.current = setInterval(() => {
       setUploadProgress(prev => {
         if (prev >= 100) {
-          clearInterval(interval);
+          if (videoIntervalRef.current) {
+            clearInterval(videoIntervalRef.current);
+            videoIntervalRef.current = null;
+          }
           setVideoUploading(false);
           setFormData(prev => ({
             ...prev,

--- a/frontend/src/pages/dashboard/instructor/profile/steps/FinalReview.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/FinalReview.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaArrowLeft, FaCheckCircle, FaUpload, FaExclamationTriangle, FaPlayCircle, FaTrash } from "react-icons/fa";
 import logger from "@/utils/logger";
@@ -8,6 +8,15 @@ const FinalReview = ({ formData = {}, prevStep = () => {} }) => {
   const [demoVideo, setDemoVideo] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [submitted, setSubmitted] = useState(false);
+  const uploadIntervalRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (uploadIntervalRef.current) {
+        clearInterval(uploadIntervalRef.current);
+      }
+    };
+  }, []);
 
   // ✅ Handle Demo Video Upload with Progress Simulation
   const handleVideoUpload = (e) => {
@@ -29,12 +38,19 @@ const FinalReview = ({ formData = {}, prevStep = () => {} }) => {
     setDemoVideo(file.name);
     setUploadProgress(0);
 
+    if (uploadIntervalRef.current) {
+      clearInterval(uploadIntervalRef.current);
+    }
+
     // 🔹 Simulating Upload Progress
     let progress = 0;
-    const interval = setInterval(() => {
+    uploadIntervalRef.current = setInterval(() => {
       progress += 10;
       setUploadProgress(progress);
-      if (progress >= 100) clearInterval(interval);
+      if (progress >= 100) {
+        clearInterval(uploadIntervalRef.current);
+        uploadIntervalRef.current = null;
+      }
     }, 300);
   };
 
@@ -42,6 +58,10 @@ const FinalReview = ({ formData = {}, prevStep = () => {} }) => {
   const removeVideo = () => {
     setDemoVideo(null);
     setUploadProgress(0);
+    if (uploadIntervalRef.current) {
+      clearInterval(uploadIntervalRef.current);
+      uploadIntervalRef.current = null;
+    }
   };
 
   // ✅ Handle Submission


### PR DESCRIPTION
## Summary
- manage video upload progress intervals with `useRef`
- clear intervals on unmount or new uploads in FinalReview and class creation pages

## Testing
- `npx jest src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js')*


------
https://chatgpt.com/codex/tasks/task_e_68c5b0eb6e7083289ff3a0a8f3ea5578