### PR TITLE
Point frontend API base URL to internal backend

### DIFF
--- a/.env
+++ b/.env
@@ -31,7 +31,7 @@ SMTP_SECURE=false
 SMTP_USER=smtp_user
 SMTP_PASS=smtp_pass
 
-NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+NEXT_PUBLIC_API_BASE_URL=http://backend:${BACKEND_PORT}/api
 
 ENABLE_INSTALL=false
 INSTALL_API_ENABLED=false

--- a/frontend/.env.production.expanded
+++ b/frontend/.env.production.expanded
@@ -1,4 +1,4 @@
 APP_DOMAIN=eduskillbridge.net
-NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
+NEXT_PUBLIC_API_BASE_URL=http://backend:${BACKEND_PORT}/api
 NEXT_PUBLIC_PGADMIN_URL=http://pgadmin:80
 NEXT_PUBLIC_SOCKET_URL=wss://eduskillbridge.net


### PR DESCRIPTION
## Summary
- update the root .env and frontend .env.production.expanded files so the frontend uses the internal backend service URL

## Testing
- not run (docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c957fe5ff48328b0bf3da793bdd82c