### PR TITLE
Validate social platform configuration file

### DIFF
--- a/backend/src/modules/users/common/socialPlatforms.js
+++ b/backend/src/modules/users/common/socialPlatforms.js
@@ -1,3 +1,24 @@
-const allowedPlatforms = require("../../../../../shared/socialPlatforms.json");
+const fs = require('fs');
+const path = require('path');
+
+const platformsPath = path.resolve(
+  __dirname,
+  '../../../../../shared/socialPlatforms.json'
+);
+
+if (!fs.existsSync(platformsPath)) {
+  throw new Error(`socialPlatforms.json file not found at ${platformsPath}`);
+}
+
+let allowedPlatforms;
+try {
+  allowedPlatforms = require(platformsPath);
+  if (!Array.isArray(allowedPlatforms)) {
+    throw new Error('socialPlatforms.json must export an array');
+  }
+} catch (err) {
+  throw new Error(`Failed to parse socialPlatforms.json: ${err.message}`);
+}
 
 module.exports = { allowedPlatforms };
+

--- a/backend/tests/socialPlatforms.test.js
+++ b/backend/tests/socialPlatforms.test.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+describe('socialPlatforms', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  it('throws an error when socialPlatforms.json is missing', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    expect(() =>
+      require('../src/modules/users/common/socialPlatforms')
+    ).toThrow(/socialPlatforms\.json file not found/);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure `socialPlatforms.json` exists and is valid before loading
- add unit test for missing socialPlatforms configuration

## Testing
- `cd backend && npm test tests/socialPlatforms.test.js`
- `pre-commit run --files backend/src/modules/users/common/socialPlatforms.js backend/tests/socialPlatforms.test.js` *(fails: 52 errors, 270 warnings from frontend lint)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b8b5e4d883288eb9dcb3f4467502