### PR TITLE
Handle replacement of student identity documents

### DIFF
--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -213,11 +213,25 @@ exports.updateIdentity = async (req, res) => {
     if (!req.file) {
       return res.status(400).json({ message: "No identity document uploaded" });
     }
-    const identityUrl = `/uploads/identity/student/${req.file.filename}`;
-    const exists = await db("student_profiles")
+    const profile = await db("student_profiles")
       .where({ user_id: req.user.id })
       .first();
-    if (exists) {
+
+    if (profile && profile.identity_doc_url) {
+      const oldPath = path.join(
+        __dirname,
+        "../../../../",
+        profile.identity_doc_url
+      );
+      fs.unlink(oldPath, (err) =>
+        err &&
+        logger.error("Failed to remove old identity document:", err)
+      );
+    }
+
+    const identityUrl = `/uploads/identity/student/${req.file.filename}`;
+
+    if (profile) {
       await db("student_profiles")
         .where({ user_id: req.user.id })
         .update({ identity_doc_url: identityUrl });
@@ -227,8 +241,12 @@ exports.updateIdentity = async (req, res) => {
         identity_doc_url: identityUrl,
       });
     }
+
     res.json({ identity_doc_url: identityUrl });
   } catch (error) {
+    if (req.file) {
+      fs.unlink(req.file.path, (err) => err && logger.error(err));
+    }
     logger.error(error);
     res.status(500).json({ message: "Failed to update identity document" });
   }


### PR DESCRIPTION
## Summary
- remove previous student identity document before storing new upload
- clean up new identity files on failure to match avatar error handling

## Testing
- `npm test` (fails: Test Suites: 23 failed, 2 skipped, 116 passed, 139 total; Tests: 33 failed, 15 skipped, 428 passed, 476 total)

------
https://chatgpt.com/codex/tasks/task_e_68c5c95de4908328bb9bb3ef003606fc