### PR TITLE
Improve student identity document update handling

### DIFF
--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -147,26 +147,36 @@ exports.updateAvatar = async (req, res) => {
  * @access Student
  */
 exports.updateIdentity = async (req, res) => {
-  try {
-    if (!req.file) {
-      return res.status(400).json({ message: "No identity document uploaded" });
-    }
-    const identityUrl = `/uploads/identity/student/${req.file.filename}`;
+  if (!req.file) {
+    return res.status(400).json({ message: "No identity document uploaded" });
+  }
 
-    const existing = await db("student_profiles")
+  const identityUrl = `/uploads/identity/student/${req.file.filename}`;
+
+  const removeFile = async (targetPath) => {
+    if (!targetPath) return;
+
+    try {
+      await fs.promises.unlink(targetPath);
+    } catch (err) {
+      if (err.code !== "ENOENT") {
+        logger.error("Failed to remove identity document", err);
+      }
+    }
+  };
+
+  try {
+    const existingProfile = await db("student_profiles")
       .where({ user_id: req.user.id })
       .first();
 
-    if (existing) {
-      if (existing.identity_doc_url) {
-        const sanitizedOldDoc = existing.identity_doc_url.replace(/^\//, "");
-        const oldPath = path.join(process.cwd(), sanitizedOldDoc);
-        fs.unlink(oldPath, (err) =>
-          err && logger.error("Failed to remove old identity document:", err)
-        );
-      }
+    if (existingProfile && existingProfile.identity_doc_url) {
+      const sanitizedOldDoc = existingProfile.identity_doc_url.replace(/^\//, "");
+      const oldPath = path.join(process.cwd(), sanitizedOldDoc);
+      await removeFile(oldPath);
+    }
 
-    if (profile) {
+    if (existingProfile) {
       await db("student_profiles")
         .where({ user_id: req.user.id })
         .update({ identity_doc_url: identityUrl });
@@ -179,9 +189,7 @@ exports.updateIdentity = async (req, res) => {
 
     res.json({ identity_doc_url: identityUrl });
   } catch (error) {
-    if (req.file) {
-      fs.unlink(req.file.path, (err) => err && logger.error(err));
-    }
+    await removeFile(req.file && req.file.path);
     logger.error(error);
     res.status(500).json({ message: "Failed to update identity document" });
   }


### PR DESCRIPTION
## Summary
- validate the presence of a new identity upload before performing any database work
- centralize identity document cleanup with fs.promises to remove stale or failed uploads while ignoring missing files
- reuse the existing profile lookup for conditional update/insert without optional chaining to avoid parser issues in production

## Testing
- `npm test -- --watchAll=false` *(fails: backend test suite requires secrets such as JWT_SECRET in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd2d25a848328a60e64a9691658ab