### PR TITLE
fix(frontend): set dedicated build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,7 @@ services:
 
   frontend:
     build:
-      context: .
-      dockerfile: frontend/Dockerfile
+      context: ./frontend
     ports:
       - "3000:3000"
     env_file:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,10 +1,10 @@
 # Build stage
 FROM node:18 AS builder
 WORKDIR /app
-COPY frontend/package.json frontend/package-lock.json ./
+COPY package.json package-lock.json ./
 RUN npm ci && npm cache clean --force
-COPY frontend/ ./
-COPY shared /shared
+COPY . .
+COPY ../shared /shared
 
 # Default build-time environment variables.
 ARG NEXT_PUBLIC_API_BASE_URL="http://localhost:5002/api"
@@ -21,7 +21,7 @@ RUN set -a && [ -f .env.production ] && . .env.production; npm run build
 FROM node:18-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache curl
-COPY frontend/package.json frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js ./
+COPY package.json package-lock.json next.config.mjs next-i18next.config.js ./
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary
- use `./frontend` as build context for the frontend service
- copy frontend and shared files relative to new context
- simplify frontend service build by relying on default Dockerfile

## Testing
- `pre-commit run --files docker-compose.yml frontend/Dockerfile` *(fails: 52 errors, 270 warnings)*
- `npm test --prefix frontend` *(terminated: console warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c71f8f8e688328bbccabc076b48c5f