### PR TITLE
Add database healthcheck and backend service readiness

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - app-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   pgadmin:
     image: dpage/pgadmin4
@@ -70,8 +75,10 @@ services:
       retries: 3
       start_period: 30s
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     volumes:
       - ./backend/uploads:/app/uploads
     networks:


### PR DESCRIPTION
## Summary
- add a healthcheck for the Postgres `db` service
- ensure backend waits for a healthy database before starting

## Testing
- `pre-commit run --files docker-compose.yml` *(fails: interrupted)*
- `npm run lint --prefix frontend` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68c71a2a7f908328904d23d8d3e04201