### PR TITLE
Add progress feedback and error handling to installer UI

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -12,6 +12,24 @@
     <a href="/docs" class="text-blue-600 underline">Documentation</a>
   </nav>
   <h1 class="text-2xl font-bold mb-4">SkillBridge Installation</h1>
+  <div class="mb-4">
+    <div class="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
+      <div
+        id="progressBar"
+        class="bg-blue-500 h-full w-0 transition-all duration-300"
+        role="progressbar"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="0"
+      ></div>
+    </div>
+  </div>
+  <div
+    id="errorBox"
+    class="hidden mb-4 rounded border border-red-300 bg-red-50 p-3 text-red-700"
+    role="alert"
+    aria-live="polite"
+  ></div>
   <section id="step1" class="mb-8">
     <h2 class="text-xl font-semibold mb-2">Step 1: Prerequisite Check</h2>
     <button id="checkBtn" class="px-4 py-2 bg-blue-500 text-white rounded">Recheck</button>

--- a/install/install.js
+++ b/install/install.js
@@ -1,45 +1,67 @@
 const progressBar = document.getElementById('progressBar');
 const errorBox = document.getElementById('errorBox');
+const step2Section = document.getElementById('step2');
 
 function setProgress(p) {
-  progressBar.style.width = `${p}%`;
+  if (!progressBar) return;
+  const value = Number.isFinite(p) ? Math.max(0, Math.min(100, p)) : 0;
+  progressBar.style.width = `${value}%`;
+  progressBar.setAttribute('aria-valuenow', value.toString());
 }
 
 function showError(msg) {
+  if (!errorBox) return;
   errorBox.textContent = msg;
   errorBox.classList.remove('hidden');
 }
 
 function clearError() {
+  if (!errorBox) return;
   errorBox.textContent = '';
   errorBox.classList.add('hidden');
 }
 
 async function checkPrereqs() {
   const output = document.getElementById('prereqOutput');
+  if (!output) return;
+  clearError();
+  setProgress(5);
   output.textContent = 'Checking...';
   output.className = 'text-gray-600';
   try {
     const res = await fetch('/api/install/prereqs');
+    setProgress(20);
     if (res.status === 401 || res.status === 403) {
       alert('Please log in to continue.');
       output.textContent = 'Authentication required. Please log in.';
       output.classList.add('error');
+      showError('Authentication required. Please log in to continue.');
+      setProgress(0);
       return;
     }
     const data = await res.json();
+    setProgress(35);
     if (data.ok) {
       output.className = 'text-green-600';
       output.textContent = 'Success:\n' + (data.output || JSON.stringify(data, null, 2));
-      document.getElementById('step2').style.display = 'block';
+      if (step2Section) {
+        step2Section.style.display = 'block';
+      }
+      setProgress(50);
     } else {
       output.className = 'text-red-600';
       output.textContent = 'Error:\n' + (data.output || JSON.stringify(data, null, 2));
-      document.getElementById('step2').style.display = 'none';
+      if (step2Section) {
+        step2Section.style.display = 'none';
+      }
+      showError('Prerequisite check failed. Review the details below.');
+      setProgress(10);
     }
   } catch (err) {
     output.textContent = 'Error: ' + err.message;
     output.className = 'text-red-600';
+    showError(`Prerequisite check failed: ${err.message}`);
+    setProgress(10);
   }
 }
 
@@ -52,6 +74,9 @@ const installBtn = document.getElementById('installBtn');
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const out = document.getElementById('installOutput');
+  if (!out) return;
+  clearError();
+  setProgress(60);
   out.textContent = 'Running install...';
   out.className = 'text-gray-600';
   installBtn.disabled = true;
@@ -62,20 +87,38 @@ form.addEventListener('submit', async (e) => {
   try {
     const res = await fetch('/api/install/run', {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
     });
+    setProgress(80);
     if (res.status === 401 || res.status === 403) {
       alert('Please log in to continue.');
       out.textContent = 'Authentication required. Please log in.';
       out.classList.add('error');
+      showError('Authentication required. Please log in to continue.');
+      setProgress(60);
       return;
     }
     const data = await res.json();
     out.textContent = (data.ok ? 'Success:\n' : 'Error:\n') + (data.output || JSON.stringify(data, null, 2));
     out.className = data.ok ? 'text-green-600' : 'text-red-600';
+    if (data.ok) {
+      setProgress(100);
+    } else {
+      showError('Installation failed. Review the details below.');
+      setProgress(60);
+    }
   } catch (err) {
     out.textContent = 'Error: ' + err.message;
     out.className = 'text-red-600';
+    showError(`Installation failed: ${err.message}`);
+    setProgress(60);
   } finally {
     installBtn.disabled = false;
   }
 });
+
+setProgress(0);
+clearError();


### PR DESCRIPTION
## Summary
- add a progress bar and alert placeholder to the installer page
- update the installer script to drive progress updates and surface errors during prerequisite and install steps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c961c797588328bccea9d42ead875c