### PR TITLE
Fix uploads root redirect and add test

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -172,11 +172,15 @@ app.use(passport.session());
 const uploadsPath = path.join(__dirname, "../uploads");
 const serveUploads = express.static(uploadsPath, {
   maxAge: "1h",
+  redirect: false,
   setHeaders: (res) => {
     res.setHeader("Cache-Control", "public, max-age=3600");
   },
 });
 const blockPdfMiddleware = (req, res, next) => {
+  if (!req.path || req.path === "/") {
+    return res.status(404).json({ message: "Not Found" });
+  }
   if (req.path.toLowerCase().endsWith(".pdf")) {
     return res.status(403).json({ message: "Direct PDF access is forbidden" });
   }

--- a/backend/tests/uploadsRoute.test.js
+++ b/backend/tests/uploadsRoute.test.js
@@ -1,0 +1,65 @@
+const request = require('supertest');
+
+describe('GET /api/uploads', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    process.env = { ...originalEnv };
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = process.env.JWT_SECRET || 'jwt-secret';
+    process.env.REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET || 'refresh-secret';
+    process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'session-secret';
+    process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
+    process.env.TEST_DATABASE_URL = process.env.TEST_DATABASE_URL ||
+      'postgres://user:pass@localhost:5432/test-db';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns 404 without redirecting when no file is requested', async () => {
+    jest.doMock('express-session', () => jest.fn(() => (_req, _res, next) => next()));
+    jest.doMock('connect-redis', () => ({
+      default: jest.fn().mockImplementation(() => ({ on: jest.fn() })),
+    }));
+    jest.doMock('../src/config/passport', () => ({
+      passport: {
+        initialize: () => (_req, _res, next) => next(),
+        session: () => (_req, _res, next) => next(),
+      },
+      initStrategies: jest.fn(),
+    }));
+    jest.doMock('../src/config/database', () => ({
+      connectWithRetry: jest.fn(),
+      migrate: { list: jest.fn().mockResolvedValue([[], []]) },
+    }));
+    jest.doMock('../src/routes', () => {
+      const express = require('express');
+      return express.Router();
+    });
+    jest.doMock('../src/jobs', () => jest.fn());
+    jest.doMock('../src/middleware/csrf', () => [(_req, _res, next) => next()]);
+    jest.doMock('../src/sockets', () => ({
+      initSockets: jest.fn(),
+      state: { io: {}, rooms: {}, participants: {}, userSockets: {} },
+    }));
+    jest.doMock('../src/utils/logger.js', () => ({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }));
+
+    const { app } = require('../src/server');
+
+    const res = await request(app).get('/api/uploads');
+
+    expect(res.status).toBe(404);
+    expect(res.headers.location).toBeUndefined();
+    expect(res.body).toEqual({ message: 'Not Found' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- disable express static redirect for uploads and return a 404 when the uploads root is requested
- add regression test covering GET /api/uploads without a file path

## Testing
- JWT_SECRET=jwt REFRESH_TOKEN_SECRET=refresh SESSION_SECRET=session npm test -- --runTestsByPath tests/uploadsRoute.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd5690a8c48328b9ad429cba93c2bb