### PR TITLE
fix student identity doc handling

### DIFF
--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -220,25 +220,18 @@ exports.updateIdentity = async (req, res) => {
     if (!req.file) {
       return res.status(400).json({ message: "No identity document uploaded" });
     }
-    const profile = await db("student_profiles")
+    const identityUrl = `/uploads/identity/student/${req.file.filename}`;
+    const existingProfile = await db("student_profiles")
       .where({ user_id: req.user.id })
       .first();
-    if (exists) {
-      if (exists.identity_doc_url) {
-        const oldPath = path.join(
-          __dirname,
-          "../../../../",
-          exists.identity_doc_url
+    if (existingProfile) {
+      if (existingProfile.identity_doc_url) {
+        const sanitizedPath = existingProfile.identity_doc_url.replace(/^\//, "");
+        const oldPath = path.join(process.cwd(), sanitizedPath);
+        fs.unlink(oldPath, (err) =>
+          err &&
+          logger.error("Failed to remove old identity document:", err)
         );
-        fs.unlink(oldPath, (err) => {
-          if (err) {
-            if (err.code === "ENOENT") {
-              logger.warn("Old identity document not found:", err);
-            } else {
-              logger.error("Failed to remove old identity document:", err);
-            }
-          }
-        });
       }
 
       await db("student_profiles")


### PR DESCRIPTION
## Summary
- ensure student identity document updates handle existing profile correctly
- sanitize and resolve old identity document paths before deletion

## Testing
- `npm test tests/adminIdentityDocController.test.js`
- `npm test` *(fails: 27 failed, 117 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6609174cc8328968ce2f45e85c787