### PR TITLE
feat: make public api check optional

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -11,3 +11,6 @@ NEXT_PUBLIC_PGADMIN_URL=http://localhost:5050
 APP_DOMAIN=localhost
 # Comma-separated hosts allowed for external payment icons.
 NEXT_PUBLIC_TRUSTED_ICON_HOSTS=yourdomain.com,cdn.yourdomain.com
+# Set to true in real deployments to enforce public API URL validation.
+# Leave unset or false for local development.
+STRICT_PUBLIC_API=false

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -50,7 +50,9 @@ try {
 
   // Prevent shipping a build that points at an internal HTTP host which would
   // cause browsers to block requests with mixed-content errors.
+  const enforcePublicAPI = process.env.STRICT_PUBLIC_API === 'true';
   if (
+    enforcePublicAPI &&
     process.env.NODE_ENV === 'production' &&
     /^https?:\/\/(localhost|backend)(:\\d+)?/i.test(apiBase)
   ) {


### PR DESCRIPTION
## Summary
- add STRICT_PUBLIC_API flag so API base URL validation runs only when enabled
- document STRICT_PUBLIC_API in example env file

## Testing
- `pre-commit run --files frontend/next.config.mjs frontend/.env.local.example` *(fails: 322 problems (52 errors, 270 warnings))*
- `CI=true npm test` *(hangs with numerous warnings; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dcad9b4883288aee0d508293ea30