### PR TITLE
Require instructor expertise for profile completion

### DIFF
--- a/backend/src/modules/users/instructor/instructor.service.js
+++ b/backend/src/modules/users/instructor/instructor.service.js
@@ -101,9 +101,18 @@ const updateInstructorProfile = async (
     userData.phone &&
     userData.gender &&
     userData.date_of_birth;
+  const hasExpertise = Array.isArray(instructorData.expertise)
+    ? instructorData.expertise.length > 0
+    : Boolean(instructorData.expertise);
   const hasInstructorFields =
     instructorData.experience !== undefined &&
-    instructorData.experience !== null;
+    instructorData.experience !== null &&
+    hasExpertise &&
+    typeof instructorData.bio === "string" &&
+    instructorData.bio.trim() !== "" &&
+    instructorData.pricing !== undefined &&
+    instructorData.pricing !== null &&
+    Number(instructorData.pricing) > 0;
   const isProfileComplete =
     hasUserFields && hasInstructorFields && sanitizedLinks.length > 0;
 

--- a/backend/tests/instructorProfileService.test.js
+++ b/backend/tests/instructorProfileService.test.js
@@ -1,0 +1,78 @@
+const { newDb } = require('pg-mem');
+const { v4: uuidv4 } = require('uuid');
+
+const db = newDb();
+db.public.registerFunction({ name: 'uuid_generate_v4', returns: 'uuid', implementation: uuidv4 });
+const mockDb = db.adapters.createKnex();
+
+jest.mock('../src/config/database.js', () => mockDb);
+
+const service = require('../src/modules/users/instructor/instructor.service');
+
+describe('instructor.service updateInstructorProfile', () => {
+  beforeAll(async () => {
+    await mockDb.schema.createTable('users', (table) => {
+      table.uuid('id').primary();
+      table.string('full_name');
+      table.string('phone');
+      table.string('gender');
+      table.date('date_of_birth');
+      table.boolean('profile_complete').defaultTo(false);
+    });
+    await mockDb.schema.createTable('instructor_profiles', (table) => {
+      table.uuid('user_id').primary().references('users.id');
+      table.text('expertise');
+      table.integer('experience');
+      table.text('bio');
+      table.text('certifications');
+      table.float('pricing');
+      table.string('demo_video_url');
+    });
+    await mockDb.schema.createTable('user_social_links', (table) => {
+      table.increments('id').primary();
+      table.uuid('user_id').references('users.id');
+      table.string('platform');
+      table.string('url');
+    });
+  });
+
+  afterAll(async () => {
+    await mockDb.destroy();
+  });
+
+  beforeEach(async () => {
+    await mockDb('user_social_links').del();
+    await mockDb('instructor_profiles').del();
+    await mockDb('users').del();
+  });
+
+  it('marks profile as complete when all required fields are provided', async () => {
+    const userId = uuidv4();
+    await mockDb('users').insert({ id: userId });
+
+    await service.updateInstructorProfile(
+      userId,
+      { full_name: 'John Doe', phone: '123', gender: 'male', date_of_birth: '1990-01-01' },
+      { experience: 5, expertise: ['Math'], bio: 'Teacher', pricing: 50 },
+      [{ platform: 'facebook', url: 'facebook.com/johndoe' }]
+    );
+
+    const user = await mockDb('users').where({ id: userId }).first();
+    expect(user.profile_complete).toBe(true);
+  });
+
+  it('marks profile as incomplete when missing bio', async () => {
+    const userId = uuidv4();
+    await mockDb('users').insert({ id: userId });
+
+    await service.updateInstructorProfile(
+      userId,
+      { full_name: 'Jane Doe', phone: '456', gender: 'female', date_of_birth: '1992-02-02' },
+      { experience: 3, expertise: ['Science'], pricing: 75 },
+      [{ platform: 'facebook', url: 'facebook.com/janedoe' }]
+    );
+
+    const user = await mockDb('users').where({ id: userId }).first();
+    expect(user.profile_complete).toBe(false);
+  });
+});

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -24,7 +24,7 @@
   "language_load_error": "Failed to load languages",
   "logged_out": "Logged out successfully",
   "logout_failed": "Logout failed. Please try again.",
-  "please_complete_profile": "Please complete your profile to continue.",
+  "please_complete_profile": "Please complete your profile (expertise, bio, and pricing) to continue.",
   "visit_website": "Visit Website",
   "search_placeholder": "Search...",
   "available": "Available",

--- a/frontend/src/components/auth/IncompleteAlertModal.js
+++ b/frontend/src/components/auth/IncompleteAlertModal.js
@@ -28,7 +28,7 @@ export default function IncompleteAlertModal() {
       <div className="bg-white p-6 rounded-lg text-center max-w-md">
         <h2 className="text-xl font-semibold text-red-600 mb-2">Complete Your Profile</h2>
         <p className="text-gray-700 mb-4">
-          You must verify your email and phone, and complete your profile before using the platform.
+          You must verify your email and phone, and complete your profile (including expertise, bio, and pricing) before using the platform.
         </p>
         <button
           onClick={() => {

--- a/frontend/src/hooks/RequireProfileCompletion.js
+++ b/frontend/src/hooks/RequireProfileCompletion.js
@@ -16,7 +16,9 @@ export default function RequireProfileCompletion({ children }) {
 
       // Avoid redirecting if already on the profile page
       if (router.pathname !== targetPath) {
-        toast.info("Please complete your profile to continue.");
+        toast.info(
+          "Please complete your profile (including expertise, bio, and pricing) to continue."
+        );
         router.replace(targetPath);
       }
     }


### PR DESCRIPTION
## Summary
- tighten instructor profile completion check to require expertise, bio, and pricing
- clarify profile completion requirements in frontend messaging
- add unit tests for instructor profile completeness

## Testing
- `cd backend && npm test tests/instructorProfileService.test.js`
- `cd frontend && npm test src/tests/__tests__/TutorialsSection.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c5c924fc7083288380bb43af6fe9aa