### PR TITLE
Remove redundant installer location block in Nginx config

### DIFF
--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -105,13 +105,3 @@
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
-
-  # Forward installer requests to the backend
-  location ^~ /install/ {
-    proxy_pass http://backend:5002;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-  }


### PR DESCRIPTION
## Summary
- Remove duplicate `location ^~ /install/` block to avoid conflicting installer routes
- Ensure installer requests proxy to `backend:5002/install/`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6df96388328bc636953ca009a08