### PR TITLE
Reduce backend Docker build disk usage

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,21 +3,15 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache curl netcat-openbsd postgresql-client
 COPY package*.json ./
-RUN npm ci && npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force
 COPY ./ ./
-COPY shared /shared
 
 # Production stage
 FROM node:20-alpine
 WORKDIR /app
 RUN apk add --no-cache curl netcat-openbsd postgresql-client && \
     (id -u node 2>/dev/null || adduser -S node)
-COPY package*.json ./
-RUN npm ci --only=production && npm cache clean --force
-COPY --from=builder /app/src ./src
-COPY --from=builder /app/knexfile.js ./knexfile.js
-COPY --from=builder /app/shared ./shared
-COPY --from=builder /app/scripts ./scripts
+COPY --from=builder /app ./
 RUN chmod +x scripts/wait-for-db.sh scripts/docker-entrypoint.sh && \
     chown -R node:node /app
 EXPOSE 5002


### PR DESCRIPTION
## Summary
- install only production dependencies in the backend builder stage
- reuse the builder stage output in the runtime image to avoid duplicate installs

## Testing
- `docker build -t backend-test .` *(fails: docker CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd63225b708328bc9a07014e21a2e7