### PR TITLE
Allow login when reCAPTCHA configuration is unavailable

### DIFF
--- a/backend/src/modules/recaptcha/recaptcha.service.js
+++ b/backend/src/modules/recaptcha/recaptcha.service.js
@@ -16,6 +16,14 @@ exports.verify = async (token, remoteIp) => {
   if (!recaptcha.active) {
     return true; // disabled -> skip verification
   }
+  if (!recaptcha.secretKey) {
+    logger.warn('reCAPTCHA is active but missing a secret key – skipping verification');
+    return true;
+  }
+  if (!recaptcha.siteKey) {
+    logger.warn('reCAPTCHA is active but missing a site key – skipping verification');
+    return true; // disabled -> skip verification
+  }
   if (!token) {
     return false;
   }

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -84,52 +84,60 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
   // 🔑 Handle form submission
   // ─────────────────────────────
   const onSubmit = async (data) => {
-  try {
-    logger.log("➡️ login onSubmit invoked");
-    let cfg = recaptchaCfg;
-    if (!cfg) {
-      setCfgLoading(true);
-      cfg = await fetchSocialLoginConfig().catch(() => null);
-      setRecaptchaCfg(cfg);
-      setCfgLoading(false);
-    }
-    if (!cfg) {
-      toast.error(t("recaptcha_config_failed"));
-      return;
-    }
-    if (cfg?.recaptcha?.active && !executeRecaptcha) {
-      toast.error(t("recaptcha_config_failed"));
-      return;
-    }
-    let token;
-    if (cfg?.recaptcha?.active && executeRecaptcha) {
-      token = await executeRecaptcha("login");
-    }
-    const loggedInUser = await login({ ...data, recaptchaToken: token });
-    toast.success(t("login_successful"));
-    fetchNotifications();
+    try {
+      logger.log("➡️ login onSubmit invoked");
+      let cfg = recaptchaCfg;
+      if (!cfg && cfgLoading) {
+        setCfgLoading(true);
+        cfg = await fetchSocialLoginConfig().catch(() => null);
+        setRecaptchaCfg(cfg);
+        setCfgLoading(false);
+      }
 
-    const targetPath =
-      loggedInUser.profile_complete === false
-        ? profileRoutes[loggedInUser.role?.toLowerCase()] || "/website"
-        : "/website";
+      const recaptchaConfigured = Boolean(
+        cfg?.recaptcha?.active &&
+          cfg?.recaptcha?.siteKey &&
+          executeRecaptcha
+      );
 
-    // 🚀 Redirect after a short delay so the toast is visible
-    setTimeout(() => {
-      router.push(targetPath);
-    }, 500);
-  } catch (err) {
-    logger.error("❌ login onSubmit error", err);
-    handleError(err, t("login_failed"));
-    setValue("password", "");
-    document.activeElement?.blur();
+      if (cfg?.recaptcha?.active && !cfg?.recaptcha?.siteKey) {
+        logger.warn("⚠️ reCAPTCHA enabled without a site key – skipping");
+      }
 
-    setTimeout(() => {
-      const loginBtn = document.querySelector("button[type=submit]");
-      loginBtn?.blur();
-    }, 100);
-  }
-};
+      let token;
+      if (recaptchaConfigured) {
+        try {
+          token = await executeRecaptcha("login");
+        } catch (recaptchaErr) {
+          logger.warn("⚠️ Failed to execute reCAPTCHA, proceeding without token", recaptchaErr);
+        }
+      }
+
+      const loggedInUser = await login({ ...data, recaptchaToken: token });
+      toast.success(t("login_successful"));
+      fetchNotifications();
+
+      const targetPath =
+        loggedInUser.profile_complete === false
+          ? profileRoutes[loggedInUser.role?.toLowerCase()] || "/website"
+          : "/website";
+
+      // 🚀 Redirect after a short delay so the toast is visible
+      setTimeout(() => {
+        router.push(targetPath);
+      }, 500);
+    } catch (err) {
+      logger.error("❌ login onSubmit error", err);
+      handleError(err, t("login_failed"));
+      setValue("password", "");
+      document.activeElement?.blur();
+
+      setTimeout(() => {
+        const loginBtn = document.querySelector("button[type=submit]");
+        loginBtn?.blur();
+      }, 100);
+    }
+  };
 
 
 
@@ -234,7 +242,11 @@ export default function Login() {
       .finally(() => setCfgLoading(false));
   }, []);
 
-  if (recaptchaCfg?.recaptcha?.active) {
+  const recaptchaEnabled = Boolean(
+    recaptchaCfg?.recaptcha?.active && recaptchaCfg?.recaptcha?.siteKey
+  );
+
+  if (recaptchaEnabled) {
     return (
       <GoogleReCaptchaProvider reCaptchaKey={recaptchaCfg.recaptcha.siteKey}>
         <LoginForm

--- a/frontend/src/pages/auth/register.js
+++ b/frontend/src/pages/auth/register.js
@@ -67,13 +67,29 @@ function RegisterForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading
       const { full_name, email, phone, password, role } = data;
       let cfg = recaptchaCfg;
       if (!cfg && cfgLoading) {
+        setCfgLoading(true);
         cfg = await fetchSocialLoginConfig().catch(() => null);
         setRecaptchaCfg(cfg);
         setCfgLoading(false);
       }
+
+      const recaptchaConfigured = Boolean(
+        cfg?.recaptcha?.active &&
+          cfg?.recaptcha?.siteKey &&
+          executeRecaptcha
+      );
+
+      if (cfg?.recaptcha?.active && !cfg?.recaptcha?.siteKey) {
+        console.warn("⚠️ reCAPTCHA enabled without a site key – skipping");
+      }
+
       let token;
-      if (cfg?.recaptcha?.active && executeRecaptcha) {
-        token = await executeRecaptcha("register");
+      if (recaptchaConfigured) {
+        try {
+          token = await executeRecaptcha("register");
+        } catch (recaptchaErr) {
+          console.warn("⚠️ Failed to execute reCAPTCHA, proceeding without token", recaptchaErr);
+        }
       }
       await registerUser({
         full_name,
@@ -201,9 +217,9 @@ function RegisterForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading
         <motion.button
           whileHover={{ scale: 1.05 }}
           onClick={handleSubmit(onSubmit)}
-          disabled={isSubmitting || (cfgLoading && !recaptchaCfg)}
+          disabled={isSubmitting}
           className={`w-full mt-4 py-2 rounded-lg font-semibold transition ${
-            isSubmitting || (cfgLoading && !recaptchaCfg)
+            isSubmitting
               ? "bg-gray-500 cursor-not-allowed"
               : "bg-yellow-500 hover:bg-yellow-600 text-gray-900"
           }`}
@@ -237,7 +253,11 @@ export default function Register() {
       .finally(() => setCfgLoading(false));
   }, []);
 
-  if (recaptchaCfg?.recaptcha?.active) {
+  const recaptchaEnabled = Boolean(
+    recaptchaCfg?.recaptcha?.active && recaptchaCfg?.recaptcha?.siteKey
+  );
+
+  if (recaptchaEnabled) {
     return (
       <GoogleReCaptchaProvider reCaptchaKey={recaptchaCfg.recaptcha.siteKey}>
         <RegisterForm


### PR DESCRIPTION
## Summary
- skip backend reCAPTCHA verification when the integration is enabled but lacks a site or secret key so that logins can proceed while configuration is repaired
- make the login and registration forms gracefully fall back when reCAPTCHA configuration fails to load, only invoking reCAPTCHA when a usable site key is present

## Testing
- npm test *(fails: requires JWT/refresh/session secrets in test env)*
- npm run lint *(fails: existing react/display-name lint errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc35508248328b8dd9f3898e733a8