### PR TITLE
Allow SEO config store to retry after failed fetch

### DIFF
--- a/frontend/src/store/seoConfigStore.js
+++ b/frontend/src/store/seoConfigStore.js
@@ -15,17 +15,23 @@ const useSEOConfigStore = create(
       pages: [],
       loading: false,
       loaded: false,
+      failed: false,
       error: null,
       fetch: async () => {
         if (get().loading) return;
-        set({ loading: true, error: null });
+        set({ loading: true, error: null, failed: false });
         try {
           const data = await fetchSEOConfig();
-          set({ settings: data || {}, loaded: true, loading: false });
+          set({ settings: data || {}, loaded: true, loading: false, failed: false });
         } catch (err) {
           toast.error("Failed to load SEO settings");
-          set({ loaded: true, loading: false, error: err.message });
+          set({ loaded: false, loading: false, error: err.message, failed: true });
         }
+      },
+      retry: () => {
+        if (get().loading) return;
+        set({ loaded: false, failed: false });
+        return get().fetch();
       },
       update: (newSettings) =>
         set((state) => ({ settings: { ...state.settings, ...newSettings } })),
@@ -60,7 +66,7 @@ const useSEOConfigStore = create(
           set({ pages: [], error: err.message });
         }
       },
-      clear: () => set({ settings: {}, loaded: false })
+      clear: () => set({ settings: {}, loaded: false, failed: false })
     }),
     { name: "seo-config" }
   )


### PR DESCRIPTION
## Summary
- Track failed SEO config fetches and keep `loaded` false when errors occur
- Add `retry` method so users can reattempt fetching settings
- Reset failure state on `clear` for subsequent loads

## Testing
- `npm test src/tests/pages/dashboard/student/profile/edit.test.js` *(fails: Cannot find module '../../../../components/layouts/StudentLayout')*
- `npm run lint` *(fails: ✖ 322 problems (52 errors, 270 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c697725ac88328bc6a5ffae9a2f8b8