### PR TITLE
Limit backend build context

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,9 +2,9 @@
 FROM node:18-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache curl netcat-openbsd
-COPY backend/package*.json ./
+COPY package*.json ./
 RUN npm ci && npm cache clean --force
-COPY backend/ ./
+COPY . ./
 COPY shared /shared
 
 # Production stage
@@ -12,7 +12,7 @@ FROM node:18-alpine
 WORKDIR /app
 RUN apk add --no-cache curl netcat-openbsd && \
     (id -u node 2>/dev/null || adduser -S node)
-COPY backend/package*.json ./
+COPY package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/knexfile.js ./knexfile.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,8 @@ services:
 
   backend:
     build:
-      context: .
-      dockerfile: backend/Dockerfile
+      context: ./backend
+      dockerfile: Dockerfile
     restart: always
     env_file:
       - ./.env


### PR DESCRIPTION
## Summary
- Send only the backend folder to Docker by restricting compose build context
- Simplify backend Dockerfile COPY paths for packages and source

## Testing
- `docker compose build backend` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68c71c8f43348328aee5da10047622ff