### PR TITLE
feat: add i18n imports to student profile edit

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -4,6 +4,8 @@ import { toast } from "react-toastify";
 import { z } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import StudentLayout from "@/components/layouts/StudentLayout";
 import {
   getStudentProfile,


### PR DESCRIPTION
## Summary
- add next-i18next serverSideTranslations import for student profile editing
- reference shared i18n config in student profile edit page

## Testing
- `pre-commit run --files frontend/src/pages/dashboard/student/profile/edit.js` *(fails: 327 problems, 56 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c9743eb0832882184a1587145e3b