### PR TITLE
docs: expand Swagger definitions

### DIFF
--- a/backend/src/docs/swagger.yaml
+++ b/backend/src/docs/swagger.yaml
@@ -2,9 +2,98 @@ openapi: 3.0.0
 info:
   title: SkillBridge API
   version: 1.0.0
+servers:
+  - url: /
 tags:
+  - name: Health
+  - name: Auth
   - name: Users
 paths:
+  /api/health:
+    get:
+      tags: [Health]
+      summary: Health check
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /api/auth/register:
+    post:
+      tags: [Auth]
+      summary: Register a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+      responses:
+        '201':
+          description: Registration successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/auth/login:
+    post:
+      tags: [Auth]
+      summary: Authenticate user and return tokens
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '400':
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/auth/logout:
+    post:
+      tags: [Auth]
+      summary: Logout user and clear refresh token
+      responses:
+        '200':
+          description: Logged out successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+  /api/auth/refresh:
+    post:
+      tags: [Auth]
+      summary: Refresh access token using refresh token cookie
+      responses:
+        '200':
+          description: Token refreshed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefreshResponse'
+        '401':
+          description: Invalid or expired refresh token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/users/me:
     get:
       tags: [Users]
@@ -12,3 +101,172 @@ paths:
       responses:
         '200':
           description: Profile fetched
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/users/me/full-profile:
+    get:
+      tags: [Users]
+      summary: Get authenticated user's full profile with role-specific data
+      responses:
+        '200':
+          description: Full profile fetched
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FullUserProfile'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+    MessageResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Logged out successfully
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+      required:
+        - error
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        full_name:
+          type: string
+        email:
+          type: string
+          format: email
+        phone:
+          type: string
+        role:
+          type: string
+          enum: [Student, Instructor, Admin, SuperAdmin]
+        avatar_url:
+          type: string
+          format: uri
+        status:
+          type: string
+        profile_complete:
+          type: boolean
+        is_email_verified:
+          type: boolean
+        is_phone_verified:
+          type: boolean
+        is_online:
+          type: boolean
+    RegisterRequest:
+      type: object
+      required:
+        - full_name
+        - email
+        - phone
+        - password
+      properties:
+        full_name:
+          type: string
+        email:
+          type: string
+          format: email
+        phone:
+          type: string
+        password:
+          type: string
+          format: password
+        role:
+          type: string
+          enum: [Student, Instructor, Admin]
+        recaptchaToken:
+          type: string
+    RegisterResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Registration successful. A verification email has been sent.
+        user:
+          $ref: '#/components/schemas/User'
+    LoginRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password
+        recaptchaToken:
+          type: string
+    LoginResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Login successful
+        accessToken:
+          type: string
+        user:
+          $ref: '#/components/schemas/User'
+    RefreshResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Token refreshed
+        accessToken:
+          type: string
+    FullUserProfile:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            roles:
+              type: array
+              items:
+                type: string
+            permissions:
+              type: array
+              items:
+                type: string
+            student:
+              type: object
+              nullable: true
+            instructor:
+              type: object
+              nullable: true
+            admin_profile:
+              type: object
+              nullable: true
+            certificates:
+              type: array
+              items:
+                type: object
+            social_links:
+              type: array
+              items:
+                type: object


### PR DESCRIPTION
## Summary
- add health, auth, and user profile endpoints to Swagger docs
- define request/response schemas and shared components
- document new user profile schema

## Testing
- `npx swagger-cli validate backend/src/docs/swagger.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68c7a6eb07ac8328ade879a401be5dc7