### PR TITLE
docs: document allowed origins for CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ JWT_SECRET=your_jwt_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret
 SESSION_SECRET=your_session_secret
 REDIS_URL=redis://redis:6379
+# Comma-separated origins Nginx should allow for CORS.
+# Example: http://localhost:3000,https://example.com
+ALLOWED_ORIGINS=http://localhost:3000
 # Allowed frontend origin(s) for CORS. Must match the exact scheme, host,
 # and port used by the frontend to avoid CORS errors. Separate multiple
 # origins with commas, e.g. http://localhost:3000,https://example.com

--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ npm --prefix frontend install
       - `PGADMIN_DEFAULT_EMAIL`, `PGADMIN_DEFAULT_PASSWORD`
       - `JWT_SECRET`, `REFRESH_TOKEN_SECRET`
       - `FRONTEND_URL`
+      - `ALLOWED_ORIGINS`
       - `REDIS_URL`
+
+    Nginx uses `ALLOWED_ORIGINS` to emit CORS headers. Provide a
+    comma-separated list of origins, e.g. `http://localhost:3000,https://example.com`.
+    The default `http://localhost:3000` supports local development.
 
     A Redis instance (or compatible session store) is required in production
     to persist user sessions. Set `REDIS_URL` to your store's connection

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,8 @@ services:
     restart: always
     env_file:
       - ./.env
+    environment:
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:3000}
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary
- add `ALLOWED_ORIGINS` to env example with localhost default
- expose `ALLOWED_ORIGINS` to nginx in docker compose
- document `ALLOWED_ORIGINS` usage and defaults in README

## Testing
- `npm --prefix backend test` *(fails: Test Suites: 25 failed, 2 skipped, 120 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6e4e0a48328b5173a634bc3c02a