### PR TITLE
Fix tutorial status module path in backend

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -5,7 +5,7 @@ const chapterService = require("./chapters/tutorialChapter.service");
 const { withTransaction } = require("../../../services/transaction.service");
 const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
-const { TUTORIAL_STATUS } = require("../../../../../shared/tutorialStatus");
+const { TUTORIAL_STATUS } = require("../../../shared/tutorialStatus");
 
 exports.createTutorial = async (data, trx = db) => {
   const insertData = { included_plans: [], ...data };

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -1,5 +1,5 @@
 const { z } = require("zod");
-const { TUTORIAL_STATUS } = require("../../../../../shared/tutorialStatus");
+const { TUTORIAL_STATUS } = require("../../../shared/tutorialStatus");
 
 // Helper preprocessor for boolean values coming from multipart/form-data
 const toBoolean = (val) => {

--- a/backend/src/shared/tutorialStatus.js
+++ b/backend/src/shared/tutorialStatus.js
@@ -1,0 +1,7 @@
+const TUTORIAL_STATUS = Object.freeze({
+  DRAFT: 'draft',
+  PUBLISHED: 'published',
+  ARCHIVED: 'archived',
+});
+
+module.exports = { TUTORIAL_STATUS };


### PR DESCRIPTION
## Summary
- move tutorial status constant into backend src
- update service and validator imports to use backend-local shared constant

## Testing
- `npm test` *(fails: Test Suites: 24 failed, 2 skipped, 120 passed, 144 of 146 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a3a8528483289db603b2bffdadc1