### PR TITLE
Add JSON prerequisite reporting for installer UI

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -9,19 +9,49 @@ const SAFE_SCRIPTS = {
   install: path.resolve(__dirname, '../../../../install.sh'),
 };
 
-const executeScript = (res, scriptKey) => {
+const executeScript = (res, scriptKey, options = {}) => {
   const script = SAFE_SCRIPTS[scriptKey];
   if (!script || !fs.existsSync(script)) {
     return res.status(400).json({ ok: false, output: 'Invalid script' });
   }
+
   execFile(script, { shell: false }, (error, stdout, stderr) => {
-    const output = stdout + stderr;
+    const trimmedStdout = stdout ? stdout.trim() : '';
+    const trimmedStderr = stderr ? stderr.trim() : '';
+
+    if (options.expectJson) {
+      const rawForParsing = trimmedStdout || trimmedStderr;
+      if (rawForParsing) {
+        try {
+          const parsed = JSON.parse(trimmedStdout || rawForParsing);
+          const ok = options.evaluateOk ? options.evaluateOk(parsed, error) : !error;
+          const statusCode = options.determineStatusCode
+            ? options.determineStatusCode(ok, error)
+            : error && ok
+              ? 500
+              : 200;
+          return res.status(statusCode).json({ ok, output: parsed });
+        } catch (parseError) {
+          const fallback = rawForParsing || (error ? error.message : '');
+          return res.status(500).json({ ok: false, output: fallback || 'Invalid JSON output.' });
+        }
+      }
+
+      return res.status(500).json({ ok: false, output: 'No output received from script.' });
+    }
+
+    const output = (stdout + stderr).trim();
     if (error) {
-      return res.status(500).json({ ok: false, output });
+      return res.status(500).json({ ok: false, output: output || error.message });
     }
     res.json({ ok: true, output });
   });
 };
 
-exports.checkPrereqs = (req, res) => executeScript(res, 'prereqs');
+exports.checkPrereqs = (req, res) =>
+  executeScript(res, 'prereqs', {
+    expectJson: true,
+    evaluateOk: (parsed) => Boolean(parsed && parsed.allPassed),
+    determineStatusCode: () => 200,
+  });
 exports.runInstall = (req, res) => executeScript(res, 'install');

--- a/install/install.js
+++ b/install/install.js
@@ -1,5 +1,6 @@
 const progressBar = document.getElementById('progressBar');
 const errorBox = document.getElementById('errorBox');
+const step2 = document.getElementById('step2');
 
 function setProgress(p) {
   progressBar.style.width = `${p}%`;
@@ -15,31 +16,92 @@ function clearError() {
   errorBox.classList.add('hidden');
 }
 
+function renderChecklist(output, results, allPassed) {
+  const requirements = [
+    { key: 'node', label: 'Node.js (v18+)' },
+    { key: 'docker', label: 'Docker' },
+    { key: 'dockerCompose', label: 'Docker Compose' },
+    { key: 'git', label: 'Git' },
+  ];
+
+  if (typeof output.replaceChildren === 'function') {
+    output.replaceChildren();
+  } else {
+    while (output.firstChild) {
+      output.removeChild(output.firstChild);
+    }
+  }
+  output.className = 'mt-2 whitespace-pre-wrap';
+  output.setAttribute('role', 'list');
+
+  requirements.forEach((req) => {
+    const status = (results && results[req.key]) || {};
+    const passed = Boolean(status.passed);
+
+    const item = document.createElement('span');
+    item.classList.add('block', 'leading-6');
+    item.setAttribute('role', 'listitem');
+
+    const icon = document.createElement('span');
+    icon.className = `${passed ? 'text-green-600' : 'text-red-600'} font-bold mr-2`;
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = passed ? '✔' : '✖';
+
+    const label = document.createElement('span');
+    label.classList.add('font-semibold');
+    label.textContent = req.label;
+
+    const message = document.createElement('span');
+    message.classList.add('ml-2', 'text-gray-700');
+    message.textContent =
+      status.message || (passed ? 'Requirement satisfied.' : 'Requirement missing.');
+
+    item.append(icon, label, message);
+    output.appendChild(item);
+  });
+
+  const summary = document.createElement('span');
+  summary.classList.add('block', 'mt-3', 'font-semibold', allPassed ? 'text-green-600' : 'text-red-600');
+  summary.textContent = allPassed
+    ? 'All prerequisites are satisfied.'
+    : 'Please address the missing prerequisites before continuing.';
+  output.appendChild(summary);
+}
+
 async function checkPrereqs() {
   const output = document.getElementById('prereqOutput');
+  output.removeAttribute('role');
   output.textContent = 'Checking...';
   output.className = 'text-gray-600';
+  step2.style.display = 'none';
   try {
     const res = await fetch('/api/install/prereqs');
     if (res.status === 401 || res.status === 403) {
       alert('Please log in to continue.');
       output.textContent = 'Authentication required. Please log in.';
       output.classList.add('error');
+      step2.style.display = 'none';
       return;
     }
     const data = await res.json();
-    if (data.ok) {
-      output.className = 'text-green-600';
-      output.textContent = 'Success:\n' + (data.output || JSON.stringify(data, null, 2));
-      document.getElementById('step2').style.display = 'block';
+    const results =
+      data && data.output && typeof data.output === 'object' ? data.output : null;
+    const allPassed = Boolean(data && data.ok);
+    if (results) {
+      renderChecklist(output, results, allPassed);
     } else {
-      output.className = 'text-red-600';
-      output.textContent = 'Error:\n' + (data.output || JSON.stringify(data, null, 2));
-      document.getElementById('step2').style.display = 'none';
+      output.className = allPassed ? 'text-green-600' : 'text-red-600';
+      const fallback = data && data.output ? data.output : data;
+      const formattedFallback =
+        typeof fallback === 'string' ? fallback : JSON.stringify(fallback, null, 2);
+      output.textContent = (allPassed ? 'Success:\n' : 'Error:\n') + formattedFallback;
     }
+    step2.style.display = allPassed ? 'block' : 'none';
   } catch (err) {
+    output.removeAttribute('role');
     output.textContent = 'Error: ' + err.message;
     output.className = 'text-red-600';
+    step2.style.display = 'none';
   }
 }
 

--- a/scripts/check_prereqs.sh
+++ b/scripts/check_prereqs.sh
@@ -1,37 +1,100 @@
 #!/usr/bin/env bash
 set -e
 
+json_escape() {
+  local str="$1"
+  str=${str//\\/\\\\}
+  str=${str//"/\\"}
+  str=${str//$'\n'/\\n}
+  str=${str//$'\r'/\\r}
+  str=${str//$'\t'/\\t}
+  printf '%s' "$str"
+}
+
+all_passed=true
+
 # Verify Node.js
-if ! command -v node >/dev/null 2>&1; then
-  echo "Node.js is required. Please install Node.js 18 or newer." >&2
-  exit 1
+node_passed=false
+node_message="Node.js is required. Please install Node.js 18 or newer."
+if command -v node >/dev/null 2>&1; then
+  NODE_VERSION=$(node -v)
+  NODE_MAJOR=$(printf '%s' "$NODE_VERSION" | sed -E 's/^v([0-9]+).*/\1/')
+  if [ "$NODE_MAJOR" -ge 18 ]; then
+    node_passed=true
+    node_message="Node.js ${NODE_VERSION} detected."
+  else
+    node_message="Node.js version 18 or higher is required. Current version: ${NODE_VERSION}."
+  fi
 fi
-NODE_MAJOR=$(node -v | sed -E 's/^v([0-9]+).*/\1/')
-if [ "$NODE_MAJOR" -lt 18 ]; then
-  echo "Node.js version 18 or higher is required. Current version: $(node -v)" >&2
-  exit 1
+if [ "$node_passed" != true ]; then
+  all_passed=false
 fi
 
 # Verify Docker
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Docker is required. Please install Docker." >&2
-  exit 1
+docker_passed=false
+docker_message="Docker is required. Please install Docker."
+if command -v docker >/dev/null 2>&1; then
+  docker_passed=true
+  docker_version=$(docker --version 2>/dev/null | head -n 1)
+  if [ -n "$docker_version" ]; then
+    docker_message="$docker_version"
+  else
+    docker_message="Docker is installed."
+  fi
+fi
+if [ "$docker_passed" != true ]; then
+  all_passed=false
 fi
 
 # Verify Docker Compose
+docker_compose_passed=false
+docker_compose_message="Docker Compose is required. Please install Docker Compose."
 if command -v docker-compose >/dev/null 2>&1; then
-  :
+  docker_compose_passed=true
+  docker_compose_version=$(docker-compose --version 2>/dev/null | head -n 1)
+  if [ -n "$docker_compose_version" ]; then
+    docker_compose_message="$docker_compose_version"
+  else
+    docker_compose_message="Docker Compose is installed."
+  fi
 elif docker compose version >/dev/null 2>&1; then
-  :
-else
-  echo "Docker Compose is required. Please install Docker Compose." >&2
-  exit 1
+  docker_compose_passed=true
+  docker_compose_version=$(docker compose version 2>/dev/null | head -n 1)
+  if [ -n "$docker_compose_version" ]; then
+    docker_compose_message="$docker_compose_version"
+  else
+    docker_compose_message="Docker Compose (via docker CLI) is available."
+  fi
+fi
+if [ "$docker_compose_passed" != true ]; then
+  all_passed=false
 fi
 
 # Verify Git
-if ! command -v git >/dev/null 2>&1; then
-  echo "Git is required. Please install Git." >&2
-  exit 1
+git_passed=false
+git_message="Git is required. Please install Git."
+if command -v git >/dev/null 2>&1; then
+  git_passed=true
+  git_version=$(git --version 2>/dev/null | head -n 1)
+  if [ -n "$git_version" ]; then
+    git_message="$git_version"
+  else
+    git_message="Git is installed."
+  fi
+fi
+if [ "$git_passed" != true ]; then
+  all_passed=false
 fi
 
-echo "All prerequisites met."
+node_message_escaped=$(json_escape "$node_message")
+docker_message_escaped=$(json_escape "$docker_message")
+docker_compose_message_escaped=$(json_escape "$docker_compose_message")
+git_message_escaped=$(json_escape "$git_message")
+
+printf '{\n'
+printf '  "node": {"passed": %s, "message": "%s"},\n' "$node_passed" "$node_message_escaped"
+printf '  "docker": {"passed": %s, "message": "%s"},\n' "$docker_passed" "$docker_message_escaped"
+printf '  "dockerCompose": {"passed": %s, "message": "%s"},\n' "$docker_compose_passed" "$docker_compose_message_escaped"
+printf '  "git": {"passed": %s, "message": "%s"},\n' "$git_passed" "$git_message_escaped"
+printf '  "allPassed": %s\n' "$all_passed"
+printf '}\n'


### PR DESCRIPTION
## Summary
- update the prerequisite check script to report per-requirement status in JSON
- parse prerequisite JSON in the install controller so the API forwards structured data
- render a colored checklist in the installer UI based on the reported prerequisite results

## Testing
- scripts/check_prereqs.sh

------
https://chatgpt.com/codex/tasks/task_e_68c961b9118c8328a51b4bd7e34e8083