### PR TITLE
feat: handle loading and errors on tutorial favorites

### DIFF
--- a/frontend/public/locales/en/tutorials.json
+++ b/frontend/public/locales/en/tutorials.json
@@ -178,7 +178,9 @@
   "favoritesPage": {
     "heading": "My Favorite Tutorials",
     "empty": "You have no favorite tutorials.",
-    "remove": "Remove"
+    "remove": "Remove",
+    "load_error": "Failed to load favorite tutorials",
+    "loading": "Loading favorites..."
   }
 }
 

--- a/frontend/src/pages/dashboard/student/tutorials/favorites.js
+++ b/frontend/src/pages/dashboard/student/tutorials/favorites.js
@@ -7,6 +7,8 @@ import nextI18NextConfig from '../../../../../next-i18next.config.js';
 
 export default function TutorialFavoritesPage() {
   const [favorites, setFavorites] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const { t } = useTranslation('tutorials');
   const tr = (key, def) => {
     const res = t(key);
@@ -20,6 +22,9 @@ export default function TutorialFavoritesPage() {
         setFavorites(items);
       } catch (err) {
         console.error(err);
+        setError(tr('favoritesPage.load_error', 'Failed to load favorite tutorials'));
+      } finally {
+        setLoading(false);
       }
     };
     load();
@@ -33,6 +38,26 @@ export default function TutorialFavoritesPage() {
       console.error(err);
     }
   };
+
+  if (loading) {
+    return (
+      <StudentLayout>
+        <div className="p-6 text-center" role="status">
+          {tr('favoritesPage.loading', 'Loading favorites...')}
+        </div>
+      </StudentLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <StudentLayout>
+        <div className="p-6 text-red-500" role="alert">
+          {error}
+        </div>
+      </StudentLayout>
+    );
+  }
 
   return (
     <StudentLayout>

--- a/frontend/src/tests/__tests__/TutorialFavoritesPage.test.js
+++ b/frontend/src/tests/__tests__/TutorialFavoritesPage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../../services/tutorialService', () => ({
+  getMyTutorialFavorites: jest.fn(),
+  removeTutorialFromFavorites: jest.fn(),
+}));
+
+jest.mock('../../components/layouts/StudentLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div data-testid="student-layout">{children}</div>,
+}));
+
+import TutorialFavoritesPage from '@/pages/dashboard/student/tutorials/favorites';
+
+const { getMyTutorialFavorites } = require('../../services/tutorialService');
+
+describe('TutorialFavoritesPage', () => {
+  test('renders favorites on success', async () => {
+    getMyTutorialFavorites.mockResolvedValueOnce([
+      { id: 1, title: 'First Tutorial' },
+      { id: 2, title: 'Second Tutorial' },
+    ]);
+
+    render(<TutorialFavoritesPage />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading favorites...');
+
+    const first = await screen.findByText('First Tutorial');
+    const layout = screen.getByTestId('student-layout');
+    expect(layout).toContainElement(first);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test('renders error message on failure', async () => {
+    getMyTutorialFavorites.mockRejectedValueOnce(new Error('fail'));
+
+    render(<TutorialFavoritesPage />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Failed to load favorite tutorials');
+    const layout = screen.getByTestId('student-layout');
+    expect(layout).toContainElement(alert);
+  });
+});


### PR DESCRIPTION
## Summary
- add loading and error states to tutorial favorites page
- provide user feedback via translations
- test success and failure scenarios for favorites page

## Testing
- `npm test src/tests/__tests__/TutorialFavoritesPage.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5b13691a08328a3b95a00c0ab63ed