### PR TITLE
chore: use BACKEND_PORT env variable

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ POSTGRES_DB=skillbridge_db
 PGADMIN_DEFAULT_EMAIL=admin@skillbridge.local
 PGADMIN_DEFAULT_PASSWORD=admin_pass
 
-PORT=5002
+BACKEND_PORT=5002
 DATABASE_URL=postgres://skillbridge_user:skillbridge_pass@db:5432/skillbridge_db
 PRODUCTION_DATABASE_URL=postgres://skillbridge_user:skillbridge_pass@db:5432/skillbridge_db
 

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ POSTGRES_DB=eduSkillbridge
 PGADMIN_DEFAULT_EMAIL=admin@example.com
 PGADMIN_DEFAULT_PASSWORD=change_me
 
-PORT=5002
+BACKEND_PORT=5002
 # The credentials in DATABASE_URL must mirror POSTGRES_USER and POSTGRES_PASSWORD above
 DATABASE_URL=postgres://postgres:change_me@db:5432/eduSkillbridge
 # Alternatively, provide PRODUCTION_DATABASE_URL for production deployments

--- a/backend/README.md
+++ b/backend/README.md
@@ -18,7 +18,7 @@ any are missing:
 - `JWT_SECRET` – signing key for access tokens
 - `REFRESH_TOKEN_SECRET` – signing key for refresh tokens
 - `DATABASE_URL` – PostgreSQL connection string (use `TEST_DATABASE_URL` when running tests). For production deployments, you may instead provide `PRODUCTION_DATABASE_URL`.
-- `PORT` – port for the HTTP server
+- `BACKEND_PORT` – port for the HTTP server
 - `SESSION_SECRET` – session cookie signing secret
 
 Provide these variables via a `.env` file or the hosting environment.

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -7,7 +7,7 @@ dotenvExpand.expand(myEnv);
 
 const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
-  PORT: z.coerce.number().default(5002),
+  BACKEND_PORT: z.coerce.number().default(5002),
   JWT_SECRET: z.string(),
   REFRESH_TOKEN_SECRET: z.string(),
   SESSION_SECRET: z.string(),
@@ -49,7 +49,7 @@ if (!DATABASE_URL) {
 
 module.exports = {
   NODE_ENV: env.NODE_ENV,
-  PORT: env.PORT,
+  BACKEND_PORT: env.BACKEND_PORT,
   JWT_SECRET: env.JWT_SECRET,
   REFRESH_TOKEN_SECRET: env.REFRESH_TOKEN_SECRET,
   SESSION_SECRET: env.SESSION_SECRET,

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -214,7 +214,7 @@ if (!config.ENABLE_INSTALL) {
   });
 }
 app.use(require("./middleware/errorHandler"));
-const PORT = config.PORT;
+const BACKEND_PORT = config.BACKEND_PORT;
 
 async function startServer() {
   if (redisClient) {
@@ -242,12 +242,12 @@ async function startServer() {
     }
     await initStrategies();
     await new Promise((resolve, reject) => {
-      server.listen(PORT, "0.0.0.0", (err) => {
+      server.listen(BACKEND_PORT, "0.0.0.0", (err) => {
         if (err) {
           reject(err);
           return;
         }
-        logger.log(`✅ Server running on port ${PORT}`);
+        logger.log(`✅ Server running on port ${BACKEND_PORT}`);
         initSockets(server, ALLOWED_ORIGINS);
         const { io, userSockets } = socketState;
         global.io = io;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,9 +57,9 @@ services:
     env_file:
       - ./.env
     ports:
-      - "5002:5002"
+      - "${BACKEND_PORT}:${BACKEND_PORT}"
     environment:
-      PORT: ${PORT}
+      BACKEND_PORT: ${BACKEND_PORT}
       DATABASE_URL: ${DATABASE_URL}
       JWT_SECRET: ${JWT_SECRET}
       REFRESH_TOKEN_SECRET: ${REFRESH_TOKEN_SECRET}
@@ -70,7 +70,7 @@ services:
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
     command: ["sh", "-c", "./scripts/wait-for-db.sh && npx knex migrate:latest && node src/server.js"]
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:5002/api/health"]
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:${BACKEND_PORT}/api/health"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
## Summary
- rename backend port env var to BACKEND_PORT
- update docker-compose to reference BACKEND_PORT
- adjust backend config and server to read BACKEND_PORT

## Testing
- `pre-commit run --files .env .env.example backend/README.md backend/src/config/env.js backend/src/server.js docker-compose.yml` *(fails: 322 problems (52 errors, 270 warnings))*
- `docker-compose up -d --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d621ea908328951892a91130e84f