### PR TITLE
Invoke delete APIs on instructor profile media removal

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -21,6 +21,8 @@ import {
   uploadInstructorAvatar,
   uploadInstructorDemo,
   toggleInstructorStatus,
+  deleteInstructorAvatar,
+  deleteInstructorDemo,
 } from "@/services/instructor/instructorService";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
@@ -291,6 +293,27 @@ export default function InstructorProfileEdit() {
     }
   };
 
+  const handleAvatarRemove = async () => {
+    try {
+      await deleteInstructorAvatar(user.id);
+      setUser({ ...user, avatar_url: null });
+      setFormData((prev) => ({ ...prev, avatarPreview: null }));
+    } catch (error) {
+      const msg = error.response?.data?.message || 'Failed to delete avatar';
+      toast.error(msg);
+    }
+  };
+
+  const handleDemoRemove = async () => {
+    try {
+      await deleteInstructorDemo(user.id);
+      setFormData((prev) => ({ ...prev, demoPreview: null }));
+    } catch (error) {
+      const msg = error.response?.data?.message || 'Failed to delete demo video';
+      toast.error(msg);
+    }
+  };
+
   const handleSubmit = async () => {
     if (!validateForm()) return;
     try {
@@ -407,14 +430,14 @@ export default function InstructorProfileEdit() {
             isUploadingAvatar={isUploadingAvatar}
             t={t}
             onSelect={handleAvatarSelect}
-            onRemove={() => setFormData((prev) => ({ ...prev, avatarPreview: null }))}
+            onRemove={handleAvatarRemove}
           />
           <DemoVideoUploader
             demoPreview={formData.demoPreview}
             isUploadingDemo={isUploadingDemo}
             t={t}
             onSelect={handleDemoSelect}
-            onRemove={() => setFormData((prev) => ({ ...prev, demoPreview: null }))}
+            onRemove={handleDemoRemove}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- call deleteInstructorAvatar before clearing avatar preview
- call deleteInstructorDemo before clearing demo preview
- surface API errors via toast notifications

## Testing
- `CI=true npm test src/tests/__tests__/CacheManager.test.tsx src/tests/__tests__/InstructorSettingsPage.test.js` *(fails: Cannot find module '../../services/instructor/subscriptionService' and mockReset is not a function)*
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c91826908328818dc9f42c84b7d4