### PR TITLE
feat: add server-side pagination and filters for classes

### DIFF
--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -186,10 +186,19 @@ exports.createClass = catchAsync(async (req, res) => {
 });
 
 exports.getAllClasses = catchAsync(async (req, res) => {
-  const { page = 1, limit = 10 } = req.query;
+  const {
+    page = 1,
+    limit = 10,
+    filter,
+    approval,
+    status,
+  } = req.query;
   const result = await service.getAllClasses({
     page: Number(page),
     limit: Number(limit),
+    filter,
+    approval,
+    status,
   });
   sendSuccess(res, result.data, undefined, result.meta);
 });

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -14,12 +14,27 @@ exports.countPublishedClasses = async (instructorId) => {
   return parseInt(row.count, 10) || 0;
 };
 
-exports.getAllClasses = async ({ page = 1, limit = 10 } = {}) => {
+exports.getAllClasses = async (
+  { page = 1, limit = 10, filter, approval, status } = {}
+) => {
   const { page: pg, limit: lim, offset } = parsePagination({ page, limit });
-  const totalRow = await db("online_classes").count("id as count").first();
+
+  const countQuery = db("online_classes as c")
+    .leftJoin("users as u", "c.instructor_id", "u.id");
+  if (filter) {
+    countQuery.where(function () {
+      this.whereILike("c.title", `%${filter}%`).orWhereILike(
+        "u.full_name",
+        `%${filter}%`
+      );
+    });
+  }
+  if (approval) countQuery.where("c.moderation_status", approval);
+  if (status) countQuery.where("c.status", status);
+  const totalRow = await countQuery.countDistinct("c.id as count").first();
   const total = parseInt(totalRow.count, 10) || 0;
 
-  const classes = await db("online_classes as c")
+  const query = db("online_classes as c")
     .leftJoin("users as u", "c.instructor_id", "u.id")
     .leftJoin("categories as cat", "c.category_id", "cat.id")
     .leftJoin("class_tag_map as m", "c.id", "m.class_id")
@@ -41,7 +56,20 @@ exports.getAllClasses = async ({ page = 1, limit = 10 } = {}) => {
       db.raw(
         "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
       )
-    )
+    );
+
+  if (filter) {
+    query.where(function () {
+      this.whereILike("c.title", `%${filter}%`).orWhereILike(
+        "u.full_name",
+        `%${filter}%`
+      );
+    });
+  }
+  if (approval) query.where("c.moderation_status", approval);
+  if (status) query.where("c.status", status);
+
+  const classes = await query
     .groupBy(
       "c.id",
       "c.title",

--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -9,6 +9,7 @@ import {
   approveAdminClass,
   rejectAdminClass,
   toggleClassStatus,
+  fetchAdminClasses,
 } from "@/services/admin/classService";
 import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
@@ -31,17 +32,20 @@ import {
 } from "react-icons/fa";
 
 
-export default function AdminClassesTable({ classes = [], loading = false }) {
+export default function AdminClassesTable() {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterStatus, setFilterStatus] = useState("All");
   const [filterApproval, setFilterApproval] = useState("All");
   const [sortKey, setSortKey] = useState("start_date");
-  const [classList, setClassList] = useState(classes);
+  const [classList, setClassList] = useState([]);
   const [modalClass, setModalClass] = useState(null);
   const [modalType, setModalType] = useState(null);
   const [rejectionReason, setRejectionReason] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(5);
+  const [loading, setLoading] = useState(false);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalItems, setTotalItems] = useState(0);
   const user = useAuthStore((state) => state.user);
   const { t } = useTranslation('dashboard');
   const refreshNotifications = useNotificationStore((state) => state.fetch);
@@ -49,27 +53,28 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
   const canManageRules = user?.permissions?.includes('ADD_ONLINE_CLASS_RULE');
 
   useEffect(() => {
-    setClassList(classes);
-  }, [classes]);
-
-  const filteredClasses = classList
-    .filter((cls) =>
-      cls.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      cls.instructor.toLowerCase().includes(searchTerm.toLowerCase())
-    )
-    .filter((cls) =>
-      filterStatus === "All" ? true : cls.scheduleStatus === filterStatus
-    )
-    .filter((cls) =>
-      filterApproval === "All" ? true : cls.approvalStatus === filterApproval
-    )
-    .sort((a, b) => (a[sortKey] > b[sortKey] ? 1 : -1));
-
-  const totalPages = Math.ceil(filteredClasses.length / itemsPerPage);
-  const paginatedClasses = filteredClasses.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage
-  );
+    const load = async () => {
+      setLoading(true);
+      try {
+        const { data, meta } = await fetchAdminClasses({
+          page: currentPage,
+          limit: itemsPerPage,
+          filter: searchTerm,
+          approval: filterApproval !== "All" ? filterApproval : undefined,
+          status: filterStatus !== "All" ? filterStatus : undefined,
+        });
+        setClassList(data.sort((a, b) => (a[sortKey] > b[sortKey] ? 1 : -1)));
+        setTotalPages(meta?.totalPages || 1);
+        setTotalItems(meta?.total || data.length);
+      } catch (err) {
+        console.error(err);
+        toast.error("Failed to load classes");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [currentPage, itemsPerPage, searchTerm, filterApproval, filterStatus, sortKey]);
 
   const exportCSV = () => {
     const headers = ["Title", "Instructor", "Start Date", "End Date", "Category", "Publish Status"];
@@ -222,13 +227,13 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
             type="text"
             placeholder="Search by title or instructor"
             className="border border-gray-300 rounded-xl px-4 py-2 w-full text-sm focus:ring-2 focus:ring-yellow-500"
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }}
           />
         </div>
         <div className="flex gap-2 w-full sm:w-1/2 justify-end items-center">
           <select
             className="border border-gray-300 rounded-xl px-4 py-2 text-sm"
-            onChange={(e) => setFilterStatus(e.target.value)}
+            onChange={(e) => { setFilterStatus(e.target.value); setCurrentPage(1); }}
             value={filterStatus}
           >
             <option value="All">All Schedule</option>
@@ -238,7 +243,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
           </select>
           <select
             className="border border-gray-300 rounded-xl px-4 py-2 text-sm"
-            onChange={(e) => setFilterApproval(e.target.value)}
+            onChange={(e) => { setFilterApproval(e.target.value); setCurrentPage(1); }}
             value={filterApproval}
           >
             <option value="All">All Approval</option>
@@ -262,7 +267,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
             <option value={5}>5</option>
             <option value={10}>10</option>
             <option value={25}>25</option>
-            <option value={filteredClasses.length}>All</option>
+            <option value={totalItems}>All</option>
           </select>
           <button
             onClick={exportCSV}
@@ -293,7 +298,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
-            {paginatedClasses.map((cls) => (
+            {classList.map((cls) => (
               <tr key={cls.id} className="hover:bg-yellow-50">
                 <td className="px-6 py-4">
                   {cls.cover_image && (
@@ -421,7 +426,7 @@ export default function AdminClassesTable({ classes = [], loading = false }) {
       {totalPages > 1 && (
         <div className="mt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
           <div className="text-sm text-gray-500">
-            Showing {(currentPage - 1) * itemsPerPage + 1}–{Math.min(currentPage * itemsPerPage, filteredClasses.length)} of {filteredClasses.length} classes
+            Showing {(currentPage - 1) * itemsPerPage + 1}–{Math.min(currentPage * itemsPerPage, totalItems)} of {totalItems} classes
           </div>
           <div className="flex items-center gap-2">
             <button onClick={handlePrev} disabled={currentPage === 1} className="text-sm px-3 py-1 bg-gray-200 hover:bg-yellow-100 rounded disabled:opacity-50">

--- a/frontend/src/pages/dashboard/admin/online-classes/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/index.js
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../next-i18next.config.js';
@@ -6,30 +5,10 @@ import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import AdminClassesTable from "@/components/admin/online-classes/AdminClassesTable";
-import { fetchAdminClasses } from "@/services/admin/classService";
 import { FaChalkboardTeacher, FaPlus } from "react-icons/fa";
 
 function AdminOnlineClassesPage() {
   const { t, i18n } = useTranslation('dashboard');
-  const [classes, setClasses] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    const load = async () => {
-      setLoading(true);
-      try {
-        const list = await fetchAdminClasses();
-        setClasses(list);
-      } catch (err) {
-        console.error("Failed to load classes", err);
-        setError(t('classes_load_failed'));
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-  }, []);
 
   return (
     <div className="p-6 space-y-6" dir={i18n.dir()}>
@@ -44,8 +23,7 @@ function AdminOnlineClassesPage() {
           <FaPlus className="w-4 h-4" /> {t('create_class')}
         </Link>
       </div>
-      {error && <p className="text-red-600">{error}</p>}
-      <AdminClassesTable classes={classes} loading={loading} />
+      <AdminClassesTable />
     </div>
   );
 }

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -30,10 +30,20 @@ const formatClass = (cls) => {
   };
 };
 
-export const fetchAdminClasses = async () => {
-  const { data } = await api.get("/users/classes/admin");
+export const fetchAdminClasses = async ({
+  page = 1,
+  limit = 10,
+  filter = "",
+  approval = "All",
+  status = "All",
+} = {}) => {
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+  if (filter) params.set("filter", filter);
+  if (approval && approval !== "All") params.set("approval", approval);
+  if (status && status !== "All") params.set("status", status);
+  const { data } = await api.get(`/users/classes/admin?${params.toString()}`);
   const list = data?.data ?? [];
-  return list.map(formatClass);
+  return { data: list.map(formatClass), meta: data?.meta || {} };
 };
 
 export const fetchAdminClassById = async (id) => {


### PR DESCRIPTION
## Summary
- extend admin classes endpoint with filter, approval, status, and pagination support
- request paged class data from frontend and show loading state
- refactor admin classes table to fetch pages and handle server-side filtering

## Testing
- `cd backend && npm test` (fails: multiple failing suites)
- `cd frontend && npm test` (fails: multiple failing suites)


------
https://chatgpt.com/codex/tasks/task_e_68c5b12f75ac8328a7bec3059ca60251