### PR TITLE
Define tutorial draft types and normalize draft handling

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -23,11 +23,14 @@ import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import {
+  createTutorialDraft,
   loadDraft,
   saveDraft,
   loadCategories,
   buildTutorialFormData,
 } from "@/utils/tutorialDraft";
+
+/** @typedef {import('@/utils/tutorialDraft').TutorialDraft} TutorialDraft */
 
 function EditTutorialPage() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialEditPage' });
@@ -35,7 +38,9 @@ function EditTutorialPage() {
   const { id } = router.query;
 
   const [step, setStep] = useState(1);
-  const [tutorialData, setTutorialData] = useState(null);
+  const [tutorialData, setTutorialData] = useState(
+    /** @type {TutorialDraft | null} */ (null)
+  );
   const [categories, setCategories] = useState([]);
   const [error, setError] = useState(null);
   const user = useAuthStore((state) => state.user);
@@ -72,23 +77,14 @@ function EditTutorialPage() {
           videoUrl: ch.video_url,
           preview: ch.is_preview,
         }));
-        setTutorialData({
-          title: tutorial.title,
-          shortDescription: tutorial.shortDescription || "",
-          category: tutorial.category,
-          categoryName: tutorial.categoryName,
-          level: tutorial.level,
-          language: tutorial.language || "",
-          instructorId: tutorial.instructorId,
-          status: tutorial.status,
-          lessonCount: mappedChapters.length,
-          tags: tutorial.tags || [],
+        const normalized = createTutorialDraft({
+          ...tutorial,
           chapters: mappedChapters,
-          thumbnail: tutorial.thumbnail,
-          preview: tutorial.preview,
-          price: tutorial.price || "",
-          isFree: tutorial.isFree,
+          lessonCount: mappedChapters.length,
+          currency:
+            tutorial.currency || tutorial.currencyCode || tutorial.currency_code || "",
         });
+        setTutorialData(normalized);
         setCategories(cats);
       } catch (err) {
         console.error(err);

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.js
@@ -19,18 +19,23 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import {
+  createTutorialDraft,
   loadDraft,
   saveDraft,
   loadCategories,
   buildTutorialFormData,
 } from "@/utils/tutorialDraft";
 
+/** @typedef {import('@/utils/tutorialDraft').TutorialDraft} TutorialDraft */
+
 export default function EditTutorialPage() {
   const router = useRouter();
   const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const { id } = router.query;
   const [step, setStep] = useState(1);
-  const [tutorialData, setTutorialData] = useState(null);
+  const [tutorialData, setTutorialData] = useState(
+    /** @type {TutorialDraft | null} */ (null)
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [categories, setCategories] = useState([]);
@@ -62,11 +67,11 @@ export default function EditTutorialPage() {
         ]);
         const formatted = tutorial?.data || tutorial || null;
         if (formatted) {
-          setTutorialData({
+          const normalized = createTutorialDraft({
             ...formatted,
-            language: formatted.language || "",
-            lessonCount: formatted.chapters?.length || 1,
+            chapters: formatted.chapters,
           });
+          setTutorialData(normalized);
         } else {
           setTutorialData(null);
         }

--- a/frontend/src/utils/tutorialDraft.ts
+++ b/frontend/src/utils/tutorialDraft.ts
@@ -1,78 +1,316 @@
-interface DraftDefaults {
-  language?: string;
-  lessonCount?: number;
-  chapters?: unknown[];
-  [key: string]: unknown;
+export interface TutorialChapterDraft {
+  id?: number;
+  order?: number;
+  title: string;
+  duration: string | number;
+  video?: string | null;
+  videoUrl?: string;
+  preview: boolean;
 }
 
-export function loadDraft(key: string, defaults: DraftDefaults = {}) {
-  if (typeof window === 'undefined') return { ...defaults };
+export interface TutorialDraft {
+  title: string;
+  shortDescription: string;
+  category: string | number;
+  categoryName: string;
+  level: string;
+  language: string;
+  lessonCount: number;
+  tags: string[];
+  chapters: TutorialChapterDraft[];
+  thumbnail: File | string | null;
+  preview: File | string | null;
+  price: string | number;
+  currency: string;
+  isFree: boolean;
+  status?: string;
+  instructorId?: number | string;
+}
+
+export const DEFAULT_TUTORIAL_DRAFT: TutorialDraft = {
+  title: "",
+  shortDescription: "",
+  category: "",
+  categoryName: "",
+  level: "",
+  language: "",
+  lessonCount: 1,
+  tags: [],
+  chapters: [],
+  thumbnail: null,
+  preview: null,
+  price: "",
+  currency: "",
+  isFree: false,
+};
+
+type DraftInput = Partial<TutorialDraft> & Record<string, unknown>;
+
+const cloneDraft = (draft: TutorialDraft): TutorialDraft => ({
+  ...draft,
+  tags: [...draft.tags],
+  chapters: cloneChapters(draft.chapters),
+});
+
+const cloneChapters = (
+  chapters: TutorialChapterDraft[]
+): TutorialChapterDraft[] => chapters.map((chapter) => ({ ...chapter }));
+
+const toStringValue = (value: unknown, fallback: string): string => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && !Number.isNaN(value)) {
+    return String(value);
+  }
+  return fallback;
+};
+
+const normalizePrice = (value: unknown, fallback: string | number): string => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && !Number.isNaN(value)) {
+    return value.toString();
+  }
+  return typeof fallback === "number" ? fallback.toString() : fallback;
+};
+
+const normalizeMedia = (
+  value: unknown,
+  fallback: File | string | null
+): File | string | null => {
+  if (typeof value === "string") return value;
+  if (typeof File !== "undefined" && value instanceof File) return value;
+  return fallback;
+};
+
+const normalizeTags = (value: unknown, fallback: string[]): string[] => {
+  if (!Array.isArray(value)) return [...fallback];
+  const tags: string[] = [];
+  value.forEach((tag) => {
+    if (typeof tag === "string") {
+      tags.push(tag);
+    } else if (tag && typeof tag === "object" && typeof tag.name === "string") {
+      tags.push(tag.name);
+    }
+  });
+  return tags;
+};
+
+const normalizeChapter = (chapter: unknown): TutorialChapterDraft => {
+  if (!chapter || typeof chapter !== "object") {
+    return { title: "", duration: "", video: null, videoUrl: "", preview: false };
+  }
+
+  const data = chapter as Partial<TutorialChapterDraft> & Record<string, unknown>;
+  const rawVideoUrl =
+    typeof data.videoUrl === "string"
+      ? data.videoUrl
+      : typeof data.video_url === "string"
+      ? data.video_url
+      : "";
+  const durationValue =
+    typeof data.duration === "number" || typeof data.duration === "string"
+      ? data.duration
+      : "";
+
+  return {
+    id: typeof data.id === "number" ? data.id : undefined,
+    order: typeof data.order === "number" ? data.order : undefined,
+    title: typeof data.title === "string" ? data.title : "",
+    duration: durationValue,
+    video:
+      typeof data.video === "string"
+        ? data.video
+        : rawVideoUrl
+        ? rawVideoUrl
+        : null,
+    videoUrl: rawVideoUrl || undefined,
+    preview:
+      typeof data.preview === "boolean"
+        ? data.preview
+        : typeof data.is_preview === "boolean"
+        ? data.is_preview
+        : false,
+  };
+};
+
+const normalizeChapters = (
+  value: unknown,
+  fallback: TutorialChapterDraft[]
+): TutorialChapterDraft[] => {
+  if (!Array.isArray(value)) return cloneChapters(fallback);
+  return value.map((chapter) => normalizeChapter(chapter));
+};
+
+const normalizeLessonCount = (
+  value: unknown,
+  chapters: TutorialChapterDraft[],
+  fallback: number
+): number => {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  if (typeof value === "string") {
+    const parsed = parseInt(value, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  if (chapters.length > 0) {
+    return chapters.length;
+  }
+  return fallback > 0 ? fallback : 1;
+};
+
+const mergeDraft = (data: DraftInput = {}, defaults?: TutorialDraft): TutorialDraft => {
+  const base = cloneDraft(defaults ?? DEFAULT_TUTORIAL_DRAFT);
+
+  const tags = normalizeTags(data.tags ?? (data as { keywords?: unknown }).keywords, base.tags);
+  const chapters = normalizeChapters(
+    data.chapters ?? (data as { lessons?: unknown }).lessons,
+    base.chapters
+  );
+
+  const lessonCount = normalizeLessonCount(
+    data.lessonCount ?? (data as { lesson_count?: unknown }).lesson_count ?? (data as { lessons_count?: unknown }).lessons_count,
+    chapters,
+    base.lessonCount
+  );
+
+  const language = toStringValue((data as { language?: unknown; locale?: unknown }).language ?? (data as { locale?: unknown }).locale, base.language);
+
+  const categoryRaw =
+    data.category ??
+    (data as { categoryId?: unknown }).categoryId ??
+    (data as { category_id?: unknown }).category_id;
+
+  const categoryName = toStringValue(
+    data.categoryName ?? (data as { category_name?: unknown }).category_name ?? base.categoryName,
+    base.categoryName
+  );
+
+  const status =
+    typeof data.status === "string"
+      ? data.status
+      : typeof (data as { moderation_status?: unknown }).moderation_status === "string"
+      ? ((data as { moderation_status: string }).moderation_status as string)
+      : base.status;
+
+  const instructorIdValue =
+    data.instructorId ?? (data as { instructor_id?: unknown }).instructor_id;
+
+  return {
+    ...base,
+    title: typeof data.title === "string" ? data.title : base.title,
+    shortDescription: toStringValue(
+      data.shortDescription ?? (data as { description?: unknown }).description ?? base.shortDescription,
+      base.shortDescription
+    ),
+    category: categoryRaw !== undefined ? toStringValue(categoryRaw, base.category as string) : base.category,
+    categoryName,
+    level: toStringValue(data.level ?? base.level, base.level),
+    language,
+    lessonCount,
+    tags,
+    chapters,
+    thumbnail: normalizeMedia(
+      data.thumbnail ?? (data as { thumbnail_url?: unknown }).thumbnail_url ?? (data as { cover_image?: unknown }).cover_image,
+      base.thumbnail
+    ),
+    preview: normalizeMedia(
+      data.preview ?? (data as { preview_video?: unknown }).preview_video,
+      base.preview
+    ),
+    price: normalizePrice(data.price ?? (data as { cost?: unknown }).cost, base.price),
+    currency: toStringValue(
+      data.currency ?? (data as { currency_code?: unknown }).currency_code ?? base.currency,
+      base.currency
+    ),
+    isFree:
+      typeof data.isFree === "boolean"
+        ? data.isFree
+        : typeof (data as { is_paid?: unknown }).is_paid === "boolean"
+        ? !(data as { is_paid: boolean }).is_paid
+        : base.isFree,
+    status,
+    instructorId:
+      typeof instructorIdValue === "number" || typeof instructorIdValue === "string"
+        ? instructorIdValue
+        : base.instructorId,
+  };
+};
+
+export const createTutorialDraft = (
+  data: DraftInput = {},
+  defaults?: TutorialDraft
+): TutorialDraft => mergeDraft(data, defaults);
+
+export function loadDraft(key: string, defaults?: TutorialDraft): TutorialDraft | null {
+  if (typeof window === "undefined") {
+    return defaults ? createTutorialDraft({}, defaults) : null;
+  }
   const saved = localStorage.getItem(key);
-  if (!saved) return { ...defaults } as DraftDefaults;
+  if (!saved) {
+    return defaults ? createTutorialDraft({}, defaults) : null;
+  }
   try {
-    const draft = JSON.parse(saved) as DraftDefaults;
-    return {
-      ...defaults,
-      ...draft,
-      thumbnail: null,
-      preview: null,
-      language: draft?.language ?? defaults.language ?? '',
-      lessonCount:
-        draft?.lessonCount ??
-        draft?.chapters?.length ??
-        defaults.lessonCount ??
-        1,
-    } as TutorialDraftDefaults;
+    const parsed = JSON.parse(saved) as DraftInput;
+    return mergeDraft(parsed, defaults);
   } catch (err) {
     console.error(`Failed to parse ${key}`, err);
     localStorage.removeItem(key);
-    return { ...defaults } as TutorialDraftDefaults;
+    return defaults ? createTutorialDraft({}, defaults) : null;
   }
 }
 
-export function saveDraft(key, data) {
-  if (typeof window === 'undefined') return;
+export function saveDraft(key: string, data: TutorialDraft): void {
+  if (typeof window === "undefined") return;
   localStorage.setItem(key, JSON.stringify(data));
 }
 
-export async function loadCategories(fetchFn) {
+export async function loadCategories<T>(
+  fetchFn: () => Promise<{ data?: T } | T>
+): Promise<T | { data?: T } | T[]> {
   const result = await fetchFn();
-  return result?.data || result || [];
+  return (result as { data?: T })?.data || (result as T) || [];
 }
 
-export function buildTutorialFormData(tutorialData, status) {
+export function buildTutorialFormData(
+  tutorialData: TutorialDraft,
+  status?: string
+): FormData {
   const formData = new FormData();
-  formData.append('title', tutorialData.title);
-  formData.append('description', tutorialData.shortDescription);
-  formData.append('category_id', tutorialData.category);
-  formData.append('level', tutorialData.level);
-  formData.append('language', tutorialData.language);
-  formData.append('status', status ?? tutorialData.status);
-  formData.append('is_paid', (!tutorialData.isFree).toString());
-  if (!tutorialData.isFree) {
-    formData.append('price', tutorialData.price);
+  formData.append("title", toStringValue(tutorialData.title, ""));
+  formData.append("description", toStringValue(tutorialData.shortDescription, ""));
+  formData.append("category_id", toStringValue(tutorialData.category, ""));
+  formData.append("level", toStringValue(tutorialData.level, ""));
+  formData.append("language", toStringValue(tutorialData.language, ""));
+  if (status ?? tutorialData.status) {
+    formData.append("status", toStringValue(status ?? tutorialData.status, ""));
+  }
+  formData.append("is_paid", (!tutorialData.isFree).toString());
+  if (!tutorialData.isFree && tutorialData.price !== "") {
+    formData.append("price", normalizePrice(tutorialData.price, ""));
     if (tutorialData.currency) {
-      formData.append('currency', tutorialData.currency);
+      formData.append("currency", toStringValue(tutorialData.currency, ""));
     }
   }
-  if (tutorialData.tags?.length) {
-    formData.append('tags', JSON.stringify(tutorialData.tags));
+  if (tutorialData.tags.length) {
+    formData.append("tags", JSON.stringify(tutorialData.tags));
   }
-  if (tutorialData.chapters?.length) {
+  if (tutorialData.chapters.length) {
     const chapters = tutorialData.chapters.map((ch, idx) => ({
-      title: ch.title,
+      title: toStringValue(ch.title, ""),
       duration: ch.duration,
-      video_url: ch.videoUrl,
+      video_url: ch.videoUrl ?? "",
       order: idx + 1,
-      is_preview: ch.preview,
+      is_preview: !!ch.preview,
     }));
-    formData.append('chapters', JSON.stringify(chapters));
+    formData.append("chapters", JSON.stringify(chapters));
   }
   if (tutorialData.thumbnail instanceof File) {
-    formData.append('thumbnail', tutorialData.thumbnail);
+    formData.append("thumbnail", tutorialData.thumbnail);
   }
   if (tutorialData.preview instanceof File) {
-    formData.append('preview', tutorialData.preview);
+    formData.append("preview", tutorialData.preview);
   }
   return formData;
 }


### PR DESCRIPTION
## Summary
- introduce explicit `TutorialDraft` and `TutorialChapterDraft` interfaces with normalization helpers in the tutorialDraft utility and type the draft persistence helpers
- adjust the instructor and admin tutorial edit flows to rely on the new helper and typed state

## Testing
- npm test -- tutorialForm

------
https://chatgpt.com/codex/tasks/task_e_68c883c70768832886bc9ca518e56599