### PR TITLE
Add test for health API endpoint

### DIFF
--- a/frontend/tests/health.test.js
+++ b/frontend/tests/health.test.js
@@ -1,0 +1,24 @@
+import handler from '../src/pages/api/health';
+
+describe('GET /api/health', () => {
+  it('responds with status ok', async () => {
+    const req = { method: 'GET' };
+    const res = {
+      statusCode: undefined,
+      jsonBody: undefined,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        this.jsonBody = payload;
+        return this;
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonBody).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest test to verify the /api/health endpoint returns the expected response

## Testing
- npm test -- --runTestsByPath tests/health.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c958035a9c83288a19b852be006599