### PR TITLE
fix duplicate install location

### DIFF
--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -106,12 +106,3 @@
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
-  # Forward installer requests to the backend
-  location ^~ /install/ {
-    proxy_pass http://backend:5002;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-  }


### PR DESCRIPTION
## Summary
- remove redundant `/install/` location from nginx common snippet
- ensure `/install` paths consistently proxy to backend installer

## Testing
- `nginx -t`
- `nginx -s reload`


------
https://chatgpt.com/codex/tasks/task_e_68c7a6f0f4e08328a404f9cbe0307bb6