### PR TITLE
Fix student identity document update controller

### DIFF
--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -151,22 +151,22 @@ exports.updateIdentity = async (req, res) => {
     if (!req.file) {
       return res.status(400).json({ message: "No identity document uploaded" });
     }
+
     const identityUrl = `/uploads/identity/student/${req.file.filename}`;
 
-    const existing = await db("student_profiles")
+    const existingProfile = await db("student_profiles")
       .where({ user_id: req.user.id })
       .first();
 
-    if (existing) {
-      if (existing.identity_doc_url) {
-        const sanitizedOldDoc = existing.identity_doc_url.replace(/^\//, "");
-        const oldPath = path.join(process.cwd(), sanitizedOldDoc);
-        fs.unlink(oldPath, (err) =>
-          err && logger.error("Failed to remove old identity document:", err)
-        );
-      }
+    if (existingProfile?.identity_doc_url) {
+      const sanitizedOldDoc = existingProfile.identity_doc_url.replace(/^\//, "");
+      const oldPath = path.join(process.cwd(), sanitizedOldDoc);
+      fs.unlink(oldPath, (err) =>
+        err && logger.error("Failed to remove old identity document:", err)
+      );
+    }
 
-    if (profile) {
+    if (existingProfile) {
       await db("student_profiles")
         .where({ user_id: req.user.id })
         .update({ identity_doc_url: identityUrl });


### PR DESCRIPTION
## Summary
- restore the student identity update handler to properly close the try/catch block
- reuse the existing profile lookup while cleaning up previous identity documents when present
- ensure the profile record is updated or created without referencing an undefined variable

## Testing
- `npm test -- --watchAll=false` *(fails: requires environment secrets such as JWT_SECRET when running the full backend test suite in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd2d25a848328a60e64a9691658ab