### PR TITLE
Allow install API on first run

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -2,6 +2,7 @@ const router = require('express').Router();
 const controller = require('./install.controller');
 const { verifyToken, isAdmin } = require('../../middleware/auth/authMiddleware');
 const validate = require('../../middleware/validate');
+const userModel = require('../users/user.model');
 const { z } = require('zod');
 
 // Guard installation endpoints behind an environment flag to prevent accidental
@@ -15,8 +16,43 @@ const requireInstallApiEnabled = (req, res, next) => {
 
 router.use(requireInstallApiEnabled);
 
-// Require an authenticated administrator for all install endpoints.
-router.use(verifyToken, isAdmin);
+const hasSetupSecretConfigured = () => {
+  const secret = process.env.INSTALL_SETUP_SECRET;
+  return typeof secret === 'string' && secret.trim() !== '';
+};
+
+const shouldBypassInstallAuth = async () => {
+  if (hasSetupSecretConfigured()) {
+    return false;
+  }
+
+  try {
+    const admins = await userModel.findAdmins();
+    if (Array.isArray(admins)) {
+      return admins.length === 0;
+    }
+    return true;
+  } catch (_error) {
+    return false;
+  }
+};
+
+// Require an authenticated administrator for install endpoints when an admin
+// exists or when a setup secret is configured.
+const enforceInstallAuth = async (req, res, next) => {
+  if (await shouldBypassInstallAuth()) {
+    return next();
+  }
+
+  return verifyToken(req, res, (err) => {
+    if (err) {
+      return next(err);
+    }
+    return isAdmin(req, res, next);
+  });
+};
+
+router.use(enforceInstallAuth);
 
 // No input is accepted for the prereqs endpoint; validate empty payloads strictly.
 const emptySchema = z.object({}).strict();

--- a/backend/tests/installApi.test.js
+++ b/backend/tests/installApi.test.js
@@ -7,12 +7,18 @@ jest.mock('child_process', () => ({
   ),
 }));
 
+const mockVerifyToken = jest.fn();
+const mockIsAdmin = jest.fn();
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
-  verifyToken: (req, _res, next) => {
-    req.user = { id: 1, roles: ['admin'], role: 'admin' };
-    next();
-  },
-  isAdmin: (_req, _res, next) => next(),
+  verifyToken: (req, res, next) => mockVerifyToken(req, res, next),
+  isAdmin: (req, res, next) => mockIsAdmin(req, res, next),
+}));
+
+const mockFindAdmins = jest.fn();
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findAdmins: (...args) => mockFindAdmins(...args),
 }));
 
 const { execFile } = require('child_process');
@@ -22,21 +28,43 @@ const app = express();
 app.use('/api/install', router);
 
 describe('/api/install/prereqs', () => {
+  beforeEach(() => {
+    mockVerifyToken.mockReset();
+    mockIsAdmin.mockReset();
+    mockFindAdmins.mockReset();
+    execFile.mockClear();
+    delete process.env.INSTALL_API_ENABLED;
+    delete process.env.INSTALL_SETUP_SECRET;
+  });
+
   afterEach(() => {
     delete process.env.INSTALL_API_ENABLED;
-    jest.clearAllMocks();
+    delete process.env.INSTALL_SETUP_SECRET;
   });
 
   it('returns 403 when INSTALL_API_ENABLED is false', async () => {
     process.env.INSTALL_API_ENABLED = 'false';
+    mockFindAdmins.mockResolvedValue([]);
+
     const res = await request(app).get('/api/install/prereqs');
+
     expect(res.status).toBe(403);
     expect(execFile).not.toHaveBeenCalled();
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+    expect(mockIsAdmin).not.toHaveBeenCalled();
   });
 
   it('returns 200 for admin when flag is true', async () => {
     process.env.INSTALL_API_ENABLED = 'true';
+    mockFindAdmins.mockResolvedValue([{ id: 1 }]);
+    mockVerifyToken.mockImplementation((req, _res, next) => {
+      req.user = { id: 1, roles: ['admin'], role: 'admin' };
+      next();
+    });
+    mockIsAdmin.mockImplementation((_req, _res, next) => next());
+
     const res = await request(app).get('/api/install/prereqs');
+
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       node: true,
@@ -45,5 +73,50 @@ describe('/api/install/prereqs', () => {
       git: true,
     });
     expect(execFile).toHaveBeenCalled();
+    expect(mockVerifyToken).toHaveBeenCalledTimes(1);
+    expect(mockIsAdmin).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows unauthenticated access when no admins exist', async () => {
+    process.env.INSTALL_API_ENABLED = 'true';
+    mockFindAdmins.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/install/prereqs');
+
+    expect(res.status).toBe(200);
+    expect(execFile).toHaveBeenCalled();
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+    expect(mockIsAdmin).not.toHaveBeenCalled();
+  });
+
+  it('requires authentication once an admin exists', async () => {
+    process.env.INSTALL_API_ENABLED = 'true';
+    mockFindAdmins.mockResolvedValue([{ id: 1 }]);
+    mockVerifyToken.mockImplementation((req, res) =>
+      res.status(401).json({ message: 'Missing or malformed token' })
+    );
+
+    const res = await request(app).get('/api/install/prereqs');
+
+    expect(res.status).toBe(401);
+    expect(execFile).not.toHaveBeenCalled();
+    expect(mockVerifyToken).toHaveBeenCalledTimes(1);
+    expect(mockIsAdmin).not.toHaveBeenCalled();
+  });
+
+  it('requires authentication when a setup secret is configured', async () => {
+    process.env.INSTALL_API_ENABLED = 'true';
+    process.env.INSTALL_SETUP_SECRET = 's3cret';
+    mockFindAdmins.mockResolvedValue([]);
+    mockVerifyToken.mockImplementation((req, res) =>
+      res.status(401).json({ message: 'Missing or malformed token' })
+    );
+
+    const res = await request(app).get('/api/install/prereqs');
+
+    expect(res.status).toBe(401);
+    expect(execFile).not.toHaveBeenCalled();
+    expect(mockVerifyToken).toHaveBeenCalledTimes(1);
+    expect(mockIsAdmin).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- gate install routes behind a conditional middleware that only bypasses auth when no admins exist and no setup secret is configured
- support INSTALL_SETUP_SECRET to force authentication and add integration tests covering unauthenticated first run and protected follow-up requests

## Testing
- npm test -- installApi.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c9f5d4d8d08328988da17cbc577882