### PR TITLE
Filter instructor classes by user ID

### DIFF
--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -203,8 +203,9 @@ exports.getClassById = catchAsync(async (req, res) => {
 });
 
 exports.getMyClasses = catchAsync(async (req, res) => {
-  const { page = 1, limit = 10 } = req.query;
-  const result = await service.getClassesByInstructor(req.user.id, {
+  const { page = 1, limit = 10, instructorId } = req.query;
+  const targetId = instructorId || req.user.id;
+  const result = await service.getClassesByInstructor(targetId, {
     page: Number(page),
     limit: Number(limit),
   });

--- a/frontend/src/components/instructors/InstructorDashboard.js
+++ b/frontend/src/components/instructors/InstructorDashboard.js
@@ -29,6 +29,7 @@ import {
   fetchInstructorTutorialViews,
 } from "@/services/instructor/instructorService";
 import { fetchInstructorScheduleEvents } from "@/services/instructor/classService";
+import useAuthStore from "@/store/auth/authStore";
 
 const localizer = momentLocalizer(moment);
 
@@ -69,6 +70,7 @@ function InstructorDashboard() {
   const [chartData, setChartData] = useState([]);
   const [counts, setCounts] = useState({});
   const [events, setEvents] = useState([]);
+  const user = useAuthStore((state) => state.user);
 
   useEffect(() => {
     async function loadStats() {
@@ -92,7 +94,8 @@ function InstructorDashboard() {
     loadStats();
     async function loadEvents() {
       try {
-        const data = await fetchInstructorScheduleEvents();
+        if (!user?.id) return;
+        const data = await fetchInstructorScheduleEvents(user.id);
         const parsed = data.map((e) => ({
           ...e,
           start: new Date(e.start),
@@ -104,7 +107,7 @@ function InstructorDashboard() {
       }
     }
     loadEvents();
-  }, []);
+  }, [user?.id]);
 
   const cardStyle = "bg-white shadow-sm border rounded-2xl p-5 hover:shadow-md transition duration-300";
   const tabButtonStyle = (tab) =>

--- a/frontend/src/components/instructors/OnlineClassList.js
+++ b/frontend/src/components/instructors/OnlineClassList.js
@@ -18,7 +18,8 @@ export default function OnlineClassList() {
   useEffect(() => {
     const load = async () => {
       try {
-        const data = await fetchInstructorClasses();
+        if (!user?.id) return;
+        const data = await fetchInstructorClasses(user.id);
         setClasses(data || []);
       } catch (err) {
         console.error(err);
@@ -28,18 +29,9 @@ export default function OnlineClassList() {
       }
     };
     load();
-  }, []);
+  }, [user?.id]);
 
-  const myClasses = classes.filter((cls) => {
-    if (cls.instructor_id && user?.id) return cls.instructor_id === user.id;
-    if (cls.instructor && (user?.full_name || user?.name)) {
-      const name = user.full_name || user.name;
-      return cls.instructor === name;
-    }
-    return true;
-  });
-
-  const filteredClasses = myClasses
+  const filteredClasses = classes
     .filter((cls) =>
       cls.title.toLowerCase().includes(searchTerm.toLowerCase())
     )

--- a/frontend/src/pages/dashboard/instructor/assignments/create.js
+++ b/frontend/src/pages/dashboard/instructor/assignments/create.js
@@ -1,6 +1,7 @@
 // pages/dashboard/instructor/assignments/[classId]/create.js
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import useAuthStore from '@/store/auth/authStore';
 import { toast } from 'react-toastify';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { v4 as uuidv4 } from 'uuid';
@@ -26,20 +27,22 @@ export default function CreateAssignmentPage() {
   const [previewMode, setPreviewMode] = useState(false);
 
   const [classes, setClasses] = useState([]);
+  const user = useAuthStore((state) => state.user);
 
   useEffect(() => {
     setMounted(true);
     if (routerClassId) setClassId(routerClassId);
     const load = async () => {
       try {
-        const data = await fetchInstructorClasses();
+        if (!user?.id) return;
+        const data = await fetchInstructorClasses(user.id);
         setClasses(data || []);
       } catch (err) {
         console.error('Failed to load classes', err);
       }
     };
     load();
-  }, [routerClassId]);
+  }, [routerClassId, user?.id]);
 
   const handleAddQuestion = () => {
     setQuestions(prev => [...prev, { id: uuidv4(), question: '', options: ['', '', '', ''], correct: 0, points: 1 }]);

--- a/frontend/src/pages/dashboard/instructor/assignments/index.js
+++ b/frontend/src/pages/dashboard/instructor/assignments/index.js
@@ -1,5 +1,6 @@
 // pages/dashboard/instructor/assignments/index.js
 import { useEffect, useState } from 'react';
+import useAuthStore from '@/store/auth/authStore';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import Link from 'next/link';
 import { FaPlus, FaEye, FaEdit, FaTrashAlt } from 'react-icons/fa';
@@ -8,11 +9,13 @@ import { fetchClassAssignments } from '@/services/classService';
 
 export default function InstructorAssignmentsAll() {
   const [assignments, setAssignments] = useState([]);
+  const user = useAuthStore((state) => state.user);
 
   useEffect(() => {
     const load = async () => {
       try {
-        const classes = await fetchInstructorClasses();
+        if (!user?.id) return;
+        const classes = await fetchInstructorClasses(user.id);
         const all = [];
         for (const cls of classes) {
           const list = await fetchClassAssignments(cls.id);
@@ -24,7 +27,7 @@ export default function InstructorAssignmentsAll() {
       }
     };
     load();
-  }, []);
+  }, [user?.id]);
 
   return (
     <InstructorLayout>

--- a/frontend/src/pages/dashboard/instructor/schedule.js
+++ b/frontend/src/pages/dashboard/instructor/schedule.js
@@ -7,18 +7,21 @@ import { getLessonRoomLink } from "@/services/lessonService";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../next-i18next.config.js";
+import useAuthStore from "@/store/auth/authStore";
 
 export default function InstructorSchedule() {
   const { t } = useTranslation(["dashboard", "common"], { keyPrefix: "schedulePage" });
   const { events, clear, addEvents, prunePastEvents } = useScheduleStore();
 
   const [loading, setLoading] = useState(false);
+  const user = useAuthStore((state) => state.user);
 
   useEffect(() => {
     const load = async () => {
       try {
+        if (!user?.id) return;
         setLoading(true);
-        const data = await fetchInstructorScheduleEvents();
+        const data = await fetchInstructorScheduleEvents(user.id);
         clear();
         addEvents(data);
         prunePastEvents();
@@ -29,7 +32,7 @@ export default function InstructorSchedule() {
       }
     };
     load();
-  }, [clear, addEvents, prunePastEvents]);
+  }, [clear, addEvents, prunePastEvents, user?.id]);
 
 
 

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -30,10 +30,11 @@ const formatClass = (cls) => {
   };
 };
 
-export const fetchInstructorClasses = async () => {
-  // Fetch only classes belonging to the current instructor
-  // using the dedicated "/instructor/my" endpoint
-  const { data } = await api.get("/users/classes/instructor/my");
+export const fetchInstructorClasses = async (instructorId) => {
+  // Fetch only classes belonging to the specified instructor
+  const { data } = await api.get("/users/classes/instructor/my", {
+    params: { instructorId },
+  });
   const list = data?.data ?? [];
   return list.map(formatClass);
 };
@@ -108,8 +109,8 @@ export const deleteClassAssignment = async (assignmentId) => {
 
 // Fetch upcoming schedule events for the current instructor
 // Combines class start dates and lesson times
-export const fetchInstructorScheduleEvents = async () => {
-  const classes = await fetchInstructorClasses();
+export const fetchInstructorScheduleEvents = async (instructorId) => {
+  const classes = await fetchInstructorClasses(instructorId);
   const now = new Date();
   const events = [];
 

--- a/frontend/src/tests/__tests__/JoinLiveSession.test.js
+++ b/frontend/src/tests/__tests__/JoinLiveSession.test.js
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import InstructorSchedule from '@/pages/dashboard/instructor/schedule';
+import useAuthStore from '@/store/auth/authStore';
 
 jest.mock('../../services/instructor/classService', () => ({
   fetchInstructorScheduleEvents: jest.fn(() => Promise.resolve([
@@ -34,6 +35,7 @@ jest.mock('../../components/layouts/InstructorLayout', () => {
 
 describe('Join live session link', () => {
   it('requests room link when lesson is live', async () => {
+    useAuthStore.getState().setUser({ id: 'instructor-1' });
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
     render(<InstructorSchedule />);
     fireEvent.click(screen.getByText('cal'));


### PR DESCRIPTION
## Summary
- Filter backend instructor class listing by `instructorId` query
- Pass current user ID to `fetchInstructorClasses` and schedule events service
- Simplify online class list by removing client-side instructor filtering

## Testing
- `pre-commit run --files backend/src/modules/classes/class.controller.js frontend/src/services/instructor/classService.js frontend/src/components/instructors/OnlineClassList.js frontend/src/pages/dashboard/instructor/assignments/index.js frontend/src/pages/dashboard/instructor/assignments/create.js frontend/src/pages/dashboard/instructor/schedule.js frontend/src/components/instructors/InstructorDashboard.js frontend/src/tests/__tests__/JoinLiveSession.test.js` *(fails: 56 errors, 271 warnings)*
- `cd backend && npm test` *(fails: Test Suites: 23 failed, 2 skipped, 116 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b1014d9883288e8a408b176d5bc1