### PR TITLE
feat: validate media types and show real upload progress

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -8,7 +8,7 @@
 // Notifications and translations are also integrated.
 // ─────────────────────────────────────────────────────
 
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { toast } from 'react-toastify';
@@ -36,6 +36,9 @@ const ReactQuill = dynamic(() => import('react-quill'), {
   loading: () => <div className="h-32 bg-gray-100 animate-pulse rounded"></div>
 });
 import 'react-quill/dist/quill.snow.css';
+
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm', 'video/quicktime'];
 
 function CreateOnlineClass() {
   const router = useRouter();
@@ -76,7 +79,6 @@ function CreateOnlineClass() {
   const [allTags, setAllTags] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
   const [tagInput, setTagInput] = useState('');
-  const videoIntervalRef = useRef(null);
 
   const filteredTagSuggestions = useMemo(
     () =>
@@ -101,11 +103,6 @@ function CreateOnlineClass() {
       .catch(() => setPlans([]));
   }, []);
 
-  useEffect(() => {
-    return () => {
-      if (videoIntervalRef.current) clearInterval(videoIntervalRef.current);
-    };
-  }, []);
 
   useEffect(() => {
     if (user?.full_name) {
@@ -124,6 +121,11 @@ function CreateOnlineClass() {
   const handleImageUpload = (e) => {
     const file = e.target.files[0];
     if (!file) return;
+
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      toast.error(t('invalid_image_type', { defaultValue: 'Unsupported image type' }));
+      return;
+    }
 
     if (file.size > 5 * 1024 * 1024) {
       toast.error(t('image_size_exceeded'));
@@ -159,32 +161,22 @@ function CreateOnlineClass() {
     const file = e.target.files[0];
     if (!file) return;
 
+    if (!ALLOWED_VIDEO_TYPES.includes(file.type)) {
+      toast.error(t('invalid_video_type', { defaultValue: 'Unsupported video type' }));
+      return;
+    }
+
     if (file.size > 100 * 1024 * 1024) {
       toast.error(t('video_size_exceeded'));
       return;
     }
 
-    setVideoUploading(true);
-    setUploadProgress(0);
-
-    // Simulate upload progress (replace with actual upload logic)
-    if (videoIntervalRef.current) clearInterval(videoIntervalRef.current);
-    videoIntervalRef.current = setInterval(() => {
-      setUploadProgress((prev) => {
-        if (prev >= 100) {
-          if (videoIntervalRef.current) clearInterval(videoIntervalRef.current);
-          videoIntervalRef.current = null;
-          setVideoUploading(false);
-          setFormData((prev) => ({
-            ...prev,
-            demoVideo: file,
-            demoPreview: URL.createObjectURL(file),
-          }));
-          return 100;
-        }
-        return prev + 10;
-      });
-    }, 300);
+    setVideoUploading(false);
+    setFormData((prev) => ({
+      ...prev,
+      demoVideo: file,
+      demoPreview: URL.createObjectURL(file),
+    }));
   };
 
   const addTag = (tag) => {
@@ -237,6 +229,7 @@ function CreateOnlineClass() {
       }
       try {
         setIsSubmitting(true);
+        setVideoUploading(true);
         setUploadProgress(0);
 
         const payload = new FormData();
@@ -302,9 +295,10 @@ function CreateOnlineClass() {
         router.push('/dashboard/admin/online-classes');
       } catch (error) {
         console.error(error);
-        toast.error(error.response?.data?.message || t('class_create_failed'));
+        toast.error(error.response?.data?.message || t('upload_failed', { defaultValue: 'Upload failed. Please try again.' }));
       } finally {
         setIsSubmitting(false);
+        setVideoUploading(false);
       }
     }
   };
@@ -620,7 +614,7 @@ function CreateOnlineClass() {
                             )}
                             <input
                               type="file"
-                              accept="image/*"
+                              accept={ALLOWED_IMAGE_TYPES.join(',')}
                               onChange={handleImageUpload}
                               className="hidden"
                             />
@@ -667,7 +661,7 @@ function CreateOnlineClass() {
                             )}
                             <input
                               type="file"
-                              accept="video/*"
+                              accept={ALLOWED_VIDEO_TYPES.join(',')}
                               onChange={handleVideoUpload}
                               className="hidden"
                             />

--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -25,6 +25,9 @@ const ReactQuill = dynamic(() => import('react-quill'), {
 });
 import 'react-quill/dist/quill.snow.css';
 
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm', 'video/quicktime'];
+
 function CreateOnlineClass() {
   const router = useRouter();
   const { user } = useAuthStore();
@@ -106,6 +109,11 @@ function CreateOnlineClass() {
     const file = e.target.files[0];
     if (!file) return;
 
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      toast.error('Unsupported image type');
+      return;
+    }
+
     if (file.size > 5 * 1024 * 1024) {
       toast.error('Image must be less than 5MB');
       return;
@@ -139,31 +147,22 @@ function CreateOnlineClass() {
   const handleVideoUpload = (e) => {
     const file = e.target.files[0];
     if (!file) return;
+    if (!ALLOWED_VIDEO_TYPES.includes(file.type)) {
+      toast.error('Unsupported video type');
+      return;
+    }
 
     if (file.size > 100 * 1024 * 1024) {
       toast.error('Video must be less than 100MB');
       return;
     }
 
-    setVideoUploading(true);
-    setUploadProgress(0);
-
-    // Simulate upload progress (replace with actual upload logic)
-    const interval = setInterval(() => {
-      setUploadProgress(prev => {
-        if (prev >= 100) {
-          clearInterval(interval);
-          setVideoUploading(false);
-          setFormData(prev => ({
-            ...prev,
-            demoVideo: file,
-            demoPreview: URL.createObjectURL(file)
-          }));
-          return 100;
-        }
-        return prev + 10;
-      });
-    }, 300);
+    setVideoUploading(false);
+    setFormData(prev => ({
+      ...prev,
+      demoVideo: file,
+      demoPreview: URL.createObjectURL(file)
+    }));
   };
 
   const addTag = (tag) => {
@@ -217,6 +216,7 @@ function CreateOnlineClass() {
       }
       try {
         setIsSubmitting(true);
+        setVideoUploading(true);
         setUploadProgress(0);
 
         const payload = new FormData();
@@ -278,9 +278,10 @@ function CreateOnlineClass() {
         router.push('/dashboard/instructor/online-classes');
       } catch (error) {
         console.error(error);
-        toast.error(error.response?.data?.message || 'Failed to create class');
+        toast.error(error.response?.data?.message || 'Upload failed. Please try again.');
       } finally {
         setIsSubmitting(false);
+        setVideoUploading(false);
       }
     }
   };
@@ -566,7 +567,7 @@ function CreateOnlineClass() {
                             )}
                             <input
                               type="file"
-                              accept="image/*"
+                              accept={ALLOWED_IMAGE_TYPES.join(',')}
                               onChange={handleImageUpload}
                               className="hidden"
                             />
@@ -613,7 +614,7 @@ function CreateOnlineClass() {
                             )}
                             <input
                               type="file"
-                              accept="video/*"
+                              accept={ALLOWED_VIDEO_TYPES.join(',')}
                               onChange={handleVideoUpload}
                               className="hidden"
                             />


### PR DESCRIPTION
## Summary
- limit online class uploads to specific image and video MIME types
- hook upload progress into network requests instead of simulated timers
- surface errors for failed uploads or unsupported file types

## Testing
- `npm test -- src/tests/__tests__/bookService.test.js`
- `npx eslint src/pages/dashboard/instructor/online-classes/create.js src/pages/dashboard/admin/online-classes/create.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5b0f539788328b0909648902c45be