### PR TITLE
Update production API base URL configuration

### DIFF
--- a/frontend/.env.production.expanded
+++ b/frontend/.env.production.expanded
@@ -1,4 +1,4 @@
 APP_DOMAIN=eduskillbridge.net
-NEXT_PUBLIC_API_BASE_URL=http://backend:${BACKEND_PORT}/api
+NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api
 NEXT_PUBLIC_PGADMIN_URL=http://pgadmin:80
 NEXT_PUBLIC_SOCKET_URL=wss://eduskillbridge.net


### PR DESCRIPTION
## Summary
- point the production NEXT_PUBLIC_API_BASE_URL to the public https://eduskillbridge.net/api endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbfe0facc483288f19a377cf948877