### PR TITLE
feat: internationalize instructor class list

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1935,6 +1935,21 @@
       "pending_payment": "دفع معلق"
     }
   },
+  "onlineClassListPage": {
+    "search_placeholder": "Search classes...",
+    "all_schedule": "All Schedule",
+    "upcoming": "Upcoming",
+    "ongoing": "Ongoing",
+    "completed": "Completed",
+    "all_approval": "All Approval",
+    "loading": "Loading classes...",
+    "published": "Published",
+    "draft": "Draft",
+    "go_to_class": "Go To Class",
+    "manage_class": "Manage Class",
+    "view_details": "View Details",
+    "no_classes": "No classes found."
+  },
   "studentSchedulePage": {
     "title": "دروسي المحجوزة",
     "failed_live_session": "فشل الانضمام إلى الجلسة المباشرة",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1941,6 +1941,21 @@
       "pending_payment": "Zahlung ausstehend"
     }
   },
+  "onlineClassListPage": {
+    "search_placeholder": "Search classes...",
+    "all_schedule": "All Schedule",
+    "upcoming": "Upcoming",
+    "ongoing": "Ongoing",
+    "completed": "Completed",
+    "all_approval": "All Approval",
+    "loading": "Loading classes...",
+    "published": "Published",
+    "draft": "Draft",
+    "go_to_class": "Go To Class",
+    "manage_class": "Manage Class",
+    "view_details": "View Details",
+    "no_classes": "No classes found."
+  },
   "studentSchedulePage": {
     "title": "Meine gebuchten Lektionen",
     "failed_live_session": "Teilnahme an der Live-Sitzung fehlgeschlagen",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1951,6 +1951,21 @@
       "pending_payment": "Pending Payment"
     }
   },
+  "onlineClassListPage": {
+    "search_placeholder": "Search classes...",
+    "all_schedule": "All Schedule",
+    "upcoming": "Upcoming",
+    "ongoing": "Ongoing",
+    "completed": "Completed",
+    "all_approval": "All Approval",
+    "loading": "Loading classes...",
+    "published": "Published",
+    "draft": "Draft",
+    "go_to_class": "Go To Class",
+    "manage_class": "Manage Class",
+    "view_details": "View Details",
+    "no_classes": "No classes found."
+  },
   "studentSchedulePage": {
     "title": "My Booked Lessons",
     "failed_live_session": "Failed to join live session",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1927,6 +1927,21 @@
       "pending_payment": "Pago pendiente"
     }
   },
+  "onlineClassListPage": {
+    "search_placeholder": "Search classes...",
+    "all_schedule": "All Schedule",
+    "upcoming": "Upcoming",
+    "ongoing": "Ongoing",
+    "completed": "Completed",
+    "all_approval": "All Approval",
+    "loading": "Loading classes...",
+    "published": "Published",
+    "draft": "Draft",
+    "go_to_class": "Go To Class",
+    "manage_class": "Manage Class",
+    "view_details": "View Details",
+    "no_classes": "No classes found."
+  },
   "studentSchedulePage": {
     "title": "Mis lecciones reservadas",
     "failed_live_session": "No se pudo unir a la sesión en vivo",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1935,6 +1935,21 @@
       "pending_payment": "Paiement en attente"
     }
   },
+  "onlineClassListPage": {
+    "search_placeholder": "Search classes...",
+    "all_schedule": "All Schedule",
+    "upcoming": "Upcoming",
+    "ongoing": "Ongoing",
+    "completed": "Completed",
+    "all_approval": "All Approval",
+    "loading": "Loading classes...",
+    "published": "Published",
+    "draft": "Draft",
+    "go_to_class": "Go To Class",
+    "manage_class": "Manage Class",
+    "view_details": "View Details",
+    "no_classes": "No classes found."
+  },
   "studentSchedulePage": {
     "title": "Mes leçons réservées",
     "failed_live_session": "Échec de la connexion à la session en direct",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1927,6 +1927,21 @@
       "pending_payment": "भुगतान लंबित"
     }
   },
+  "onlineClassListPage": {
+    "search_placeholder": "Search classes...",
+    "all_schedule": "All Schedule",
+    "upcoming": "Upcoming",
+    "ongoing": "Ongoing",
+    "completed": "Completed",
+    "all_approval": "All Approval",
+    "loading": "Loading classes...",
+    "published": "Published",
+    "draft": "Draft",
+    "go_to_class": "Go To Class",
+    "manage_class": "Manage Class",
+    "view_details": "View Details",
+    "no_classes": "No classes found."
+  },
   "studentSchedulePage": {
     "title": "मेरी बुक की गई कक्षाएँ",
     "failed_live_session": "लाइव सत्र में शामिल होने में विफल",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1941,6 +1941,21 @@
       "pending_payment": "Pagamento in sospeso"
     }
   },
+  "onlineClassListPage": {
+    "search_placeholder": "Search classes...",
+    "all_schedule": "All Schedule",
+    "upcoming": "Upcoming",
+    "ongoing": "Ongoing",
+    "completed": "Completed",
+    "all_approval": "All Approval",
+    "loading": "Loading classes...",
+    "published": "Published",
+    "draft": "Draft",
+    "go_to_class": "Go To Class",
+    "manage_class": "Manage Class",
+    "view_details": "View Details",
+    "no_classes": "No classes found."
+  },
   "studentSchedulePage": {
     "title": "Le mie lezioni prenotate",
     "failed_live_session": "Impossibile partecipare alla sessione live",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1896,6 +1896,21 @@
       "pending_payment": "待付款"
     }
   },
+  "onlineClassListPage": {
+    "search_placeholder": "Search classes...",
+    "all_schedule": "All Schedule",
+    "upcoming": "Upcoming",
+    "ongoing": "Ongoing",
+    "completed": "Completed",
+    "all_approval": "All Approval",
+    "loading": "Loading classes...",
+    "published": "Published",
+    "draft": "Draft",
+    "go_to_class": "Go To Class",
+    "manage_class": "Manage Class",
+    "view_details": "View Details",
+    "no_classes": "No classes found."
+  },
   "studentSchedulePage": {
     "title": "我预订的课程",
     "failed_live_session": "加入直播课程失败",

--- a/frontend/src/components/instructors/OnlineClassList.js
+++ b/frontend/src/components/instructors/OnlineClassList.js
@@ -4,6 +4,7 @@ import { FaCalendarAlt, FaChalkboardTeacher, FaClock, FaVideo } from "react-icon
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { fetchInstructorClasses } from "@/services/instructor/classService";
 import useAuthStore from "@/store/auth/authStore";
+import { useTranslation } from "next-i18next";
 
 export default function OnlineClassList() {
   const [classes, setClasses] = useState([]);
@@ -14,6 +15,11 @@ export default function OnlineClassList() {
   const [filterApproval, setFilterApproval] = useState("All");
 
   const user = useAuthStore((state) => state.user);
+  const { t } = useTranslation("dashboard");
+  const translate = (key, fallback) => {
+    const translation = t(key);
+    return translation === key ? fallback : translation;
+  };
 
   useEffect(() => {
     const load = async () => {
@@ -22,7 +28,7 @@ export default function OnlineClassList() {
         setClasses(data || []);
       } catch (err) {
         console.error(err);
-        setError("Failed to load classes");
+        setError("classes_load_failed");
       } finally {
         setLoading(false);
       }
@@ -53,7 +59,7 @@ export default function OnlineClassList() {
   if (loading) {
     return (
       <InstructorLayout>
-        <div className="p-6">Loading classes...</div>
+        <div className="p-6">{translate("onlineClassListPage.loading", "Loading classes...")}</div>
       </InstructorLayout>
     );
   }
@@ -61,7 +67,7 @@ export default function OnlineClassList() {
   if (error) {
     return (
       <InstructorLayout>
-        <div className="p-6 text-red-500">{error}</div>
+        <div className="p-6 text-red-500">{translate(error, "Failed to load classes")}</div>
       </InstructorLayout>
     );
   }
@@ -69,12 +75,12 @@ export default function OnlineClassList() {
   return (
     <InstructorLayout>
       <div className="bg-white min-h-screen px-6 py-10 text-gray-900">
-        <h1 className="text-2xl font-bold text-yellow-500 mb-6">📚 My Classes</h1>
+        <h1 className="text-2xl font-bold text-yellow-500 mb-6">📚 {translate("my_classes", "My Classes")}</h1>
 
         <div className="flex flex-col sm:flex-row gap-4 mb-6">
           <input
             type="text"
-            placeholder="Search classes..."
+            placeholder={translate("onlineClassListPage.search_placeholder", "Search classes...")}
             className="p-3 border border-gray-300 rounded w-full sm:max-w-xs"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
@@ -84,20 +90,20 @@ export default function OnlineClassList() {
             value={filterSchedule}
             onChange={(e) => setFilterSchedule(e.target.value)}
           >
-            <option value="All">All Schedule</option>
-            <option value="Upcoming">Upcoming</option>
-            <option value="Ongoing">Ongoing</option>
-            <option value="Completed">Completed</option>
+            <option value="All">{translate("onlineClassListPage.all_schedule", "All Schedule")}</option>
+            <option value="Upcoming">{translate("onlineClassListPage.upcoming", "Upcoming")}</option>
+            <option value="Ongoing">{translate("onlineClassListPage.ongoing", "Ongoing")}</option>
+            <option value="Completed">{translate("onlineClassListPage.completed", "Completed")}</option>
           </select>
           <select
             className="p-3 border border-gray-300 rounded w-full sm:w-auto"
             value={filterApproval}
             onChange={(e) => setFilterApproval(e.target.value)}
           >
-            <option value="All">All Approval</option>
-            <option value="Approved">Approved</option>
-            <option value="Pending">Pending</option>
-            <option value="Rejected">Rejected</option>
+            <option value="All">{translate("onlineClassListPage.all_approval", "All Approval")}</option>
+            <option value="Approved">{translate("approved", "Approved")}</option>
+            <option value="Pending">{translate("pending", "Pending")}</option>
+            <option value="Rejected">{translate("rejected", "Rejected")}</option>
           </select>
         </div>
 
@@ -113,13 +119,13 @@ export default function OnlineClassList() {
                 {cls.end_date ? ` - ${cls.end_date}` : ""}
               </p>
               <p className="text-sm text-gray-600 flex items-center gap-2 mb-1">
-                <FaClock /> Schedule: {cls.scheduleStatus}
+                <FaClock /> {translate("schedule", "Schedule")}: {translate(`onlineClassListPage.${cls.scheduleStatus?.toLowerCase()}`, cls.scheduleStatus)}
               </p>
               {typeof cls.price !== "undefined" && (
-                <p className="text-sm text-gray-600 mb-1">💵 Price: ${cls.price ?? 0}</p>
+                <p className="text-sm text-gray-600 mb-1">💵 {translate("price_label", "Price")}: ${cls.price ?? 0}</p>
               )}
               {typeof cls.max_students !== "undefined" && (
-                <p className="text-sm text-gray-600 mb-1">👥 Max Students: {cls.max_students}</p>
+                <p className="text-sm text-gray-600 mb-1">👥 {translate("max_students_label", "Max Students")}: {cls.max_students}</p>
               )}
               <div className="flex gap-2 mb-4 mt-2">
                 <span
@@ -129,7 +135,9 @@ export default function OnlineClassList() {
                       : "bg-yellow-100 text-yellow-800"
                   }`}
                 >
-                  {cls.publishStatus === "published" ? "Published" : "Draft"}
+                  {cls.publishStatus === "published"
+                    ? translate("onlineClassListPage.published", "Published")
+                    : translate("onlineClassListPage.draft", "Draft")}
                 </span>
                 <span
                   className={`px-3 py-1 rounded-full text-xs font-bold ${
@@ -140,7 +148,7 @@ export default function OnlineClassList() {
                       : "bg-yellow-100 text-yellow-700"
                   }`}
                 >
-                  {cls.approvalStatus}
+                  {translate(cls.approvalStatus?.toLowerCase(), cls.approvalStatus)}
                 </span>
               </div>
               <Link
@@ -149,24 +157,24 @@ export default function OnlineClassList() {
               >
                 {cls.scheduleStatus === 'Ongoing' ? (
                   <>
-                    <FaVideo /> Go To Class
+                    <FaVideo /> {translate("onlineClassListPage.go_to_class", "Go To Class")}
                   </>
                 ) : (
-                  'Manage Class'
+                  translate("onlineClassListPage.manage_class", "Manage Class")
                 )}
               </Link>
               <Link
                 href={`/dashboard/instructor/online-classes/${cls.id}/details`}
                 className="block bg-blue-500 text-white text-center py-2 px-4 rounded hover:bg-blue-600 font-semibold mt-2"
               >
-                View Details
+                {translate("onlineClassListPage.view_details", "View Details")}
               </Link>
             </div>
           ))}
         </div>
 
         {filteredClasses.length === 0 && (
-          <p className="text-center text-gray-500 mt-10">No classes found.</p>
+          <p className="text-center text-gray-500 mt-10">{translate("onlineClassListPage.no_classes", "No classes found.")}</p>
         )}
       </div>
     </InstructorLayout>


### PR DESCRIPTION
## Summary
- localize instructor class list with dashboard translations and fallbacks
- add translation keys for class list filters, actions, and messages

## Testing
- `npm run lint` *(fails: react/display-name and other warnings)*
- `npm test` *(pass: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b102171c8328998d75868c4a1f46