### PR TITLE
Support admin credential provisioning via installer

### DIFF
--- a/backend/scripts/create-admin.js
+++ b/backend/scripts/create-admin.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+const { z } = require('zod');
+const bcrypt = require('bcrypt');
+const db = require('../src/config/database');
+
+const CredentialsSchema = z.object({
+  email: z.string().trim().email(),
+  password: z.string().min(8),
+});
+
+async function ensureAdminRole(trx, now) {
+  await trx('roles')
+    .insert({
+      name: 'Admin',
+      description: 'Administrator with management privileges',
+      created_at: now,
+    })
+    .onConflict('name')
+    .ignore();
+
+  return trx('roles').where({ name: 'Admin' }).first();
+}
+
+async function upsertAdminUser(trx, email, hashedPassword, now) {
+  const existingUser = await trx('users')
+    .whereRaw('LOWER(email) = ?', [email.toLowerCase()])
+    .first();
+
+  if (existingUser) {
+    await trx('users')
+      .where({ id: existingUser.id })
+      .update({
+        password_hash: hashedPassword,
+        role: 'Admin',
+        status: 'active',
+        is_email_verified: true,
+        updated_at: now,
+      });
+    return existingUser.id;
+  }
+
+  const insertPayload = {
+    full_name: 'Admin User',
+    email,
+    phone: null,
+    password_hash: hashedPassword,
+    role: 'Admin',
+    avatar_url: null,
+    is_online: false,
+    status: 'active',
+    profile_complete: false,
+    is_email_verified: true,
+    is_phone_verified: false,
+    created_at: now,
+    updated_at: now,
+  };
+
+  const inserted = await trx('users').insert(insertPayload).returning('id');
+  const row = Array.isArray(inserted) ? inserted[0] : inserted;
+  if (row && typeof row === 'object' && 'id' in row) {
+    return row.id;
+  }
+  if (row) {
+    return row;
+  }
+  const created = await trx('users')
+    .whereRaw('LOWER(email) = ?', [email.toLowerCase()])
+    .first('id');
+  if (!created) {
+    throw new Error('Failed to determine created admin user id');
+  }
+  return created.id;
+}
+
+async function ensureAdminProfile(trx, userId, now) {
+  const existingProfile = await trx('admin_profiles')
+    .where({ user_id: userId })
+    .first();
+
+  const profileData = {
+    job_title: 'Administrator',
+    department: 'Management',
+    updated_at: now,
+  };
+
+  if (existingProfile) {
+    await trx('admin_profiles').where({ user_id: userId }).update(profileData);
+    return;
+  }
+
+  await trx('admin_profiles').insert({
+    user_id: userId,
+    ...profileData,
+    created_at: now,
+  });
+}
+
+async function ensureRoleAssignment(trx, userId, roleId) {
+  const existing = await trx('user_roles')
+    .where({ user_id: userId, role_id: roleId })
+    .first();
+  if (!existing) {
+    await trx('user_roles').insert({ user_id: userId, role_id: roleId });
+  }
+}
+
+async function main() {
+  const [emailArg, passwordArg] = process.argv.slice(2);
+  const credentials = CredentialsSchema.parse({
+    email: emailArg ?? process.env.ADMIN_EMAIL,
+    password: passwordArg ?? process.env.ADMIN_PASSWORD,
+  });
+
+  const now = new Date();
+  const hashedPassword = await bcrypt.hash(credentials.password, 12);
+
+  await db.transaction(async (trx) => {
+    const role = await ensureAdminRole(trx, now);
+    if (!role) {
+      throw new Error('Unable to locate Admin role');
+    }
+    const userId = await upsertAdminUser(trx, credentials.email, hashedPassword, now);
+    await ensureAdminProfile(trx, userId, now);
+    await ensureRoleAssignment(trx, userId, role.id ?? role);
+  });
+
+  console.log(`✅ Admin account provisioned for ${credentials.email}`);
+}
+
+main()
+  .catch((err) => {
+    console.error('Failed to provision admin account:', err.message || err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.destroy();
+  });

--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -9,12 +9,13 @@ const SAFE_SCRIPTS = {
   install: path.resolve(__dirname, '../../../../install.sh'),
 };
 
-const executeScript = (res, scriptKey) => {
+const executeScript = (res, scriptKey, options = {}) => {
   const script = SAFE_SCRIPTS[scriptKey];
   if (!script || !fs.existsSync(script)) {
     return res.status(400).json({ ok: false, output: 'Invalid script' });
   }
-  execFile(script, { shell: false }, (error, stdout, stderr) => {
+  const env = options.env ? { ...process.env, ...options.env } : process.env;
+  execFile(script, { shell: false, env }, (error, stdout, stderr) => {
     const output = stdout + stderr;
     if (error) {
       return res.status(500).json({ ok: false, output });
@@ -24,4 +25,10 @@ const executeScript = (res, scriptKey) => {
 };
 
 exports.checkPrereqs = (req, res) => executeScript(res, 'prereqs');
-exports.runInstall = (req, res) => executeScript(res, 'install');
+exports.runInstall = (req, res) =>
+  executeScript(res, 'install', {
+    env: {
+      ADMIN_EMAIL: req.body.adminEmail,
+      ADMIN_PASSWORD: req.body.adminPassword,
+    },
+  });

--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -18,9 +18,17 @@ router.use(requireInstallApiEnabled);
 // Require an authenticated administrator for all install endpoints.
 router.use(verifyToken, isAdmin);
 
-// No input is accepted for these endpoints; validate empty payloads strictly.
+// No input is accepted for the prereqs endpoint; validate empty payloads strictly.
 const emptySchema = z.object({}).strict();
+
+const installSchema = z
+  .object({
+    adminEmail: z.string().trim().email(),
+    adminPassword: z.string().min(8),
+  })
+  .strict();
+
 router.get('/prereqs', validate({ query: emptySchema }), controller.checkPrereqs);
-router.post('/run', validate({ body: emptySchema }), controller.runInstall);
+router.post('/run', validate({ body: installSchema }), controller.runInstall);
 
 module.exports = { requireInstallApiEnabled, router };

--- a/install.sh
+++ b/install.sh
@@ -8,19 +8,30 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 MODE=${1:-}
 DOMAIN=${2:-}
+ADMIN_EMAIL="${ADMIN_EMAIL:-}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-}"
 
 if [[ -z "$MODE" ]]; then
-  echo "Welcome to the SkillBridge installation wizard."
-  read -rp "Choose mode ([d]evelopment/[p]roduction) [development]: " MODE_INPUT
-  case "$MODE_INPUT" in
-    ""|d|development) MODE=development ;;
-    p|production) MODE=production ;;
-    *) echo "Invalid selection: $MODE_INPUT" >&2; exit 1 ;;
-  esac
+  if [[ -t 0 ]]; then
+    echo "Welcome to the SkillBridge installation wizard."
+    read -rp "Choose mode ([d]evelopment/[p]roduction) [development]: " MODE_INPUT
+    case "$MODE_INPUT" in
+      ""|d|development) MODE=development ;;
+      p|production) MODE=production ;;
+      *) echo "Invalid selection: $MODE_INPUT" >&2; exit 1 ;;
+    esac
+  else
+    MODE=development
+  fi
 fi
 
 if [[ "$MODE" == "production" && -z "$DOMAIN" ]]; then
-  read -rp "Enter domain (e.g., example.com): " DOMAIN
+  if [[ -t 0 ]]; then
+    read -rp "Enter domain (e.g., example.com): " DOMAIN
+  else
+    echo "Domain is required for production" >&2
+    exit 1
+  fi
 fi
 
 if [[ "$MODE" == "production" ]]; then
@@ -34,3 +45,27 @@ if [[ "$MODE" == "production" ]]; then
 else
   echo "Running in development mode; no deployment actions performed."
 fi
+
+if [[ -z "$ADMIN_EMAIL" ]]; then
+  if [[ -t 0 ]]; then
+    read -rp "Enter admin email: " ADMIN_EMAIL
+  else
+    echo "ADMIN_EMAIL must be provided when running non-interactively." >&2
+    exit 1
+  fi
+fi
+
+if [[ -z "$ADMIN_PASSWORD" ]]; then
+  if [[ -t 0 ]]; then
+    read -rsp "Enter admin password: " ADMIN_PASSWORD
+    echo
+  else
+    echo "ADMIN_PASSWORD must be provided when running non-interactively." >&2
+    exit 1
+  fi
+fi
+
+export ADMIN_EMAIL ADMIN_PASSWORD
+
+echo "Provisioning initial admin account..."
+node "$SCRIPT_DIR/backend/scripts/create-admin.js"

--- a/install/install.js
+++ b/install/install.js
@@ -62,6 +62,11 @@ form.addEventListener('submit', async (e) => {
   try {
     const res = await fetch('/api/install/run', {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(payload),
     });
     if (res.status === 401 || res.status === 403) {
       alert('Please log in to continue.');


### PR DESCRIPTION
## Summary
- send the installer form payload to the backend as JSON
- validate admin credentials on the /api/install/run endpoint and forward them to the shell installer
- extend install.sh and add a provisioning script to create or update the initial admin account

## Testing
- npm test -- --runTestsByPath tests/installRoutes.test.js *(fails: specified test file does not exist in repository)*
- npm test *(fails: numerous suites require secrets like JWT/SESSION values in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c961b852148328b6abf871fe05f18f