### PR TITLE
Fix instructor tutorials query aggregates

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -158,11 +158,7 @@ exports.getTutorialsByInstructor = async (instructorId) => {
       "t.*",
       "c.name as category_name",
       "c.image_url as category_image_url",
-      "u.full_name as instructor_name",
-      db.raw("COALESCE(r.avg_rating, 0) as rating"),
-      db.raw("COALESCE(com.comment_count, 0) as comment_count"),
-      db.raw("COALESCE(en.enrollments, 0) as enrollments"),
-      db.raw("COALESCE(v.views, 0) as views")
+      "u.full_name as instructor_name"
     )
     .where("t.instructor_id", instructorId)
     .whereNot("t.status", TUTORIAL_STATUS.ARCHIVED)


### PR DESCRIPTION
## Summary
- remove raw aggregate selects that referenced missing aliases in `getTutorialsByInstructor`
- rely on `getTutorialAggregates` for ratings, comments, enrollments, and views

## Testing
- npm test *(fails: test suite requires JWT_SECRET, REFRESH_TOKEN_SECRET, and SESSION_SECRET environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68cd69a18c2c8328abbf0982608db8ca