### PR TITLE
Add batch tutorial status API and bulk frontend loading

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -211,6 +211,42 @@ exports.getStatus = catchAsync(async (req, res) => {
   });
 });
 
+// Get enrollment status and progress for multiple tutorials
+exports.getStatusBatch = catchAsync(async (req, res) => {
+  const userId = requireUser(req);
+  const { tutorialIds } = req.body;
+
+  const ids = Array.isArray(tutorialIds) ? tutorialIds : [];
+  let enrollments = [];
+
+  if (ids.length) {
+    enrollments = await db("tutorial_enrollments")
+      .where({ user_id: userId })
+      .whereIn("tutorial_id", ids);
+  }
+
+  const map = {};
+  ids.forEach((id) => {
+    map[id] = { enrolled: false, status: null, progress: 0 };
+  });
+
+  enrollments.forEach((e) => {
+    const progress =
+      e.progress != null
+        ? Number(e.progress)
+        : e.status === "completed"
+        ? 100
+        : 0;
+    map[e.tutorial_id] = {
+      enrolled: true,
+      status: e.status,
+      progress,
+    };
+  });
+
+  sendSuccess(res, map);
+});
+
 // Update progress percentage for a tutorial
 exports.updateProgress = catchAsync(async (req, res) => {
   const { userId, tutorialId } = requireUserAndTutorial(req);

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.routes.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.routes.js
@@ -7,6 +7,13 @@ const validator = require("./tutorialEnrollment.validator");
 router.post("/:tutorialId", verifyToken, isStudent, ctrl.enroll);
 router.post("/:tutorialId/complete", verifyToken, isStudent, ctrl.complete);
 router.get("/:tutorialId/status", verifyToken, isStudent, ctrl.getStatus);
+router.post(
+  "/status/batch",
+  verifyToken,
+  isStudent,
+  validate(validator.batchStatus),
+  ctrl.getStatusBatch
+);
 router.patch(
   "/:tutorialId/progress",
   verifyToken,

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.validator.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.validator.js
@@ -6,3 +6,9 @@ exports.updateProgress = {
   }),
 };
 
+exports.batchStatus = {
+  body: z.object({
+    tutorialIds: z.array(z.number()),
+  }),
+};
+

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -269,3 +269,31 @@ describe('POST /api/users/tutorials/enrollments/:id/complete', () => {
   });
 });
 
+describe('POST /api/users/tutorials/enrollments/status/batch', () => {
+  it('returns enrollment status map for provided tutorials', async () => {
+    db.mockImplementation((table) => {
+      if (table === 'tutorial_enrollments')
+        return {
+          where: () => ({
+            whereIn: () =>
+              Promise.resolve([
+                { tutorial_id: 1, status: 'completed', progress: null },
+                { tutorial_id: 2, status: 'enrolled', progress: 40 },
+              ]),
+          }),
+        };
+    });
+
+    const res = await request(app)
+      .post('/api/users/tutorials/enrollments/status/batch')
+      .send({ tutorialIds: [1, 2, 3] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      1: { enrolled: true, status: 'completed', progress: 100 },
+      2: { enrolled: true, status: 'enrolled', progress: 40 },
+      3: { enrolled: false, status: null, progress: 0 },
+    });
+  });
+});
+

--- a/frontend/src/pages/tutorials/index.js
+++ b/frontend/src/pages/tutorials/index.js
@@ -11,6 +11,7 @@ import FilterSidebar from "@/components/tutorials/FilterSidebar";
 import {
   fetchPublishedTutorials,
   fetchTutorialProgress,
+  fetchTutorialProgressBatch,
   getMyTutorialWishlist,
   getMyTutorialFavorites,
   addTutorialToWishlist,
@@ -31,24 +32,26 @@ import { fetchAds as fetchAdBanners } from "@/services/adsService";
  * chapter metadata.
  * @returns {Promise<{enrolled: boolean, status: string | null, progress: number}>}
  */
-export const loadTutorialStatus = async (tut) => {
+export const loadTutorialStatus = async (tut, useApi = true) => {
   const userId = useAuthStore.getState().user?.id;
   let enrolled = false;
   let progressPercent = 0;
   let status = null;
 
-  try {
-    const apiData = await fetchTutorialProgress(tut.id);
-    if (apiData) {
-      enrolled = !!apiData.enrolled;
-      status = apiData.status ?? null;
-      if (apiData.progress != null) {
-        progressPercent = Number(apiData.progress);
+  if (useApi) {
+    try {
+      const apiData = await fetchTutorialProgress(tut.id);
+      if (apiData) {
+        enrolled = !!apiData.enrolled;
+        status = apiData.status ?? null;
+        if (apiData.progress != null) {
+          progressPercent = Number(apiData.progress);
+        }
+        return { enrolled, status, progress: progressPercent };
       }
-      return { enrolled, status, progress: progressPercent };
+    } catch (err) {
+      // Ignore API errors and fall back to localStorage
     }
-  } catch (err) {
-    // Ignore API errors and fall back to localStorage
   }
 
   if (typeof window !== "undefined") {
@@ -72,6 +75,30 @@ export const loadTutorialStatus = async (tut) => {
   }
 
   return { enrolled, status, progress: progressPercent };
+};
+
+// Load statuses for multiple tutorials using batch endpoint with local fallback
+export const loadTutorialStatuses = async (tutorials) => {
+  const ids = tutorials.map((t) => t.id);
+  let apiMap = {};
+
+  if (ids.length) {
+    try {
+      const data = await fetchTutorialProgressBatch(ids);
+      if (data) apiMap = data;
+    } catch (err) {
+      // Ignore API errors and rely on local storage
+    }
+  }
+
+  const entries = await Promise.all(
+    tutorials.map(async (tut) => [
+      tut.id,
+      apiMap[tut.id] || (await loadTutorialStatus(tut, false)),
+    ])
+  );
+
+  return Object.fromEntries(entries);
 };
 
 const TutorialsSection = () => {
@@ -183,10 +210,8 @@ const TutorialsSection = () => {
   useEffect(() => {
     if (!tutorials.length) return;
     const loadStatuses = async () => {
-      const entries = await Promise.all(
-        tutorials.map(async (t) => [t.id, await loadTutorialStatus(t)])
-      );
-      setStatusMap(Object.fromEntries(entries));
+      const map = await loadTutorialStatuses(tutorials);
+      setStatusMap(map);
     };
     loadStatuses();
   }, [tutorials]);

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -205,3 +205,19 @@ export const fetchTutorialProgress = async (tutorialId) => {
     throw err;
   }
 };
+
+// Retrieve enrollment status and progress for multiple tutorials
+export const fetchTutorialProgressBatch = async (tutorialIds) => {
+  try {
+    const { data } = await api.post(
+      '/users/tutorials/enroll/status/batch',
+      { tutorialIds },
+    );
+    return data?.data ?? data ?? null;
+  } catch (err) {
+    if (err.response && [404, 500, 501].includes(err.response.status)) {
+      return null;
+    }
+    throw err;
+  }
+};

--- a/frontend/src/tests/__tests__/TutorialsNoInstructor.test.js
+++ b/frontend/src/tests/__tests__/TutorialsNoInstructor.test.js
@@ -61,6 +61,7 @@ jest.mock('../../store/cart/cartStore', () => ({
 jest.mock('../../services/tutorialService', () => ({
   fetchPublishedTutorials: jest.fn(),
   fetchTutorialProgress: jest.fn(),
+  fetchTutorialProgressBatch: jest.fn(),
 }));
 
 beforeAll(() => {
@@ -81,7 +82,7 @@ test('handles tutorials without instructor in search', async () => {
   tutorialService.fetchPublishedTutorials.mockResolvedValue([
     { id: 1, title: 'Tutorless', category_name: '', level: '', price: null },
   ]);
-  tutorialService.fetchTutorialProgress.mockResolvedValue(null);
+  tutorialService.fetchTutorialProgressBatch.mockResolvedValue({});
 
   render(<TutorialsSection />);
   const input = await screen.findByPlaceholderText('search_placeholder');

--- a/frontend/src/tests/__tests__/tutorialStatus.test.js
+++ b/frontend/src/tests/__tests__/tutorialStatus.test.js
@@ -1,15 +1,17 @@
-import { loadTutorialStatus } from '@/pages/tutorials/index';
+import { loadTutorialStatus, loadTutorialStatuses } from '@/pages/tutorials/index';
 import useAuthStore from '@/store/auth/authStore';
-import { fetchTutorialProgress } from '../../services/tutorialService';
+import { fetchTutorialProgress, fetchTutorialProgressBatch } from '../../services/tutorialService';
 
 jest.mock('../../services/tutorialService', () => ({
   fetchTutorialProgress: jest.fn(),
+  fetchTutorialProgressBatch: jest.fn(),
 }));
 
 describe('loadTutorialStatus', () => {
   beforeEach(() => {
     localStorage.clear();
     fetchTutorialProgress.mockReset();
+    fetchTutorialProgressBatch.mockReset();
     useAuthStore.setState({ user: { id: 1 } });
   });
 
@@ -40,6 +42,43 @@ describe('loadTutorialStatus', () => {
     expect(res.enrolled).toBe(true);
     expect(res.status).toBe('in_progress');
     expect(res.progress).toBe(80);
+  });
+});
+
+describe('loadTutorialStatuses', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    fetchTutorialProgressBatch.mockReset();
+    useAuthStore.setState({ user: { id: 1 } });
+  });
+
+  it('returns map from API data', async () => {
+    const tutorials = [{ id: 1 }, { id: 2 }];
+    fetchTutorialProgressBatch.mockResolvedValue({
+      1: { enrolled: true, status: 'completed', progress: 100 },
+      2: { enrolled: false, status: null, progress: 0 },
+    });
+
+    const res = await loadTutorialStatuses(tutorials);
+    expect(fetchTutorialProgressBatch).toHaveBeenCalledWith([1, 2]);
+    expect(res).toEqual({
+      1: { enrolled: true, status: 'completed', progress: 100 },
+      2: { enrolled: false, status: null, progress: 0 },
+    });
+  });
+
+  it('falls back to localStorage when API fails', async () => {
+    const tutorials = [{ id: 3, chapters: Array(4) }];
+    fetchTutorialProgressBatch.mockRejectedValue(new Error('fail'));
+    localStorage.setItem('enrolled-1-3', 'true');
+    localStorage.setItem(
+      'progress-tutorial-1-3',
+      JSON.stringify({ completedChapters: [1, 2] }),
+    );
+
+    const res = await loadTutorialStatuses(tutorials);
+    expect(res[3].enrolled).toBe(true);
+    expect(res[3].progress).toBeCloseTo(50);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `POST /status/batch` endpoint to return enrollment and progress for multiple tutorials
- create `fetchTutorialProgressBatch` and `loadTutorialStatuses` to request status data in one call
- update tutorials page to populate status map from the batch response

## Testing
- `npm test --prefix backend` *(fails: expect(res.status).toBe(200) etc., existing failures)*
- `npm test --prefix frontend` *(fails: expect(res.statusCode).toBe(500) etc., existing failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c900678883289e11dceb0bccf6c3