### PR TITLE
Fix class assignment due date validation

### DIFF
--- a/backend/src/modules/classes/assignments/classAssignment.validator.js
+++ b/backend/src/modules/classes/assignments/classAssignment.validator.js
@@ -4,7 +4,7 @@ exports.create = {
   body: z.object({
     title: z.string().min(3),
     description: z.string().optional(),
-    due_date: z.string().date(),
+    due_date: z.coerce.date(),
   }),
 };
 
@@ -12,6 +12,6 @@ exports.update = {
   body: z.object({
     title: z.string().min(3).optional(),
     description: z.string().optional(),
-    due_date: z.string().date().optional(),
+    due_date: z.coerce.date().optional(),
   }),
 };


### PR DESCRIPTION
## Summary
- replace the deprecated `z.string().date()` calls with `z.coerce.date()` in the class assignment validator

## Testing
- `npm test -- classAssignment.routes` *(fails: existing SyntaxError in tutorial.service.js due to duplicate declaration)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7e9f4fd88328aa3ec5950be970a0