### PR TITLE
Guard instructor demo upload

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -271,6 +271,47 @@ exports.deleteAvatar = async (req, res) => {
 };
 
 /**
+ * @desc Upload instructor demo video
+ * @route PATCH /api/users/instructor/:id/demo
+ * @access Instructor
+ */
+exports.uploadDemoVideo = async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        // Validate the provided id
+        if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
+            if (req.file) {
+                fs.unlink(req.file.path, (error) => error && logger.error(error));
+            }
+            return res.status(400).json({ error: "Invalid user id" });
+        }
+
+        // Ensure instructors can only update their own demo video
+        if (id !== req.user.id) {
+            if (req.file) {
+                fs.unlink(req.file.path, (error) => error && logger.error(error));
+            }
+            return res.status(403).json({ error: "Unauthorized" });
+        }
+
+        if (!req.file) {
+            return res.status(400).json({ error: "No file uploaded" });
+        }
+
+        const demoVideoUrl = `/uploads/demos/instructor/${req.file.filename}`;
+        await db("instructor_profiles")
+            .where({ user_id: id })
+            .update({ demo_video_url: demoVideoUrl });
+
+        res.json({ demo_video_url: demoVideoUrl });
+    } catch (err) {
+        logger.error("Demo video upload error:", err);
+        res.status(500).json({ error: "Failed to upload demo video" });
+    }
+};
+
+/**
  * @desc Delete instructor demo video
  * @route DELETE /api/users/instructor/:id/demo
  * @access Instructor

--- a/backend/src/modules/users/instructor/instructor.routes.js
+++ b/backend/src/modules/users/instructor/instructor.routes.js
@@ -1,4 +1,3 @@
-const logger = require('../../../utils/logger.js');
 /**
  * Instructor profile controller
  * @file instructor.routes.js
@@ -8,7 +7,6 @@ const router = express.Router();
 const controller = require("./instructor.controller");
 const { verifyToken, isInstructor } = require("../../../middleware/auth/authMiddleware");
 const { avatarUpload, demoUpload, certificateUpload } = require("./instructorUploadMiddleware");
-const db = require("../../../config/database");
 const { updateInstructorProfileSchema } = require("./instructor.validator");
 const validate = require("../../../middleware/validate");
 
@@ -112,23 +110,7 @@ router.patch(
   verifyToken,
   isInstructor,
   demoUpload.single("demo"),
-  async (req, res) => {
-    try {
-      const { id } = req.params;
-      if (!id || !/^[0-9a-fA-F-]{36}$/.test(id)) {
-        return res.status(400).json({ error: "Invalid user id" });
-      }
-
-      const demoVideoUrl = `/uploads/demos/instructor/${req.file.filename}`;
-      await db("instructor_profiles")
-        .where({ user_id: id })
-        .update({ demo_video_url: demoVideoUrl });
-      res.json({ demo_video_url: demoVideoUrl });
-    } catch (err) {
-      logger.error("Demo video upload error:", err);
-      res.status(500).json({ error: "Failed to upload demo video" });
-    }
-  }
+  controller.uploadDemoVideo
 );
 
 /**

--- a/backend/tests/instructorDemoUpload.test.js
+++ b/backend/tests/instructorDemoUpload.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/config/database', () => jest.fn());
+
+jest.mock('../src/middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: '123e4567-e89b-12d3-a456-426614174001' };
+    next();
+  },
+  isInstructor: (_req, _res, next) => next(),
+}));
+
+const routes = require('../src/modules/users/instructor/instructor.routes');
+const db = require('../src/config/database');
+
+const app = express();
+app.use(express.json());
+app.use('/api/users/instructor', routes);
+
+describe('PATCH /api/users/instructor/:id/demo', () => {
+  it('returns 403 when uploading demo video for another instructor', async () => {
+    const res = await request(app)
+      .patch('/api/users/instructor/123e4567-e89b-12d3-a456-426614174000/demo')
+      .attach('demo', Buffer.from('test'), 'demo.mp4');
+
+    expect(res.status).toBe(403);
+    expect(db).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure instructors can only upload demo videos for themselves and handle invalid IDs
- Route now delegates demo upload to controller for consistency
- Add test to prevent uploading demo video for another instructor

## Testing
- `npm test tests/instructorDemoUpload.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5c921a300832887e424ffdf7b6685