### PR TITLE
Guard installer after admin creation

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -1,6 +1,8 @@
 const { execFile } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const logger = require('../../utils/logger');
+const { refreshAdminPresence, markAdminExists } = require('./install.helpers');
 
 // Whitelisted scripts that can be executed via the install API. Paths are
 // resolved absolutely and must exist on disk to be executed.
@@ -15,7 +17,7 @@ const executeScript = (res, scriptKey, options = {}) => {
     return res.status(400).json({ ok: false, output: 'Invalid script' });
   }
 
-  execFile(script, { shell: false }, (error, stdout, stderr) => {
+  execFile(script, { shell: false }, async (error, stdout, stderr) => {
     const rawOutput = stdout + stderr;
     const trimmedStdout = stdout.trim();
     let parsedOutput;
@@ -33,6 +35,15 @@ const executeScript = (res, scriptKey, options = {}) => {
         return res.status(500).json(parsedOutput);
       }
       return res.status(500).json({ ok: false, output: rawOutput });
+    }
+
+    if (scriptKey === 'install') {
+      try {
+        markAdminExists();
+        await refreshAdminPresence();
+      } catch (refreshError) {
+        logger.warn('Failed to refresh install guard after successful run', refreshError);
+      }
     }
 
     if (parsedOutput && typeof parsedOutput === 'object') {

--- a/backend/src/modules/install/install.helpers.js
+++ b/backend/src/modules/install/install.helpers.js
@@ -1,0 +1,49 @@
+const db = require('../../config/database');
+
+const ADMIN_ROLES = ['Admin', 'SuperAdmin'];
+let cachedHasAdmin = null;
+
+const isMissingTableError = (error) => {
+  if (!error) return false;
+  if (error.code === '42P01') return true; // PostgreSQL missing table
+  const message = String(error.message || '').toLowerCase();
+  return message.includes('no such table') || message.includes('does not exist');
+};
+
+const queryAdminPresence = async (trx = db) => {
+  try {
+    const record = await trx('users').whereIn('role', ADMIN_ROLES).first();
+    return Boolean(record);
+  } catch (error) {
+    if (isMissingTableError(error)) {
+      cachedHasAdmin = false;
+      return false;
+    }
+    throw error;
+  }
+};
+
+const hasExistingAdmin = async ({ bypassCache = false } = {}) => {
+  if (!bypassCache && cachedHasAdmin === true) {
+    return true;
+  }
+  const exists = await queryAdminPresence();
+  cachedHasAdmin = exists;
+  return exists;
+};
+
+const refreshAdminPresence = async () => {
+  const exists = await queryAdminPresence();
+  cachedHasAdmin = exists;
+  return exists;
+};
+
+const markAdminExists = () => {
+  cachedHasAdmin = true;
+};
+
+module.exports = {
+  hasExistingAdmin,
+  refreshAdminPresence,
+  markAdminExists,
+};

--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -3,6 +3,7 @@ const controller = require('./install.controller');
 const { verifyToken, isAdmin } = require('../../middleware/auth/authMiddleware');
 const validate = require('../../middleware/validate');
 const { z } = require('zod');
+const { hasExistingAdmin } = require('./install.helpers');
 
 // Guard installation endpoints behind an environment flag to prevent accidental
 // exposure in production deployments.
@@ -15,8 +16,52 @@ const requireInstallApiEnabled = (req, res, next) => {
 
 router.use(requireInstallApiEnabled);
 
-// Require an authenticated administrator for all install endpoints.
-router.use(verifyToken, isAdmin);
+const extractToken = (req) => {
+  const authHeader = req.headers?.authorization;
+  if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+    const parts = authHeader.split(' ');
+    const token = parts[1]?.trim();
+    if (token) {
+      return token;
+    }
+  }
+
+  const cookieToken = typeof req.cookies?.token === 'string' ? req.cookies.token.trim() : '';
+  if (cookieToken) {
+    return cookieToken;
+  }
+
+  return null;
+};
+
+const enforceInstallerGuard = async (req, res, next) => {
+  try {
+    const adminExists = await hasExistingAdmin();
+    if (!adminExists) {
+      return next();
+    }
+
+    const token = extractToken(req);
+    if (!token) {
+      return res.status(403).json({
+        code: 'INSTALL_LOCKED',
+        message:
+          'Installation locked: An administrator already exists. Sign in to manage this instance.',
+      });
+    }
+
+    return verifyToken(req, res, (err) => {
+      if (err) {
+        return next(err);
+      }
+      return isAdmin(req, res, next);
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+router.use(enforceInstallerGuard);
 
 // No input is accepted for the prereqs endpoint; validate empty payloads strictly.
 const emptySchema = z.object({}).strict();

--- a/install/install.js
+++ b/install/install.js
@@ -347,13 +347,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     try {
       const res = await fetch('/api/install/prereqs', { cache: 'no-store' });
-      if (res.status === 401 || res.status === 403) {
-        setSummary('Authentication required. Please log in and try again.', 'error');
-        showError('Please log in to continue.');
-        setProgress(0);
-        return;
-      }
-
       const bodyText = await res.text();
       let data;
       if (bodyText) {
@@ -364,6 +357,26 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       } else {
         data = {};
+      }
+
+      if (res.status === 403 && data?.code === 'INSTALL_LOCKED') {
+        const message =
+          data?.message ||
+          'Installation locked. An administrator has already completed the setup. Please sign in.';
+        setSummary(message, 'error');
+        showError(
+          'SkillBridge is already installed. Sign in with an administrator account to manage your site.'
+        );
+        setProgress(0);
+        return;
+      }
+
+      if (res.status === 401 || res.status === 403) {
+        const message = data?.message || 'Authentication required. Please log in and try again.';
+        setSummary(message, 'error');
+        showError(message);
+        setProgress(0);
+        return;
       }
 
       const normalized = normalizePrereqResponse(data);
@@ -429,17 +442,6 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify(credentials),
       });
 
-      if (res.status === 401 || res.status === 403) {
-        showError('Please log in to continue.');
-        if (installOutput) {
-          installOutput.classList.remove('text-gray-700', 'text-green-700');
-          installOutput.classList.add('text-red-700');
-          installOutput.textContent = 'Authentication required. Please log in.';
-        }
-        updateStep('config');
-        return;
-      }
-
       const responseText = await res.text();
       let data;
       if (responseText) {
@@ -450,6 +452,32 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       } else {
         data = {};
+      }
+
+      if (res.status === 403 && data?.code === 'INSTALL_LOCKED') {
+        const message =
+          data?.message ||
+          'Installation locked. An administrator already exists. Sign in to manage this instance.';
+        showError(message);
+        if (installOutput) {
+          installOutput.classList.remove('text-gray-700', 'text-green-700');
+          installOutput.classList.add('text-red-700');
+          installOutput.textContent = message;
+        }
+        updateStep('config');
+        return;
+      }
+
+      if (res.status === 401 || res.status === 403) {
+        const message = data?.message || 'Please log in to continue.';
+        showError(message);
+        if (installOutput) {
+          installOutput.classList.remove('text-gray-700', 'text-green-700');
+          installOutput.classList.add('text-red-700');
+          installOutput.textContent = message;
+        }
+        updateStep('config');
+        return;
       }
 
       const success = typeof data.ok === 'boolean' ? data.ok : res.ok;


### PR DESCRIPTION
## Summary
- add an installation helper that checks for existing admin accounts and caches successful detections
- require installer authentication only after an admin exists and emit an INSTALL_LOCKED response when access is blocked
- refresh the admin cache after a successful install run and surface the locked state in the installer UI

## Testing
- npm test *(fails: repository test suite requires seeded env secrets and numerous suites fail under default container settings)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f5acedc48328b8e1963c28dfeb7d