### PR TITLE
chore: revoke profile pic object URL

### DIFF
--- a/frontend/src/components/profile/steps/StudentDetails.js
+++ b/frontend/src/components/profile/steps/StudentDetails.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaArrowLeft, FaArrowRight, FaUpload, FaTrash, FaCheckCircle } from "react-icons/fa";
 
@@ -6,13 +6,21 @@ const StudentDetails = ({ formData, setFormData, nextStep, prevStep }) => {
   const [errors, setErrors] = useState({});
   const [profilePic, setProfilePic] = useState(null);
 
+  useEffect(() => {
+    return () => {
+      if (profilePic) {
+        URL.revokeObjectURL(profilePic);
+      }
+    };
+  }, [profilePic]);
+
   // ✅ Handle Input Change
   const handleChange = (e) => {
-    setFormData({ 
-      ...formData, 
-      studentDetails: { 
-        ...formData.studentDetails, 
-        [e.target.name]: e.target.value 
+    setFormData({
+      ...formData,
+      studentDetails: {
+        ...formData.studentDetails,
+        [e.target.name]: e.target.value
       }
     });
   };
@@ -23,11 +31,11 @@ const StudentDetails = ({ formData, setFormData, nextStep, prevStep }) => {
     if (file) {
       const imageUrl = URL.createObjectURL(file);
       setProfilePic(imageUrl);
-      setFormData({ 
-        ...formData, 
-        studentDetails: { 
-          ...formData.studentDetails, 
-          profilePicture: imageUrl 
+      setFormData({
+        ...formData,
+        studentDetails: {
+          ...formData.studentDetails,
+          profilePicture: imageUrl
         }
       });
     }
@@ -35,12 +43,15 @@ const StudentDetails = ({ formData, setFormData, nextStep, prevStep }) => {
 
   // ✅ Remove Profile Picture
   const removeImage = () => {
+    if (profilePic) {
+      URL.revokeObjectURL(profilePic);
+    }
     setProfilePic(null);
-    setFormData({ 
-      ...formData, 
-      studentDetails: { 
-        ...formData.studentDetails, 
-        profilePicture: "" 
+    setFormData({
+      ...formData,
+      studentDetails: {
+        ...formData.studentDetails,
+        profilePicture: "",
       }
     });
   };
@@ -86,10 +97,10 @@ const StudentDetails = ({ formData, setFormData, nextStep, prevStep }) => {
       {/* ✅ Education Level */}
       <div className="mb-4">
         <label className="block text-sm font-medium">Education Level</label>
-        <select 
-          name="educationLevel" 
-          value={formData.studentDetails.educationLevel} 
-          onChange={handleChange} 
+        <select
+          name="educationLevel"
+          value={formData.studentDetails.educationLevel}
+          onChange={handleChange}
           className="w-full p-2 border rounded bg-gray-800 text-white"
         >
           <option value="">Select your education level</option>
@@ -117,10 +128,10 @@ const StudentDetails = ({ formData, setFormData, nextStep, prevStep }) => {
       {/* ✅ Preferred Learning Style */}
       <div className="mb-4">
         <label className="block text-sm font-medium">Preferred Learning Style</label>
-        <select 
-          name="learningStyle" 
-          value={formData.studentDetails.learningStyle} 
-          onChange={handleChange} 
+        <select
+          name="learningStyle"
+          value={formData.studentDetails.learningStyle}
+          onChange={handleChange}
           className="w-full p-2 border rounded bg-gray-800 text-white"
         >
           <option value="">Select your preferred learning style</option>
@@ -163,3 +174,4 @@ const StudentDetails = ({ formData, setFormData, nextStep, prevStep }) => {
 };
 
 export default StudentDetails;
+


### PR DESCRIPTION
## Summary
- revoke existing profile picture object URLs when uploading new images or unmounting
- clean up object URL when removing uploaded profile pictures

## Testing
- `npm test -- -w 1` *(fails: CacheManager.test.tsx, InstructorSettingsPage.test.js, StudentTutorialsPage.test.js, others)*
- `npm run lint` *(fails: Component definition is missing display name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c976816483288a51724d4adbf322