### PR TITLE
Fix tutorial aggregates cache integration

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -2,6 +2,7 @@
 const db = require("../../../config/database");
 const tagService = require("./tutorialTag.service");
 const chapterService = require("./chapters/tutorialChapter.service");
+const cache = require("../../../utils/cache");
 const { withTransaction } = require("../../../services/transaction.service");
 const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
@@ -54,7 +55,7 @@ exports.getTutorialAggregates = async (tutorialId) => {
     rating: parseFloat(ratingRow.rating) || 0
   };
 
-  cache.set(`tutorial:${tutorialId}:aggregates`, aggregates);
+  cache.set(`tutorial:${tutorialId}:aggregates`, aggregates, { ttl: 300 });
   return aggregates;
 };
 

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -3,12 +3,39 @@ const socketStore = require('./socketStore');
 
 const store = new Map();
 
+const normalizeTtl = (options) => {
+  if (!options) return null;
+  if (typeof options === 'number') {
+    return Number.isFinite(options) && options > 0 ? options * 1000 : null;
+  }
+
+  if (typeof options === 'object') {
+    const { ttl } = options;
+    if (Number.isFinite(ttl) && ttl > 0) {
+      return ttl * 1000;
+    }
+  }
+
+  return null;
+};
+
 module.exports = {
   get(key) {
-    return store.get(key);
+    const entry = store.get(key);
+    if (!entry) return undefined;
+
+    const { value, expiresAt } = entry;
+    if (expiresAt && expiresAt <= Date.now()) {
+      store.delete(key);
+      return undefined;
+    }
+
+    return value;
   },
-  set(key, value) {
-    store.set(key, value);
+  set(key, value, options = null) {
+    const ttlMs = normalizeTtl(options);
+    const expiresAt = ttlMs ? Date.now() + ttlMs : null;
+    store.set(key, { value, expiresAt });
   },
   del(key) {
     store.delete(key);

--- a/backend/tests/cacheUtil.test.js
+++ b/backend/tests/cacheUtil.test.js
@@ -3,6 +3,7 @@ const cache = require('../src/utils/cache');
 describe('cache utility', () => {
   afterEach(async () => {
     await cache.clear();
+    jest.useRealTimers();
   });
 
   it('stores and retrieves values', () => {
@@ -19,6 +20,17 @@ describe('cache utility', () => {
   it('clears all values', async () => {
     cache.set('foo', 'bar');
     await cache.clear();
+    expect(cache.get('foo')).toBeUndefined();
+  });
+
+  it('expires values after TTL', () => {
+    const start = new Date('2024-01-01T00:00:00Z');
+    jest.useFakeTimers({ now: start });
+
+    cache.set('foo', 'bar', { ttl: 1 });
+    expect(cache.get('foo')).toBe('bar');
+
+    jest.setSystemTime(new Date(start.getTime() + 1000));
     expect(cache.get('foo')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- require the cache utility in the tutorial service and cache aggregates with a short TTL
- enhance the cache helper to support TTL-based expirations and handle misses cleanly
- expand cache utility tests to cover TTL expiry behaviour

## Testing
- `npm test -- cacheUtil`
- `npm test -- tutorialRoutes --testNamePattern "returns tutorial details"`


------
https://chatgpt.com/codex/tasks/task_e_68cd699f8e848328ba1684be1f014785