### PR TITLE
Require HTTPS API base for frontend builds

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,12 +24,14 @@ RUN set -euo pipefail; \
         echo "NEXT_PUBLIC_API_BASE_URL must be provided via --build-arg or .env.production" >&2; \
         exit 1; \
     fi; \
-    if printf '%s' "$NEXT_PUBLIC_API_BASE_URL" | grep -Eq '^http://'; then \
-        if ! printf '%s' "$NEXT_PUBLIC_API_BASE_URL" | grep -Eq '^http://(localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0|\\[::1\\]|backend)(:\\d+)?(/|$)'; then \
+    case "$NEXT_PUBLIC_API_BASE_URL" in \
+        http://localhost*|http://127.0.0.1*|http://0.0.0.0*|http://\[::1\]*|http://backend*) \
+            ;; \
+        http://*) \
             echo "NEXT_PUBLIC_API_BASE_URL (${NEXT_PUBLIC_API_BASE_URL}) must use HTTPS for public hosts" >&2; \
             exit 1; \
-        fi; \
-    fi; \
+            ;; \
+    esac; \
     npm run build
 
 # Production stage

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,7 +21,7 @@ The production build reads configuration from `.env.production`. Define the foll
 
 Environment files support variable expansion using [`dotenv-expand`](https://github.com/motdotla/dotenv-expand). Values such as `NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api` will resolve `APP_DOMAIN` during `npm run build`.
 
-Only commit placeholder values. Supply real values in production via environment variables or a mounted `.env.production` so `npm run build` can generate a bundle that connects to the correct services. The Docker build context excludes `.env.local`, so container images **must** provide `NEXT_PUBLIC_API_BASE_URL` either by passing `--build-arg NEXT_PUBLIC_API_BASE_URL=https://your-domain/api` or by including it in `.env.production`. Builds fail if the value is missing or if a non-local host still uses `http://`.
+Only commit placeholder values. Supply real values in production via environment variables or a mounted `.env.production` so `npm run build` can generate a bundle that connects to the correct services. Docker builds export `STRICT_PUBLIC_API=true`, so container images **must** provide `NEXT_PUBLIC_API_BASE_URL` either by passing `--build-arg NEXT_PUBLIC_API_BASE_URL=https://your-domain/api` or by including it in `.env.production`. Builds fail if the value is missing or if a non-local host still uses `http://`.
 
 ## Development Server
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -19,7 +19,19 @@ dotenvExpand.expand(
 /** @type {import('next').NextConfig} */
 const defaultApiBase = 'http://localhost:5002/api';
 const apiBaseEnv = process.env.NEXT_PUBLIC_API_BASE_URL;
-let apiBase = apiBaseEnv || defaultApiBase;
+const enforcePublicAPI = process.env.STRICT_PUBLIC_API === 'true';
+const isStrictProduction = enforcePublicAPI && process.env.NODE_ENV === 'production';
+let apiBase;
+if (isStrictProduction) {
+  if (!apiBaseEnv) {
+    throw new Error(
+      'NEXT_PUBLIC_API_BASE_URL must be defined when STRICT_PUBLIC_API is enabled for production builds.',
+    );
+  }
+  apiBase = apiBaseEnv;
+} else {
+  apiBase = apiBaseEnv || defaultApiBase;
+}
 const defaultPgAdminBase = 'http://localhost:5050';
 const pgAdminEnv = process.env.NEXT_PUBLIC_PGADMIN_URL;
 let pgAdminBase = pgAdminEnv || defaultPgAdminBase;
@@ -50,8 +62,6 @@ try {
 
   // Prevent shipping a build that points at an internal HTTP host which would
   // cause browsers to block requests with mixed-content errors.
-  const enforcePublicAPI = process.env.STRICT_PUBLIC_API === 'true';
-  const isStrictProduction = enforcePublicAPI && process.env.NODE_ENV === 'production';
   if (isStrictProduction) {
     const localHostPattern =
       /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|backend)(:\\d+)?/i;
@@ -69,7 +79,7 @@ try {
 
   ({ protocol, hostname, port } = new URL(apiBase));
 } catch (error) {
-  if (process.env.STRICT_PUBLIC_API === 'true' && process.env.NODE_ENV === 'production') {
+  if (isStrictProduction) {
     throw error;
   }
   console.warn(


### PR DESCRIPTION
## Summary
- require providing NEXT_PUBLIC_API_BASE_URL during the Docker build and fail when non-local HTTP URLs are supplied
- ensure next.config.mjs enforces the HTTPS guard whenever STRICT_PUBLIC_API is enabled for production builds
- document the build-time requirement and guard configuration in the frontend README

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd17eeb3fc8328b8a0003ffe74b952