### PR TITLE
Prevent CacheManager state update after unmount

### DIFF
--- a/frontend/src/components/pwa/CacheManager.tsx
+++ b/frontend/src/components/pwa/CacheManager.tsx
@@ -26,10 +26,16 @@ export default function CacheManager({
   const [clearing, setClearing] = useState(false);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined") return () => {};
+    let isMounted = true;
     if ("serviceWorker" in navigator) {
-      navigator.serviceWorker.ready.then(() => setReady(true));
+      navigator.serviceWorker.ready.then(() => {
+        if (isMounted) setReady(true);
+      });
     }
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const warmCache = async () => {

--- a/frontend/src/tests/__tests__/CacheManager.test.tsx
+++ b/frontend/src/tests/__tests__/CacheManager.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import CacheManager from '@/components/pwa/CacheManager';
 import { clearCache as mockClearCache } from '../../services/admin/cacheService';
 
-jest.mock('../../utils/cache', () => ({
+jest.mock('../../services/admin/cacheService', () => ({
   clearCache: jest.fn(),
 }));
 jest.mock('next-i18next', () => ({


### PR DESCRIPTION
## Summary
- avoid setState on unmounted CacheManager by tracking isMounted flag
- mock cacheService correctly in CacheManager tests

## Testing
- `npm test src/tests/__tests__/CacheManager.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c5b126edc88328b2a0db332c562f84