### PR TITLE
Ensure frontend Dockerfile creates app group

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,7 +29,9 @@ RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /shared /shared
-RUN adduser -S app && chown -R app:app /app
+RUN addgroup -S app \
+    && adduser -S app -G app \
+    && chown -R app:app /app
 EXPOSE 3000
 USER app
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- ensure the app group exists before creating the app user in the frontend production Dockerfile stage
- keep the chown command aligned with the new app user/group

## Testing
- docker compose build frontend *(fails: `docker` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca12c404848328924148b8552daeda