### PR TITLE
feat: add instructor tutorial creation service

### DIFF
--- a/frontend/src/pages/dashboard/instructor/tutorials/create.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { fetchAllCategories } from "@/services/instructor/categoryService";
-import { createTutorial } from "@/services/admin/tutorialService";
+import { createTutorial } from "@/services/instructor/tutorialService";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -40,6 +40,12 @@ export const fetchInstructorTutorials = async (config = {}) => {
   }));
 };
 
+/**
+ * Create a new tutorial for the current instructor.
+ *
+ * @param {FormData} formData - Tutorial payload following backend validator
+ * @returns {Promise<object>} Newly created tutorial data
+ */
 export const createTutorial = async (formData) => {
   const { data } = await api.post("/users/tutorials/admin", formData, {
     headers: { "Content-Type": "multipart/form-data" },


### PR DESCRIPTION
## Summary
- document and export instructor tutorial `createTutorial` helper
- switch instructor tutorial creation page to use instructor service

## Testing
- `npm test src/tests/__tests__/instructorTutorialService.test.js`
- `npm test tests/tutorialCreate.test.js tests/tutorialRoutes.test.js tests/tutorialUpdateTransaction.test.js` *(fails: TypeError in tutorialUpdateTransaction.test.js; status mismatch in tutorialRoutes.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b135aaf88328b925b99a47109d30