### PR TITLE
Update login route warning expectation

### DIFF
--- a/backend/tests/authLoginRoutes.test.js
+++ b/backend/tests/authLoginRoutes.test.js
@@ -82,7 +82,7 @@ describe('POST /api/auth/login', () => {
     const cookies = res.headers['set-cookie'] || [];
     expect(cookies.some((cookie) => cookie.startsWith('csrfToken='))).toBe(false);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringMatching(/CSRF token function unavailable during login response/)
+      expect.stringMatching(/CSRF token helper missing on login request; skipping csrfToken cookie/)
     );
   });
 


### PR DESCRIPTION
## Summary
- align the auth login route warning test with the updated CSRF helper warning string using a resilient substring match

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce7c965650832896f89f9631cc5846