### PR TITLE
Add transactional helpers for tutorial creation and tags

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -14,6 +14,44 @@ exports.createTutorial = async (data, trx = db) => {
   return tutorial;
 };
 
+exports.createTutorialWithRelations = async (
+  data,
+  tags = [],
+  chapters = []
+) => {
+  return withTransaction(async (trx) => {
+    const tutorial = await exports.createTutorial(data, trx);
+
+    if (tags && tags.length) {
+      await exports.updateTutorialTags(tutorial.id, tags, trx);
+    }
+
+    const createdChapters = [];
+    if (chapters && chapters.length) {
+      for (let index = 0; index < chapters.length; index += 1) {
+        const chapter = chapters[index];
+        const chapterData = {
+          id: uuidv4(),
+          tutorial_id: tutorial.id,
+          title: chapter.title,
+          video_url: chapter.video_url || null,
+          duration: chapter.duration ?? null,
+          order: chapter.order ?? index + 1,
+          is_preview: Boolean(chapter.is_preview),
+        };
+        await chapterService.create(chapterData, trx);
+        createdChapters.push(chapterData);
+      }
+    }
+
+    const tutorialTags = tags && tags.length
+      ? await exports.getTutorialTags(tutorial.id, trx)
+      : [];
+
+    return { ...tutorial, tags: tutorialTags, chapters: createdChapters };
+  });
+};
+
 exports.findByTitle = async (title) => {
   return db("tutorials")
     .whereRaw('LOWER(title) = ?', title.toLowerCase())
@@ -362,6 +400,13 @@ exports.updateTutorialTags = async (tutorialId, tags, trx = db) => {
     tagIds.push(tag.id);
   }
   await exports.addTutorialTags(tutorialId, tagIds, trx);
+};
+
+exports.updateTutorialTagsTransactional = async (tutorialId, tags) => {
+  return withTransaction(async (trx) => {
+    await exports.updateTutorialTags(tutorialId, tags, trx);
+    return exports.getTutorialTags(tutorialId, trx);
+  });
 };
 
 exports.getTutorialTags = async (tutorialId, trx = db) => {

--- a/backend/tests/tutorialCreate.test.js
+++ b/backend/tests/tutorialCreate.test.js
@@ -3,6 +3,7 @@ jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({
   addTutorialTags: jest.fn(),
   getTutorialTags: jest.fn(),
   countPublishedTutorials: jest.fn(),
+  updateTutorialTagsTransactional: jest.fn(),
 }));
 
 jest.mock('../src/modules/users/tutorials/chapters/tutorialChapter.service', () => ({
@@ -26,6 +27,13 @@ jest.mock('../src/modules/messages/messages.service', () => ({
 jest.mock('../src/modules/users/user.model', () => ({
   findById: jest.fn(),
   findAdmins: jest.fn(),
+}));
+
+jest.mock('../src/modules/users/tutorials/certificate/certificate.service', () => ({
+  generateCode: jest.fn(),
+  isUserCompletedTutorial: jest.fn(),
+  findExisting: jest.fn(),
+  issueCertificate: jest.fn(),
 }));
 
 jest.mock('../src/utils/email', () => ({


### PR DESCRIPTION
## Summary
- add a transactional helper to create tutorials, tags, and chapters together so the controller can use one service call
- introduce a transactional tag update helper that returns the refreshed tag list for updates
- update controller tests to mock the new service export and avoid DB access during unit tests

## Testing
- JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres npm test -- tutorialCreate

------
https://chatgpt.com/codex/tasks/task_e_68cd69af4dc48328a629ce65e42bf2c2