### PR TITLE
Ensure health check bypasses session dependencies

### DIFF
--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -5,7 +5,6 @@ const {
   router: installRouter,
 } = require('../modules/install/install.routes');
 
-router.use('/api/health', require('./health.routes'));
 router.use('/api/csrf-token', require('./csrf.routes'));
 // grouped routers
 router.use(require('./auth'));

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -128,6 +128,11 @@ app.use(
       config.NODE_ENV === "production" && req.url === "/api/health",
   })
 );
+
+// Lightweight health check that stays available even if downstream middleware fails
+app.get("/api/health", (_req, res) => {
+  res.status(200).json({ status: "ok" });
+});
 const sessionOptions = {
   secret: config.SESSION_SECRET,
   resave: false,

--- a/backend/tests/healthRoute.test.js
+++ b/backend/tests/healthRoute.test.js
@@ -1,0 +1,71 @@
+const request = require('supertest');
+
+describe('GET /api/health', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    process.env = { ...originalEnv };
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = process.env.JWT_SECRET || 'jwt-secret';
+    process.env.REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET || 'refresh-secret';
+    process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'session-secret';
+    process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
+    process.env.TEST_DATABASE_URL = process.env.TEST_DATABASE_URL ||
+      'postgres://user:pass@localhost:5432/test-db';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('responds with 200 even when the session store is unavailable', async () => {
+    const sessionHandler = jest.fn((req, res, next) => {
+      const error = new Error('Session store unavailable');
+      next(error);
+    });
+    const sessionMock = jest.fn(() => sessionHandler);
+
+    jest.doMock('express-session', () => sessionMock);
+    jest.doMock('connect-redis', () => ({
+      default: jest.fn().mockImplementation(() => ({ on: jest.fn() })),
+    }));
+    jest.doMock('../src/config/passport', () => ({
+      passport: {
+        initialize: () => (_req, _res, next) => next(),
+        session: () => (_req, _res, next) => next(),
+      },
+      initStrategies: jest.fn(),
+    }));
+    jest.doMock('../src/config/database', () => ({
+      connectWithRetry: jest.fn(),
+      migrate: { list: jest.fn().mockResolvedValue([[], []]) },
+    }));
+    jest.doMock('../src/routes', () => {
+      const express = require('express');
+      return express.Router();
+    });
+    jest.doMock('../src/jobs', () => jest.fn());
+    jest.doMock('../src/sockets', () => ({
+      initSockets: jest.fn(),
+      state: { io: {}, rooms: {}, participants: {}, userSockets: {} },
+    }));
+    jest.doMock('../src/utils/logger.js', () => ({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }));
+
+    const { app } = require('../src/server');
+
+    const res = await request(app).get('/api/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+    expect(sessionHandler).not.toHaveBeenCalled();
+    expect(sessionMock).toHaveBeenCalledWith(expect.objectContaining({ secret: expect.any(String) }));
+  });
+});
+


### PR DESCRIPTION
## Summary
- register the /api/health endpoint directly on the express app before session, CSRF, and rate limit middleware so it always answers
- remove the redundant /api/health registration from the shared router
- add a Jest test that stubs a failed session middleware and confirms the health route still responds 200

## Testing
- npm test -- healthRoute.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cbb55f86ac83289d07d104292f1bdd