### PR TITLE
refactor: centralize shared assets

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,19 +2,21 @@
 FROM node:18-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache curl
-COPY package*.json ./
+COPY backend/package*.json ./
 RUN npm ci && npm cache clean --force
-COPY . .
+COPY backend/ ./
+COPY shared /shared
 
 # Production stage
 FROM node:18-alpine
 WORKDIR /app
 RUN apk add --no-cache curl && \
     (id -u node 2>/dev/null || adduser -S node)
-COPY package*.json ./
+COPY backend/package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/knexfile.js ./knexfile.js
+COPY --from=builder /shared /shared
 RUN chown -R node:node /app
 EXPOSE 5002
 USER node

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -5,7 +5,7 @@ const chapterService = require("./chapters/tutorialChapter.service");
 const { withTransaction } = require("../../../services/transaction.service");
 const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
-const { TUTORIAL_STATUS } = require("../../../shared/tutorialStatus");
+const { TUTORIAL_STATUS } = require("../../../../../shared/tutorialStatus");
 
 exports.createTutorial = async (data, trx = db) => {
   const insertData = { included_plans: [], ...data };

--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -1,5 +1,5 @@
 const { z } = require("zod");
-const { TUTORIAL_STATUS } = require("../../../shared/tutorialStatus");
+const { TUTORIAL_STATUS } = require("../../../../../shared/tutorialStatus");
 
 // Helper preprocessor for boolean values coming from multipart/form-data
 const toBoolean = (val) => {

--- a/backend/src/shared/tutorialStatus.js
+++ b/backend/src/shared/tutorialStatus.js
@@ -1,7 +1,0 @@
-const TUTORIAL_STATUS = Object.freeze({
-  DRAFT: 'draft',
-  PUBLISHED: 'published',
-  ARCHIVED: 'archived',
-});
-
-module.exports = { TUTORIAL_STATUS };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,9 @@ services:
       - app-network
 
   backend:
-    build: ./backend
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     restart: always
     env_file:
       - ./.env
@@ -78,7 +80,8 @@ services:
 
   frontend:
     build:
-      context: ./frontend
+      context: .
+      dockerfile: frontend/Dockerfile
     ports:
       - "3000:3000"
     env_file:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,10 @@
 # Build stage
 FROM node:18 AS builder
 WORKDIR /app
-COPY package.json package-lock.json ./
+COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci && npm cache clean --force
-COPY . .
+COPY frontend/ ./
+COPY shared /shared
 
 # Default build-time environment variables.
 ARG NEXT_PUBLIC_API_BASE_URL="http://localhost:5002/api"
@@ -20,9 +21,10 @@ RUN set -a && [ -f .env.production ] && . .env.production; npm run build
 FROM node:18-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache curl
-COPY package.json package-lock.json next.config.mjs next-i18next.config.js ./
+COPY frontend/package.json frontend/package-lock.json next.config.mjs next-i18next.config.js ./
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
+COPY --from=builder /shared /shared
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/frontend/src/components/dashboard/admin/tutorials/Filters.js
+++ b/frontend/src/components/dashboard/admin/tutorials/Filters.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { FaSearch } from "react-icons/fa";
 import { Button } from "@/components/ui/button";
-import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
 
 function Filters({
   searchQuery,

--- a/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
+++ b/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
 import { FaSpinner, FaSearch, FaEdit, FaTrash } from "react-icons/fa";
 
 function TutorialsTable({

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -26,7 +26,7 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
-import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
 
 function AdminTutorialsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "tutorialsPage" });

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -4,7 +4,7 @@ import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
-import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
 import {
   FaPlus,
   FaEdit,

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -2,7 +2,7 @@
 // Admin specific API calls for managing tutorials
 
 import api from "@/services/api/api";
-import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
 
 /**
  * Create a new tutorial as an admin or instructor.

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -1,6 +1,6 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
-import { TUTORIAL_STATUS } from "@/shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
 
 const formatBase = (tut) => ({
   ...tut,

--- a/frontend/src/shared/socialPlatforms.json
+++ b/frontend/src/shared/socialPlatforms.json
@@ -1,9 +1,0 @@
-[
-  "linkedin",
-  "github",
-  "twitter",
-  "youtube",
-  "facebook",
-  "instagram",
-  "website"
-]

--- a/frontend/src/shared/tutorialStatus.js
+++ b/frontend/src/shared/tutorialStatus.js
@@ -1,7 +1,0 @@
-export const TUTORIAL_STATUS = Object.freeze({
-  DRAFT: "draft",
-  PUBLISHED: "published",
-  ARCHIVED: "archived",
-});
-
-export default TUTORIAL_STATUS;

--- a/frontend/src/utils/socialPlatforms.js
+++ b/frontend/src/utils/socialPlatforms.js
@@ -1,4 +1,4 @@
-import platformNames from "@/shared/socialPlatforms.json";
+import platformNames from "@shared/socialPlatforms.json";
 import {
   FaLinkedin,
   FaGithub,


### PR DESCRIPTION
## Summary
- centralize tutorial status and social platform constants in top-level `shared/`
- update backend and frontend imports to consume centralized assets
- adjust Docker builds and compose config to include shared directory

## Testing
- `npm test` (backend) *(fails: Test Suites: 24 failed, 2 skipped, 120 passed, 144 of 146 total)*
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68c6b8a912ec8328adcaf587df6b180b