### PR TITLE
Use public axios client for social login config

### DIFF
--- a/frontend/src/services/socialLoginService.js
+++ b/frontend/src/services/socialLoginService.js
@@ -1,6 +1,15 @@
+import axios from "axios";
 import api from "@/services/api/api";
 
+// Use a dedicated public Axios client that skips auth/CSRF interceptors and
+// cookies so the request can succeed even when the backend runs on a different
+// domain without CORS support for credentials or custom headers.
+const publicApi = axios.create({
+  baseURL: api.defaults.baseURL,
+  withCredentials: false,
+});
+
 export const fetchSocialLoginConfig = async () => {
-  const { data } = await api.get("/social-login/config");
+  const { data } = await publicApi.get("/social-login/config");
   return data?.data ?? null;
 };


### PR DESCRIPTION
## Summary
- create a dedicated public Axios client for the social login config request so it skips auth interceptors and credentials that trigger cross-site CORS failures

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0966a2c48328ad5379e6b995112f