### PR TITLE
Use expanded frontend env file in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       - "3000:3000"
     env_file:
       - ./.env
-      - ./frontend/.env.production
+      - ./frontend/.env.production.expanded
     healthcheck:
       test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:3000"]
       interval: 30s

--- a/frontend/.env.production.expanded
+++ b/frontend/.env.production.expanded
@@ -1,0 +1,3 @@
+APP_DOMAIN=example.com
+NEXT_PUBLIC_API_BASE_URL=https://example.com/api
+NEXT_PUBLIC_PGADMIN_URL=https://example.com/pgadmin

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 .env*
 !.env.local.example
 !.env.production
+!.env.production.expanded
 
 # vercel
 .vercel

--- a/scripts/expand_frontend_env.sh
+++ b/scripts/expand_frontend_env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+# Generate a fully expanded frontend/.env.production.expanded from frontend/.env.production template
+script_dir="$(dirname "$0")"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+set -a
+. frontend/.env.production
+set +a
+envsubst < frontend/.env.production > frontend/.env.production.expanded


### PR DESCRIPTION
## Summary
- add script to expand frontend .env using envsubst
- include fully-expanded .env for frontend and ignore rule
- reference expanded env file from docker-compose

## Testing
- `npm test` (backend) *(fails: various test failures)*
- `npm test` (frontend) *(fails: some test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6e9ef6c83288b686f535e4386ac