### PR TITLE
feat: validate tutorials and restrict upload types

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -23,6 +23,8 @@ const { parsePlanFeatures } = require("../../../utils/planFeatures");
 const { sendSuccess } = require("../../../utils/response");
 const { parseTags, parseChapters } = require("./tutorial.helpers");
 const { sendCreationNotifications } = require("./tutorial.notifications");
+const tutorialValidator = require("./tutorial.validator");
+const { ZodError } = require("zod");
 
 // Helper to resolve uploads subdirectory based on user role
 const getRoleDir = (req) => {
@@ -39,6 +41,19 @@ const assertInstructorOwnsTutorial = async (userId, tutorialId) => {
 };
 
 exports.createTutorial = catchAsync(async (req, res) => {
+  let body;
+  try {
+    ({ body } = await tutorialValidator.create.parseAsync({ body: req.body }));
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return res.status(400).json({
+        message: "Validation error",
+        errors: err.errors,
+      });
+    }
+    throw err;
+  }
+
   const {
     title,
     description,
@@ -51,7 +66,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     chapters: rawChapters,
     included_plans = [],
     instructor_id: bodyInstructorId,
-  } = req.body;
+  } = body;
 
   const parsedChapters = parseChapters(rawChapters);
   const tags = parseTags(rawTags);
@@ -169,7 +184,21 @@ exports.updateTutorial = catchAsync(async (req, res) => {
   if (req.user.role === "instructor") {
     await assertInstructorOwnsTutorial(req.user.id, req.params.id);
   }
-  const { tags: rawTags, ...data } = req.body;
+
+  let body;
+  try {
+    ({ body } = await tutorialValidator.update.parseAsync({ body: req.body }));
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return res.status(400).json({
+        message: "Validation error",
+        errors: err.errors,
+      });
+    }
+    throw err;
+  }
+
+  const { tags: rawTags, ...data } = body;
   const roleDir = getRoleDir(req);
   if (req.files?.thumbnail) {
     data.cover_image = `/uploads/tutorials/${roleDir}/${req.files.thumbnail[0].filename}`;

--- a/backend/src/modules/users/tutorials/tutorial.routes.js
+++ b/backend/src/modules/users/tutorials/tutorial.routes.js
@@ -14,10 +14,7 @@ router.post(
   "/admin",
   verifyToken,
   isInstructorOrAdmin,
-  upload.fields([
-    { name: "thumbnail", maxCount: 1 },
-    { name: "preview", maxCount: 1 },
-  ]),
+  upload,
   validate(tutorialValidator.create),
   controller.createTutorial
 );
@@ -36,10 +33,7 @@ router.put(
   "/admin/:id",
   verifyToken,
   isInstructorOrAdmin,
-  upload.fields([
-    { name: "thumbnail", maxCount: 1 },
-    { name: "preview", maxCount: 1 },
-  ]),
+  upload,
   validate(tutorialValidator.update),
   controller.updateTutorial
 );

--- a/backend/src/modules/users/tutorials/tutorialUploadMiddleware.js
+++ b/backend/src/modules/users/tutorials/tutorialUploadMiddleware.js
@@ -2,6 +2,18 @@
 const multer = require("multer");
 const path = require("path");
 const fs = require("fs");
+const mime = require("mime-types");
+
+const IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp", "image/jpg"];
+const VIDEO_TYPES = [
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+  "video/x-matroska",
+];
+
+const MAX_THUMBNAIL_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_PREVIEW_SIZE = 100 * 1024 * 1024; // 100MB
 
 // Helper to determine base directory based on user role
 const resolveUploadPath = (req) => {
@@ -15,11 +27,11 @@ const resolveUploadPath = (req) => {
 
 // Configure multer storage
 const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
+  destination: (req, _file, cb) => {
     const dir = resolveUploadPath(req);
     cb(null, dir);
   },
-  filename: (req, file, cb) => {
+  filename: (_req, file, cb) => {
     const timestamp = Date.now();
     const ext = path.extname(file.originalname);
     const base = path.basename(file.originalname, ext).replace(/\s+/g, "-");
@@ -27,13 +39,50 @@ const storage = multer.diskStorage({
   },
 });
 
-// Optional: strict file type filter
-const fileFilter = (req, file, cb) => {
-  const allowed = ["image/jpeg", "image/png", "video/mp4", "video/webm"];
-  if (!allowed.includes(file.mimetype)) {
-    return cb(new Error("Unsupported file type"), false);
+const fileFilter = (_req, file, cb) => {
+  const detectedMime = mime.lookup(file.originalname) || "";
+  if (file.fieldname === "thumbnail") {
+    if (IMAGE_TYPES.includes(file.mimetype) && IMAGE_TYPES.includes(detectedMime)) {
+      return cb(null, true);
+    }
+    return cb(new Error("Invalid thumbnail file type"), false);
   }
-  cb(null, true);
+  if (file.fieldname === "preview") {
+    if (VIDEO_TYPES.includes(file.mimetype) && VIDEO_TYPES.includes(detectedMime)) {
+      return cb(null, true);
+    }
+    return cb(new Error("Invalid preview file type"), false);
+  }
+  return cb(new Error("Invalid file field"), false);
 };
 
-module.exports = multer({ storage, fileFilter });
+const baseUpload = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: MAX_PREVIEW_SIZE },
+});
+
+module.exports = (req, res, next) => {
+  baseUpload.fields([
+    { name: "thumbnail", maxCount: 1 },
+    { name: "preview", maxCount: 1 },
+  ])(req, res, (err) => {
+    if (err) return next(err);
+    const thumb = req.files?.thumbnail?.[0];
+    const preview = req.files?.preview?.[0];
+    if (thumb && thumb.size > MAX_THUMBNAIL_SIZE) {
+      fs.unlink(thumb.path, () => {});
+      return next(new Error("Thumbnail file too large"));
+    }
+    if (preview && preview.size > MAX_PREVIEW_SIZE) {
+      fs.unlink(preview.path, () => {});
+      return next(new Error("Preview file too large"));
+    }
+    next();
+  });
+};
+
+module.exports.storage = storage;
+module.exports.fileFilter = fileFilter;
+module.exports.MAX_THUMBNAIL_SIZE = MAX_THUMBNAIL_SIZE;
+module.exports.MAX_PREVIEW_SIZE = MAX_PREVIEW_SIZE;


### PR DESCRIPTION
## Summary
- validate tutorial payloads in controller using zod schemas and return 400 with details
- enforce thumbnail and preview upload restrictions with mime whitelists and size limits
- wire routes to new tutorial upload middleware

## Testing
- `npm test` *(fails: bookRoutes.test, tutorialRoutes.test, paymentCommission.test, paymentInvoiceEmail.test, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b11693108328a5a30b7811c4176e