### PR TITLE
Enforce HTTPS API configuration for frontend builds

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,16 +7,28 @@ COPY frontend/ ./
 COPY shared /shared
 
 # Default build-time environment variables.
-ARG NEXT_PUBLIC_API_BASE_URL="http://localhost:5002/api"
+ARG NEXT_PUBLIC_API_BASE_URL
 ARG NEXT_PUBLIC_PGADMIN_URL="http://localhost:5050"
 ARG APP_DOMAIN=""
 ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL \
     NEXT_PUBLIC_PGADMIN_URL=$NEXT_PUBLIC_PGADMIN_URL \
-    APP_DOMAIN=$APP_DOMAIN
+    APP_DOMAIN=$APP_DOMAIN \
+    STRICT_PUBLIC_API=true
 
 # Source optional production env file if present before building.
-RUN if [ -f .env.production ]; then \
-        set -a && . ./.env.production; \
+RUN set -euo pipefail; \
+    if [ -f .env.production ]; then \
+        set -a && . ./.env.production && set +a; \
+    fi; \
+    if [ -z "${NEXT_PUBLIC_API_BASE_URL:-}" ]; then \
+        echo "NEXT_PUBLIC_API_BASE_URL must be provided via --build-arg or .env.production" >&2; \
+        exit 1; \
+    fi; \
+    if printf '%s' "$NEXT_PUBLIC_API_BASE_URL" | grep -Eq '^http://'; then \
+        if ! printf '%s' "$NEXT_PUBLIC_API_BASE_URL" | grep -Eq '^http://(localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0|\\[::1\\]|backend)(:\\d+)?(/|$)'; then \
+            echo "NEXT_PUBLIC_API_BASE_URL (${NEXT_PUBLIC_API_BASE_URL}) must use HTTPS for public hosts" >&2; \
+            exit 1; \
+        fi; \
     fi; \
     npm run build
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,13 +15,13 @@ npm install
 The production build reads configuration from `.env.production`. Define the following keys before building:
 
 - `APP_DOMAIN` – domain where the app is hosted (e.g. `eduskillbridge.net`).
-- `NEXT_PUBLIC_API_BASE_URL` – base URL for backend API requests.
+- `NEXT_PUBLIC_API_BASE_URL` – base URL for backend API requests. Production builds must point to an HTTPS endpoint.
 - `NEXT_PUBLIC_PGADMIN_URL` – pgAdmin interface endpoint.
 - `NEXT_PUBLIC_SOCKET_URL` – WebSocket endpoint, typically `wss://${APP_DOMAIN}`.
 
 Environment files support variable expansion using [`dotenv-expand`](https://github.com/motdotla/dotenv-expand). Values such as `NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api` will resolve `APP_DOMAIN` during `npm run build`.
 
-Only commit placeholder values. Supply real values in production via environment variables or a mounted `.env.production` so `npm run build` can generate a bundle that connects to the correct services. The Docker build context excludes `.env.local`, ensuring container images read the API host from the `DOCKER_NEXT_PUBLIC_API_BASE_URL` build argument (defaulting to the in-stack backend) or from a supplied `.env.production`.
+Only commit placeholder values. Supply real values in production via environment variables or a mounted `.env.production` so `npm run build` can generate a bundle that connects to the correct services. The Docker build context excludes `.env.local`, so container images **must** provide `NEXT_PUBLIC_API_BASE_URL` either by passing `--build-arg NEXT_PUBLIC_API_BASE_URL=https://your-domain/api` or by including it in `.env.production`. Builds fail if the value is missing or if a non-local host still uses `http://`.
 
 ## Development Server
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -51,18 +51,27 @@ try {
   // Prevent shipping a build that points at an internal HTTP host which would
   // cause browsers to block requests with mixed-content errors.
   const enforcePublicAPI = process.env.STRICT_PUBLIC_API === 'true';
-  if (
-    enforcePublicAPI &&
-    process.env.NODE_ENV === 'production' &&
-    /^https?:\/\/(localhost|backend)(:\\d+)?/i.test(apiBase)
-  ) {
-    throw new Error(
-      `NEXT_PUBLIC_API_BASE_URL (${apiBase}) points to a non-public host. Set this to your public HTTPS domain in frontend/.env.production.`,
-    );
+  const isStrictProduction = enforcePublicAPI && process.env.NODE_ENV === 'production';
+  if (isStrictProduction) {
+    const localHostPattern =
+      /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|backend)(:\\d+)?/i;
+    if (localHostPattern.test(apiBase)) {
+      throw new Error(
+        `NEXT_PUBLIC_API_BASE_URL (${apiBase}) points to a non-public host. Set this to your public HTTPS domain in frontend/.env.production.`,
+      );
+    }
+    if (!/^https:\/\//i.test(apiBase)) {
+      throw new Error(
+        `NEXT_PUBLIC_API_BASE_URL (${apiBase}) must use HTTPS when building production images.`,
+      );
+    }
   }
 
   ({ protocol, hostname, port } = new URL(apiBase));
 } catch (error) {
+  if (process.env.STRICT_PUBLIC_API === 'true' && process.env.NODE_ENV === 'production') {
+    throw error;
+  }
   console.warn(
     `Invalid NEXT_PUBLIC_API_BASE_URL ("${apiBase}"): ${error.message}. Falling back to ${defaultApiBase}.`,
   );


### PR DESCRIPTION
## Summary
- require a production API base URL during the frontend Docker build and fail the build when the value is missing or uses insecure HTTP for public hosts
- enable strict API validation and expand next.config.mjs checks to reject non-public or non-HTTPS endpoints during production builds
- document the mandatory HTTPS API base configuration for container images in the frontend README

## Testing
- NEXT_PUBLIC_API_BASE_URL=https://example.com/api npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68cd0bc543d88328bc381fc206048cea