### PR TITLE
refactor frontend docker build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,8 @@ services:
 
   frontend:
     build:
-      context: .
-      dockerfile: frontend/Dockerfile
+      context: ./frontend
+      dockerfile: Dockerfile
     ports:
       - "3000:3000"
     env_file:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,9 @@
 # Build stage
 FROM node:18 AS builder
 WORKDIR /app
-COPY frontend/package.json frontend/package-lock.json ./
+COPY package.json package-lock.json ./
 RUN npm ci && npm cache clean --force
-COPY frontend/ ./
+COPY . ./
 COPY shared /shared
 
 # Default build-time environment variables.
@@ -21,7 +21,7 @@ RUN set -a && [ -f .env.production ] && . .env.production; npm run build
 FROM node:18-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache curl
-COPY frontend/package.json frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js ./
+COPY package.json package-lock.json next.config.mjs next-i18next.config.js ./
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary
- simplify frontend Dockerfile COPY instructions to use build context
- scope docker-compose frontend build to its directory

## Testing
- `docker-compose build frontend` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_68c71f8ae46483289e76b309c481a821