### PR TITLE
Improve API error handling and rollback language updates

### DIFF
--- a/frontend/src/pages/dashboard/admin/settings/languages/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/index.js
@@ -9,6 +9,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
+import handleApiError from "@/utils/apiError";
 
 const fetcher = url => api.get(url).then(res => res.data.data);
 
@@ -20,36 +21,58 @@ export default function LanguagesPage() {
   const ITEMS_PER_PAGE = 5;
 
   const toggleActive = async (lang) => {
+    const previous = languages;
+    const updated = languages?.map((l) =>
+      l.id === lang.id ? { ...l, is_active: !l.is_active } : l
+    );
+
+    mutate(updated, false);
+
     try {
       await api.put(`/languages/${lang.id}`, { ...lang, is_active: !lang.is_active });
       mutate();
       mutateGlobal("/app-config");
       toast.success(t('language_updated'));
     } catch (err) {
-      toast.error(t('failed_to_save'));
+      mutate(previous, false);
+      handleApiError(err, t('failed_to_save'));
     }
   };
 
   const setDefault = async (lang) => {
+    const previous = languages;
+    const updated = languages?.map((l) => ({
+      ...l,
+      is_default: l.id === lang.id
+    }));
+
+    mutate(updated, false);
+
     try {
       await api.put(`/languages/${lang.id}`, { ...lang, is_default: true });
       mutate();
       mutateGlobal("/app-config");
       toast.success(t('language_updated'));
     } catch (err) {
-      toast.error(t('failed_to_save'));
+      mutate(previous, false);
+      handleApiError(err, t('failed_to_save'));
     }
   };
 
   const remove = async (id) => {
     if (confirm(t('confirm_delete'))) {
+      const previous = languages;
+      const updated = languages?.filter((l) => l.id !== id);
+      mutate(updated, false);
+
       try {
         await api.delete(`/languages/${id}`);
         mutate();
         mutateGlobal("/app-config");
         toast.success(t('language_updated'));
       } catch (err) {
-        toast.error(t('failed_to_save'));
+        mutate(previous, false);
+        handleApiError(err, t('failed_to_save'));
       }
     }
   };

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -32,4 +32,18 @@ const api = axios.create({
   xsrfHeaderName: "x-csrf-token", // and sends it in this header automatically
 });
 
+// Attach a response interceptor so we can inspect status codes centrally.
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error?.response?.status;
+    if (status === 401) {
+      error.statusMessage = "Please log in to continue";
+    } else if (status && status >= 500) {
+      error.statusMessage = "Server error. Please try again later.";
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default api;

--- a/frontend/src/utils/apiError.js
+++ b/frontend/src/utils/apiError.js
@@ -1,0 +1,23 @@
+import { toast } from "react-toastify";
+
+/**
+ * Display a user friendly error message based on HTTP status.
+ * @param {any} err - Error object from axios.
+ * @param {string} fallbackMessage - Message to display when status is not handled.
+ */
+export default function handleApiError(err, fallbackMessage = "Request failed") {
+  if (err?.statusMessage) {
+    toast.error(err.statusMessage);
+    return;
+  }
+
+  const status = err?.response?.status;
+
+  if (status === 401) {
+    toast.error("Please log in to continue");
+  } else if (status && status >= 500) {
+    toast.error("Server error. Please try again later.");
+  } else {
+    toast.error(err?.response?.data?.message || fallbackMessage);
+  }
+}


### PR DESCRIPTION
## Summary
- add centralized API error helper
- attach axios interceptor for status messages
- rollback language list on failed updates and show specific errors

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*
- `npx jest src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: see above)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b11fbd988328b0d5c06b62f7a716