### PR TITLE
feat(frontend): localize profile edit strings

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1974,6 +1974,7 @@
     "github_label": "GitHub Profile URL",
     "github_placeholder": "https://github.com/yourusername",
     "cancel": "Cancel",
+    "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
     "load_failed": "Failed to load profile data",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1980,6 +1980,7 @@
     "github_label": "GitHub Profile URL",
     "github_placeholder": "https://github.com/yourusername",
     "cancel": "Cancel",
+    "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
     "load_failed": "Failed to load profile data",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1990,6 +1990,7 @@
     "github_label": "GitHub Profile URL",
     "github_placeholder": "https://github.com/yourusername",
     "cancel": "Cancel",
+    "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
     "load_failed": "Failed to load profile data",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1966,6 +1966,7 @@
     "github_label": "GitHub Profile URL",
     "github_placeholder": "https://github.com/yourusername",
     "cancel": "Cancel",
+    "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
     "load_failed": "Failed to load profile data",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1974,6 +1974,7 @@
     "github_label": "GitHub Profile URL",
     "github_placeholder": "https://github.com/yourusername",
     "cancel": "Cancel",
+    "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
     "load_failed": "Failed to load profile data",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1966,6 +1966,7 @@
     "github_label": "GitHub Profile URL",
     "github_placeholder": "https://github.com/yourusername",
     "cancel": "Cancel",
+    "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
     "load_failed": "Failed to load profile data",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1980,6 +1980,7 @@
     "github_label": "GitHub Profile URL",
     "github_placeholder": "https://github.com/yourusername",
     "cancel": "Cancel",
+    "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
     "load_failed": "Failed to load profile data",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1935,6 +1935,7 @@
     "github_label": "GitHub Profile URL",
     "github_placeholder": "https://github.com/yourusername",
     "cancel": "Cancel",
+    "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
     "load_failed": "Failed to load profile data",

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -200,7 +200,7 @@ const handleAvatarSelect = (e) => {
         avatar_url,
         avatarPreview: `${process.env.NEXT_PUBLIC_API_BASE_URL}${avatar_url}?v=${Date.now()}`
       }));
-      toast.success("Avatar uploaded successfully!");
+      toast.success(t('avatar_upload_success'));
       setShowCropper(false);
       URL.revokeObjectURL(tempAvatar);
       setTempAvatar(null);
@@ -745,14 +745,14 @@ const handleAvatarSelect = (e) => {
                 onClick={handleCropCancel}
                 className="px-4 py-2 bg-gray-200 rounded"
               >
-                Cancel
+                {t('cancel')}
               </button>
               <button
                 onClick={handleCropUpload}
                 className="px-4 py-2 bg-yellow-600 text-white rounded flex items-center gap-2"
               >
                 {isUploadingAvatar ? <FaSpinner className="animate-spin" /> : <FaCheck />}
-                Upload
+                {t('upload')}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- refactor student profile avatar upload and cropper controls to use i18n `t()` strings
- add missing `upload` translation key across all locale files

## Testing
- `npm test`
- `npm run lint` *(fails: 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c97c4a6c8328b0db5a7518333848