### PR TITLE
Support multiple allowed origins for Nginx CORS

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,7 +23,16 @@ referenced in `nginx/conf.d/ssl.conf`.
 
 ## Configure environment variables
 
-1. **Backend** – copy `backend/.env.example` to `backend/.env` and set:
+1. **Nginx** – set the `ALLOWED_ORIGINS` environment variable to a
+   comma-separated list of origins that should be allowed by the reverse
+   proxy (e.g. `https://foo.com,https://bar.com`). After updating this list
+   reload Nginx so the new value takes effect:
+
+   ```bash
+   docker compose exec nginx nginx -s reload
+   ```
+
+2. **Backend** – copy `backend/.env.example` to `backend/.env` and set:
    - `PORT` – typically `5000` unless changed.
    - `APP_DOMAIN` – your production domain (e.g. `yourdomain.com`).
    - `SUPPORT_EMAIL` – address used for outbound messages.
@@ -88,7 +97,7 @@ referenced in `nginx/conf.d/ssl.conf`.
     `http://localhost:3001` you may see `Network Error` or CORS errors when
     logging in from the deployed site.
 
- 2. **Frontend** – for Docker Compose production builds, set variables in
+ 3. **Frontend** – for Docker Compose production builds, set variables in
    `frontend/.env.production`:
 
  ```bash

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,10 +1,16 @@
 env APP_DOMAIN;
+env ALLOWED_ORIGINS;  # Comma-separated list of allowed origins
 events {}
 
 http {
     map $APP_DOMAIN $app_domain {
         "" _;
         default $APP_DOMAIN;
+    }
+
+    map $ALLOWED_ORIGINS $allowed_origins {
+        "" "";
+        default $ALLOWED_ORIGINS;
     }
 
     # Load virtual hosts from the conf.d directory

--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -1,6 +1,14 @@
-  set $allowed_origin "";
-  if ($app_domain != "") {
-    set $allowed_origin https://$app_domain;
+  # Determine if the request Origin is allowed based on a comma-separated
+  # list supplied via the ALLOWED_ORIGINS environment variable.
+  # Example: "https://foo.com,https://bar.com"
+  set $cors_allowed_origin "";
+  if ($allowed_origins != "") {
+    set $allowed_origins_list ",$allowed_origins,";
+    if ($http_origin != "") {
+      if ($allowed_origins_list ~ ",$http_origin,") {
+        set $cors_allowed_origin $http_origin;
+      }
+    }
   }
 
   location / {
@@ -12,10 +20,8 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($allowed_origin != "") {
-      if ($http_origin = $allowed_origin) {
-        add_header Access-Control-Allow-Origin $allowed_origin always;
-      }
+    if ($cors_allowed_origin != "") {
+      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
     }
     add_header Access-Control-Allow-Credentials true always;
   }
@@ -30,10 +36,8 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($allowed_origin != "") {
-      if ($http_origin = $allowed_origin) {
-        add_header Access-Control-Allow-Origin $allowed_origin always;
-      }
+    if ($cors_allowed_origin != "") {
+      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
     }
     add_header Access-Control-Allow-Credentials true always;
     expires 1y;
@@ -52,10 +56,8 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($allowed_origin != "") {
-      if ($http_origin = $allowed_origin) {
-        add_header Access-Control-Allow-Origin $allowed_origin always;
-      }
+    if ($cors_allowed_origin != "") {
+      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
     }
     add_header Access-Control-Allow-Credentials true always;
   }
@@ -70,10 +72,8 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($allowed_origin != "") {
-      if ($http_origin = $allowed_origin) {
-        add_header Access-Control-Allow-Origin $allowed_origin always;
-      }
+    if ($cors_allowed_origin != "") {
+      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
     }
     add_header Access-Control-Allow-Credentials true always;
   }


### PR DESCRIPTION
## Summary
- Allow Nginx to validate requests against a comma-separated `ALLOWED_ORIGINS` list
- Document `ALLOWED_ORIGINS` usage and how to reload Nginx config

## Testing
- `nginx -t -c /workspace/Skillbridge/nginx/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6976bdcf883289d130469ce2e9276