### PR TITLE
Add generated Postman collection

### DIFF
--- a/backend/src/docs/postman_collection.json
+++ b/backend/src/docs/postman_collection.json
@@ -1,0 +1,92 @@
+{
+  "item": [
+    {
+      "name": "api",
+      "description": "",
+      "item": [
+        {
+          "name": "users",
+          "description": "",
+          "item": [
+            {
+              "name": "me",
+              "description": "",
+              "item": [
+                {
+                  "id": "19a4d4fa-11c1-4861-867f-12a8df549f93",
+                  "name": "Get authenticated user's base profile",
+                  "request": {
+                    "name": "Get authenticated user's base profile",
+                    "description": {},
+                    "url": {
+                      "path": [
+                        "api",
+                        "users",
+                        "me"
+                      ],
+                      "host": [
+                        "{{baseUrl}}"
+                      ],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {},
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "94472356-2320-449e-9f82-5ac9087fe70e",
+                      "name": "Profile fetched",
+                      "originalRequest": {
+                        "url": {
+                          "path": [
+                            "api",
+                            "users",
+                            "me"
+                          ],
+                          "host": [
+                            "{{baseUrl}}"
+                          ],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "GET",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [],
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": [],
+                  "protocolProfileBehavior": {
+                    "disableBodyPruning": true
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "/"
+    }
+  ],
+  "info": {
+    "_postman_id": "70679409-791d-4b98-854d-ffd6e1383b66",
+    "name": "SkillBridge API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- generate Postman collection JSON from existing Swagger spec

## Testing
- `pre-commit run --files backend/src/docs/postman_collection.json` *(fails: 52 errors)*
- `npm test --prefix backend` *(fails: 25 failed, 2 skipped, 120 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a6ece4008328903e3f04904f2337