### PR TITLE
Handle CSRF token errors in auth controller

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -74,10 +74,21 @@ exports.login = catchAsync(async (req, res) => {
   }
   const { accessToken, refreshToken, user } =
     await authService.loginUser({ ...req.body, ip: req.ip });
-  res
-    .cookie("refreshToken", refreshToken, refreshCookieOptions)
-    .cookie("csrfToken", req.csrfToken(), csrfCookieOptions)
-    .json({ message: "Login successful", accessToken, user });
+
+  let csrfToken;
+  if (typeof req.csrfToken === "function") {
+    try {
+      csrfToken = req.csrfToken();
+    } catch (err) {
+      logger.warn("Failed to generate CSRF token during login: %s", err.message);
+    }
+  }
+
+  const response = res.cookie("refreshToken", refreshToken, refreshCookieOptions);
+  if (csrfToken) {
+    response.cookie("csrfToken", csrfToken, csrfCookieOptions);
+  }
+  response.json({ message: "Login successful", accessToken, user });
 });
 
 /**
@@ -106,10 +117,24 @@ exports.refreshToken = catchAsync(async (req, res) => {
     if (process.env.NODE_ENV !== "production") {
       logger.debug("\u2705 Refresh token rotated for user", decoded.id);
     }
-    res
-      .cookie("refreshToken", newRefreshToken, refreshCookieOptions)
-      .cookie("csrfToken", req.csrfToken(), csrfCookieOptions)
-      .json({ message: "Token refreshed", accessToken });
+    let csrfToken;
+    if (typeof req.csrfToken === "function") {
+      try {
+        csrfToken = req.csrfToken();
+      } catch (err) {
+        logger.warn(
+          "Failed to generate CSRF token during refresh for user %s: %s",
+          decoded.id,
+          err.message
+        );
+      }
+    }
+
+    const response = res.cookie("refreshToken", newRefreshToken, refreshCookieOptions);
+    if (csrfToken) {
+      response.cookie("csrfToken", csrfToken, csrfCookieOptions);
+    }
+    response.json({ message: "Token refreshed", accessToken });
   } catch (err) {
     logger.error("❌ Refresh token error:", err.message);
     return res.status(401).json({ message: "Invalid or expired refresh token" });

--- a/backend/tests/authControllerCsrf.test.js
+++ b/backend/tests/authControllerCsrf.test.js
@@ -1,0 +1,112 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
+process.env.SESSION_SECRET = 'sessionsecret';
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+process.env.TEST_DATABASE_URL = 'postgres://user:pass@localhost:5432/testdb';
+
+jest.mock('../src/modules/auth/services/auth.service', () => ({
+  loginUser: jest.fn(),
+  rotateRefreshToken: jest.fn(),
+  generateAccessToken: jest.fn(),
+}));
+
+jest.mock('../src/modules/socialLoginConfig/socialLoginConfig.service', () => ({
+  getSettings: jest.fn().mockResolvedValue({ recaptcha: { active: false } }),
+}));
+
+jest.mock('../src/modules/recaptcha/recaptcha.service', () => ({
+  verify: jest.fn(),
+  shouldBypass: jest.fn(() => true),
+}));
+
+jest.mock('../src/utils/logger.js', () => ({
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const authController = require('../src/modules/auth/controllers/auth.controller');
+const authService = require('../src/modules/auth/services/auth.service');
+
+describe('auth controller CSRF resilience', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('handles csrf token generation failure during login', async () => {
+    authService.loginUser.mockResolvedValue({
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      user: { id: 1 },
+    });
+
+    const req = {
+      body: { email: 'user@example.com', password: 'Pass123!' },
+      ip: '127.0.0.1',
+      csrfToken: jest.fn(() => {
+        throw new Error('csrf failed');
+      }),
+    };
+
+    const res = {
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await authController.login(req, res, next);
+    await new Promise(setImmediate);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.cookie).toHaveBeenCalledWith(
+      'refreshToken',
+      'refresh',
+      expect.any(Object)
+    );
+    expect(res.cookie).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Login successful',
+      accessToken: 'access',
+      user: { id: 1 },
+    });
+  });
+
+  it('handles csrf token generation failure during refresh', async () => {
+    authService.rotateRefreshToken.mockResolvedValue({
+      decoded: { id: 2, role: 'User', roles: ['User'] },
+      refreshToken: 'newRefresh',
+    });
+    authService.generateAccessToken.mockReturnValue('newAccess');
+
+    const req = {
+      cookies: { refreshToken: 'oldRefresh' },
+      csrfToken: jest.fn(() => {
+        throw new Error('csrf failed');
+      }),
+    };
+
+    const res = {
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    };
+    const next = jest.fn();
+
+    await authController.refreshToken(req, res, next);
+    await new Promise(setImmediate);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.cookie).toHaveBeenCalledWith(
+      'refreshToken',
+      'newRefresh',
+      expect.any(Object)
+    );
+    expect(res.cookie).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Token refreshed',
+      accessToken: 'newAccess',
+    });
+  });
+});
+

--- a/backend/tests/authLoginRoutes.test.js
+++ b/backend/tests/authLoginRoutes.test.js
@@ -2,6 +2,10 @@ const request = require('supertest');
 const express = require('express');
 
 process.env.NODE_ENV = 'production';
+process.env.JWT_SECRET = 'testsecret';
+process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
+process.env.SESSION_SECRET = 'sessionsecret';
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
 
 jest.mock('../src/config/database', () => ({
   raw: jest.fn(() => Promise.resolve()),
@@ -17,6 +21,7 @@ jest.mock('../src/modules/socialLoginConfig/socialLoginConfig.service', () => ({
 
 jest.mock('../src/modules/recaptcha/recaptcha.service', () => ({
   verify: jest.fn(),
+  shouldBypass: jest.fn(() => true),
 }));
 
 // Mock unrelated grouped routes
@@ -36,6 +41,15 @@ const errorHandler = require('../src/middleware/errorHandler');
 
 const app = express();
 app.use(express.json());
+app.use((req, res, next) => {
+  req.csrfToken = jest.fn(() => {
+    if (req.headers['x-force-csrf-error']) {
+      throw new Error('csrf failure');
+    }
+    return 'csrf-token';
+  });
+  next();
+});
 app.use(routes);
 app.use(errorHandler);
 
@@ -65,5 +79,22 @@ describe('POST /api/auth/login', () => {
     const res = await request(app).post('/api/auth/login').send(payload);
     expect(res.status).toBe(429);
     expect(res.body.message).toMatch(/too many failed login attempts/i);
+  });
+
+  it('still succeeds when csrf token generation fails', async () => {
+    authService.loginUser.mockResolvedValue({ accessToken: 'a', refreshToken: 'r', user: { id: 1 } });
+    const res = await request(app)
+      .post('/api/auth/login')
+      .set('x-force-csrf-error', '1')
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.accessToken).toBe('a');
+    expect(res.headers['set-cookie']).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^refreshToken=r/)]),
+    );
+    expect(res.headers['set-cookie']).toEqual(
+      expect.not.arrayContaining([expect.stringMatching(/^csrfToken=/)]),
+    );
   });
 });

--- a/backend/tests/authRefreshRoutes.test.js
+++ b/backend/tests/authRefreshRoutes.test.js
@@ -4,6 +4,11 @@ const cookieParser = require('cookie-parser');
 const session = require('express-session');
 
 process.env.NODE_ENV = 'production';
+process.env.JWT_SECRET = 'testsecret';
+process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
+process.env.SESSION_SECRET = 'sessionsecret';
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+process.env.TEST_DATABASE_URL = 'postgres://user:pass@localhost:5432/testdb';
 
 jest.mock('../src/config/database', () => ({
   raw: jest.fn(() => Promise.resolve()),
@@ -67,12 +72,6 @@ describe('POST /api/auth/refresh', () => {
       refreshToken: 'newR',
     });
     authService.generateAccessToken.mockReturnValue('newA');
-    const tokenRes = await request(app).get('/api/auth/refresh');
-    const cookies = tokenRes.headers['set-cookie'];
-    const csrfCookie = cookies.find((c) => c.startsWith('csrfToken=')).split(';')[0];
-    const sessionCookie = cookies.find((c) => c.startsWith('connect.sid=')).split(';')[0];
-    const csrfToken = csrfCookie.split('=')[1];
-
     const { sessionCookie, csrfCookie, csrfToken } = await getCsrf();
 
     const refreshRes = await request(app)


### PR DESCRIPTION
## Summary
- guard auth login and refresh responses so CSRF token generation failures only warn and skip the cookie
- extend auth login/refresh route tests and add controller coverage for CSRF failures

## Testing
- npm test -- authLoginRoutes authRefreshRoutes authControllerCsrf

------
https://chatgpt.com/codex/tasks/task_e_68ce65ee11ec8328b9c45f9baee80c5c