### PR TITLE
Update install route test for new installer UI

### DIFF
--- a/backend/tests/installRoute.test.js
+++ b/backend/tests/installRoute.test.js
@@ -33,7 +33,15 @@ describe('/install route', () => {
     server.close();
     expect(res.status).toBe(200);
     expect(res.text).toContain('<!DOCTYPE html>');
-    expect(res.text).not.toContain('Admin Email');
-    expect(res.text).not.toContain('Admin Password');
+    expect(res.text).toContain('id="configForm"');
+    expect(res.text).toContain('Admin Email');
+    expect(res.text).toContain('Admin Password');
+    expect(res.text).toContain('id="progressBar"');
+    expect(res.text).toContain('data-stepper-item="prereq"');
+    expect(res.text).toContain('data-stepper-item="config"');
+    expect(res.text).toContain('data-stepper-item="install"');
+    expect(res.text).toContain('Prerequisites');
+    expect(res.text).toContain('Configuration');
+    expect(res.text).toContain('Run Install');
   });
 });


### PR DESCRIPTION
## Summary
- update the install route integration test to expect the new configuration form UI
- assert that the installer response still includes the progress bar and stepper labels to catch regressions

## Testing
- `JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test npm test` *(fails: multiple existing suites require additional environment/database setup and mail mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f5df94ac8328b94e20361817a953