### PR TITLE
Define tutorial draft interface

### DIFF
--- a/frontend/src/utils/tutorialDraft.ts
+++ b/frontend/src/utils/tutorialDraft.ts
@@ -5,12 +5,20 @@ interface DraftDefaults {
   [key: string]: unknown;
 }
 
-export function loadDraft(key: string, defaults: DraftDefaults = {}) {
+interface TutorialDraftDefaults extends DraftDefaults {
+  thumbnail?: File | string | null;
+  preview?: File | string | null;
+}
+
+export function loadDraft(
+  key: string,
+  defaults: TutorialDraftDefaults = {}
+): TutorialDraftDefaults {
   if (typeof window === 'undefined') return { ...defaults };
   const saved = localStorage.getItem(key);
-  if (!saved) return { ...defaults } as DraftDefaults;
+  if (!saved) return { ...defaults };
   try {
-    const draft = JSON.parse(saved) as DraftDefaults;
+    const draft = JSON.parse(saved) as TutorialDraftDefaults;
     return {
       ...defaults,
       ...draft,
@@ -22,15 +30,15 @@ export function loadDraft(key: string, defaults: DraftDefaults = {}) {
         draft?.chapters?.length ??
         defaults.lessonCount ??
         1,
-    } as TutorialDraftDefaults;
+    };
   } catch (err) {
     console.error(`Failed to parse ${key}`, err);
     localStorage.removeItem(key);
-    return { ...defaults } as TutorialDraftDefaults;
+    return { ...defaults };
   }
 }
 
-export function saveDraft(key, data) {
+export function saveDraft(key: string, data: TutorialDraftDefaults): void {
   if (typeof window === 'undefined') return;
   localStorage.setItem(key, JSON.stringify(data));
 }


### PR DESCRIPTION
## Summary
- add a TutorialDraftDefaults interface that extends the existing draft defaults with thumbnail and preview metadata
- update loadDraft and saveDraft to share this interface for arguments and return types while removing the previous casts

## Testing
- npm --prefix frontend run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c883c60abc83289525374e7231efcd