### PR TITLE
Support relative API base URL during frontend builds

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -100,19 +100,24 @@ referenced in `nginx/conf.d/ssl.conf`.
 3. **Frontend** – for Docker Compose production builds, set variables in
   `frontend/.env.production`:
 
- ```bash
- APP_DOMAIN=yourdomain.com
- NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api
- NEXT_PUBLIC_PGADMIN_URL=https://${APP_DOMAIN}/pgadmin
- ```
+```bash
+APP_DOMAIN=yourdomain.com
+NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api
+NEXT_PUBLIC_PGADMIN_URL=https://${APP_DOMAIN}/pgadmin
+```
 
-  Commit only placeholder values. Provide real production settings via
-  environment variables or by mounting a `.env.production` file at deploy time
-  so secrets stay out of version control. The root `.env` is intended for local
-  development and defaults `NEXT_PUBLIC_API_BASE_URL` to
-  `http://localhost:5002/api` for internal container communication. Remove or
-  override this file in production so the frontend uses your public HTTPS
-  domain.
+> **Tip:** When `APP_DOMAIN` is defined you can alternatively set
+> `NEXT_PUBLIC_API_BASE_URL=/api`. During the build the relative value expands
+> to `https://${APP_DOMAIN}/api`, letting reverse proxies expose the API at the
+> same origin without hard-coding the domain in your environment file.
+
+Commit only placeholder values. Provide real production settings via
+environment variables or by mounting a `.env.production` file at deploy time
+so secrets stay out of version control. The root `.env` is intended for local
+development and defaults `NEXT_PUBLIC_API_BASE_URL` to
+`http://localhost:5002/api` for internal container communication. Remove or
+override this file in production so the frontend uses your public HTTPS
+domain.
 
  Without these variables the frontend defaults to `/api` which may point to the
  wrong server when deployed.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -30,8 +30,12 @@ RUN \
         echo "NEXT_PUBLIC_API_BASE_URL must be provided via --build-arg or .env.production" >&2; \
         exit 1; \
     fi; \
+    if [[ "$NEXT_PUBLIC_API_BASE_URL" == /* ]] && [ -z "${APP_DOMAIN:-}" ]; then \
+        echo "APP_DOMAIN must be set when NEXT_PUBLIC_API_BASE_URL is provided as a relative path" >&2; \
+        exit 1; \
+    fi; \
     case "$NEXT_PUBLIC_API_BASE_URL" in \
-        http://localhost*|http://127.0.0.1*|http://0.0.0.0*|http://\[::1\]*|http://backend*) \
+        http://localhost*|http://127.0.0.1*|http://0.0.0.0*|http://\[::1\]*|http://backend*|/*) \
             ;; \
         http://*) \
             echo "NEXT_PUBLIC_API_BASE_URL (${NEXT_PUBLIC_API_BASE_URL}) must use HTTPS for public hosts" >&2; \

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,7 +21,9 @@ The production build reads configuration from `.env.production`. Define the foll
 
 Environment files support variable expansion using [`dotenv-expand`](https://github.com/motdotla/dotenv-expand). Values such as `NEXT_PUBLIC_API_BASE_URL=https://${APP_DOMAIN}/api` will resolve `APP_DOMAIN` during `npm run build`.
 
-Only commit placeholder values. Supply real values in production via environment variables or a mounted `.env.production` so `npm run build` can generate a bundle that connects to the correct services. Docker builds export `STRICT_PUBLIC_API=true`, so container images **must** provide `NEXT_PUBLIC_API_BASE_URL` either by passing `--build-arg NEXT_PUBLIC_API_BASE_URL=https://your-domain/api` or by including it in `.env.production`. Builds fail if the value is missing or if a non-local host still uses `http://`.
+Only commit placeholder values. Supply real values in production via environment variables or a mounted `.env.production` so `npm run build` can generate a bundle that connects to the correct services. If `APP_DOMAIN` is defined you may set `NEXT_PUBLIC_API_BASE_URL=/api`; the build expands the relative path to `https://${APP_DOMAIN}/api` while still rejecting non-HTTPS public hosts.
+
+Docker builds export `STRICT_PUBLIC_API=true`, so container images **must** provide `NEXT_PUBLIC_API_BASE_URL` either by passing `--build-arg NEXT_PUBLIC_API_BASE_URL=https://your-domain/api` (or `/api` alongside `--build-arg APP_DOMAIN=your-domain`) or by including it in `.env.production`. Builds fail if the value is missing or if a non-local host still uses `http://`.
 
 ## Development Server
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -21,6 +21,38 @@ const defaultApiBase = 'http://localhost:5002/api';
 const apiBaseEnv = process.env.NEXT_PUBLIC_API_BASE_URL;
 const enforcePublicAPI = process.env.STRICT_PUBLIC_API === 'true';
 const isStrictProduction = enforcePublicAPI && process.env.NODE_ENV === 'production';
+const appDomain = process.env.APP_DOMAIN;
+
+const resolveApiBase = (candidate) => {
+  if (!candidate) {
+    return defaultApiBase;
+  }
+
+  if (/^https?:\/\//i.test(candidate)) {
+    return candidate;
+  }
+
+  if (candidate.startsWith('/')) {
+    if (!appDomain) {
+      throw new Error(
+        `NEXT_PUBLIC_API_BASE_URL (${candidate}) is a relative path, but APP_DOMAIN is not set.`,
+      );
+    }
+
+    const hasProtocol = /^https?:\/\//i.test(appDomain);
+    const normalizedDomain = appDomain.replace(/\/+$/, '');
+    const normalizedPath = `/${candidate.replace(/^\/+/, '')}`;
+    const domainWithProtocol = hasProtocol
+      ? normalizedDomain
+      : `https://${normalizedDomain}`;
+    return `${domainWithProtocol}${normalizedPath}`;
+  }
+
+  throw new Error(
+    `NEXT_PUBLIC_API_BASE_URL must be an absolute URL or start with "/". Received: ${candidate}`,
+  );
+};
+
 let apiBase;
 if (isStrictProduction) {
   if (!apiBaseEnv) {
@@ -28,9 +60,16 @@ if (isStrictProduction) {
       'NEXT_PUBLIC_API_BASE_URL must be defined when STRICT_PUBLIC_API is enabled for production builds.',
     );
   }
-  apiBase = apiBaseEnv;
+  apiBase = resolveApiBase(apiBaseEnv);
 } else {
-  apiBase = apiBaseEnv || defaultApiBase;
+  try {
+    apiBase = resolveApiBase(apiBaseEnv);
+  } catch (error) {
+    console.warn(
+      `Invalid NEXT_PUBLIC_API_BASE_URL ("${apiBaseEnv}"): ${error.message}. Falling back to ${defaultApiBase}.`,
+    );
+    apiBase = defaultApiBase;
+  }
 }
 const defaultPgAdminBase = 'http://localhost:5050';
 const pgAdminEnv = process.env.NEXT_PUBLIC_PGADMIN_URL;
@@ -88,7 +127,6 @@ try {
   apiBase = defaultApiBase;
   ({ protocol, hostname, port } = new URL(defaultApiBase));
 }
-const appDomain = process.env.APP_DOMAIN;
 const nextConfig = {
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary
- expand NEXT_PUBLIC_API_BASE_URL values that start with a slash using APP_DOMAIN inside next.config.mjs so builds accept relative API paths while still enforcing HTTPS in production
- allow the frontend Docker build to accept relative API base URLs when APP_DOMAIN is provided and document the behavior in the frontend README and deployment guide

## Testing
- APP_DOMAIN=example.com NEXT_PUBLIC_API_BASE_URL=/api STRICT_PUBLIC_API=true npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd461488548328af9080c468f07f93