### PR TITLE
fix: mount shared config into backend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - redis
     volumes:
       - ./backend/uploads:/app/uploads
+      - ./shared:/shared:ro
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- mount repository `shared` directory into backend container to resolve missing socialPlatforms.json

## Testing
- `pre-commit run --files docker-compose.yml` *(fails: 322 problems)*
- `npm test --prefix backend` *(fails: 24 failed, 120 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a8e186988328873ee6f1d30755a1