### PR TITLE
Create app group before user in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,7 +29,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /shared /shared
-RUN adduser -S app && chown -R app:app /app
+RUN addgroup -S app && adduser -S -G app app && chown -R app:app /app
 EXPOSE 3000
 USER app
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- ensure the production image creates the app group and user before adjusting ownership of /app

## Testing
- docker build -t skillbridge-frontend -f frontend/Dockerfile . *(fails: `docker` not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca12bf3b2883289d4453a845e10238