### PR TITLE
fix: sanitize student identity document path

### DIFF
--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -220,27 +220,26 @@ exports.updateIdentity = async (req, res) => {
     if (!req.file) {
       return res.status(400).json({ message: "No identity document uploaded" });
     }
+    const identityUrl = `/uploads/identity/student/${req.file.filename}`;
     const profile = await db("student_profiles")
       .where({ user_id: req.user.id })
       .first();
-    if (exists) {
-      if (exists.identity_doc_url) {
-        const oldPath = path.join(
-          __dirname,
-          "../../../../",
-          exists.identity_doc_url
-        );
-        fs.unlink(oldPath, (err) => {
-          if (err) {
-            if (err.code === "ENOENT") {
-              logger.warn("Old identity document not found:", err);
-            } else {
-              logger.error("Failed to remove old identity document:", err);
-            }
-          }
-        });
-      }
 
+    if (profile && profile.identity_doc_url) {
+      const sanitizedOldUrl = profile.identity_doc_url.replace(/^\//, "");
+      const oldPath = path.join(process.cwd(), sanitizedOldUrl);
+      fs.unlink(oldPath, (err) => {
+        if (err) {
+          if (err.code === "ENOENT") {
+            logger.warn("Old identity document not found:", err);
+          } else {
+            logger.error("Failed to remove old identity document:", err);
+          }
+        }
+      });
+    }
+
+    if (profile) {
       await db("student_profiles")
         .where({ user_id: req.user.id })
         .update({ identity_doc_url: identityUrl });


### PR DESCRIPTION
## Summary
- remove stale identity document when updating student profile
- sanitize stored identity document URL

## Testing
- `npm test` *(fails: Test Suites: 27 failed, 2 skipped, 117 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6609be5188328bc6d173c3cebd7da