### PR TITLE
feat: abort admin class fetch

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/index.js
@@ -16,12 +16,14 @@ function AdminOnlineClassesPage() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     const load = async () => {
       setLoading(true);
       try {
-        const list = await fetchAdminClasses();
+        const list = await fetchAdminClasses({ signal: controller.signal });
         setClasses(list);
       } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
         console.error("Failed to load classes", err);
         setError(t('classes_load_failed'));
       } finally {
@@ -29,6 +31,7 @@ function AdminOnlineClassesPage() {
       }
     };
     load();
+    return () => controller.abort();
   }, []);
 
   return (

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -30,8 +30,8 @@ const formatClass = (cls) => {
   };
 };
 
-export const fetchAdminClasses = async () => {
-  const { data } = await api.get("/users/classes/admin");
+export const fetchAdminClasses = async (config = {}) => {
+  const { data } = await api.get("/users/classes/admin", config);
   const list = data?.data ?? [];
   return list.map(formatClass);
 };


### PR DESCRIPTION
## Summary
- add AbortController to admin online classes page
- allow passing request config to fetchAdminClasses

## Testing
- `npm test`
- `npm run lint` *(fails: react/display-name, no-img-element, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c5b0ff3f9083288fc03cce29b9915b