### PR TITLE
Ensure shared directory is copied into backend runtime image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,7 @@ COPY package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/knexfile.js ./knexfile.js
-COPY --from=builder /shared /shared
+COPY --from=builder /app/shared ./shared
 COPY --from=builder /app/scripts ./scripts
 RUN chmod +x scripts/wait-for-db.sh scripts/docker-entrypoint.sh && \
     chown -R node:node /app


### PR DESCRIPTION
## Summary
- update the backend Dockerfile so the production image copies the built shared directory into /app/shared

## Testing
- docker compose build backend *(fails: docker command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9c54e8ec83288be969cd50f725fa