### PR TITLE
fix: remove redundant cache flush

### DIFF
--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -21,14 +21,6 @@ module.exports = {
       await socketStore.clearAll();
     }
     store.clear();
-
-    if (redisClient && typeof redisClient.flushAll === 'function') {
-      await redisClient.flushAll();
-    }
-
-    if (socketStore && typeof socketStore.clearAll === 'function') {
-      await socketStore.clearAll();
-    }
   },
 };
 


### PR DESCRIPTION
## Summary
- ensure cache utility imports redis client
- clear Redis and socket stores once when resetting cache

## Testing
- `npm test` *(fails: 25 failed, 120 passed)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6efd5408328a629eebcd5f6fb75