### PR TITLE
fix: keep seo config unloaded on fetch failure

### DIFF
--- a/frontend/src/store/seoConfigStore.js
+++ b/frontend/src/store/seoConfigStore.js
@@ -24,9 +24,10 @@ const useSEOConfigStore = create(
           set({ settings: data || {}, loaded: true, loading: false });
         } catch (err) {
           toast.error("Failed to load SEO settings");
-          set({ loaded: true, loading: false, error: err.message });
+          set({ loaded: false, loading: false, error: err.message });
         }
       },
+      retry: () => get().fetch(),
       update: (newSettings) =>
         set((state) => ({ settings: { ...state.settings, ...newSettings } })),
       regenerate: async () => {


### PR DESCRIPTION
## Summary
- keep `loaded` flag false when SEO config fetch fails
- add `retry` helper to reattempt fetching SEO settings

## Testing
- `npm test src/tests/pages/dashboard/student/profile/edit.test.js` *(fails: Cannot find module '../../../../components/layouts/StudentLayout')*
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c69777b2208328889925d057a93fe3