### PR TITLE
Handle empty optional database URLs

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -31,7 +31,25 @@ const EnvSchema = z.object({
   ENABLE_INSTALL: z.coerce.boolean().default(false),
 });
 
-const env = EnvSchema.parse(process.env);
+const OPTIONAL_URL_KEYS = [
+  'DATABASE_URL',
+  'PRODUCTION_DATABASE_URL',
+  'TEST_DATABASE_URL',
+  'REDIS_URL',
+];
+
+const coerceEmptyStringToUndefined = (value) =>
+  value === '' ? undefined : value;
+
+const rawEnv = { ...process.env };
+
+OPTIONAL_URL_KEYS.forEach((key) => {
+  if (Object.prototype.hasOwnProperty.call(rawEnv, key)) {
+    rawEnv[key] = coerceEmptyStringToUndefined(rawEnv[key]);
+  }
+});
+
+const env = EnvSchema.parse(rawEnv);
 
 let FRONTEND_URL = env.FRONTEND_URL;
 if (FRONTEND_URL.startsWith('FRONTEND_URL=')) {

--- a/backend/tests/envConfig.test.js
+++ b/backend/tests/envConfig.test.js
@@ -1,0 +1,37 @@
+const ORIGINAL_ENV = process.env;
+
+describe('env config optional URL handling', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('allows optional database URLs to be empty strings', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'jwt-secret';
+    process.env.REFRESH_TOKEN_SECRET = 'refresh-secret';
+    process.env.SESSION_SECRET = 'session-secret';
+    process.env.POSTGRES_HOST = 'localhost';
+    process.env.POSTGRES_USER = 'postgres';
+    process.env.POSTGRES_PASSWORD = 'password';
+    process.env.POSTGRES_DB = 'skillbridge';
+    process.env.PRODUCTION_DATABASE_URL = '';
+    process.env.DATABASE_URL = '';
+    process.env.TEST_DATABASE_URL = '';
+    process.env.REDIS_URL = '';
+
+    const loadConfig = () => require('../src/config/env');
+
+    expect(loadConfig).not.toThrow();
+
+    const config = loadConfig();
+
+    expect(config.getDatabaseUrl('production')).toEqual(
+      'postgres://postgres:password@localhost:5432/skillbridge'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- treat optional database-related URL environment variables as undefined when set to an empty string before validation
- validate the sanitized environment configuration with the existing Zod schema
- add a Jest test verifying that empty strings on optional URLs do not trigger validation errors

## Testing
- npm test -- envConfig.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8f1b08db083288f37c1baeff782c5