### PR TITLE
Log endpoint details for network errors

### DIFF
--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -60,8 +60,12 @@ api.interceptors.response.use(
       (error.code === "ERR_NETWORK" || !error.response) &&
       Date.now() - lastNetworkToast > 5000
     ) {
+      const failedUrl = error.config?.url;
+      const errMsg = error.message;
+      const logMessage = `Network error on ${failedUrl || "unknown endpoint"}: ${errMsg}`;
+      logger.error(logMessage);
       toast.error(
-        "Network error: check NEXT_PUBLIC_API_BASE_URL and backend CORS settings."
+        `${logMessage}. Check NEXT_PUBLIC_API_BASE_URL and backend CORS settings.`
       );
       lastNetworkToast = Date.now();
     }


### PR DESCRIPTION
## Summary
- log failed request URL and message on network errors
- surface details in toast and console

## Testing
- `CI=true npm test` (fails: src/tests/pages/dashboard/student/profile/edit.test.js, WebsiteHomeScroll.test.js, InstructorTutorialsPage.test.js, InstructorSettingsPage.test.js)
- `npm run lint` (errors: 52, warnings: 270)


------
https://chatgpt.com/codex/tasks/task_e_68c69769abc88328a4d51f99e65bd138