### PR TITLE
chore: update frontend build URLs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,9 +90,9 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
       args:
-        NEXT_PUBLIC_API_BASE_URL: https://your-domain/api
-        NEXT_PUBLIC_PGADMIN_URL: https://your-domain/pgadmin
-        APP_DOMAIN: your-domain
+        NEXT_PUBLIC_API_BASE_URL: https://eduskillbridge.net/api
+        NEXT_PUBLIC_PGADMIN_URL: https://eduskillbridge.net/pgadmin
+        APP_DOMAIN: eduskillbridge.net
     ports:
       - "3000:3000"
     env_file:


### PR DESCRIPTION
## Summary
- replace placeholder domain with eduskillbridge.net for API and pgAdmin URLs

## Testing
- `docker-compose build frontend` (fails: Cannot connect to the Docker daemon)
- `docker-compose up -d frontend` (fails: Cannot connect to the Docker daemon)


------
https://chatgpt.com/codex/tasks/task_e_68c7dcb293408328aba4785a66a6f4c9