### PR TITLE
Guard CSRF token helper before issuing cookies

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -74,10 +74,17 @@ exports.login = catchAsync(async (req, res) => {
   }
   const { accessToken, refreshToken, user } =
     await authService.loginUser({ ...req.body, ip: req.ip });
-  res
-    .cookie("refreshToken", refreshToken, refreshCookieOptions)
-    .cookie("csrfToken", req.csrfToken(), csrfCookieOptions)
-    .json({ message: "Login successful", accessToken, user });
+  let response = res.cookie("refreshToken", refreshToken, refreshCookieOptions);
+
+  if (typeof req.csrfToken === "function") {
+    response = response.cookie("csrfToken", req.csrfToken(), csrfCookieOptions);
+  } else {
+    logger.warn(
+      "⚠️ CSRF token helper missing on login request; skipping csrfToken cookie. Verify session/Redis configuration."
+    );
+  }
+
+  response.json({ message: "Login successful", accessToken, user });
 });
 
 /**
@@ -106,10 +113,25 @@ exports.refreshToken = catchAsync(async (req, res) => {
     if (process.env.NODE_ENV !== "production") {
       logger.debug("\u2705 Refresh token rotated for user", decoded.id);
     }
-    res
-      .cookie("refreshToken", newRefreshToken, refreshCookieOptions)
-      .cookie("csrfToken", req.csrfToken(), csrfCookieOptions)
-      .json({ message: "Token refreshed", accessToken });
+    let response = res.cookie(
+      "refreshToken",
+      newRefreshToken,
+      refreshCookieOptions
+    );
+
+    if (typeof req.csrfToken === "function") {
+      response = response.cookie(
+        "csrfToken",
+        req.csrfToken(),
+        csrfCookieOptions
+      );
+    } else {
+      logger.warn(
+        "⚠️ CSRF token helper missing on refresh request; skipping csrfToken cookie. Verify session/Redis configuration."
+      );
+    }
+
+    response.json({ message: "Token refreshed", accessToken });
   } catch (err) {
     logger.error("❌ Refresh token error:", err.message);
     return res.status(401).json({ message: "Invalid or expired refresh token" });

--- a/backend/src/routes/csrf.routes.js
+++ b/backend/src/routes/csrf.routes.js
@@ -1,10 +1,17 @@
 const express = require('express');
 const router = express.Router();
 const { csrfCookieOptions } = require('../utils/cookie');
+const logger = require('../utils/logger');
 
 router.get('/', (req, res) => {
-  const token = req.csrfToken();
-  res.cookie('csrfToken', token, csrfCookieOptions);
+  if (typeof req.csrfToken === 'function') {
+    const token = req.csrfToken();
+    res.cookie('csrfToken', token, csrfCookieOptions);
+  } else {
+    logger.warn(
+      '⚠️ CSRF token helper missing on CSRF route; skipping csrfToken cookie. Verify session/Redis configuration.'
+    );
+  }
   return res.status(204).json();
 });
 


### PR DESCRIPTION
## Summary
- guard CSRF token generation in the auth login and refresh handlers so the request still succeeds if the helper is unavailable
- emit warnings when the CSRF helper is missing to surface potential session or Redis misconfiguration
- apply the same guard and logging to the standalone CSRF token route

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce6770f81c8328b48a01c8c58eb6da