### PR TITLE
Handle enrolled class load errors and memoize filtering

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/index.js
+++ b/frontend/src/pages/dashboard/student/online-classes/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import Link from 'next/link';
 import {
   FaChalkboardTeacher,
@@ -24,30 +24,46 @@ export default function MyEnrolledClassesPage() {
   const [visibleCount, setVisibleCount] = useState(6);
   const [search, setSearch] = useState('');
   const [sortOrder, setSortOrder] = useState('asc');
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const load = async () => {
       try {
         const list = await fetchMyEnrolledClasses();
         setClasses(list);
+        setError(null);
       } catch (err) {
         console.error('Failed to load classes', err);
+        toast.error('Failed to load classes');
+        setError('Failed to load classes');
       }
     };
     load();
   }, []);
 
-  const filteredClasses = classes
-    .filter(cls => filter === 'all' || cls.scheduleStatus.toLowerCase() === filter)
-    .filter(cls => cls.title.toLowerCase().includes(search.toLowerCase()))
-    .sort((a, b) => {
-      const dateA = new Date(a.startDate);
-      const dateB = new Date(b.startDate);
-      return sortOrder === 'asc' ? dateA - dateB : dateB - dateA;
-    });
+  const filteredClasses = useMemo(() => {
+    return classes
+      .filter(cls => filter === 'all' || cls.scheduleStatus.toLowerCase() === filter)
+      .filter(cls => cls.title.toLowerCase().includes(search.toLowerCase()))
+      .sort((a, b) => {
+        const dateA = new Date(a.startDate);
+        const dateB = new Date(b.startDate);
+        return sortOrder === 'asc' ? dateA - dateB : dateB - dateA;
+      });
+  }, [classes, filter, search, sortOrder]);
 
   const visibleClasses = filteredClasses.slice(0, visibleCount);
   const hasMore = visibleCount < filteredClasses.length;
+
+  if (error) {
+    return (
+      <StudentLayout>
+        <div className="min-h-screen px-6 py-10 bg-white text-gray-900">
+          <p className="text-center text-red-500">{error}</p>
+        </div>
+      </StudentLayout>
+    );
+  }
 
   return (
     <StudentLayout>


### PR DESCRIPTION
## Summary
- memoize filtering of enrolled classes
- display toast and UI message when class fetch fails

## Testing
- `pre-commit run --files frontend/src/pages/dashboard/student/online-classes/index.js` (fails: 327 problems, 56 errors)
- `npm test --prefix frontend` (fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)


------
https://chatgpt.com/codex/tasks/task_e_68c5b0ecf6788328bb6f90cdbe8a6d2a