### PR TITLE
Fix tutorial imports and cleanup creation flow

### DIFF
--- a/frontend/src/components/dashboard/admin/tutorials/Filters.js
+++ b/frontend/src/components/dashboard/admin/tutorials/Filters.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { FaSearch } from "react-icons/fa";
 import { Button } from "@/components/ui/button";
-import { TUTORIAL_STATUS } from "../../../../../../shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
 
 function Filters({
   searchQuery,

--- a/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
+++ b/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { TUTORIAL_STATUS } from "../../../../../../shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
 import { FaSpinner, FaSearch, FaEdit, FaTrash } from "react-icons/fa";
 
 function TutorialsTable({

--- a/frontend/src/hooks/useTutorialCreation.js
+++ b/frontend/src/hooks/useTutorialCreation.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { buildTutorialFormData } from "@/utils/tutorialForm";
+import { buildTutorialFormData } from "@/utils/tutorialDraft";
 import { toast } from "react-toastify";
 
 // Shared hook for tutorial creation form

--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -14,11 +14,6 @@ import { fetchAllCategories } from "@/services/admin/categoryService";
 import StepProgressBar from "@/components/tutorials/create/StepProgressBar";
 import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
-import {
-  loadDraft,
-  loadCategories,
-  buildTutorialFormData,
-} from "@/utils/tutorialDraft";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
@@ -59,42 +54,6 @@ function CreateTutorialPage() {
       toast.error(msg);
     }
   };
-
-  const [step, setStep] = useState(1);
-  const router = useRouter();
-  const defaultTutorial = {
-    title: "",
-    shortDescription: "",
-    category: "",
-    categoryName: "",
-    level: "",
-    lessonCount: 1,
-    tags: [],
-    chapters: [],
-    thumbnail: null,
-    preview: null,
-    language: "",
-    price: "",
-    isFree: false,
-  };
-  const [tutorialData, setTutorialData] = useState(() =>
-    loadDraft("tutorialDraft", defaultTutorial)
-  );
-
-  const [categories, setCategories] = useState([]);
-
-  useEffect(() => {
-    loadCategories(fetchAllCategories)
-      .then((result) => setCategories(result || []))
-      .catch((err) => {
-        console.error("Failed to load categories", err);
-        toast.error(t("load_categories_failed"));
-      });
-  }, [t]);
-
-  const nextStep = () => setStep((prev) => prev + 1);
-  const prevStep = () => setStep((prev) => prev - 1);
-
 
   const submitTutorial = async (status) => {
     if (tutorialData.chapters.some((ch) => !ch.videoUrl)) {

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -26,7 +26,7 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
-import { TUTORIAL_STATUS } from "../../../../../../shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
 
 function AdminTutorialsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "tutorialsPage" });

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -4,7 +4,7 @@ import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
-import { TUTORIAL_STATUS } from "../../../../../../shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
 import {
   FaPlus,
   FaEdit,

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -2,7 +2,7 @@
 // Admin specific API calls for managing tutorials
 
 import api from "@/services/api/api";
-import { TUTORIAL_STATUS } from "../../../../shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
 
 /**
  * Create a new tutorial as an admin or instructor.

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -1,6 +1,6 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
-import { TUTORIAL_STATUS } from "../../../../shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
 
 const formatBase = (tut) => ({
   ...tut,

--- a/frontend/src/shared/tutorialStatus.js
+++ b/frontend/src/shared/tutorialStatus.js
@@ -1,0 +1,7 @@
+export const TUTORIAL_STATUS = Object.freeze({
+  DRAFT: "draft",
+  PUBLISHED: "published",
+  ARCHIVED: "archived",
+});
+
+export default TUTORIAL_STATUS;


### PR DESCRIPTION
## Summary
- expose tutorial status constants within frontend
- fix tutorial creation utilities and imports
- remove duplicated state from admin tutorial creation page

## Testing
- `npm test -- --silent` *(fails: WebsiteHomeScroll.test.js, InstructorTutorialsPage.test.js, edit.test.js, InstructorSettingsPage.test.js, StudentTutorialsPage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c65f26cf348328877d425f355b0f5a