### PR TITLE
Sanitize optional database URLs in env config

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -31,7 +31,32 @@ const EnvSchema = z.object({
   ENABLE_INSTALL: z.coerce.boolean().default(false),
 });
 
-const env = EnvSchema.parse(process.env);
+const OPTIONAL_URL_ENV_VARS = [
+  'DATABASE_URL',
+  'PRODUCTION_DATABASE_URL',
+  'TEST_DATABASE_URL',
+  'REDIS_URL',
+];
+
+const normalizeOptionalUrl = (value) => (value === '' ? undefined : value);
+
+const createValidatedEnv = () => {
+  const modifiedEnv = { ...process.env };
+
+  OPTIONAL_URL_ENV_VARS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(modifiedEnv, key)) {
+      modifiedEnv[key] = normalizeOptionalUrl(modifiedEnv[key]);
+    }
+  });
+
+  const sanitizedEnv = EnvSchema.parse(modifiedEnv);
+
+  // Re-run validation after sanitizing optional URLs to ensure the final
+  // environment object still satisfies the schema.
+  return EnvSchema.parse(sanitizedEnv);
+};
+
+const env = createValidatedEnv();
 
 let FRONTEND_URL = env.FRONTEND_URL;
 if (FRONTEND_URL.startsWith('FRONTEND_URL=')) {

--- a/backend/tests/envConfig.test.js
+++ b/backend/tests/envConfig.test.js
@@ -1,0 +1,50 @@
+describe('environment configuration optional URLs', () => {
+  const envKeys = [
+    'NODE_ENV',
+    'DATABASE_URL',
+    'PRODUCTION_DATABASE_URL',
+    'JWT_SECRET',
+    'REFRESH_TOKEN_SECRET',
+    'SESSION_SECRET',
+  ];
+
+  let originalValues;
+
+  beforeEach(() => {
+    jest.resetModules();
+    originalValues = {};
+    envKeys.forEach((key) => {
+      originalValues[key] = process.env[key];
+    });
+  });
+
+  afterEach(() => {
+    envKeys.forEach((key) => {
+      if (originalValues[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalValues[key];
+      }
+    });
+    jest.resetModules();
+  });
+
+  it('treats empty optional database URLs as absent', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+    process.env.PRODUCTION_DATABASE_URL = '';
+    process.env.JWT_SECRET = 'jwt';
+    process.env.REFRESH_TOKEN_SECRET = 'refresh';
+    process.env.SESSION_SECRET = 'session';
+
+    let envConfig;
+    expect(() => {
+      envConfig = require('../src/config/env');
+    }).not.toThrow();
+
+    expect(envConfig.getDatabaseUrl('production')).toBe(
+      'postgres://user:pass@localhost:5432/db'
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- normalize optional database-related URL environment variables so empty strings are treated as undefined
- run the environment schema validation again after sanitizing the inputs
- add a regression test confirming empty optional database URLs no longer fail validation

## Testing
- npm test -- envConfig

------
https://chatgpt.com/codex/tasks/task_e_68c8f19c7c8c83289edf25e8e9edb261