### PR TITLE
Handle password reset side-effect failures gracefully

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -191,8 +191,18 @@ exports.verifyOtp = catchAsync(async (req, res) => {
  */
 exports.resetPassword = catchAsync(async (req, res) => {
   const { email, code, new_password } = req.body;
-  await authService.resetPassword({ email, code, new_password });
-  res.json({ message: "Password reset successful" });
+  const { warnings = [] } = await authService.resetPassword({
+    email,
+    code,
+    new_password,
+  });
+
+  const response = { message: "Password reset successful" };
+  if (warnings.length) {
+    response.warnings = warnings;
+  }
+
+  res.json(response);
 });
 
 /**

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -552,15 +552,39 @@ exports.resetPassword = async ({ email, code, new_password, accessToken }) => {
     }
   }
 
-  await sendPasswordChangeEmail(user.email);
+  const warnings = [];
 
-  await notificationService.createNotification({
-    user_id: user.id,
-    type: "security",
-    message: "Your password was changed successfully",
-  });
+  try {
+    await sendPasswordChangeEmail(user.email);
+  } catch (err) {
+    logger.error("Failed to send password change email", err);
+    warnings.push({
+      type: "email",
+      message:
+        "Password reset succeeded, but the confirmation email could not be sent.",
+    });
+  }
+
+  try {
+    await notificationService.createNotification({
+      user_id: user.id,
+      type: "security",
+      message: "Your password was changed successfully",
+    });
+  } catch (err) {
+    logger.error("Failed to create password change notification", err);
+    warnings.push({
+      type: "notification",
+      message:
+        "Password reset succeeded, but the security notification could not be recorded.",
+    });
+  }
+
   await clearOtpAttempts(user.id);
-  return sanitizeUserUtil(user);
+  return {
+    user: sanitizeUserUtil(user),
+    warnings,
+  };
 };
 
 /**

--- a/backend/tests/authResetPasswordRoutes.test.js
+++ b/backend/tests/authResetPasswordRoutes.test.js
@@ -1,6 +1,11 @@
 const request = require('supertest');
 const express = require('express');
 
+process.env.JWT_SECRET = 'test-jwt';
+process.env.REFRESH_TOKEN_SECRET = 'test-refresh';
+process.env.SESSION_SECRET = 'test-session';
+process.env.TEST_DATABASE_URL = 'postgres://user:pass@localhost:5432/testdb';
+
 jest.mock('../src/config/database', () => ({
   raw: jest.fn(() => Promise.resolve()),
 }));
@@ -32,12 +37,25 @@ app.use(errorHandler);
 
 describe('POST /api/auth/reset-password', () => {
   it('resets password and returns success', async () => {
-    service.resetPassword.mockResolvedValue();
+    service.resetPassword.mockResolvedValue({ warnings: [] });
     const payload = { email: 'test@example.com', code: '123456', new_password: 'NewPass1!' };
     const res = await request(app).post('/api/auth/reset-password').send(payload);
     expect(res.status).toBe(200);
     expect(service.resetPassword).toHaveBeenCalledWith(payload);
     expect(res.body.message).toMatch(/successful/i);
+    expect(res.body.warnings).toBeUndefined();
+  });
+
+  it('returns 200 with warnings when side-effects fail', async () => {
+    const warning = {
+      type: 'email',
+      message: 'Password reset succeeded, but the confirmation email could not be sent.',
+    };
+    service.resetPassword.mockResolvedValue({ warnings: [warning] });
+    const payload = { email: 'test@example.com', code: '123456', new_password: 'NewPass1!' };
+    const res = await request(app).post('/api/auth/reset-password').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.warnings).toEqual([warning]);
   });
 
   it('returns 400 for invalid OTP', async () => {

--- a/backend/tests/authResetPasswordService.test.js
+++ b/backend/tests/authResetPasswordService.test.js
@@ -49,9 +49,8 @@ jest.mock('../src/modules/notifications/notifications.service', () => ({
 jest.mock('../src/modules/messages/messages.service', () => ({
   createMessage: jest.fn(),
 }));
-jest.mock('../src/services/tokenBlacklistService', () => ({ addToken: jest.fn(), }));
 
-jest.mock('../src/modules/auth/utils/sanitizeUser', () => jest.fn((u) => u));
+jest.mock('../src/modules/auth/utils/sanitizeUser', () => jest.fn((u) => ({ id: u.id, email: u.email })));
 
 jest.mock('bcrypt', () => ({
   compare: jest.fn(),
@@ -86,7 +85,7 @@ describe('resetPassword service', () => {
     bcrypt.compare.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     bcrypt.hash.mockResolvedValue('new_hash');
 
-    await authService.resetPassword({
+    const result = await authService.resetPassword({
       email: 'test@example.com',
       code: '123456',
       new_password: 'NewPass1!',
@@ -103,28 +102,12 @@ describe('resetPassword service', () => {
     // Ensure refresh tokens were revoked
     expect(refreshTokensTable.where).toHaveBeenCalledWith({ user_id: 1 });
     expect(refreshTokensWhere.del).toHaveBeenCalled();
-      expect(addToken).not.toHaveBeenCalled();
-  });
-  it('blacklists provided access token', async () => {
-    userModel.findByEmail.mockResolvedValue({
-      id: 1,
-      email: 'test@example.com',
-      password_hash: 'old_hash',
+    expect(addToken).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      user: { id: 1, email: 'test@example.com' },
+      warnings: [],
     });
-
-    bcrypt.compare.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
-    bcrypt.hash.mockResolvedValue('new_hash');
-
-    await authService.resetPassword({
-      email: 'test@example.com',
-      code: '123456',
-      new_password: 'NewPass1!',
-      accessToken: 'token123',
-    });
-
-    expect(addToken).toHaveBeenCalledWith('token123');
   });
-
   it('blacklists provided access token', async () => {
     userModel.findByEmail.mockResolvedValue({
       id: 1,
@@ -145,5 +128,42 @@ describe('resetPassword service', () => {
     });
 
     expect(addToken).toHaveBeenCalledWith(accessToken);
+  });
+
+  it('returns warnings when email and notification fail', async () => {
+    userModel.findByEmail.mockResolvedValue({
+      id: 2,
+      email: 'warn@example.com',
+      password_hash: 'old_hash',
+    });
+
+    bcrypt.compare
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    bcrypt.hash.mockResolvedValue('new_hash');
+
+    sendPasswordChangeEmail.mockRejectedValueOnce(new Error('smtp down'));
+    notificationService.createNotification.mockRejectedValueOnce(
+      new Error('db down'),
+    );
+
+    const result = await authService.resetPassword({
+      email: 'warn@example.com',
+      code: '123456',
+      new_password: 'NewPass1!',
+    });
+
+    expect(result.warnings).toEqual([
+      {
+        type: 'email',
+        message:
+          'Password reset succeeded, but the confirmation email could not be sent.',
+      },
+      {
+        type: 'notification',
+        message:
+          'Password reset succeeded, but the security notification could not be recorded.',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- guard password reset side-effects so email and notification failures are logged and surfaced as warnings without aborting the reset
- return optional warnings from the reset service/controller for clients to notify admins when side-effects fail
- extend reset password service and route tests to cover warning propagation and ensure 200 responses when side-effects throw

## Testing
- npm test -- authResetPassword

------
https://chatgpt.com/codex/tasks/task_e_68ce7cd91f688328881676a3b14a0cdb