### PR TITLE
Configure allowed origins environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -21,6 +21,7 @@ REDIS_URL=redis://redis:6379
 FRONTEND_URL=http://localhost:3000
 APP_DOMAIN=localhost
 COOKIE_DOMAIN=.localhost
+ALLOWED_ORIGINS=https://eduskillbridge.net,http://localhost:3000
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=development
 


### PR DESCRIPTION
## Summary
- set the `ALLOWED_ORIGINS` entry in the root `.env` so the Nginx container allows `https://eduskillbridge.net`

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c8f630ab7083289c2d3a96840d596f