### PR TITLE
Handle Notify Me subscriptions for upcoming classes

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/index.js
+++ b/frontend/src/pages/dashboard/student/online-classes/index.js
@@ -37,6 +37,16 @@ export default function MyEnrolledClassesPage() {
     load();
   }, []);
 
+  const handleNotify = async (classId) => {
+    try {
+      await subscribeToClassReminder(classId);
+      toast.success('Subscribed to class reminder');
+    } catch (err) {
+      console.error('Failed to subscribe to class reminder', err);
+      toast.error('Failed to subscribe to reminder');
+    }
+  };
+
   const filteredClasses = classes
     .filter(cls => filter === 'all' || cls.scheduleStatus.toLowerCase() === filter)
     .filter(cls => cls.title.toLowerCase().includes(search.toLowerCase()))
@@ -131,7 +141,10 @@ export default function MyEnrolledClassesPage() {
                 </span>
 
                 {cls.scheduleStatus === 'Upcoming' && (
-                  <button className="text-xs text-blue-600 underline mb-2 flex items-center gap-1">
+                  <button
+                    onClick={() => handleNotify(cls.id)}
+                    className="text-xs text-blue-600 underline mb-2 flex items-center gap-1"
+                  >
                     <FaBell /> Notify Me
                   </button>
                 )}


### PR DESCRIPTION
## Summary
- call `subscribeToClassReminder` when students click "Notify Me" on upcoming classes
- show toast feedback for successful/failed reminder subscriptions

## Testing
- `pre-commit run --files frontend/src/pages/dashboard/student/online-classes/index.js` *(fails: 327 problems (56 errors))*
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b0f913d883288db9f1e0fd187dd8