### PR TITLE
Add instructor stats endpoint

### DIFF
--- a/backend/src/modules/instructors/instructor.controller.js
+++ b/backend/src/modules/instructors/instructor.controller.js
@@ -31,6 +31,16 @@ exports.getAvailability = catchAsync(async (req, res) => {
   sendSuccess(res, availability);
 });
 
+exports.getStats = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
+    return res.status(400).json({ message: "Invalid instructor id" });
+  }
+
+  const stats = await service.getInstructorStats(id);
+  sendSuccess(res, stats);
+});
+
 exports.sendEmail = catchAsync(async (req, res) => {
   const { id } = req.params;
   if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {

--- a/backend/src/modules/instructors/instructor.routes.js
+++ b/backend/src/modules/instructors/instructor.routes.js
@@ -7,6 +7,7 @@ router.post("/:id/email", verifyToken, controller.sendEmail);
 router.post("/:id/whatsapp", verifyToken, controller.sendWhatsApp);
 router.post("/:id/video-call", verifyToken, controller.startVideoCall);
 // More specific routes should be defined before parameterized ones
+router.get("/:id/stats", controller.getStats);
 router.get("/:id/availability", controller.getAvailability);
 router.get("/:id", controller.getById);
 

--- a/backend/src/modules/instructors/instructor.service.js
+++ b/backend/src/modules/instructors/instructor.service.js
@@ -1,4 +1,6 @@
 const db = require("../../config/database");
+const classService = require("../classes/class.service");
+const tutorialService = require("../users/tutorials/tutorial.service");
 
 // Convert comma separated or JSON strings to arrays
 const parseArrayField = (val) => {
@@ -121,4 +123,12 @@ exports.getInstructorAvailability = async (id) => {
     }
   }
   return availability;
+};
+
+exports.getInstructorStats = async (id) => {
+  const [classes, tutorials] = await Promise.all([
+    classService.countPublishedClasses(id),
+    tutorialService.countPublishedTutorials(id),
+  ]);
+  return { classes, tutorials };
 };

--- a/frontend/src/pages/instructors/[id].js
+++ b/frontend/src/pages/instructors/[id].js
@@ -5,13 +5,11 @@ import useAuthStore from "@/store/auth/authStore";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
-import { FaUserCheck, FaComments, FaStar, FaChalkboardTeacher, FaVideo, FaCalendarAlt } from "react-icons/fa";
+import { FaComments, FaStar, FaChalkboardTeacher, FaVideo, FaCalendarAlt } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { IoMdTime } from "react-icons/io";
 import BookingRequestModal from "@/components/student/instructors/BookingRequestModal";
-import { fetchPublicInstructorById } from "@/services/public/instructorService";
-import { fetchPublishedClasses } from "@/services/classService";
-import { fetchPublishedTutorials } from "@/services/tutorialService";
+import { fetchPublicInstructorById, fetchInstructorStats } from "@/services/public/instructorService";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
 import { safeEncodeURI } from "@/utils/url";
 
@@ -218,19 +216,12 @@ export async function getServerSideProps({ params }) {
       avatar_url: data?.avatar_url ? `${API_BASE_URL}${data.avatar_url}` : "/images/profile/user.png",
       demo_video_url: data?.demo_video_url ? `${API_BASE_URL}${data.demo_video_url}` : null,
     };
-
-    const classRes = await fetchPublishedClasses();
-    const classList = classRes?.data ?? classRes ?? [];
-    const classCount = classList.filter((c) => String(c.instructor_id) === String(id)).length;
-
-    const tutRes = await fetchPublishedTutorials();
-    const tutList = tutRes?.data ?? tutRes ?? [];
-    const tutCount = tutList.filter((t) => String(t.creator_id) === String(id)).length;
+    const stats = await fetchInstructorStats(id);
 
     return {
       props: {
         initialInstructor: formatted,
-        initialStats: { classes: classCount, tutorials: tutCount },
+        initialStats: stats || { classes: 0, tutorials: 0 },
       },
     };
   } catch (err) {

--- a/frontend/src/services/public/instructorService.js
+++ b/frontend/src/services/public/instructorService.js
@@ -15,6 +15,11 @@ export const fetchInstructorAvailability = async (id) => {
   return data?.data ?? [];
 };
 
+export const fetchInstructorStats = async (id) => {
+  const { data } = await api.get(`/instructors/${id}/stats`);
+  return data?.data || data;
+};
+
 export const sendEmailToInstructor = async (id, { subject, message }) => {
   const { data } = await api.post(`/instructors/${id}/email`, { subject, message });
   return data?.data || data;


### PR DESCRIPTION
## Summary
- add instructor stats route returning class and tutorial counts
- use new stats API in instructor profile page
- expose public helper to fetch instructor stats

## Testing
- `npm test` (backend) *(fails: Route.post requires callback and other existing failures)*
- `npm test` (frontend) *(fails: multiple unit tests such as CacheManager and InstructorSettingsPage)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c8fef4e8832880f459f23cbf9c53