### PR TITLE
Add database healthcheck to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - app-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   pgadmin:
     image: dpage/pgadmin4
@@ -70,8 +75,10 @@ services:
       retries: 3
       start_period: 30s
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     volumes:
       - ./backend/uploads:/app/uploads
     networks:


### PR DESCRIPTION
## Summary
- add pg_isready healthcheck to postgres service
- wait for healthy database before starting backend

## Testing
- `docker --version`
- `docker ps` *(fails: Cannot connect to the Docker daemon)*
- `dockerd >/tmp/dockerd.log 2>&1 &` *(fails: Error initializing network controller)*
- `docker-compose up db backend` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_68c71a2124f88328bc3c056d479e7bca