### PR TITLE
refactor: add instructor tutorials hook and card

### DIFF
--- a/frontend/src/components/instructor/tutorials/TutorialCard.js
+++ b/frontend/src/components/instructor/tutorials/TutorialCard.js
@@ -1,0 +1,160 @@
+import { FaEye, FaUsers, FaStar, FaRegComments, FaEdit, FaTrash, FaDownload } from 'react-icons/fa';
+import { useTranslation } from 'next-i18next';
+
+export default function TutorialCard({ tutorial, onView, onEdit, onChecklist, onSubmit, onDelete }) {
+  const { t } = useTranslation(['dashboard', 'tutorials']);
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col transition-all duration-300 hover:shadow-xl border border-gray-100">
+      <div className="relative">
+        <img
+          src={tutorial.thumbnail || '/default-thumbnail.jpg'}
+          alt={tutorial.title}
+          className="h-48 w-full object-cover"
+        />
+        <div className="absolute top-3 right-3">
+          <span
+            className={`inline-block px-3 py-1 rounded-full text-xs font-bold ${
+              tutorial.status === 'Approved'
+                ? 'bg-green-100 text-green-800'
+                : tutorial.status === 'Pending'
+                ? 'bg-blue-100 text-blue-800'
+                : tutorial.status === 'Draft'
+                ? 'bg-yellow-100 text-yellow-800'
+                : 'bg-red-100 text-red-800'
+            }`}
+          >
+            {t(`dashboard:tutorialsPage.status_label.${tutorial.status.toLowerCase()}`)}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex-1 p-5 flex flex-col justify-between">
+        <div>
+          <div className="flex justify-between items-start">
+            <h2 className="text-lg font-bold text-gray-800 line-clamp-2">{tutorial.title}</h2>
+            <span className="font-bold text-indigo-700 whitespace-nowrap ml-2">
+              {tutorial.price ? `$${tutorial.price}` : t('tutorials:list.free')}
+            </span>
+          </div>
+
+          <div className="flex items-center mt-2 text-sm text-gray-600">
+            <span className="mr-3">{new Date(tutorial.updatedAt).toLocaleDateString()}</span>
+            <div className="h-1 w-1 bg-gray-400 rounded-full mr-3"></div>
+            <span>{tutorial.language || t('dashboard:tutorialsPage.default_language')}</span>
+          </div>
+
+          <div className="mt-3 flex flex-wrap gap-1">
+            <span className="bg-indigo-50 text-indigo-700 px-2 py-1 rounded-md text-xs">
+              {tutorial.category_name || t('dashboard:tutorialsPage.category_general')}
+            </span>
+            <span className="bg-purple-50 text-purple-700 px-2 py-1 rounded-md text-xs">
+              {tutorial.level || t('dashboard:tutorialsPage.all_levels')}
+            </span>
+          </div>
+
+          {tutorial.tags && tutorial.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {tutorial.tags.map((tag) => (
+                <span key={tag.id || tag} className="bg-gray-100 px-2 py-1 rounded-md text-xs text-gray-700">
+                  {tag.name || tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="grid grid-cols-4 gap-2 mt-4 text-center">
+            <div className="p-2 bg-blue-50 rounded-lg">
+              <FaEye className="mx-auto text-blue-500" />
+              <span className="text-xs mt-1">{tutorial.views}</span>
+            </div>
+            <div className="p-2 bg-green-50 rounded-lg">
+              <FaUsers className="mx-auto text-green-500" />
+              <span className="text-xs mt-1">{tutorial.enrollments}</span>
+            </div>
+            <div className="p-2 bg-yellow-50 rounded-lg">
+              <FaStar className="mx-auto text-yellow-500" />
+              <span className="text-xs mt-1">{tutorial.rating}</span>
+            </div>
+            <div className="p-2 bg-purple-50 rounded-lg">
+              <FaRegComments className="mx-auto text-purple-500" />
+              <span className="text-xs mt-1">{tutorial.comments}</span>
+            </div>
+          </div>
+
+          {tutorial.status === 'Draft' && (
+            <div className="mt-4">
+              <div className="flex justify-between text-xs text-gray-600 mb-1">
+                <span>{t('dashboard:tutorialsPage.progress')}</span>
+                <span>{tutorial.progress || 40}%</span>
+              </div>
+              <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
+                <div
+                  className="h-2 bg-gradient-to-r from-yellow-400 to-yellow-500 rounded-full"
+                  style={{ width: `${tutorial.progress || 40}%` }}
+                ></div>
+              </div>
+            </div>
+          )}
+
+          {tutorial.status === 'Pending' && (
+            <div className="mt-4 bg-blue-50 text-blue-700 text-xs font-medium px-3 py-2 rounded-lg">
+              ⏳ {t('dashboard:tutorialsPage.pending_approval')}
+            </div>
+          )}
+          {tutorial.status === 'Rejected' && tutorial.rejection_reason && (
+            <div className="mt-4 bg-red-50 text-red-700 text-xs font-medium px-3 py-2 rounded-lg">
+              ❌ {tutorial.rejection_reason}
+            </div>
+          )}
+        </div>
+
+        <div className="mt-5 grid grid-cols-2 gap-2">
+          <button onClick={onView} className="bg-gray-100 hover:bg-gray-200 text-gray-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors">
+            <FaEye className="mr-2" /> {t('dashboard:tutorialsPage.view')}
+          </button>
+
+          {(tutorial.status === 'Draft' || tutorial.status === 'Rejected') && (
+            <button onClick={onEdit} className="bg-green-100 hover:bg-green-200 text-green-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors">
+              <FaEdit className="mr-2" /> {t('dashboard:tutorialsPage.edit')}
+            </button>
+          )}
+
+          <button onClick={onChecklist} className="bg-indigo-100 hover:bg-indigo-200 text-indigo-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors">
+            <span className="mr-2">📋</span> {t('dashboard:tutorialsPage.checklist')}
+          </button>
+
+          {tutorial.status === 'Draft' && tutorial.progress === 100 && (
+            <button onClick={onSubmit} className="bg-purple-100 hover:bg-purple-200 text-purple-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors">
+              {t('dashboard:tutorialsPage.submit')}
+            </button>
+          )}
+
+          {(tutorial.status === 'Draft' || tutorial.status === 'Rejected') && (
+            <button onClick={onDelete} className="bg-red-100 hover:bg-red-200 text-red-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors">
+              <FaTrash className="mr-2" /> {t('dashboard:tutorialsPage.delete')}
+            </button>
+          )}
+
+          <button
+            onClick={() => {
+              const dataStr =
+                'data:text/json;charset=utf-8,' +
+                encodeURIComponent(JSON.stringify(tutorial, null, 2));
+              const a = document.createElement('a');
+              a.href = dataStr;
+              a.download = `${tutorial.slug || tutorial.id}.json`;
+              document.body.appendChild(a);
+              a.click();
+              a.remove();
+            }}
+            className="bg-gray-100 hover:bg-gray-200 text-gray-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
+          >
+            <FaDownload className="mr-2" /> {t('dashboard:tutorialsPage.export')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/hooks/useInstructorTutorials.js
+++ b/frontend/src/hooks/useInstructorTutorials.js
@@ -1,0 +1,44 @@
+import { useState, useMemo } from 'react';
+
+export default function useInstructorTutorials(initialTutorials = []) {
+  const [tutorials, setTutorials] = useState(initialTutorials);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [sortBy, setSortBy] = useState('newest');
+
+  const handleSearch = (query) => {
+    setSearchQuery(query.toLowerCase());
+  };
+
+  const handleFilter = (status) => {
+    setStatusFilter(status);
+  };
+
+  const filteredTutorials = useMemo(() => {
+    return tutorials
+      .filter((tut) => {
+        const matchesTitle = tut.title?.toLowerCase().includes(searchQuery);
+        const matchesStatus = statusFilter ? tut.status === statusFilter : true;
+        return matchesTitle && matchesStatus;
+      })
+      .sort((a, b) => {
+        if (sortBy === 'views') return b.views - a.views;
+        if (sortBy === 'enrollments') return b.enrollments - a.enrollments;
+        if (sortBy === 'oldest') return new Date(a.createdAt) - new Date(b.createdAt);
+        return new Date(b.createdAt) - new Date(a.createdAt);
+      });
+  }, [tutorials, searchQuery, statusFilter, sortBy]);
+
+  return {
+    tutorials,
+    setTutorials,
+    searchQuery,
+    statusFilter,
+    sortBy,
+    setSortBy,
+    handleSearch,
+    handleFilter,
+    filteredTutorials,
+  };
+}
+

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -4,19 +4,8 @@ import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
-import {
-  FaPlus,
-  FaEdit,
-  FaEye,
-  FaTrash,
-  FaRegComments,
-  FaStar,
-  FaUsers,
-  FaDownload,
-  FaSearch,
-  FaFilter,
-  FaSortAmountDown
-} from "react-icons/fa";
+import { FaPlus, FaSearch, FaFilter, FaSortAmountDown } from "react-icons/fa";
+import TutorialCard from "@/components/instructor/tutorials/TutorialCard";
 import {
   fetchInstructorTutorials,
   submitTutorialForReview,
@@ -25,16 +14,22 @@ import {
 import ProgressChecklistModal from "@/components/tutorials/ProgressChecklistModal";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { toast } from "react-toastify";
+import useInstructorTutorials from "@/hooks/useInstructorTutorials";
 
 export default function InstructorTutorialsPage() {
   const router = useRouter();
   const { t } = useTranslation(["dashboard", "tutorials"]);
-  const [tutorials, setTutorials] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState("");
-  const [sortBy, setSortBy] = useState("newest");
+  const {
+    tutorials,
+    setTutorials,
+    sortBy,
+    setSortBy,
+    handleSearch,
+    handleFilter,
+    filteredTutorials,
+  } = useInstructorTutorials();
   const [checklistTutorial, setChecklistTutorial] = useState(null);
   const [showChecklist, setShowChecklist] = useState(false);
 
@@ -76,14 +71,6 @@ export default function InstructorTutorialsPage() {
     };
   }, []);
 
-  const handleSearch = (query) => {
-    setSearchQuery(query.toLowerCase());
-  };
-
-  const handleFilter = (status) => {
-    setStatusFilter(status);
-  };
-
   const handleDelete = (id) => {
     openConfirmModal({
       title: t("dashboard:tutorialsPage.delete_confirm_title"),
@@ -102,20 +89,6 @@ export default function InstructorTutorialsPage() {
       },
     });
   };
-
-  const filteredTutorials = tutorials
-    .filter((tut) => {
-      const matchesTitle = tut.title.toLowerCase().includes(searchQuery);
-      const matchesStatus = statusFilter ? tut.status === statusFilter : true;
-      return matchesTitle && matchesStatus;
-    })
-    .sort((a, b) => {
-      if (sortBy === "views") return b.views - a.views;
-      if (sortBy === "enrollments") return b.enrollments - a.enrollments;
-      if (sortBy === "oldest")
-        return new Date(a.createdAt) - new Date(b.createdAt);
-      return new Date(b.createdAt) - new Date(a.createdAt); // newest
-    });
 
   if (loading) {
     return (
@@ -237,206 +210,39 @@ export default function InstructorTutorialsPage() {
         {/* Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredTutorials.map((tutorial) => (
-            <div
+            <TutorialCard
               key={tutorial.id}
-              className="bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col transition-all duration-300 hover:shadow-xl border border-gray-100"
-            >
-              <div className="relative">
-                <img
-                  src={tutorial.thumbnail || "/default-thumbnail.jpg"}
-                  alt={tutorial.title}
-                  className="h-48 w-full object-cover"
-                />
-                <div className="absolute top-3 right-3">
-                  <span
-                    className={`inline-block px-3 py-1 rounded-full text-xs font-bold ${
-                      tutorial.status === "Approved"
-                        ? "bg-green-100 text-green-800"
-                        : tutorial.status === "Pending"
-                        ? "bg-blue-100 text-blue-800"
-                        : tutorial.status === "Draft"
-                        ? "bg-yellow-100 text-yellow-800"
-                        : "bg-red-100 text-red-800"
-                    }`}
-                  >
-                    {t(`dashboard:tutorialsPage.status_label.${tutorial.status.toLowerCase()}`)}
-                  </span>
-                </div>
-              </div>
-
-              <div className="flex-1 p-5 flex flex-col justify-between">
-                <div>
-                  <div className="flex justify-between items-start">
-                    <h2 className="text-lg font-bold text-gray-800 line-clamp-2">
-                      {tutorial.title}
-                    </h2>
-                    <span className="font-bold text-indigo-700 whitespace-nowrap ml-2">
-                      {tutorial.price ? `$${tutorial.price}` : t("tutorials:list.free")}
-                    </span>
-                  </div>
-                  
-                  <div className="flex items-center mt-2 text-sm text-gray-600">
-                    <span className="mr-3">
-                      {new Date(tutorial.updatedAt).toLocaleDateString()}
-                    </span>
-                    <div className="h-1 w-1 bg-gray-400 rounded-full mr-3"></div>
-                    <span>{tutorial.language || t("dashboard:tutorialsPage.default_language")}</span>
-                  </div>
-                  
-                  <div className="mt-3 flex flex-wrap gap-1">
-                    <span className="bg-indigo-50 text-indigo-700 px-2 py-1 rounded-md text-xs">
-                      {tutorial.category_name || t("dashboard:tutorialsPage.category_general")}
-                    </span>
-                    <span className="bg-purple-50 text-purple-700 px-2 py-1 rounded-md text-xs">
-                      {tutorial.level || t("dashboard:tutorialsPage.all_levels")}
-                    </span>
-                  </div>
-                  
-                  {tutorial.tags && tutorial.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-2">
-                      {tutorial.tags.map((tag) => (
-                        <span
-                          key={tag.id || tag}
-                          className="bg-gray-100 px-2 py-1 rounded-md text-xs text-gray-700"
-                        >
-                          {tag.name || tag}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                  
-                  {/* Stats */}
-                  <div className="grid grid-cols-4 gap-2 mt-4 text-center">
-                    <div className="p-2 bg-blue-50 rounded-lg">
-                      <FaEye className="mx-auto text-blue-500" />
-                      <span className="text-xs mt-1">{tutorial.views}</span>
-                    </div>
-                    <div className="p-2 bg-green-50 rounded-lg">
-                      <FaUsers className="mx-auto text-green-500" />
-                      <span className="text-xs mt-1">{tutorial.enrollments}</span>
-                    </div>
-                    <div className="p-2 bg-yellow-50 rounded-lg">
-                      <FaStar className="mx-auto text-yellow-500" />
-                      <span className="text-xs mt-1">{tutorial.rating}</span>
-                    </div>
-                    <div className="p-2 bg-purple-50 rounded-lg">
-                      <FaRegComments className="mx-auto text-purple-500" />
-                      <span className="text-xs mt-1">{tutorial.comments}</span>
-                    </div>
-                  </div>
-                  
-                  {/* Progress bar if Draft */}
-                  {tutorial.status === "Draft" && (
-                    <div className="mt-4">
-                      <div className="flex justify-between text-xs text-gray-600 mb-1">
-                        <span>{t("dashboard:tutorialsPage.progress")}</span>
-                        <span>{tutorial.progress || 40}%</span>
-                      </div>
-                      <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
-                        <div
-                          className="h-2 bg-gradient-to-r from-yellow-400 to-yellow-500 rounded-full"
-                          style={{ width: `${tutorial.progress || 40}%` }}
-                        ></div>
-                      </div>
-                    </div>
-                  )}
-                  
-                  {/* Submission Banner */}
-                  {tutorial.status === "Pending" && (
-                    <div className="mt-4 bg-blue-50 text-blue-700 text-xs font-medium px-3 py-2 rounded-lg">
-                      ⏳ {t("dashboard:tutorialsPage.pending_approval")}
-                    </div>
-                  )}
-                  {tutorial.status === "Rejected" && tutorial.rejection_reason && (
-                    <div className="mt-4 bg-red-50 text-red-700 text-xs font-medium px-3 py-2 rounded-lg">
-                      ❌ {tutorial.rejection_reason}
-                    </div>
-                  )}
-                </div>
-
-                {/* Buttons */}
-                <div className="mt-5 grid grid-cols-2 gap-2">
-                  <button
-                    onClick={() =>
-                      router.push(`/dashboard/instructor/tutorials/${tutorial.id}/view`)
-                    }
-                    className="bg-gray-100 hover:bg-gray-200 text-gray-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
-                  >
-                    <FaEye className="mr-2" /> {t("dashboard:tutorialsPage.view")}
-                  </button>
-
-                  {(tutorial.status === "Draft" || tutorial.status === "Rejected") && (
-                    <button
-                      onClick={() =>
-                        router.push(`/dashboard/instructor/tutorials/${tutorial.id}/edit`)
-                      }
-                      className="bg-green-100 hover:bg-green-200 text-green-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
-                    >
-                      <FaEdit className="mr-2" /> {t("dashboard:tutorialsPage.edit")}
-                    </button>
-                  )}
-
-                  <button
-                    onClick={() => {
-                      setChecklistTutorial(tutorial);
-                      setShowChecklist(true);
-                    }}
-                    className="bg-indigo-100 hover:bg-indigo-200 text-indigo-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
-                  >
-                    <span className="mr-2">📋</span> {t("dashboard:tutorialsPage.checklist")}
-                  </button>
-
-                  {tutorial.status === "Draft" && tutorial.progress === 100 && (
-                    <button
-                      onClick={async () => {
-                        try {
-                          await submitTutorialForReview(tutorial.id);
-                          setTutorials((prev) =>
-                            prev.map((t) =>
-                              t.id === tutorial.id ? { ...t, status: "Pending" } : t
-                            )
-                          );
-                          toast.success(t("dashboard:tutorialsPage.submit_for_review_success"));
-                        } catch (err) {
-                          console.error(err);
-                          toast.error(t("dashboard:tutorialsPage.submit_for_review_failed"));
-                        }
-                      }}
-                      className="bg-purple-100 hover:bg-purple-200 text-purple-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
-                    >
-                      {t("dashboard:tutorialsPage.submit")}
-                    </button>
-                  )}
-
-                  {(tutorial.status === "Draft" || tutorial.status === "Rejected") && (
-                    <button
-                      onClick={() => handleDelete(tutorial.id)}
-                      className="bg-red-100 hover:bg-red-200 text-red-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
-                    >
-                      <FaTrash className="mr-2" /> {t("dashboard:tutorialsPage.delete")}
-                    </button>
-                  )}
-
-
-                  <button
-                    onClick={() => {
-                      const dataStr =
-                        "data:text/json;charset=utf-8," +
-                        encodeURIComponent(JSON.stringify(tutorial, null, 2));
-                      const a = document.createElement("a");
-                      a.href = dataStr;
-                      a.download = `${tutorial.slug || tutorial.id}.json`;
-                      document.body.appendChild(a);
-                      a.click();
-                      a.remove();
-                    }}
-                    className="bg-gray-100 hover:bg-gray-200 text-gray-800 py-2 px-3 rounded-lg text-sm flex items-center justify-center transition-colors"
-                  >
-                    <FaDownload className="mr-2" /> {t("dashboard:tutorialsPage.export")}
-                  </button>
-                </div>
-              </div>
-            </div>
+              tutorial={tutorial}
+              onView={() =>
+                router.push(`/dashboard/instructor/tutorials/${tutorial.id}/view`)
+              }
+              onEdit={() =>
+                router.push(`/dashboard/instructor/tutorials/${tutorial.id}/edit`)
+              }
+              onChecklist={() => {
+                setChecklistTutorial(tutorial);
+                setShowChecklist(true);
+              }}
+              onSubmit={async () => {
+                try {
+                  await submitTutorialForReview(tutorial.id);
+                  setTutorials((prev) =>
+                    prev.map((t) =>
+                      t.id === tutorial.id ? { ...t, status: "Pending" } : t
+                    )
+                  );
+                  toast.success(
+                    t("dashboard:tutorialsPage.submit_for_review_success")
+                  );
+                } catch (err) {
+                  console.error(err);
+                  toast.error(
+                    t("dashboard:tutorialsPage.submit_for_review_failed")
+                  );
+                }
+              }}
+              onDelete={() => handleDelete(tutorial.id)}
+            />
           ))}
         </div>
 


### PR DESCRIPTION
## Summary
- factor out instructor tutorial search, filter, and sort logic into `useInstructorTutorials`
- extract tutorial card UI into `TutorialCard` component for instructor dashboard

## Testing
- `CI=true npm test` *(failed: CacheManager.test.tsx, InstructorSettingsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b11c11bc83289d9017ba8ffaf07a