### PR TITLE
Add migration to enable pgcrypto extension

### DIFF
--- a/backend/src/migrations/20250709192111_enable_pgcrypto_extension.js
+++ b/backend/src/migrations/20250709192111_enable_pgcrypto_extension.js
@@ -1,0 +1,7 @@
+exports.up = async function up(knex) {
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS "pgcrypto"');
+};
+
+exports.down = async function down(knex) {
+  await knex.raw('DROP EXTENSION IF EXISTS "pgcrypto"');
+};


### PR DESCRIPTION
## Summary
- add a migration that ensures the pgcrypto extension exists before UUID defaults that call gen_random_uuid()

## Testing
- npm --prefix backend test *(fails: missing JWT_SECRET/REFRESH_TOKEN_SECRET/SESSION_SECRET env vars in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaa796d648328b8da776dd620291f