### PR TITLE
fix(frontend): serve /api/health from next app

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -133,16 +133,12 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: '/api/health',
-        destination: '/api/health',
-      },
-      {
         source: '/api/pgadmin/:path*',
         destination: `${pgAdminBase}/:path*`,
       },
       {
-        source: '/api/:path*',
-        destination: `${apiBase}/:path*`,
+        source: '/api/:path((?!health$).*)',
+        destination: `${apiBase}/:path`,
       },
       {
         source: '/uploads/:path*',

--- a/frontend/src/pages/api/health.js
+++ b/frontend/src/pages/api/health.js
@@ -1,3 +1,0 @@
-export default function handler(req, res) {
-  res.status(200).json({ status: 'ok' });
-}

--- a/frontend/src/pages/api/health.ts
+++ b/frontend/src/pages/api/health.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  res.status(200).json({ status: 'ok' });
+}


### PR DESCRIPTION
## Summary
- remove rewrite loop for /api/health and exclude from backend proxy
- add typed `/api/health` api route

## Testing
- `npm run lint` *(fails: Component definition is missing display name)*
- `npm test` *(fails: Cannot find module '../../../../components/layouts/StudentLayout')*

------
https://chatgpt.com/codex/tasks/task_e_68c807f4dc048328bd29afce412651c3