### PR TITLE
Refine tutorial draft utilities typing

### DIFF
--- a/frontend/src/utils/tutorialDraft.ts
+++ b/frontend/src/utils/tutorialDraft.ts
@@ -1,14 +1,55 @@
-interface DraftDefaults {
-  language?: string;
-  lessonCount?: number;
-  chapters?: unknown[];
+interface TutorialChapterDraft {
+  id?: number | string;
+  title: string;
+  duration: string | number;
+  video?: File | string | null;
+  videoUrl?: string | null;
+  preview?: boolean;
   [key: string]: unknown;
 }
 
-export function loadDraft(key: string, defaults: DraftDefaults = {}) {
-  if (typeof window === 'undefined') return { ...defaults };
+export interface TutorialDraft {
+  title: string;
+  shortDescription: string;
+  category: string | number;
+  categoryName?: string;
+  level: string;
+  language: string;
+  lessonCount: number | string;
+  tags: string[];
+  chapters?: TutorialChapterDraft[];
+  thumbnail: File | string | null;
+  preview: File | string | null;
+  price?: string | number;
+  currency?: string;
+  isFree: boolean;
+  status?: string;
+  instructorId?: number | string;
+  [key: string]: unknown;
+}
+
+type DraftDefaults = Partial<TutorialDraft>;
+
+type TutorialDraftDefaults = DraftDefaults & {
+  language: string;
+  lessonCount: number | string;
+  thumbnail: File | string | null;
+  preview: File | string | null;
+};
+
+export function loadDraft(
+  key: string,
+  defaults: DraftDefaults = {}
+): TutorialDraftDefaults {
+  if (typeof window === 'undefined') {
+    return { ...defaults } as TutorialDraftDefaults;
+  }
+
   const saved = localStorage.getItem(key);
-  if (!saved) return { ...defaults } as DraftDefaults;
+  if (!saved) {
+    return { ...defaults } as TutorialDraftDefaults;
+  }
+
   try {
     const draft = JSON.parse(saved) as DraftDefaults;
     return {
@@ -30,34 +71,82 @@ export function loadDraft(key: string, defaults: DraftDefaults = {}) {
   }
 }
 
-export function saveDraft(key, data) {
+export function saveDraft(key: string, data: TutorialDraft): void {
   if (typeof window === 'undefined') return;
   localStorage.setItem(key, JSON.stringify(data));
 }
 
-export async function loadCategories(fetchFn) {
-  const result = await fetchFn();
-  return result?.data || result || [];
+type Category = Record<string, unknown>;
+
+interface CategoryResponse {
+  data?: Category[] | CategoryResponse | null;
+  [key: string]: unknown;
 }
 
-export function buildTutorialFormData(tutorialData, status) {
+type CategoryFetchResult = Category[] | CategoryResponse | null | undefined;
+
+function isCategoryResponse(value: unknown): value is CategoryResponse {
+  return Boolean(value) && typeof value === 'object' && 'data' in (value as object);
+}
+
+function extractCategories(result: CategoryFetchResult): Category[] {
+  if (Array.isArray(result)) {
+    return result;
+  }
+
+  if (isCategoryResponse(result)) {
+    const { data } = result;
+
+    if (Array.isArray(data)) {
+      return data;
+    }
+
+    if (isCategoryResponse(data)) {
+      return extractCategories(data);
+    }
+  }
+
+  return [];
+}
+
+export async function loadCategories(
+  fetchFn: () => Promise<CategoryFetchResult>
+): Promise<Category[]> {
+  const result = await fetchFn();
+  return extractCategories(result);
+}
+
+export function buildTutorialFormData(
+  tutorialData: TutorialDraft,
+  status?: string
+) {
   const formData = new FormData();
   formData.append('title', tutorialData.title);
   formData.append('description', tutorialData.shortDescription);
-  formData.append('category_id', tutorialData.category);
+  formData.append('category_id', String(tutorialData.category));
   formData.append('level', tutorialData.level);
   formData.append('language', tutorialData.language);
-  formData.append('status', status ?? tutorialData.status);
+
+  const resolvedStatus = status ?? tutorialData.status;
+  if (resolvedStatus) {
+    formData.append('status', resolvedStatus);
+  }
+
   formData.append('is_paid', (!tutorialData.isFree).toString());
+
   if (!tutorialData.isFree) {
-    formData.append('price', tutorialData.price);
+    if (tutorialData.price !== undefined && tutorialData.price !== null) {
+      formData.append('price', String(tutorialData.price));
+    }
     if (tutorialData.currency) {
       formData.append('currency', tutorialData.currency);
     }
   }
+
   if (tutorialData.tags?.length) {
     formData.append('tags', JSON.stringify(tutorialData.tags));
   }
+
   if (tutorialData.chapters?.length) {
     const chapters = tutorialData.chapters.map((ch, idx) => ({
       title: ch.title,
@@ -68,11 +157,13 @@ export function buildTutorialFormData(tutorialData, status) {
     }));
     formData.append('chapters', JSON.stringify(chapters));
   }
+
   if (tutorialData.thumbnail instanceof File) {
     formData.append('thumbnail', tutorialData.thumbnail);
   }
   if (tutorialData.preview instanceof File) {
     formData.append('preview', tutorialData.preview);
   }
+
   return formData;
 }


### PR DESCRIPTION
## Summary
- define strong typing for tutorial draft data structures and reuse them across the utility helpers
- tighten category loading logic with typed helpers that normalize nested API responses
- update tutorial FormData builder to honor the new types and ensure values are appended as strings

## Testing
- npm run lint -- src/utils/tutorialDraft.ts *(fails: pre-existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c883c8f7d88328a0448e7479043e52