### PR TITLE
feat: paginate student tutorials

### DIFF
--- a/frontend/src/pages/dashboard/student/tutorials/index.js
+++ b/frontend/src/pages/dashboard/student/tutorials/index.js
@@ -12,6 +12,9 @@ export default function StudentTutorialsPage() {
   const [tutorials, setTutorials] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const limit = 6;
   const [sortBy, setSortBy] = useState("title");
   const { t } = useTranslation("tutorials");
   const tr = (key, def, opts) => {
@@ -22,8 +25,14 @@ export default function StudentTutorialsPage() {
   useEffect(() => {
     const controller = new AbortController();
     const load = async () => {
+      setLoading(true);
+      setError(null);
       try {
-        const data = await fetchPublishedTutorials({ signal: controller.signal });
+        const data = await fetchPublishedTutorials({
+          page,
+          limit,
+          signal: controller.signal,
+        });
         const enriched = data.map((tut) => {
           const saved = localStorage.getItem(`progress-tutorial-${tut.id}`);
           let progress = { completedChapters: [], completedQuiz: false };
@@ -42,6 +51,7 @@ export default function StudentTutorialsPage() {
           };
         });
         setTutorials(enriched);
+        setHasMore(data.length === limit);
       } catch (err) {
         if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         console.error(err);
@@ -54,7 +64,7 @@ export default function StudentTutorialsPage() {
     return () => {
       controller.abort();
     };
-  }, []);
+  }, [page]);
 
   const filtered = tutorials.filter((tut) => {
     const matchesSearch = tut.title
@@ -162,6 +172,28 @@ export default function StudentTutorialsPage() {
             <StudentTutorialCard key={tut.id} tutorial={tut} />
           ))}
         </div>
+
+        {sorted.length > 0 && (
+          <div className="flex items-center justify-center gap-2 mt-4">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="px-3 py-1 border rounded disabled:opacity-50"
+            >
+              {tr("studentPage.prev", "Previous")}
+            </button>
+            <span className="text-sm">
+              {tr("studentPage.page", "Page {{page}}", { page })}
+            </span>
+            <button
+              onClick={() => setPage((p) => p + 1)}
+              disabled={!hasMore}
+              className="px-3 py-1 border rounded disabled:opacity-50"
+            >
+              {tr("studentPage.next", "Next")}
+            </button>
+          </div>
+        )}
 
         {sorted.length === 0 && (
           <div className="text-center text-gray-500">

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -88,8 +88,12 @@ export const fetchFeaturedTutorials = async () => {
   return Array.isArray(list) ? list.map(formatTutorial) : list;
 };
 
-export const fetchPublishedTutorials = async (config = {}) => {
-  const res = await api.get("/users/tutorials", config);
+export const fetchPublishedTutorials = async ({ page, limit, ...config } = {}) => {
+  const params = { ...(config?.params || {}) };
+  if (page != null) params.page = page;
+  if (limit != null) params.limit = limit;
+
+  const res = await api.get("/users/tutorials", { ...config, params });
   const list = extractData(res);
   return Array.isArray(list) ? list.map(formatTutorial) : list;
 };


### PR DESCRIPTION
## Summary
- support page and limit in tutorial service fetchPublishedTutorials
- add pagination controls to student tutorials page

## Testing
- `npm run lint --prefix frontend` *(fails: many lint warnings/errors across repository)*
- `npm test --prefix frontend src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: CacheManager.mockReset not a function; InstructorSettingsPage missing module)*


------
https://chatgpt.com/codex/tasks/task_e_68c5b11ddb8083288eeaf8d97c429cc7