### PR TITLE
Remove duplicate FaGlobe import

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -26,7 +26,6 @@ import {
   FaUpload, FaTrash, FaFilePdf, FaSpinner,
   FaUserCircle, FaIdCard, FaGlobe,
   FaChevronDown, FaChevronUp, FaTimesCircle, FaGraduationCap,
-  FaGlobe,
   FaCheck
 } from "react-icons/fa";
 import Cropper from "react-easy-crop";


### PR DESCRIPTION
## Summary
- remove duplicate `FaGlobe` icon import in student profile editor

## Testing
- `npm test` *(fails: WebsiteHomeScroll.test.js, InstructorTutorialsPage.test.js, edit.test.js, InstructorSettingsPage.test.js, StudentTutorialsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c66085e5b8832893fdc8c4e8034aed