### PR TITLE
Use locale-based country for phone validation

### DIFF
--- a/backend/src/modules/auth/validators/auth.validator.js
+++ b/backend/src/modules/auth/validators/auth.validator.js
@@ -3,8 +3,16 @@ const { z } = require("zod");
 const { PASSWORD_REGEX, OTP_LENGTH } = require("../constants");
 const { isValidPhoneNumber } = require("libphonenumber-js");
 
-// Default country used for phone number validation
-const DEFAULT_COUNTRY = "US";
+// Determine user country for phone validation with fallback to US
+const getUserCountry = () => {
+  try {
+    const locale = process.env.USER_LOCALE || Intl.DateTimeFormat().resolvedOptions().locale;
+    const country = locale?.split("-")[1];
+    return country || "US";
+  } catch {
+    return "US";
+  }
+};
 
 /**
  * @desc Validation for user registration
@@ -14,7 +22,7 @@ exports.registerSchema = z.object({
   email: z.string().email("Invalid email address"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
+    .refine((val) => isValidPhoneNumber(val, getUserCountry()), {
       message: "Invalid phone number",
     }),
   password: z

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -9,6 +9,7 @@ import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
 import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
+import { getUserCountry } from "@/utils/getUserCountry";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import dynamic from "next/dynamic";
@@ -35,9 +36,6 @@ import getCroppedImg from "@/utils/cropImage";
 import { toSocialLinksArray } from "@/utils/socialLinks";
 import { allowedPlatforms } from "@/utils/socialPlatforms";
 
-// Default country for phone validation
-const DEFAULT_COUNTRY = "US";
-
 // Add service imports as needed, e.g., getProfile, updateProfile, uploadAvatar, etc.
 
 export const profileSchema = z.object({
@@ -45,7 +43,7 @@ export const profileSchema = z.object({
   email: z.string().email("invalid_email_address"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
+    .refine((val) => isValidPhoneNumber(val, getUserCountry()), {
       message: "invalid_phone_number",
     }),
   job_title: z.string().min(2, 'job_title_min'),

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -9,6 +9,7 @@ import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
 import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
+import { getUserCountry } from "@/utils/getUserCountry";
 import { API_BASE_URL } from "@/config/config";
 import { getCurrencies } from "@/services/currencyService";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
@@ -44,14 +45,12 @@ import ExpertiseList from "@/components/instructor/profile/ExpertiseList";
 import CertificatesSection from "@/components/instructor/profile/CertificatesSection";
 import SocialLinksSection from "@/components/instructor/profile/SocialLinksSection";
 
-// Default country for phone validation
-const DEFAULT_COUNTRY = "US";
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
 export const instructorProfileSchema = z.object({
   full_name: z.string().min(3, "full_name_min"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
+    .refine((val) => isValidPhoneNumber(val, getUserCountry()), {
       message: "invalid_phone_number",
     }),
   gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
+import { getUserCountry } from "@/utils/getUserCountry";
 import { useTranslation } from "next-i18next";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import {
@@ -28,12 +29,9 @@ import {
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
 
-// Default country for phone validation
-const DEFAULT_COUNTRY = "US";
-
 export const studentProfileSchema = z.object({
   full_name: z.string().min(3, "full_name_min"),
-  phone: z.string().refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
+  phone: z.string().refine((val) => isValidPhoneNumber(val, getUserCountry()), {
     message: "invalid_phone_number",
   }),
   gender: z.enum(['male', 'female']),

--- a/frontend/src/utils/auth/validationSchemas.js
+++ b/frontend/src/utils/auth/validationSchemas.js
@@ -1,9 +1,7 @@
 // 📁 src/utils/validationSchemas.js
 import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
-
-// Default country for phone validation
-const DEFAULT_COUNTRY = "US";
+import { getUserCountry } from "@/utils/getUserCountry";
 // These helpers generate validation schemas using i18n translations
 // 🔐 Login Schema
 export const loginSchema = (t) =>
@@ -23,7 +21,7 @@ export const registerSchema = (t) =>
       email: z.string().email(t("invalid_email_address")),
       phone: z
         .string()
-        .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
+        .refine((val) => isValidPhoneNumber(val, getUserCountry()), {
           message: t("invalid_phone_number"),
         }),
 

--- a/frontend/src/utils/getUserCountry.js
+++ b/frontend/src/utils/getUserCountry.js
@@ -1,0 +1,15 @@
+export const getUserCountry = () => {
+  try {
+    if (typeof window !== 'undefined') {
+      const locale = navigator.languages?.[0] || navigator.language;
+      const country = locale?.split('-')[1];
+      return country || 'US';
+    }
+    // Fallback for server-side rendering
+    const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+    const country = locale?.split('-')[1];
+    return country || 'US';
+  } catch {
+    return 'US';
+  }
+};

--- a/frontend/src/utils/validation/adminProfileSchema.js
+++ b/frontend/src/utils/validation/adminProfileSchema.js
@@ -1,15 +1,13 @@
 // 📁 src/utils/validation/adminProfileSchema.js
 import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
-
-// Default country for phone validation
-const DEFAULT_COUNTRY = "US";
+import { getUserCountry } from "@/utils/getUserCountry";
 
 export const adminProfileSchema = z.object({
   full_name: z.string().min(3, "Full name is required"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val, DEFAULT_COUNTRY), {
+    .refine((val) => isValidPhoneNumber(val, getUserCountry()), {
       message: "Invalid phone number",
     }),
   gender: z.enum(["male", "female"]),


### PR DESCRIPTION
## Summary
- Derive the phone validation country from user locale with a US fallback in backend and frontend validators
- Add `getUserCountry` utility and use it across auth and profile forms instead of a hardcoded default

## Testing
- `npm test --prefix backend` *(fails: bookRoutes.test.js, bankPaymentRoutes.test.js, and others)*
- `npm test --prefix frontend` *(fails: studentPaymentRoutes.test.js and others)*
- `npm run lint --prefix frontend` *(fails: 327 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c92e4d348328b1b421ddaf0f7c32