### PR TITLE
Expose frontend on all network interfaces

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -H 0.0.0.0",
     "lint": "eslint .",
     "test": "NODE_ENV=test jest"
   },


### PR DESCRIPTION
## Summary
- allow `npm start` to listen on all interfaces by default

## Testing
- `npm test` *(fails: src/tests/pages/dashboard/student/profile/edit.test.js, src/tests/__tests__/WebsiteHomeScroll.test.js, src/tests/__tests__/InstructorTutorialsPage.test.js, src/tests/__tests__/InstructorSettingsPage.test.js)*
- `npm run lint` *(fails: Component definition is missing display name, no-console)*
- `docker-compose build frontend` *(fails: Error while fetching server API version: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d62e3b4c8328800cb01270649ff2