### PR TITLE
Sanitize class description with DOMPurify

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -53,6 +53,10 @@ Visit `/admin/alerts` while logged in as an admin to monitor recent warnings and
 
 The invoice page allows students selecting bank transfer to upload payment proof. Files are sent to the backend `POST /api/payments/student/receipts` endpoint.
 
+### HTML Sanitization
+
+User-provided HTML such as class descriptions is sanitized with [DOMPurify](https://github.com/cure53/DOMPurify) before rendering. This prevents cross-site scripting by stripping all markup and dangerous attributes.
+
 ## Resources
 
 - [Next.js Documentation](https://nextjs.org/docs) – learn about Next.js features and API.

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -18,6 +18,7 @@ import useCartStore from '@/store/cart/cartStore';
 import useAuthStore from '@/store/auth/authStore';
 import { toast } from 'react-toastify';
 import { useTranslation } from 'next-i18next';
+import DOMPurify from 'isomorphic-dompurify';
 import ClassReviews from '@/components/online-classes/detail/ClassReviews';
 import ClassComments from '@/components/online-classes/detail/ClassComments';
 
@@ -216,7 +217,7 @@ export default function ClassDetailsPage() {
 
   const shareUrl = typeof window !== 'undefined' ? window.location.href : '';
   const plainDescription = classInfo.description
-    ? classInfo.description.replace(/<[^>]*>/g, '')
+    ? DOMPurify.sanitize(classInfo.description, { ALLOWED_TAGS: [] })
     : '';
   const classFull =
     typeof classInfo.spots_left === 'number' && classInfo.spots_left <= 0;

--- a/frontend/src/tests/__tests__/ClassDetailSanitization.test.js
+++ b/frontend/src/tests/__tests__/ClassDetailSanitization.test.js
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { id: '1' }, back: jest.fn(), push: jest.fn() }),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('../../components/website/sections/Navbar', () => () => <div />);
+jest.mock('../../components/website/sections/Footer', () => () => <div />);
+jest.mock('../../components/shared/CustomVideoPlayer', () => () => <div />);
+jest.mock('../../components/online-classes/detail/ClassReviews', () => () => <div />);
+jest.mock('../../components/online-classes/detail/ClassComments', () => () => <div />);
+
+const addItemMock = jest.fn();
+jest.mock('../../store/cart/cartStore', () => ({
+  __esModule: true,
+  default: (selector) => selector({ addItem: addItemMock }),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: { info: jest.fn(), error: jest.fn(), success: jest.fn() },
+}));
+
+jest.mock('../../store/auth/authStore', () => ({
+  __esModule: true,
+  default: () => ({ user: null, isAuthenticated: () => false }),
+}));
+
+const mockFetchDetails = jest.fn();
+const mockFetchReviews = jest.fn();
+jest.mock('../../services/classService', () => ({
+  enrollInClass: jest.fn(),
+  fetchClassDetails: (...args) => mockFetchDetails(...args),
+  fetchMyEnrolledClasses: jest.fn(),
+  addClassToWishlist: jest.fn(),
+  removeClassFromWishlist: jest.fn(),
+  getMyClassWishlist: jest.fn(),
+  fetchClassReviews: (...args) => mockFetchReviews(...args),
+}));
+
+import ClassDetailsPage from '@/pages/online-classes/[id]';
+
+test('sanitizes class description before rendering', async () => {
+  const dirty = '<p>Safe</p><img src=x onerror="alert(1)" /><script>alert(1)</script>';
+  mockFetchDetails.mockResolvedValue({
+    data: {
+      id: 1,
+      title: 'Class',
+      description: dirty,
+      cover_image: '',
+      instructor_image: '',
+      instructor: '',
+      instructor_id: 1,
+      price: 0,
+      demo_video_url: '',
+      start_date: null,
+      end_date: null,
+      spots_left: 5,
+    },
+  });
+  mockFetchReviews.mockResolvedValue([]);
+
+  render(<ClassDetailsPage />);
+  const paragraph = await screen.findByText('Safe');
+  expect(paragraph.innerHTML).toBe('Safe');
+  expect(paragraph.innerHTML).not.toContain('<script>');
+  expect(paragraph.innerHTML).not.toContain('onerror');
+});


### PR DESCRIPTION
## Summary
- sanitize online class descriptions using DOMPurify instead of regex stripping
- document DOMPurify sanitization
- add test to verify class description sanitization

## Testing
- `npm test src/tests/__tests__/ClassDetailSanitization.test.js`
- `npm test` *(fails: TypeError: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService')*
- `npm run lint` *(fails: 61 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b0ef604c8328b2152639e23a7cb3