### PR TITLE
Import cache utility in tutorial service

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -5,6 +5,7 @@ const chapterService = require("./chapters/tutorialChapter.service");
 const { withTransaction } = require("../../../services/transaction.service");
 const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
+const cache = require("../../../utils/cache");
 const { TUTORIAL_STATUS } = require("../../../../shared/tutorialStatus");
 
 exports.createTutorial = async (data, trx = db) => {


### PR DESCRIPTION
## Summary
- add the missing cache import in the tutorial service so cache-backed aggregate lookups work without a ReferenceError

## Testing
- node - <<'NODE'
const cache = require('./backend/src/utils/cache');
cache.get = () => ({ cached: true });
cache.set = () => {};
const service = require('./backend/src/modules/users/tutorials/tutorial.service');
service.getTutorialAggregates('demo').then((res) => {
  console.log('Aggregates result:', res);
  process.exit(0);
}).catch((err) => {
  console.error('Error:', err);
  process.exit(1);
});
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cd6983f4108328a2762af01c9c4c48