### PR TITLE
Update auth refresh warning test expectation

### DIFF
--- a/backend/tests/authRefreshRoutes.test.js
+++ b/backend/tests/authRefreshRoutes.test.js
@@ -149,7 +149,7 @@ describe('POST /api/auth/refresh', () => {
     const cookies = res.headers['set-cookie'] || [];
     expect(cookies.some((cookie) => cookie.startsWith('csrfToken='))).toBe(false);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringMatching(/CSRF token function unavailable during refresh response/)
+      expect.stringMatching(/CSRF token helper missing on refresh request.*skipping csrfToken cookie/i)
     );
   });
 });


### PR DESCRIPTION
## Summary
- update the refresh route warning assertion to match the new CSRF helper message

## Testing
- npm test -- authRefreshRoutes

------
https://chatgpt.com/codex/tasks/task_e_68ce7c983ba0832896b950995cc59f75