### PR TITLE
docs: clarify FRONTEND_URL origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,10 @@ JWT_SECRET=your_jwt_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret
 SESSION_SECRET=your_session_secret
 REDIS_URL=redis://redis:6379
-FRONTEND_URL=https://example.com
+# Allowed frontend origin(s) for CORS. Must match the exact scheme, host,
+# and port used by the frontend to avoid CORS errors. Separate multiple
+# origins with commas, e.g. http://localhost:3000,https://example.com
+FRONTEND_URL=http://localhost:3000
 APP_DOMAIN=example.com
 COOKIE_DOMAIN=.example.com
 MAX_BLOG_IMAGE_BYTES=10485760

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ npm --prefix frontend install
      ```bash
      cp backend/.env.example backend/.env
      # edit backend/.env and set your secrets
-     # FRONTEND_URL defaults to http://localhost:3000
+     # FRONTEND_URL must match the exact origin (scheme + host + port) of your
+     # frontend to avoid CORS errors. Separate multiple origins with commas,
+     # e.g. http://localhost:3000,https://example.com. Defaults to http://localhost:3000
      # REDIS_URL should point to your Redis instance for session persistence
      # set it to your frontend's domain if different and omit any trailing slash
      # When using docker-compose make sure the value does

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,10 +30,17 @@ For deployments, Docker Compose additionally reads `backend/.env.production`.
 Copy `backend/.env.production.example` to `backend/.env.production` and fill in
 production database credentials and JWT secrets.
 
-Edit `backend/.env` and provide your secrets. `FRONTEND_URL` should match the
-domain where the frontend will run (defaults to `http://localhost:3000`). Leave
-`NODE_ENV` unset so cookies work over HTTP. If you need cross-subdomain cookies
-without HTTPS, also set:
+Edit `backend/.env` and provide your secrets. `FRONTEND_URL` must match the
+exact origin (scheme, host, and port) where the frontend will run to avoid
+CORS errors. Separate multiple origins with commas, for example:
+
+```bash
+FRONTEND_URL=http://localhost:3000,https://example.com
+```
+
+The variable defaults to `http://localhost:3000`. Leave `NODE_ENV` unset so
+cookies work over HTTP. If you need cross-subdomain cookies without HTTPS,
+also set:
 
 ```bash
 COOKIE_SECURE=false


### PR DESCRIPTION
## Summary
- default FRONTEND_URL to http://localhost:3000 in example env with guidance for multiple origins
- document that FRONTEND_URL must match the exact frontend origin to avoid CORS errors

## Testing
- `pre-commit run --files .env.example README.md docs/installation.md` *(fails: 322 problems (52 errors, 270 warnings))*
- `npm --prefix backend test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c697705b7083289b652a482a8542b5