### PR TITLE
Refine tutorial draft loading with generics

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.tsx
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.tsx
@@ -1,5 +1,4 @@
-// EditTutorialPage.js
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
@@ -11,10 +10,7 @@ import BasicInfoStep from "@/components/tutorials/create/BasicInfoStep";
 import CurriculumStep from "@/components/tutorials/create/CurriculumStep";
 import MediaStep from "@/components/tutorials/create/MediaStep";
 import ReviewStep from "@/components/tutorials/create/ReviewStep";
-import {
-  fetchTutorialById,
-  updateTutorial,
-} from "@/services/admin/tutorialService";
+import { fetchTutorialById, updateTutorial } from "@/services/admin/tutorialService";
 import { fetchAllCategories } from "@/services/admin/categoryService";
 import { fetchChaptersByTutorial } from "@/services/admin/tutorialChapterService";
 import { createNotification } from "@/services/notificationService";
@@ -23,49 +19,77 @@ import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import {
+  buildTutorialFormData,
+  loadCategories,
   loadDraft,
   saveDraft,
-  loadCategories,
-  buildTutorialFormData,
+  tutorialDraftDefaults,
+  type TutorialDraft,
 } from "@/utils/tutorialDraft";
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const extractErrorMessage = (error: unknown): string | undefined => {
+  if (!isRecord(error) || !("response" in error)) {
+    return undefined;
+  }
+
+  const response = error.response;
+  if (!isRecord(response) || !("data" in response)) {
+    return undefined;
+  }
+
+  const data = response.data;
+  if (!isRecord(data) || typeof data.message !== "string") {
+    return undefined;
+  }
+
+  return data.message;
+};
+
 function EditTutorialPage() {
-  const { t } = useTranslation('dashboard', { keyPrefix: 'tutorialEditPage' });
+  const { t } = useTranslation("dashboard", { keyPrefix: "tutorialEditPage" });
   const router = useRouter();
   const { id } = router.query;
+  const tutorialId = Array.isArray(id) ? id[0] : id;
 
   const [step, setStep] = useState(1);
-  const [tutorialData, setTutorialData] = useState(null);
-  const [categories, setCategories] = useState([]);
-  const [error, setError] = useState(null);
+  const [tutorialData, setTutorialData] = useState<TutorialDraft | null>(null);
+  const [categories, setCategories] = useState<unknown[]>([]);
+  const [error, setError] = useState<string | null>(null);
   const user = useAuthStore((state) => state.user);
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
 
   useEffect(() => {
-    if (!id) return;
+    if (!tutorialId) return;
 
-    const draft = loadDraft(`editTutorialDraft-${id}`);
-    if (draft) {
-      setTutorialData(draft);
-      loadCategories(fetchAllCategories)
-        .then((cats) => setCategories(cats))
-        .catch((err) => {
-          console.error(err);
-          setError("Failed to load tutorial.");
-        });
-      return;
+    const storageKey = `editTutorialDraft-${tutorialId}`;
+    if (typeof window !== "undefined") {
+      const savedDraft = localStorage.getItem(storageKey);
+      if (savedDraft) {
+        const draft = loadDraft(storageKey, tutorialDraftDefaults);
+        setTutorialData(draft);
+        loadCategories(fetchAllCategories)
+          .then((cats) => setCategories(cats))
+          .catch((err) => {
+            console.error(err);
+            setError("Failed to load tutorial.");
+          });
+        return;
+      }
     }
 
     const load = async () => {
       try {
         setError(null);
         const [tutorial, chapters, cats] = await Promise.all([
-          fetchTutorialById(id),
-          fetchChaptersByTutorial(id),
+          fetchTutorialById(tutorialId),
+          fetchChaptersByTutorial(tutorialId),
           loadCategories(fetchAllCategories),
         ]);
-        const mappedChapters = chapters.map((ch) => ({
+        const mappedChapters = chapters.map((ch: any) => ({
           title: ch.title,
           duration: ch.duration,
           video: `${process.env.NEXT_PUBLIC_API_BASE_URL}${ch.video_url}`,
@@ -87,34 +111,35 @@ function EditTutorialPage() {
           thumbnail: tutorial.thumbnail,
           preview: tutorial.preview,
           price: tutorial.price || "",
+          currency: tutorial.currency || "",
           isFree: tutorial.isFree,
         });
         setCategories(cats);
       } catch (err) {
         console.error(err);
-        setError("Failed to load tutorial.");
+        setError(extractErrorMessage(err) ?? "Failed to load tutorial.");
       }
     };
 
     load();
-  }, [id]);
+  }, [tutorialId]);
 
   useEffect(() => {
-    if (tutorialData && id) {
-      saveDraft(`editTutorialDraft-${id}`, tutorialData);
+    if (tutorialData && tutorialId) {
+      saveDraft(`editTutorialDraft-${tutorialId}`, tutorialData);
     }
-  }, [tutorialData, id]);
+  }, [tutorialData, tutorialId]);
 
   const onNext = () => setStep((prev) => prev + 1);
   const onPrev = () => setStep((prev) => prev - 1);
 
-  if (error)
-    return (
-      <div className="p-6 max-w-4xl mx-auto text-red-600">{error}</div>
-    );
+  if (error) {
+    return <div className="p-6 max-w-4xl mx-auto text-red-600">{error}</div>;
+  }
 
-  if (!tutorialData)
+  if (!tutorialData) {
     return <div className="p-6 max-w-4xl mx-auto">Loading...</div>;
+  }
 
   return (
     <AdminLayout>
@@ -144,16 +169,17 @@ function EditTutorialPage() {
           />
         )}
         {step === 4 && (
-            <ReviewStep
-              tutorialData={tutorialData}
-              onPrev={onPrev}
-              actionLabel="Save Changes"
-              onPublish={async () => {
-                const formData = buildTutorialFormData(tutorialData);
+          <ReviewStep
+            tutorialData={tutorialData}
+            onPrev={onPrev}
+            actionLabel="Save Changes"
+            onPublish={async () => {
+              if (!tutorialId) return;
+              const formData = buildTutorialFormData(tutorialData);
 
-                try {
-                  await updateTutorial(id, formData);
-                  toast.success(t('update_success'));
+              try {
+                await updateTutorial(tutorialId, formData);
+                toast.success(t("update_success"));
 
                 try {
                   await createNotification({
@@ -176,15 +202,15 @@ function EditTutorialPage() {
                   });
                 } catch (err) {
                   console.error(err);
-                  toast.error('Failed to send notification or message');
+                  toast.error("Failed to send notification or message");
                 }
                 refreshNotifications?.();
                 refreshMessages?.();
-                localStorage.removeItem(`editTutorialDraft-${id}`);
+                localStorage.removeItem(`editTutorialDraft-${tutorialId}`);
                 router.push("/dashboard/admin/tutorials");
               } catch (err) {
                 console.error(err);
-                toast.error(t('update_failed'));
+                toast.error(t("update_failed"));
               }
             }}
           />
@@ -201,7 +227,7 @@ export default withAuthProtection(EditTutorialPage, {
 export async function getServerSideProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["dashboard"], nextI18NextConfig)),
+      ...(await serverSideTranslations(locale, ["dashboard", "tutorials"], nextI18NextConfig)),
     },
   };
 }

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.tsx
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/edit.tsx
@@ -1,5 +1,4 @@
-// EditTutorialPage.js
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import InstructorLayout from '@/components/layouts/InstructorLayout';
@@ -7,8 +6,7 @@ import BasicInfoStep from '@/components/tutorials/create/BasicInfoStep';
 import CurriculumStep from '@/components/tutorials/create/CurriculumStep';
 import MediaStep from '@/components/tutorials/create/MediaStep';
 import ReviewStep from '@/components/tutorials/create/ReviewStep';
-import { fetchInstructorTutorialById } from "@/services/instructor/tutorialService";
-import { updateTutorial } from "@/services/instructor/tutorialService";
+import { fetchInstructorTutorialById, updateTutorial } from "@/services/instructor/tutorialService";
 import { fetchAllCategories } from "@/services/instructor/categoryService";
 import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
@@ -19,45 +17,74 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import {
+  buildTutorialFormData,
+  loadCategories,
   loadDraft,
   saveDraft,
-  loadCategories,
-  buildTutorialFormData,
+  tutorialDraftDefaults,
+  type TutorialDraft,
 } from "@/utils/tutorialDraft";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const extractErrorMessage = (error: unknown): string | undefined => {
+  if (!isRecord(error) || !("response" in error)) {
+    return undefined;
+  }
+
+  const response = error.response;
+  if (!isRecord(response) || !("data" in response)) {
+    return undefined;
+  }
+
+  const data = response.data;
+  if (!isRecord(data) || typeof data.message !== "string") {
+    return undefined;
+  }
+
+  return data.message;
+};
 
 export default function EditTutorialPage() {
   const router = useRouter();
   const { t } = useTranslation(["common", "dashboard", "tutorials"]);
   const { id } = router.query;
+  const tutorialId = Array.isArray(id) ? id[0] : id;
   const [step, setStep] = useState(1);
-  const [tutorialData, setTutorialData] = useState(null);
+  const [tutorialData, setTutorialData] = useState<TutorialDraft | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [categories, setCategories] = useState([]);
+  const [error, setError] = useState<string | null>(null);
+  const [categories, setCategories] = useState<unknown[]>([]);
 
   const user = useAuthStore((state) => state.user);
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
 
   useEffect(() => {
-    if (!id) return;
-    const draft = loadDraft(`editTutorialDraft-${id}`);
-    if (draft) {
-      setTutorialData(draft);
-      loadCategories(fetchAllCategories)
-        .then((cats) => setCategories(cats?.data || cats || []))
-        .catch((err) => {
-          console.error(err);
-          setError(t("tutorials:detail.load_error"));
-        })
-        .finally(() => setLoading(false));
-      return;
+    if (!tutorialId) return;
+
+    const storageKey = `editTutorialDraft-${tutorialId}`;
+    if (typeof window !== "undefined") {
+      const savedDraft = localStorage.getItem(storageKey);
+      if (savedDraft) {
+        const draft = loadDraft(storageKey, tutorialDraftDefaults);
+        setTutorialData(draft);
+        loadCategories(fetchAllCategories)
+          .then((cats) => setCategories(cats))
+          .catch((err) => {
+            console.error(err);
+            setError(t("tutorials:detail.load_error"));
+          })
+          .finally(() => setLoading(false));
+        return;
+      }
     }
 
     const load = async () => {
       try {
         const [tutorial, cats] = await Promise.all([
-          fetchInstructorTutorialById(id),
+          fetchInstructorTutorialById(tutorialId),
           loadCategories(fetchAllCategories),
         ]);
         const formatted = tutorial?.data || tutorial || null;
@@ -73,19 +100,20 @@ export default function EditTutorialPage() {
         setCategories(cats);
       } catch (err) {
         console.error(err);
-        setError(t("tutorials:detail.load_error"));
+        setError(extractErrorMessage(err) ?? t("tutorials:detail.load_error"));
       } finally {
         setLoading(false);
       }
     };
+
     load();
-  }, [id]);
+  }, [tutorialId, t]);
 
   useEffect(() => {
-    if (tutorialData && id) {
-      saveDraft(`editTutorialDraft-${id}`, tutorialData);
+    if (tutorialData && tutorialId) {
+      saveDraft(`editTutorialDraft-${tutorialId}`, tutorialData);
     }
-  }, [tutorialData, id]);
+  }, [tutorialData, tutorialId]);
 
   const onNext = () => setStep((prev) => prev + 1);
   const onBack = () => setStep((prev) => prev - 1);
@@ -127,10 +155,11 @@ export default function EditTutorialPage() {
             onBack={onBack}
             actionLabel={t("dashboard:tutorialEditPage.save_changes")}
             onPublish={async () => {
+              if (!tutorialId) return;
               const formData = buildTutorialFormData(tutorialData);
 
               try {
-                await updateTutorial(id, formData);
+                await updateTutorial(tutorialId, formData);
                 toast.success(t("dashboard:tutorialEditPage.update_success"));
 
                 try {
@@ -144,12 +173,12 @@ export default function EditTutorialPage() {
                   });
                 } catch (err) {
                   console.error(err);
-                  toast.error('Failed to send notification or message');
+                  toast.error("Failed to send notification or message");
                 }
 
                 refreshNotifications?.();
                 refreshMessages?.();
-                localStorage.removeItem(`editTutorialDraft-${id}`);
+                localStorage.removeItem(`editTutorialDraft-${tutorialId}`);
                 router.push("/dashboard/instructor/tutorials");
               } catch (err) {
                 console.error(err);
@@ -170,5 +199,3 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
-
-

--- a/frontend/src/pages/dashboard/instructor/tutorials/create.tsx
+++ b/frontend/src/pages/dashboard/instructor/tutorials/create.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { fetchAllCategories } from "@/services/instructor/categoryService";
@@ -11,36 +12,47 @@ import StepProgressBar from "@/components/tutorials/create/StepProgressBar";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
-import useTutorialCreation from "@/hooks/useTutorialCreation";
+import {
+  buildTutorialFormData,
+  loadCategories,
+  loadDraft,
+  tutorialDraftDefaults,
+  type TutorialDraft,
+} from "@/utils/tutorialDraft";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const extractErrorMessage = (error: unknown): string | undefined => {
+  if (!isRecord(error) || !("response" in error)) {
+    return undefined;
+  }
+
+  const response = error.response;
+  if (!isRecord(response) || !("data" in response)) {
+    return undefined;
+  }
+
+  const data = response.data;
+  if (!isRecord(data) || typeof data.message !== "string") {
+    return undefined;
+  }
+
+  return data.message;
+};
 
 export default function CreateTutorialPage() {
   const router = useRouter();
   const { t } = useTranslation(["dashboard", "tutorials"]);
-  const defaultTutorial = {
-    title: "",
-    shortDescription: "",
-    category: "",
-    categoryName: "",
-    level: "",
-    language: "",
-    lessonCount: 1,
-    tags: [],
-    chapters: [],
-    thumbnail: null,
-    preview: null,
-    price: "",
-    currency: "",
-    isFree: false,
-  };
-  const [tutorialData, setTutorialData] = useState(() =>
-    loadDraft("tutorialDraft", defaultTutorial)
+  const [step, setStep] = useState(1);
+  const [tutorialData, setTutorialData] = useState<TutorialDraft>(() =>
+    loadDraft("tutorialDraft", tutorialDraftDefaults)
   );
-
-  const [categories, setCategories] = useState([]);
+  const [categories, setCategories] = useState<unknown[]>([]);
 
   useEffect(() => {
     loadCategories(fetchAllCategories)
-      .then((res) => setCategories(res?.data || res || []))
+      .then((res) => setCategories(res))
       .catch((err) => {
         console.error(
           t('tutorialCreatePage.load_categories_failed', { ns: 'dashboard' }),
@@ -52,7 +64,7 @@ export default function CreateTutorialPage() {
   const nextStep = () => setStep((prev) => prev + 1);
   const prevStep = () => setStep((prev) => prev - 1);
 
-  const submitTutorial = async (status) => {
+  const submitTutorial = async (status: "draft" | "published") => {
     if (tutorialData.chapters.some((ch) => !ch.videoUrl)) {
       toast.error(t("dashboard:tutorialCreatePage.upload_video_each_lesson"));
       return;
@@ -69,7 +81,10 @@ export default function CreateTutorialPage() {
       router.push("/dashboard/instructor/tutorials");
     } catch (err) {
       console.error(err);
-      toast.error(err.response?.data?.message || t("dashboard:tutorialCreatePage.failed_create"));
+      const message =
+        extractErrorMessage(err) ??
+        t("dashboard:tutorialCreatePage.failed_create");
+      toast.error(message);
     }
   };
 

--- a/frontend/src/utils/tutorialDraft.ts
+++ b/frontend/src/utils/tutorialDraft.ts
@@ -1,53 +1,175 @@
-interface DraftDefaults {
-  language?: string;
-  lessonCount?: number;
-  chapters?: unknown[];
+export interface ChapterDraft {
+  title: string;
+  duration: string | number;
+  video?: string | File | null;
+  videoUrl?: string;
+  preview: boolean;
   [key: string]: unknown;
 }
 
-export function loadDraft(key: string, defaults: DraftDefaults = {}) {
-  if (typeof window === 'undefined') return { ...defaults };
+export interface DraftDefaults {
+  language?: string;
+  lessonCount?: number;
+  chapters?: ChapterDraft[];
+  thumbnail?: File | string | null;
+  preview?: File | string | null;
+  [key: string]: unknown;
+}
+
+export interface TutorialDraft extends DraftDefaults {
+  title: string;
+  shortDescription: string;
+  category: string | number;
+  categoryName?: string;
+  level: string;
+  tags: string[];
+  chapters: ChapterDraft[];
+  thumbnail: File | string | null;
+  preview: File | string | null;
+  price: string;
+  currency: string;
+  isFree: boolean;
+  status?: string;
+  instructorId?: string | number;
+}
+
+export const tutorialDraftDefaults: TutorialDraft = {
+  title: '',
+  shortDescription: '',
+  category: '',
+  categoryName: '',
+  level: '',
+  language: '',
+  lessonCount: 1,
+  tags: [],
+  chapters: [],
+  thumbnail: null,
+  preview: null,
+  price: '',
+  currency: '',
+  isFree: false,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isDraftDefaults(value: unknown): value is DraftDefaults {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (
+    'language' in value &&
+    value.language !== undefined &&
+    typeof value.language !== 'string'
+  ) {
+    return false;
+  }
+
+  if (
+    'lessonCount' in value &&
+    value.lessonCount !== undefined &&
+    typeof value.lessonCount !== 'number'
+  ) {
+    return false;
+  }
+
+  if (
+    'chapters' in value &&
+    value.chapters !== undefined &&
+    !Array.isArray(value.chapters)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+const emptyDraft: DraftDefaults = {};
+
+export function loadDraft<T extends DraftDefaults>(key: string, defaults: T): T {
+  if (typeof window === 'undefined') {
+    return { ...defaults };
+  }
+
   const saved = localStorage.getItem(key);
-  if (!saved) return { ...defaults } as DraftDefaults;
+  if (!saved) {
+    return { ...defaults };
+  }
+
   try {
-    const draft = JSON.parse(saved) as DraftDefaults;
-    return {
-      ...defaults,
-      ...draft,
-      thumbnail: null,
-      preview: null,
-      language: draft?.language ?? defaults.language ?? '',
-      lessonCount:
-        draft?.lessonCount ??
-        draft?.chapters?.length ??
-        defaults.lessonCount ??
-        1,
-    } as TutorialDraftDefaults;
+    const parsed: unknown = JSON.parse(saved);
+    const draft = isDraftDefaults(parsed) ? parsed : emptyDraft;
+    const merged: T = { ...defaults };
+
+    Object.assign(merged, draft);
+
+    merged.thumbnail = null;
+    merged.preview = null;
+
+    const defaultLanguage =
+      typeof defaults.language === 'string' ? defaults.language : undefined;
+    const draftLanguage =
+      typeof draft.language === 'string' ? draft.language : undefined;
+    merged.language = draftLanguage ?? defaultLanguage ?? '';
+
+    const defaultLessonCount =
+      typeof defaults.lessonCount === 'number' ? defaults.lessonCount : undefined;
+    const draftLessonCount =
+      typeof draft.lessonCount === 'number' ? draft.lessonCount : undefined;
+    const chapterCount = Array.isArray(draft.chapters)
+      ? draft.chapters.length
+      : undefined;
+
+    merged.lessonCount =
+      draftLessonCount ?? chapterCount ?? defaultLessonCount ?? 1;
+
+    return merged;
   } catch (err) {
     console.error(`Failed to parse ${key}`, err);
     localStorage.removeItem(key);
-    return { ...defaults } as TutorialDraftDefaults;
+    return { ...defaults };
   }
 }
 
-export function saveDraft(key, data) {
+export function saveDraft<T>(key: string, data: T): void {
   if (typeof window === 'undefined') return;
   localStorage.setItem(key, JSON.stringify(data));
 }
 
-export async function loadCategories(fetchFn) {
-  const result = await fetchFn();
-  return result?.data || result || [];
+function hasDataArray(value: unknown): value is { data: unknown[] } {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return Array.isArray(value.data);
 }
 
-export function buildTutorialFormData(tutorialData, status) {
+export async function loadCategories(
+  fetchFn: () => Promise<unknown>
+): Promise<unknown[]> {
+  const result = await fetchFn();
+
+  if (hasDataArray(result)) {
+    return result.data;
+  }
+
+  return Array.isArray(result) ? result : [];
+}
+
+export function buildTutorialFormData(
+  tutorialData: TutorialDraft,
+  status?: string
+): FormData {
   const formData = new FormData();
   formData.append('title', tutorialData.title);
   formData.append('description', tutorialData.shortDescription);
-  formData.append('category_id', tutorialData.category);
+  formData.append('category_id', String(tutorialData.category ?? ''));
   formData.append('level', tutorialData.level);
   formData.append('language', tutorialData.language);
-  formData.append('status', status ?? tutorialData.status);
+  const resolvedStatus = status ?? tutorialData.status ?? '';
+  formData.append('status', resolvedStatus);
   formData.append('is_paid', (!tutorialData.isFree).toString());
   if (!tutorialData.isFree) {
     formData.append('price', tutorialData.price);
@@ -62,7 +184,7 @@ export function buildTutorialFormData(tutorialData, status) {
     const chapters = tutorialData.chapters.map((ch, idx) => ({
       title: ch.title,
       duration: ch.duration,
-      video_url: ch.videoUrl,
+      video_url: ch.videoUrl ?? '',
       order: idx + 1,
       is_preview: ch.preview,
     }));


### PR DESCRIPTION
## Summary
- update tutorial draft utilities to use generic typing and shared defaults while cleaning up form building helpers
- convert instructor tutorial creation and edit pages to TypeScript with typed draft loading and error handling
- convert admin tutorial edit page to TypeScript and ensure typed draft loading and persistence

## Testing
- `npm run lint` *(fails: existing project warnings/errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68c883c07334832886175c1e25da9719