### PR TITLE
Adjust backend healthcheck start period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,10 +79,10 @@ services:
           curl --noproxy localhost,127.0.0.1 --fail --silent --show-error
           --connect-timeout 5 --max-time 10
           http://127.0.0.1:${BACKEND_PORT}/api/health
-      interval: 30s
+      interval: 60s
       timeout: 30s
-      retries: 3
-      start_period: 30s
+      retries: 5
+      start_period: 5m
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- extend the backend service healthcheck start period to five minutes to cover lengthy migrations
- slow the healthcheck interval to once per minute and increase retries so the container has more opportunities to report healthy during startup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb9c4f4e4c8328a5fd9ae01d8c00ba