### PR TITLE
Handle missing mail transporter and add test

### DIFF
--- a/backend/src/services/mailService.js
+++ b/backend/src/services/mailService.js
@@ -9,6 +9,11 @@ module.exports = {
     const cfg = (await getSettings()) || {};
     const transporter = await createTransporter();
 
+    if (!transporter) {
+      logger.log(`Emails disabled. Email to ${to} not sent.`);
+      return;
+    }
+
     const fromEmail = (cfg.fromEmail || process.env.SMTP_USER || "").trim();
     const fromName = (cfg.fromName || process.env.SMTP_NAME || "SkillBridge").trim();
 

--- a/backend/tests/services/mailService.test.js
+++ b/backend/tests/services/mailService.test.js
@@ -1,0 +1,39 @@
+jest.mock('../../src/modules/emailConfig/emailConfig.service', () => ({
+  getSettings: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../src/utils/email', () => ({
+  createTransporter: jest.fn(),
+}));
+
+jest.mock('../../src/utils/logger.js', () => ({
+  log: jest.fn(),
+  error: jest.fn(),
+}));
+
+const { createTransporter } = require('../../src/utils/email');
+const logger = require('../../src/utils/logger.js');
+const mailService = require('../../src/services/mailService');
+
+describe('mailService.sendMail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns early when transporter is unavailable', async () => {
+    createTransporter.mockResolvedValue(null);
+
+    await expect(
+      mailService.sendMail({
+        to: 'user@test.com',
+        subject: 'Test',
+        html: '<p>Test</p>',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      'Emails disabled. Email to user@test.com not sent.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- skip sending email when the transporter factory returns a falsy value
- log a concise message when emails are disabled to mirror other helpers
- cover the branch with a unit test that confirms no errors are logged

## Testing
- npm test -- mailService

------
https://chatgpt.com/codex/tasks/task_e_68cb9c479e588328ba1f1173ad0975ce