### PR TITLE
Allow root env production file for Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,7 @@ backend/uploads
 # Environment files
 .env
 *.env
+!/.env.production
 !frontend/.env.production
 !backend/.env.production
 

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,5 @@
+# Placeholder production environment variables
+APP_DOMAIN=example.com
+NEXT_PUBLIC_API_BASE_URL=https://api.example.com
+NEXT_PUBLIC_PGADMIN_URL=https://pgadmin.example.com
+NEXT_PUBLIC_SOCKET_URL=wss://example.com

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules/
 
 # Local environment variables
 /.env
-/.env.production
 backend/.env
 backend/.env.production
 dist/


### PR DESCRIPTION
## Summary
- add placeholder `.env.production` at repo root for frontend build-time vars
- include root `.env.production` in Docker context and git tracking

## Testing
- `pre-commit run --files .dockerignore .gitignore .env.production` *(fails: 322 problems, 52 errors)*
- `docker-compose build frontend` *(fails: command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_e_68c7149bafd083289083646f4c9c80dc