### PR TITLE
fix: use container port in frontend healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
     environment:
       PORT: 3000
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS -o /dev/null http://127.0.0.1:${PORT:-3000}"]
+      test: ["CMD-SHELL", "curl -fsS -o /dev/null http://127.0.0.1:$${PORT:-3000}"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
## Summary
- ensure frontend health check uses container PORT env variable

## Testing
- `pre-commit run --files docker-compose.yml` *(fails: command not found)*
- `docker-compose build frontend && docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d67c73088328bf19fd2e81db9694