### PR TITLE
Set production database URL in env file

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ BACKEND_PORT=5002
 # DATABASE_URL and PRODUCTION_DATABASE_URL are optional. When omitted, the
 # backend will build a connection string using the POSTGRES_* values above.
 # DATABASE_URL=postgres://skillbridge_user:skillbridge_pass@db:5432/skillbridge_db
-# PRODUCTION_DATABASE_URL=postgres://skillbridge_user:skillbridge_pass@db:5432/skillbridge_db
+PRODUCTION_DATABASE_URL=postgres://skillbridge_user:skillbridge_pass@db:5432/skillbridge_db
 
 JWT_SECRET=devjwtsecret
 REFRESH_TOKEN_SECRET=devrefreshsecret


### PR DESCRIPTION
## Summary
- set `PRODUCTION_DATABASE_URL` in `.env` to the default Postgres connection string used by docker-compose

## Testing
- not run (Docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c94d316d5c8328a087aa8b58732468