### PR TITLE
Pass installer credentials through environment

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -15,32 +15,39 @@ const executeScript = (res, scriptKey, options = {}) => {
     return res.status(400).json({ ok: false, output: 'Invalid script' });
   }
 
-  execFile(script, { shell: false }, (error, stdout, stderr) => {
-    const rawOutput = stdout + stderr;
-    const trimmedStdout = stdout.trim();
-    let parsedOutput;
+  const { env: customEnv, ...execOptions } = options;
+  const mergedEnv = { ...process.env, ...(customEnv || {}) };
 
-    if (trimmedStdout) {
-      try {
-        parsedOutput = JSON.parse(trimmedStdout);
-      } catch (_err) {
-        parsedOutput = undefined;
+  execFile(
+    script,
+    { shell: false, ...execOptions, env: mergedEnv },
+    (error, stdout, stderr) => {
+      const rawOutput = stdout + stderr;
+      const trimmedStdout = stdout.trim();
+      let parsedOutput;
+
+      if (trimmedStdout) {
+        try {
+          parsedOutput = JSON.parse(trimmedStdout);
+        } catch (_err) {
+          parsedOutput = undefined;
+        }
       }
-    }
 
-    if (error) {
+      if (error) {
+        if (parsedOutput && typeof parsedOutput === 'object') {
+          return res.status(500).json(parsedOutput);
+        }
+        return res.status(500).json({ ok: false, output: rawOutput });
+      }
+
       if (parsedOutput && typeof parsedOutput === 'object') {
-        return res.status(500).json(parsedOutput);
+        return res.json(parsedOutput);
       }
-      return res.status(500).json({ ok: false, output: rawOutput });
-    }
 
-    if (parsedOutput && typeof parsedOutput === 'object') {
-      return res.json(parsedOutput);
+      res.json({ ok: true, output: rawOutput });
     }
-
-    res.json({ ok: true, output: rawOutput });
-  });
+  );
 };
 
 exports.checkPrereqs = (req, res) =>
@@ -49,4 +56,22 @@ exports.checkPrereqs = (req, res) =>
     evaluateOk: (parsed) => Boolean(parsed && parsed.allPassed),
     determineStatusCode: () => 200,
   });
-exports.runInstall = (req, res) => executeScript(res, 'install');
+exports.runInstall = (req, res) => {
+  const sanitizeCredential = (value) => {
+    if (typeof value !== 'string') {
+      return '';
+    }
+
+    return value.replace(/\0/g, '').replace(/[\r\n]/g, '').trim();
+  };
+
+  const adminEmail = sanitizeCredential(req.body?.adminEmail);
+  const adminPassword = sanitizeCredential(req.body?.adminPassword);
+
+  return executeScript(res, 'install', {
+    env: {
+      ADMIN_EMAIL: adminEmail,
+      ADMIN_PASSWORD: adminPassword,
+    },
+  });
+};

--- a/backend/tests/installApi.test.js
+++ b/backend/tests/installApi.test.js
@@ -19,14 +19,15 @@ const { execFile } = require('child_process');
 const { router } = require('../src/modules/install/install.routes');
 
 const app = express();
+app.use(express.json());
 app.use('/api/install', router);
 
-describe('/api/install/prereqs', () => {
-  afterEach(() => {
-    delete process.env.INSTALL_API_ENABLED;
-    jest.clearAllMocks();
-  });
+afterEach(() => {
+  delete process.env.INSTALL_API_ENABLED;
+  jest.clearAllMocks();
+});
 
+describe('/api/install/prereqs', () => {
   it('returns 403 when INSTALL_API_ENABLED is false', async () => {
     process.env.INSTALL_API_ENABLED = 'false';
     const res = await request(app).get('/api/install/prereqs');
@@ -45,5 +46,41 @@ describe('/api/install/prereqs', () => {
       git: true,
     });
     expect(execFile).toHaveBeenCalled();
+  });
+});
+
+describe('/api/install/run', () => {
+  it('passes sanitized credentials to the install script via environment', async () => {
+    process.env.INSTALL_API_ENABLED = 'true';
+
+    const res = await request(app)
+      .post('/api/install/run')
+      .send({
+        adminEmail: '  admin@example.com  \n',
+        adminPassword: '  pass\nword  ',
+      });
+
+    expect(res.status).toBe(200);
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+    const execOptions = execFile.mock.calls[0][1];
+    expect(execOptions.shell).toBe(false);
+    expect(execOptions.env).toEqual(
+      expect.objectContaining({
+        ADMIN_EMAIL: 'admin@example.com',
+        ADMIN_PASSWORD: 'password',
+      })
+    );
+
+    if (process.env.PATH) {
+      expect(execOptions.env.PATH).toBe(process.env.PATH);
+    }
+
+    expect(res.body).toEqual({
+      node: true,
+      docker: true,
+      dockerCompose: true,
+      git: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- merge optional environment overrides into executeScript before invoking installer scripts
- read and sanitize admin credentials from the request body before calling the install script
- expand install API tests to confirm credentials are forwarded via environment variables

## Testing
- npm test -- installApi

------
https://chatgpt.com/codex/tasks/task_e_68c9f5b573bc8328b31a3b99142d9951