### PR TITLE
Update frontend API base URL to internal backend

### DIFF
--- a/.env
+++ b/.env
@@ -31,7 +31,7 @@ SMTP_SECURE=false
 SMTP_USER=smtp_user
 SMTP_PASS=smtp_pass
 
-NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+NEXT_PUBLIC_API_BASE_URL=http://backend:${BACKEND_PORT}/api
 
 ENABLE_INSTALL=false
 INSTALL_API_ENABLED=false

--- a/frontend/.env.production.expanded
+++ b/frontend/.env.production.expanded
@@ -1,4 +1,4 @@
 APP_DOMAIN=eduskillbridge.net
-NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+NEXT_PUBLIC_API_BASE_URL=http://backend:${BACKEND_PORT}/api
 NEXT_PUBLIC_PGADMIN_URL=http://pgadmin:80
 NEXT_PUBLIC_SOCKET_URL=wss://eduskillbridge.net


### PR DESCRIPTION
## Summary
- point the frontend API base URL variables to the internal backend service address

## Testing
- not run (docker not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c958435f98832881548da32b02e031