### PR TITLE
docs: update backend port to 5002

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ SMTP_PASS=your_smtp_password
 
 # The frontend uses this URL for browser requests.
 # Replace it with your public API endpoint before deploying.
-NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
+NEXT_PUBLIC_API_BASE_URL=http://localhost:5002/api
 
 # Feature flags
 ENABLE_INSTALL=false

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ npm --prefix frontend install
    docker-compose up --build
    ```
 
-4. Visit `http://localhost:3000` to access the frontend when running locally. The API will be available at `http://localhost:5000/api`.
+4. Visit `http://localhost:3000` to access the frontend when running locally. The API will be available at `http://localhost:5002/api`.
 
 For detailed instructions see [docs/installation.md](docs/installation.md).
 See [docs/deployment.md](docs/deployment.md) for tips on configuring environment variables when hosting the app.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,7 +24,7 @@ referenced in `nginx/conf.d/ssl.conf`.
 ## Configure environment variables
 
 1. **Backend** – copy `backend/.env.example` to `backend/.env` and set:
-   - `PORT` – typically `5000` unless changed.
+   - `PORT` – typically `5002` unless changed.
    - `APP_DOMAIN` – your production domain (e.g. `yourdomain.com`).
    - `SUPPORT_EMAIL` – address used for outbound messages.
    - `FRONTEND_URL` – set this to the full URL of your frontend. You can
@@ -97,7 +97,7 @@ referenced in `nginx/conf.d/ssl.conf`.
  ```
 
    The root `.env` is intended for local development and defaults
-   `NEXT_PUBLIC_API_BASE_URL` to `http://backend:5002/api` for internal
+   `NEXT_PUBLIC_API_BASE_URL` to `http://localhost:5002/api` for internal
    container communication. Remove or override this file in production so the
    frontend uses your public HTTPS domain.
 
@@ -171,10 +171,10 @@ domains you can still extend `remotePatterns` in
 
 ## Troubleshooting
 
-### Login page requests `http://localhost:5000`
+### Login page requests `http://localhost:5002`
 
 If you deploy the frontend and see network errors pointing to
-`http://localhost:5000/api` it means the build did not have
+`http://localhost:5002/api` it means the build did not have
 `NEXT_PUBLIC_API_BASE_URL` set.  Update `frontend/.env.local` with the correct
 backend URL and rebuild/restart the frontend container so the new value is
 picked up.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,7 +95,7 @@ hosts for payment method icons. URLs outside this list will fall back to a
 default icon.
 
 The root `.env` file defaults `NEXT_PUBLIC_API_BASE_URL` to
-`http://backend:5002/api` so Docker services can reach the backend container
+`http://localhost:5002/api` so Docker services can reach the backend container
 internally during development. For production builds use
 `frontend/.env.production` instead and remove or override the root `.env` so the
 frontend points to your public domain (for example,

--- a/docs/social-login-setup.md
+++ b/docs/social-login-setup.md
@@ -16,10 +16,10 @@ knex seed:run --specific=08_social_login_settings_seed.js
 2. Add the following URI to the **Authorized redirect URIs** list:
 
    ```
-   http://localhost:5000/api/auth/google/callback
+   http://localhost:5002/api/auth/google/callback
    ```
 
-   Replace `http://localhost:5000` with your production backend URL when deploying. For example:
+   Replace `http://localhost:5002` with your production backend URL when deploying. For example:
 
    ```
    https://yourdomain.com/api/auth/google/callback
@@ -32,7 +32,7 @@ knex seed:run --specific=08_social_login_settings_seed.js
 If the redirect URI does not exactly match what is configured on Google, the login page will display **Error 400: redirect_uri_mismatch**.
 
 
-If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, verify the frontend's `NEXT_PUBLIC_API_BASE_URL` points to your backend URL including the `/api` prefix. When using Docker Compose, configure this in `frontend/.env.production` and remove or ignore the root `.env` which defaults to `http://backend:5002/api`. Set it to your externally reachable domain such as `https://yourdomain.com/api`. Without this variable the login and register buttons default to `/api/auth/*` which only works when the frontend and backend share the same host. Both buttons now append `?origin=` with the current site origin so the API can redirect back correctly even when `FRONTEND_URL` is not configured.
+If clicking **Sign in with Google** takes you to `/auth/google` and shows a 404 error, verify the frontend's `NEXT_PUBLIC_API_BASE_URL` points to your backend URL including the `/api` prefix. When using Docker Compose, configure this in `frontend/.env.production` and remove or ignore the root `.env` which defaults to `http://localhost:5002/api`. Set it to your externally reachable domain such as `https://yourdomain.com/api`. Without this variable the login and register buttons default to `/api/auth/*` which only works when the frontend and backend share the same host. Both buttons now append `?origin=` with the current site origin so the API can redirect back correctly even when `FRONTEND_URL` is not configured.
 
 If requests to `/api/*` still return a Next.js 404 page, confirm your reverse proxy forwards the `/api` path to the backend container. The provided `nginx/conf.d` configs use `location ^~ /api/` to proxy to `backend:5002` without rewriting the prefix. Restart nginx after updating the configuration.
 
@@ -87,7 +87,7 @@ SkillBridge can optionally validate a Google reCAPTCHA token during login and re
 To temporarily disable reCAPTCHA you can call the configuration endpoint with admin credentials:
 
 ```bash
-curl -X PUT http://localhost:5000/api/social-login/config \
+curl -X PUT http://localhost:5002/api/social-login/config \
   -H 'Content-Type: application/json' \
   -d '{ "recaptcha": { "active": false } }'
 ```

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,10 +1,10 @@
 # Example frontend environment file
 # Point the frontend to your API including the /api prefix.
-# For local development this can be http://localhost:5000/api
+# For local development this can be http://localhost:5002/api
 # When deploying to production replace it with your live API URL.
-NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api
+NEXT_PUBLIC_API_BASE_URL=http://localhost:5002/api
 # WebSocket server URL. Set to your API domain in production.
-NEXT_PUBLIC_SOCKET_URL=http://localhost:5000
+NEXT_PUBLIC_SOCKET_URL=http://localhost:5002
 # URL to pgAdmin instance for database management routes.
 NEXT_PUBLIC_PGADMIN_URL=http://localhost:5050
 # Public domain where the frontend is hosted, used for image rewrites.

--- a/frontend/src/config/config.js
+++ b/frontend/src/config/config.js
@@ -1,5 +1,5 @@
 // 📁 config.js
-// Default API URL should align with backend PORT (5000)
+// Default API URL should align with backend PORT (5002)
 // Default to a relative path so the frontend works on any domain by default
 export const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || '/api';


### PR DESCRIPTION
## Summary
- reference backend on port 5002 in env examples and docs
- note backend port 5002 in frontend config comment

## Testing
- `npm test` (frontend)
- `npm test` (backend, fails: relation "settings" does not exist)


------
https://chatgpt.com/codex/tasks/task_e_68c6976f13a88328adf8b283b95deb80