### PR TITLE
Handle missing csrf helper in auth controllers

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -74,10 +74,21 @@ exports.login = catchAsync(async (req, res) => {
   }
   const { accessToken, refreshToken, user } =
     await authService.loginUser({ ...req.body, ip: req.ip });
-  res
-    .cookie("refreshToken", refreshToken, refreshCookieOptions)
-    .cookie("csrfToken", req.csrfToken(), csrfCookieOptions)
-    .json({ message: "Login successful", accessToken, user });
+  let response = res.cookie("refreshToken", refreshToken, refreshCookieOptions);
+
+  if (typeof req.csrfToken === "function") {
+    response = response.cookie(
+      "csrfToken",
+      req.csrfToken(),
+      csrfCookieOptions
+    );
+  } else {
+    logger.warn(
+      "CSRF token function unavailable during login response; skipping csrfToken cookie"
+    );
+  }
+
+  response.json({ message: "Login successful", accessToken, user });
 });
 
 /**
@@ -106,10 +117,25 @@ exports.refreshToken = catchAsync(async (req, res) => {
     if (process.env.NODE_ENV !== "production") {
       logger.debug("\u2705 Refresh token rotated for user", decoded.id);
     }
-    res
-      .cookie("refreshToken", newRefreshToken, refreshCookieOptions)
-      .cookie("csrfToken", req.csrfToken(), csrfCookieOptions)
-      .json({ message: "Token refreshed", accessToken });
+    let response = res.cookie(
+      "refreshToken",
+      newRefreshToken,
+      refreshCookieOptions
+    );
+
+    if (typeof req.csrfToken === "function") {
+      response = response.cookie(
+        "csrfToken",
+        req.csrfToken(),
+        csrfCookieOptions
+      );
+    } else {
+      logger.warn(
+        "CSRF token function unavailable during refresh response; skipping csrfToken cookie"
+      );
+    }
+
+    response.json({ message: "Token refreshed", accessToken });
   } catch (err) {
     logger.error("❌ Refresh token error:", err.message);
     return res.status(401).json({ message: "Invalid or expired refresh token" });

--- a/backend/tests/authLoginRoutes.test.js
+++ b/backend/tests/authLoginRoutes.test.js
@@ -1,6 +1,8 @@
 const request = require('supertest');
 const express = require('express');
 
+const logger = require('../src/utils/logger');
+
 process.env.NODE_ENV = 'production';
 
 jest.mock('../src/config/database', () => ({
@@ -17,6 +19,7 @@ jest.mock('../src/modules/socialLoginConfig/socialLoginConfig.service', () => ({
 
 jest.mock('../src/modules/recaptcha/recaptcha.service', () => ({
   verify: jest.fn(),
+  shouldBypass: jest.fn().mockReturnValue(false),
 }));
 
 // Mock unrelated grouped routes
@@ -42,6 +45,11 @@ app.use(errorHandler);
 describe('POST /api/auth/login', () => {
   const payload = { email: 'test@example.com', password: 'StrongPass1!' };
 
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
   it('logs in a user successfully', async () => {
     authService.loginUser.mockResolvedValue({ accessToken: 'a', refreshToken: 'r', user: { id: 1 } });
     const res = await request(app).post('/api/auth/login').send(payload);
@@ -49,6 +57,20 @@ describe('POST /api/auth/login', () => {
     expect(authService.loginUser).toHaveBeenCalledWith(expect.objectContaining(payload));
     expect(res.body.accessToken).toBe('a');
     expect(res.headers['set-cookie']).toEqual(expect.arrayContaining([expect.stringMatching(/^refreshToken=r/)]));
+  });
+
+  it('skips csrf cookie and logs warning when csrf helper missing', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    authService.loginUser.mockResolvedValue({ accessToken: 'a', refreshToken: 'r', user: { id: 1 } });
+
+    const res = await request(app).post('/api/auth/login').send(payload);
+
+    expect(res.status).toBe(200);
+    const cookies = res.headers['set-cookie'] || [];
+    expect(cookies.some((cookie) => cookie.startsWith('csrfToken='))).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/CSRF token function unavailable during login response/)
+    );
   });
 
   it('returns 401 for invalid credentials', async () => {

--- a/backend/tests/authRefreshRoutes.test.js
+++ b/backend/tests/authRefreshRoutes.test.js
@@ -3,6 +3,8 @@ const express = require('express');
 const cookieParser = require('cookie-parser');
 const session = require('express-session');
 
+const logger = require('../src/utils/logger');
+
 process.env.NODE_ENV = 'production';
 
 jest.mock('../src/config/database', () => ({
@@ -21,6 +23,7 @@ jest.mock('../src/modules/socialLoginConfig/socialLoginConfig.service', () => ({
 
 jest.mock('../src/modules/recaptcha/recaptcha.service', () => ({
   verify: jest.fn(),
+  shouldBypass: jest.fn().mockReturnValue(false),
 }));
 
 // Mock unrelated grouped routes
@@ -36,6 +39,7 @@ jest.mock('../src/modules/subscriptions/subscriptions.routes', () => require('ex
 
 const csrf = require('../src/middleware/csrf');
 const authService = require('../src/modules/auth/services/auth.service');
+const authController = require('../src/modules/auth/controllers/auth.controller');
 const routes = require('../src/routes/auth');
 const errorHandler = require('../src/middleware/errorHandler');
 
@@ -50,6 +54,10 @@ app.use(errorHandler);
 describe('POST /api/auth/refresh', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   const getCsrf = async () => {
@@ -67,12 +75,6 @@ describe('POST /api/auth/refresh', () => {
       refreshToken: 'newR',
     });
     authService.generateAccessToken.mockReturnValue('newA');
-    const tokenRes = await request(app).get('/api/auth/refresh');
-    const cookies = tokenRes.headers['set-cookie'];
-    const csrfCookie = cookies.find((c) => c.startsWith('csrfToken=')).split(';')[0];
-    const sessionCookie = cookies.find((c) => c.startsWith('connect.sid=')).split(';')[0];
-    const csrfToken = csrfCookie.split('=')[1];
-
     const { sessionCookie, csrfCookie, csrfToken } = await getCsrf();
 
     const refreshRes = await request(app)
@@ -114,5 +116,35 @@ describe('POST /api/auth/refresh', () => {
     expect(res.status).toBe(403);
     expect(res.body.message).toMatch(/invalid csrf token/i);
     expect(authService.rotateRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('skips csrf cookie and logs warning when helper missing after verification', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    authService.rotateRefreshToken.mockResolvedValue({
+      decoded: { id: 1, role: 'User' },
+      refreshToken: 'newR',
+    });
+    authService.generateAccessToken.mockReturnValue('newA');
+
+    const missingCsrfApp = express();
+    missingCsrfApp.use(cookieParser());
+    missingCsrfApp.use(express.json());
+    missingCsrfApp.post('/api/auth/refresh', (req, res, next) => {
+      req.csrfToken = undefined;
+      return authController.refreshToken(req, res, next);
+    });
+    missingCsrfApp.use(errorHandler);
+
+    const res = await request(missingCsrfApp)
+      .post('/api/auth/refresh')
+      .set('Cookie', ['refreshToken=r']);
+
+    expect(res.status).toBe(200);
+    const cookies = res.headers['set-cookie'] || [];
+    expect(cookies.some((cookie) => cookie.startsWith('csrfToken='))).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/CSRF token function unavailable during refresh response/)
+    );
   });
 });


### PR DESCRIPTION
## Summary
- guard auth login and refresh controllers so csrf cookies are only set when the csrf helper is available and emit a warning otherwise
- extend login and refresh route tests to cover successful responses when req.csrfToken is absent
- add targeted assertions that warnings are logged and csrf cookies are skipped in the degraded scenario

## Testing
- JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test DATABASE_URL=postgres://user:pass@localhost:5432/db npx jest --runTestsByPath tests/authLoginRoutes.test.js tests/authRefreshRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ce65f5e644832885cc58f9589aff8c