### PR TITLE
Embed social platform data directly in backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,16 +2,17 @@
 FROM node:18-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache curl
-COPY package*.json ./
+COPY backend/package*.json ./
 RUN npm ci && npm cache clean --force
-COPY . .
+COPY backend/ ./
+COPY shared/socialPlatforms.json ./src/shared/socialPlatforms.json
 
 # Production stage
 FROM node:18-alpine
 WORKDIR /app
 RUN apk add --no-cache curl && \
     (id -u node 2>/dev/null || adduser -S node)
-COPY package*.json ./
+COPY backend/package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/knexfile.js ./knexfile.js

--- a/backend/src/modules/users/common/socialPlatforms.js
+++ b/backend/src/modules/users/common/socialPlatforms.js
@@ -1,3 +1,8 @@
-const allowedPlatforms = require("../../../../../shared/socialPlatforms.json");
+let allowedPlatforms;
+try {
+  allowedPlatforms = require("../../../shared/socialPlatforms.json");
+} catch {
+  allowedPlatforms = require("../../../../../shared/socialPlatforms.json");
+}
 
 module.exports = { allowedPlatforms };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,9 @@ services:
       - app-network
 
   backend:
-    build: ./backend
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     restart: always
     env_file:
       - ./.env
@@ -72,7 +74,6 @@ services:
       - redis
     volumes:
       - ./backend/uploads:/app/uploads
-      - ./shared:/shared:ro
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- copy `shared/socialPlatforms.json` into `/app/src/shared` during backend image build
- fallback to repo-level `shared` file when local `src/shared` copy is absent
- drop redundant shared volume and build backend from repo root in docker-compose

## Testing
- `npm test tests/instructorProfileService.test.js`
- `docker build -f backend/Dockerfile -t skillbridge-backend .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b8b46b508328bd8f18a078cac88b