### PR TITLE
fix(frontend): ensure Next.js listens on port 3000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,10 @@ services:
     env_file:
       - ./.env
       - ./frontend/.env.production.expanded
+    environment:
+      PORT: 3000
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:3000"]
+      test: ["CMD-SHELL", "curl -fsS -o /dev/null http://127.0.0.1:${PORT:-3000}"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
## Summary
- fix frontend healthcheck to use IPv4 loopback and $PORT variable

## Testing
- `docker compose config` *(fails: command not found)*
- `cd backend && npm test` *(fails: Cannot find module 'dotenv-expand')*
- `cd frontend && npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68c7d24a58d88328bc214a12f8e58963