### PR TITLE
Handle non-Zod validation errors in profile edit pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -7,7 +7,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
-import { z } from "zod";
+import { z, ZodError } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
@@ -321,7 +321,7 @@ function ProfileEditTemplate() {
       setErrors({});
       return true;
     } catch (err) {
-      if (err instanceof z.ZodError) {
+      if (err instanceof ZodError) {
         const newErrors = {};
         err.errors.forEach((error) => {
           const key = error.path.join(".");
@@ -330,7 +330,11 @@ function ProfileEditTemplate() {
         setErrors(newErrors);
         if (err.errors?.length) {
           toast.error(t(err.errors[0].message));
+        } else {
+          toast.error(t('fix_errors'));
         }
+      } else {
+        toast.error(t('fix_errors'));
       }
       return false;
     }

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -7,7 +7,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
-import { z } from "zod";
+import { z, ZodError } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import { API_BASE_URL } from "@/config/config";
 import { getCurrencies } from "@/services/currencyService";
@@ -216,15 +216,19 @@ export default function InstructorProfileEdit() {
       return true;
     } catch (err) {
       const errs = {};
-      err.errors.forEach(error => {
-        const key = error.path.join(".");
-        errs[key] = t(error.message);
-      });
-      setErrors(errs);
-      if (err.errors?.length) {
-        toast.error(t(err.errors[0].message));
-      } else {
+      if (err instanceof ZodError) {
+        err.errors.forEach(error => {
+          const key = error.path.join(".");
+          errs[key] = t(error.message);
+        });
+        setErrors(errs);
+        if (err.errors?.length) {
+          toast.error(t(err.errors[0].message));
+        } else {
           toast.error(t('fix_errors'));
+        }
+      } else {
+        toast.error(t('fix_errors'));
       }
       return false;
     }

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
-import { z } from "zod";
+import { z, ZodError } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import { useTranslation } from "next-i18next";
 import StudentLayout from "@/components/layouts/StudentLayout";
@@ -275,13 +275,19 @@ const handleAvatarSelect = (e) => {
       return true;
     } catch (err) {
       const errs = {};
-      err.errors.forEach((error) => {
-        const key = error.path.join(".");
-        errs[key] = t(error.message);
-      });
-      setErrors(errs);
-      if (err.errors?.length) {
-        toast.error(t(err.errors[0].message));
+      if (err instanceof ZodError) {
+        err.errors.forEach((error) => {
+          const key = error.path.join(".");
+          errs[key] = t(error.message);
+        });
+        setErrors(errs);
+        if (err.errors?.length) {
+          toast.error(t(err.errors[0].message));
+        } else {
+          toast.error(t('fix_errors'));
+        }
+      } else {
+        toast.error(t('fix_errors'));
       }
       return false;
     }


### PR DESCRIPTION
## Summary
- Import and use `ZodError` in profile edit pages
- Gracefully handle non-Zod errors with a generic message

## Testing
- `npm test` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js)*
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c91c4388832891a9303d269ec94d