### PR TITLE
fix: remove duplicate health rewrite rule

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -141,10 +141,6 @@ const nextConfig = {
         destination: `${pgAdminBase}/:path*`,
       },
       {
-        source: '/api/health',
-        destination: '/api/health',
-      },
-      {
         source: '/api/:path*',
         destination: `${apiBase}/:path*`,
       },


### PR DESCRIPTION
## Summary
- remove duplicate `/api/health` rewrite entry from Next.js config

## Testing
- `npm test` *(fails: Cannot find module '../../../../components/layouts/StudentLayout')*
- `npm run lint` *(fails: Component definition is missing display name)*
- `docker compose build frontend` *(fails: command not found: docker)*
- `docker compose up -d frontend` *(fails: command not found: docker)*
- `docker exec -it skillbridge-frontend-1 curl -f http://localhost:3000/api/health` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fe2090808328865aaa5ac96d58ed