### PR TITLE
Sanitize student avatar deletion path

### DIFF
--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -189,8 +189,11 @@ exports.updateAvatar = async (req, res) => {
       .update({ avatar_url: avatarUrl });
 
     if (oldAvatar) {
-      const oldPath = path.join(__dirname, "../../../../", oldAvatar);
-      fs.unlink(oldPath, (err) => err && logger.error("Failed to remove old avatar:", err));
+      const sanitizedOldAvatar = oldAvatar.replace(/^\//, "");
+      const oldPath = path.join(process.cwd(), sanitizedOldAvatar);
+      fs.unlink(oldPath, (err) =>
+        err && logger.error("Failed to remove old avatar:", err)
+      );
     }
 
     res.json({ avatar_url: avatarUrl });


### PR DESCRIPTION
## Summary
- sanitize old avatar path before joining to avoid incorrect deletion
- join avatar paths against project root when removing old images

## Testing
- `npm test` *(fails: 23 failed, 2 skipped)*
- Manually created and removed a dummy avatar file to verify deletion logic

------
https://chatgpt.com/codex/tasks/task_e_68c5c95ebd4c8328878e5bf5f3bd6e34