### PR TITLE
Refactor student profile updates into service layer

### DIFF
--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -9,7 +9,7 @@ const db = require("../../../config/database");
 const notificationService = require("../../notifications/notifications.service");
 
 const messageService = require("../../messages/messages.service");
-const { allowedPlatforms } = require("../common/socialPlatforms");
+const studentService = require("./student.service");
 
 
 /**
@@ -66,93 +66,17 @@ exports.updateProfile = async (req, res) => {
     social_links,
   } = req.body;
 
-  const normalizeUrl = (url = "") => {
-    const trimmed = url.trim();
-    return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
-  };
-
-  // Sanitize social links before database operations
-  const sanitizedLinks = Array.isArray(social_links)
-    ? social_links
-        .filter(
-          (link) =>
-            link &&
-            typeof link.url === "string" &&
-            typeof link.platform === "string" &&
-            allowedPlatforms.includes(link.platform.trim().toLowerCase()) &&
-            link.url.trim()
-        )
-        .map((link) => ({
-          platform: link.platform.trim().toLowerCase(),
-          url: normalizeUrl(link.url),
-        }))
-        .filter((link) => allowedPlatforms.includes(link.platform))
-    : [];
-
-  let trx;
   try {
-    trx = await db.transaction();
+    await studentService.updateStudentProfile(
+      userId,
+      { full_name, phone, gender, date_of_birth },
+      { education_level, topics, learning_goals },
+      social_links
+    );
 
-    await trx("users")
-      .where({ id: userId })
-      .update({
-        full_name,
-        phone,
-        gender,
-        date_of_birth,
-        profile_complete: isProfileComplete,
-      });
-
-    const exists = await trx("student_profiles").where({ user_id: userId }).first();
-    const studentData = { education_level, topics, learning_goals };
-    if (exists) {
-      await trx("student_profiles").where({ user_id: userId }).update(studentData);
-    } else {
-      await trx("student_profiles").insert({ user_id: userId, ...studentData });
-    }
-
-    await trx("user_social_links").where({ user_id: userId }).del();
-    for (const link of sanitizedLinks) {
-      await trx("user_social_links").insert({
-        user_id: userId,
-        platform: link.platform,
-        url: link.url,
-      });
-    }
-
-    await trx.commit();
-
-    const [user] = await db("users")
-      .where({ id: userId })
-      .select(
-        "id",
-        "full_name",
-        "email",
-        "phone",
-        "gender",
-        "date_of_birth",
-        "avatar_url",
-        "is_email_verified",
-        "is_phone_verified",
-        "profile_complete",
-        "created_at",
-        "updated_at"
-      );
-
-    const [student] = await db("student_profiles")
-      .where({ user_id: userId })
-      .select("education_level", "topics", "learning_goals", "identity_doc_url");
-
-    const socialLinks = await db("user_social_links")
-      .where({ user_id: userId })
-      .select("platform", "url");
-
-    res.json({ ...user, student, social_links: socialLinks });
+    const profile = await studentService.getStudentProfile(userId);
+    res.json(profile);
   } catch (err) {
-    if (trx) {
-      await trx.rollback();
-    }
-
     // Handle unique constraint violations for email and phone
     if (err.code === "23505") {
       if (err.constraint === "users_email_unique") {

--- a/backend/src/modules/users/student/student.service.js
+++ b/backend/src/modules/users/student/student.service.js
@@ -1,66 +1,124 @@
 const db = require("../../../config/database");
+const { allowedPlatforms } = require("../common/socialPlatforms");
+
+// Normalize and sanitize social links
+const normalizeUrl = (url = "") => {
+  const trimmed = url.trim();
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+};
+
+const sanitizeSocialLinks = (links) =>
+  Array.isArray(links)
+    ? links
+        .filter(
+          (link) =>
+            link &&
+            typeof link.url === "string" &&
+            typeof link.platform === "string" &&
+            allowedPlatforms.includes(link.platform.trim().toLowerCase()) &&
+            link.url.trim()
+        )
+        .map((link) => ({
+          platform: link.platform.trim().toLowerCase(),
+          url: normalizeUrl(link.url),
+        }))
+    : [];
 
 // 🔹 Get full student profile
 const getStudentProfile = async (userId) => {
-    const [user] = await db("users")
-        .where({ id: userId })
-        .select("id", "full_name", "email", "phone", "avatar_url", "gender", "date_of_birth", "profile_complete");
+  const [user] = await db("users")
+    .where({ id: userId })
+    .select(
+      "id",
+      "full_name",
+      "email",
+      "phone",
+      "avatar_url",
+      "gender",
+      "date_of_birth",
+      "profile_complete"
+    );
 
-    const [student] = await db("student_profiles")
-        .where({ user_id: userId })
-        .select("education_level", "topics", "learning_goals", "identity_doc_url");
+  const [student] = await db("student_profiles")
+    .where({ user_id: userId })
+    .select("education_level", "topics", "learning_goals", "identity_doc_url");
 
-    const socialLinks = await db("user_social_links")
-        .where({ user_id: userId })
-        .select("platform", "url");
+  const socialLinks = await db("user_social_links")
+    .where({ user_id: userId })
+    .select("platform", "url");
 
-    return { ...user, student, social_links: socialLinks };
+  return { ...user, student, social_links: socialLinks };
 };
 
 // 🔹 Update student + profile + links in a transaction
-const updateStudentProfile = async (userId, userData, studentData, socialLinks = []) => {
-    try {
-        return await db.transaction(async (trx) => {
-            const requiredUserFields = ["full_name", "phone", "gender", "date_of_birth"];
-            const hasUserFields = requiredUserFields.every((f) => userData && userData[f]);
-            const hasStudentDetails = studentData && studentData.education_level;
-            const hasSocialLinks = Array.isArray(socialLinks) && socialLinks.length > 0;
+const updateStudentProfile = async (
+  userId,
+  userData = {},
+  studentData = {},
+  socialLinks = []
+) => {
+  const sanitizedLinks = sanitizeSocialLinks(socialLinks);
 
-            const profileComplete = hasUserFields && hasStudentDetails && hasSocialLinks;
+  try {
+    return await db.transaction(async (trx) => {
+      const requiredUserFields = [
+        "full_name",
+        "phone",
+        "gender",
+        "date_of_birth",
+      ];
+      const hasUserFields = requiredUserFields.every(
+        (f) => userData && userData[f]
+      );
+      const hasStudentDetails = studentData && studentData.education_level;
+      const hasSocialLinks = sanitizedLinks.length > 0;
 
-            const userUpdateData = { ...userData };
-            if (profileComplete) userUpdateData.profile_complete = true;
+      const profileComplete =
+        hasUserFields && hasStudentDetails && hasSocialLinks;
 
-            const updated = await trx("users").where({ id: userId }).update(userUpdateData);
-            if (updated === 0) throw new Error("Failed to update user record");
+      const updated = await trx("users")
+        .where({ id: userId })
+        .update({ ...userData, profile_complete: profileComplete });
+      if (updated === 0) throw new Error("Failed to update user record");
 
-            const existing = await trx("student_profiles").where({ user_id: userId }).first();
-            if (existing) {
-                const updatedProfile = await trx("student_profiles").where({ user_id: userId }).update(studentData);
-                if (updatedProfile === 0) throw new Error("Failed to update student profile");
-            } else {
-                const insertedProfile = await trx("student_profiles").insert({ user_id: userId, ...studentData });
-                if (!insertedProfile || insertedProfile.length === 0) throw new Error("Failed to create student profile");
-            }
-
-            await trx("user_social_links").where({ user_id: userId }).del();
-            for (const link of socialLinks) {
-                if (link.url) {
-                    const insertedLink = await trx("user_social_links").insert({ user_id: userId, platform: link.platform, url: link.url });
-                    if (!insertedLink || insertedLink.length === 0) throw new Error("Failed to add social link");
-                }
-            }
-
-            return { profile_complete: profileComplete };
+      const existing = await trx("student_profiles")
+        .where({ user_id: userId })
+        .first();
+      if (existing) {
+        const updatedProfile = await trx("student_profiles")
+          .where({ user_id: userId })
+          .update(studentData);
+        if (updatedProfile === 0)
+          throw new Error("Failed to update student profile");
+      } else {
+        const insertedProfile = await trx("student_profiles").insert({
+          user_id: userId,
+          ...studentData,
         });
-    } catch (err) {
-        throw err;
-    }
+        if (!insertedProfile || insertedProfile.length === 0)
+          throw new Error("Failed to create student profile");
+      }
+
+      await trx("user_social_links").where({ user_id: userId }).del();
+      for (const link of sanitizedLinks) {
+        const insertedLink = await trx("user_social_links").insert({
+          user_id: userId,
+          platform: link.platform,
+          url: link.url,
+        });
+        if (!insertedLink || insertedLink.length === 0)
+          throw new Error("Failed to add social link");
+      }
+
+      return { profile_complete: profileComplete };
+    });
+  } catch (err) {
+    throw err;
+  }
 };
-
-
 
 module.exports = {
-    getStudentProfile,
-    updateStudentProfile,
+  getStudentProfile,
+  updateStudentProfile,
 };
+

--- a/backend/tests/studentProfileService.test.js
+++ b/backend/tests/studentProfileService.test.js
@@ -1,0 +1,75 @@
+const { newDb } = require('pg-mem');
+const { v4: uuidv4 } = require('uuid');
+
+const db = newDb();
+db.public.registerFunction({ name: 'uuid_generate_v4', returns: 'uuid', implementation: uuidv4 });
+const mockDb = db.adapters.createKnex();
+
+jest.mock('../src/config/database.js', () => mockDb);
+
+const service = require('../src/modules/users/student/student.service');
+
+describe('student.service updateStudentProfile', () => {
+  beforeAll(async () => {
+    await mockDb.schema.createTable('users', (table) => {
+      table.uuid('id').primary();
+      table.string('full_name');
+      table.string('phone');
+      table.string('gender');
+      table.date('date_of_birth');
+      table.boolean('profile_complete').defaultTo(false);
+    });
+
+    await mockDb.schema.createTable('student_profiles', (table) => {
+      table.uuid('user_id').primary().references('users.id');
+      table.string('education_level');
+      table.string('topics');
+      table.string('learning_goals');
+    });
+
+    await mockDb.schema.createTable('user_social_links', (table) => {
+      table.increments('id');
+      table.uuid('user_id').references('users.id');
+      table.string('platform');
+      table.string('url');
+    });
+  });
+
+  afterAll(async () => {
+    await mockDb.destroy();
+  });
+
+  beforeEach(async () => {
+    await mockDb('user_social_links').del();
+    await mockDb('student_profiles').del();
+    await mockDb('users').del();
+  });
+
+  it('updates profile, social links and marks profile complete', async () => {
+    const userId = uuidv4();
+    await mockDb('users').insert({ id: userId });
+
+    await service.updateStudentProfile(
+      userId,
+      { full_name: 'John', phone: '123', gender: 'male', date_of_birth: '2000-01-01' },
+      { education_level: 'college', topics: 'math', learning_goals: 'learn' },
+      [
+        { platform: 'github', url: 'github.com/john' },
+        { platform: 'invalid', url: 'http://example.com' },
+      ]
+    );
+
+    const user = await mockDb('users').where({ id: userId }).first();
+    expect(user.profile_complete).toBe(true);
+    expect(user.full_name).toBe('John');
+
+    const profile = await mockDb('student_profiles').where({ user_id: userId }).first();
+    expect(profile.education_level).toBe('college');
+
+    const links = await mockDb('user_social_links').where({ user_id: userId });
+    expect(links).toHaveLength(1);
+    expect(links[0].platform).toBe('github');
+    expect(links[0].url).toBe('https://github.com/john');
+  });
+});
+


### PR DESCRIPTION
## Summary
- move student profile update logic and social link sanitization into `student.service`
- simplify student controller to use service
- add unit test for `updateStudentProfile`

## Testing
- `cd backend && npm test tests/studentProfileService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5c95d4ab48328b829e0dfc48d92c8