### PR TITLE
Resolve APP_DOMAIN references during Next build

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,6 +19,8 @@ The production build reads configuration from `.env.production`. Define the foll
 - `NEXT_PUBLIC_PGADMIN_URL` – pgAdmin interface endpoint.
 - `NEXT_PUBLIC_SOCKET_URL` – WebSocket endpoint, typically `https://${APP_DOMAIN}`.
 
+Environment files support variable expansion using [`dotenv-expand`](https://github.com/motdotla/dotenv-expand). Values such as `NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api` will resolve `APP_DOMAIN` during `npm run build`.
+
 Only commit placeholder values. Supply real values in production via environment variables or a mounted `.env.production` so `npm run build` can generate a bundle that connects to the correct services.
 
 ## Development Server

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,15 +1,44 @@
 import nextI18NextConfig from './next-i18next.config.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+import dotenvExpand from 'dotenv-expand';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+dotenvExpand.expand(
+  dotenv.config({
+    path: path.join(
+      __dirname,
+      `.env${process.env.NODE_ENV ? `.${process.env.NODE_ENV}` : ''}`,
+    ),
+  }),
+);
 
 /** @type {import('next').NextConfig} */
 const defaultApiBase = 'http://localhost:5002/api';
 const apiBaseEnv = process.env.NEXT_PUBLIC_API_BASE_URL;
 let apiBase = apiBaseEnv || defaultApiBase;
-const pgAdminBase = process.env.NEXT_PUBLIC_PGADMIN_URL || 'http://localhost:5050';
+const defaultPgAdminBase = 'http://localhost:5050';
+const pgAdminEnv = process.env.NEXT_PUBLIC_PGADMIN_URL;
+let pgAdminBase = pgAdminEnv || defaultPgAdminBase;
+
+try {
+  if (!/^https?:\/\//i.test(pgAdminBase)) {
+    throw new Error(
+      `NEXT_PUBLIC_PGADMIN_URL must be an absolute URL. Received: ${pgAdminBase}`,
+    );
+  }
+
+  // Ensure URL is well-formed
+  new URL(pgAdminBase);
+} catch (error) {
+  console.warn(
+    `Invalid NEXT_PUBLIC_PGADMIN_URL ("${pgAdminBase}"): ${error.message}. Falling back to ${defaultPgAdminBase}.`,
+  );
+  pgAdminBase = defaultPgAdminBase;
+}
 
 let protocol, hostname, port;
 try {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -89,6 +89,8 @@
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^14.2.1",
         "autoprefixer": "^10.4.20",
+        "dotenv": "^16.5.0",
+        "dotenv-expand": "^12.0.3",
         "eslint": "^9",
         "eslint-config-next": "15.1.6",
         "jest": "^29.7.0",
@@ -6136,6 +6138,35 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/draft-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,9 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.5.1",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "dotenv": "^16.5.0",
+    "dotenv-expand": "^12.0.3"
   },
   "overrides": {
     "prismjs": "^1.30.0",


### PR DESCRIPTION
## Summary
- expand `.env` files using dotenv-expand so `${APP_DOMAIN}` references resolve before Next.js build
- validate `NEXT_PUBLIC_PGADMIN_URL` alongside `NEXT_PUBLIC_API_BASE_URL`
- document env variable expansion and install dotenv tooling

## Testing
- `npm install`
- `npm test` *(fails: Cannot find module '../../../../components/layouts/StudentLayout')*


------
https://chatgpt.com/codex/tasks/task_e_68c7a6dbf8fc8328a4b3ad678df52ba5