### PR TITLE
feat: internationalize dashboard page strings

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -138,6 +138,13 @@
   "user_info_unavailable": "معلومات المستخدم غير متاحة",
   "step_of_total": "الخطوة {{current}} من {{total}}",
   "preview_alt": "معاينة",
+  "dashboardPage": {
+    "progress": "التقدم",
+    "continue_learning": "متابعة التعلم",
+    "ai_recommendations_title": "🤖 توصيات تعتمد على الذكاء الاصطناعي",
+    "category": "الفئة",
+    "view_course": "عرض الدورة"
+  },
   "categoriesPage": {
     "title": "الفئات",
     "new_category": "فئة جديدة",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -138,6 +138,13 @@
   "user_info_unavailable": "User information unavailable",
   "step_of_total": "Step {{current}} of {{total}}",
   "preview_alt": "Preview",
+  "dashboardPage": {
+    "progress": "Fortschritt",
+    "continue_learning": "Weiter lernen",
+    "ai_recommendations_title": "🤖 KI-basierte Empfehlungen",
+    "category": "Kategorie",
+    "view_course": "Kurs ansehen"
+  },
   "categoriesPage": {
     "title": "Categories",
     "new_category": "New Category",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -138,6 +138,13 @@
   "user_info_unavailable": "User information unavailable",
   "step_of_total": "Step {{current}} of {{total}}",
   "preview_alt": "Preview",
+  "dashboardPage": {
+    "progress": "Progress",
+    "continue_learning": "Continue Learning",
+    "ai_recommendations_title": "🤖 AI-Based Recommendations",
+    "category": "Category",
+    "view_course": "View Course"
+  },
   "categoriesPage": {
     "title": "Categories",
     "new_category": "New Category",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -138,6 +138,13 @@
   "user_info_unavailable": "Información del usuario no disponible",
   "step_of_total": "Paso {{actual}} de {{Total}}",
   "preview_alt": "Avance",
+  "dashboardPage": {
+    "progress": "Progreso",
+    "continue_learning": "Continuar aprendiendo",
+    "ai_recommendations_title": "🤖 Recomendaciones basadas en IA",
+    "category": "Categoría",
+    "view_course": "Ver curso"
+  },
   "categoriesPage": {
     "title": "Categorías",
     "new_category": "Nueva categoría",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -138,6 +138,13 @@
   "user_info_unavailable": "Informations utilisateur indisponibles",
   "step_of_total": "Étape {{current}} sur {{total}}",
   "preview_alt": "Aperçu",
+  "dashboardPage": {
+    "progress": "Progression",
+    "continue_learning": "Continuer à apprendre",
+    "ai_recommendations_title": "🤖 Recommandations basées sur l'IA",
+    "category": "Catégorie",
+    "view_course": "Voir le cours"
+  },
   "categoriesPage": {
     "title": "Catégories",
     "new_category": "Nouvelle catégorie",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -138,6 +138,13 @@
   "user_info_unavailable": "उपयोगकर्ता जानकारी अनुपलब्ध है",
   "step_of_total": "{{total}} का चरण {{current}}",
   "preview_alt": "पूर्व दर्शन",
+  "dashboardPage": {
+    "progress": "प्रगति",
+    "continue_learning": "सीखना जारी रखें",
+    "ai_recommendations_title": "🤖 एआई आधारित सिफारिशें",
+    "category": "श्रेणी",
+    "view_course": "कोर्स देखें"
+  },
   "categoriesPage": {
     "title": "श्रेणियां",
     "new_category": "नई श्रेणी",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -138,6 +138,13 @@
   "user_info_unavailable": "Informazioni sull'utente non disponibile",
   "step_of_total": "Passaggio {{current}} di {{total}}",
   "preview_alt": "Anteprima",
+  "dashboardPage": {
+    "progress": "Progresso",
+    "continue_learning": "Continua a imparare",
+    "ai_recommendations_title": "🤖 Raccomandazioni basate sull'IA",
+    "category": "Categoria",
+    "view_course": "Vedi corso"
+  },
   "categoriesPage": {
     "title": "Categorie",
     "new_category": "Nuova categoria",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -138,6 +138,13 @@
   "user_info_unavailable": "用户信息不可用",
   "step_of_total": "第 {{current}} 步，共 {{total}} 步",
   "preview_alt": "预览",
+  "dashboardPage": {
+    "progress": "进度",
+    "continue_learning": "继续学习",
+    "ai_recommendations_title": "🤖 基于AI的推荐",
+    "category": "类别",
+    "view_course": "查看课程"
+  },
   "categoriesPage": {
     "title": "类别",
     "new_category": "新建类别",

--- a/frontend/src/components/dashboard/AIRecommendations.js
+++ b/frontend/src/components/dashboard/AIRecommendations.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import Link from "next/link";
+import { useTranslation } from "next-i18next";
 
 const recommendedCourses = [
   { id: 4, title: "Advanced JavaScript", category: "JavaScript" },
@@ -9,9 +10,12 @@ const recommendedCourses = [
 ];
 
 const AIRecommendations = () => {
+  const { t } = useTranslation('dashboard');
   return (
     <div className="mt-8">
-      <h2 className="text-2xl font-semibold text-yellow-400 mb-4">🤖 AI-Based Recommendations</h2>
+      <h2 className="text-2xl font-semibold text-yellow-400 mb-4">
+        {t('dashboardPage.ai_recommendations_title')}
+      </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         {recommendedCourses.map((course) => (
           <motion.div
@@ -20,13 +24,15 @@ const AIRecommendations = () => {
             whileHover={{ scale: 1.05 }}
           >
             <h3 className="text-xl font-semibold text-yellow-400">{course.title}</h3>
-            <p className="text-gray-300">Category: {course.category}</p>
+            <p className="text-gray-300">
+              {t('dashboardPage.category')}: {course.category}
+            </p>
             <Link href={`/classes/${course.id}/details`}>
               <motion.button
                 whileHover={{ scale: 1.05 }}
                 className="mt-4 bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
               >
-                View Course
+                {t('dashboardPage.view_course')}
               </motion.button>
             </Link>
           </motion.div>

--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -71,7 +71,9 @@ const DashboardPage = () => {
               <h3 className="text-xl font-semibold text-yellow-400">
                 {course.title}
               </h3>
-              <p className="text-gray-300">Progress: {course.progress}%</p>
+              <p className="text-gray-300">
+                {t('dashboardPage.progress')}: {course.progress}%
+              </p>
               <div className="w-full bg-gray-700 rounded-lg overflow-hidden mt-2">
                 <motion.div
                   className="bg-yellow-500 text-black text-center py-1"
@@ -83,7 +85,7 @@ const DashboardPage = () => {
                   whileHover={{ scale: 1.05 }}
                   className="mt-4 bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
                 >
-                  Continue Learning
+                  {t('dashboardPage.continue_learning')}
                 </motion.button>
               </Link>
             </motion.div>


### PR DESCRIPTION
## Summary
- localize dashboard and AI recommendations text using `useTranslation`
- add dashboardPage keys to locale files across languages

## Testing
- `pre-commit run --files frontend/src/pages/dashboard/index.js frontend/src/components/dashboard/AIRecommendations.js frontend/public/locales/en/dashboard.json frontend/public/locales/fr/dashboard.json frontend/public/locales/ar/dashboard.json frontend/public/locales/de/dashboard.json frontend/public/locales/es/dashboard.json frontend/public/locales/hi/dashboard.json frontend/public/locales/it/dashboard.json frontend/public/locales/zh/dashboard.json`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68c5b0f472208328b8c1145e3a250bfb