### PR TITLE
fix: remove duplicate tutorial validator import

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -23,7 +23,6 @@ const tutorialValidator = require("./tutorial.validator");
 const { sendSuccess } = require("../../../utils/response");
 const { parseTags, parseChapters } = require("./tutorial.helpers");
 const { sendCreationNotifications } = require("./tutorial.notifications");
-const tutorialValidator = require("./tutorial.validator");
 const { ZodError } = require("zod");
 
 // Helper to resolve uploads subdirectory based on user role


### PR DESCRIPTION
## Summary
- remove duplicate tutorialValidator import from tutorial controller

## Testing
- `cd backend && npm test` *(fails: Test Suites: 24 failed, 2 skipped, 120 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c697aecae88328ada6d3357c28d64c