### PR TITLE
Add translation key for file size limit

### DIFF
--- a/frontend/src/components/instructor/profile/CertificatesSection.js
+++ b/frontend/src/components/instructor/profile/CertificatesSection.js
@@ -134,7 +134,7 @@ export default function CertificatesSection({ certificates, onChange, t, baseUrl
                   const file = e.target.files[0];
                   if (!file) return;
                   if (file.size > 10 * 1024 * 1024) {
-                    toast.error('File size must be 10MB or less');
+                    toast.error(t('file_size_limit'));
                     return;
                   }
                   let preview = null;

--- a/frontend/src/locales/ar.json
+++ b/frontend/src/locales/ar.json
@@ -76,8 +76,7 @@
     "profile_updated": "تم تحديث الملف الشخصي بنجاح",
     "assignment_submitted": "تم تسليم الواجب بنجاح",
     "class_joined": "تم الانضمام إلى الدورة"
-  }
-,
+  },
   "adminDashboardHome": {
     "recentAlerts": "التنبيهات الأخيرة",
     "unauthorizedUsageDetected": "تم اكتشاف استخدام غير مصرح به",
@@ -143,43 +142,44 @@
     }
   },
   "dashboard": {
-      "tutorialEditPage": {
-        "loading": "جارٍ تحميل الدرس...",
-        "not_found": "الدرس غير موجود",
-        "save_changes": "حفظ التغييرات",
-        "update_success": "تم تحديث الدرس بنجاح",
-        "notification_updated": "تم تحديث الإشعار",
-        "update_failed": "فشل تحديث الدرس"
-      },
-      "appSettingsPage": {
-        "title": "إعدادات التطبيق",
-        "save": "حفظ الإعدادات",
-        "saving": "جاري الحفظ...",
-        "basic_settings": "الإعدادات الأساسية",
-        "application_name_label": "اسم التطبيق",
-        "site_title_label": "عنوان الموقع",
-        "contact_email_label": "البريد الإلكتروني للتواصل",
-        "app_name_placeholder": "تطبيقي الرائع",
-        "site_title_placeholder": "مرحباً بكم في تطبيقي",
-        "contact_email_placeholder": "contact@example.com",
-        "media_settings": "إعدادات الوسائط",
-        "application_logo": "شعار التطبيق",
-        "recommended_logo": "المقاس الموصى به: ‎300×100‎ بكسل (PNG شفاف)",
-        "choose_file": "اختر ملفاً",
-        "upload": "رفع",
-        "favicon": "أيقونة الموقع",
-        "recommended_favicon": "المقاس الموصى به: ‎64×64‎ بكسل (ICO أو PNG)",
-        "home_background": "خلفية الصفحة الرئيسية",
-        "recommended_home_bg": "المقاس الموصى به: ‎1600×900‎ بكسل",
-        "load_failed": "فشل تحميل الإعدادات",
-        "save_success": "تم حفظ الإعدادات بنجاح",
-        "save_failed": "فشل حفظ الإعدادات",
-        "logo_upload_success": "تم رفع الشعار بنجاح",
-        "logo_upload_failed": "فشل رفع الشعار",
-        "favicon_upload_success": "تم رفع الأيقونة بنجاح",
-        "favicon_upload_failed": "فشل رفع الأيقونة",
-        "background_upload_success": "تم رفع الخلفية بنجاح",
-        "background_upload_failed": "فشل رفع الخلفية"
-      }
-  }
+    "tutorialEditPage": {
+      "loading": "جارٍ تحميل الدرس...",
+      "not_found": "الدرس غير موجود",
+      "save_changes": "حفظ التغييرات",
+      "update_success": "تم تحديث الدرس بنجاح",
+      "notification_updated": "تم تحديث الإشعار",
+      "update_failed": "فشل تحديث الدرس"
+    },
+    "appSettingsPage": {
+      "title": "إعدادات التطبيق",
+      "save": "حفظ الإعدادات",
+      "saving": "جاري الحفظ...",
+      "basic_settings": "الإعدادات الأساسية",
+      "application_name_label": "اسم التطبيق",
+      "site_title_label": "عنوان الموقع",
+      "contact_email_label": "البريد الإلكتروني للتواصل",
+      "app_name_placeholder": "تطبيقي الرائع",
+      "site_title_placeholder": "مرحباً بكم في تطبيقي",
+      "contact_email_placeholder": "contact@example.com",
+      "media_settings": "إعدادات الوسائط",
+      "application_logo": "شعار التطبيق",
+      "recommended_logo": "المقاس الموصى به: ‎300×100‎ بكسل (PNG شفاف)",
+      "choose_file": "اختر ملفاً",
+      "upload": "رفع",
+      "favicon": "أيقونة الموقع",
+      "recommended_favicon": "المقاس الموصى به: ‎64×64‎ بكسل (ICO أو PNG)",
+      "home_background": "خلفية الصفحة الرئيسية",
+      "recommended_home_bg": "المقاس الموصى به: ‎1600×900‎ بكسل",
+      "load_failed": "فشل تحميل الإعدادات",
+      "save_success": "تم حفظ الإعدادات بنجاح",
+      "save_failed": "فشل حفظ الإعدادات",
+      "logo_upload_success": "تم رفع الشعار بنجاح",
+      "logo_upload_failed": "فشل رفع الشعار",
+      "favicon_upload_success": "تم رفع الأيقونة بنجاح",
+      "favicon_upload_failed": "فشل رفع الأيقونة",
+      "background_upload_success": "تم رفع الخلفية بنجاح",
+      "background_upload_failed": "فشل رفع الخلفية"
+    }
+  },
+  "file_size_limit": "يجب ألا يتجاوز حجم الملف 10 ميجابايت"
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -104,6 +104,7 @@
         "favicon_upload_failed": "Favicon upload failed",
         "background_upload_success": "Background uploaded successfully",
         "background_upload_failed": "Background upload failed"
-      }
-  }
+    }
+  },
+  "file_size_limit": "File size must be 10MB or less"
 }

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -104,6 +104,7 @@
         "favicon_upload_failed": "Échec du téléversement du favicon",
         "background_upload_success": "Arrière-plan téléversé avec succès",
         "background_upload_failed": "Échec du téléversement de l'arrière-plan"
-      }
-  }
+    }
+  },
+  "file_size_limit": "La taille du fichier doit être de 10 Mo ou moins"
 }


### PR DESCRIPTION
## Summary
- replace hard-coded file upload size warning with `t('file_size_limit')`
- add `file_size_limit` translations in English, French, and Arabic locale files

## Testing
- `npm test` (fails: _cacheService.clearCache.mockReset is not a function; Cannot find module '../../services/instructor/subscriptionService')
- `npm run lint` (fails: Component definition is missing display name)


------
https://chatgpt.com/codex/tasks/task_e_68c5c92be4a0832897af5dce880105cb