### PR TITLE
refactor: use service for tutorial title lookup

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -1,6 +1,5 @@
 const logger = require('../../../utils/logger.js');
 // 📁 src/modules/users/tutorials/tutorial.controller.js
-const db = require("../../../config/database");
 const service = require("./tutorial.service");
 const notificationService = require("../../notifications/notifications.service");
 const messageService = require("../../messages/messages.service");
@@ -57,9 +56,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
   const tags = parseTags(rawTags);
 
   // 🚫 Prevent duplicate titles
-  const existing = await db("tutorials")
-    .whereRaw('LOWER(title) = ?', title.toLowerCase())
-    .first();
+  const existing = await service.findByTitle(title);
   if (existing) {
     return res.status(400).json({ message: "Tutorial title already exists" });
   }

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -13,6 +13,12 @@ exports.createTutorial = async (data, trx = db) => {
   return tutorial;
 };
 
+exports.findByTitle = async (title) => {
+  return db("tutorials")
+    .whereRaw('LOWER(title) = ?', title.toLowerCase())
+    .first();
+};
+
 exports.countPublishedTutorials = async (instructorId) => {
   const row = await db("tutorials")
     .where({ instructor_id: instructorId, status: "published" })


### PR DESCRIPTION
## Summary
- reuse service for duplicate tutorial title check
- add case-insensitive title finder in tutorial service

## Testing
- `npm test -- tests/tutorialCreate.test.js` *(fails: Number of calls: 0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b114c2948328820c3177ebe8856a