### PR TITLE
feat: prioritize local health rewrite

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -133,6 +133,10 @@ const nextConfig = {
   async rewrites() {
     return [
       {
+        source: '/api/health',
+        destination: '/api/health',
+      },
+      {
         source: '/api/pgadmin/:path*',
         destination: `${pgAdminBase}/:path*`,
       },


### PR DESCRIPTION
## Summary
- handle `/api/health` rewrite before external API routes

## Testing
- `npm test` *(fails: Home page section scrolling – clicking the down arrow scrolls to the next section)*
- `npx eslint next.config.mjs`
- `docker compose build --no-cache frontend` *(fails: docker: 'compose' is not a docker command.)*
- `docker exec -it skillbridge-frontend-1 curl -i http://localhost:3000/api/health` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68c802575c808328a2bbc89aacc9846a