### PR TITLE
Standardize service error handling

### DIFF
--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -21,6 +21,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 import logger from "@/utils/logger";
+import { handleError } from "@/utils/error";
 
 // ─────────────────────
 // 🔐 Validation schema
@@ -118,33 +119,8 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
       router.push(targetPath);
     }, 500);
   } catch (err) {
-    logger.error("❌ login onSubmit error", { message: err?.message });
-    let msg =
-      err?.response?.data?.message ||
-      err?.response?.data?.error ||
-      err?.message ||
-      t("login_failed");
-
-    if (err?.response?.status === 403 || msg === "Account is not active") {
-      msg = t("account_inactive");
-    } else if (msg === "Invalid credentials") {
-      msg = t("invalid_credentials");
-    } else if (msg === "Account is not active") {
-      msg = t("account_not_active");
-    }
-
-    if (
-      msg ===
-      "Account pending activation. Please verify your email or contact support."
-    ) {
-      msg = t("account_pending_activation");
-    }
-
-    if (err.code === "ERR_NETWORK") {
-      msg = t("network_error_check_config");
-    }
-
-    toast.error(msg);
+    logger.error("❌ login onSubmit error", err);
+    handleError(err, t("login_failed"));
     setValue("password", "");
     document.activeElement?.blur();
 

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -3,6 +3,7 @@ import api from "@/services/api/api";
 import logger from "@/utils/logger";
 import { ensureCsrfToken } from "@/services/api/csrf";
 import { getCookie } from "@/utils/cookies";
+import { normalizeError } from "@/utils/error";
 
 /**
  * 🔐 Log in a user and retrieve access token and user info.
@@ -28,7 +29,7 @@ export const loginUser = async ({ email, password, recaptchaToken }) => {
       message: err?.message,
       status: err?.response?.status,
     });
-    throw err;
+    throw normalizeError(err);
   }
 };
 
@@ -39,8 +40,12 @@ export const loginUser = async ({ email, password, recaptchaToken }) => {
  * @returns {Promise<{ message: string, user: object }>}
  */
 export const registerUser = async (payload) => {
-  const res = await api.post("/auth/register", payload);
-  return res.data;
+  try {
+    const res = await api.post("/auth/register", payload);
+    return res.data;
+  } catch (err) {
+    throw normalizeError(err);
+  }
 };
 
 /**
@@ -50,8 +55,12 @@ export const registerUser = async (payload) => {
  * @returns {Promise<{ message: string }>}
  */
 export const requestPasswordReset = async ({ email, via = "email" }) => {
-  const res = await api.post("/auth/forgot-password", { email, via });
-  return res.data;
+  try {
+    const res = await api.post("/auth/forgot-password", { email, via });
+    return res.data;
+  } catch (err) {
+    throw normalizeError(err);
+  }
 };
 
 /**
@@ -63,8 +72,12 @@ export const requestPasswordReset = async ({ email, via = "email" }) => {
  * @returns {Promise<{ valid: boolean }>}
  */
 export const verifyOtpCode = async ({ email, code }) => {
-  const res = await api.post("/auth/verify-otp", { email, code });
-  return res.data;
+  try {
+    const res = await api.post("/auth/verify-otp", { email, code });
+    return res.data;
+  } catch (err) {
+    throw normalizeError(err);
+  }
 };
 
 /**
@@ -77,12 +90,16 @@ export const verifyOtpCode = async ({ email, code }) => {
  * @returns {Promise<{ message: string }>}
  */
 export const resetPassword = async ({ email, code, new_password }) => {
-  const res = await api.post("/auth/reset-password", {
-    email,
-    code,
-    new_password,
-  });
-  return res.data;
+  try {
+    const res = await api.post("/auth/reset-password", {
+      email,
+      code,
+      new_password,
+    });
+    return res.data;
+  } catch (err) {
+    throw normalizeError(err);
+  }
 };
 
 /**
@@ -92,16 +109,20 @@ export const resetPassword = async ({ email, code, new_password }) => {
  * @returns {Promise<{ accessToken: string }>}
  */
 export const refreshAccessToken = async () => {
-  const csrfToken = getCookie("csrfToken");
-  const res = await api.post(
-    "/auth/refresh",
-    null,
-    {
-      headers: csrfToken ? { "x-csrf-token": csrfToken } : {},
-    }
-  );
-  await ensureCsrfToken();
-  return res.data;
+  try {
+    const csrfToken = getCookie("csrfToken");
+    const res = await api.post(
+      "/auth/refresh",
+      null,
+      {
+        headers: csrfToken ? { "x-csrf-token": csrfToken } : {},
+      }
+    );
+    await ensureCsrfToken();
+    return res.data;
+  } catch (err) {
+    throw normalizeError(err);
+  }
 };
 
 /**
@@ -110,6 +131,10 @@ export const refreshAccessToken = async () => {
  * @returns {Promise<{ message: string }>}
  */
 export const logoutUser = async () => {
-  const res = await api.post("/auth/logout");
-  return res.data;
+  try {
+    const res = await api.post("/auth/logout");
+    return res.data;
+  } catch (err) {
+    throw normalizeError(err);
+  }
 };

--- a/frontend/src/utils/error.js
+++ b/frontend/src/utils/error.js
@@ -1,0 +1,28 @@
+import { toast } from "react-toastify";
+
+/**
+ * Normalize API errors to a consistent shape.
+ * @param {any} error - Error thrown by Axios or fetch
+ * @returns {{status: number, message: string}}
+ */
+export const normalizeError = (error) => {
+  const status = error?.response?.status || 500;
+  const message =
+    error?.response?.data?.message ||
+    error?.response?.data?.error ||
+    error?.message ||
+    "An unexpected error occurred";
+  return { status, message };
+};
+
+/**
+ * Show a toast for a normalized error.
+ * @param {any} error
+ * @param {string} [fallback]
+ */
+export const handleError = (error, fallback) => {
+  const { message } = normalizeError(error);
+  toast.error(message || fallback || "An unexpected error occurred");
+};
+
+export default normalizeError;


### PR DESCRIPTION
## Summary
- add utility to normalize API errors and show toast messages
- wrap auth service calls in try/catch to rethrow normalized errors
- simplify login page error handling using shared helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b12089188328b0e382721a3e61b8