### PR TITLE
docs: clarify production Redis configuration

### DIFF
--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -6,9 +6,11 @@ PRODUCTION_DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/DB_NAME
 JWT_SECRET=change_me
 REFRESH_TOKEN_SECRET=change_me
 SESSION_SECRET=change_me
+# Redis connection string
+# Use redis://redis:6379 when running with docker-compose.
+# Replace with your managed Redis URL for other deployments.
 REDIS_URL=redis://redis:6379
 FRONTEND_URL=https://example.com
-REDIS_URL=redis://redis:6379
 APP_DOMAIN=example.com
 COOKIE_DOMAIN=.example.com
 MAX_BLOG_IMAGE_BYTES=10485760


### PR DESCRIPTION
## Summary
- deduplicate REDIS_URL in backend production env example
- document how to set Redis URLs for docker and managed deployments

## Testing
- `npm test` *(fails: Test Suites: 25 failed, 2 skipped, 120 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6dcf2788328a1d150ecb49bb8d9