### PR TITLE
Add validation for messaging routes

### DIFF
--- a/backend/src/modules/instructors/instructor.routes.js
+++ b/backend/src/modules/instructors/instructor.routes.js
@@ -1,10 +1,22 @@
 const router = require("express").Router();
 const controller = require("./instructor.controller");
 const { verifyToken } = require("../../middleware/auth/authMiddleware");
+const validate = require("../../middleware/validate");
+const msgValidator = require("../messages/messages.validator");
 
 router.get("/", controller.list);
-router.post("/:id/email", verifyToken, controller.sendEmail);
-router.post("/:id/whatsapp", verifyToken, controller.sendWhatsApp);
+router.post(
+  "/:id/email",
+  verifyToken,
+  validate(msgValidator.sendEmail),
+  controller.sendEmail,
+);
+router.post(
+  "/:id/whatsapp",
+  verifyToken,
+  validate(msgValidator.sendWhatsApp),
+  controller.sendWhatsApp,
+);
 router.post("/:id/video-call", verifyToken, controller.startVideoCall);
 // More specific routes should be defined before parameterized ones
 router.get("/:id/availability", controller.getAvailability);

--- a/backend/src/modules/students/student.routes.js
+++ b/backend/src/modules/students/student.routes.js
@@ -1,10 +1,22 @@
 const router = require("express").Router();
 const controller = require("./student.controller");
 const { verifyToken } = require("../../middleware/auth/authMiddleware");
+const validate = require("../../middleware/validate");
+const msgValidator = require("../messages/messages.validator");
 
 router.get("/", controller.list);
-router.post("/:id/email", verifyToken, controller.sendEmail);
-router.post("/:id/whatsapp", verifyToken, controller.sendWhatsApp);
+router.post(
+  "/:id/email",
+  verifyToken,
+  validate(msgValidator.sendEmail),
+  controller.sendEmail,
+);
+router.post(
+  "/:id/whatsapp",
+  verifyToken,
+  validate(msgValidator.sendWhatsApp),
+  controller.sendWhatsApp,
+);
 router.post("/:id/video-call", verifyToken, controller.startVideoCall);
 router.get("/:id", controller.getById);
 


### PR DESCRIPTION
## Summary
- Validate instructor messaging endpoints with Zod ensuring non-empty subject and message
- Apply same validation to student messaging endpoints

## Testing
- `npm test` *(fails: bookRoutes.test.js expected 200 received 400; paymentCommission.test.js Route.post requires a callback, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b12e5eac832888d90b252bc35f91