### PR TITLE
Preserve frontend local health endpoint

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -133,6 +133,10 @@ const nextConfig = {
   async rewrites() {
     return [
       {
+        source: '/api/health',
+        destination: '/api/health',
+      }, // allow local handler
+      {
         source: '/api/pgadmin/:path*',
         destination: `${pgAdminBase}/:path*`,
       },


### PR DESCRIPTION
## Summary
- ensure Next.js rewrites keep `/api/health` handled locally

## Testing
- `pre-commit run --files frontend/next.config.mjs` *(fails: 52 errors, 270 warnings)*
- `docker build -f frontend/Dockerfile -t frontend-image .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f5971e0483289e1b61ea0ba8b6f6