### PR TITLE
Deduplicate REDIS_URL in backend env example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -43,7 +43,6 @@ COOKIE_SECURE=false
 COOKIE_SAMESITE=None
 
 SESSION_SECRET=skillbridge_secret
-REDIS_URL=redis://localhost:6379
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 FACEBOOK_CLIENT_ID=your_facebook_app_id


### PR DESCRIPTION
## Summary
- remove duplicate `REDIS_URL` entry in `backend/.env.example`
- checked docs and scripts to ensure references use the consolidated `REDIS_URL`

## Testing
- `npm test` *(fails: SyntaxError in tutorial.controller.js, various failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c697738c6c8328b50c29ef23dcbb1c