### PR TITLE
Fix social login config request when backend uses different domain

### DIFF
--- a/frontend/src/services/socialLoginService.js
+++ b/frontend/src/services/socialLoginService.js
@@ -1,6 +1,11 @@
 import api from "@/services/api/api";
 
 export const fetchSocialLoginConfig = async () => {
-  const { data } = await api.get("/social-login/config");
+  const { data } = await api.get("/social-login/config", {
+    // This endpoint only returns public config so skip credentials to avoid
+    // cross-site cookie requirements that would otherwise trigger CORS errors
+    // in environments where the backend domain differs from the frontend.
+    withCredentials: false,
+  });
   return data?.data ?? null;
 };


### PR DESCRIPTION
## Summary
- avoid sending cookies when requesting the public social login configuration to prevent cross-site CORS failures
- document why credentials are disabled for this specific request

## Testing
- npm run lint *(fails: existing repository lint warnings/errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0966a2c48328ad5379e6b995112f