### PR TITLE
Use internal Docker hosts for frontend build args

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,7 +85,8 @@ USER_LOCALE=en-US
 
 # The frontend uses this URL for browser requests.
 # Replace it with your public API endpoint before deploying.
-NEXT_PUBLIC_API_BASE_URL=http://localhost:5002/api
+NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
+NEXT_PUBLIC_PGADMIN_URL=http://pgadmin:80
 
 # Feature flags
 ENABLE_INSTALL=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,9 +90,9 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
       args:
-        NEXT_PUBLIC_API_BASE_URL: https://eduskillbridge.net/api
-        NEXT_PUBLIC_PGADMIN_URL: https://eduskillbridge.net/pgadmin
-        APP_DOMAIN: eduskillbridge.net
+        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://backend:${BACKEND_PORT:-5002}/api}
+        NEXT_PUBLIC_PGADMIN_URL: ${NEXT_PUBLIC_PGADMIN_URL:-http://pgadmin:80}
+        APP_DOMAIN: ${APP_DOMAIN:-eduskillbridge.net}
     ports:
       - "3000:3000"
     env_file:


### PR DESCRIPTION
## Summary
- default frontend build args to internal Docker network hosts for API and pgAdmin
- allow overriding APP_DOMAIN via env variable and provide internal defaults in .env.example

## Testing
- `npm test --prefix backend` (fails: multiple failing test suites)
- `npm test --prefix frontend`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c807f572dc8328865164ad2649a24d