### PR TITLE
feat: add shared tutorial creation hook

### DIFF
--- a/frontend/src/hooks/useTutorialCreation.js
+++ b/frontend/src/hooks/useTutorialCreation.js
@@ -1,0 +1,78 @@
+import { useState, useEffect } from "react";
+import { buildTutorialFormData } from "@/utils/tutorialForm";
+import { toast } from "react-toastify";
+
+// Shared hook for tutorial creation form
+// Handles form state, step navigation, category fetching and FormData generation
+export default function useTutorialCreation({ fetchCategories } = {}) {
+  const [step, setStep] = useState(1);
+  const [tutorialData, setTutorialData] = useState({
+    title: "",
+    shortDescription: "",
+    category: "",
+    categoryName: "",
+    level: "",
+    lessonCount: 1,
+    tags: [],
+    chapters: [],
+    thumbnail: null,
+    preview: null,
+    language: "",
+    price: "",
+    currency: "",
+    isFree: false,
+  });
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    const savedDraft = localStorage.getItem("tutorialDraft");
+    if (savedDraft) {
+      try {
+        const draft = JSON.parse(savedDraft);
+        setTutorialData((prev) => ({
+          ...prev,
+          ...draft,
+          thumbnail: null,
+          preview: null,
+          language: draft.language || "",
+          lessonCount: draft.lessonCount || draft.chapters?.length || 1,
+          currency: draft.currency || "",
+        }));
+      } catch (err) {
+        console.error("Failed to parse tutorialDraft", err);
+        localStorage.removeItem("tutorialDraft");
+      }
+    }
+
+    const loadCategories = async () => {
+      if (!fetchCategories) return;
+      try {
+        const result = await fetchCategories();
+        // support both array and {data: []}
+        setCategories(result?.data || result || []);
+      } catch (err) {
+        console.error("Failed to load categories", err);
+        toast.error("Failed to load categories");
+      }
+    };
+
+    loadCategories();
+  }, [fetchCategories]);
+
+  const nextStep = () => setStep((s) => s + 1);
+  const prevStep = () => setStep((s) => s - 1);
+
+  const buildFormData = (status) => buildTutorialFormData(tutorialData, status);
+
+  return {
+    step,
+    setStep,
+    nextStep,
+    prevStep,
+    tutorialData,
+    setTutorialData,
+    categories,
+    buildFormData,
+  };
+}
+

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
@@ -15,16 +14,29 @@ import { fetchAllCategories } from "@/services/admin/categoryService";
 import StepProgressBar from "@/components/tutorials/create/StepProgressBar";
 import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
-import { buildTutorialFormData } from "@/utils/tutorialForm";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import useTutorialCreation from "@/hooks/useTutorialCreation";
 
 function CreateTutorialPage() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialCreatePage' });
   const user = useAuthStore((s) => s.user);
   const refreshNotifications = useNotificationStore((s) => s.fetch);
   const refreshMessages = useMessageStore((s) => s.fetch);
+  const router = useRouter();
+
+  const {
+    step,
+    setStep,
+    nextStep,
+    prevStep,
+    tutorialData,
+    setTutorialData,
+    categories,
+    buildFormData,
+  } = useTutorialCreation({ fetchCategories: fetchAllCategories });
+
   const notify = async (type, message) => {
     if (!user?.id) {
       toast.warn('Notification skipped: missing user data.');
@@ -42,63 +54,6 @@ function CreateTutorialPage() {
       toast.error(msg);
     }
   };
-  const [step, setStep] = useState(1);
-  const router = useRouter();
-  const [tutorialData, setTutorialData] = useState({
-    title: "",
-    shortDescription: "",
-    category: "",
-    categoryName: "",
-    level: "",
-    lessonCount: 1,
-    tags: [],
-    chapters: [],
-    thumbnail: null,
-    preview: null,
-    language: "",
-    price: "",
-    isFree: false,
-  });
-
-  const [categories, setCategories] = useState([]);
-
-  useEffect(() => {
-    const savedDraft = localStorage.getItem("tutorialDraft");
-    if (savedDraft) {
-      try {
-        const draft = JSON.parse(savedDraft);
-        setTutorialData({
-          ...draft,
-          thumbnail: null,
-          preview: null,
-          language: draft.language || "",
-          lessonCount: draft.lessonCount || draft.chapters?.length || 1,
-        });
-      } catch (err) {
-        console.error("Failed to parse tutorialDraft", err);
-        localStorage.removeItem("tutorialDraft");
-      }
-    }
-
-    const loadCategories = async () => {
-      try {
-        const result = await fetchAllCategories();
-
-        setCategories(result || []);
-
-      
-      } catch (err) {
-        console.error("Failed to load categories", err);
-        toast.error(t('load_categories_failed'));
-      }
-    };
-
-    loadCategories();
-  }, []);
-
-  const nextStep = () => setStep((prev) => prev + 1);
-  const prevStep = () => setStep((prev) => prev - 1);
-
 
   const submitTutorial = async (status) => {
     if (tutorialData.chapters.some((ch) => !ch.videoUrl)) {
@@ -106,7 +61,7 @@ function CreateTutorialPage() {
       return;
     }
 
-    const formData = buildTutorialFormData(tutorialData, status);
+    const formData = buildFormData(status);
 
     try {
       await createTutorial(formData);

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -1,8 +1,7 @@
-import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { fetchAllCategories } from "@/services/instructor/categoryService";
-import { createTutorial } from "@/services/admin/tutorialService";
+import { createTutorial } from "@/services/instructor/tutorialService";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
@@ -12,95 +11,30 @@ import StepProgressBar from "@/components/tutorials/create/StepProgressBar";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import useTutorialCreation from "@/hooks/useTutorialCreation";
 
 export default function CreateTutorialPage() {
-  const [step, setStep] = useState(1);
   const router = useRouter();
   const { t } = useTranslation(["dashboard", "tutorials"]);
-  const [tutorialData, setTutorialData] = useState({
-    title: "",
-    shortDescription: "",
-    category: "",
-    categoryName: "",
-    level: "",
-    language: "",
-    lessonCount: 1,
-    tags: [],
-    chapters: [],
-    thumbnail: null,
-    preview: null,
-    price: "",
-    currency: "",
-    isFree: false,
-  });
 
-  const [categories, setCategories] = useState([]);
-
-  useEffect(() => {
-    const savedDraft = localStorage.getItem("tutorialDraft");
-    if (savedDraft) {
-      const draft = JSON.parse(savedDraft);
-      setTutorialData({
-        ...draft,
-        thumbnail: null,
-        preview: null,
-        language: draft.language || "",
-        lessonCount: draft.lessonCount || 1,
-        currency: draft.currency || "",
-      });
-    }
-
-    const loadCategories = async () => {
-      try {
-        const result = await fetchAllCategories();
-
-        setCategories(result?.data || []);
-
-      } catch (err) {
-        console.error(t('tutorialCreatePage.load_categories_failed', { ns: 'dashboard' }), err);
-      }
-    };
-
-    loadCategories();
-  }, [t]);
-
-  const nextStep = () => setStep((prev) => prev + 1);
-  const prevStep = () => setStep((prev) => prev - 1);
+  const {
+    step,
+    setStep,
+    nextStep,
+    prevStep,
+    tutorialData,
+    setTutorialData,
+    categories,
+    buildFormData,
+  } = useTutorialCreation({ fetchCategories: fetchAllCategories });
 
   const submitTutorial = async (status) => {
     if (tutorialData.chapters.some((ch) => !ch.videoUrl)) {
       toast.error(t("dashboard:tutorialCreatePage.upload_video_each_lesson"));
       return;
     }
-    const formData = new FormData();
-    formData.append("title", tutorialData.title);
-    formData.append("description", tutorialData.shortDescription);
-    formData.append("category_id", tutorialData.category);
-    formData.append("level", tutorialData.level);
-    formData.append("language", tutorialData.language);
-    formData.append("status", status);
-    formData.append("is_paid", (!tutorialData.isFree).toString());
-    if (!tutorialData.isFree) {
-      formData.append("price", tutorialData.price);
-      if (tutorialData.currency) {
-        formData.append("currency", tutorialData.currency);
-      }
-    }
-    if (tutorialData.tags.length) {
-      formData.append("tags", JSON.stringify(tutorialData.tags));
-    }
-    if (tutorialData.chapters.length) {
-      const chapters = tutorialData.chapters.map((ch, idx) => ({
-        title: ch.title,
-        duration: ch.duration,
-        video_url: ch.videoUrl,
-        order: idx + 1,
-        is_preview: ch.preview,
-      }));
-      formData.append("chapters", JSON.stringify(chapters));
-    }
-    if (tutorialData.thumbnail) formData.append("thumbnail", tutorialData.thumbnail);
-    if (tutorialData.preview) formData.append("preview", tutorialData.preview);
+
+    const formData = buildFormData(status);
 
     try {
       await createTutorial(formData);


### PR DESCRIPTION
## Summary
- create `useTutorialCreation` for shared tutorial form state, step control, and FormData building
- refactor admin tutorial create page to use shared hook and remove duplicate logic
- refactor instructor tutorial create page similarly with instructor services

## Testing
- `npm test` (fails: CacheManager test missing mockReset; InstructorSettingsPage test missing module)
- `npm run lint` (fails: 56 errors, 270 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68c5b11a7740832890ac9f2bb1580864