### PR TITLE
Avoid dropping pgcrypto extension in down migration

### DIFF
--- a/backend/src/migrations/20250709192111_enable_pgcrypto_extension.js
+++ b/backend/src/migrations/20250709192111_enable_pgcrypto_extension.js
@@ -2,6 +2,6 @@ exports.up = async function up(knex) {
   await knex.raw('CREATE EXTENSION IF NOT EXISTS "pgcrypto"');
 };
 
-exports.down = async function down(knex) {
-  await knex.raw('DROP EXTENSION IF EXISTS "pgcrypto"');
+exports.down = async function down() {
+  // Intentionally left blank to keep dependent defaults using pgcrypto
 };


### PR DESCRIPTION
## Summary
- keep the pgcrypto extension available when rolling back the enabling migration by making the down migration a no-op

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdc058bf0083288ece6fcec96fe996