### PR TITLE
Show identity upload progress

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -58,7 +58,7 @@ export default function StudentProfileEdit() {
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
-  const [, setIsUploadingIdentity] = useState(false);
+  const [isUploadingIdentity, setIsUploadingIdentity] = useState(false);
   const [expanded, setExpanded] = useState({
     avatar: true,
     identity: true,
@@ -465,7 +465,11 @@ const handleAvatarSelect = (e) => {
               {expanded.identity && (
                 <div className="p-4 space-y-4">
                   <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center">
-                    {formData.identityPreview ? (
+                    {isUploadingIdentity ? (
+                      <div className="flex justify-center">
+                        <FaSpinner className="w-6 h-6 text-purple-600 animate-spin" />
+                      </div>
+                    ) : formData.identityPreview ? (
                       <div className="space-y-3">
                         <div className="inline-flex items-center justify-center p-3 bg-purple-100 rounded-full">
                           <FaFilePdf className="w-8 h-8 text-purple-600" />


### PR DESCRIPTION
## Summary
- add `isUploadingIdentity` state for student profile editing
- display spinner while uploading identity document

## Testing
- `npm test` (fails: CacheManager.test.tsx, InstructorSettingsPage.test.js, StudentTutorialsPage.test.js)
- `npm run lint` (fails: 56 errors, 271 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c5c97524b0832892b80415a78856b7