### PR TITLE
Enforce non-empty auth secrets in env validation

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -8,9 +8,18 @@ dotenvExpand.expand(myEnv);
 const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   BACKEND_PORT: z.coerce.number().default(5002),
-  JWT_SECRET: z.string(),
-  REFRESH_TOKEN_SECRET: z.string(),
-  SESSION_SECRET: z.string(),
+  JWT_SECRET: z
+    .string()
+    .trim()
+    .min(1, 'JWT_SECRET must not be empty'),
+  REFRESH_TOKEN_SECRET: z
+    .string()
+    .trim()
+    .min(1, 'REFRESH_TOKEN_SECRET must not be empty'),
+  SESSION_SECRET: z
+    .string()
+    .trim()
+    .min(1, 'SESSION_SECRET must not be empty'),
   DATABASE_URL: z.string().url().optional(),
   PRODUCTION_DATABASE_URL: z.string().url().optional(),
   TEST_DATABASE_URL: z.string().url().optional(),
@@ -38,7 +47,14 @@ const OPTIONAL_URL_ENV_VARS = [
   'REDIS_URL',
 ];
 
-const normalizeOptionalUrl = (value) => (value === '' ? undefined : value);
+const normalizeOptionalUrl = (value) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue === '' ? undefined : trimmedValue;
+};
 
 const createValidatedEnv = () => {
   const modifiedEnv = { ...process.env };

--- a/backend/tests/authMissingSecrets.test.js
+++ b/backend/tests/authMissingSecrets.test.js
@@ -43,14 +43,25 @@ const mockUser = {
   status: 'active',
 };
 
+const ORIGINAL_ENV = { ...process.env };
+
 describe('loginUser token secret validation', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    process.env = {
+      ...ORIGINAL_ENV,
+      JWT_SECRET: 'testsecret',
+      REFRESH_TOKEN_SECRET: 'refreshsecret',
+      SESSION_SECRET: 'sessionsecret',
+    };
+  });
+
+  afterAll(() => {
+    process.env = { ...ORIGINAL_ENV };
   });
 
   it('fails when JWT_SECRET is missing', async () => {
-    process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
     delete process.env.JWT_SECRET;
 
     const authService = require('../src/modules/auth/services/auth.service');
@@ -65,7 +76,6 @@ describe('loginUser token secret validation', () => {
   });
 
   it('fails when REFRESH_TOKEN_SECRET is missing', async () => {
-    process.env.JWT_SECRET = 'testsecret';
     delete process.env.REFRESH_TOKEN_SECRET;
 
     const authService = require('../src/modules/auth/services/auth.service');
@@ -77,5 +87,29 @@ describe('loginUser token secret validation', () => {
     await expect(
       authService.loginUser({ email: 'test@example.com', password: 'pass' })
     ).rejects.toThrow('Missing environment variable(s): REFRESH_TOKEN_SECRET');
+  });
+
+  it('fails when JWT_SECRET is blank', () => {
+    process.env.JWT_SECRET = '   ';
+
+    expect(() => require('../src/config/env')).toThrow(
+      'JWT_SECRET must not be empty'
+    );
+  });
+
+  it('fails when REFRESH_TOKEN_SECRET is blank', () => {
+    process.env.REFRESH_TOKEN_SECRET = '   ';
+
+    expect(() => require('../src/config/env')).toThrow(
+      'REFRESH_TOKEN_SECRET must not be empty'
+    );
+  });
+
+  it('fails when SESSION_SECRET is blank', () => {
+    process.env.SESSION_SECRET = '   ';
+
+    expect(() => require('../src/config/env')).toThrow(
+      'SESSION_SECRET must not be empty'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- require JWT_SECRET, REFRESH_TOKEN_SECRET, and SESSION_SECRET to be non-empty trimmed strings during environment validation
- trim optional URL environment variables before normalizing them
- add tests to ensure blank secrets prevent the server from starting

## Testing
- npm test -- authMissingSecrets

------
https://chatgpt.com/codex/tasks/task_e_68ce7c7b22c083289546c8a7a20d9253