### PR TITLE
refactor: add country-aware instructor profile schema

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -56,7 +56,7 @@ export const instructorProfileSchema = (country) => z.object({
   full_name: z.string().min(3, "full_name_min"),
   phone: z
     .string()
-    .refine((val) => isValidPhoneNumber(val, getUserCountry()), {
+    .refine((val) => isValidPhoneNumber(val, country), {
       message: "invalid_phone_number",
     }),
   gender: z.enum(["male", "female", "other", "prefer-not-to-say"]),
@@ -241,7 +241,7 @@ export default function InstructorProfileEdit() {
       const sanitizedLinks = Object.fromEntries(
         Object.entries(formData.socialLinks || {}).filter(([, url]) => url.trim() !== "")
       );
-      instructorProfileSchema(user?.country).parse({
+      instructorProfileSchema(user?.country || getUserCountry()).parse({
         ...formData,
         socialLinks: Object.keys(sanitizedLinks).length ? sanitizedLinks : undefined,
       });

--- a/frontend/src/tests/__tests__/instructorProfileSchemaCountry.test.js
+++ b/frontend/src/tests/__tests__/instructorProfileSchemaCountry.test.js
@@ -1,0 +1,46 @@
+import { ZodError } from 'zod';
+import { instructorProfileSchema } from '@/pages/dashboard/instructor/profile/edit';
+import { getUserCountry } from '../../utils/getUserCountry';
+
+jest.mock('../../utils/getUserCountry');
+
+describe('instructorProfileSchema country-specific phone validation', () => {
+  const base = {
+    full_name: 'John Doe',
+    gender: 'male',
+    date_of_birth: '1990-01-01',
+    experience: 1,
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('client-side uses user country over fallback', () => {
+    getUserCountry.mockReturnValue('GB');
+    const user = { country: 'US' };
+    const schema = instructorProfileSchema(user.country || getUserCountry());
+
+    expect(() =>
+      schema.parse({ ...base, phone: '4155552671' })
+    ).not.toThrow();
+
+    expect(() =>
+      schema.parse({ ...base, phone: '07911123456' })
+    ).toThrow(ZodError);
+  });
+
+  test('SSR uses fallback country when user country is missing', () => {
+    getUserCountry.mockReturnValue('GB');
+    const user = { country: undefined };
+    const schema = instructorProfileSchema(user.country || getUserCountry());
+
+    expect(() =>
+      schema.parse({ ...base, phone: '07911123456' })
+    ).not.toThrow();
+
+    expect(() =>
+      schema.parse({ ...base, phone: '4155552671' })
+    ).toThrow(ZodError);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor instructor profile schema into country-aware factory
- validate phone numbers using user country with fallback
- test profile schema country validation for SSR and client scenarios

## Testing
- `npm test src/tests/__tests__/instructorProfileSchemaCountry.test.js`
- `npm test -- src/tests/__tests__/InstructorTutorialsPage.test.js src/pages/dashboard/student/profile/edit.test.js` *(fails: Test Suites: 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6658fd98483288e24decb19a41254