### PR TITLE
feat: translate student instructor pages

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1345,6 +1345,40 @@
     "purchased_on": "تم شراؤها على {{date}}",
     "no_books": "لا توجد كتب في مكتبتك."
   },
+  "studentInstructorsPage": {
+    "title": "Find Instructors",
+    "search_placeholder": "Search instructors...",
+    "filter_all": "All",
+    "only_available": "Only Available",
+    "sort": {
+      "highest_rated": "Highest Rated",
+      "most_experienced": "Most Experienced"
+    },
+    "loading": "Loading instructors...",
+    "load_error": "Failed to load instructors.",
+    "online": "Online",
+    "verified": "Verified",
+    "book": "Book",
+    "chat": "Chat",
+    "view_profile": "View Profile",
+    "cancel": "Cancel",
+    "favorites_title": "My Favorite Instructors",
+    "favorites_empty": "You haven’t favorited any instructors yet.",
+    "bookings_title": "My Bookings",
+    "bookings_empty": "No bookings yet.",
+    "cancel_confirm": "Are you sure you want to cancel this request?",
+    "status": {
+      "pending": "pending",
+      "approved": "approved",
+      "completed": "completed"
+    },
+    "chat_modal": {
+      "title": "Open Chat",
+      "message": "Start chatting with this instructor now?",
+      "confirm": "Yes, Open Chat",
+      "cancel": "Cancel"
+    }
+  },
   "adminOffersPage": {
     "title": "المسؤول: إدارة جميع العروض",
     "all_roles": "جميع الأدوار",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1359,6 +1359,40 @@
     "purchased_on": "Purchased on {{date}}",
     "no_books": "No books in your library."
   },
+  "studentInstructorsPage": {
+    "title": "Find Instructors",
+    "search_placeholder": "Search instructors...",
+    "filter_all": "All",
+    "only_available": "Only Available",
+    "sort": {
+      "highest_rated": "Highest Rated",
+      "most_experienced": "Most Experienced"
+    },
+    "loading": "Loading instructors...",
+    "load_error": "Failed to load instructors.",
+    "online": "Online",
+    "verified": "Verified",
+    "book": "Book",
+    "chat": "Chat",
+    "view_profile": "View Profile",
+    "cancel": "Cancel",
+    "favorites_title": "My Favorite Instructors",
+    "favorites_empty": "You haven’t favorited any instructors yet.",
+    "bookings_title": "My Bookings",
+    "bookings_empty": "No bookings yet.",
+    "cancel_confirm": "Are you sure you want to cancel this request?",
+    "status": {
+      "pending": "pending",
+      "approved": "approved",
+      "completed": "completed"
+    },
+    "chat_modal": {
+      "title": "Open Chat",
+      "message": "Start chatting with this instructor now?",
+      "confirm": "Yes, Open Chat",
+      "cancel": "Cancel"
+    }
+  },
   "adminOffersPage": {
     "title": "Admin: Manage All Offers",
     "all_roles": "All Roles",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1361,6 +1361,40 @@
     "purchased_on": "Purchased on {{date}}",
     "no_books": "No books in your library."
   },
+  "studentInstructorsPage": {
+    "title": "Find Instructors",
+    "search_placeholder": "Search instructors...",
+    "filter_all": "All",
+    "only_available": "Only Available",
+    "sort": {
+      "highest_rated": "Highest Rated",
+      "most_experienced": "Most Experienced"
+    },
+    "loading": "Loading instructors...",
+    "load_error": "Failed to load instructors.",
+    "online": "Online",
+    "verified": "Verified",
+    "book": "Book",
+    "chat": "Chat",
+    "view_profile": "View Profile",
+    "cancel": "Cancel",
+    "favorites_title": "My Favorite Instructors",
+    "favorites_empty": "You haven’t favorited any instructors yet.",
+    "bookings_title": "My Bookings",
+    "bookings_empty": "No bookings yet.",
+    "cancel_confirm": "Are you sure you want to cancel this request?",
+    "status": {
+      "pending": "pending",
+      "approved": "approved",
+      "completed": "completed"
+    },
+    "chat_modal": {
+      "title": "Open Chat",
+      "message": "Start chatting with this instructor now?",
+      "confirm": "Yes, Open Chat",
+      "cancel": "Cancel"
+    }
+  },
   "adminOffersPage": {
     "title": "Admin: Manage All Offers",
     "all_roles": "All Roles",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1345,6 +1345,40 @@
     "purchased_on": "Comprado en {{date}}",
     "no_books": "No hay libros en tu biblioteca."
   },
+  "studentInstructorsPage": {
+    "title": "Find Instructors",
+    "search_placeholder": "Search instructors...",
+    "filter_all": "All",
+    "only_available": "Only Available",
+    "sort": {
+      "highest_rated": "Highest Rated",
+      "most_experienced": "Most Experienced"
+    },
+    "loading": "Loading instructors...",
+    "load_error": "Failed to load instructors.",
+    "online": "Online",
+    "verified": "Verified",
+    "book": "Book",
+    "chat": "Chat",
+    "view_profile": "View Profile",
+    "cancel": "Cancel",
+    "favorites_title": "My Favorite Instructors",
+    "favorites_empty": "You haven’t favorited any instructors yet.",
+    "bookings_title": "My Bookings",
+    "bookings_empty": "No bookings yet.",
+    "cancel_confirm": "Are you sure you want to cancel this request?",
+    "status": {
+      "pending": "pending",
+      "approved": "approved",
+      "completed": "completed"
+    },
+    "chat_modal": {
+      "title": "Open Chat",
+      "message": "Start chatting with this instructor now?",
+      "confirm": "Yes, Open Chat",
+      "cancel": "Cancel"
+    }
+  },
   "adminOffersPage": {
     "title": "Administrador: Administre todas las ofertas",
     "all_roles": "Todos los roles",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1345,6 +1345,40 @@
     "purchased_on": "Acheté le {{date}}",
     "no_books": "Aucun livre dans votre bibliothèque."
   },
+  "studentInstructorsPage": {
+    "title": "Find Instructors",
+    "search_placeholder": "Search instructors...",
+    "filter_all": "All",
+    "only_available": "Only Available",
+    "sort": {
+      "highest_rated": "Highest Rated",
+      "most_experienced": "Most Experienced"
+    },
+    "loading": "Loading instructors...",
+    "load_error": "Failed to load instructors.",
+    "online": "Online",
+    "verified": "Verified",
+    "book": "Book",
+    "chat": "Chat",
+    "view_profile": "View Profile",
+    "cancel": "Cancel",
+    "favorites_title": "My Favorite Instructors",
+    "favorites_empty": "You haven’t favorited any instructors yet.",
+    "bookings_title": "My Bookings",
+    "bookings_empty": "No bookings yet.",
+    "cancel_confirm": "Are you sure you want to cancel this request?",
+    "status": {
+      "pending": "pending",
+      "approved": "approved",
+      "completed": "completed"
+    },
+    "chat_modal": {
+      "title": "Open Chat",
+      "message": "Start chatting with this instructor now?",
+      "confirm": "Yes, Open Chat",
+      "cancel": "Cancel"
+    }
+  },
   "adminOffersPage": {
     "title": "Admin : Gérer toutes les offres",
     "all_roles": "Tous les rôles",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1345,6 +1345,40 @@
     "purchased_on": "{{date}} पर खरीदा गया",
     "no_books": "आपकी लाइब्रेरी में कोई किताबें नहीं।"
   },
+  "studentInstructorsPage": {
+    "title": "Find Instructors",
+    "search_placeholder": "Search instructors...",
+    "filter_all": "All",
+    "only_available": "Only Available",
+    "sort": {
+      "highest_rated": "Highest Rated",
+      "most_experienced": "Most Experienced"
+    },
+    "loading": "Loading instructors...",
+    "load_error": "Failed to load instructors.",
+    "online": "Online",
+    "verified": "Verified",
+    "book": "Book",
+    "chat": "Chat",
+    "view_profile": "View Profile",
+    "cancel": "Cancel",
+    "favorites_title": "My Favorite Instructors",
+    "favorites_empty": "You haven’t favorited any instructors yet.",
+    "bookings_title": "My Bookings",
+    "bookings_empty": "No bookings yet.",
+    "cancel_confirm": "Are you sure you want to cancel this request?",
+    "status": {
+      "pending": "pending",
+      "approved": "approved",
+      "completed": "completed"
+    },
+    "chat_modal": {
+      "title": "Open Chat",
+      "message": "Start chatting with this instructor now?",
+      "confirm": "Yes, Open Chat",
+      "cancel": "Cancel"
+    }
+  },
   "adminOffersPage": {
     "title": "व्यवस्थापक: सभी ऑफ़र प्रबंधित करें",
     "all_roles": "सभी भूमिकाएँ",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1359,6 +1359,40 @@
     "purchased_on": "Acquistato su {{date}}",
     "no_books": "Nessun libro nella tua biblioteca."
   },
+  "studentInstructorsPage": {
+    "title": "Find Instructors",
+    "search_placeholder": "Search instructors...",
+    "filter_all": "All",
+    "only_available": "Only Available",
+    "sort": {
+      "highest_rated": "Highest Rated",
+      "most_experienced": "Most Experienced"
+    },
+    "loading": "Loading instructors...",
+    "load_error": "Failed to load instructors.",
+    "online": "Online",
+    "verified": "Verified",
+    "book": "Book",
+    "chat": "Chat",
+    "view_profile": "View Profile",
+    "cancel": "Cancel",
+    "favorites_title": "My Favorite Instructors",
+    "favorites_empty": "You haven’t favorited any instructors yet.",
+    "bookings_title": "My Bookings",
+    "bookings_empty": "No bookings yet.",
+    "cancel_confirm": "Are you sure you want to cancel this request?",
+    "status": {
+      "pending": "pending",
+      "approved": "approved",
+      "completed": "completed"
+    },
+    "chat_modal": {
+      "title": "Open Chat",
+      "message": "Start chatting with this instructor now?",
+      "confirm": "Yes, Open Chat",
+      "cancel": "Cancel"
+    }
+  },
   "adminOffersPage": {
     "title": "Amministratore: gestisci tutte le offerte",
     "all_roles": "Tutti i ruoli",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1345,6 +1345,40 @@
     "purchased_on": "在{{date}}上购买",
     "no_books": "您的图书馆没有书籍。"
   },
+  "studentInstructorsPage": {
+    "title": "Find Instructors",
+    "search_placeholder": "Search instructors...",
+    "filter_all": "All",
+    "only_available": "Only Available",
+    "sort": {
+      "highest_rated": "Highest Rated",
+      "most_experienced": "Most Experienced"
+    },
+    "loading": "Loading instructors...",
+    "load_error": "Failed to load instructors.",
+    "online": "Online",
+    "verified": "Verified",
+    "book": "Book",
+    "chat": "Chat",
+    "view_profile": "View Profile",
+    "cancel": "Cancel",
+    "favorites_title": "My Favorite Instructors",
+    "favorites_empty": "You haven’t favorited any instructors yet.",
+    "bookings_title": "My Bookings",
+    "bookings_empty": "No bookings yet.",
+    "cancel_confirm": "Are you sure you want to cancel this request?",
+    "status": {
+      "pending": "pending",
+      "approved": "approved",
+      "completed": "completed"
+    },
+    "chat_modal": {
+      "title": "Open Chat",
+      "message": "Start chatting with this instructor now?",
+      "confirm": "Yes, Open Chat",
+      "cancel": "Cancel"
+    }
+  },
   "adminOffersPage": {
     "title": "管理员：管理所有优惠",
     "all_roles": "所有角色",

--- a/frontend/src/components/student/instructors/BookingCard.js
+++ b/frontend/src/components/student/instructors/BookingCard.js
@@ -1,6 +1,7 @@
 // components/student/instructors/BookingCard.js
 import { FaCalendarAlt, FaComments, FaTimes } from "react-icons/fa";
 import { motion } from "framer-motion";
+import { useTranslation } from "next-i18next";
 
 const statusColors = {
   pending: "bg-yellow-100 text-yellow-700",
@@ -9,6 +10,7 @@ const statusColors = {
 };
 
 export default function BookingCard({ booking, onCancel, onChat }) {
+  const { t } = useTranslation("dashboard", { keyPrefix: "studentInstructorsPage" });
   return (
     <motion.div
       whileHover={{ scale: 1.01 }}
@@ -31,14 +33,14 @@ export default function BookingCard({ booking, onCancel, onChat }) {
 
       <div className="flex items-center gap-3">
         <span className={`text-sm px-3 py-1 rounded-full ${statusColors[booking.status]}`}>
-          {booking.status}
+          {t(`status.${booking.status}`)}
         </span>
 
         <button
           onClick={onChat}
           className="px-3 py-2 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 flex items-center gap-1"
         >
-          <FaComments /> Chat
+          <FaComments /> {t('chat')}
         </button>
 
         {booking.status === "pending" && (
@@ -46,7 +48,7 @@ export default function BookingCard({ booking, onCancel, onChat }) {
             onClick={onCancel}
             className="px-3 py-2 text-sm bg-red-500 text-white rounded hover:bg-red-600 flex items-center gap-1"
           >
-            <FaTimes /> Cancel
+            <FaTimes /> {t('cancel')}
           </button>
         )}
       </div>

--- a/frontend/src/components/student/instructors/ChatRedirectModal.js
+++ b/frontend/src/components/student/instructors/ChatRedirectModal.js
@@ -1,8 +1,10 @@
 // components/student/instructors/ChatRedirectModal.js
 import { motion } from "framer-motion";
-import { FaComments, FaCheck, FaTimes } from "react-icons/fa";
+import { FaComments } from "react-icons/fa";
+import { useTranslation } from "next-i18next";
 
 export default function ChatRedirectModal({ onConfirm, onCancel }) {
+  const { t } = useTranslation("dashboard", { keyPrefix: "studentInstructorsPage.chat_modal" });
   return (
     <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-60 z-50">
       <motion.div
@@ -10,20 +12,20 @@ export default function ChatRedirectModal({ onConfirm, onCancel }) {
         animate={{ scale: 1, opacity: 1 }}
         className="bg-white p-6 rounded-xl max-w-md text-center"
       >
-        <h3 className="text-xl font-bold mb-3">Open Chat</h3>
-        <p className="text-gray-700">Start chatting with this instructor now?</p>
+        <h3 className="text-xl font-bold mb-3">{t('title')}</h3>
+        <p className="text-gray-700">{t('message')}</p>
         <div className="mt-4 flex justify-center gap-4">
           <button
             onClick={onConfirm}
             className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 flex items-center gap-2"
           >
-            <FaComments /> Yes, Open Chat
+            <FaComments /> {t('confirm')}
           </button>
           <button
             onClick={onCancel}
             className="bg-gray-300 text-black px-4 py-2 rounded hover:bg-gray-400"
           >
-            Cancel
+            {t('cancel')}
           </button>
         </div>
       </motion.div>

--- a/frontend/src/components/student/instructors/InstructorCard.js
+++ b/frontend/src/components/student/instructors/InstructorCard.js
@@ -1,20 +1,22 @@
 import { FaStar, FaUserCheck, FaComments, FaHeart, FaCheckCircle } from "react-icons/fa";
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
 
 export default function InstructorCard({ instructor, isFavorite, onToggleFavorite, onBook, onChat }) {
   const router = useRouter();
+  const { t } = useTranslation("dashboard", { keyPrefix: "studentInstructorsPage" });
 
   return (
     <div className="p-5 bg-white rounded-lg shadow border text-center flex flex-col items-center relative">
       {instructor.availableNow && (
         <span className="absolute top-2 right-2 bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full">
-          Online
+          {t('online')}
         </span>
       )}
 
       {instructor.verified && (
         <span className="absolute top-2 left-2 text-green-500 text-xs flex items-center gap-1">
-          <FaCheckCircle /> Verified
+          <FaCheckCircle /> {t('verified')}
         </span>
       )}
 
@@ -61,21 +63,21 @@ export default function InstructorCard({ instructor, isFavorite, onToggleFavorit
           onClick={onBook}
           className="bg-yellow-400 text-black px-4 py-2 rounded-lg text-sm hover:bg-yellow-500"
         >
-          <FaUserCheck className="inline mr-1" /> Book
+          <FaUserCheck className="inline mr-1" /> {t('book')}
         </button>
 
         <button
           onClick={onChat}
           className="bg-blue-500 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-600"
         >
-          <FaComments className="inline mr-1" /> Chat
+          <FaComments className="inline mr-1" /> {t('chat')}
         </button>
 
         <button
           onClick={() => router.push(`/instructors/${instructor.id}`)}
           className="bg-gray-500 text-white px-4 py-2 rounded-lg text-sm hover:bg-gray-600"
         >
-          View Profile
+          {t('view_profile')}
         </button>
 
         <button

--- a/frontend/src/components/student/instructors/InstructorFilters.js
+++ b/frontend/src/components/student/instructors/InstructorFilters.js
@@ -1,5 +1,6 @@
 // components/student/instructors/InstructorFilters.js
 import { FaSearch } from "react-icons/fa";
+import { useTranslation } from "next-i18next";
 
 export default function InstructorFilters({
   categories,
@@ -11,14 +12,15 @@ export default function InstructorFilters({
   searchQuery,
   setSearchQuery,
   onlyAvailable,
-  setOnlyAvailable
+  setOnlyAvailable,
 }) {
+  const { t } = useTranslation("dashboard", { keyPrefix: "studentInstructorsPage" });
   return (
     <div className="flex flex-wrap gap-4 mb-8">
       <div className="relative w-full max-w-xs">
         <input
           type="text"
-          placeholder="Search instructors..."
+          placeholder={t('search_placeholder')}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="w-full p-3 pl-10 rounded-lg border border-gray-300"
@@ -32,7 +34,9 @@ export default function InstructorFilters({
         onChange={(e) => setSelectedCategory(e.target.value)}
       >
         {categories.map((cat) => (
-          <option key={cat} value={cat}>{cat}</option>
+          <option key={cat} value={cat}>
+            {cat === 'all' ? t('filter_all') : cat}
+          </option>
         ))}
       </select>
 
@@ -42,7 +46,9 @@ export default function InstructorFilters({
         onChange={(e) => setSortBy(e.target.value)}
       >
         {sortOptions.map((opt) => (
-          <option key={opt}>{opt}</option>
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
         ))}
       </select>
 
@@ -52,7 +58,7 @@ export default function InstructorFilters({
           checked={onlyAvailable}
           onChange={(e) => setOnlyAvailable(e.target.checked)}
         />
-        Only Available
+        {t('only_available')}
       </label>
     </div>
   );

--- a/frontend/src/pages/dashboard/student/instructors/bookings.js
+++ b/frontend/src/pages/dashboard/student/instructors/bookings.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "next-i18next";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import BookingCard from "@/components/student/instructors/BookingCard";
 import {
@@ -7,6 +8,7 @@ import {
 } from "@/services/student/bookingService";
 
 export default function StudentBookings() {
+  const { t } = useTranslation("dashboard", { keyPrefix: "studentInstructorsPage" });
   const [bookings, setBookings] = useState([]);
 
   useEffect(() => {
@@ -18,7 +20,7 @@ export default function StudentBookings() {
   }, []);
 
   const handleCancel = async (id) => {
-    const confirm = window.confirm("Are you sure you want to cancel this request?");
+    const confirm = window.confirm(t('cancel_confirm'));
     if (confirm) {
       await deleteStudentBooking(id);
       setBookings((prev) => prev.filter((b) => b.id !== id));
@@ -32,10 +34,10 @@ export default function StudentBookings() {
   return (
     <StudentLayout>
       <section className="py-10 px-4">
-        <h1 className="text-2xl font-bold mb-6">My Bookings</h1>
+        <h1 className="text-2xl font-bold mb-6">{t('bookings_title')}</h1>
 
         {bookings.length === 0 ? (
-          <p className="text-gray-600 text-center">No bookings yet.</p>
+          <p className="text-gray-600 text-center">{t('bookings_empty')}</p>
         ) : (
           <div className="space-y-4">
             {bookings.map((b) => (

--- a/frontend/src/pages/dashboard/student/instructors/favorites.js
+++ b/frontend/src/pages/dashboard/student/instructors/favorites.js
@@ -1,6 +1,7 @@
 // pages/dashboard/student/instructors/favorites.js
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import InstructorCard from "@/components/student/instructors/InstructorCard";
 
@@ -31,6 +32,7 @@ const allInstructors = [
 
 export default function StudentFavorites() {
   const router = useRouter();
+  const { t } = useTranslation("dashboard", { keyPrefix: "studentInstructorsPage" });
   const [favorites, setFavorites] = useState([]);
   const [bookingInstructor, setBookingInstructor] = useState(null);
   const [chatInstructorId, setChatInstructorId] = useState(null);
@@ -53,10 +55,10 @@ export default function StudentFavorites() {
   return (
     <StudentLayout>
       <section className="py-10 px-4">
-        <h1 className="text-2xl font-bold mb-6">My Favorite Instructors</h1>
+        <h1 className="text-2xl font-bold mb-6">{t('favorites_title')}</h1>
 
         {favoriteInstructors.length === 0 ? (
-          <p className="text-gray-600 text-center">You haven’t favorited any instructors yet.</p>
+          <p className="text-gray-600 text-center">{t('favorites_empty')}</p>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {favoriteInstructors.map((i) => (

--- a/frontend/src/pages/dashboard/student/instructors/index.js
+++ b/frontend/src/pages/dashboard/student/instructors/index.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import InstructorCard from "@/components/student/instructors/InstructorCard";
 import InstructorFilters from "@/components/student/instructors/InstructorFilters";
@@ -7,18 +8,21 @@ import BookingRequestModal from "@/components/student/instructors/BookingRequest
 import ChatRedirectModal from "@/components/student/instructors/ChatRedirectModal";
 import { fetchPublicInstructors } from "@/services/public/instructorService";
 
-const sortOptions = ["Highest Rated", "Most Experienced"];
-
 export default function StudentInstructorsAll() {
   const router = useRouter();
+  const { t } = useTranslation("dashboard", { keyPrefix: "studentInstructorsPage" });
   const [instructors, setInstructors] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState("All");
+  const [selectedCategory, setSelectedCategory] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [favorites, setFavorites] = useState([]);
-  const [sortBy, setSortBy] = useState("Highest Rated");
+  const [sortBy, setSortBy] = useState("highest_rated");
   const [onlyAvailable, setOnlyAvailable] = useState(false);
+  const sortOptions = [
+    { value: "highest_rated", label: t("sort.highest_rated") },
+    { value: "most_experienced", label: t("sort.most_experienced") },
+  ];
 
   const [bookingInstructor, setBookingInstructor] = useState(null);
   const [chatInstructorId, setChatInstructorId] = useState(null);
@@ -48,13 +52,13 @@ export default function StudentInstructorsAll() {
         setInstructors(mapped);
       } catch (err) {
         console.error("Failed to load instructors", err);
-        setError("Failed to load instructors.");
+        setError(t("load_error"));
       } finally {
         setLoading(false);
       }
     };
     load();
-  }, []);
+  }, [t]);
 
   const toggleFavorite = (id) => {
     const updated = favorites.includes(id)
@@ -64,7 +68,7 @@ export default function StudentInstructorsAll() {
     localStorage.setItem("favorites", JSON.stringify(updated));
   };
   const categories = useMemo(
-    () => ["All", ...new Set(instructors.flatMap((i) => i.tags))],
+    () => ["all", ...new Set(instructors.flatMap((i) => i.tags))],
     [instructors]
   );
 
@@ -72,12 +76,12 @@ export default function StudentInstructorsAll() {
     .filter(
       (i) =>
         (!onlyAvailable || i.availableNow) &&
-        (selectedCategory === "All" || i.tags.includes(selectedCategory)) &&
+        (selectedCategory === "all" || i.tags.includes(selectedCategory)) &&
         i.name.toLowerCase().includes(searchQuery.toLowerCase())
     )
     .sort((a, b) => {
-      if (sortBy === "Highest Rated") return b.rating - a.rating;
-      if (sortBy === "Most Experienced") {
+      if (sortBy === "highest_rated") return b.rating - a.rating;
+      if (sortBy === "most_experienced") {
         const getYears = (exp) => parseInt(exp);
         return getYears(b.experience) - getYears(a.experience);
       }
@@ -87,7 +91,7 @@ export default function StudentInstructorsAll() {
   return (
     <StudentLayout>
       <section className="py-10 px-4">
-        <h1 className="text-2xl font-bold mb-6">Find Instructors</h1>
+        <h1 className="text-2xl font-bold mb-6">{t('title')}</h1>
 
         <InstructorFilters
           categories={categories}
@@ -104,7 +108,7 @@ export default function StudentInstructorsAll() {
 
         {error && <p className="text-red-500 mb-4">{error}</p>}
         {loading ? (
-          <p>Loading instructors...</p>
+          <p>{t('loading')}</p>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {filtered.map((i) => (


### PR DESCRIPTION
## Summary
- add `useTranslation` to student instructor listings, favorites, and bookings
- localize instructor-related UI components
- extend dashboard locale files with instructor list keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b0f6aad883289f3b5bd8d276f234