### PR TITLE
feat: add database wait script for backend container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 FROM node:18-alpine AS builder
 WORKDIR /app
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl netcat-openbsd
 COPY backend/package*.json ./
 RUN npm ci && npm cache clean --force
 COPY backend/ ./
@@ -10,14 +10,16 @@ COPY shared /shared
 # Production stage
 FROM node:18-alpine
 WORKDIR /app
-RUN apk add --no-cache curl && \
+RUN apk add --no-cache curl netcat-openbsd && \
     (id -u node 2>/dev/null || adduser -S node)
 COPY backend/package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/knexfile.js ./knexfile.js
 COPY --from=builder /shared /shared
-RUN chown -R node:node /app
+COPY --from=builder /app/scripts ./scripts
+RUN chmod +x scripts/wait-for-db.sh && \
+    chown -R node:node /app
 EXPOSE 5002
 USER node
 CMD ["sh", "-c", "npx knex migrate:latest && node src/server.js"]

--- a/backend/scripts/wait-for-db.sh
+++ b/backend/scripts/wait-for-db.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+until nc -z db 5432; do
+  echo "Waiting for database..."
+  sleep 1
+done
+
+echo "Database is up!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       MAX_BLOG_IMAGE_BYTES: ${MAX_BLOG_IMAGE_BYTES}
       NODE_ENV: ${NODE_ENV}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+    command: ["sh", "-c", "./scripts/wait-for-db.sh && npx knex migrate:latest && node src/server.js"]
     healthcheck:
       test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:5002/api/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- add wait-for-db.sh to poll postgres before server start
- install netcat and include script in backend image
- run database wait script in docker-compose command

## Testing
- `npm test` *(fails: Test Suites: 25 failed, 2 skipped, 120 passed)*
- `pre-commit run --files backend/Dockerfile backend/scripts/wait-for-db.sh docker-compose.yml` *(fails: ✖ 322 problems (52 errors, 270 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c71a2649d08328a735298e50764671