### PR TITLE
Align class filters with backend status and robust date sorting

### DIFF
--- a/frontend/src/components/website/sections/OnlineClasses.js
+++ b/frontend/src/components/website/sections/OnlineClasses.js
@@ -30,7 +30,7 @@ const computeStatus = (start, end) => {
   const s = start ? new Date(start) : null;
   const e = end ? new Date(end) : null;
   if (s && now < s) return "Upcoming";
-  if (s && (!e || now <= e) && now >= s) return "Live";
+  if (s && (!e || now <= e) && now >= s) return "Ongoing";
   if (e && now > e) return "Completed";
   return "Upcoming";
 };
@@ -95,7 +95,7 @@ const OnlineClasses = () => {
       (selectedCategory === "All" ||
         (selectedCategory === "Trending" && classItem.trending) ||
         classItem.category === selectedCategory) &&
-      (showLiveClasses ? classItem.status === "Live" : true) &&
+      (showLiveClasses ? classItem.status === "Ongoing" : true) &&
       classItem.title?.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
@@ -210,7 +210,7 @@ const OnlineClasses = () => {
                   )}
                   <span
                     className={`px-3 py-1 text-xs font-bold rounded-full ${
-                      classItem.status === "Live"
+                      classItem.status === "Ongoing"
                         ? "bg-red-500 text-white animate-pulse"
                         : classItem.status === "Completed"
                         ? "bg-gray-600 text-white"
@@ -222,7 +222,7 @@ const OnlineClasses = () => {
                 </div>
 
                 {/* Icon */}
-                {classItem.status === "Live" ? (
+                {classItem.status === "Ongoing" ? (
                   <FaVideo className="text-red-400 text-5xl mb-4 mx-auto" />
                 ) : (
                   <FaBookOpen className="text-yellow-400 text-5xl mb-4 mx-auto" />
@@ -240,7 +240,7 @@ const OnlineClasses = () => {
                   className="mt-4 bg-yellow-500 text-gray-900 font-semibold px-5 py-2 rounded-lg hover:bg-yellow-600 transition w-full"
                   onClick={() => router.push(`/online-classes/${classItem.id}`)}
                 >
-                  {classItem.status === "Live" ? `🎥 ${t('join_live')}` : `📘 ${t('view_class')}`}
+                  {classItem.status === "Ongoing" ? `🎥 ${t('join_live')}` : `📘 ${t('view_class')}`}
                 </button>
               </motion.div>
             ))}

--- a/frontend/src/pages/dashboard/student/online-classes/index.js
+++ b/frontend/src/pages/dashboard/student/online-classes/index.js
@@ -38,11 +38,17 @@ export default function MyEnrolledClassesPage() {
   }, []);
 
   const filteredClasses = classes
-    .filter(cls => filter === 'all' || cls.scheduleStatus.toLowerCase() === filter)
-    .filter(cls => cls.title.toLowerCase().includes(search.toLowerCase()))
+    .filter(
+      (cls) => filter === 'all' || cls.scheduleStatus?.toLowerCase() === filter,
+    )
+    .filter((cls) => (cls.title || '').toLowerCase().includes(search.toLowerCase()))
     .sort((a, b) => {
-      const dateA = new Date(a.startDate);
-      const dateB = new Date(b.startDate);
+      const dateA = new Date(
+        a.start_date || a.startDate || a.end_date || a.endDate || 0,
+      );
+      const dateB = new Date(
+        b.start_date || b.startDate || b.end_date || b.endDate || 0,
+      );
       return sortOrder === 'asc' ? dateA - dateB : dateB - dateA;
     });
 
@@ -76,7 +82,7 @@ export default function MyEnrolledClassesPage() {
 
         {/* Filters */}
         <div className="flex gap-4 mb-8 flex-wrap">
-          {['all', 'live', 'upcoming', 'completed'].map((status) => (
+          {['all', 'ongoing', 'upcoming', 'completed'].map((status) => (
             <button
               key={status}
               onClick={() => setFilter(status)}
@@ -89,7 +95,9 @@ export default function MyEnrolledClassesPage() {
               {status.charAt(0).toUpperCase() + status.slice(1)} ({
                 status === 'all'
                   ? classes.length
-                  : classes.filter(c => c.scheduleStatus.toLowerCase() === status).length
+                  : classes.filter(
+                      (c) => c.scheduleStatus?.toLowerCase() === status,
+                    ).length
               })
             </button>
           ))}
@@ -110,7 +118,14 @@ export default function MyEnrolledClassesPage() {
                 </div>
                 <p className="text-sm text-gray-600 mb-1">Instructor: {cls.instructor}</p>
                 <p className="text-sm text-gray-600 flex items-center gap-2 mb-3">
-                  <FaCalendarAlt /> {new Date(cls.startDate).toLocaleString()}
+                  <FaCalendarAlt />
+                  {new Date(
+                    cls.start_date ||
+                      cls.startDate ||
+                      cls.end_date ||
+                      cls.endDate ||
+                      0,
+                  ).toLocaleString()}
                 </p>
                 <p className="flex items-center text-xs text-gray-500 mb-2">
                   <FaTags className="mr-1 text-gray-400" /> {cls.tags?.join(', ') || 'General'}
@@ -120,13 +135,15 @@ export default function MyEnrolledClassesPage() {
                 </div>
                 <p className="text-xs text-gray-500 mb-2">{cls.progress || 0}% completed</p>
 
-                <span className={`inline-block px-3 py-1 text-xs font-medium rounded-full mb-2 ${
-                  cls.scheduleStatus === 'Live'
-                    ? 'bg-green-100 text-green-800'
-                    : cls.scheduleStatus === 'Upcoming'
-                    ? 'bg-yellow-100 text-yellow-800'
-                    : 'bg-gray-200 text-gray-600'
-                }`}>
+                <span
+                  className={`inline-block px-3 py-1 text-xs font-medium rounded-full mb-2 ${
+                    cls.scheduleStatus === 'Ongoing'
+                      ? 'bg-green-100 text-green-800'
+                      : cls.scheduleStatus === 'Upcoming'
+                      ? 'bg-yellow-100 text-yellow-800'
+                      : 'bg-gray-200 text-gray-600'
+                  }`}
+                >
                   {cls.scheduleStatus}
                 </span>
 
@@ -149,7 +166,7 @@ export default function MyEnrolledClassesPage() {
                 >
                   <FaClipboardList className="inline mr-1" /> View Assignments
                 </Link>
-                {cls.scheduleStatus === 'Live' && cls.joined ? (
+                {cls.scheduleStatus === 'Ongoing' && cls.joined ? (
                   <Link
                     href={`/dashboard/student/online-classes/${cls.linkId || cls.id}`}
                     className="block bg-yellow-500 text-black text-center py-2 px-4 rounded hover:bg-yellow-600 font-semibold"


### PR DESCRIPTION
## Summary
- match class filter options to backend statuses
- handle sorting with `start_date`/`end_date`
- display "Ongoing" state in website class listings

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*
- `pre-commit run --files frontend/src/pages/dashboard/student/online-classes/index.js frontend/src/components/website/sections/OnlineClasses.js` *(fails: 327 problems (56 errors, 271 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_68c5b0fa0e9c8328a618744b93cdd86d