### PR TITLE
Remove duplicate cache import from tutorial service

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -6,7 +6,6 @@ const { withTransaction } = require("../../../services/transaction.service");
 const cache = require("../../../utils/cache");
 const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
-const cache = require("../../../utils/cache");
 const { TUTORIAL_STATUS } = require("../../../../shared/tutorialStatus");
 
 exports.createTutorial = async (data, trx = db) => {


### PR DESCRIPTION
## Summary
- remove the duplicate cache import in the tutorials service module

## Testing
- NODE_ENV=test JWT_SECRET=dummy REFRESH_TOKEN_SECRET=dummy SESSION_SECRET=dummy TEST_DATABASE_URL=postgres://user:pass@localhost:5432/db npm run start

------
https://chatgpt.com/codex/tasks/task_e_68cd7e99995883288f8504d36127350d