### PR TITLE
Fix tutorial draft type assertions

### DIFF
--- a/frontend/src/utils/tutorialDraft.ts
+++ b/frontend/src/utils/tutorialDraft.ts
@@ -22,11 +22,11 @@ export function loadDraft(key: string, defaults: DraftDefaults = {}) {
         draft?.chapters?.length ??
         defaults.lessonCount ??
         1,
-    } as TutorialDraftDefaults;
+    } as DraftDefaults;
   } catch (err) {
     console.error(`Failed to parse ${key}`, err);
     localStorage.removeItem(key);
-    return { ...defaults } as TutorialDraftDefaults;
+    return { ...defaults } as DraftDefaults;
   }
 }
 


### PR DESCRIPTION
## Summary
- align the tutorial draft loader defaults with the DraftDefaults interface by replacing outdated type assertions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c883cca7a88328aea6bb39142af3e8