### PR TITLE
Validate instructor pricing and experience

### DIFF
--- a/backend/src/modules/users/instructor/instructor.service.js
+++ b/backend/src/modules/users/instructor/instructor.service.js
@@ -108,25 +108,21 @@ const updateInstructorProfile = async (
     userData.phone &&
     userData.gender &&
     userData.date_of_birth;
-  const hasExpertise = Array.isArray(instructorData.expertise)
-    ? instructorData.expertise.length > 0
-    : Boolean(instructorData.expertise);
+  const hasValidExperience =
+    instructorData.experience !== undefined &&
+    instructorData.experience !== null &&
+    Number(instructorData.experience) > 0;
+  const hasValidPricing =
+    instructorData.pricing !== undefined &&
+    instructorData.pricing !== null &&
+    Number(instructorData.pricing) > 0;
   const hasInstructorFields =
     Array.isArray(instructorData.expertise) &&
     instructorData.expertise.length > 0 &&
     typeof instructorData.bio === "string" &&
     instructorData.bio.trim().length > 0 &&
-    instructorData.pricing !== undefined &&
-    instructorData.pricing !== null;
-  const hasExperience =
-    instructorData.experience !== undefined &&
-    instructorData.experience !== null &&
-    hasExpertise &&
-    typeof instructorData.bio === "string" &&
-    instructorData.bio.trim() !== "" &&
-    instructorData.pricing !== undefined &&
-    instructorData.pricing !== null &&
-    Number(instructorData.pricing) > 0;
+    hasValidExperience &&
+    hasValidPricing;
   const isProfileComplete =
     hasUserFields && hasInstructorFields && uniqueLinks.length > 0;
 

--- a/backend/tests/instructorProfileService.test.js
+++ b/backend/tests/instructorProfileService.test.js
@@ -75,4 +75,60 @@ describe('instructor.service updateInstructorProfile', () => {
     const user = await mockDb('users').where({ id: userId }).first();
     expect(user.profile_complete).toBe(false);
   });
+
+  it('marks profile as incomplete when experience is missing or zero', async () => {
+    const userId1 = uuidv4();
+    await mockDb('users').insert({ id: userId1 });
+
+    await service.updateInstructorProfile(
+      userId1,
+      { full_name: 'No Exp', phone: '123', gender: 'male', date_of_birth: '1990-01-01' },
+      { expertise: ['Math'], bio: 'Teacher', pricing: 50 },
+      [{ platform: 'facebook', url: 'facebook.com/noexp' }]
+    );
+
+    const user1 = await mockDb('users').where({ id: userId1 }).first();
+    expect(user1.profile_complete).toBe(false);
+
+    const userId2 = uuidv4();
+    await mockDb('users').insert({ id: userId2 });
+
+    await service.updateInstructorProfile(
+      userId2,
+      { full_name: 'Zero Exp', phone: '123', gender: 'male', date_of_birth: '1990-01-01' },
+      { experience: 0, expertise: ['Math'], bio: 'Teacher', pricing: 50 },
+      [{ platform: 'facebook', url: 'facebook.com/zeroexp' }]
+    );
+
+    const user2 = await mockDb('users').where({ id: userId2 }).first();
+    expect(user2.profile_complete).toBe(false);
+  });
+
+  it('marks profile as incomplete when pricing is missing or zero', async () => {
+    const userId1 = uuidv4();
+    await mockDb('users').insert({ id: userId1 });
+
+    await service.updateInstructorProfile(
+      userId1,
+      { full_name: 'No Price', phone: '123', gender: 'male', date_of_birth: '1990-01-01' },
+      { experience: 5, expertise: ['Math'], bio: 'Teacher' },
+      [{ platform: 'facebook', url: 'facebook.com/noprice' }]
+    );
+
+    const user1 = await mockDb('users').where({ id: userId1 }).first();
+    expect(user1.profile_complete).toBe(false);
+
+    const userId2 = uuidv4();
+    await mockDb('users').insert({ id: userId2 });
+
+    await service.updateInstructorProfile(
+      userId2,
+      { full_name: 'Zero Price', phone: '123', gender: 'male', date_of_birth: '1990-01-01' },
+      { experience: 5, expertise: ['Math'], bio: 'Teacher', pricing: 0 },
+      [{ platform: 'facebook', url: 'facebook.com/zeroprice' }]
+    );
+
+    const user2 = await mockDb('users').where({ id: userId2 }).first();
+    expect(user2.profile_complete).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- enforce positive numeric checks for instructor experience and pricing
- treat profiles as incomplete when experience or pricing missing or zero
- test instructor profile completeness for missing or zero experience/pricing

## Testing
- `pre-commit run --files backend/src/modules/users/instructor/instructor.service.js backend/tests/instructorProfileService.test.js` *(fails: numerous frontend lint errors)*
- `cd backend && npm test` *(fails: 27 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6658e31bc8328842ca4bb02069fdb