### PR TITLE
Restrict instructor media deletions

### DIFF
--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -251,11 +251,11 @@ exports.updateAvatar = async (req, res) => {
  * @access Instructor
  */
 exports.deleteAvatar = async (req, res) => {
-    if (req.params.id !== req.user.id) {
+    const userId = String(req.user.id);
+
+    if (req.params.id !== userId) {
         return res.status(403).json({ message: "Forbidden" });
     }
-
-    const userId = req.user.id;
 
     const [user] = await db("users").where({ id: userId }).select("avatar_url");
     if (!user || !user.avatar_url) {
@@ -321,11 +321,11 @@ exports.uploadDemoVideo = async (req, res) => {
  * @access Instructor
  */
 exports.deleteDemoVideo = async (req, res) => {
-    if (req.params.id !== req.user.id) {
+    const userId = String(req.user.id);
+
+    if (req.params.id !== userId) {
         return res.status(403).json({ message: "Forbidden" });
     }
-
-    const userId = req.user.id;
 
     const [profile] = await db("instructor_profiles").where({ user_id: userId }).select("demo_video_url");
     if (!profile || !profile.demo_video_url) {


### PR DESCRIPTION
## Summary
- Validate instructors can only delete their own avatar and demo video
- Use authenticated user ID for related database lookups and file removals

## Testing
- `cd backend && npm test` *(fails: 27 failed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c6659aa21483288f874a8dccc5fd18