### PR TITLE
Define redis_data volume in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,8 +120,11 @@ services:
 
 volumes:
   postgres_data:
+    driver: local
   pgadmin_data:
+    driver: local
   redis_data:
+    driver: local
 
 networks:
   app-network:


### PR DESCRIPTION
## Summary
- declare redis_data named volume explicitly with local driver

## Testing
- `pre-commit run --files docker-compose.yml` *(fails: React lint errors and warnings)*
- `npm test --prefix backend` *(fails: 24 failed, 120 passed, 2 skipped)*
- `npm test --prefix frontend` *(fails: multiple test and lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c6abaca1f083289e8db7d1c1dee7ff