### PR TITLE
Add cache dependency to tutorial service

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -3,6 +3,7 @@ const db = require("../../../config/database");
 const tagService = require("./tutorialTag.service");
 const chapterService = require("./chapters/tutorialChapter.service");
 const { withTransaction } = require("../../../services/transaction.service");
+const cache = require("../../../utils/cache");
 const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
 const { TUTORIAL_STATUS } = require("../../../../shared/tutorialStatus");


### PR DESCRIPTION
## Summary
- import the shared cache utility in the tutorials service so aggregate caching works

## Testing
- node - <<'NODE' (manual smoke test verifying the service loads and aggregate caching executes)


------
https://chatgpt.com/codex/tasks/task_e_68cd69ad3cc08328b46f243a70c52473