### PR TITLE
Remove duplicate install location in Nginx config

### DIFF
--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -78,15 +78,6 @@
     add_header Access-Control-Allow-Credentials true always;
   }
 
-  location ^~ /install/ {
-    proxy_pass http://backend:5002/install/;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-  }
-
   location = /install {
     proxy_pass http://backend:5002/install/;
     proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
- remove duplicate `/install/` location block from `common_locations.inc`

## Testing
- `pre-commit run --files nginx/snippets/common_locations.inc` *(fails: 322 problems in frontend lint)*
- `nginx -t -c /tmp/test_nginx.conf` *(fails: "if" directive is not allowed here)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6da9a288328a0ae008fcdcfcc7f