### PR TITLE
fix(frontend): ensure Next.js listens on port 3000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,8 @@ services:
     env_file:
       - ./.env
       - ./frontend/.env.production.expanded
+    environment:
+      PORT: 3000
     healthcheck:
       test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:3000"]
       interval: 30s


### PR DESCRIPTION
## Summary
- fix frontend docker configuration to force PORT=3000

## Testing
- `docker compose config` *(fails: command not found)*
- `cd backend && npm test` *(fails: multiple test failures)
- `cd frontend && npm test` *(fails: missing modules/tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d24a58d88328bc214a12f8e58963