### PR TITLE
feat(blog): configurable upload size

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ REDIS_URL=redis://redis:6379
 FRONTEND_URL=http://localhost:3000
 APP_DOMAIN=example.com
 COOKIE_DOMAIN=.example.com
+# Maximum upload size for blog images in bytes
 MAX_BLOG_IMAGE_BYTES=10485760
 # Set to 'production' when deploying
 NODE_ENV=development

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,7 @@ REDIS_URL=redis://localhost:6379
 # in the project root `.env` when running via docker-compose.
 JWT_SECRET=your_jwt_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret
+# Maximum upload size for blog images in bytes
 MAX_BLOG_IMAGE_BYTES=10485760
 CLOUDINARY_API_KEY=your_key
 # SMTP configuration

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -11,6 +11,7 @@ FRONTEND_URL=https://example.com
 REDIS_URL=redis://redis:6379
 APP_DOMAIN=example.com
 COOKIE_DOMAIN=.example.com
+# Maximum upload size for blog images in bytes
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production
 

--- a/backend/src/modules/blog/blogUploadMiddleware.js
+++ b/backend/src/modules/blog/blogUploadMiddleware.js
@@ -20,8 +20,15 @@ const fileFilter = (_req, file, cb) => {
   else cb(new Error("Invalid file type. Only images are allowed."), false);
 };
 
+const DEFAULT_MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+const envMax = Number(process.env.MAX_BLOG_IMAGE_BYTES);
+const maxFileSize =
+  Number.isInteger(envMax) && envMax > 0 && envMax <= 20 * 1024 * 1024
+    ? envMax
+    : DEFAULT_MAX_SIZE;
+
 module.exports = multer({
   storage,
   fileFilter,
-  limits: { fileSize: process.env.MAX_BLOG_IMAGE_BYTES || 10 * 1024 * 1024 }
+  limits: { fileSize: maxFileSize },
 });


### PR DESCRIPTION
## Summary
- parse MAX_BLOG_IMAGE_BYTES as a number and validate bounds
- note in env examples that MAX_BLOG_IMAGE_BYTES is specified in bytes

## Testing
- `npm test` (fails: Test Suites: 25 failed, 2 skipped, 120 passed, 145 of 147 total)


------
https://chatgpt.com/codex/tasks/task_e_68c7a6d9ce248328a95c4fb3b3f6096f