### PR TITLE
Handle missing .env file in frontend build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,10 @@ ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL \
     APP_DOMAIN=$APP_DOMAIN
 
 # Source optional production env file if present before building.
-RUN set -a && [ -f .env.production ] && . .env.production; npm run build
+RUN if [ -f .env.production ]; then \
+        set -a && . ./.env.production; \
+    fi; \
+    npm run build
 
 # Production stage
 FROM node:20-alpine AS production


### PR DESCRIPTION
## Summary
- Avoid frontend Docker build failure when `.env.production` is absent by guarding `set -a` and sourcing inside a conditional

## Testing
- `CI=true npm test` *(fails: Could not read package.json: ENOENT: no such file or directory)*
- `(cd frontend && CI=true npm test)` *(fails: Cannot find package 'dotenv' imported from next.config.mjs)*
- `docker build --target builder -f frontend/Dockerfile .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ca76c5588328b3cc6dcf5d9dd021