### PR TITLE
feat: remove hardcoded phone country

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -44,14 +44,12 @@ import ExpertiseList from "@/components/instructor/profile/ExpertiseList";
 import CertificatesSection from "@/components/instructor/profile/CertificatesSection";
 import SocialLinksSection from "@/components/instructor/profile/SocialLinksSection";
 
-// Default country for phone validation
-const DEFAULT_COUNTRY = "US";
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
-export const instructorProfileSchema = z.object({
+export const instructorProfileSchema = (country) => z.object({
   full_name: z.string().min(3, "full_name_min"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
+    .refine((val) => isValidPhoneNumber(val, country), {
       message: "invalid_phone_number",
     }),
   gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
@@ -208,7 +206,7 @@ export default function InstructorProfileEdit() {
       const sanitizedLinks = Object.fromEntries(
         Object.entries(formData.socialLinks || {}).filter(([, url]) => url.trim() !== "")
       );
-      instructorProfileSchema.parse({
+      instructorProfileSchema(user?.country).parse({
         ...formData,
         socialLinks: Object.keys(sanitizedLinks).length ? sanitizedLinks : undefined,
       });

--- a/frontend/src/tests/__tests__/profileSchemaSocialLinks.test.js
+++ b/frontend/src/tests/__tests__/profileSchemaSocialLinks.test.js
@@ -33,9 +33,9 @@ describe('profile schema socialLinks URL validation', () => {
       experience: 1,
       socialLinks: { twitter: 'invalid-url' },
     };
-    expect(() => instructorProfileSchema.parse(data)).toThrow(ZodError);
+    expect(() => instructorProfileSchema('US').parse(data)).toThrow(ZodError);
     try {
-      instructorProfileSchema.parse(data);
+      instructorProfileSchema('US').parse(data);
     } catch (err) {
       expect(err.errors[0].message).toBe('invalid_url');
     }

--- a/frontend/src/tests/tests/profileSchemaSocialLinks.test.js
+++ b/frontend/src/tests/tests/profileSchemaSocialLinks.test.js
@@ -27,7 +27,7 @@ describe('profile schema allows empty social link URLs', () => {
       experience: 1,
       socialLinks: { twitter: '' },
     };
-    expect(() => instructorProfileSchema.parse(data)).not.toThrow();
+    expect(() => instructorProfileSchema('US').parse(data)).not.toThrow();
   });
 
   test('student profile accepts empty social link', () => {


### PR DESCRIPTION
## Summary
- allow dynamic phone validation in instructor profile
- adjust schema validation calls and tests

## Testing
- `npm test` *(fails: TypeError: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService' from 'src/tests/__tests__/InstructorSettingsPage.test.js')*
- `npm test -- src/tests/tests/profileSchemaSocialLinks.test.js src/tests/__tests__/profileSchemaSocialLinks.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5c90db8948328be0f7f87b66e104f