### PR TITLE
Refactor admin tutorials admin page with reusable hooks

### DIFF
--- a/frontend/src/components/dashboard/admin/tutorials/DeleteTutorialModal.js
+++ b/frontend/src/components/dashboard/admin/tutorials/DeleteTutorialModal.js
@@ -1,0 +1,13 @@
+import ConfirmModal from "@/components/common/ConfirmModal";
+
+export default function DeleteTutorialModal({ isOpen, onClose, onConfirm, t }) {
+  return (
+    <ConfirmModal
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title={t("confirm_title")}
+      message={t("confirm_delete")}
+    />
+  );
+}

--- a/frontend/src/components/dashboard/admin/tutorials/RejectTutorialModal.js
+++ b/frontend/src/components/dashboard/admin/tutorials/RejectTutorialModal.js
@@ -1,0 +1,12 @@
+import RejectionReasonModal from "@/components/common/RejectionReasonModal";
+
+export default function RejectTutorialModal({ isOpen, onClose, onConfirm, t }) {
+  return (
+    <RejectionReasonModal
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title={t("reject_title")}
+    />
+  );
+}

--- a/frontend/src/hooks/admin/tutorials/useBulkSelection.js
+++ b/frontend/src/hooks/admin/tutorials/useBulkSelection.js
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+
+export default function useBulkSelection(paginatedTutorials, deps = []) {
+  const [selectedTutorials, setSelectedTutorials] = useState([]);
+
+  useEffect(() => {
+    setSelectedTutorials([]);
+  }, deps);
+
+  const toggleSelectOne = (id) => {
+    setSelectedTutorials((prev) =>
+      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id],
+    );
+  };
+
+  const toggleSelectAll = (isChecked) => {
+    const pageIds = paginatedTutorials.map((tut) => tut.id);
+    if (isChecked) {
+      setSelectedTutorials((prevSelected) => [
+        ...new Set([...prevSelected, ...pageIds]),
+      ]);
+    } else {
+      setSelectedTutorials((prevSelected) =>
+        prevSelected.filter((id) => !pageIds.includes(id)),
+      );
+    }
+  };
+
+  const clearSelected = () => setSelectedTutorials([]);
+
+  return {
+    selectedTutorials,
+    setSelectedTutorials,
+    toggleSelectOne,
+    toggleSelectAll,
+    clearSelected,
+  };
+}

--- a/frontend/src/hooks/admin/tutorials/useTutorialFilters.js
+++ b/frontend/src/hooks/admin/tutorials/useTutorialFilters.js
@@ -1,0 +1,60 @@
+import { useState, useMemo, useEffect } from "react";
+
+export default function useTutorialFilters(tutorials, tutorialsPerPage = 10) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [filterCategory, setFilterCategory] = useState("All");
+  const [filterStatus, setFilterStatus] = useState("All");
+  const [filterApproval, setFilterApproval] = useState("All");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const filteredTutorials = useMemo(() => {
+    return tutorials.filter((tut) => {
+      const matchesSearch =
+        tut.title?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        tut.instructor?.toLowerCase().includes(searchQuery.toLowerCase());
+      const matchesCategory =
+        filterCategory === "All" || tut.category === filterCategory;
+      const matchesStatus = filterStatus === "All" || tut.status === filterStatus;
+      const matchesApproval =
+        filterApproval === "All" || tut.approvalStatus === filterApproval;
+      return matchesSearch && matchesCategory && matchesStatus && matchesApproval;
+    });
+  }, [tutorials, searchQuery, filterCategory, filterStatus, filterApproval]);
+
+  const totalPages = Math.ceil(filteredTutorials.length / tutorialsPerPage) || 1;
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(Math.min(currentPage, totalPages) || 1);
+    }
+  }, [currentPage, totalPages]);
+
+  const startIndex = (currentPage - 1) * tutorialsPerPage;
+  const endIndex = startIndex + tutorialsPerPage;
+  const paginatedTutorials = filteredTutorials.slice(startIndex, endIndex);
+
+  const goToPage = (page) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    filterCategory,
+    setFilterCategory,
+    filterStatus,
+    setFilterStatus,
+    filterApproval,
+    setFilterApproval,
+    currentPage,
+    setCurrentPage,
+    filteredTutorials,
+    paginatedTutorials,
+    totalPages,
+    startIndex,
+    endIndex,
+    goToPage,
+  };
+}

--- a/frontend/src/hooks/admin/tutorials/useTutorialsData.js
+++ b/frontend/src/hooks/admin/tutorials/useTutorialsData.js
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+import { toast } from "react-toastify";
+import { fetchAllCategories } from "@/services/admin/categoryService";
+import { fetchAllTutorials } from "@/services/admin/tutorialService";
+
+export default function useTutorialsData(t) {
+  const [tutorials, setTutorials] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isMounted = true;
+
+    const loadData = async () => {
+      try {
+        setLoading(true);
+        const [tuts, cats] = await Promise.all([
+          fetchAllTutorials({ signal: controller.signal }),
+          fetchAllCategories({}, { signal: controller.signal }),
+        ]);
+        if (!isMounted) return;
+        setTutorials(tuts);
+        setCategories(cats?.data || cats || []);
+      } catch (err) {
+        if (err.name === "AbortError" || err.name === "CanceledError") return;
+        console.error(err);
+        if (isMounted) toast.error(t("load_error"));
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    loadData();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [t]);
+
+  return { tutorials, setTutorials, categories, loading };
+}

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useRouter } from "next/router";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import { Button } from "@/components/ui/button";
@@ -12,11 +12,9 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import ConfirmModal from "@/components/common/ConfirmModal";
-import RejectionReasonModal from "@/components/common/RejectionReasonModal";
-import { fetchAllCategories } from "@/services/admin/categoryService";
+import DeleteTutorialModal from "@/components/dashboard/admin/tutorials/DeleteTutorialModal";
+import RejectTutorialModal from "@/components/dashboard/admin/tutorials/RejectTutorialModal";
 import {
-  fetchAllTutorials,
   permanentlyDeleteTutorial,
   toggleTutorialStatus,
   approveTutorial,
@@ -29,117 +27,56 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
+import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
+import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
+import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
 
 function AdminTutorialsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "tutorialsPage" });
   const router = useRouter();
-  const [tutorials, setTutorials] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const { tutorials, setTutorials, categories, loading } = useTutorialsData(t);
+
+  const {
+    searchQuery,
+    setSearchQuery,
+    filterCategory,
+    setFilterCategory,
+    filterStatus,
+    setFilterStatus,
+    filterApproval,
+    setFilterApproval,
+    currentPage,
+    setCurrentPage,
+    filteredTutorials,
+    paginatedTutorials,
+    totalPages,
+    startIndex,
+    endIndex,
+    goToPage,
+  } = useTutorialFilters(tutorials);
+
+  const {
+    selectedTutorials,
+    setSelectedTutorials,
+    toggleSelectOne,
+    toggleSelectAll,
+    clearSelected,
+  } = useBulkSelection(paginatedTutorials, [
+    searchQuery,
+    filterCategory,
+    filterStatus,
+    filterApproval,
+  ]);
 
   const user = useAuthStore((state) => state.user);
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
 
-  // Filters
-  const [searchQuery, setSearchQuery] = useState("");
-  const [filterCategory, setFilterCategory] = useState("All");
-  const [filterStatus, setFilterStatus] = useState("All");
-  const [filterApproval, setFilterApproval] = useState("All");
-  const [categories, setCategories] = useState([]);
-
-  // Modals and Selections
+  // Modals
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isRejectionModalOpen, setIsRejectionModalOpen] = useState(false);
   const [tutorialToDelete, setTutorialToDelete] = useState(null);
   const [tutorialToReject, setTutorialToReject] = useState(null);
-  const [selectedTutorials, setSelectedTutorials] = useState([]);
-
-  useEffect(() => {
-    setSelectedTutorials([]);
-  }, [searchQuery, filterCategory, filterStatus, filterApproval]);
-
-  // Load tutorials and categories from backend on mount
-  useEffect(() => {
-    const controller = new AbortController();
-    let isMounted = true;
-
-    const loadData = async () => {
-      try {
-        setLoading(true);
-        const [tuts, cats] = await Promise.all([
-          fetchAllTutorials({ signal: controller.signal }),
-          fetchAllCategories({}, { signal: controller.signal }),
-        ]);
-        if (!isMounted) return;
-        setTutorials(tuts);
-        setCategories(cats?.data || cats || []);
-      } catch (err) {
-        if (err.name === 'AbortError' || err.name === 'CanceledError') return;
-        console.error(err);
-        if (isMounted) toast.error(t('load_error'));
-      } finally {
-        if (isMounted) setLoading(false);
-      }
-    };
-
-    loadData();
-
-    return () => {
-      isMounted = false;
-      controller.abort();
-    };
-  }, []);
-
-  // Pagination
-  const [currentPage, setCurrentPage] = useState(1);
-  const tutorialsPerPage = 10;
-
-  // Filtering
-  const filteredTutorials = tutorials.filter((tut) => {
-    const matchesSearch =
-      tut.title?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      tut.instructor?.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesCategory =
-      filterCategory === "All" || tut.category === filterCategory;
-    const matchesStatus = filterStatus === "All" || tut.status === filterStatus;
-    const matchesApproval =
-      filterApproval === "All" || tut.approvalStatus === filterApproval;
-    return matchesSearch && matchesCategory && matchesStatus && matchesApproval;
-  });
-
-  const totalPages = Math.ceil(filteredTutorials.length / tutorialsPerPage);
-
-  useEffect(() => {
-    if (currentPage > totalPages) {
-      setCurrentPage(Math.min(currentPage, totalPages) || 1);
-    }
-  }, [currentPage, totalPages]);
-  const startIndex = (currentPage - 1) * tutorialsPerPage;
-  const endIndex = startIndex + tutorialsPerPage;
-  const paginatedTutorials = filteredTutorials.slice(startIndex, endIndex);
-
-  // Functions
-  const toggleSelectOne = (id) => {
-    setSelectedTutorials((prev) =>
-      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id],
-    );
-  };
-
-  const toggleSelectAll = (isChecked) => {
-    if (isChecked) {
-      const pageIds = paginatedTutorials.map((tut) => tut.id);
-      setSelectedTutorials((prevSelected) => [
-        ...new Set([...prevSelected, ...pageIds]), // Add only current page IDs
-      ]);
-    } else {
-      const pageIds = paginatedTutorials.map((tut) => tut.id);
-      setSelectedTutorials(
-        (prevSelected) => prevSelected.filter((id) => !pageIds.includes(id)), // Remove only current page IDs
-      );
-    }
-  };
-
-  const clearSelected = () => setSelectedTutorials([]);
 
   const togglePublishStatus = async (id) => {
     try {
@@ -377,13 +314,6 @@ function AdminTutorialsPage() {
     setSelectedTutorials([]);
   };
 
-  // Pagination controls
-  const goToPage = (page) => {
-    if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page);
-    }
-  };
-
   return (
     <AdminLayout>
       <div className="p-6 bg-gray-50 min-h-screen space-y-6">
@@ -485,19 +415,18 @@ function AdminTutorialsPage() {
         </div>
 
         {/* Modals */}
-        <ConfirmModal
+        <DeleteTutorialModal
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
           onConfirm={handleConfirmDelete}
-          title={t("confirm_title")}
-          message={t("confirm_delete")}
+          t={t}
         />
 
-        <RejectionReasonModal
+        <RejectTutorialModal
           isOpen={isRejectionModalOpen}
           onClose={() => setIsRejectionModalOpen(false)}
           onConfirm={handleConfirmReject}
-          title={t("reject_title")}
+          t={t}
         />
       </div>
     </AdminLayout>


### PR DESCRIPTION
## Summary
- add hooks for fetching tutorials/categories, filtering & pagination, and bulk selection
- split delete/reject modals into dedicated components and wire them into the page
- refactor admin tutorials page to use new hooks and modals

## Testing
- `npm test src/tests/__tests__/CacheManager.test.tsx` *(fails: _cacheService.clearCache.mockReset is not a function)*
- `npm test src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: Cannot find module '../../services/instructor/subscriptionService')*
- `npm run lint` *(errors: missing display name in several test components)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b134037483289d517f46a0b5fbe7