### PR TITLE
feat: add admin guard hook

### DIFF
--- a/frontend/src/hooks/useAdminGuard.js
+++ b/frontend/src/hooks/useAdminGuard.js
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import useAuthStore from "@/store/auth/authStore";
+import { isTokenExpired } from "@/utils/auth/tokenUtils";
+
+/**
+ * Hook that verifies the current user is an admin or superadmin.
+ * Redirects unauthenticated or unauthorized users and returns
+ * whether the admin check has passed.
+ */
+export default function useAdminGuard() {
+  const { user, accessToken, logout, hasHydrated } = useAuthStore();
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    if (!hasHydrated) return;
+
+    const role = user?.role?.toLowerCase();
+    if (!user) {
+      router.replace("/auth/login");
+      return;
+    }
+    if (!accessToken || isTokenExpired(accessToken)) {
+      logout();
+      router.replace("/auth/login");
+      return;
+    }
+    if (!["admin", "superadmin"].includes(role)) {
+      router.replace("/error/403");
+      return;
+    }
+
+    setAuthorized(true);
+  }, [hasHydrated, user, accessToken, logout, router]);
+
+  return authorized;
+}
+

--- a/frontend/src/hooks/withAdminGuard.js
+++ b/frontend/src/hooks/withAdminGuard.js
@@ -1,0 +1,15 @@
+import useAdminGuard from "./useAdminGuard";
+
+/**
+ * Higher-order component that renders the wrapped component only
+ * if the current user is an admin or superadmin. Unauthorized users
+ * are redirected inside the `useAdminGuard` hook.
+ */
+export default function withAdminGuard(Component) {
+  return function AdminProtected(props) {
+    const ok = useAdminGuard();
+    if (!ok) return null;
+    return <Component {...props} />;
+  };
+}
+

--- a/frontend/src/pages/dashboard/admin/index.js
+++ b/frontend/src/pages/dashboard/admin/index.js
@@ -1,11 +1,10 @@
 import { useEffect, useState } from "react";
-import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import nextI18NextConfig from "../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import useAuthStore from "@/store/auth/authStore";
-import withAuthProtection from "@/hooks/withAuthProtection";
+import withAdminGuard from "@/hooks/withAdminGuard";
 import WelcomeBanner from "@/components/admin/WelcomeBanner";
 import StatsGrid from "@/components/admin/StatsGrid";
 import Link from "next/link";
@@ -26,8 +25,6 @@ import { fetchLicenseStatus } from "@/services/admin/licenseService";
 
 function AdminDashboardHome() {
   const { user } = useAuthStore();
-  const router = useRouter();
-  const [hydrated, setHydrated] = useState(false);
   const [stats, setStats] = useState(null);
   const [statsLoading, setStatsLoading] = useState(false);
   const [alerts, setAlerts] = useState([]);
@@ -37,20 +34,6 @@ function AdminDashboardHome() {
   const [licenseStatus, setLicenseStatus] = useState(null);
   const [licenseLoading, setLicenseLoading] = useState(false);
   const { t } = useTranslation("dashboard");
-
-  useEffect(() => {
-    setHydrated(true);
-  }, []);
-
-  useEffect(() => {
-    if (hydrated) {
-      if (!user) {
-        router.replace("/auth/login");
-      } else if (!["admin", "superadmin"].includes(user.role?.toLowerCase())) {
-        router.replace("/error/403");
-      }
-    }
-  }, [user, hydrated, router]);
 
   useEffect(() => {
     const loadData = async () => {
@@ -100,14 +83,8 @@ function AdminDashboardHome() {
         setLicenseLoading(false);
       }
     };
-    if (hydrated && user && ["admin", "superadmin"].includes(user.role?.toLowerCase())) {
-      loadData();
-    }
-  }, [hydrated, user]);
-
-  if (!hydrated || !user || !["admin", "superadmin"].includes(user.role?.toLowerCase())) {
-    return null;
-  }
+    loadData();
+  }, []);
 
   const statsArray = stats
     ? [
@@ -233,7 +210,7 @@ function AdminDashboardHome() {
   );
 }
 
-const ProtectedAdminDashboard = withAuthProtection(AdminDashboardHome, ["admin", "superadmin"]);
+const ProtectedAdminDashboard = withAdminGuard(AdminDashboardHome);
 
 ProtectedAdminDashboard.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;

--- a/frontend/src/pages/dashboard/admin/instructors/index.js
+++ b/frontend/src/pages/dashboard/admin/instructors/index.js
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../next-i18next.config.js';
@@ -13,11 +12,11 @@ import {
   updateInstructorStatus,
   deleteInstructor as apiDeleteInstructor,
 } from '@/services/admin/instructorService';
-import useAuthStore from '@/store/auth/authStore';
 import { toast } from 'react-toastify';
+import withAdminGuard from '@/hooks/withAdminGuard';
 
 
-export default function AdminInstructorsPage() {
+function AdminInstructorsPage() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'instructorsPage' });
   const { t: tCommon } = useTranslation('common');
   const [instructors, setInstructors] = useState([]);
@@ -29,25 +28,9 @@ export default function AdminInstructorsPage() {
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
-
-  const router = useRouter();
-  const { accessToken, user, hasHydrated } = useAuthStore();
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!hasHydrated) return;
-
-    if (!accessToken || !user) {
-      router.replace('/auth/login');
-      return;
-    }
-
-    const role = user.role?.toLowerCase() ?? '';
-    if (role !== 'admin' && role !== 'superadmin') {
-      router.replace('/error/403');
-      return;
-    }
-
     const loadData = async () => {
       try {
         const { instructors: data, meta } = await fetchAllInstructors(1, 20);
@@ -77,7 +60,7 @@ export default function AdminInstructorsPage() {
     };
 
     loadData();
-  }, [accessToken, hasHydrated, router, user, t]);
+  }, [t]);
 
   const loadMore = async () => {
     if (loadingMore || !hasMore) return;
@@ -268,6 +251,8 @@ export default function AdminInstructorsPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(AdminInstructorsPage);
 
 export async function getServerSideProps({ locale }) {
   return {

--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -1,17 +1,16 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
 import Link from "next/link";
 import { createPlan } from "@/services/admin/planService";
-import useAuthStore from "@/store/auth/authStore";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function CreatePlanPage() {
+function CreatePlanPage() {
   const router = useRouter();
   const { t } = useTranslation('dashboard', { keyPrefix: 'plansPage' });
-  const { accessToken, user, hasHydrated } = useAuthStore();
 
   const [form, setForm] = useState({
     name: "",
@@ -45,18 +44,6 @@ export default function CreatePlanPage() {
 
   const removeFeature = (index) =>
     setFeatures(features.filter((_, i) => i !== index));
-
-  useEffect(() => {
-    if (!hasHydrated) return;
-    if (!accessToken || !user) {
-      router.replace("/auth/login");
-      return;
-    }
-    const role = user.role?.toLowerCase() ?? "";
-    if (role !== "admin" && role !== "superadmin") {
-      router.replace("/error/403");
-    }
-  }, [accessToken, hasHydrated, router, user]);
 
   const isHex = (val) => /^#([0-9A-F]{3}){1,2}$/i.test(val);
 
@@ -345,3 +332,5 @@ export default function CreatePlanPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(CreatePlanPage);

--- a/frontend/src/pages/dashboard/admin/plans/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/plans/edit/[id].js
@@ -3,19 +3,15 @@ import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
 import Link from "next/link";
-import {
-  fetchPlanById,
-  updatePlan,
-} from "@/services/admin/planService";
-import useAuthStore from "@/store/auth/authStore";
+import { fetchPlanById, updatePlan } from "@/services/admin/planService";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditPlanPage() {
+function EditPlanPage() {
   const router = useRouter();
   const { t } = useTranslation('dashboard', { keyPrefix: 'plansPage' });
   const { id } = router.query;
-  const { accessToken, user, hasHydrated } = useAuthStore();
 
   const [form, setForm] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -34,17 +30,7 @@ export default function EditPlanPage() {
     setFeatures(features.filter((_, i) => i !== index));
 
   useEffect(() => {
-    if (!router.isReady || !hasHydrated) return;
-
-    if (!accessToken || !user) {
-      router.replace("/auth/login");
-      return;
-    }
-    const role = user.role?.toLowerCase() ?? "";
-    if (role !== "admin" && role !== "superadmin") {
-      router.replace("/error/403");
-      return;
-    }
+    if (!router.isReady) return;
 
     const loadPlan = async () => {
       try {
@@ -93,7 +79,7 @@ export default function EditPlanPage() {
     };
 
     loadPlan();
-  }, [accessToken, hasHydrated, id, router, user]);
+  }, [router.isReady, id]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -392,3 +378,5 @@ export default function EditPlanPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(EditPlanPage);

--- a/frontend/src/pages/dashboard/admin/plans/index.js
+++ b/frontend/src/pages/dashboard/admin/plans/index.js
@@ -1,37 +1,20 @@
 import { useEffect, useState } from "react";
-import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaPlus, FaEdit, FaTrash, FaToggleOn, FaToggleOff } from "react-icons/fa";
 import Link from "next/link";
 import { fetchPlans, deletePlan, updatePlan } from "@/services/admin/planService";
-import useAuthStore from "@/store/auth/authStore";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function PlansIndex() {
+function PlansIndex() {
   const [plans, setPlans] = useState([]);
   const [loading, setLoading] = useState(true);
   const [selectedIds, setSelectedIds] = useState([]);
 
   const { t } = useTranslation('dashboard', { keyPrefix: 'plansPage' });
 
-  const router = useRouter();
-  const { accessToken, user, hasHydrated } = useAuthStore();
-
   useEffect(() => {
-    if (!hasHydrated) return;
-
-    if (!accessToken || !user) {
-      router.replace("/auth/login");
-      return;
-    }
-
-    const role = user.role?.toLowerCase() ?? "";
-    if (role !== "admin" && role !== "superadmin") {
-      router.replace("/error/403");
-      return;
-    }
-
     const loadPlans = async () => {
       try {
         const data = await fetchPlans();
@@ -45,7 +28,7 @@ export default function PlansIndex() {
     };
 
     loadPlans();
-  }, [accessToken, hasHydrated, router, user]);
+  }, []);
 
   const toggleActive = async (id) => {
     const plan = plans.find((p) => p.id === id);
@@ -96,14 +79,6 @@ export default function PlansIndex() {
       toast.error(t('failed_to_delete'));
     }
   };
-
-  if (!hasHydrated) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-white">
-        <p className="text-gray-500 text-lg">{t('loading')}</p>
-      </div>
-    );
-  }
 
   return (
     <AdminLayout title={t('title')}>
@@ -207,3 +182,5 @@ export default function PlansIndex() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(PlansIndex);

--- a/frontend/src/pages/dashboard/admin/users/index.js
+++ b/frontend/src/pages/dashboard/admin/users/index.js
@@ -6,8 +6,7 @@ import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import UserList from "@/components/admin/users/UserList";
 import { fetchAllUsers } from "@/services/admin/userService";
-import useAuthStore from "@/store/auth/authStore";
-import withAuthProtection from "@/hooks/withAuthProtection";
+import withAdminGuard from "@/hooks/withAdminGuard";
 import { toast } from "react-toastify";
 import logger from "@/utils/logger";
 
@@ -18,22 +17,8 @@ function UsersPage() {
   const [editUser, setEditUser] = useState(null);
 
   const router = useRouter();
-  const { accessToken, user, hasHydrated } = useAuthStore();
 
   useEffect(() => {
-    if (!hasHydrated) return;
-
-    if (!accessToken || !user) {
-      router.replace("/auth/login");
-      return;
-    }
-
-    const role = user.role?.toLowerCase() ?? "";
-    if (role !== "admin" && role !== "superadmin") {
-      router.replace("/error/403");
-      return;
-    }
-
     const loadUsers = async () => {
       try {
         const data = await fetchAllUsers(); // ✅ No token needed (cookie session)
@@ -60,15 +45,7 @@ function UsersPage() {
     };
 
     loadUsers();
-  }, [accessToken, hasHydrated, router, user]);
-
-  if (!hasHydrated) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-white">
-        <p className="text-gray-500 text-lg">Loading...</p>
-      </div>
-    );
-  }
+  }, []);
 
   return (
     <AdminLayout>
@@ -113,9 +90,7 @@ function UsersPage() {
   );
 }
 
-const ProtectedUsersPage = withAuthProtection(UsersPage, ["admin", "superadmin"]);
-
-export default ProtectedUsersPage;
+export default withAdminGuard(UsersPage);
 
 export async function getStaticProps({ locale }) {
   return {


### PR DESCRIPTION
## Summary
- add `useAdminGuard` and `withAdminGuard` for reusable admin auth and redirects
- refactor admin dashboard and management pages to rely on guard instead of manual hydrated/role checks

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68c5b13098b0832899a6650fe123f6e2