### PR TITLE
Refine tutorial draft utility typing

### DIFF
--- a/frontend/src/utils/tutorialDraft.ts
+++ b/frontend/src/utils/tutorialDraft.ts
@@ -7,61 +7,149 @@ export interface TutorialChapterDraft {
   videoUrl?: string;
   preview: boolean;
 }
-interface TutorialDraftDefaults extends DraftDefaults {
+
+interface DraftDefaults extends Record<string, unknown> {
+  id?: number;
+  title?: string;
+  shortDescription?: string;
+  short_description?: string;
+  description?: string;
+  category?: string | number;
+  categoryId?: string | number;
+  category_id?: string | number;
+  categoryName?: string;
+  category_name?: string;
+  level?: string;
+  language?: string;
+  lessonCount?: number;
+  chapters?: unknown[];
   thumbnail?: File | string | null;
   preview?: File | string | null;
+  status?: string;
+  isFree?: boolean;
+  is_free?: boolean;
+  price?: string | number;
+  currency?: string;
+  currencyCode?: string;
+  currency_code?: string;
+  tags?: unknown[];
+  instructorId?: number;
+  instructor_id?: number;
 }
 
-export interface TutorialDraftDefaults extends DraftDefaults {
-  thumbnail: File | string | null;
-  preview: File | string | null;
+export interface TutorialDraft extends Record<string, unknown> {
+  id?: number;
+  title: string;
+  shortDescription: string;
+  description?: string;
+  category: string;
+  categoryName?: string;
+  level: string;
   language: string;
   lessonCount: number;
+  chapters: TutorialChapterDraft[];
+  thumbnail: File | string | null;
+  preview: File | string | null;
+  status?: string;
+  isFree: boolean;
+  price: string;
+  currency?: string;
+  tags: string[];
+  instructorId?: number;
 }
 
-function createTutorialDraft(
+export function createTutorialDraft(
   defaults: DraftDefaults = {},
   draft?: DraftDefaults
-): TutorialDraftDefaults {
-  const defaultThumbnail =
-    (defaults.thumbnail as File | string | null | undefined) ?? null;
-  const defaultPreview =
-    (defaults.preview as File | string | null | undefined) ?? null;
-  const defaultLanguage =
-    typeof defaults.language === 'string' ? defaults.language : '';
-  const defaultLessonCount =
-    typeof defaults.lessonCount === 'number' ? defaults.lessonCount : 1;
+): TutorialDraft {
+  const combined: DraftDefaults = { ...defaults, ...draft };
 
-  const draftThumbnail =
-    (draft?.thumbnail as File | string | null | undefined) ?? defaultThumbnail;
-  const draftPreview =
-    (draft?.preview as File | string | null | undefined) ?? defaultPreview;
-  const draftLanguage =
-    typeof draft?.language === 'string' ? draft.language : undefined;
-  const draftChaptersLength =
-    draft && Array.isArray(draft.chapters)
-      ? (draft.chapters as unknown[]).length
-      : undefined;
-  const draftLessonCount =
-    typeof draft?.lessonCount === 'number'
+  const thumbnail = resolveFileLike(draft?.thumbnail, defaults.thumbnail);
+  const preview = resolveFileLike(draft?.preview, defaults.preview);
+  const language = pickString(draft?.language, defaults.language) ?? "";
+  const chapters = pickChapters(draft?.chapters, defaults.chapters) ?? [];
+  const defaultLessonCount =
+    typeof defaults.lessonCount === "number" ? defaults.lessonCount : 1;
+  const lessonCount =
+    typeof draft?.lessonCount === "number"
       ? draft.lessonCount
-      : draftChaptersLength;
+      : chapters.length || defaultLessonCount;
+
+  const tags = pickTags(draft?.tags, defaults.tags) ?? [];
+
+  const title = pickString(draft?.title, defaults.title) ?? "";
+  const shortDescription =
+    pickString(
+      draft?.shortDescription,
+      draft?.short_description,
+      defaults.shortDescription,
+      defaults.short_description
+    ) ?? "";
+  const description = pickString(draft?.description, defaults.description);
+
+  const category = pickCategory(draft, defaults);
+  const categoryName =
+    pickString(
+      draft?.categoryName,
+      draft?.category_name,
+      defaults.categoryName,
+      defaults.category_name
+    ) ?? undefined;
+  const level = pickString(draft?.level, defaults.level) ?? "";
+  const status = pickString(draft?.status, defaults.status);
+
+  const isFree =
+    pickBoolean(
+      draft?.isFree,
+      draft?.is_free,
+      defaults.isFree,
+      defaults.is_free
+    ) ?? false;
+  const price = pickPrice(draft?.price, defaults.price);
+  const currency =
+    pickString(
+      draft?.currency,
+      draft?.currencyCode,
+      draft?.currency_code,
+      defaults.currency,
+      defaults.currencyCode,
+      defaults.currency_code
+    ) ?? undefined;
+
+  const instructorId = pickNumber(
+    draft?.instructorId,
+    draft?.instructor_id,
+    defaults.instructorId,
+    defaults.instructor_id
+  );
 
   return {
-    ...defaults,
-    ...draft,
-    thumbnail: draftThumbnail,
-    preview: draftPreview,
-    language: draftLanguage ?? defaultLanguage,
-    lessonCount: draftLessonCount ?? defaultLessonCount,
+    ...combined,
+    title,
+    shortDescription,
+    description,
+    category,
+    categoryName,
+    level,
+    language,
+    lessonCount,
+    chapters,
+    thumbnail,
+    preview,
+    status,
+    isFree,
+    price,
+    currency,
+    tags,
+    instructorId,
   };
 }
 
 export function loadDraft(
   key: string,
   defaults: DraftDefaults = {}
-): TutorialDraftDefaults {
-  if (typeof window === 'undefined') return createTutorialDraft(defaults);
+): TutorialDraft {
+  if (typeof window === "undefined") return createTutorialDraft(defaults);
   const saved = localStorage.getItem(key);
   if (!saved) return createTutorialDraft(defaults);
   try {
@@ -74,8 +162,8 @@ export function loadDraft(
   }
 }
 
-export function saveDraft(key: string, data: TutorialDraftDefaults): void {
-  if (typeof window === 'undefined') return;
+export function saveDraft(key: string, data: TutorialDraft): void {
+  if (typeof window === "undefined") return;
   localStorage.setItem(key, JSON.stringify(data));
 }
 
@@ -92,8 +180,14 @@ export function buildTutorialFormData(
 ): FormData {
   const formData = new FormData();
   formData.append("title", toStringValue(tutorialData.title, ""));
-  formData.append("description", toStringValue(tutorialData.shortDescription, ""));
-  formData.append("category_id", toStringValue(tutorialData.category, ""));
+  formData.append(
+    "description",
+    toStringValue(tutorialData.shortDescription, "")
+  );
+  formData.append(
+    "category_id",
+    toStringValue(tutorialData.category, "")
+  );
   formData.append("level", toStringValue(tutorialData.level, ""));
   formData.append("language", toStringValue(tutorialData.language, ""));
   if (status ?? tutorialData.status) {
@@ -128,4 +222,205 @@ export function buildTutorialFormData(
   }
 
   return formData;
+}
+
+function resolveFileLike(
+  primary?: File | string | null,
+  fallback?: File | string | null
+): File | string | null {
+  const candidates = [primary, fallback];
+  for (const candidate of candidates) {
+    if (isFileInstance(candidate) || typeof candidate === "string") {
+      return candidate;
+    }
+    if (candidate === null) {
+      return null;
+    }
+  }
+  return null;
+}
+
+function isFileInstance(value: unknown): value is File {
+  return typeof File !== "undefined" && value instanceof File;
+}
+
+function pickString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function pickNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function pickBoolean(...values: unknown[]): boolean | undefined {
+  for (const value of values) {
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true") return true;
+      if (normalized === "false") return false;
+    }
+  }
+  return undefined;
+}
+
+function pickPrice(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value.toString();
+    }
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return "";
+}
+
+function pickTags(
+  ...values: (unknown[] | undefined)[]
+): string[] | undefined {
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      return value
+        .map((tag) => {
+          if (typeof tag === "string") return tag;
+          if (tag && typeof tag === "object" && "name" in tag) {
+            const name = (tag as Record<string, unknown>).name;
+            return typeof name === "string" ? name : undefined;
+          }
+          return undefined;
+        })
+        .filter((tag): tag is string => typeof tag === "string");
+    }
+  }
+  return undefined;
+}
+
+function pickChapters(
+  ...values: (unknown[] | undefined)[]
+): TutorialChapterDraft[] | undefined {
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      return value.map((chapter, index) => normalizeChapter(chapter, index));
+    }
+  }
+  return undefined;
+}
+
+function normalizeChapter(
+  input: unknown,
+  index: number
+): TutorialChapterDraft {
+  if (!input || typeof input !== "object") {
+    return {
+      order: index + 1,
+      title: "",
+      duration: "",
+      video: null,
+      videoUrl: "",
+      preview: false,
+    };
+  }
+
+  const data = input as Record<string, unknown>;
+  const durationValue = data.duration;
+  const videoValue = data.video;
+
+  const videoUrl =
+    typeof data.videoUrl === "string"
+      ? data.videoUrl
+      : typeof data.video_url === "string"
+      ? data.video_url
+      : undefined;
+
+  return {
+    id: typeof data.id === "number" ? data.id : undefined,
+    order:
+      typeof data.order === "number"
+        ? data.order
+        : typeof data.position === "number"
+        ? data.position
+        : index + 1,
+    title: typeof data.title === "string" ? data.title : "",
+    duration:
+      typeof durationValue === "number" || typeof durationValue === "string"
+        ? durationValue
+        : "",
+    video:
+      typeof videoValue === "string"
+        ? videoValue
+        : videoValue === null
+        ? null
+        : undefined,
+    videoUrl,
+    preview:
+      typeof data.preview === "boolean"
+        ? data.preview
+        : typeof data.is_preview === "boolean"
+        ? data.is_preview
+        : false,
+  };
+}
+
+function pickCategory(
+  draft?: DraftDefaults,
+  defaults?: DraftDefaults
+): string {
+  const values = [
+    draft?.category,
+    draft?.categoryId,
+    draft?.category_id,
+    defaults?.category,
+    defaults?.categoryId,
+    defaults?.category_id,
+  ];
+
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value.toString();
+    }
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+function normalizePrice(value: unknown, fallback: string): string {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value.toString() : fallback;
+  }
+  if (typeof value === "string") {
+    const cleaned = value.trim();
+    if (!cleaned) return fallback;
+    const normalized = cleaned.replace(/[^0-9.]/g, "");
+    return normalized || fallback;
+  }
+  return fallback;
+}
+
+function toStringValue(value: unknown, fallback: string): string {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return fallback;
 }


### PR DESCRIPTION
## Summary
- replace the loose tutorial draft definitions with explicit DraftDefaults and TutorialDraft interfaces
- normalize draft creation, persistence and form data building to coerce values, merge defaults, and keep arrays consistent
- add reusable helpers for value coercion, chapter shaping, and local price/string utilities used by the form serializer

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c88d906fa88328b50af261c679c7e0