### PR TITLE
refactor: escape CSV values before export

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -71,6 +71,11 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
     currentPage * itemsPerPage
   );
 
+  const formatCSVRow = (row) =>
+    row
+      .map((value) => `"${String(value).replace(/"/g, '""')}"`)
+      .join(",");
+
   const exportCSV = () => {
     const headers = ["Title", "Instructor", "Start Date", "End Date", "Category", "Publish Status"];
     const rows = classList.map(cls => [
@@ -81,7 +86,8 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
       cls.category,
       cls.publishStatus
     ]);
-    const csvContent = [headers, ...rows].map(e => e.join(",")).join("\n");
+    const csvRows = [headers, ...rows].map(formatCSVRow);
+    const csvContent = csvRows.join("\n");
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");


### PR DESCRIPTION
## Summary
- ensure CSV export wraps each field in quotes and escapes quotes

## Testing
- `pre-commit run --files frontend/src/components/admin/online-classes/AdminClassesTable.js` *(fails: Component definition is missing display name in unrelated test files)*
- `cd frontend && npx --yes eslint src/components/admin/online-classes/AdminClassesTable.js`

------
https://chatgpt.com/codex/tasks/task_e_68c5b10006b0832894716f5e5ea72b5b