### PR TITLE
Add production socket URL configuration

### DIFF
--- a/frontend/.env.production.expanded
+++ b/frontend/.env.production.expanded
@@ -1,3 +1,4 @@
 APP_DOMAIN=localhost
 NEXT_PUBLIC_API_BASE_URL=http://backend:5002/api
 NEXT_PUBLIC_PGADMIN_URL=http://pgadmin:80
+NEXT_PUBLIC_SOCKET_URL=wss://eduskillbridge.net


### PR DESCRIPTION
## Summary
- add the NEXT_PUBLIC_SOCKET_URL setting to the production env file so builds include the websocket endpoint

## Testing
- docker compose build frontend *(fails: docker not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f6301ca48328b8dce0e634bebe84