### PR TITLE
Add COOKIE_DOMAIN env support for cookie utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ REDIS_URL=redis://redis:6379
 # origins with commas, e.g. http://localhost:3000,https://example.com
 FRONTEND_URL=http://localhost:3000
 APP_DOMAIN=example.com
+# Optional domain to share cookies across subdomains
 COOKIE_DOMAIN=.example.com
 MAX_BLOG_IMAGE_BYTES=10485760
 # Set to 'production' when deploying

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -15,6 +15,7 @@ const EnvSchema = z.object({
   REDIS_URL: z.string().url().optional(),
   FRONTEND_URL: z.string().default('http://localhost:3000'),
   APP_DOMAIN: z.string().optional(),
+  COOKIE_DOMAIN: z.string().optional(),
   ENABLE_INSTALL: z.coerce.boolean().default(false),
 });
 
@@ -47,5 +48,6 @@ module.exports = {
   REDIS_URL: env.REDIS_URL,
   FRONTEND_URL,
   APP_DOMAIN: env.APP_DOMAIN,
+  COOKIE_DOMAIN: env.COOKIE_DOMAIN,
   ENABLE_INSTALL: env.ENABLE_INSTALL,
 };

--- a/backend/src/utils/cookie.js
+++ b/backend/src/utils/cookie.js
@@ -9,17 +9,18 @@
 // ---------------------------------------------------------------------------
 
 const { REFRESH_TOKEN_MAX_AGE } = require("../config/tokens");
+const { COOKIE_DOMAIN, NODE_ENV } = require("../config/env");
 
 // Use the provided cookie domain or fall back to the production domain so
 // browsers store the csrfToken cookie when deployed.
-const COOKIE_DOMAIN =
-  process.env.COOKIE_DOMAIN ||
-  (process.env.NODE_ENV === "production" ? ".eduskillbridge.net" : undefined);
+const domain =
+  COOKIE_DOMAIN ||
+  (NODE_ENV === "production" ? ".eduskillbridge.net" : undefined);
 
 const refreshCookieOptions = {
   httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
+  secure: NODE_ENV === 'production',
+  sameSite: NODE_ENV === 'production' ? 'None' : 'Lax',
   maxAge: REFRESH_TOKEN_MAX_AGE,
 };
 
@@ -28,13 +29,13 @@ const refreshCookieOptions = {
 // token to ensure it is available across subdomains in production.
 const csrfCookieOptions = {
   httpOnly: false,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
+  secure: NODE_ENV === 'production',
+  sameSite: NODE_ENV === 'production' ? 'None' : 'Lax',
 };
 
-if (COOKIE_DOMAIN) {
-  refreshCookieOptions.domain = COOKIE_DOMAIN;
-  csrfCookieOptions.domain = COOKIE_DOMAIN;
+if (domain) {
+  refreshCookieOptions.domain = domain;
+  csrfCookieOptions.domain = domain;
 }
 
 module.exports = { refreshCookieOptions, csrfCookieOptions };


### PR DESCRIPTION
## Summary
- add optional `COOKIE_DOMAIN` to env schema and export
- use `COOKIE_DOMAIN` from env config in cookie helpers
- document `COOKIE_DOMAIN` in `.env.example`

## Testing
- `npm test` *(fails: Test Suites: 31 failed, 2 skipped, 114 passed, 145 of 147 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6e05e108328aecdb801804b4e7a