### PR TITLE
fix: allow frontend docker build access to shared

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,8 @@ services:
 
   frontend:
     build:
-      context: ./frontend
+      context: .
+      dockerfile: frontend/Dockerfile
     ports:
       - "3000:3000"
     env_file:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,10 +1,10 @@
 # Build stage
 FROM node:18 AS builder
 WORKDIR /app
-COPY package.json package-lock.json ./
+COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci && npm cache clean --force
-COPY . .
-COPY ../shared /shared
+COPY frontend/ ./
+COPY shared /shared
 
 # Default build-time environment variables.
 ARG NEXT_PUBLIC_API_BASE_URL="http://localhost:5002/api"
@@ -21,7 +21,7 @@ RUN set -a && [ -f .env.production ] && . .env.production; npm run build
 FROM node:18-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache curl
-COPY package.json package-lock.json next.config.mjs next-i18next.config.js ./
+COPY frontend/package.json frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js ./
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary
- allow frontend Dockerfile to copy root shared directory
- configure docker-compose to build frontend from repository root

## Testing
- `pre-commit run --files docker-compose.yml frontend/Dockerfile` *(fails: 52 errors)*
- `docker compose build frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a46ca390832893518ca255843086