### PR TITLE
chore: remove unused state and imports from instructor profile edit page

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -24,8 +24,6 @@ import {
   deleteInstructorAvatar,
   deleteInstructorDemo,
   toggleInstructorStatus,
-  uploadCertificateFile,
-  deleteCertificateFile,
 } from "@/services/instructor/instructorService";
 import Cropper from "react-easy-crop";
 import getCroppedImg from "@/utils/cropImage";
@@ -38,18 +36,14 @@ import {
   FaVenusMars,
   FaUser,
   FaCheck,
-  FaCertificate,
-  FaFilePdf,
-  FaFileImage,
-  FaTrash,
-  FaUpload,
-  FaPlus,
 } from "react-icons/fa";
 import { MdOutlineWorkOutline } from "react-icons/md";
 
 import AvatarUploader from "@/components/instructor/profile/AvatarUploader";
 import DemoVideoUploader from "@/components/instructor/profile/DemoVideoUploader";
 import CertificatesSection from "@/components/instructor/profile/CertificatesSection";
+import ExpertiseList from "@/components/instructor/profile/ExpertiseList";
+import SocialLinksSection from "@/components/instructor/profile/SocialLinksSection";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
 export const instructorProfileSchema = (country) => z.object({
@@ -123,9 +117,6 @@ export default function InstructorProfileEdit() {
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
   const [isUploadingDemo, setIsUploadingDemo] = useState(false);
 
-  const [avatarInputKey, setAvatarInputKey] = useState(0);
-  const [demoInputKey, setDemoInputKey] = useState(0);
-
   const [showCropper, setShowCropper] = useState(false);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
@@ -134,13 +125,6 @@ export default function InstructorProfileEdit() {
   const [tempFileName, setTempFileName] = useState("");
   const [currencyOptions, setCurrencyOptions] = useState([]);
   const [available, setAvailable] = useState(user?.is_online ?? false);
-  const [newExpertise, setNewExpertise] = useState("");
-  const [newCertificate, setNewCertificate] = useState({
-    title: "",
-    file: null,
-    preview: null,
-  });
-  const [certificateUploading, setCertificateUploading] = useState(false);
 
   useEffect(() => {
     setAvailable(user?.is_online ?? false);
@@ -478,7 +462,6 @@ export default function InstructorProfileEdit() {
         {/* Avatar and Demo Upload Section */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-10">
           <AvatarUploader
-            key={avatarInputKey}
             avatarPreview={formData.avatarPreview}
             isUploadingAvatar={isUploadingAvatar}
             t={t}
@@ -486,7 +469,6 @@ export default function InstructorProfileEdit() {
             onRemove={handleAvatarRemove}
           />
           <DemoVideoUploader
-            key={demoInputKey}
             demoPreview={formData.demoPreview}
             isUploadingDemo={isUploadingDemo}
             t={t}


### PR DESCRIPTION
## Summary
- remove unused state variables and related props from instructor profile edit page
- drop obsolete certificate imports and unused react-icons
- add missing ExpertiseList and SocialLinksSection imports

## Testing
- `npx eslint src/pages/dashboard/instructor/profile/edit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6658df4788328aeca390bcce91885