### PR TITLE
Fix frontend/backend health checks for proxy environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,11 @@ services:
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
     command: ["sh", "-c", "./scripts/wait-for-db.sh && npx knex migrate:latest && node src/server.js"]
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:${BACKEND_PORT}/api/health"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl --noproxy '*' -fsS -o /dev/null http://127.0.0.1:${BACKEND_PORT}/api/health",
+        ]
       interval: 30s
       timeout: 30s
       retries: 3
@@ -103,7 +107,11 @@ services:
       HOST: 0.0.0.0
       NODE_ENV: production
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS -o /dev/null http://127.0.0.1:${PORT:-3000}/api/health"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl --noproxy '*' -fsS -o /dev/null http://127.0.0.1:${PORT:-3000}/api/health",
+        ]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
## Summary
- update the backend and frontend healthchecks to bypass any configured HTTP proxies so curl can reach the container-local services

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c8a40447cc83288f6355ab5edf53f5