### PR TITLE
Ensure health API endpoint available in JavaScript

### DIFF
--- a/frontend/src/pages/api/health.js
+++ b/frontend/src/pages/api/health.js
@@ -1,0 +1,3 @@
+export default function handler(_req, res) {
+  res.status(200).json({ status: 'ok' });
+}

--- a/frontend/src/pages/api/health.ts
+++ b/frontend/src/pages/api/health.ts
@@ -1,8 +1,0 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-
-export default function handler(
-  _req: NextApiRequest,
-  res: NextApiResponse,
-) {
-  res.status(200).json({ status: 'ok' });
-}


### PR DESCRIPTION
## Summary
- replace the TypeScript health API route with a JavaScript implementation that returns HTTP 200

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c89cf1a6648328818903b335111f3e