### PR TITLE
Validate book price range env values

### DIFF
--- a/backend/src/config/books.js
+++ b/backend/src/config/books.js
@@ -1,5 +1,39 @@
-const PRICE_RANGE_DEFAULT = Number(process.env.BOOK_PRICE_RANGE_DEFAULT || 100);
-const PRICE_RANGE_MAX = Number(process.env.BOOK_PRICE_RANGE_MAX || 500);
+const logger = require('../utils/logger.js');
+
+/**
+ * Parse a numeric environment variable.
+ * Falls back to a default when the value is not a finite number.
+ * @param {string|undefined} value Raw environment variable
+ * @param {number} fallback Default value to use when parsing fails
+ * @param {string} name Name of the environment variable for logging
+ * @returns {number}
+ */
+function parseEnvNumber(value, fallback, name) {
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+
+  if (value !== undefined) {
+    logger.warn(
+      `Invalid ${name} environment value: ${value}. Falling back to ${fallback}.`
+    );
+  }
+
+  return fallback;
+}
+
+const PRICE_RANGE_DEFAULT = parseEnvNumber(
+  process.env.BOOK_PRICE_RANGE_DEFAULT,
+  100,
+  'BOOK_PRICE_RANGE_DEFAULT'
+);
+
+const PRICE_RANGE_MAX = parseEnvNumber(
+  process.env.BOOK_PRICE_RANGE_MAX,
+  500,
+  'BOOK_PRICE_RANGE_MAX'
+);
 
 module.exports = {
   PRICE_RANGE_DEFAULT,


### PR DESCRIPTION
## Summary
- ensure BOOK_PRICE_RANGE_DEFAULT and BOOK_PRICE_RANGE_MAX env vars parse to finite numbers
- log a warning and fall back to defaults when values are invalid

## Testing
- `npm test` *(fails: multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6e1765c83289a62101ea840f6dc