### PR TITLE
Add progress and error UI feedback to installer

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -12,6 +12,24 @@
     <a href="/docs" class="text-blue-600 underline">Documentation</a>
   </nav>
   <h1 class="text-2xl font-bold mb-4">SkillBridge Installation</h1>
+  <div class="mb-6 space-y-3">
+    <div class="w-full bg-gray-200 rounded-full h-2 overflow-hidden" aria-hidden="true">
+      <div
+        id="progressBar"
+        class="h-2 bg-blue-500 transition-all duration-300"
+        role="progressbar"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="0"
+        style="width: 0%;"
+      ></div>
+    </div>
+    <div
+      id="errorBox"
+      class="hidden rounded border border-red-300 bg-red-50 p-3 text-red-700"
+      role="alert"
+    ></div>
+  </div>
   <section id="step1" class="mb-8">
     <h2 class="text-xl font-semibold mb-2">Step 1: Prerequisite Check</h2>
     <button id="checkBtn" class="px-4 py-2 bg-blue-500 text-white rounded">Recheck</button>

--- a/install/install.js
+++ b/install/install.js
@@ -2,15 +2,20 @@ const progressBar = document.getElementById('progressBar');
 const errorBox = document.getElementById('errorBox');
 
 function setProgress(p) {
-  progressBar.style.width = `${p}%`;
+  if (!progressBar) return;
+  const clamped = Math.max(0, Math.min(100, p));
+  progressBar.style.width = `${clamped}%`;
+  progressBar.setAttribute('aria-valuenow', String(clamped));
 }
 
 function showError(msg) {
+  if (!errorBox) return;
   errorBox.textContent = msg;
   errorBox.classList.remove('hidden');
 }
 
 function clearError() {
+  if (!errorBox) return;
   errorBox.textContent = '';
   errorBox.classList.add('hidden');
 }
@@ -19,12 +24,16 @@ async function checkPrereqs() {
   const output = document.getElementById('prereqOutput');
   output.textContent = 'Checking...';
   output.className = 'text-gray-600';
+  clearError();
+  setProgress(10);
   try {
     const res = await fetch('/api/install/prereqs');
     if (res.status === 401 || res.status === 403) {
       alert('Please log in to continue.');
       output.textContent = 'Authentication required. Please log in.';
       output.classList.add('error');
+      setProgress(0);
+      showError('Please log in to continue.');
       return;
     }
     const data = await res.json();
@@ -32,14 +41,20 @@ async function checkPrereqs() {
       output.className = 'text-green-600';
       output.textContent = 'Success:\n' + (data.output || JSON.stringify(data, null, 2));
       document.getElementById('step2').style.display = 'block';
+      setProgress(50);
+      clearError();
     } else {
       output.className = 'text-red-600';
       output.textContent = 'Error:\n' + (data.output || JSON.stringify(data, null, 2));
       document.getElementById('step2').style.display = 'none';
+      setProgress(0);
+      showError('Prerequisite check failed. Review the output below.');
     }
   } catch (err) {
     output.textContent = 'Error: ' + err.message;
     output.className = 'text-red-600';
+    setProgress(0);
+    showError('Error checking prerequisites: ' + err.message);
   }
 }
 
@@ -55,6 +70,8 @@ form.addEventListener('submit', async (e) => {
   out.textContent = 'Running install...';
   out.className = 'text-gray-600';
   installBtn.disabled = true;
+  clearError();
+  setProgress(75);
   const payload = {
     adminEmail: form.adminEmail.value,
     adminPassword: form.adminPassword.value,
@@ -67,14 +84,25 @@ form.addEventListener('submit', async (e) => {
       alert('Please log in to continue.');
       out.textContent = 'Authentication required. Please log in.';
       out.classList.add('error');
+      setProgress(50);
+      showError('Please log in to continue.');
       return;
     }
     const data = await res.json();
     out.textContent = (data.ok ? 'Success:\n' : 'Error:\n') + (data.output || JSON.stringify(data, null, 2));
     out.className = data.ok ? 'text-green-600' : 'text-red-600';
+    if (data.ok) {
+      setProgress(100);
+      clearError();
+    } else {
+      setProgress(50);
+      showError('Installation failed. Review the log below.');
+    }
   } catch (err) {
     out.textContent = 'Error: ' + err.message;
     out.className = 'text-red-600';
+    setProgress(50);
+    showError('Error running install: ' + err.message);
   } finally {
     installBtn.disabled = false;
   }


### PR DESCRIPTION
## Summary
- add Tailwind-based progress bar and error box near the installer steps
- enhance installer script to drive the new UI elements for progress and errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c961c0013c8328b35b8973ee90bc7a