### PR TITLE
Update production CORS origins

### DIFF
--- a/backend/.env.production
+++ b/backend/.env.production
@@ -1,0 +1,3 @@
+# Production environment variables
+FRONTEND_URL=https://eduskillbridge.net,https://www.eduskillbridge.net
+ALLOWED_ORIGINS=https://eduskillbridge.net,https://www.eduskillbridge.net

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -10,7 +10,8 @@ SESSION_SECRET=change_me
 # Use redis://redis:6379 when running with docker-compose.
 # Replace with your managed Redis URL for other deployments.
 REDIS_URL=redis://redis:6379
-FRONTEND_URL=https://example.com
+FRONTEND_URL=https://example.com,https://www.example.com
+ALLOWED_ORIGINS=https://example.com,https://www.example.com
 APP_DOMAIN=example.com
 COOKIE_DOMAIN=.example.com
 # Maximum upload size for blog images in bytes


### PR DESCRIPTION
## Summary
- add the production CORS origins for eduskillbridge.net and www.eduskillbridge.net to the committed production env file
- update the production env example so both FRONTEND_URL and ALLOWED_ORIGINS accept comma-separated origins

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc3e700b2483289f899f313228860e