### PR TITLE
refactor: use expertise and certificates components

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -27,8 +27,6 @@ import getCroppedImg from "@/utils/cropImage";
 import { allowedPlatforms } from "@/utils/socialPlatforms";
 import {
   FaSpinner,
-  FaUserCircle,
-  FaVideo,
   FaDollarSign,
   FaCalendarAlt,
   FaPhone,
@@ -42,7 +40,6 @@ import AvatarUploader from "@/components/instructor/profile/AvatarUploader";
 import DemoVideoUploader from "@/components/instructor/profile/DemoVideoUploader";
 import ExpertiseList from "@/components/instructor/profile/ExpertiseList";
 import CertificatesSection from "@/components/instructor/profile/CertificatesSection";
-import SocialLinksSection from "@/components/instructor/profile/SocialLinksSection";
 
 // Default country for phone validation
 const DEFAULT_COUNTRY = "US";
@@ -580,182 +577,23 @@ export default function InstructorProfileEdit() {
           </div>
 
           {/* Expertise List */}
-          <div>
-            <label className="block text-sm font-medium mb-1 flex items-center gap-2">
-              <FaBriefcase className="text-gray-500" /> {t('expertise')}
-            </label>
-            <div className="flex flex-wrap gap-2 mb-2">
-              {formData.expertise.map((tag, i) => (
-                <span key={i} className="inline-flex items-center bg-yellow-100 text-yellow-800 text-sm px-3 py-1 rounded-full">
-                  {tag}
-                  <button
-                    type="button"
-                    onClick={() => setFormData(prev => ({
-                      ...prev,
-                      expertise: prev.expertise.filter((_, idx) => idx !== i)
-                    }))}
-                    className="ml-2 text-yellow-600 hover:text-yellow-800"
-                  >
-                    <RiDeleteBin6Line size={14} />
-                  </button>
-                </span>
-              ))}
-            </div>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={newExpertise}
-                onChange={(e) => setNewExpertise(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && newExpertise.trim()) {
-                    setFormData(prev => ({
-                      ...prev,
-                      expertise: [...prev.expertise, newExpertise.trim()],
-                    }));
-                    setNewExpertise("");
-                  }
-                }}
-                placeholder={t('add_expertise_placeholder')}
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:ring-yellow-500 focus:border-yellow-500"
-              />
-              <button
-                type="button"
-                onClick={() => {
-                  if (!newExpertise.trim()) return;
-                  setFormData(prev => ({
-                    ...prev,
-                    expertise: [...prev.expertise, newExpertise.trim()]
-                  }));
-                  setNewExpertise("");
-                }}
-                className="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-md border border-gray-300 flex items-center gap-2"
-              >
-                <FaPlus size={14} /> {t('add')}
-              </button>
-            </div>
-          </div>
+          <ExpertiseList
+            expertise={formData.expertise}
+            onChange={(updated) =>
+              setFormData({ ...formData, expertise: updated })
+            }
+            t={t}
+          />
 
           {/* Certificates Section */}
-          <div>
-            <label className="block text-sm font-medium mb-2 flex items-center gap-2">
-              <FaCertificate className="text-gray-500" /> {t('certificates')}
-            </label>
-
-            {/* Existing Certificates */}
-            <div className="space-y-4 mb-6">
-              {formData.certificates.map((certificate) => (
-                <div key={certificate.id} className="border rounded-lg p-4 flex justify-between items-center">
-                  <div className="flex items-center gap-4">
-                    {certificate.file_url.endsWith('.pdf') ? (
-                      <FaFilePdf className="text-red-500 text-2xl" />
-                    ) : (
-                      <FaFileImage className="text-blue-500 text-2xl" />
-                    )}
-                    <div>
-                      <h4 className="font-medium">{certificate.title}</h4>
-                      <a
-                        href={`${BASE_URL}${certificate.file_url}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sm text-blue-600 hover:underline"
-                      >
-                        {t('view_certificate')}
-                      </a>
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => handleRemoveCertificate(certificate.id)}
-                    className="p-2 text-red-600 hover:text-red-800 hover:bg-red-50 rounded-full"
-                  >
-                    <FaTrash />
-                  </button>
-                </div>
-              ))}
-            </div>
-
-            {/* Add New Certificate */}
-            <div className="border-2 border-dashed border-gray-300 rounded-lg p-4">
-              <h4 className="font-medium mb-3 flex items-center gap-2">
-                <FaPlus className="text-gray-500" /> {t('add_new_certificate')}
-              </h4>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">{t('certificate_title')} *</label>
-                  <input
-                    type="text"
-                    value={newCertificate.title}
-                    onChange={(e) => setNewCertificate(prev => ({ ...prev, title: e.target.value }))}
-                    placeholder="e.g. Yoga Instructor Certification"
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-yellow-500 focus:border-yellow-500"
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-1">{t('certificate_file')} *</label>
-                  <label className="cursor-pointer">
-                    <input
-                      type="file"
-                      accept=".pdf,.jpg,.jpeg,.png"
-                      onChange={(e) => {
-                        const file = e.target.files[0];
-                        if (!file) return;
-
-                        if (file.size > 10 * 1024 * 1024) {
-                          toast.error('File size must be 10MB or less');
-                          return;
-                        }
-
-                        // Preview for images
-                        let preview = null;
-                        if (file.type.startsWith('image/')) {
-                          preview = URL.createObjectURL(file);
-                        }
-
-                        setNewCertificate(prev => ({
-                          ...prev,
-                          file,
-                          preview
-                        }));
-                      }}
-                      className="hidden"
-                    />
-                    <div className="w-full px-4 py-2 border border-gray-300 rounded-md flex items-center justify-between">
-                      <span className="truncate">
-                        {newCertificate.file ? newCertificate.file.name : t('choose_file')}
-                      </span>
-                      <FaUpload className="text-gray-500" />
-                    </div>
-                  </label>
-                </div>
-              </div>
-
-              {/* Preview for image certificates */}
-              {newCertificate.preview && (
-                <div className="mt-4">
-                  <label className="block text-sm font-medium mb-1">{t('preview')}</label>
-                  <img
-                    src={newCertificate.preview}
-                    alt="Certificate preview"
-                    className="max-h-40 border rounded-md"
-                  />
-                </div>
-              )}
-
-              <button
-                onClick={handleCertificateUpload}
-                disabled={!newCertificate.title || !newCertificate.file || certificateUploading}
-                className="mt-4 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-300 disabled:cursor-not-allowed flex items-center gap-2"
-              >
-                {certificateUploading ? (
-                  <FaSpinner className="animate-spin" />
-                ) : (
-                  <FaUpload />
-                )}
-                {t('upload_certificate')}
-              </button>
-            </div>
-          </div>
+          <CertificatesSection
+            certificates={formData.certificates}
+            onChange={(updated) =>
+              setFormData({ ...formData, certificates: updated })
+            }
+            t={t}
+            baseUrl={BASE_URL}
+          />
 
           {/* Social Links */}
           <div>


### PR DESCRIPTION
## Summary
- replace inline expertise and certificates JSX with reusable components
- clean up unused icon imports

## Testing
- `npm test` *(fails: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService')*
- `npm run lint` *(fails: 46 errors, 270 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c929ad988328b61e6ecce3239b01