### PR TITLE
chore: set frontend node env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
     environment:
       PORT: 3000
       HOST: 0.0.0.0
+      NODE_ENV: production
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS -o /dev/null http://127.0.0.1:${PORT:-3000}/api/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- add NODE_ENV=production for frontend service

## Testing
- `docker-compose config`
- `docker-compose up -d --build frontend` *(fails: Cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dcb4a7948328ac29258cdd75762b