### PR TITLE
Wrap student routes with catchAsync and test error handling

### DIFF
--- a/backend/src/modules/students/student.controller.js
+++ b/backend/src/modules/students/student.controller.js
@@ -3,12 +3,12 @@ const { sendSuccess } = require("../../utils/response");
 const catchAsync = require("../../utils/catchAsync");
 const msgService = require("../messages/messages.service");
 
-exports.list = async (_req, res) => {
+exports.list = catchAsync(async (_req, res) => {
   const data = await service.getPublicStudents();
   sendSuccess(res, data, "Students fetched");
-};
+});
 
-exports.getById = async (req, res) => {
+exports.getById = catchAsync(async (req, res) => {
   const { id } = req.params;
   if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
     return res.status(400).json({ message: "Invalid student id" });
@@ -19,7 +19,7 @@ exports.getById = async (req, res) => {
     return res.status(404).json({ message: "Student not found" });
   }
   sendSuccess(res, student);
-};
+});
 
 exports.sendEmail = catchAsync(async (req, res) => {
   const { id } = req.params;

--- a/backend/tests/studentRoutes.test.js
+++ b/backend/tests/studentRoutes.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest');
 const express = require('express');
+const errorHandler = require('../src/middleware/errorHandler');
 
 jest.mock('../src/modules/messages/messages.service', () => ({
   sendEmail: jest.fn(),
@@ -14,11 +15,13 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
 }));
 
 const msgService = require('../src/modules/messages/messages.service');
+const service = require('../src/modules/students/student.service');
 const routes = require('../src/modules/students/student.routes');
 
 const app = express();
 app.use(express.json());
 app.use('/api/students', routes);
+app.use(errorHandler);
 
 describe('POST /api/students/:id/email', () => {
   it('sends email to student', async () => {
@@ -60,5 +63,23 @@ describe('POST /api/students/:id/video-call', () => {
       sender_id: 'user1',
       receiver_id: '123e4567-e89b-12d3-a456-426614174000',
     });
+  });
+});
+
+describe('GET /api/students', () => {
+  it('forwards errors to handler', async () => {
+    service.getPublicStudents = jest.fn().mockRejectedValue(new Error('fail'));
+    const res = await request(app).get('/api/students');
+    expect(res.status).toBe(500);
+    expect(res.body.message).toBe('fail');
+  });
+});
+
+describe('GET /api/students/:id', () => {
+  it('forwards errors to handler', async () => {
+    service.getPublicStudent = jest.fn().mockRejectedValue(new Error('oops'));
+    const res = await request(app).get('/api/students/123e4567-e89b-12d3-a456-426614174000');
+    expect(res.status).toBe(500);
+    expect(res.body.message).toBe('oops');
   });
 });


### PR DESCRIPTION
## Summary
- wrap student list and getById controllers with catchAsync to forward errors
- cover student list/getById error handling in tests

## Testing
- `npm test` *(fails: Route.post() requires a callback function but got a [object Undefined])*

------
https://chatgpt.com/codex/tasks/task_e_68c5b12b004c832890b6acc40a478ff1