### PR TITLE
Fix duplicate cache import in tutorial service

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -6,7 +6,6 @@ const { withTransaction } = require("../../../services/transaction.service");
 const cache = require("../../../utils/cache");
 const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
-const cache = require("../../../utils/cache");
 const { TUTORIAL_STATUS } = require("../../../../shared/tutorialStatus");
 
 exports.createTutorial = async (data, trx = db) => {


### PR DESCRIPTION
## Summary
- remove the duplicate cache helper import from the tutorials service

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7f7ed16c8328af6dd88f3dedbd4a