### PR TITLE
Exclude health route from frontend proxy

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -132,18 +132,9 @@ const nextConfig = {
   },
   async rewrites() {
     return [
-      {
-        source: '/api/pgadmin/:path*',
-        destination: `${pgAdminBase}/:path*`,
-      },
-      {
-        source: '/api/:path*',
-        destination: `${apiBase}/:path*`,
-      },
-      {
-        source: '/uploads/:path*',
-        destination: `${apiBase}/uploads/:path*`,
-      },
+      { source: '/api/:path((?!health).*)', destination: `${apiBase}/:path*` },
+      { source: '/api/pgadmin/:path*', destination: `${pgAdminBase}/:path*` },
+      { source: '/uploads/:path*', destination: `${apiBase}/uploads/:path*` },
     ];
   },
 };


### PR DESCRIPTION
## Summary
- avoid proxying `/api/health` to the backend so local handler can respond

## Testing
- `npm test` *(fails: command not found)*
- `docker-compose build frontend` *(fails: Cannot connect to the Docker daemon)*
- `docker-compose logs frontend` *(fails: Cannot connect to the Docker daemon)*
- `docker exec -it skillbridge-frontend-1 curl -f http://localhost:3000/api/health` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c802a7ea548328af0c1908ac7aead7