### PR TITLE
Revamp installer flow with interactive stepper

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -6,32 +6,176 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="p-4 font-sans">
-  <nav class="mb-4 space-x-4">
-    <a href="/" class="text-blue-600 underline">Main Site</a>
-    <a href="/docs" class="text-blue-600 underline">Documentation</a>
-  </nav>
-  <h1 class="text-2xl font-bold mb-4">SkillBridge Installation</h1>
-  <section id="step1" class="mb-8">
-    <h2 class="text-xl font-semibold mb-2">Step 1: Prerequisite Check</h2>
-    <button id="checkBtn" class="px-4 py-2 bg-blue-500 text-white rounded">Recheck</button>
-    <pre id="prereqOutput" class="mt-2"></pre>
-  </section>
-  <section id="step2" style="display: none;" class="mb-8">
-    <h2 class="text-xl font-semibold mb-2">Step 2: Configuration</h2>
-    <form id="configForm" class="space-y-4">
-      <label class="block">
-        <span class="block">Admin Email</span>
-        <input type="email" name="adminEmail" required class="border p-2 w-full" />
-      </label>
-      <label class="block">
-        <span class="block">Admin Password</span>
-        <input type="password" name="adminPassword" required class="border p-2 w-full" />
-      </label>
-      <button type="submit" id="installBtn" class="px-4 py-2 bg-green-600 text-white rounded">Run Install</button>
-    </form>
-    <pre id="installOutput" class="mt-2"></pre>
-  </section>
+<body class="min-h-screen bg-slate-50 p-6 font-sans text-slate-800">
+  <div class="mx-auto flex max-w-4xl flex-col gap-6">
+    <nav class="flex flex-wrap items-center gap-4 text-sm text-blue-600">
+      <a href="/" class="transition hover:text-blue-800">Main Site</a>
+      <a href="/docs" class="transition hover:text-blue-800">Documentation</a>
+    </nav>
+    <header class="space-y-2">
+      <h1 class="text-3xl font-bold text-slate-900">SkillBridge Installation</h1>
+      <p class="text-sm text-slate-600">
+        Follow the guided steps to verify prerequisites, configure your admin account, and run the automated installer.
+      </p>
+    </header>
+    <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div id="stepper" class="space-y-8">
+        <div class="flex flex-wrap items-center justify-between gap-4">
+          <div
+            class="step-item flex flex-col items-center gap-2 text-center text-sm transition-all duration-300"
+            data-step-index="0"
+            role="button"
+            tabindex="0"
+            aria-disabled="false"
+          >
+            <span
+              class="step-circle flex h-10 w-10 items-center justify-center rounded-full border-2 font-semibold transition-all duration-300"
+            >
+              1
+            </span>
+            <span class="step-label text-xs uppercase tracking-wide text-slate-500 transition-colors duration-300">
+              Prerequisites
+            </span>
+          </div>
+          <div
+            class="hidden h-1 flex-1 rounded bg-slate-200 transition-colors duration-300 sm:block"
+            data-step-connector="0"
+            aria-hidden="true"
+          ></div>
+          <div
+            class="step-item flex flex-col items-center gap-2 text-center text-sm transition-all duration-300"
+            data-step-index="1"
+            role="button"
+            tabindex="-1"
+            aria-disabled="true"
+          >
+            <span
+              class="step-circle flex h-10 w-10 items-center justify-center rounded-full border-2 font-semibold transition-all duration-300"
+            >
+              2
+            </span>
+            <span class="step-label text-xs uppercase tracking-wide text-slate-500 transition-colors duration-300">
+              Configuration
+            </span>
+          </div>
+          <div
+            class="hidden h-1 flex-1 rounded bg-slate-200 transition-colors duration-300 sm:block"
+            data-step-connector="1"
+            aria-hidden="true"
+          ></div>
+          <div
+            class="step-item flex flex-col items-center gap-2 text-center text-sm transition-all duration-300"
+            data-step-index="2"
+            role="button"
+            tabindex="-1"
+            aria-disabled="true"
+          >
+            <span
+              class="step-circle flex h-10 w-10 items-center justify-center rounded-full border-2 font-semibold transition-all duration-300"
+            >
+              3
+            </span>
+            <span class="step-label text-xs uppercase tracking-wide text-slate-500 transition-colors duration-300">
+              Installation
+            </span>
+          </div>
+        </div>
+        <div id="stepPanels" class="relative overflow-hidden transition-all duration-500">
+          <section
+            class="step-panel relative transform opacity-100 transition-all duration-500 ease-in-out"
+            data-panel-index="0"
+          >
+            <div class="rounded-xl bg-slate-50 p-6 ring-1 ring-slate-200 shadow-sm">
+              <h2 class="text-xl font-semibold text-slate-900">Prerequisite Check</h2>
+              <p class="mt-2 text-sm text-slate-600">
+                We will verify that Docker, PostgreSQL, and the required runtime dependencies are available before installation begins.
+              </p>
+              <div class="mt-4 flex flex-wrap items-center gap-3">
+                <button
+                  id="checkBtn"
+                  type="button"
+                  class="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                >
+                  Recheck prerequisites
+                </button>
+                <span class="text-xs text-slate-500">
+                  Run this step anytime you update your environment.
+                </span>
+              </div>
+              <pre
+                id="prereqOutput"
+                aria-live="polite"
+                class="mt-4 min-h-[120px] w-full whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm leading-relaxed text-slate-600 transition-colors"
+              >Waiting to run the prerequisite check.</pre>
+            </div>
+          </section>
+          <section
+            class="step-panel absolute inset-0 transform opacity-0 transition-all duration-500 ease-in-out"
+            data-panel-index="1"
+          >
+            <div class="rounded-xl bg-slate-50 p-6 ring-1 ring-slate-200 shadow-sm">
+              <h2 class="text-xl font-semibold text-slate-900">Configuration</h2>
+              <p class="mt-2 text-sm text-slate-600">
+                Provide the administrator credentials that will be created during installation.
+              </p>
+              <form id="configForm" class="mt-6 space-y-5">
+                <label class="block text-left text-sm font-medium text-slate-700">
+                  <span class="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">Admin Email</span>
+                  <input
+                    type="email"
+                    name="adminEmail"
+                    required
+                    autocomplete="email"
+                    class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  />
+                </label>
+                <label class="block text-left text-sm font-medium text-slate-700">
+                  <span class="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">Admin Password</span>
+                  <input
+                    type="password"
+                    name="adminPassword"
+                    required
+                    autocomplete="new-password"
+                    class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  />
+                </label>
+                <div class="flex justify-end">
+                  <button
+                    type="submit"
+                    id="installBtn"
+                    class="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Start installation
+                  </button>
+                </div>
+              </form>
+            </div>
+          </section>
+          <section
+            class="step-panel absolute inset-0 transform opacity-0 transition-all duration-500 ease-in-out"
+            data-panel-index="2"
+          >
+            <div class="rounded-xl bg-slate-50 p-6 ring-1 ring-slate-200 shadow-sm">
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <h2 class="text-xl font-semibold text-slate-900">Installation Progress</h2>
+                <p id="installStatus" aria-live="polite" class="text-xs uppercase tracking-wide text-slate-500">
+                  Waiting to start installation
+                </p>
+              </div>
+              <p class="mt-2 text-sm text-slate-600">
+                Installation output and logs will appear below. You can return to previous steps to adjust configuration if needed.
+              </p>
+              <pre
+                id="installOutput"
+                aria-live="polite"
+                class="mt-4 min-h-[140px] w-full whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm leading-relaxed text-slate-600 transition-colors"
+              >Installation output will appear here once the process starts.</pre>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  </div>
   <script src="install.js" defer></script>
 </body>
 </html>

--- a/install/install.js
+++ b/install/install.js
@@ -1,81 +1,317 @@
-const progressBar = document.getElementById('progressBar');
-const errorBox = document.getElementById('errorBox');
+const stepItems = Array.from(document.querySelectorAll('[data-step-index]'));
+const stepPanels = Array.from(document.querySelectorAll('[data-panel-index]'));
+const connectors = Array.from(document.querySelectorAll('[data-step-connector]'));
+const panelContainer = document.getElementById('stepPanels');
+const checkBtn = document.getElementById('checkBtn');
+const prereqOutput = document.getElementById('prereqOutput');
+const configForm = document.getElementById('configForm');
+const installStatus = document.getElementById('installStatus');
+const installOutput = document.getElementById('installOutput');
 
-function setProgress(p) {
-  progressBar.style.width = `${p}%`;
+let activeStepIndex = 0;
+const completedSteps = new Set();
+
+const STATUS_CLASSES = {
+  neutral: ['border-slate-200', 'bg-slate-50', 'text-slate-600'],
+  loading: ['border-blue-200', 'bg-blue-50', 'text-blue-700'],
+  success: ['border-emerald-300', 'bg-emerald-50', 'text-emerald-700'],
+  error: ['border-rose-300', 'bg-rose-50', 'text-rose-700'],
+};
+
+const ALL_STATUS_CLASSES = Array.from(new Set(Object.values(STATUS_CLASSES).flat()));
+const CIRCLE_STATE_CLASSES = [
+  'bg-blue-600',
+  'bg-green-600',
+  'bg-white',
+  'border-blue-600',
+  'border-green-600',
+  'border-gray-300',
+  'text-white',
+  'text-gray-400',
+  'shadow-lg',
+  'scale-110',
+];
+const LABEL_STATE_CLASSES = ['text-blue-600', 'text-green-600', 'text-slate-500', 'font-semibold'];
+const CONNECTOR_STATE_CLASSES = ['bg-slate-200', 'bg-blue-500', 'bg-emerald-500'];
+
+function applyStatusClasses(element, state = 'neutral') {
+  if (!element) return;
+  element.classList.remove(...ALL_STATUS_CLASSES);
+  const classes = STATUS_CLASSES[state] || STATUS_CLASSES.neutral;
+  element.classList.add(...classes);
 }
 
-function showError(msg) {
-  errorBox.textContent = msg;
-  errorBox.classList.remove('hidden');
+function refreshPanelHeight() {
+  const activePanel = stepPanels[activeStepIndex];
+  if (!panelContainer || !activePanel) return;
+  window.requestAnimationFrame(() => {
+    panelContainer.style.height = `${activePanel.scrollHeight}px`;
+  });
 }
 
-function clearError() {
-  errorBox.textContent = '';
-  errorBox.classList.add('hidden');
+function updateStepItems() {
+  stepItems.forEach((item, index) => {
+    const circle = item.querySelector('.step-circle');
+    const label = item.querySelector('.step-label');
+    const isActive = index === activeStepIndex;
+    const isCompleted = completedSteps.has(index);
+    const isAccessible = index <= activeStepIndex;
+
+    if (circle) {
+      circle.classList.remove(...CIRCLE_STATE_CLASSES);
+      if (isCompleted) {
+        circle.classList.add('bg-green-600', 'border-green-600', 'text-white');
+      } else if (isActive) {
+        circle.classList.add('bg-blue-600', 'border-blue-600', 'text-white', 'shadow-lg', 'scale-110');
+      } else {
+        circle.classList.add('bg-white', 'border-gray-300', 'text-gray-400');
+      }
+    }
+
+    if (label) {
+      label.classList.remove(...LABEL_STATE_CLASSES);
+      if (isCompleted) {
+        label.classList.add('text-green-600', 'font-semibold');
+      } else if (isActive) {
+        label.classList.add('text-blue-600', 'font-semibold');
+      } else {
+        label.classList.add('text-slate-500');
+      }
+    }
+
+    item.classList.toggle('cursor-pointer', isAccessible);
+    item.classList.toggle('cursor-not-allowed', !isAccessible);
+    item.setAttribute('tabindex', isAccessible ? '0' : '-1');
+    item.setAttribute('aria-disabled', isAccessible ? 'false' : 'true');
+  });
+}
+
+function updateConnectors() {
+  connectors.forEach((connector) => {
+    if (!connector) return;
+    const index = Number(connector.dataset.stepConnector);
+    connector.classList.remove(...CONNECTOR_STATE_CLASSES);
+    if (completedSteps.has(index)) {
+      connector.classList.add('bg-emerald-500');
+    } else if (activeStepIndex > index) {
+      connector.classList.add('bg-blue-500');
+    } else {
+      connector.classList.add('bg-slate-200');
+    }
+  });
+}
+
+function updatePanels(nextIndex) {
+  stepPanels.forEach((panel, index) => {
+    if (!panel) return;
+    panel.classList.remove(
+      'relative',
+      'absolute',
+      'inset-0',
+      'opacity-0',
+      'opacity-100',
+      'pointer-events-none',
+      'pointer-events-auto',
+      'translate-x-0',
+      'translate-x-6',
+      '-translate-x-6',
+    );
+    if (index === nextIndex) {
+      panel.classList.add('relative', 'opacity-100', 'translate-x-0');
+    } else {
+      panel.classList.add('absolute', 'inset-0', 'opacity-0', 'pointer-events-none');
+      panel.classList.add(index < nextIndex ? '-translate-x-6' : 'translate-x-6');
+    }
+  });
+}
+
+function goToStep(nextIndex) {
+  const targetIndex = Math.max(0, Math.min(nextIndex, stepPanels.length - 1));
+  activeStepIndex = targetIndex;
+  updateStepItems();
+  updateConnectors();
+  updatePanels(targetIndex);
+  refreshPanelHeight();
+}
+
+function markStepComplete(stepIndex) {
+  completedSteps.add(stepIndex);
+  updateStepItems();
+  updateConnectors();
+}
+
+function resetStepsFrom(startIndex) {
+  for (let i = startIndex; i < stepItems.length; i += 1) {
+    completedSteps.delete(i);
+  }
+  updateStepItems();
+  updateConnectors();
+}
+
+function setInstallStatus(text) {
+  if (!installStatus) return;
+  installStatus.textContent = text;
+  refreshPanelHeight();
+}
+
+function updateOutput(element, text, state) {
+  if (!element) return;
+  applyStatusClasses(element, state);
+  element.textContent = text;
+  refreshPanelHeight();
+}
+
+function setConfigFormDisabled(disabled) {
+  if (!configForm) return;
+  const fields = configForm.querySelectorAll('input, button');
+  fields.forEach((field) => {
+    field.disabled = disabled;
+  });
+}
+
+function buildOutputMessage(prefix, payload) {
+  if (!payload) {
+    return prefix;
+  }
+  const details = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
+  return `${prefix}\n${details}`;
 }
 
 async function checkPrereqs() {
-  const output = document.getElementById('prereqOutput');
-  output.textContent = 'Checking...';
-  output.className = 'text-gray-600';
+  resetStepsFrom(0);
+  goToStep(0);
+  updateOutput(prereqOutput, 'Checking prerequisites...', 'loading');
+  setConfigFormDisabled(true);
+
   try {
-    const res = await fetch('/api/install/prereqs');
-    if (res.status === 401 || res.status === 403) {
+    const response = await fetch('/api/install/prereqs');
+    if (response.status === 401 || response.status === 403) {
       alert('Please log in to continue.');
-      output.textContent = 'Authentication required. Please log in.';
-      output.classList.add('error');
+      updateOutput(prereqOutput, 'Authentication required. Please log in.', 'error');
       return;
     }
-    const data = await res.json();
+
+    const data = await response.json();
     if (data.ok) {
-      output.className = 'text-green-600';
-      output.textContent = 'Success:\n' + (data.output || JSON.stringify(data, null, 2));
-      document.getElementById('step2').style.display = 'block';
+      const message = buildOutputMessage('Success:', data.output || data);
+      updateOutput(prereqOutput, message, 'success');
+      markStepComplete(0);
+      resetStepsFrom(1);
+      setInstallStatus('Waiting to start installation');
+      updateOutput(
+        installOutput,
+        'Installation output will appear here once the process starts.',
+        'neutral',
+      );
+      setConfigFormDisabled(false);
+      goToStep(1);
+      if (configForm && typeof configForm.adminEmail?.focus === 'function') {
+        window.setTimeout(() => {
+          configForm.adminEmail.focus();
+        }, 200);
+      }
     } else {
-      output.className = 'text-red-600';
-      output.textContent = 'Error:\n' + (data.output || JSON.stringify(data, null, 2));
-      document.getElementById('step2').style.display = 'none';
+      const message = buildOutputMessage('Error:', data.output || data);
+      updateOutput(prereqOutput, message, 'error');
     }
-  } catch (err) {
-    output.textContent = 'Error: ' + err.message;
-    output.className = 'text-red-600';
+  } catch (error) {
+    updateOutput(prereqOutput, `Error: ${error.message}`, 'error');
   }
 }
 
-document.getElementById('checkBtn').addEventListener('click', checkPrereqs);
+async function handleInstall(event) {
+  event.preventDefault();
+  if (!completedSteps.has(0)) {
+    goToStep(0);
+    updateOutput(
+      prereqOutput,
+      'Please complete the prerequisite check before starting the installation.',
+      'error',
+    );
+    return;
+  }
 
-window.addEventListener('DOMContentLoaded', checkPrereqs);
+  if (!configForm) return;
 
-const form = document.getElementById('configForm');
-const installBtn = document.getElementById('installBtn');
-form.addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const out = document.getElementById('installOutput');
-  out.textContent = 'Running install...';
-  out.className = 'text-gray-600';
-  installBtn.disabled = true;
   const payload = {
-    adminEmail: form.adminEmail.value,
-    adminPassword: form.adminPassword.value,
+    adminEmail: configForm.adminEmail.value,
+    adminPassword: configForm.adminPassword.value,
   };
+
+  setConfigFormDisabled(true);
+  markStepComplete(1);
+  resetStepsFrom(2);
+  setInstallStatus('Running installation');
+  updateOutput(installOutput, 'Running installation...', 'loading');
+  goToStep(2);
+
   try {
-    const res = await fetch('/api/install/run', {
+    const response = await fetch('/api/install/run', {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
     });
-    if (res.status === 401 || res.status === 403) {
+
+    if (response.status === 401 || response.status === 403) {
       alert('Please log in to continue.');
-      out.textContent = 'Authentication required. Please log in.';
-      out.classList.add('error');
+      updateOutput(installOutput, 'Authentication required. Please log in.', 'error');
+      setInstallStatus('Authentication required');
       return;
     }
-    const data = await res.json();
-    out.textContent = (data.ok ? 'Success:\n' : 'Error:\n') + (data.output || JSON.stringify(data, null, 2));
-    out.className = data.ok ? 'text-green-600' : 'text-red-600';
-  } catch (err) {
-    out.textContent = 'Error: ' + err.message;
-    out.className = 'text-red-600';
+
+    const data = await response.json();
+    if (data.ok) {
+      const message = buildOutputMessage('Success:', data.output || data);
+      updateOutput(installOutput, message, 'success');
+      setInstallStatus('Installation completed successfully');
+      markStepComplete(2);
+    } else {
+      const message = buildOutputMessage('Error:', data.output || data);
+      updateOutput(installOutput, message, 'error');
+      setInstallStatus('Installation failed. Review the output for details.');
+    }
+  } catch (error) {
+    updateOutput(installOutput, `Error: ${error.message}`, 'error');
+    setInstallStatus('Installation encountered an unexpected error.');
   } finally {
-    installBtn.disabled = false;
+    setConfigFormDisabled(false);
   }
+}
+
+stepItems.forEach((item, index) => {
+  item.addEventListener('click', () => {
+    if (index <= activeStepIndex) {
+      goToStep(index);
+    }
+  });
+
+  item.addEventListener('keydown', (event) => {
+    if ((event.key === 'Enter' || event.key === ' ') && index <= activeStepIndex) {
+      event.preventDefault();
+      goToStep(index);
+    }
+  });
 });
+
+if (checkBtn) {
+  checkBtn.addEventListener('click', () => {
+    checkPrereqs();
+  });
+}
+
+if (configForm) {
+  configForm.addEventListener('submit', handleInstall);
+}
+
+function init() {
+  applyStatusClasses(prereqOutput, 'neutral');
+  applyStatusClasses(installOutput, 'neutral');
+  setConfigFormDisabled(true);
+  goToStep(0);
+  window.addEventListener('resize', refreshPanelHeight);
+  checkPrereqs();
+}
+
+init();


### PR DESCRIPTION
## Summary
- replace the static prerequisite and install sections with a Tailwind-powered three-step wizard that surfaces the active step
- add animated panel transitions and interactive step indicators so completed steps and connectors update as the user progresses
- overhaul the installer script to drive step navigation, status styling, and installation state updates based on API responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9eae711708328bef96df3cf9a5b12