### PR TITLE
fix: import profile list components

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -50,6 +50,8 @@ import { MdOutlineWorkOutline } from "react-icons/md";
 import AvatarUploader from "@/components/instructor/profile/AvatarUploader";
 import DemoVideoUploader from "@/components/instructor/profile/DemoVideoUploader";
 import CertificatesSection from "@/components/instructor/profile/CertificatesSection";
+import ExpertiseList from "@/components/instructor/profile/ExpertiseList";
+import SocialLinksSection from "@/components/instructor/profile/SocialLinksSection";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
 export const instructorProfileSchema = (country) => z.object({


### PR DESCRIPTION
## Summary
- add missing imports for expertise and social links sections in instructor profile edit page

## Testing
- `npm test` *(fails: Test suite failed to run)*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c6658e019c8328867ef31643b077eb