### PR TITLE
Pass installer credentials to install script via environment

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -15,32 +15,41 @@ const executeScript = (res, scriptKey, options = {}) => {
     return res.status(400).json({ ok: false, output: 'Invalid script' });
   }
 
-  execFile(script, { shell: false }, (error, stdout, stderr) => {
-    const rawOutput = stdout + stderr;
-    const trimmedStdout = stdout.trim();
-    let parsedOutput;
+  const mergedEnv = { ...process.env, ...(options.env || {}) };
 
-    if (trimmedStdout) {
-      try {
-        parsedOutput = JSON.parse(trimmedStdout);
-      } catch (_err) {
-        parsedOutput = undefined;
+  execFile(
+    script,
+    {
+      shell: false,
+      env: mergedEnv,
+    },
+    (error, stdout, stderr) => {
+      const rawOutput = stdout + stderr;
+      const trimmedStdout = stdout.trim();
+      let parsedOutput;
+
+      if (trimmedStdout) {
+        try {
+          parsedOutput = JSON.parse(trimmedStdout);
+        } catch (_err) {
+          parsedOutput = undefined;
+        }
       }
-    }
 
-    if (error) {
+      if (error) {
+        if (parsedOutput && typeof parsedOutput === 'object') {
+          return res.status(500).json(parsedOutput);
+        }
+        return res.status(500).json({ ok: false, output: rawOutput });
+      }
+
       if (parsedOutput && typeof parsedOutput === 'object') {
-        return res.status(500).json(parsedOutput);
+        return res.json(parsedOutput);
       }
-      return res.status(500).json({ ok: false, output: rawOutput });
-    }
 
-    if (parsedOutput && typeof parsedOutput === 'object') {
-      return res.json(parsedOutput);
+      res.json({ ok: true, output: rawOutput });
     }
-
-    res.json({ ok: true, output: rawOutput });
-  });
+  );
 };
 
 exports.checkPrereqs = (req, res) =>
@@ -49,4 +58,20 @@ exports.checkPrereqs = (req, res) =>
     evaluateOk: (parsed) => Boolean(parsed && parsed.allPassed),
     determineStatusCode: () => 200,
   });
-exports.runInstall = (req, res) => executeScript(res, 'install');
+exports.runInstall = (req, res) => {
+  const { adminEmail, adminPassword } = req.body || {};
+
+  if (!adminEmail || !adminPassword) {
+    return res.status(400).json({
+      ok: false,
+      message: 'Admin email and password are required.',
+    });
+  }
+
+  return executeScript(res, 'install', {
+    env: {
+      ADMIN_EMAIL: adminEmail,
+      ADMIN_PASSWORD: adminPassword,
+    },
+  });
+};

--- a/backend/tests/installApi.test.js
+++ b/backend/tests/installApi.test.js
@@ -17,15 +17,18 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
 
 const { execFile } = require('child_process');
 const { router } = require('../src/modules/install/install.routes');
+const controller = require('../src/modules/install/install.controller');
 
 const app = express();
+app.use(express.json());
 app.use('/api/install', router);
 
+afterEach(() => {
+  delete process.env.INSTALL_API_ENABLED;
+  jest.clearAllMocks();
+});
+
 describe('/api/install/prereqs', () => {
-  afterEach(() => {
-    delete process.env.INSTALL_API_ENABLED;
-    jest.clearAllMocks();
-  });
 
   it('returns 403 when INSTALL_API_ENABLED is false', async () => {
     process.env.INSTALL_API_ENABLED = 'false';
@@ -45,5 +48,67 @@ describe('/api/install/prereqs', () => {
       git: true,
     });
     expect(execFile).toHaveBeenCalled();
+  });
+});
+
+describe('/api/install/run', () => {
+  it('passes credentials to the installer environment', async () => {
+    process.env.INSTALL_API_ENABLED = 'true';
+    const adminEmail = 'admin@example.com';
+    const adminPassword = 'super-secret';
+    const envKey = 'INSTALLER_EXISTING_ENV';
+    const originalEnvValue = process.env[envKey];
+    process.env[envKey] = 'keep-me';
+
+    execFile.mockImplementationOnce((_script, options, cb) => {
+      expect(options).toEqual(
+        expect.objectContaining({
+          shell: false,
+        })
+      );
+      expect(options.env).toEqual(
+        expect.objectContaining({
+          ADMIN_EMAIL: adminEmail,
+          ADMIN_PASSWORD: adminPassword,
+          [envKey]: 'keep-me',
+        })
+      );
+      cb(null, '', '');
+    });
+
+    try {
+      const res = await request(app)
+        .post('/api/install/run')
+        .send({ adminEmail, adminPassword });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, output: '' });
+      expect(execFile).toHaveBeenCalled();
+    } finally {
+      if (originalEnvValue === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = originalEnvValue;
+      }
+    }
+  });
+});
+
+describe('runInstall controller', () => {
+  it('returns a clear error when credentials are missing', () => {
+    const req = { body: {} };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    controller.runInstall(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: false,
+      message: 'Admin email and password are required.',
+    });
+    expect(execFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- pass the admin email and password from the request body to install.sh through execFile environment variables
- return a clear 400 error when installer credentials are missing
- add install API tests that cover environment propagation and missing credential handling

## Testing
- npm test -- installApi.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c9f5d5cc948328806cd99984ae70df