### PR TITLE
chore: set frontend API base URL

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api


### PR DESCRIPTION
## Summary
- define `NEXT_PUBLIC_API_BASE_URL` in `frontend/.env.local`

## Testing
- `npm run build` *(fails: terminated due to long runtime)*
- `npm test` *(fails: terminated due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68c697766eb88328b949edb16793b5e8