### PR TITLE
Use bash shell in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,6 +6,9 @@ RUN npm ci && npm cache clean --force
 COPY frontend/ ./
 COPY shared /shared
 
+# Ensure subsequent RUN instructions use bash so pipefail is respected.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Default build-time environment variables.
 ARG NEXT_PUBLIC_API_BASE_URL
 ARG NEXT_PUBLIC_PGADMIN_URL="http://localhost:5050"


### PR DESCRIPTION
## Summary
- ensure builder stage uses bash for RUN commands so pipefail is honored

## Testing
- docker compose build frontend *(fails: docker command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1afa4bb083288344e1bcd92d4597