### PR TITLE
Add abort controller to student online class page

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/student/online-classes/[id].js
@@ -33,20 +33,27 @@ export default function StudentClassRoom() {
 
   useEffect(() => {
     if (!id) return;
+    const controller = new AbortController();
+    const { signal } = controller;
     const load = async () => {
       try {
-        const details = await fetchClassDetails(id);
-        const lessons = await fetchClassLessons(id);
-        const assigns = await fetchClassAssignments(id);
+        const details = await fetchClassDetails(id, signal);
+        const lessons = await fetchClassLessons(id, signal);
+        const assigns = await fetchClassAssignments(id, signal);
         const status = computeScheduleStatus(details.start_date, details.end_date);
-        setClassData({ ...details, lessons, scheduleStatus: status });
-        setScheduleStatus(status);
-        setAssignments(assigns);
+        if (!signal.aborted) {
+          setClassData({ ...details, lessons, scheduleStatus: status });
+          setScheduleStatus(status);
+          setAssignments(assigns);
+        }
       } catch (err) {
-        console.error('Failed to load class', err);
+        if (err.name !== 'CanceledError' && err.name !== 'AbortError') {
+          console.error('Failed to load class', err);
+        }
       }
     };
     load();
+    return () => controller.abort();
   }, [id]);
 
   const markComplete = (index) => {

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -43,8 +43,8 @@ export const fetchPublishedClasses = async () => {
   return { ...res.data, data: formatted };
 };
 
-export const fetchClassDetails = async (id) => {
-  const res = await api.get(`/users/classes/${id}`);
+export const fetchClassDetails = async (id, signal) => {
+  const res = await api.get(`/users/classes/${id}`, { signal });
   const cls = res.data?.data ?? res.data;
   return cls ? formatClass(cls) : cls;
 };
@@ -72,13 +72,13 @@ export const fetchMyEnrolledClasses = async () => {
   }
 };
 
-export const fetchClassLessons = async (classId) => {
-  const res = await api.get(`/users/classes/lessons/class/${classId}`);
+export const fetchClassLessons = async (classId, signal) => {
+  const res = await api.get(`/users/classes/lessons/class/${classId}`, { signal });
   return extractData(res);
 };
 
-export const fetchClassAssignments = async (classId) => {
-  const res = await api.get(`/users/classes/assignments/class/${classId}`);
+export const fetchClassAssignments = async (classId, signal) => {
+  const res = await api.get(`/users/classes/assignments/class/${classId}`, { signal });
   return extractData(res);
 };
 


### PR DESCRIPTION
## Summary
- prevent state updates after unmount in student class page by using AbortController
- allow class service to accept abort signals for details, lessons, and assignments requests

## Testing
- `npm test src/tests/__tests__/CacheManager.test.tsx`
- `npm test src/tests/__tests__/InstructorSettingsPage.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5b1051f80832897186c89a80af7e0