### PR TITLE
Await message fetching in admin profile update

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -383,7 +383,7 @@ function ProfileEditTemplate() {
 
       toast.success(t('profile_update_success'));
       await fetchNotifications();
-      fetchMessages();
+      await fetchMessages();
       router.push("/dashboard/admin/profile/steps/verification");
     } catch (err) {
       toast.error(err.message || t('profile_update_failed'));


### PR DESCRIPTION
## Summary
- Ensure admin profile update awaits message fetch for proper error handling

## Testing
- `CI=true npx jest src/tests/__tests__/CacheManager.test.tsx 2>&1 | tail -n 20` *(fails: TypeError: _cacheService.clearCache.mockReset is not a function)*
- `CI=true npx jest src/tests/__tests__/InstructorSettingsPage.test.js 2>&1 | tail -n 20` *(fails: Cannot find module '../../services/instructor/subscriptionService')*
- `npm run lint` *(fails: 327 problems, 56 errors, 271 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a333984083288dc7a8db7d119056