### PR TITLE
Ensure frontend Dockerfile uses bash with pipefail

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,9 @@ ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL \
     APP_DOMAIN=$APP_DOMAIN \
     STRICT_PUBLIC_API=true
 
+# Ensure subsequent RUN commands execute with pipefail enabled.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Source optional production env file if present before building.
 RUN set -euo pipefail; \
     if [ -f .env.production ]; then \


### PR DESCRIPTION
## Summary
- configure the frontend build stage to use bash with pipefail enabled before environment validation

## Testing
- `docker compose build frontend` *(fails: `docker` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1b0428948328a162fdb4bbe456d5