### PR TITLE
Insert health check rewrite exception

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -133,17 +133,13 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: '/api/health',
-        destination: '/api/health',
-      }, // allow local handler
-      {
         source: '/api/pgadmin/:path*',
         destination: `${pgAdminBase}/:path*`,
       },
       {
         source: '/api/health',
         destination: '/api/health',
-      },
+      }, // allow local handler
       {
         source: '/api/:path*',
         destination: `${apiBase}/:path*`,


### PR DESCRIPTION
## Summary
- ensure `/api/health` bypasses API proxying by inserting explicit rewrite before the general `/api/:path*` rule

## Testing
- `npm test`
- `docker-compose build frontend` *(fails: Error while fetching server API version)*
- `docker-compose up` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fc1c84a08328b8fb2c33ccedb9e0