### PR TITLE
Cleanup certificate preview URLs with effect

### DIFF
--- a/frontend/src/components/instructor/profile/CertificatesSection.js
+++ b/frontend/src/components/instructor/profile/CertificatesSection.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   FaCertificate,
   FaFilePdf,
@@ -21,6 +21,16 @@ export default function CertificatesSection({ certificates, onChange, t, baseUrl
     preview: null,
   });
   const [uploading, setUploading] = useState(false);
+  const previewUrlRef = useRef(null);
+
+  useEffect(() => {
+    previewUrlRef.current = newCertificate.preview;
+    return () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+    };
+  }, [newCertificate.preview]);
 
   const handleUpload = async () => {
     if (!newCertificate.title || !newCertificate.file) {
@@ -37,9 +47,6 @@ export default function CertificatesSection({ certificates, onChange, t, baseUrl
         ...certificates,
         { id: response.id, title: newCertificate.title, file_url: response.file_url },
       ]);
-      if (newCertificate.preview) {
-        URL.revokeObjectURL(newCertificate.preview);
-      }
       setNewCertificate({ title: "", file: null, preview: null });
       toast.success(t('certificate_upload_success'));
     } catch (error) {


### PR DESCRIPTION
## Summary
- track certificate preview URL with `useRef`
- revoke object URLs on preview change or unmount via `useEffect`

## Testing
- `npm test` *(fails: CacheManager, InstructorSettingsPage)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c92d37708328965e2c285e0ec606