### PR TITLE
feat: localize student online classes page

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1997,5 +1997,25 @@
       "invalid_date": "Invalid date format",
       "education_required": "Education level is required"
     }
+  },
+  "studentOnlineClassesPage": {
+    "title": "🎓 دوراتي المسجلة",
+    "search_placeholder": "ابحث عن الدورات...",
+    "sort_by_date": "ترتيب حسب التاريخ",
+    "status_all": "الكل",
+    "status_live": "مباشر",
+    "status_upcoming": "قادمة",
+    "status_completed": "مكتملة",
+    "no_classes": "لا توجد دورات تحت هذا الفلتر.",
+    "instructor": "المدرب:",
+    "progress_completed": "{{progress}}٪ مكتمل",
+    "notify_me": "أبلغني",
+    "view_certificate": "عرض الشهادة",
+    "view_assignments": "عرض الواجبات",
+    "join_class": "انضم إلى الدرس",
+    "starts_soon": "يبدأ قريباً",
+    "completed": "مكتمل",
+    "class_ended": "انتهى الدرس",
+    "load_more": "تحميل المزيد"
   }
 }

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -2003,5 +2003,25 @@
       "invalid_date": "Invalid date format",
       "education_required": "Education level is required"
     }
+  },
+  "studentOnlineClassesPage": {
+    "title": "🎓 Meine eingeschriebenen Kurse",
+    "search_placeholder": "Kurse suchen...",
+    "sort_by_date": "Nach Datum sortieren",
+    "status_all": "Alle",
+    "status_live": "Live",
+    "status_upcoming": "Bevorstehend",
+    "status_completed": "Abgeschlossen",
+    "no_classes": "Keine Kurse unter diesem Filter gefunden.",
+    "instructor": "Dozent:",
+    "progress_completed": "{{progress}}% abgeschlossen",
+    "notify_me": "Benachrichtige mich",
+    "view_certificate": "Zertifikat ansehen",
+    "view_assignments": "Aufgaben anzeigen",
+    "join_class": "Kurs beitreten",
+    "starts_soon": "Beginnt bald",
+    "completed": "Abgeschlossen",
+    "class_ended": "Kurs beendet",
+    "load_more": "Mehr laden"
   }
 }

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -2013,5 +2013,25 @@
       "invalid_date": "Invalid date format",
       "education_required": "Education level is required"
     }
+  },
+  "studentOnlineClassesPage": {
+    "title": "\uD83C\uDF93 My Enrolled Classes",
+    "search_placeholder": "Search classes...",
+    "sort_by_date": "Sort by Date",
+    "status_all": "All",
+    "status_live": "Live",
+    "status_upcoming": "Upcoming",
+    "status_completed": "Completed",
+    "no_classes": "No classes found under this filter.",
+    "instructor": "Instructor:",
+    "progress_completed": "{{progress}}% completed",
+    "notify_me": "Notify Me",
+    "view_certificate": "View Certificate",
+    "view_assignments": "View Assignments",
+    "join_class": "Join Class",
+    "starts_soon": "Starts Soon",
+    "completed": "Completed",
+    "class_ended": "Class Ended",
+    "load_more": "Load More"
   }
 }

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1989,5 +1989,25 @@
       "invalid_date": "Invalid date format",
       "education_required": "Education level is required"
     }
+  },
+  "studentOnlineClassesPage": {
+    "title": "🎓 Mis clases inscritas",
+    "search_placeholder": "Buscar clases...",
+    "sort_by_date": "Ordenar por fecha",
+    "status_all": "Todas",
+    "status_live": "En vivo",
+    "status_upcoming": "Próximas",
+    "status_completed": "Completadas",
+    "no_classes": "No se encontraron clases con este filtro.",
+    "instructor": "Instructor:",
+    "progress_completed": "{{progress}}% completado",
+    "notify_me": "Notifícame",
+    "view_certificate": "Ver certificado",
+    "view_assignments": "Ver tareas",
+    "join_class": "Unirse a la clase",
+    "starts_soon": "Empieza pronto",
+    "completed": "Completado",
+    "class_ended": "Clase finalizada",
+    "load_more": "Cargar más"
   }
 }

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1997,5 +1997,25 @@
       "invalid_date": "Invalid date format",
       "education_required": "Education level is required"
     }
+  },
+  "studentOnlineClassesPage": {
+    "title": "🎓 Mes cours inscrits",
+    "search_placeholder": "Rechercher des cours...",
+    "sort_by_date": "Trier par date",
+    "status_all": "Tous",
+    "status_live": "En direct",
+    "status_upcoming": "À venir",
+    "status_completed": "Terminés",
+    "no_classes": "Aucun cours trouvé pour ce filtre.",
+    "instructor": "Formateur :",
+    "progress_completed": "{{progress}}% terminé",
+    "notify_me": "Me notifier",
+    "view_certificate": "Voir le certificat",
+    "view_assignments": "Voir les devoirs",
+    "join_class": "Rejoindre le cours",
+    "starts_soon": "Commence bientôt",
+    "completed": "Terminé",
+    "class_ended": "Cours terminé",
+    "load_more": "Charger plus"
   }
 }

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1989,5 +1989,25 @@
       "invalid_date": "Invalid date format",
       "education_required": "Education level is required"
     }
+  },
+  "studentOnlineClassesPage": {
+    "title": "🎓 मेरी नामांकित कक्षाएँ",
+    "search_placeholder": "कक्षाएँ खोजें...",
+    "sort_by_date": "तारीख के अनुसार क्रमबद्ध करें",
+    "status_all": "सभी",
+    "status_live": "लाइव",
+    "status_upcoming": "आगामी",
+    "status_completed": "पूर्ण",
+    "no_classes": "इस फ़िल्टर के अंतर्गत कोई कक्षा नहीं मिली।",
+    "instructor": "प्रशिक्षक:",
+    "progress_completed": "{{progress}}% पूरा हुआ",
+    "notify_me": "मुझे सूचित करें",
+    "view_certificate": "प्रमाणपत्र देखें",
+    "view_assignments": "असाइनमेंट देखें",
+    "join_class": "कक्षा में शामिल हों",
+    "starts_soon": "जल्द शुरू होगा",
+    "completed": "पूर्ण",
+    "class_ended": "कक्षा समाप्त",
+    "load_more": "और लोड करें"
   }
 }

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -2003,5 +2003,25 @@
       "invalid_date": "Invalid date format",
       "education_required": "Education level is required"
     }
+  },
+  "studentOnlineClassesPage": {
+    "title": "🎓 I miei corsi iscritti",
+    "search_placeholder": "Cerca corsi...",
+    "sort_by_date": "Ordina per data",
+    "status_all": "Tutti",
+    "status_live": "Live",
+    "status_upcoming": "In arrivo",
+    "status_completed": "Completati",
+    "no_classes": "Nessuna classe trovata con questo filtro.",
+    "instructor": "Istruttore:",
+    "progress_completed": "{{progress}}% completato",
+    "notify_me": "Avvisami",
+    "view_certificate": "Vedi certificato",
+    "view_assignments": "Vedi compiti",
+    "join_class": "Partecipa alla classe",
+    "starts_soon": "Inizia presto",
+    "completed": "Completato",
+    "class_ended": "Classe terminata",
+    "load_more": "Carica altro"
   }
 }

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1958,5 +1958,25 @@
       "invalid_date": "Invalid date format",
       "education_required": "Education level is required"
     }
+  },
+  "studentOnlineClassesPage": {
+    "title": "🎓 我报名的课程",
+    "search_placeholder": "搜索课程...",
+    "sort_by_date": "按日期排序",
+    "status_all": "全部",
+    "status_live": "直播",
+    "status_upcoming": "即将开始",
+    "status_completed": "已完成",
+    "no_classes": "在此筛选下未找到课程。",
+    "instructor": "讲师：",
+    "progress_completed": "{{progress}}% 已完成",
+    "notify_me": "通知我",
+    "view_certificate": "查看证书",
+    "view_assignments": "查看作业",
+    "join_class": "加入课程",
+    "starts_soon": "即将开始",
+    "completed": "已完成",
+    "class_ended": "课程已结束",
+    "load_more": "加载更多"
   }
 }

--- a/frontend/src/pages/dashboard/student/online-classes/index.js
+++ b/frontend/src/pages/dashboard/student/online-classes/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Link from 'next/link';
 import {
   FaChalkboardTeacher,
@@ -24,6 +25,19 @@ export default function MyEnrolledClassesPage() {
   const [visibleCount, setVisibleCount] = useState(6);
   const [search, setSearch] = useState('');
   const [sortOrder, setSortOrder] = useState('asc');
+  const { t } = useTranslation('dashboard');
+
+  const statusLabels = {
+    all: t('studentOnlineClassesPage.status_all'),
+    live: t('studentOnlineClassesPage.status_live'),
+    upcoming: t('studentOnlineClassesPage.status_upcoming'),
+    completed: t('studentOnlineClassesPage.status_completed')
+  };
+  const scheduleStatusLabels = {
+    Live: t('studentOnlineClassesPage.status_live'),
+    Upcoming: t('studentOnlineClassesPage.status_upcoming'),
+    Completed: t('studentOnlineClassesPage.status_completed')
+  };
 
   useEffect(() => {
     const load = async () => {
@@ -52,7 +66,7 @@ export default function MyEnrolledClassesPage() {
   return (
     <StudentLayout>
       <div className="min-h-screen px-6 py-10 bg-white text-gray-900">
-        <h1 className="text-2xl font-bold text-yellow-500 mb-6">🎓 My Enrolled Classes</h1>
+        <h1 className="text-2xl font-bold text-yellow-500 mb-6">{t('studentOnlineClassesPage.title')}</h1>
 
         {/* Search and Sort */}
         <div className="flex flex-col sm:flex-row justify-between gap-4 mb-6">
@@ -60,7 +74,7 @@ export default function MyEnrolledClassesPage() {
             <FaSearch className="text-gray-500" />
             <input
               type="text"
-              placeholder="Search classes..."
+              placeholder={t('studentOnlineClassesPage.search_placeholder')}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="w-full outline-none"
@@ -70,7 +84,7 @@ export default function MyEnrolledClassesPage() {
             onClick={() => setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc')}
             className="flex items-center gap-2 bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-full text-sm"
           >
-            <FaSortAmountDown /> Sort by Date ({sortOrder.toUpperCase()})
+            <FaSortAmountDown /> {t('studentOnlineClassesPage.sort_by_date')} ({sortOrder.toUpperCase()})
           </button>
         </div>
 
@@ -86,7 +100,7 @@ export default function MyEnrolledClassesPage() {
                   : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
               }`}
             >
-              {status.charAt(0).toUpperCase() + status.slice(1)} ({
+              {statusLabels[status]} ({
                 status === 'all'
                   ? classes.length
                   : classes.filter(c => c.scheduleStatus.toLowerCase() === status).length
@@ -97,7 +111,7 @@ export default function MyEnrolledClassesPage() {
 
         {/* Class Cards */}
         {visibleClasses.length === 0 ? (
-          <p className="text-gray-600 text-center">No classes found under this filter.</p>
+          <p className="text-gray-600 text-center">{t('studentOnlineClassesPage.no_classes')}</p>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {visibleClasses.map(cls => (
@@ -106,19 +120,19 @@ export default function MyEnrolledClassesPage() {
                   <h2 className="text-lg font-semibold mb-2 flex items-center gap-2 text-gray-800">
                     <FaChalkboardTeacher className="text-yellow-500" /> {cls.title}
                   </h2>
-                  <FaEye className="text-gray-500 hover:text-gray-800 cursor-pointer mt-1" title="Preview" />
+                  <FaEye className="text-gray-500 hover:text-gray-800 cursor-pointer mt-1" title={t('preview')} />
                 </div>
-                <p className="text-sm text-gray-600 mb-1">Instructor: {cls.instructor}</p>
+                <p className="text-sm text-gray-600 mb-1">{t('studentOnlineClassesPage.instructor')} {cls.instructor}</p>
                 <p className="text-sm text-gray-600 flex items-center gap-2 mb-3">
                   <FaCalendarAlt /> {new Date(cls.startDate).toLocaleString()}
                 </p>
                 <p className="flex items-center text-xs text-gray-500 mb-2">
-                  <FaTags className="mr-1 text-gray-400" /> {cls.tags?.join(', ') || 'General'}
+                  <FaTags className="mr-1 text-gray-400" /> {cls.tags?.join(', ') || t('category_general')}
                 </p>
                 <div className="h-2 bg-gray-300 rounded-full mb-2">
                   <div className="h-full bg-yellow-500 rounded-full" style={{ width: `${cls.progress || 0}%` }}></div>
                 </div>
-                <p className="text-xs text-gray-500 mb-2">{cls.progress || 0}% completed</p>
+                <p className="text-xs text-gray-500 mb-2">{t('studentOnlineClassesPage.progress_completed', { progress: cls.progress || 0 })}</p>
 
                 <span className={`inline-block px-3 py-1 text-xs font-medium rounded-full mb-2 ${
                   cls.scheduleStatus === 'Live'
@@ -127,12 +141,12 @@ export default function MyEnrolledClassesPage() {
                     ? 'bg-yellow-100 text-yellow-800'
                     : 'bg-gray-200 text-gray-600'
                 }`}>
-                  {cls.scheduleStatus}
+                  {scheduleStatusLabels[cls.scheduleStatus] || cls.scheduleStatus}
                 </span>
 
                 {cls.scheduleStatus === 'Upcoming' && (
                   <button className="text-xs text-blue-600 underline mb-2 flex items-center gap-1">
-                    <FaBell /> Notify Me
+                    <FaBell /> {t('studentOnlineClassesPage.notify_me')}
                   </button>
                 )}
                 {cls.enrollmentStatus === 'completed' && (
@@ -140,34 +154,34 @@ export default function MyEnrolledClassesPage() {
                     href={`/dashboard/student/certificates/${cls.id}`}
                     className="text-xs text-green-600 underline mb-2 block text-center"
                   >
-                    <FaCertificate className="inline mr-1" /> View Certificate
+                    <FaCertificate className="inline mr-1" /> {t('studentOnlineClassesPage.view_certificate')}
                   </Link>
                 )}
                 <Link
                   href={`/dashboard/student/assignments/${cls.id}`}
                   className="text-xs text-blue-600 underline mb-3 block text-center"
                 >
-                  <FaClipboardList className="inline mr-1" /> View Assignments
+                  <FaClipboardList className="inline mr-1" /> {t('studentOnlineClassesPage.view_assignments')}
                 </Link>
                 {cls.scheduleStatus === 'Live' && cls.joined ? (
                   <Link
                     href={`/dashboard/student/online-classes/${cls.linkId || cls.id}`}
                     className="block bg-yellow-500 text-black text-center py-2 px-4 rounded hover:bg-yellow-600 font-semibold"
                   >
-                    <FaVideo className="inline mr-2" /> Join Class
+                    <FaVideo className="inline mr-2" /> {t('studentOnlineClassesPage.join_class')}
                   </Link>
                 ) : cls.scheduleStatus === 'Upcoming' ? (
                   <p className="text-center text-sm text-yellow-600">
-                    <FaHourglassHalf className="inline mr-1" /> Starts Soon
+                    <FaHourglassHalf className="inline mr-1" /> {t('studentOnlineClassesPage.starts_soon')}
                   </p>
                 ) : (
                   cls.enrollmentStatus === 'completed' ? (
                     <p className="text-center text-sm text-gray-500">
-                      <FaCheckCircle className="inline mr-1" /> Completed
+                      <FaCheckCircle className="inline mr-1" /> {t('studentOnlineClassesPage.completed')}
                     </p>
                   ) : (
                     <p className="text-center text-sm text-gray-500">
-                      <FaHourglassHalf className="inline mr-1" /> Class Ended
+                      <FaHourglassHalf className="inline mr-1" /> {t('studentOnlineClassesPage.class_ended')}
                     </p>
                   )
                 )}
@@ -181,7 +195,7 @@ export default function MyEnrolledClassesPage() {
             onClick={() => setVisibleCount(prev => prev + 6)}
             className="mt-10 block mx-auto bg-yellow-500 hover:bg-yellow-600 text-black font-bold px-6 py-3 rounded-full"
           >
-            Load More
+            {t('studentOnlineClassesPage.load_more')}
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- integrate dashboard i18n into student online classes page
- add translation keys for student online classes across locales

## Testing
- `npm test` *(fails: _CacheManager.test.tsx_, _InstructorSettingsPage.test.js_)*
- `npm run lint` *(fails: Component definition is missing display name, no-console)*
- `node scripts/checkTranslations.js` *(fails: missing translation keys in various locales)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b10437308328872e7ce11919fbc3