### PR TITLE
Allow temporary reCAPTCHA bypass when execution fails

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -17,7 +17,10 @@ const { refreshCookieOptions, csrfCookieOptions } = require("../../../utils/cook
 exports.register = catchAsync(async (req, res, next) => {
   try {
     const cfg = await socialLoginConfigService.getSettings();
-    if (cfg?.recaptcha?.active) {
+    const bypassRecaptcha = recaptchaService.shouldBypass(cfg, req.body);
+    if (bypassRecaptcha) {
+      logger.warn('reCAPTCHA bypass requested during registration – allowing request without verification');
+    } else if (cfg?.recaptcha?.active) {
       const valid = await recaptchaService.verify(req.body.recaptchaToken, req.ip);
       if (!valid) {
         throw new AppError('Failed reCAPTCHA verification', 400);
@@ -60,7 +63,10 @@ exports.register = catchAsync(async (req, res, next) => {
  */
 exports.login = catchAsync(async (req, res) => {
   const cfg = await socialLoginConfigService.getSettings();
-  if (cfg?.recaptcha?.active) {
+  const bypassRecaptcha = recaptchaService.shouldBypass(cfg, req.body);
+  if (bypassRecaptcha) {
+    logger.warn('reCAPTCHA bypass requested during login – allowing request without verification');
+  } else if (cfg?.recaptcha?.active) {
     const valid = await recaptchaService.verify(req.body.recaptchaToken, req.ip);
     if (!valid) {
       throw new AppError('Failed reCAPTCHA verification', 400);

--- a/backend/src/modules/recaptcha/recaptcha.service.js
+++ b/backend/src/modules/recaptcha/recaptcha.service.js
@@ -10,10 +10,28 @@ const fetchFn =
     ? fetch
     : (...args) => import('node-fetch').then(({ default: f }) => f(...args));
 
+const FAILS_OPEN = process.env.RECAPTCHA_FAILS_OPEN !== 'false';
+
+exports.shouldBypass = (cfg, body = {}) => {
+  if (!cfg?.recaptcha?.active) return false;
+  if (!FAILS_OPEN) return false;
+  if (!body?.recaptchaBypass) return false;
+  if (body?.recaptchaToken) return false;
+  return true;
+};
+
 exports.verify = async (token, remoteIp) => {
   const cfg = await socialLoginConfigService.getSettings();
   const recaptcha = cfg?.recaptcha || {};
   if (!recaptcha.active) {
+    return true; // disabled -> skip verification
+  }
+  if (!recaptcha.secretKey) {
+    logger.warn('reCAPTCHA is active but missing a secret key – skipping verification');
+    return true;
+  }
+  if (!recaptcha.siteKey) {
+    logger.warn('reCAPTCHA is active but missing a site key – skipping verification');
     return true; // disabled -> skip verification
   }
   if (!token) {
@@ -33,6 +51,10 @@ exports.verify = async (token, remoteIp) => {
     return !!data.success;
   } catch (err) {
     logger.error('reCAPTCHA verify failed:', err.message);
+    if (FAILS_OPEN) {
+      logger.warn('reCAPTCHA verification failed but fails-open mode is enabled – skipping verification');
+      return true;
+    }
     return false;
   }
 };

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -84,52 +84,76 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
   // 🔑 Handle form submission
   // ─────────────────────────────
   const onSubmit = async (data) => {
-  try {
-    logger.log("➡️ login onSubmit invoked");
-    let cfg = recaptchaCfg;
-    if (!cfg) {
-      setCfgLoading(true);
-      cfg = await fetchSocialLoginConfig().catch(() => null);
-      setRecaptchaCfg(cfg);
-      setCfgLoading(false);
-    }
-    if (!cfg) {
-      toast.error(t("recaptcha_config_failed"));
-      return;
-    }
-    if (cfg?.recaptcha?.active && !executeRecaptcha) {
-      toast.error(t("recaptcha_config_failed"));
-      return;
-    }
-    let token;
-    if (cfg?.recaptcha?.active && executeRecaptcha) {
-      token = await executeRecaptcha("login");
-    }
-    const loggedInUser = await login({ ...data, recaptchaToken: token });
-    toast.success(t("login_successful"));
-    fetchNotifications();
+    try {
+      logger.log("➡️ login onSubmit invoked");
+      let cfg = recaptchaCfg;
+      if (!cfg && cfgLoading) {
+        setCfgLoading(true);
+        cfg = await fetchSocialLoginConfig().catch(() => null);
+        setRecaptchaCfg(cfg);
+        setCfgLoading(false);
+      }
 
-    const targetPath =
-      loggedInUser.profile_complete === false
-        ? profileRoutes[loggedInUser.role?.toLowerCase()] || "/website"
-        : "/website";
+      const recaptchaConfigured = Boolean(
+        cfg?.recaptcha?.active &&
+          cfg?.recaptcha?.siteKey &&
+          executeRecaptcha
+      );
 
-    // 🚀 Redirect after a short delay so the toast is visible
-    setTimeout(() => {
-      router.push(targetPath);
-    }, 500);
-  } catch (err) {
-    logger.error("❌ login onSubmit error", err);
-    handleError(err, t("login_failed"));
-    setValue("password", "");
-    document.activeElement?.blur();
+      let shouldBypassRecaptcha = Boolean(
+        cfg?.recaptcha?.active && !recaptchaConfigured
+      );
 
-    setTimeout(() => {
-      const loginBtn = document.querySelector("button[type=submit]");
-      loginBtn?.blur();
-    }, 100);
-  }
-};
+      if (cfg?.recaptcha?.active && !cfg?.recaptcha?.siteKey) {
+        logger.warn("⚠️ reCAPTCHA enabled without a site key – skipping");
+      }
+
+      let token;
+      if (recaptchaConfigured) {
+        try {
+          token = await executeRecaptcha("login");
+          if (!token) {
+            shouldBypassRecaptcha = Boolean(cfg?.recaptcha?.active);
+          }
+        } catch (recaptchaErr) {
+          shouldBypassRecaptcha = Boolean(cfg?.recaptcha?.active);
+          logger.warn("⚠️ Failed to execute reCAPTCHA, proceeding without token", recaptchaErr);
+        }
+      }
+
+      if (shouldBypassRecaptcha) {
+        logger.warn("⚠️ Bypassing reCAPTCHA for login so the request can proceed");
+      }
+
+      const loggedInUser = await login({
+        ...data,
+        recaptchaToken: token,
+        recaptchaBypass: shouldBypassRecaptcha,
+      });
+      toast.success(t("login_successful"));
+      fetchNotifications();
+
+      const targetPath =
+        loggedInUser.profile_complete === false
+          ? profileRoutes[loggedInUser.role?.toLowerCase()] || "/website"
+          : "/website";
+
+      // 🚀 Redirect after a short delay so the toast is visible
+      setTimeout(() => {
+        router.push(targetPath);
+      }, 500);
+    } catch (err) {
+      logger.error("❌ login onSubmit error", err);
+      handleError(err, t("login_failed"));
+      setValue("password", "");
+      document.activeElement?.blur();
+
+      setTimeout(() => {
+        const loginBtn = document.querySelector("button[type=submit]");
+        loginBtn?.blur();
+      }, 100);
+    }
+  };
 
 
 
@@ -234,7 +258,11 @@ export default function Login() {
       .finally(() => setCfgLoading(false));
   }, []);
 
-  if (recaptchaCfg?.recaptcha?.active) {
+  const recaptchaEnabled = Boolean(
+    recaptchaCfg?.recaptcha?.active && recaptchaCfg?.recaptcha?.siteKey
+  );
+
+  if (recaptchaEnabled) {
     return (
       <GoogleReCaptchaProvider reCaptchaKey={recaptchaCfg.recaptcha.siteKey}>
         <LoginForm

--- a/frontend/src/pages/auth/register.js
+++ b/frontend/src/pages/auth/register.js
@@ -19,6 +19,7 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import { registerSchema } from "@/utils/auth/validationSchemas";
 import { GoogleReCaptchaProvider, useGoogleReCaptcha } from "react-google-recaptcha-v3";
 import { fetchSocialLoginConfig } from "@/services/socialLoginService";
+import logger from "@/utils/logger";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
@@ -67,14 +68,43 @@ function RegisterForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading
       const { full_name, email, phone, password, role } = data;
       let cfg = recaptchaCfg;
       if (!cfg && cfgLoading) {
+        setCfgLoading(true);
         cfg = await fetchSocialLoginConfig().catch(() => null);
         setRecaptchaCfg(cfg);
         setCfgLoading(false);
       }
-      let token;
-      if (cfg?.recaptcha?.active && executeRecaptcha) {
-        token = await executeRecaptcha("register");
+
+      const recaptchaConfigured = Boolean(
+        cfg?.recaptcha?.active &&
+          cfg?.recaptcha?.siteKey &&
+          executeRecaptcha
+      );
+
+      let shouldBypassRecaptcha = Boolean(
+        cfg?.recaptcha?.active && !recaptchaConfigured
+      );
+
+      if (cfg?.recaptcha?.active && !cfg?.recaptcha?.siteKey) {
+        logger.warn("⚠️ reCAPTCHA enabled without a site key – skipping");
       }
+
+      let token;
+      if (recaptchaConfigured) {
+        try {
+          token = await executeRecaptcha("register");
+          if (!token) {
+            shouldBypassRecaptcha = Boolean(cfg?.recaptcha?.active);
+          }
+        } catch (recaptchaErr) {
+          shouldBypassRecaptcha = Boolean(cfg?.recaptcha?.active);
+          logger.warn("⚠️ Failed to execute reCAPTCHA, proceeding without token", recaptchaErr);
+        }
+      }
+
+      if (shouldBypassRecaptcha) {
+        logger.warn("⚠️ Bypassing reCAPTCHA for registration so the request can proceed");
+      }
+
       await registerUser({
         full_name,
         email,
@@ -82,6 +112,7 @@ function RegisterForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading
         password,
         role,
         recaptchaToken: token,
+        recaptchaBypass: shouldBypassRecaptcha,
       });
       toast.success(t("registration_successful"));
       fetchNotifications();
@@ -201,9 +232,9 @@ function RegisterForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading
         <motion.button
           whileHover={{ scale: 1.05 }}
           onClick={handleSubmit(onSubmit)}
-          disabled={isSubmitting || (cfgLoading && !recaptchaCfg)}
+          disabled={isSubmitting}
           className={`w-full mt-4 py-2 rounded-lg font-semibold transition ${
-            isSubmitting || (cfgLoading && !recaptchaCfg)
+            isSubmitting
               ? "bg-gray-500 cursor-not-allowed"
               : "bg-yellow-500 hover:bg-yellow-600 text-gray-900"
           }`}
@@ -237,7 +268,11 @@ export default function Register() {
       .finally(() => setCfgLoading(false));
   }, []);
 
-  if (recaptchaCfg?.recaptcha?.active) {
+  const recaptchaEnabled = Boolean(
+    recaptchaCfg?.recaptcha?.active && recaptchaCfg?.recaptcha?.siteKey
+  );
+
+  if (recaptchaEnabled) {
     return (
       <GoogleReCaptchaProvider reCaptchaKey={recaptchaCfg.recaptcha.siteKey}>
         <RegisterForm

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -14,13 +14,23 @@ import { normalizeError } from "@/utils/error";
  * @param {string} credentials.password
  * @returns {Promise<{ message: string, user: object }>}
  */
-export const loginUser = async ({ email, password, recaptchaToken }) => {
+export const loginUser = async ({
+  email,
+  password,
+  recaptchaToken,
+  recaptchaBypass,
+}) => {
   try {
     logger.log(
       "🔐 loginUser requesting",
       `${api.defaults.baseURL}/auth/login`
     );
-    const res = await api.post("/auth/login", { email, password, recaptchaToken });
+    const res = await api.post("/auth/login", {
+      email,
+      password,
+      recaptchaToken,
+      recaptchaBypass,
+    });
     // Ensure the CSRF cookie from the backend is present for subsequent requests
     await ensureCsrfToken();
     return res.data;


### PR DESCRIPTION
## Summary
- allow the backend to skip reCAPTCHA verification when a fails-open bypass is requested so misconfigured installs can still log in
- treat reCAPTCHA verification transport failures as non-fatal when fails-open mode is enabled and surface clear warnings in the logs
- flag login and registration submissions that cannot execute reCAPTCHA so the backend can honor the bypass and keep admins from getting locked out

## Testing
- npm test -- loginRecaptchaRefetch
- npm run lint *(fails: numerous pre-existing lint warnings and react/display-name errors)*
- npm test *(backend, fails: missing JWT/refresh/session secrets and other existing suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc35508248328b8dd9f3898e733a8