### PR TITLE
Use dynamic imports for homepage sections

### DIFF
--- a/frontend/src/pages/website/index.js
+++ b/frontend/src/pages/website/index.js
@@ -1,43 +1,36 @@
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useState, useMemo } from "react";
 import { motion } from "framer-motion";
 import { FaArrowUp, FaArrowDown } from "react-icons/fa";
 import Navbar from "@/components/website/sections/Navbar";
-import Hero from "@/components/website/sections/Hero";
-import OnlineClasses from "@/components/website/sections/OnlineClasses";
-import StudyCategories from "@/components/website/sections/StudyCategories";
-import CommunityEngagement from "@/components/website/sections/CommunityEngagement";
-import LearningMarketplace from "@/components/website/sections/LearningMarketplace";
-import StudyGroups from "@/components/website/sections/StudyGroups";
-import InstructorBooking from "@/components/website/sections/InstructorBooking";
-import SubscriptionPlans from "@/components/website/sections/SubscriptionPlans";
-import TutorialsSection from "@/components/website/sections/TutorialsSection";
-import BooksSection from "@/components/website/sections/BooksSection";
-import Footer from "@/components/website/sections/Footer";
-import AITutoring from "@/components/website/sections/AITutoring";
+import dynamic from 'next/dynamic';
 import IncompleteAlertModal from "@/components/auth/IncompleteAlertModal";
 import useAuthStore from "@/store/auth/authStore";
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 
 
+const SectionLoader = () => (
+  <div className="py-10 text-center text-gray-500">Loading...</div>
+);
+
 export default function Home() {
   const { user } = useAuthStore();
   const planRole = user?.role === "instructor" ? "instructor" : "student";
 
-  const sections = [
-    { component: Hero },
-    { component: OnlineClasses },
-    { component: TutorialsSection },
-    { component: BooksSection },
-    { component: LearningMarketplace },
-    { component: StudyCategories },
-    { component: StudyGroups },
-    { component: InstructorBooking },
-    { component: SubscriptionPlans, props: { role: planRole } },
-    { component: AITutoring },
-    { component: CommunityEngagement },
-    { component: Footer }, // ✅ Removed last section before the footer
-  ];
+  const sections = useMemo(() => [
+    { component: dynamic(() => import('@/components/website/sections/Hero'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/OnlineClasses'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/TutorialsSection'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/BooksSection'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/LearningMarketplace'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/StudyCategories'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/StudyGroups'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/InstructorBooking'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/SubscriptionPlans'), { loading: SectionLoader }), props: { role: planRole } },
+    { component: dynamic(() => import('@/components/website/sections/AITutoring'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/CommunityEngagement'), { loading: SectionLoader }) },
+    { component: dynamic(() => import('@/components/website/sections/Footer'), { loading: SectionLoader }) },
+  ], [planRole]);
 
   const sectionRefs = useRef(sections.map(() => useRef(null)));
   const [currentSection, setCurrentSection] = useState(0);

--- a/frontend/src/tests/__tests__/WebsiteHomeScroll.test.js
+++ b/frontend/src/tests/__tests__/WebsiteHomeScroll.test.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Home from '../../pages/website/index';
+
+function createMock(name) {
+  return () => <div>{name}</div>;
+}
+
+jest.mock('../../components/website/sections/Navbar', () => createMock('Navbar'));
+jest.mock('../../components/website/sections/Hero', () => createMock('Hero'));
+jest.mock('../../components/website/sections/OnlineClasses', () => createMock('OnlineClasses'));
+jest.mock('../../components/website/sections/TutorialsSection', () => createMock('TutorialsSection'));
+jest.mock('../../components/website/sections/BooksSection', () => createMock('BooksSection'));
+jest.mock('../../components/website/sections/LearningMarketplace', () => createMock('LearningMarketplace'));
+jest.mock('../../components/website/sections/StudyCategories', () => createMock('StudyCategories'));
+jest.mock('../../components/website/sections/StudyGroups', () => createMock('StudyGroups'));
+jest.mock('../../components/website/sections/InstructorBooking', () => createMock('InstructorBooking'));
+jest.mock('../../components/website/sections/SubscriptionPlans', () => createMock('SubscriptionPlans'));
+jest.mock('../../components/website/sections/AITutoring', () => createMock('AITutoring'));
+jest.mock('../../components/website/sections/CommunityEngagement', () => createMock('CommunityEngagement'));
+jest.mock('../../components/website/sections/Footer', () => createMock('Footer'));
+jest.mock('../../components/auth/IncompleteAlertModal', () => createMock('IncompleteAlertModal'));
+
+jest.mock('../../store/auth/authStore', () => ({
+  __esModule: true,
+  default: () => ({ user: { role: 'student' } }),
+}));
+
+jest.mock('framer-motion', () => {
+  const React = require('react');
+  return {
+    motion: {
+      div: React.forwardRef(({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>{children}</div>
+      )),
+      button: React.forwardRef(({ children, ...props }, ref) => (
+        <button ref={ref} {...props}>{children}</button>
+      )),
+    },
+  };
+});
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+describe('Home page section scrolling', () => {
+  test('clicking the down arrow scrolls to the next section', () => {
+    const { container } = render(<Home />);
+    const sections = container.querySelectorAll('section');
+    expect(sections.length).toBeGreaterThan(1);
+
+    const nextSection = sections[1];
+    const scrollSpy = jest.fn();
+    nextSection.scrollIntoView = scrollSpy;
+
+    const button = container.querySelector('button');
+    fireEvent.click(button);
+
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- convert website homepage sections to use `next/dynamic` with lightweight loading placeholders
- add test ensuring scroll buttons still navigate between dynamically loaded sections

## Testing
- `npm run lint` *(fails: Component definition is missing display name)*
- `npm test` *(fails: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService')*
- `npm test src/tests/__tests__/WebsiteHomeScroll.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5b0f0529c83288fb1e377aa437dfc