### PR TITLE
chore: update backend build context

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,9 +2,9 @@
 FROM node:18-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache curl netcat-openbsd
-COPY backend/package*.json ./
+COPY package*.json ./
 RUN npm ci && npm cache clean --force
-COPY backend/ ./
+COPY ./ ./
 COPY shared /shared
 
 # Production stage
@@ -12,7 +12,7 @@ FROM node:18-alpine
 WORKDIR /app
 RUN apk add --no-cache curl netcat-openbsd && \
     (id -u node 2>/dev/null || adduser -S node)
-COPY backend/package*.json ./
+COPY package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/knexfile.js ./knexfile.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,8 @@ services:
 
   backend:
     build:
-      context: .
-      dockerfile: backend/Dockerfile
+      context: ./backend
+      dockerfile: Dockerfile
     restart: always
     env_file:
       - ./.env


### PR DESCRIPTION
## Summary
- point backend service build context to `./backend`
- adjust backend Dockerfile copy commands

## Testing
- `docker compose build backend` *(fails: docker: 'compose' is not a docker command)*
- `apt-get install -y docker-compose-plugin` *(fails: Unable to locate package docker-compose-plugin)*
- `docker-compose build backend` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68c71c94b8f8832880d20bb79cbbb0b2