### PR TITLE
refactor: use shared API base for search suggestions

### DIFF
--- a/frontend/src/pages/api/search/suggestions.js
+++ b/frontend/src/pages/api/search/suggestions.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { API_BASE_URL } from '@/config/config';
 
 export default async function handler(req, res) {
   const { q = '' } = req.query;
@@ -7,7 +8,7 @@ export default async function handler(req, res) {
   }
 
   try {
-    const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000/api';
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
     const { data } = await axios.get(`${base}/search`, { params: { q } });
     const payload = data.data || data;
     const suggestions = Object.values(payload)


### PR DESCRIPTION
## Summary
- import API_BASE_URL from shared config
- use API_BASE_URL fallback instead of hardcoded localhost URL

## Testing
- `npm run lint` (fails: Component definition is missing display name)
- `npx jest src/tests/pages/dashboard/student/profile/edit.test.js` (fails: Cannot find module '../../../../components/layouts/StudentLayout')

------
https://chatgpt.com/codex/tasks/task_e_68c6977148e083288600bb32ddb97c3d