### PR TITLE
feat(server): allow extra cors origins

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -92,10 +92,20 @@ const APP_DOMAIN = process.env.APP_DOMAIN;
 const defaultOrigins = APP_DOMAIN
   ? [`https://${APP_DOMAIN}`, `https://www.${APP_DOMAIN}`]
   : [];
+const EXTRA_CORS_ORIGINS = process.env.EXTRA_CORS_ORIGINS
+  ? process.env.EXTRA_CORS_ORIGINS.split(",").filter(Boolean).map((url) => {
+      try {
+        return new URL(url.trim()).origin;
+      } catch {
+        throw new Error(`Invalid EXTRA_CORS_ORIGINS: ${url}`);
+      }
+    })
+  : [];
 const ALLOWED_ORIGINS = Array.from(
   new Set([
     ...defaultOrigins,
     ...FRONTEND_ORIGINS,
+    ...EXTRA_CORS_ORIGINS,
   ])
 );
 // 🌐 CORS must run before body parsing so even 4xx responses include the header

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,6 +40,16 @@ COOKIE_SECURE=false
 COOKIE_SAMESITE=None
 ```
 
+If additional domains need access to the API, add them to
+`EXTRA_CORS_ORIGINS` as a comma-separated list of URLs:
+
+```bash
+EXTRA_CORS_ORIGINS=https://admin.example.com,https://docs.example.com
+```
+
+These origins are merged with `FRONTEND_URL` and the default app domain to
+configure CORS.
+
 A Redis instance (or compatible store) is required to persist sessions in
 production. Set `REDIS_URL` in `backend/.env` to point to your Redis server
 (for example `redis://localhost:6379`).


### PR DESCRIPTION
## Summary
- parse EXTRA_CORS_ORIGINS env var and merge into CORS allowlist
- document EXTRA_CORS_ORIGINS in installation guide

## Testing
- `npm test` *(fails: 27 failed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c6976b6fd483288785ef4ee4c3a212