### PR TITLE
Remove duplicate FaGlobe import

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -26,7 +26,6 @@ import {
   FaUpload, FaTrash, FaFilePdf, FaSpinner,
   FaUserCircle, FaIdCard, FaGlobe,
   FaChevronDown, FaChevronUp, FaTimesCircle, FaGraduationCap,
-  FaGlobe,
   FaCheck
 } from "react-icons/fa";
 import Cropper from "react-easy-crop";


### PR DESCRIPTION
## Summary
- remove duplicate FaGlobe import from student profile edit page

## Testing
- `npm test src/pages/dashboard/student/profile/edit.test.js` *(fails: expect input to be disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68c6609231c0832884257cbf90f6c2f2