### PR TITLE
refactor: centralize social platforms list

### DIFF
--- a/backend/src/modules/users/common/socialPlatforms.js
+++ b/backend/src/modules/users/common/socialPlatforms.js
@@ -1,11 +1,3 @@
-const allowedPlatforms = [
-  "linkedin",
-  "github",
-  "twitter",
-  "youtube",
-  "facebook",
-  "instagram",
-  "website",
-];
+const allowedPlatforms = require("../../../../../shared/socialPlatforms.json");
 
 module.exports = { allowedPlatforms };

--- a/frontend/src/utils/socialPlatforms.js
+++ b/frontend/src/utils/socialPlatforms.js
@@ -1,3 +1,4 @@
+import platformNames from "../../../shared/socialPlatforms.json";
 import {
   FaLinkedin,
   FaGithub,
@@ -8,14 +9,19 @@ import {
   FaGlobe,
 } from "react-icons/fa";
 
-export const allowedPlatforms = [
-  { name: "linkedin", Icon: FaLinkedin, className: "text-blue-600" },
-  { name: "github", Icon: FaGithub, className: "text-gray-800" },
-  { name: "twitter", Icon: FaTwitter, className: "text-blue-400" },
-  { name: "youtube", Icon: FaYoutube, className: "text-red-600" },
-  { name: "facebook", Icon: FaFacebook, className: "text-blue-700" },
-  { name: "instagram", Icon: FaInstagram, className: "text-pink-600" },
-  { name: "website", Icon: FaGlobe, className: "text-green-600" },
-];
+const iconMap = {
+  linkedin: { Icon: FaLinkedin, className: "text-blue-600" },
+  github: { Icon: FaGithub, className: "text-gray-800" },
+  twitter: { Icon: FaTwitter, className: "text-blue-400" },
+  youtube: { Icon: FaYoutube, className: "text-red-600" },
+  facebook: { Icon: FaFacebook, className: "text-blue-700" },
+  instagram: { Icon: FaInstagram, className: "text-pink-600" },
+  website: { Icon: FaGlobe, className: "text-green-600" },
+};
 
-export const socialPlatforms = allowedPlatforms.map((p) => p.name);
+export const allowedPlatforms = platformNames.map((name) => ({
+  name,
+  ...iconMap[name],
+}));
+
+export const socialPlatforms = platformNames;

--- a/shared/socialPlatforms.json
+++ b/shared/socialPlatforms.json
@@ -1,0 +1,9 @@
+[
+  "linkedin",
+  "github",
+  "twitter",
+  "youtube",
+  "facebook",
+  "instagram",
+  "website"
+]


### PR DESCRIPTION
## Summary
- create shared socialPlatforms.json for platform names
- import shared list in backend users module
- reuse shared list in frontend utilities while keeping local icon map

## Testing
- `npm test` (backend) *(fails: 23 failed, 116 passed)*
- `npm test` (frontend) *(warn: execution produced large output and could not capture final summary)*


------
https://chatgpt.com/codex/tasks/task_e_68c5c964bdc08328894b4f548e1a627a