### PR TITLE
Add stepper-driven installer flow

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -31,6 +31,97 @@
       max-height: 0;
       pointer-events: none;
     }
+
+    .stepper {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    @media (min-width: 640px) {
+      .stepper {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+    }
+
+    .stepper-item {
+      position: relative;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex: 1 1 0%;
+    }
+
+    .stepper-item:not(:last-child)::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      right: -0.5rem;
+      transform: translateY(-50%);
+      height: 2px;
+      width: calc(100% + 1rem);
+      background-color: #e5e7eb;
+      z-index: 0;
+    }
+
+    @media (max-width: 639px) {
+      .stepper-item:not(:last-child)::after {
+        display: none;
+      }
+    }
+
+    .stepper-index {
+      z-index: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      height: 2.5rem;
+      width: 2.5rem;
+      border-radius: 9999px;
+      border: 2px solid #d1d5db;
+      background-color: #ffffff;
+      font-weight: 600;
+      color: #6b7280;
+      transition: all 0.3s ease;
+    }
+
+    .stepper-item.stepper-active .stepper-index {
+      border-color: #2563eb;
+      background-color: #2563eb;
+      color: #ffffff;
+    }
+
+    .stepper-item.stepper-complete .stepper-index {
+      border-color: #16a34a;
+      background-color: #16a34a;
+      color: #ffffff;
+    }
+
+    .stepper-item.stepper-complete::after {
+      background-color: #16a34a;
+    }
+
+    .stepper-item.stepper-active::after {
+      background: linear-gradient(90deg, #2563eb, #3b82f6);
+    }
+
+    .stepper-item.stepper-upcoming .stepper-index {
+      border-color: #d1d5db;
+      background-color: #ffffff;
+      color: #6b7280;
+    }
+
+    .stepper-item .stepper-title {
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .stepper-item .stepper-caption {
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
   </style>
 </head>
 <body class="min-h-screen bg-gray-50 p-6 font-sans text-gray-900">
@@ -39,7 +130,30 @@
     <a href="/docs" class="text-blue-600 underline transition hover:text-blue-800">Documentation</a>
   </nav>
   <h1 class="text-2xl font-bold mb-4">SkillBridge Installation</h1>
-  <div class="mb-6 space-y-3">
+  <div class="mb-6 space-y-4">
+    <ol id="stepper" class="stepper" aria-label="Installation steps" role="list">
+      <li class="stepper-item stepper-active" data-stepper-item="prereq">
+        <span class="stepper-index">1</span>
+        <div>
+          <p class="stepper-title">Prerequisites</p>
+          <p class="stepper-caption">Verify environment</p>
+        </div>
+      </li>
+      <li class="stepper-item stepper-upcoming" data-stepper-item="config">
+        <span class="stepper-index">2</span>
+        <div>
+          <p class="stepper-title">Configuration</p>
+          <p class="stepper-caption">Define admin access</p>
+        </div>
+      </li>
+      <li class="stepper-item stepper-upcoming" data-stepper-item="install">
+        <span class="stepper-index">3</span>
+        <div>
+          <p class="stepper-title">Run Install</p>
+          <p class="stepper-caption">Finalize setup</p>
+        </div>
+      </li>
+    </ol>
     <div class="w-full bg-gray-200 rounded-full h-2 overflow-hidden" aria-hidden="true">
       <div
         id="progressBar"
@@ -57,9 +171,10 @@
       role="alert"
     ></div>
   </div>
-  <section id="step1" class="mb-8">
+  <section id="step-prereq" class="mb-8 step-container step-visible" aria-hidden="false">
     <h2 class="text-xl font-semibold mb-2">Step 1: Prerequisite Check</h2>
-    <button id="checkBtn" class="px-4 py-2 bg-blue-500 text-white rounded">Recheck</button>
+    <p class="text-sm text-gray-600">We’ll verify that your environment meets the requirements before continuing.</p>
+    <button id="checkBtn" class="mt-4 rounded bg-blue-500 px-4 py-2 text-white transition hover:bg-blue-600">Recheck</button>
     <div
       id="prereqStatus"
       class="mt-4 space-y-3"
@@ -67,20 +182,46 @@
     ></div>
     <p id="prereqSummary" class="mt-2 text-sm text-gray-600" role="status" aria-live="polite"></p>
   </section>
-  <section id="step2" class="mb-8 step-container step-hidden-right" aria-hidden="true">
+  <section id="step-config" class="mb-8 step-container step-hidden-right" aria-hidden="true">
     <h2 class="text-xl font-semibold mb-2">Step 2: Configuration</h2>
-    <form id="configForm" class="space-y-4">
+    <p class="text-sm text-gray-600">Provide the admin credentials for the new installation.</p>
+    <form id="configForm" class="mt-4 space-y-4">
       <label class="block">
-        <span class="block">Admin Email</span>
-        <input type="email" name="adminEmail" required class="border p-2 w-full" />
+        <span class="block font-medium">Admin Email</span>
+        <input type="email" name="adminEmail" required class="mt-1 w-full rounded border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
       </label>
       <label class="block">
-        <span class="block">Admin Password</span>
-        <input type="password" name="adminPassword" required class="border p-2 w-full" />
+        <span class="block font-medium">Admin Password</span>
+        <input type="password" name="adminPassword" required class="mt-1 w-full rounded border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
       </label>
-      <button type="submit" id="installBtn" class="px-4 py-2 bg-green-600 text-white rounded">Run Install</button>
+      <button type="submit" id="installBtn" class="rounded bg-green-600 px-4 py-2 text-white transition hover:bg-green-700">Run Install</button>
     </form>
-    <pre id="installOutput" class="mt-2"></pre>
+  </section>
+  <section id="step-install" class="mb-8 step-container step-hidden-right" aria-hidden="true">
+    <h2 class="text-xl font-semibold mb-2">Step 3: Run Installation</h2>
+    <p class="text-sm text-gray-600">We’ll execute the installer and share the results along with recommended next steps.</p>
+    <div class="mt-4 space-y-4">
+      <pre
+        id="installOutput"
+        class="hidden whitespace-pre-wrap rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700"
+        aria-live="polite"
+      ></pre>
+      <div
+        id="completionCard"
+        class="hidden rounded border border-green-200 bg-green-50 p-4 text-sm text-green-800"
+      >
+        <h3 class="text-base font-semibold text-green-700">Installation complete</h3>
+        <p id="completionMessage" class="mt-1 text-green-700"></p>
+        <ul id="completionNextSteps" class="mt-3 list-disc space-y-1 pl-5"></ul>
+      </div>
+      <button
+        type="button"
+        id="backToConfigBtn"
+        class="hidden text-sm font-medium text-blue-600 transition hover:text-blue-800"
+      >
+        ← Back to configuration
+      </button>
+    </div>
   </section>
   <script src="install.js" defer></script>
 </body>

--- a/install/install.js
+++ b/install/install.js
@@ -1,158 +1,531 @@
+const STEP_ORDER = ['prereq', 'config', 'install'];
+const STEP_PROGRESS = {
+  config: 55,
+  install: 80,
+};
+const FRIENDLY_LABELS = {
+  node: 'Node.js',
+  npm: 'npm',
+  docker: 'Docker',
+  dockerCompose: 'Docker Compose',
+  git: 'Git',
+  postgres: 'PostgreSQL',
+  redis: 'Redis',
+  yarn: 'Yarn',
+  pnpm: 'pnpm',
+  python: 'Python',
+};
 
-function setProgress(p) {
-  if (!progressBar) return;
-  const clamped = Math.max(0, Math.min(100, p));
-  progressBar.style.width = `${clamped}%`;
-  progressBar.setAttribute('aria-valuenow', String(clamped));
-}
+document.addEventListener('DOMContentLoaded', () => {
+  const progressBar = document.getElementById('progressBar');
+  const errorBox = document.getElementById('errorBox');
+  const stepSections = {
+    prereq: document.getElementById('step-prereq'),
+    config: document.getElementById('step-config'),
+    install: document.getElementById('step-install'),
+  };
+  const stepperItems = Array.from(document.querySelectorAll('[data-stepper-item]'));
+  const prereqStatus = document.getElementById('prereqStatus');
+  const prereqSummary = document.getElementById('prereqSummary');
+  const checkBtn = document.getElementById('checkBtn');
+  const configForm = document.getElementById('configForm');
+  const installBtn = document.getElementById('installBtn');
+  const installOutput = document.getElementById('installOutput');
+  const completionCard = document.getElementById('completionCard');
+  const completionMessage = document.getElementById('completionMessage');
+  const completionNextSteps = document.getElementById('completionNextSteps');
+  const backToConfigBtn = document.getElementById('backToConfigBtn');
 
-function showError(msg) {
-  if (!errorBox) return;
-  errorBox.textContent = msg;
-  errorBox.classList.remove('hidden');
-}
+  function setProgress(percent) {
+    if (!progressBar) return;
+    const clamped = Math.max(0, Math.min(100, Number(percent) || 0));
+    progressBar.style.width = `${clamped}%`;
+    progressBar.setAttribute('aria-valuenow', String(clamped));
+  }
 
-function clearError() {
-  if (!errorBox) return;
-  errorBox.textContent = '';
-  errorBox.classList.add('hidden');
-}
+  function showError(message) {
+    if (!errorBox) return;
+    errorBox.textContent = message;
+    errorBox.classList.remove('hidden');
+  }
 
-async function checkPrereqs() {
-  const output = document.getElementById('prereqOutput');
-  output.textContent = 'Checking...';
-  output.className = 'text-gray-600';
-  clearError();
-  setProgress(10);
-  try {
-    const res = await fetch('/api/install/prereqs');
-    setProgress(30);
-    if (res.status === 401 || res.status === 403) {
-      alert('Please log in to continue.');
-      output.textContent = 'Authentication required. Please log in.';
-      output.classList.add('error');
-      setProgress(0);
-      showError('Please log in to continue.');
-      return;
+  function clearError() {
+    if (!errorBox) return;
+    errorBox.textContent = '';
+    errorBox.classList.add('hidden');
+  }
+
+  function updateStep(step, options = {}) {
+    if (!STEP_ORDER.includes(step)) return;
+    const { preserveProgress = false } = options;
+    const targetIndex = STEP_ORDER.indexOf(step);
+
+    STEP_ORDER.forEach((key, index) => {
+      const section = stepSections[key];
+      if (!section) return;
+      section.classList.remove('step-visible', 'step-hidden-left', 'step-hidden-right');
+      if (index === targetIndex) {
+        section.classList.add('step-visible');
+        section.setAttribute('aria-hidden', 'false');
+      } else if (index < targetIndex) {
+        section.classList.add('step-hidden-left');
+        section.setAttribute('aria-hidden', 'true');
+      } else {
+        section.classList.add('step-hidden-right');
+        section.setAttribute('aria-hidden', 'true');
+      }
+    });
+
+    stepperItems.forEach((item) => {
+      const itemStep = item.dataset.stepperItem;
+      const itemIndex = STEP_ORDER.indexOf(itemStep);
+      if (itemIndex === -1) return;
+      item.classList.remove('stepper-active', 'stepper-complete', 'stepper-upcoming');
+      if (itemIndex === targetIndex) {
+        item.classList.add('stepper-active');
+        item.setAttribute('aria-current', 'step');
+      } else if (itemIndex < targetIndex) {
+        item.classList.add('stepper-complete');
+        item.removeAttribute('aria-current');
+      } else {
+        item.classList.add('stepper-upcoming');
+        item.removeAttribute('aria-current');
+      }
+    });
+
+    if (!preserveProgress) {
+      const base = STEP_PROGRESS[step];
+      if (typeof base === 'number') {
+        setProgress(base);
+      }
+    }
+  }
+
+  function formatKey(key) {
+    if (!key) return 'Requirement';
+    return key
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/[_-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .replace(/^./, (char) => char.toUpperCase());
+  }
+
+  function normalizePrereqResponse(raw) {
+    const normalized = { requirements: [], summary: '', allPassing: false, rawText: '' };
+    if (raw == null) {
+      normalized.summary = 'No prerequisite information was returned.';
+      return normalized;
     }
 
-    const data = await res.json();
-    let parsedOutput = null;
-
-    if (typeof data.output === 'string') {
+    let payload;
+    if (typeof raw === 'string') {
+      const trimmed = raw.trim();
+      if (!trimmed) {
+        normalized.summary = 'No prerequisite information was returned.';
+        return normalized;
+      }
       try {
-        parsedOutput = JSON.parse(data.output);
-      } catch (err) {
-        parsedOutput = null;
+        payload = JSON.parse(trimmed);
+      } catch {
+        normalized.rawText = trimmed;
+        normalized.summary = trimmed;
+        return normalized;
+      }
+    } else {
+      payload = { ...raw };
+    }
+
+    if (typeof payload.output === 'string') {
+      const trimmedOutput = payload.output.trim();
+      if (trimmedOutput) {
+        try {
+          const parsed = JSON.parse(trimmedOutput);
+          if (parsed && typeof parsed === 'object') {
+            payload = { ...parsed, ...payload };
+          }
+        } catch {
+          normalized.rawText = trimmedOutput;
+        }
       }
     }
 
-    if (parsedOutput && Array.isArray(parsedOutput.requirements)) {
-      renderRequirements(parsedOutput.requirements);
-      const summaryText = parsedOutput.summary
-        || (data.ok ? 'All prerequisites satisfied.' : 'Please address the issues above.');
-      setSummary(summaryText, data.ok ? 'success' : 'error');
+    let requirements = [];
+    if (Array.isArray(payload.requirements)) {
+      requirements = payload.requirements.map((req, index) => {
+        const id = req?.id || req?.key || req?.name || `requirement-${index}`;
+        const label = req?.label || req?.name || FRIENDLY_LABELS[id] || formatKey(id);
+        const value = req?.ok ?? req?.passed ?? req?.status ?? req?.value ?? req?.isMet ?? false;
+        const passed =
+          typeof value === 'boolean'
+            ? value
+            : typeof value === 'string'
+              ? ['ok', 'pass', 'passed', 'true', 'ready'].includes(value.toLowerCase())
+              : Boolean(value);
+        const details = req?.details || req?.message || req?.hint || '';
+        return { id, label, passed, details };
+      });
     } else {
-      const pre = document.createElement('pre');
-      pre.className = 'whitespace-pre-wrap rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-800';
-      pre.textContent = data.output || 'No output received.';
-      prereqStatus.appendChild(pre);
-      setSummary(
-        data.ok
-          ? 'All prerequisites satisfied.'
-          : 'An unexpected error occurred while checking prerequisites.',
-        data.ok ? 'success' : 'error',
-      );
+      const ignoreKeys = new Set(['ok', 'summary', 'message', 'output', 'requirements']);
+      requirements = Object.entries(payload)
+        .filter(([key, value]) => !ignoreKeys.has(key) && value !== undefined && value !== null)
+        .map(([key, value]) => {
+          const label = FRIENDLY_LABELS[key] || formatKey(key);
+          let passed = false;
+          let details = '';
+          if (typeof value === 'boolean') {
+            passed = value;
+          } else if (typeof value === 'string') {
+            const lowered = value.toLowerCase();
+            passed = ['ok', 'pass', 'passed', 'true', 'ready', 'success'].includes(lowered);
+            if (!passed && lowered.length) {
+              details = value;
+            }
+          } else if (typeof value === 'number') {
+            passed = value > 0;
+          } else if (typeof value === 'object') {
+            if (typeof value.ok === 'boolean') {
+              passed = value.ok;
+            } else if (typeof value.passed === 'boolean') {
+              passed = value.passed;
+            } else if (typeof value.status === 'string') {
+              passed = ['ok', 'pass', 'passed', 'ready', 'success'].includes(value.status.toLowerCase());
+            } else if (typeof value.value === 'boolean') {
+              passed = value.value;
+            } else if (typeof value.isMet === 'boolean') {
+              passed = value.isMet;
+            }
+            details = value.message || value.details || value.hint || '';
+          }
+          return { id: key, label, passed, details };
+        });
     }
 
-    if (data.ok) {
-      output.className = 'text-green-600';
-      output.textContent = 'Success:\n' + (data.output || JSON.stringify(data, null, 2));
-      document.getElementById('step2').style.display = 'block';
-      setProgress(50);
-      clearError();
-    } else {
-      output.className = 'text-red-600';
-      output.textContent = 'Error:\n' + (data.output || JSON.stringify(data, null, 2));
-      document.getElementById('step2').style.display = 'none';
-      setProgress(0);
-      showError('Prerequisite check failed. Review the output below.');
+    normalized.requirements = requirements;
+    const requirementsPassing = requirements.length ? requirements.every((req) => req.passed) : false;
+
+    if (typeof payload.ok === 'boolean') {
+      normalized.allPassing = payload.ok && (requirements.length ? requirementsPassing : true);
+    } else if (requirements.length) {
+      normalized.allPassing = requirementsPassing;
+    } else if (normalized.rawText) {
+      normalized.allPassing = false;
     }
 
-    const allPassing = dependencyEntries.every(([, value]) => value === true);
-    const lines = dependencyEntries.map(([key, value]) => {
-      const label = DEPENDENCY_LABELS[key];
-      const icon = value ? '✅' : '❌';
-      const colorClass = value ? 'text-green-600' : 'text-red-600';
-      return `<span class="${colorClass}">${icon} ${label}</span>`;
-    });
+    normalized.summary =
+      payload.summary ||
+      payload.message ||
+      (normalized.allPassing
+        ? 'All prerequisites satisfied.'
+        : requirements.length
+          ? 'Some prerequisites need attention.'
+          : normalized.rawText || 'No prerequisite information was returned.');
 
-    output.className = 'mt-2';
-    output.innerHTML = lines.join('<br />');
-    step2Section.style.display = allPassing ? 'block' : 'none';
-  } catch (err) {
-    output.textContent = 'Error: ' + err.message;
-    output.className = 'text-red-600';
-    setProgress(0);
-    showError('Error checking prerequisites: ' + err.message);
+    return normalized;
   }
-}
-const checkBtn = document.getElementById('checkBtn');
-if (checkBtn) {
-  checkBtn.addEventListener('click', checkPrereqs);
-}
-if (checkBtn) {
-  checkBtn.addEventListener('click', checkPrereqs);
-}
 
-window.addEventListener('DOMContentLoaded', checkPrereqs);
-
-window.addEventListener('DOMContentLoaded', () => {
-  setProgress(0);
-  checkPrereqs();
-});
-const form = document.getElementById('configForm');
-const installBtn = document.getElementById('installBtn');
-form.addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const out = document.getElementById('installOutput');
-  out.textContent = 'Running install...';
-  out.className = 'text-gray-600';
-  installBtn.disabled = true;
-  clearError();
-  setProgress(75);
-  const payload = {
-    adminEmail: form.adminEmail.value,
-    adminPassword: form.adminPassword.value,
-  };
-  try {
-    const res = await fetch('/api/install/run', {
-      method: 'POST',
-    });
-    if (res.status === 401 || res.status === 403) {
-      alert('Please log in to continue.');
-      out.textContent = 'Authentication required. Please log in.';
-      out.classList.add('error');
-      setProgress(50);
-      showError('Please log in to continue.');
+  function renderRequirements(requirements, rawText = '') {
+    if (!prereqStatus) return;
+    prereqStatus.innerHTML = '';
+    if (!requirements.length) {
+      if (rawText) {
+        const pre = document.createElement('pre');
+        pre.className =
+          'whitespace-pre-wrap rounded border border-gray-200 bg-gray-50 p-3 text-xs text-gray-700';
+        pre.textContent = rawText;
+        prereqStatus.appendChild(pre);
+      } else {
+        const empty = document.createElement('p');
+        empty.className = 'text-sm text-gray-600';
+        empty.textContent = 'No prerequisite details were returned.';
+        prereqStatus.appendChild(empty);
+      }
       return;
     }
-    const data = await res.json();
-    out.textContent = (data.ok ? 'Success:\n' : 'Error:\n') + (data.output || JSON.stringify(data, null, 2));
-    out.className = data.ok ? 'text-green-600' : 'text-red-600';
-    if (data.ok) {
-      setProgress(100);
-      clearError();
-    } else {
-      setProgress(50);
-      showError('Installation failed. Review the log below.');
-    }
-  } catch (err) {
-    out.textContent = 'Error: ' + err.message;
-    out.className = 'text-red-600';
-    setProgress(50);
-    showError('Error running install: ' + err.message);
-  } finally {
-    installBtn.disabled = false;
+
+    requirements.forEach((req) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = [
+        'flex items-start gap-3 rounded border p-3 text-sm transition-colors duration-300',
+        req.passed ? 'border-green-200 bg-green-50 text-green-800' : 'border-red-200 bg-red-50 text-red-700',
+      ].join(' ');
+
+      const icon = document.createElement('span');
+      icon.className = `mt-0.5 text-base ${req.passed ? 'text-green-600' : 'text-red-600'}`;
+      icon.textContent = req.passed ? '✓' : '!';
+      icon.setAttribute('aria-hidden', 'true');
+
+      const content = document.createElement('div');
+      content.className = 'space-y-1';
+      const title = document.createElement('p');
+      title.className = 'font-medium';
+      title.textContent = req.label || 'Requirement';
+      content.appendChild(title);
+
+      if (req.details) {
+        const details = document.createElement('p');
+        details.className = 'text-xs';
+        details.textContent = req.details;
+        content.appendChild(details);
+      }
+
+      wrapper.append(icon, content);
+      prereqStatus.appendChild(wrapper);
+    });
   }
+
+  function setSummary(message, status = 'info') {
+    if (!prereqSummary) return;
+    prereqSummary.textContent = message || '';
+    prereqSummary.className = 'mt-2 text-sm';
+    if (status === 'success') {
+      prereqSummary.classList.add('text-green-700');
+    } else if (status === 'error') {
+      prereqSummary.classList.add('text-red-600');
+    } else {
+      prereqSummary.classList.add('text-gray-600');
+    }
+  }
+
+  function showCompletion(data, credentials) {
+    if (!completionCard) return;
+    const messageFromApi =
+      data?.message || data?.summary || data?.success || data?.statusMessage || '';
+    const instructionsFromApi = Array.isArray(data?.nextSteps)
+      ? data.nextSteps
+      : typeof data?.nextSteps === 'string'
+        ? [data.nextSteps]
+        : [];
+
+    if (completionMessage) {
+      completionMessage.className = 'mt-1 text-green-700';
+      completionMessage.textContent =
+        messageFromApi || 'SkillBridge is installed and ready to go.';
+    }
+
+    if (completionNextSteps) {
+      completionNextSteps.innerHTML = '';
+      const steps =
+        instructionsFromApi.length > 0
+          ? instructionsFromApi
+          : [
+              credentials?.adminEmail
+                ? `Sign in to the SkillBridge admin dashboard with ${credentials.adminEmail}.`
+                : 'Sign in to the SkillBridge admin dashboard with the credentials you configured.',
+              'Complete the organization setup and invite your teammates.',
+              'Visit the documentation for deployment and integration guidance.',
+            ];
+      steps
+        .filter((step) => typeof step === 'string' && step.trim().length > 0)
+        .forEach((step) => {
+          const li = document.createElement('li');
+          li.textContent = step.trim();
+          completionNextSteps.appendChild(li);
+        });
+    }
+
+    completionCard.classList.remove('hidden');
+    backToConfigBtn?.classList.add('hidden');
+  }
+
+  async function checkPrereqs() {
+    updateStep('prereq', { preserveProgress: true });
+    clearError();
+    completionCard?.classList.add('hidden');
+    backToConfigBtn?.classList.add('hidden');
+
+    if (prereqStatus) {
+      prereqStatus.innerHTML = '';
+      const loading = document.createElement('p');
+      loading.className = 'text-sm text-gray-600';
+      loading.textContent = 'Checking prerequisites...';
+      prereqStatus.appendChild(loading);
+    }
+    setSummary('Checking prerequisites...', 'info');
+    setProgress(12);
+    if (checkBtn) checkBtn.disabled = true;
+
+    try {
+      const res = await fetch('/api/install/prereqs', { cache: 'no-store' });
+      if (res.status === 401 || res.status === 403) {
+        setSummary('Authentication required. Please log in and try again.', 'error');
+        showError('Please log in to continue.');
+        setProgress(0);
+        return;
+      }
+
+      const bodyText = await res.text();
+      let data;
+      if (bodyText) {
+        try {
+          data = JSON.parse(bodyText);
+        } catch {
+          data = { output: bodyText };
+        }
+      } else {
+        data = {};
+      }
+
+      const normalized = normalizePrereqResponse(data);
+      renderRequirements(normalized.requirements, normalized.rawText);
+      const summaryStatus = normalized.allPassing
+        ? 'success'
+        : normalized.requirements.length
+          ? 'error'
+          : 'info';
+      setSummary(normalized.summary, summaryStatus);
+
+      if (normalized.allPassing && res.ok) {
+        clearError();
+        updateStep('config');
+      } else {
+        showError(
+          res.ok
+            ? 'Prerequisite check failed. Review the requirements below.'
+            : `Prerequisite check failed${res.status ? ` (HTTP ${res.status})` : ''}.`,
+        );
+        setProgress(20);
+      }
+    } catch (err) {
+      showError(`Error checking prerequisites: ${err.message}`);
+      setSummary('Unable to verify prerequisites. Please try again.', 'error');
+      setProgress(10);
+    } finally {
+      if (checkBtn) checkBtn.disabled = false;
+    }
+  }
+
+  async function handleInstallSubmit(event) {
+    event.preventDefault();
+    clearError();
+    completionCard?.classList.add('hidden');
+    backToConfigBtn?.classList.add('hidden');
+
+    if (!configForm) return;
+
+    const formData = new FormData(configForm);
+    const credentials = {
+      adminEmail: String(formData.get('adminEmail') || '').trim(),
+      adminPassword: String(formData.get('adminPassword') || ''),
+    };
+
+    updateStep('install');
+    setProgress(90);
+
+    if (installBtn) installBtn.disabled = true;
+
+    if (installOutput) {
+      installOutput.classList.remove('hidden', 'text-green-700', 'text-red-700');
+      installOutput.classList.add('text-gray-700');
+      installOutput.textContent = 'Running install...';
+    }
+
+    try {
+      const res = await fetch('/api/install/run', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(credentials),
+      });
+
+      if (res.status === 401 || res.status === 403) {
+        showError('Please log in to continue.');
+        if (installOutput) {
+          installOutput.classList.remove('text-gray-700', 'text-green-700');
+          installOutput.classList.add('text-red-700');
+          installOutput.textContent = 'Authentication required. Please log in.';
+        }
+        updateStep('config');
+        return;
+      }
+
+      const responseText = await res.text();
+      let data;
+      if (responseText) {
+        try {
+          data = JSON.parse(responseText);
+        } catch {
+          data = { output: responseText };
+        }
+      } else {
+        data = {};
+      }
+
+      const success = typeof data.ok === 'boolean' ? data.ok : res.ok;
+      const outputText =
+        typeof data.output === 'string' && data.output.trim().length > 0
+          ? data.output
+          : typeof data.log === 'string'
+            ? data.log
+            : responseText;
+
+      if (installOutput) {
+        installOutput.classList.remove('text-gray-700', 'text-green-700', 'text-red-700');
+        installOutput.classList.add(success ? 'text-green-700' : 'text-red-700');
+        if (outputText && outputText.trim().length > 0) {
+          installOutput.classList.remove('hidden');
+          installOutput.textContent = outputText.trim();
+        } else if (!success) {
+          installOutput.classList.remove('hidden');
+          installOutput.textContent = 'Installation failed with no additional output.';
+        } else {
+          installOutput.classList.add('hidden');
+          installOutput.textContent = '';
+        }
+      }
+
+      if (success) {
+        setProgress(100);
+        clearError();
+        showCompletion(data, credentials);
+      } else {
+        showError('Installation failed. Review the log below and try again.');
+        backToConfigBtn?.classList.remove('hidden');
+        setProgress(STEP_PROGRESS.install);
+      }
+    } catch (err) {
+      showError(`Error running install: ${err.message}`);
+      if (installOutput) {
+        installOutput.classList.remove('hidden', 'text-green-700');
+        installOutput.classList.add('text-red-700');
+        installOutput.textContent = `Error: ${err.message}`;
+      }
+      backToConfigBtn?.classList.remove('hidden');
+      setProgress(STEP_PROGRESS.install);
+    } finally {
+      if (installBtn) installBtn.disabled = false;
+    }
+  }
+
+  if (checkBtn) {
+    checkBtn.addEventListener('click', checkPrereqs);
+  }
+  if (configForm) {
+    configForm.addEventListener('submit', handleInstallSubmit);
+  }
+  if (backToConfigBtn) {
+    backToConfigBtn.addEventListener('click', () => {
+      clearError();
+      updateStep('config');
+      setProgress(STEP_PROGRESS.config);
+      completionCard?.classList.add('hidden');
+      if (installOutput) {
+        installOutput.classList.add('hidden');
+        installOutput.classList.remove('text-green-700', 'text-red-700');
+        installOutput.classList.add('text-gray-700');
+        installOutput.textContent = '';
+      }
+      if (configForm) {
+        const firstInput = configForm.querySelector('input');
+        if (firstInput) {
+          firstInput.focus();
+        }
+      }
+    });
+  }
+
+  updateStep('prereq', { preserveProgress: true });
+  setProgress(0);
+  checkPrereqs();
 });


### PR DESCRIPTION
## Summary
- add a visual stepper to the installer page and restructure the layout into three phases
- overhaul the installer script to manage step transitions, progress, and error handling with smooth animations
- surface installation results with a completion card, next steps, and a retry path when failures occur

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9ef833ff88328bebc821ee51f3aca