### PR TITLE
Remove duplicate FaGlobe import in profile edit page

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -26,7 +26,6 @@ import {
   FaUpload, FaTrash, FaFilePdf, FaSpinner,
   FaUserCircle, FaIdCard, FaGlobe,
   FaChevronDown, FaChevronUp, FaTimesCircle, FaGraduationCap,
-  FaGlobe,
   FaCheck
 } from "react-icons/fa";
 import Cropper from "react-easy-crop";


### PR DESCRIPTION
## Summary
- remove repeated FaGlobe icon import on student profile edit page

## Testing
- `npm run lint` *(fails: 57 errors, 266 warnings)*
- `npx eslint src/pages/dashboard/student/profile/edit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6609d48ac8328a3ba9b2afc8b08fa