### PR TITLE
Ensure frontend Dockerfile creates app group before chown

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,7 +29,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /shared /shared
-RUN adduser -S app && chown -R app:app /app
+RUN addgroup -S app && adduser -S -G app app && chown -R app:app /app
 EXPOSE 3000
 USER app
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- create the `app` group in the frontend production image before adding the `app` user so ownership changes succeed

## Testing
- docker build -t skillbridge-frontend -f frontend/Dockerfile . *(fails in container: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca130217988328b85acfa399342e51