### PR TITLE
Serialize tutorial is_paid field as numeric string

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.validator.js
+++ b/backend/src/modules/users/tutorials/tutorial.validator.js
@@ -3,7 +3,14 @@ const { TUTORIAL_STATUS } = require("../../../../../shared/tutorialStatus");
 
 // Helper preprocessor for boolean values coming from multipart/form-data
 const toBoolean = (val) => {
-  if (typeof val === "string") return val === "true";
+  if (typeof val === "string") {
+    if (val === "true" || val === "1") return true;
+    if (val === "false" || val === "0") return false;
+    return val === "true";
+  }
+  if (typeof val === "number") {
+    return val === 1;
+  }
   return val;
 };
 

--- a/frontend/src/tests/__tests__/tutorialForm.test.js
+++ b/frontend/src/tests/__tests__/tutorialForm.test.js
@@ -27,7 +27,7 @@ describe("buildTutorialFormData", () => {
     expect(formData.get("level")).toBe("beginner");
     expect(formData.get("language")).toBe("en");
     expect(formData.get("status")).toBe("draft");
-    expect(formData.get("is_paid")).toBe("true");
+    expect(formData.get("is_paid")).toBe("1");
     expect(formData.get("price")).toBe("100");
     expect(JSON.parse(formData.get("tags"))).toEqual(["a", "b"]);
     expect(JSON.parse(formData.get("chapters"))).toEqual([
@@ -68,7 +68,7 @@ describe("buildTutorialFormData", () => {
     const formData = buildTutorialFormData(tutorialData);
 
     expect(formData.get("status")).toBe("draft");
-    expect(formData.get("is_paid")).toBe("false");
+    expect(formData.get("is_paid")).toBe("0");
     expect(formData.has("price")).toBe(false);
     expect(formData.has("tags")).toBe(false);
     expect(formData.has("chapters")).toBe(false);

--- a/frontend/src/utils/tutorialDraft.ts
+++ b/frontend/src/utils/tutorialDraft.ts
@@ -48,7 +48,8 @@ export function buildTutorialFormData(tutorialData, status) {
   formData.append('level', tutorialData.level);
   formData.append('language', tutorialData.language);
   formData.append('status', status ?? tutorialData.status);
-  formData.append('is_paid', (!tutorialData.isFree).toString());
+  // The API expects `is_paid` to be serialized as "0" for free tutorials and "1" for paid ones.
+  formData.append('is_paid', tutorialData.isFree ? '0' : '1');
   if (!tutorialData.isFree) {
     formData.append('price', tutorialData.price);
     if (tutorialData.currency) {


### PR DESCRIPTION
## Summary
- teach the tutorial validator to coerce numeric string values into booleans for multipart payloads
- send tutorial draft `is_paid` as `"0"`/`"1"` and document the expected format
- update the tutorial form unit test to reflect the new serialization

## Testing
- npm test -- --runTestsByPath src/tests/__tests__/tutorialForm.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c883c9d23c83288420a8edde1521f0