### PR TITLE
Run frontend container as non-root user

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,5 +29,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /shared /shared
+RUN adduser -S app && chown -R app:app /app
 EXPOSE 3000
+USER app
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- create a system user for the production frontend image after installing dependencies and ensure `/app` is owned by it
- run the frontend container as the non-root `app` user for the production stage

## Testing
- not run (Docker CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c957f9a4a083288dda27bb99e904a4