### PR TITLE
Improve pricing field validation

### DIFF
--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -574,6 +574,8 @@
     "invalid_date": "Invalid date format",
     "experience_positive": "Experience must be a positive number",
     "amount_positive": "Amount must be positive",
+    "pricing_amount_required": "Please enter an amount",
+    "pricing_currency_required": "Please select a currency",
     "bio_max_words": "Bio must be 150 words or fewer",
     "url_invalid": "Must be a valid URL"
   },

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -71,7 +71,25 @@ export const instructorProfileSchema = z.object({
   socialLinks: z
     .record(z.string().url("invalid_url").or(z.literal("")))
     .optional(),
-});
+})
+  .superRefine((data, ctx) => {
+    const hasAmount = typeof data.pricing_amount === "number";
+    const hasCurrency = !!data.pricing_currency;
+    if (hasAmount && !hasCurrency) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["pricing_currency"],
+        message: "pricing_currency_required",
+      });
+    }
+    if (!hasAmount && hasCurrency) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["pricing_amount"],
+        message: "pricing_amount_required",
+      });
+    }
+  });
 // Currency options will be loaded from the backend configuration
 export default function InstructorProfileEdit() {
   const router = useRouter();
@@ -298,7 +316,7 @@ export default function InstructorProfileEdit() {
 
       // Combine pricing amount and currency
       const pricing =
-        typeof formData.pricing_amount === "number"
+        typeof formData.pricing_amount === "number" && formData.pricing_currency
           ? `${formData.pricing_amount} ${formData.pricing_currency}`
           : "";
       const social_links = toSocialLinksArray(formData.socialLinks);
@@ -575,6 +593,12 @@ export default function InstructorProfileEdit() {
                   ))}
                 </select>
               </div>
+              {errors.pricing_amount && (
+                <p className="text-sm text-red-600 mt-1">{errors.pricing_amount}</p>
+              )}
+              {errors.pricing_currency && (
+                <p className="text-sm text-red-600 mt-1">{errors.pricing_currency}</p>
+              )}
               <p className="text-sm text-gray-500 mt-1">e.g. 100 USD per hour</p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- validate instructor pricing amount and currency pair
- show pricing field errors when amount or currency missing
- build pricing string only when both amount and currency provided

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get install -y nodejs npm` *(partial output, install did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c91a5cd08328803df48e35a62689