### PR TITLE
Improve frontend health check reliability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,9 +115,7 @@ services:
       test:
         - CMD-SHELL
         - >-
-          curl --noproxy localhost,127.0.0.1 --fail --silent --show-error
-          --connect-timeout 5 --max-time 10
-          http://127.0.0.1:${PORT:-3000}/api/health
+          node ./scripts/docker-healthcheck.mjs
       interval: 30s
       timeout: 30s
       retries: 3

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,6 +25,7 @@ FROM node:20-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache curl
 COPY frontend/package.json frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js ./
+COPY frontend/scripts ./scripts
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public

--- a/frontend/scripts/docker-healthcheck.mjs
+++ b/frontend/scripts/docker-healthcheck.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+const host = process.env.HEALTHCHECK_HOST ?? '127.0.0.1';
+const rawPort = process.env.PORT ?? '3000';
+const parsedPort = Number.parseInt(rawPort, 10);
+const port = Number.isFinite(parsedPort) ? parsedPort : 3000;
+const pathEnv = process.env.HEALTHCHECK_PATH ?? '/api/health';
+const normalizedPath = pathEnv.startsWith('/') ? pathEnv : `/${pathEnv}`;
+const timeoutEnv = process.env.HEALTHCHECK_TIMEOUT_MS ?? '8000';
+const parsedTimeout = Number.parseInt(timeoutEnv, 10);
+const timeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : 8000;
+const url = `http://${host}:${port}${normalizedPath}`;
+
+function exitWithError(message) {
+  if (message) {
+    console.error(message);
+  }
+  process.exit(1);
+}
+
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+try {
+  const response = await fetch(url, {
+    signal: controller.signal,
+    headers: {
+      'user-agent': 'skillbridge-frontend-healthcheck',
+      accept: 'application/json, text/plain;q=0.9, */*;q=0.8',
+    },
+  });
+
+  if (!response.ok) {
+    exitWithError(`Health check responded with HTTP ${response.status} ${response.statusText}`);
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    try {
+      const body = await response.json();
+      if (body && typeof body === 'object' && 'status' in body && body.status !== 'ok') {
+        exitWithError(`Unexpected health payload: ${JSON.stringify(body)}`);
+      }
+    } catch (error) {
+      exitWithError(`Failed to parse JSON health response: ${error.message}`);
+    }
+  } else {
+    // Ensure the body is fully read to avoid leaving the stream open.
+    await response.arrayBuffer();
+  }
+
+  clearTimeout(timeout);
+  process.exit(0);
+} catch (error) {
+  clearTimeout(timeout);
+  if (error.name === 'AbortError') {
+    exitWithError(`Health check timed out fetching ${url}`);
+  } else {
+    exitWithError(`Health check request failed: ${error.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add a Node-based health check script for the frontend container so we can see clear failure reasons and avoid curl issues
- include the health check script in the production image and invoke it from docker-compose

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8dbdad27c83289d0a9c552c21d54e