### PR TITLE
feat: abort async effects on unmount

### DIFF
--- a/frontend/src/components/admin/categories/CategoryList.js
+++ b/frontend/src/components/admin/categories/CategoryList.js
@@ -9,15 +9,22 @@ export default function CategoryList() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     let isMounted = true;
-    fetchBookCategories()
+    fetchBookCategories({ signal: controller.signal })
       .then((data) => {
         if (isMounted) setCategories(data);
       })
-      .catch(() => isMounted && setError("Failed to load categories"))
-      .finally(() => isMounted && setLoading(false));
+      .catch((err) => {
+        if (err.name === "AbortError" || err.name === "CanceledError") return;
+        if (isMounted) setError("Failed to load categories");
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, []);
 

--- a/frontend/src/components/books/BookReviewList.js
+++ b/frontend/src/components/books/BookReviewList.js
@@ -9,14 +9,20 @@ export default function BookReviewList({ bookId, version = 0 }) {
 
   useEffect(() => {
     if (!bookId) return;
+    const controller = new AbortController();
     let isMounted = true;
-    fetchReviews(bookId).then((data) => {
-      if (!isMounted) return;
-      setReviews(data.reviews || []);
-      setAverage(data.averageRating || 0);
-    });
+    fetchReviews(bookId, { signal: controller.signal })
+      .then((data) => {
+        if (!isMounted) return;
+        setReviews(data.reviews || []);
+        setAverage(data.averageRating || 0);
+      })
+      .catch((err) => {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
+      });
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, [bookId, version]);
 

--- a/frontend/src/components/chat/GroupChat.js
+++ b/frontend/src/components/chat/GroupChat.js
@@ -17,13 +17,18 @@ export default function GroupChat({ group, groupId: idProp, groupName: nameProp 
 
   useEffect(() => {
     if (!groupId) return;
+    const controller = new AbortController();
     let isMounted = true;
 
     const fetchMessages = async () => {
       try {
-        const msgs = await groupService.getGroupMessages(groupId);
+        const msgs = await groupService.getGroupMessages(groupId, {
+          signal: controller.signal,
+        });
         if (isMounted) setMessages(msgs);
-      } catch (_) {}
+      } catch (err) {
+        if (err.name === "AbortError" || err.name === "CanceledError") return;
+      }
     };
 
     setMessages([]);
@@ -31,13 +36,18 @@ export default function GroupChat({ group, groupId: idProp, groupName: nameProp 
     const interval = setInterval(fetchMessages, 5000);
     const typingPoll = setInterval(async () => {
       try {
-        const names = await groupService.getTypingStatus(groupId);
-        setTypingUsers(names);
-      } catch (_) {}
+        const names = await groupService.getTypingStatus(groupId, {
+          signal: controller.signal,
+        });
+        if (isMounted) setTypingUsers(names);
+      } catch (err) {
+        if (err.name === "AbortError" || err.name === "CanceledError") return;
+      }
     }, 2000);
 
     return () => {
       isMounted = false;
+      controller.abort();
       clearInterval(interval);
       clearInterval(typingPoll);
     };

--- a/frontend/src/components/chat/GroupMemberList.js
+++ b/frontend/src/components/chat/GroupMemberList.js
@@ -15,16 +15,23 @@ export default function GroupMembersList({ groupId }) {
 
   useEffect(() => {
     if (!groupId) return;
+    const controller = new AbortController();
     let isMounted = true;
     groupService
-      .getGroupMembers(groupId)
+      .getGroupMembers(groupId, { signal: controller.signal })
       .then((data) => {
         if (isMounted) setMembers(data);
       })
-      .catch(() => isMounted && setError('Failed to load members'))
-      .finally(() => isMounted && setLoading(false));
+      .catch((err) => {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
+        if (isMounted) setError('Failed to load members');
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, [groupId]);
 

--- a/frontend/src/components/chat/PendingJoinRequests.js
+++ b/frontend/src/components/chat/PendingJoinRequests.js
@@ -9,16 +9,23 @@ export default function PendingJoinRequests({ groupId, onApprove, onReject }) {
 
   useEffect(() => {
     if (!groupId) return;
+    const controller = new AbortController();
     let isMounted = true;
     groupService
-      .getJoinRequestsForGroup(groupId)
+      .getJoinRequestsForGroup(groupId, { signal: controller.signal })
       .then((data) => {
         if (isMounted) setRequests(data);
       })
-      .catch(() => isMounted && setError('Failed to load requests'))
-      .finally(() => isMounted && setLoading(false));
+      .catch((err) => {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
+        if (isMounted) setError('Failed to load requests');
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, [groupId]);
 

--- a/frontend/src/components/shared/DynamicAds.js
+++ b/frontend/src/components/shared/DynamicAds.js
@@ -8,12 +8,14 @@ const DynamicAds = () => {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     let isMounted = true;
     const loadAds = async () => {
       try {
-        const { data } = await fetchAds();
+        const { data } = await fetchAds({}, { signal: controller.signal });
         if (isMounted) setAds(data);
       } catch (err) {
+        if (err.name === "AbortError" || err.name === "CanceledError") return;
         if (isMounted) setError("Failed to load ads");
       } finally {
         if (isMounted) setLoading(false);
@@ -22,6 +24,7 @@ const DynamicAds = () => {
     loadAds();
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, []);
 

--- a/frontend/src/components/website/sections/TutorialsSection.js
+++ b/frontend/src/components/website/sections/TutorialsSection.js
@@ -68,11 +68,12 @@ const LandingTutorialsSection = () => {
     if (typeof navigator !== "undefined") {
       setIsMobile(/Mobi|Android/i.test(navigator.userAgent));
     }
+    const controller = new AbortController();
     let isMounted = true;
 
     const load = async () => {
-      const tutorialsPromise = fetchFeaturedTutorials().catch((err) => ({ error: err }));
-      const categoriesPromise = fetchAllCategories({ limit: 100 }).catch((err) => ({ error: err }));
+      const tutorialsPromise = fetchFeaturedTutorials({ signal: controller.signal }).catch((err) => ({ error: err }));
+      const categoriesPromise = fetchAllCategories({ limit: 100 }, { signal: controller.signal }).catch((err) => ({ error: err }));
 
       const [tutorialRes, categoryRes] = await Promise.all([
         tutorialsPromise,
@@ -82,23 +83,27 @@ const LandingTutorialsSection = () => {
       if (isMounted) {
         if (tutorialRes?.error) {
           const err = tutorialRes.error;
-          const msg =
-            err.code === "ERR_NETWORK"
-              ? t('network_error')
-              : t('tutorials_load_error');
-          toast.error(msg);
+          if (err.name !== "AbortError" && err.name !== "CanceledError") {
+            const msg =
+              err.code === "ERR_NETWORK"
+                ? t('network_error')
+                : t('tutorials_load_error');
+            toast.error(msg);
+          }
         } else {
           setTutorials(tutorialRes || []);
         }
 
         if (categoryRes?.error) {
           const err = categoryRes.error;
-          const msg =
-            err.code === "ERR_NETWORK"
-              ? t('network_error')
-              : t('categories_load_error');
-          toast.error(msg);
-          console.error(t('categories_load_error'), err);
+          if (err.name !== "AbortError" && err.name !== "CanceledError") {
+            const msg =
+              err.code === "ERR_NETWORK"
+                ? t('network_error')
+                : t('categories_load_error');
+            toast.error(msg);
+            console.error(t('categories_load_error'), err);
+          }
         } else {
           setCategories(categoryRes?.data || categoryRes || []);
         }
@@ -108,6 +113,7 @@ const LandingTutorialsSection = () => {
 
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, [user, isStudent]);
 
@@ -128,22 +134,30 @@ const LandingTutorialsSection = () => {
 
   useEffect(() => {
     if (!user || !isStudent) return;
+    const controller = new AbortController();
+    let isMounted = true;
     const loadLists = async () => {
       try {
         const [w, f, e] = await Promise.all([
-          getMyTutorialWishlist(),
-          getMyTutorialFavorites(),
-          getMyEnrolledTutorials(),
+          getMyTutorialWishlist({ signal: controller.signal }),
+          getMyTutorialFavorites({ signal: controller.signal }),
+          getMyEnrolledTutorials({ signal: controller.signal }),
         ]);
+        if (!isMounted) return;
         setWishlistIds(w.map((t) => t.id));
         setFavoriteIds(f.map((t) => t.id));
         setEnrolledIds(e.map((t) => t.id));
       } catch (err) {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         console.error('Failed to load user lists', err);
       }
     };
     loadLists();
-  }, [user]);
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [user, isStudent]);
 
   useEffect(() => {
     if (!user) return;

--- a/frontend/src/hooks/useLastSeen.js
+++ b/frontend/src/hooks/useLastSeen.js
@@ -9,10 +9,13 @@ const useLastSeen = (userId) => {
 
   useEffect(() => {
     if (!userId) return;
+    const controller = new AbortController();
     let isMounted = true;
     const fetchStatus = async () => {
       try {
-        const { data } = await api.get(`/users/usersmanagement/${userId}`);
+        const { data } = await api.get(`/users/usersmanagement/${userId}`, {
+          signal: controller.signal,
+        });
         if (!isMounted) return;
         const user = data?.data || data;
         const online = user?.is_online ?? false;
@@ -25,6 +28,7 @@ const useLastSeen = (userId) => {
           setLastSeen("Offline");
         }
       } catch (err) {
+        if (err.name === "AbortError" || err.name === "CanceledError") return;
         if (isMounted) setError("Failed to fetch status");
       } finally {
         if (isMounted) setLoading(false);
@@ -33,6 +37,7 @@ const useLastSeen = (userId) => {
     fetchStatus();
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, [userId]);
 

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -109,14 +109,23 @@ function ProfileEditTemplate() {
 
   useEffect(() => {
     if (!hasHydrated) return;
+    const controller = new AbortController();
+    let isMounted = true;
+
     if (!user) {
       if (isMounted) setLoadingProfile(false);
-      return;
+      return () => {
+        isMounted = false;
+        controller.abort();
+      };
     }
     const role = user.role?.toLowerCase();
     if (role !== "admin" && role !== "superadmin") {
       if (isMounted) setLoadingProfile(false);
-      return;
+      return () => {
+        isMounted = false;
+        controller.abort();
+      };
     }
 
     // Pre-fill with existing user info while fetching latest data
@@ -142,7 +151,7 @@ function ProfileEditTemplate() {
         if (!isMounted) return;
         setLoadingProfile(true);
 
-        const res = await getAdminProfile();
+        const res = await getAdminProfile({ signal: controller.signal });
         if (!isMounted) return;
         const {
           full_name,
@@ -180,6 +189,7 @@ function ProfileEditTemplate() {
           socialLinks: socialMap,
         }));
       } catch (err) {
+        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
         if (isMounted) toast.error(t('load_profile_failed'));
         console.error("Profile load error:", err);
       } finally {
@@ -188,6 +198,11 @@ function ProfileEditTemplate() {
     };
 
     loadProfile();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
   }, [hasHydrated, user, fetchNotifications, fetchMessages]);
 
 

--- a/frontend/src/pages/search/index.js
+++ b/frontend/src/pages/search/index.js
@@ -35,10 +35,11 @@ const SearchPage = () => {
       return;
     }
 
+    const controller = new AbortController();
     let isMounted = true;
     setLoading(true);
     setError(null);
-    searchAll(searchQuery)
+    searchAll(searchQuery, { signal: controller.signal })
       .then((data) => {
         if (!isMounted) return;
         const flat = [];
@@ -55,11 +56,17 @@ const SearchPage = () => {
         });
         setResults(flat);
       })
-      .catch(() => isMounted && setError("Failed to fetch results"))
-      .finally(() => isMounted && setLoading(false));
+      .catch((err) => {
+        if (err.name === "AbortError" || err.name === "CanceledError") return;
+        if (isMounted) setError("Failed to fetch results");
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
 
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, [searchQuery]);
 

--- a/frontend/src/pages/support/ticket-status.js
+++ b/frontend/src/pages/support/ticket-status.js
@@ -10,15 +10,22 @@ export default function TicketStatusPage() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     let isMounted = true;
-    fetchMyTickets()
+    fetchMyTickets({ signal: controller.signal })
       .then((data) => {
         if (isMounted) setTickets(data);
       })
-      .catch(() => isMounted && setError("Failed to load tickets"))
-      .finally(() => isMounted && setLoading(false));
+      .catch((err) => {
+        if (err.name === "AbortError" || err.name === "CanceledError") return;
+        if (isMounted) setError("Failed to load tickets");
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, []);
 

--- a/frontend/src/services/admin/adminService.js
+++ b/frontend/src/services/admin/adminService.js
@@ -7,8 +7,9 @@ import { ensureCsrfToken } from "@/services/api/csrf";
  * 
  * @returns {Promise<Object>} Admin profile object
  */
-export const getAdminProfile = async () => {
-  const res = await api.get("/users/admin/profile");
+export const getAdminProfile = async (config = {}) => {
+  const cfg = Object.keys(config).length ? config : undefined;
+  const res = await api.get("/users/admin/profile", cfg);
   return res.data;
 };
 

--- a/frontend/src/services/adsService.js
+++ b/frontend/src/services/adsService.js
@@ -1,15 +1,17 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
 
-export const fetchAds = async ({ role, limit, offset } = {}) => {
+export const fetchAds = async ({ role, limit, offset } = {}, config = {}) => {
   try {
     const params = {
       ...(role ? { role } : {}),
       ...(limit !== undefined ? { limit } : {}),
       ...(offset !== undefined ? { offset } : {}),
     };
-    const config = Object.keys(params).length ? { params } : undefined;
-    const { data } = await api.get("/ads", config);
+    const hasParams = Object.keys(params).length > 0;
+    const hasConfig = Object.keys(config).length > 0;
+    const reqConfig = hasParams || hasConfig ? { ...config, ...(hasParams ? { params } : {}) } : undefined;
+    const { data } = await api.get("/ads", reqConfig);
     // Backend already filters out inactive ads so simply map the returned list.
     const ads = data?.data ?? [];
 

--- a/frontend/src/services/bookCategoryService.js
+++ b/frontend/src/services/bookCategoryService.js
@@ -1,6 +1,10 @@
 import api from "@/services/api/api";
 
-export const fetchBookCategories = async () => {
+export const fetchBookCategories = async (config = {}) => {
+  if (Object.keys(config).length) {
+    const { data } = await api.get("/book-categories", config);
+    return data?.data ?? [];
+  }
   const { data } = await api.get("/book-categories");
   return data?.data ?? [];
 };

--- a/frontend/src/services/bookReviewService.js
+++ b/frontend/src/services/bookReviewService.js
@@ -1,7 +1,8 @@
 import api from "@/services/api/api";
 
-export const fetchReviews = async (bookId) => {
-  const { data } = await api.get(`/book-reviews/books/${bookId}`);
+export const fetchReviews = async (bookId, config = {}) => {
+  const cfg = Object.keys(config).length ? config : undefined;
+  const { data } = await api.get(`/book-reviews/books/${bookId}`, cfg);
   return data?.data || { reviews: [], averageRating: 0 };
 };
 

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -128,8 +128,8 @@ const groupService = {
     return data?.data;
   },
 
-  getGroupMessages: async (groupId) => {
-    const { data } = await api.get(`/groups/${groupId}/messages`);
+  getGroupMessages: async (groupId, opts = {}) => {
+    const { data } = await api.get(`/groups/${groupId}/messages`, opts);
     const list = data?.data ?? [];
     const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
     return list.map((m) => ({
@@ -189,8 +189,8 @@ const groupService = {
     return true;
   },
 
-  getTypingStatus: async (groupId) => {
-    const { data } = await api.get(`/groups/${groupId}/typing`);
+  getTypingStatus: async (groupId, opts = {}) => {
+    const { data } = await api.get(`/groups/${groupId}/typing`, opts);
     return data?.data ?? [];
   },
 

--- a/frontend/src/services/instructor/categoryService.js
+++ b/frontend/src/services/instructor/categoryService.js
@@ -1,7 +1,9 @@
 import api from "@/services/api/api";
 
-export const fetchAllCategories = async (params = {}) => {
-  const { data } = await api.get("/users/categories", { params });
+export const fetchAllCategories = async (params = {}, config = {}) => {
+  const hasConfig = Object.keys(config).length > 0;
+  const cfg = hasConfig ? { params, ...config } : { params };
+  const { data } = await api.get("/users/categories", cfg);
   return data?.data;
 };
 

--- a/frontend/src/services/searchService.js
+++ b/frontend/src/services/searchService.js
@@ -1,7 +1,11 @@
 import api from '@/services/api/api';
 
-export const searchAll = async (query) => {
-  const { data } = await api.get('/search', { params: { q: query } });
+export const searchAll = async (query, config = {}) => {
+  const reqConfig = {
+    ...config,
+    params: { ...(config.params || {}), q: query },
+  };
+  const { data } = await api.get('/search', reqConfig);
   // API may return `{status, message, data}` or the raw results object
   // Normalize by always returning the payload containing the lists
   return data.data || data;

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -19,8 +19,9 @@ export const createTicket = async ({ subject, message }) => {
   return data?.data;
 };
 
-export const fetchMyTickets = async () => {
-  const { data } = await api.get("/support/my-tickets");
+export const fetchMyTickets = async (config = {}) => {
+  const cfg = Object.keys(config).length ? config : undefined;
+  const { data } = await api.get("/support/my-tickets", cfg);
   const list = data?.data ?? [];
   return list.map(({ created_at, user_avatar, ...rest }) => ({
     ...rest,

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -82,8 +82,9 @@ export const formatTutorial = (tut) => {
   };
 };
 
-export const fetchFeaturedTutorials = async () => {
-  const res = await api.get("/users/tutorials/featured");
+export const fetchFeaturedTutorials = async (config = {}) => {
+  const cfg = Object.keys(config).length ? config : undefined;
+  const res = await api.get("/users/tutorials/featured", cfg);
   const list = extractData(res);
   return Array.isArray(list) ? list.map(formatTutorial) : list;
 };
@@ -105,9 +106,10 @@ export const enrollInTutorial = async (tutorialId) => {
   return data;
 };
 
-export const getMyEnrolledTutorials = async () => {
+export const getMyEnrolledTutorials = async (config = {}) => {
   try {
-    const res = await api.get('/users/tutorials/enroll/my');
+    const cfg = Object.keys(config).length ? config : undefined;
+    const res = await api.get('/users/tutorials/enroll/my', cfg);
     const list = extractData(res);
     return list.map(formatTutorial);
   } catch (err) {
@@ -144,8 +146,9 @@ export const removeTutorialFromWishlist = async (id) => {
   return data;
 };
 
-export const getMyTutorialWishlist = async () => {
-  const res = await api.get('/users/tutorials/wishlist/my');
+export const getMyTutorialWishlist = async (config = {}) => {
+  const cfg = Object.keys(config).length ? config : undefined;
+  const res = await api.get('/users/tutorials/wishlist/my', cfg);
   return extractData(res);
 };
 
@@ -159,8 +162,9 @@ export const removeTutorialFromFavorites = async (id) => {
   return data;
 };
 
-export const getMyTutorialFavorites = async () => {
-  const res = await api.get('/users/tutorials/favorites/my');
+export const getMyTutorialFavorites = async (config = {}) => {
+  const cfg = Object.keys(config).length ? config : undefined;
+  const res = await api.get('/users/tutorials/favorites/my', cfg);
   return extractData(res);
 };
 


### PR DESCRIPTION
## Summary
- safeguard async hooks and components with AbortController
- abort outstanding requests and prevent state updates after unmount
- expose signal-aware service functions for cancellable requests

## Testing
- `npm test` *(failing: Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js'; TypeError: _cacheService.clearCache.mockReset is not a function)*
- `npm run lint` *(errors: Component definition is missing display name; Unexpected console statement)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b11eb43883288171aaba214a6c28