### PR TITLE
Stabilize container health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,9 +68,16 @@ services:
       MAX_BLOG_IMAGE_BYTES: ${MAX_BLOG_IMAGE_BYTES}
       NODE_ENV: ${NODE_ENV}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      NO_PROXY: localhost,127.0.0.1,backend,frontend,db,redis,pgadmin,nginx
+      no_proxy: localhost,127.0.0.1,backend,frontend,db,redis,pgadmin,nginx
     command: ["sh", "-c", "./scripts/wait-for-db.sh && npx knex migrate:latest && node src/server.js"]
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:${BACKEND_PORT}/api/health"]
+      test:
+        - CMD-SHELL
+        - >-
+          curl --noproxy localhost,127.0.0.1 --fail --silent --show-error
+          --connect-timeout 5 --max-time 10
+          http://127.0.0.1:${BACKEND_PORT}/api/health
       interval: 30s
       timeout: 30s
       retries: 3
@@ -102,8 +109,15 @@ services:
       PORT: 3000
       HOST: 0.0.0.0
       NODE_ENV: production
+      NO_PROXY: localhost,127.0.0.1,backend,frontend,db,redis,pgadmin,nginx
+      no_proxy: localhost,127.0.0.1,backend,frontend,db,redis,pgadmin,nginx
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS -o /dev/null http://127.0.0.1:${PORT:-3000}/api/health"]
+      test:
+        - CMD-SHELL
+        - >-
+          curl --noproxy localhost,127.0.0.1 --fail --silent --show-error
+          --connect-timeout 5 --max-time 10
+          http://127.0.0.1:${PORT:-3000}/api/health
       interval: 30s
       timeout: 30s
       retries: 3

--- a/frontend/.env.production.expanded
+++ b/frontend/.env.production.expanded
@@ -1,3 +1,3 @@
 APP_DOMAIN=localhost
-NEXT_PUBLIC_API_BASE_URL=https://your-domain/api
-NEXT_PUBLIC_PGADMIN_URL=https://your-domain/pgadmin
+NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
+NEXT_PUBLIC_PGADMIN_URL=http://pgadmin:80


### PR DESCRIPTION
## Summary
- add explicit NO_PROXY/no_proxy settings so backend and frontend containers bypass proxies for internal service calls
- harden the backend and frontend curl health probes with timeouts and clearer failure output to avoid false unhealthy states
- align the default production env expansion file with the docker-compose network endpoints so the frontend talks to the backend service in the stack

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8a40447cc83288f6355ab5edf53f5