### PR TITLE
Add optional recaptcha bypass to auth validators

### DIFF
--- a/backend/src/modules/auth/validators/auth.validator.js
+++ b/backend/src/modules/auth/validators/auth.validator.js
@@ -33,6 +33,7 @@ exports.registerSchema = z.object({
     ),
   role: z.enum(["Student", "Instructor", "Admin"]).optional(), // Optional for fallback logic
   recaptchaToken: z.string().optional(),
+  recaptchaBypass: z.boolean().optional(),
 });
 
 /**
@@ -42,6 +43,7 @@ exports.loginSchema = z.object({
   email: z.string().email("Invalid email"),
   password: z.string().min(6, "Password must be at least 6 characters long"),
   recaptchaToken: z.string().optional(),
+  recaptchaBypass: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- allow both register and login validator schemas to accept an optional `recaptchaBypass` boolean alongside the existing `recaptchaToken`

## Testing
- `DATABASE_URL=postgres://user:pass@localhost:5432/testdb TEST_DATABASE_URL=postgres://user:pass@localhost:5432/testdb JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test npm test -- authRegisterRoutes` *(fails: validation rejects the fixture phone number used in the test)*
- `DATABASE_URL=postgres://user:pass@localhost:5432/testdb TEST_DATABASE_URL=postgres://user:pass@localhost:5432/testdb JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test npm test -- authLoginRoutes` *(fails: mocked recaptcha service does not expose shouldBypass)*

------
https://chatgpt.com/codex/tasks/task_e_68ce65f3cd6883288a8ce9f7d7d762d0