### PR TITLE
Refine nginx CORS configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
+      - ./nginx/snippets/cors_headers.inc:/etc/nginx/snippets/cors_headers.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,6 +13,11 @@ http {
         default $ALLOWED_ORIGINS;
     }
 
+    map $allowed_origins $allowed_origins_list {
+        "" "";
+        default ",$allowed_origins,";
+    }
+
     # Load virtual hosts from the conf.d directory
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -1,16 +1,3 @@
-  # Determine if the request Origin is allowed based on a comma-separated
-  # list supplied via the ALLOWED_ORIGINS environment variable.
-  # Example: "https://foo.com,https://bar.com"
-  set $cors_allowed_origin "";
-  if ($allowed_origins != "") {
-    set $allowed_origins_list ",$allowed_origins,";
-    if ($http_origin != "") {
-      if ($allowed_origins_list ~ ",$http_origin,") {
-        set $cors_allowed_origin $http_origin;
-      }
-    }
-  }
-
   location / {
     proxy_pass http://frontend:3000;
     proxy_http_version 1.1;
@@ -20,10 +7,7 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($cors_allowed_origin != "") {
-      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
-    }
-    add_header Access-Control-Allow-Credentials true always;
+    include /etc/nginx/snippets/cors_headers.inc;
   }
 
   # Serve Next.js static assets directly from the frontend service
@@ -36,10 +20,7 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($cors_allowed_origin != "") {
-      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
-    }
-    add_header Access-Control-Allow-Credentials true always;
+    include /etc/nginx/snippets/cors_headers.inc;
     expires 1y;
     add_header Cache-Control "public, max-age=31536000, immutable";
   }
@@ -56,10 +37,7 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($cors_allowed_origin != "") {
-      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
-    }
-    add_header Access-Control-Allow-Credentials true always;
+    include /etc/nginx/snippets/cors_headers.inc;
   }
 
   location ^~ /api/ {
@@ -72,10 +50,7 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     # Ensure a single Access-Control-Allow-Origin header
     proxy_hide_header Access-Control-Allow-Origin;
-    if ($cors_allowed_origin != "") {
-      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
-    }
-    add_header Access-Control-Allow-Credentials true always;
+    include /etc/nginx/snippets/cors_headers.inc;
   }
   # Forward installer requests to the backend
   location ^~ /install/ {

--- a/nginx/snippets/cors_headers.inc
+++ b/nginx/snippets/cors_headers.inc
@@ -1,0 +1,12 @@
+    set $cors_allowed_origin "";
+    if ($allowed_origins_list != "") {
+      if ($http_origin != "") {
+        if ($allowed_origins_list ~ ",$http_origin,") {
+          set $cors_allowed_origin $http_origin;
+        }
+      }
+    }
+    if ($cors_allowed_origin != "") {
+      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
+    }
+    add_header Access-Control-Allow-Credentials true always;


### PR DESCRIPTION
## Summary
- move CORS header logic into a reusable snippet that runs inside each nginx location block to avoid invalid top-level directives
- add a derived `$allowed_origins_list` map and mount the new snippet in docker compose so nginx can resolve allowed origins at runtime

## Testing
- `docker compose config` *(fails: docker command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceadcb0f188328a58b16792cfaccb5