### PR TITLE
fix: remove duplicate FaGlobe import

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -26,7 +26,6 @@ import {
   FaUpload, FaTrash, FaFilePdf, FaSpinner,
   FaUserCircle, FaIdCard, FaGlobe,
   FaChevronDown, FaChevronUp, FaTimesCircle, FaGraduationCap,
-  FaGlobe,
   FaCheck
 } from "react-icons/fa";
 import Cropper from "react-easy-crop";


### PR DESCRIPTION
## Summary
- remove duplicate `FaGlobe` import from student profile edit page

## Testing
- `npm run lint` (fails: react/display-name errors in unrelated test files)
- `npx eslint src/pages/dashboard/student/profile/edit.js`
- `npm test` (fails: Cannot find module '../../services/instructor/subscriptionService' from 'InstructorSettingsPage.test.js')

------
https://chatgpt.com/codex/tasks/task_e_68c6608c8d1c832886bf90ce9e19140e