### PR TITLE
Trim and validate instructor social links

### DIFF
--- a/backend/src/modules/users/instructor/instructor.service.js
+++ b/backend/src/modules/users/instructor/instructor.service.js
@@ -71,6 +71,7 @@ const getInstructorProfile = async (userId) => {
 
 const normalizeUrl = (url = "") => {
   const trimmed = url.trim();
+  if (!trimmed) return "";
   return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
 };
 
@@ -87,6 +88,7 @@ const updateInstructorProfile = async (
           (link) =>
             link &&
             typeof link.url === "string" &&
+            link.url.trim() !== "" &&
             typeof link.platform === "string" &&
             allowedPlatforms.includes(link.platform.trim().toLowerCase())
         )

--- a/backend/src/modules/users/instructor/instructor.validator.js
+++ b/backend/src/modules/users/instructor/instructor.validator.js
@@ -36,8 +36,8 @@ const updateInstructorProfileSchema = z.object({
   social_links: z
     .array(
       z.object({
-        platform: z.string().min(2),
-        url: z.string(),
+        platform: z.string().trim().min(2),
+        url: z.string().trim().url("Invalid URL"),
       })
     )
     .optional()


### PR DESCRIPTION
## Summary
- require instructor social link URLs to be trimmed and valid
- ignore empty social link URLs when updating profiles

## Testing
- `npm test 2>&1 | tail -n 20` *(fails: Test Suites: 23 failed, 2 skipped, 116 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c91105e88328970914d152ff2770