### PR TITLE
feat: debounce class tag fetching

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -1,11 +1,12 @@
 
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { toast } from 'react-toastify';
 import { FaTrash, FaSpinner, FaUpload, FaCheck } from 'react-icons/fa';
 import { motion, AnimatePresence } from 'framer-motion';
+import debounce from 'lodash/debounce';
 
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import withAuthProtection from '@/hooks/withAuthProtection';
@@ -67,26 +68,31 @@ function CreateOnlineClass() {
       .catch(() => setCategories([]));
   }, []);
 
+  const debouncedFetchTags = useMemo(
+    () =>
+      debounce(async (input) => {
+        try {
+          const tags = await fetchClassTags(input);
+          const filtered = tags.filter((t) => !selectedTags.includes(t.name));
+          setTagSuggestions(filtered);
+        } catch {
+          setTagSuggestions([]);
+        }
+      }, 300),
+    [selectedTags]
+  );
+
   useEffect(() => {
     if (!tagInput) {
       setTagSuggestions([]);
+      debouncedFetchTags.cancel();
       return;
     }
-    let ignore = false;
-    fetchClassTags(tagInput)
-      .then((tags) => {
-        if (!ignore) {
-          const filtered = tags.filter((t) => !selectedTags.includes(t.name));
-          setTagSuggestions(filtered);
-        }
-      })
-      .catch(() => {
-        if (!ignore) setTagSuggestions([]);
-      });
+    debouncedFetchTags(tagInput);
     return () => {
-      ignore = true;
+      debouncedFetchTags.cancel();
     };
-  }, [tagInput, selectedTags]);
+  }, [tagInput, debouncedFetchTags]);
 
   useEffect(() => {
     if (user?.full_name) {


### PR DESCRIPTION
## Summary
- debounce class tag search calls on instructor class creation to reduce request spam

## Testing
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService' in InstructorSettingsPage.test.js; _cacheService.clearCache.mockReset is not a function in CacheManager.test.tsx)*
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b0f840d8832899a6d11e500f0107