### PR TITLE
refactor: clear avatar preview after upload

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -187,9 +187,9 @@ const handleAvatarSelect = (e) => {
 };
 
   const handleCropUpload = async () => {
-    if (!tempAvatar || !croppedAreaPixels) return;
     setIsUploadingAvatar(true);
     try {
+      if (!tempAvatar || !croppedAreaPixels) return;
       const blob = await getCroppedImg(tempAvatar, croppedAreaPixels);
       const file = new File([blob], tempFileName || "avatar.jpg", { type: blob.type });
       const res = await uploadStudentAvatar(user.id, file);
@@ -202,13 +202,15 @@ const handleAvatarSelect = (e) => {
       }));
       toast.success("Avatar uploaded successfully!");
       setShowCropper(false);
-      URL.revokeObjectURL(tempAvatar);
       setTempAvatar(null);
     } catch (error) {
       console.error('Avatar upload error:', error.response);
       const msg = error.response?.data?.message || t('avatar_upload_failed');
       toast.error(msg);
     } finally {
+      if (tempAvatar) {
+        URL.revokeObjectURL(tempAvatar);
+      }
       setIsUploadingAvatar(false);
     }
   };


### PR DESCRIPTION
## Summary
- ensure avatar crop uploads clear preview URL via finally block

## Testing
- `npm test --silent` (fails: Test Suites: 2 failed, 60 passed)
- `npm run lint` (fails: 56 errors, 271 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c5c96e696c8328a0b2d833b30e2dbb