### PR TITLE
feat: disable identity upload button during pdf upload

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -23,6 +23,7 @@ import {
   FaUpload, FaTrash, FaFilePdf, FaSpinner,
   FaUserCircle, FaIdCard, FaLinkedin, FaGithub,
   FaChevronDown, FaChevronUp, FaTimesCircle, FaGraduationCap,
+  FaGlobe,
   FaCheck
 } from "react-icons/fa";
 import Cropper from "react-easy-crop";
@@ -58,7 +59,7 @@ export default function StudentProfileEdit() {
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
-  const [, setIsUploadingIdentity] = useState(false);
+  const [isUploadingIdentity, setIsUploadingIdentity] = useState(false);
   const [expanded, setExpanded] = useState({
     avatar: true,
     identity: true,
@@ -498,15 +499,20 @@ const handleAvatarSelect = (e) => {
                         <p className="text-sm font-medium text-gray-700">{t('upload_id')}</p>
                         <p className="text-xs text-gray-500">{t('pdf_hint')}</p>
                         <label className="cursor-pointer inline-block mt-2">
-                          <div className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors flex items-center justify-center space-x-2">
-                            <FaUpload className="w-4 h-4" />
-                            <span>{t('select_file')}</span>
+                          <div className={`px-4 py-2 bg-purple-600 text-white rounded-lg transition-colors flex items-center justify-center space-x-2 ${isUploadingIdentity ? 'opacity-50 cursor-not-allowed' : 'hover:bg-purple-700'}`}>
+                            {isUploadingIdentity ? (
+                              <FaSpinner className="w-4 h-4 animate-spin" />
+                            ) : (
+                              <FaUpload className="w-4 h-4" />
+                            )}
+                            <span>{isUploadingIdentity ? t('uploading') : t('select_file')}</span>
                           </div>
                           <input
                             type="file"
                             accept="application/pdf"
                             onChange={handleIdentityUpload}
                             className="hidden"
+                            disabled={isUploadingIdentity}
                           />
                         </label>
                       </div>

--- a/frontend/src/pages/dashboard/student/profile/edit.test.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.test.js
@@ -1,0 +1,87 @@
+const { render, fireEvent, waitFor, act, screen } = require('@testing-library/react');
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('../../../../components/layouts/StudentLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock('../../../../store/auth/authStore', () => ({
+  __esModule: true,
+  default: () => ({
+    user: { id: 1, role: 'student' },
+    logout: jest.fn(),
+    hasHydrated: true,
+    setUser: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../store/notifications/notificationStore', () => ({
+  __esModule: true,
+  default: () => ({ fetch: jest.fn() }),
+}));
+
+jest.mock('../../../../store/messages/messageStore', () => ({
+  __esModule: true,
+  default: () => ({ fetch: jest.fn() }),
+}));
+
+jest.mock('../../../../services/student/studentService.js', () => ({
+  getStudentProfile: jest.fn().mockResolvedValue({
+    full_name: '',
+    phone: '',
+    gender: 'male',
+    date_of_birth: '',
+    student: {},
+    social_links: [],
+    avatar_url: null,
+  }),
+  updateStudentProfile: jest.fn(),
+  uploadStudentAvatar: jest.fn(),
+  uploadStudentIdentity: jest.fn(),
+}));
+
+const studentService = require('../../../../services/student/studentService');
+const StudentProfileEdit = require('./edit').default;
+
+beforeAll(() => {
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+  global.URL.revokeObjectURL = jest.fn();
+});
+
+test('disables identity upload button during upload', async () => {
+  let resolveUpload;
+  studentService.uploadStudentIdentity.mockImplementation(
+    () => new Promise((res) => {
+      resolveUpload = res;
+    })
+  );
+
+  const { container } = render(<StudentProfileEdit />);
+
+  await waitFor(() => {
+    if (!container.querySelector('input[type="file"][accept="application/pdf"]')) {
+      throw new Error('waiting for input');
+    }
+  });
+
+  const input = container.querySelector('input[type="file"][accept="application/pdf"]');
+  const file = new File(['dummy'], 'id.pdf', { type: 'application/pdf' });
+
+  fireEvent.change(input, { target: { files: [file] } });
+
+  await waitFor(() => expect(input).toBeDisabled());
+  expect(screen.getByText('uploading')).toBeInTheDocument();
+
+  await act(async () => {
+    resolveUpload();
+  });
+  await waitFor(() => expect(input).not.toBeDisabled());
+});


### PR DESCRIPTION
## Summary
- track identity upload state
- disable upload button and show spinner during identity file upload
- add test covering upload button disabled state

## Testing
- `npm test src/pages/dashboard/student/profile/edit.test.js` *(fails: Exceeded timeout of 5000 ms)*
- `npm test` *(fails: Cannot find module '../../services/instructor/subscriptionService')*

------
https://chatgpt.com/codex/tasks/task_e_68c5c95ba7a083288184ea169b52bf5b