### PR TITLE
Fix tutorial assignment due date validator

### DIFF
--- a/backend/src/modules/users/tutorials/assignments/tutorialAssignment.validator.js
+++ b/backend/src/modules/users/tutorials/assignments/tutorialAssignment.validator.js
@@ -4,7 +4,7 @@ exports.create = {
   body: z.object({
     title: z.string().min(3),
     description: z.string().optional(),
-    due_date: z.string().date(),
+    due_date: z.coerce.date(),
   }),
 };
 
@@ -12,6 +12,6 @@ exports.update = {
   body: z.object({
     title: z.string().min(3).optional(),
     description: z.string().optional(),
-    due_date: z.string().date().optional(),
+    due_date: z.coerce.date().optional(),
   }),
 };


### PR DESCRIPTION
## Summary
- switch tutorial assignment due date validation to use zod's coercion-based date schema for create and update flows

## Testing
- npm test *(fails: existing suite requires additional environment secrets and has unrelated syntax errors)*
- node -e "process.env.JWT_SECRET='x'; process.env.REFRESH_TOKEN_SECRET='y'; process.env.SESSION_SECRET='z'; const validator=require('./src/modules/users/tutorials/assignments/tutorialAssignment.validator'); console.log(typeof validator.create.body.shape.due_date);"


------
https://chatgpt.com/codex/tasks/task_e_68cd7e9b24bc832882e17b664656cc31