### PR TITLE
Add dotenv-expand and validate FRONTEND_URL parsing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,8 +31,8 @@ SUPPORT_EMAIL=support@yourdomain.com
 # Allowed frontend origins separated by commas
 # Configure this to match your production domain and server IP.
 # List multiple domains separated by commas if needed.
-FRONTEND_URL=https://${APP_DOMAIN},https://www.${APP_DOMAIN}
-COOKIE_DOMAIN=.${APP_DOMAIN}
+FRONTEND_URL=https://yourdomain.com,https://www.yourdomain.com
+COOKIE_DOMAIN=.yourdomain.com
 
 # Optional overrides for cookie security
 # Set COOKIE_SECURE=false to allow HTTP when NODE_ENV=production

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.5",
         "csurf": "^1.11.0",
         "dotenv": "^16.5.0",
+        "dotenv-expand": "^12.0.3",
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
         "express-session": "^1.17.3",
@@ -3631,6 +3632,21 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "engines": {
         "node": ">=12"
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "cors": "^2.8.5",
     "csurf": "^1.11.0",
     "dotenv": "^16.5.0",
+    "dotenv-expand": "^12.0.3",
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.0",
     "express-session": "^1.17.3",

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -1,7 +1,9 @@
 const { z } = require('zod');
 const dotenv = require('dotenv');
+const dotenvExpand = require('dotenv-expand');
 
-dotenv.config();
+const myEnv = dotenv.config();
+dotenvExpand.expand(myEnv);
 
 const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
@@ -25,6 +27,13 @@ if (FRONTEND_URL.startsWith('FRONTEND_URL=')) {
   FRONTEND_URL = FRONTEND_URL.replace(/^FRONTEND_URL=/, '');
 }
 
+let FRONTEND_ORIGINS;
+try {
+  FRONTEND_ORIGINS = FRONTEND_URL.split(',').map((url) => new URL(url.trim()).origin);
+} catch {
+  throw new Error(`Invalid FRONTEND_URL: ${FRONTEND_URL}`);
+}
+
 const DATABASE_URL =
   env.NODE_ENV === 'test'
     ? env.TEST_DATABASE_URL
@@ -46,6 +55,7 @@ module.exports = {
   DATABASE_URL,
   REDIS_URL: env.REDIS_URL,
   FRONTEND_URL,
+  FRONTEND_ORIGINS,
   APP_DOMAIN: env.APP_DOMAIN,
   ENABLE_INSTALL: env.ENABLE_INSTALL,
 };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,5 +1,4 @@
-require("dotenv").config();
-
+const config = require("./config/env");
 const logger = require('./utils/logger.js');
 // ─── SkillBridge Backend – Main Server Entry Point ───
 
@@ -23,7 +22,6 @@ const { refreshCookieOptions } = require("./utils/cookie");
 const startJobs = require("./jobs");
 const { initSockets, state: socketState } = require("./sockets");
 const routes = require("./routes");
-const config = require("./config/env");
 // Expose a global cache-clearing utility so other modules (like routes) can
 // programmatically flush any server-side caches. This clears Redis, the socket
 // store, and the in-memory cache.
@@ -79,16 +77,8 @@ app.use(
 );
 
 // 🌐 Fix CORS (must be very early)
-const FRONTEND_ORIGINS = (process.env.FRONTEND_URL || "http://localhost:3000")
-  .split(",")
-  .map((url) => {
-    try {
-      return new URL(url.trim()).origin;
-    } catch {
-      throw new Error(`Invalid FRONTEND_URL: ${url}`);
-    }
-  });
-const APP_DOMAIN = process.env.APP_DOMAIN;
+const FRONTEND_ORIGINS = config.FRONTEND_ORIGINS;
+const APP_DOMAIN = config.APP_DOMAIN;
 const defaultOrigins = APP_DOMAIN
   ? [`https://${APP_DOMAIN}`, `https://www.${APP_DOMAIN}`]
   : [];


### PR DESCRIPTION
## Summary
- replace APP_DOMAIN placeholders in backend .env example with explicit URLs
- add dotenv-expand to expand variables and parse FRONTEND_URL during env load
- use parsed frontend origins in server startup

## Testing
- `cd backend && npm test` *(fails: 25 failed, 120 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6d7b47c8328bc16e7f4bbff2563