### PR TITLE
refactor: centralize social platform list

### DIFF
--- a/frontend/src/components/instructor/profile/SocialLinksSection.js
+++ b/frontend/src/components/instructor/profile/SocialLinksSection.js
@@ -1,39 +1,21 @@
-import {
-  FaLinkedin,
-  FaGithub,
-  FaTwitter,
-  FaYoutube,
-  FaFacebook,
-  FaInstagram,
-  FaGlobe,
-} from "react-icons/fa";
-
-const socialPlatforms = [
-  { name: "linkedin", icon: <FaLinkedin className="text-blue-600" /> },
-  { name: "github", icon: <FaGithub className="text-gray-800" /> },
-  { name: "twitter", icon: <FaTwitter className="text-blue-400" /> },
-  { name: "youtube", icon: <FaYoutube className="text-red-600" /> },
-  { name: "facebook", icon: <FaFacebook className="text-blue-700" /> },
-  { name: "instagram", icon: <FaInstagram className="text-pink-600" /> },
-  { name: "website", icon: <FaGlobe className="text-green-600" /> },
-];
+import { allowedPlatforms } from "@/utils/socialPlatforms";
 
 export default function SocialLinksSection({ socialLinks, onChange, t }) {
   return (
     <div>
       <label className="block text-sm font-medium mb-2">{t('social_links')}</label>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {socialPlatforms.map((platform) => (
-          <div key={platform.name} className="bg-gray-50 p-3 rounded-lg">
+        {allowedPlatforms.map(({ name, Icon, className }) => (
+          <div key={name} className="bg-gray-50 p-3 rounded-lg">
             <label className="text-sm flex items-center gap-2 font-medium mb-1">
-              {platform.icon} {platform.name.charAt(0).toUpperCase() + platform.name.slice(1)}
+              <Icon className={className} /> {name.charAt(0).toUpperCase() + name.slice(1)}
             </label>
             <input
               type="text"
-              name={platform.name}
-              value={socialLinks[platform.name] || ""}
-              onChange={(e) => onChange({ ...socialLinks, [platform.name]: e.target.value })}
-              placeholder={`https://${platform.name}.com/yourprofile`}
+              name={name}
+              value={socialLinks[name] || ""}
+              onChange={(e) => onChange({ ...socialLinks, [name]: e.target.value })}
+              placeholder={`https://${name}.com/yourprofile`}
               className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-yellow-500 focus:border-yellow-500"
             />
           </div>

--- a/frontend/src/shared/socialPlatforms.json
+++ b/frontend/src/shared/socialPlatforms.json
@@ -1,9 +1,0 @@
-[
-  "linkedin",
-  "github",
-  "twitter",
-  "youtube",
-  "facebook",
-  "instagram",
-  "website"
-]

--- a/frontend/src/utils/socialPlatforms.js
+++ b/frontend/src/utils/socialPlatforms.js
@@ -1,4 +1,4 @@
-import platformNames from "@/shared/socialPlatforms.json";
+import platformNames from "@shared/socialPlatforms.json";
 import {
   FaLinkedin,
   FaGithub,


### PR DESCRIPTION
## Summary
- centralize social platform names in `shared/socialPlatforms.json`
- import platform list via shared alias in frontend utilities
- reuse shared platform list for instructor social links component

## Testing
- `npm test` (frontend) *(fails: Cannot find module '../../../../components/layouts/StudentLayout' from 'src/tests/pages/dashboard/student/profile/edit.test.js')*
- `npm test` (backend) *(fails: 24 failed, 2 skipped, 120 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b8b3ab108328a4c8d036e3638812