### PR TITLE
Handle missing .env file in frontend build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,11 @@ ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL \
     APP_DOMAIN=$APP_DOMAIN
 
 # Source optional production env file if present before building.
-RUN set -a && [ -f .env.production ] && . .env.production; npm run build
+RUN set -a; \
+    if [ -f .env.production ]; then \
+        . .env.production; \
+    fi; \
+    npm run build
 
 # Production stage
 FROM node:20-alpine AS production


### PR DESCRIPTION
## Summary
- Avoid frontend Docker build failure when `.env.production` is absent by sourcing it only if present

## Testing
- `CI=true npm test` *(fails: missing StudentLayout module and WebsiteHomeScroll test)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ca76c5588328b3cc6dcf5d9dd021