### PR TITLE
Fix nginx startup failure caused by invalid CORS logic

### DIFF
--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -1,16 +1,3 @@
-  # Determine if the request Origin is allowed based on a comma-separated
-  # list supplied via the ALLOWED_ORIGINS environment variable.
-  # Example: "https://foo.com,https://bar.com"
-  set $cors_allowed_origin "";
-  if ($allowed_origins != "") {
-    set $allowed_origins_list ",$allowed_origins,";
-    if ($http_origin != "") {
-      if ($allowed_origins_list ~ ",$http_origin,") {
-        set $cors_allowed_origin $http_origin;
-      }
-    }
-  }
-
   location / {
     proxy_pass http://frontend:3000;
     proxy_http_version 1.1;
@@ -18,12 +5,7 @@
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    # Ensure a single Access-Control-Allow-Origin header
-    proxy_hide_header Access-Control-Allow-Origin;
-    if ($cors_allowed_origin != "") {
-      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
-    }
-    add_header Access-Control-Allow-Credentials true always;
+    include /etc/nginx/snippets/cors.inc;
   }
 
   # Serve Next.js static assets directly from the frontend service
@@ -34,12 +16,7 @@
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    # Ensure a single Access-Control-Allow-Origin header
-    proxy_hide_header Access-Control-Allow-Origin;
-    if ($cors_allowed_origin != "") {
-      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
-    }
-    add_header Access-Control-Allow-Credentials true always;
+    include /etc/nginx/snippets/cors.inc;
     expires 1y;
     add_header Cache-Control "public, max-age=31536000, immutable";
   }
@@ -54,12 +31,7 @@
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    # Ensure a single Access-Control-Allow-Origin header
-    proxy_hide_header Access-Control-Allow-Origin;
-    if ($cors_allowed_origin != "") {
-      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
-    }
-    add_header Access-Control-Allow-Credentials true always;
+    include /etc/nginx/snippets/cors.inc;
   }
 
   location ^~ /api/ {
@@ -70,12 +42,7 @@
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    # Ensure a single Access-Control-Allow-Origin header
-    proxy_hide_header Access-Control-Allow-Origin;
-    if ($cors_allowed_origin != "") {
-      add_header Access-Control-Allow-Origin $cors_allowed_origin always;
-    }
-    add_header Access-Control-Allow-Credentials true always;
+    include /etc/nginx/snippets/cors.inc;
   }
   # Forward installer requests to the backend
   location ^~ /install/ {

--- a/nginx/snippets/cors.inc
+++ b/nginx/snippets/cors.inc
@@ -1,0 +1,15 @@
+    proxy_hide_header Access-Control-Allow-Origin;
+    set $cors_allowed_origin "";
+    if ($allowed_origins != "") {
+        set $allowed_origins_list ",$allowed_origins,";
+        if ($http_origin != "") {
+            set $normalized_origin ",$http_origin,";
+            if ($allowed_origins_list ~ $normalized_origin) {
+                set $cors_allowed_origin $http_origin;
+            }
+        }
+    }
+    if ($cors_allowed_origin != "") {
+        add_header Access-Control-Allow-Origin $cors_allowed_origin always;
+    }
+    add_header Access-Control-Allow-Credentials true always;


### PR DESCRIPTION
## Summary
- move the reusable CORS response logic into a dedicated snippet that can run inside each location block
- update the shared location include to reference the new snippet and drop the invalid top-level if directives so nginx can start cleanly

## Testing
- ❌ `docker compose run --rm nginx nginx -t -c /etc/nginx/nginx.conf` *(not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceadcb0f188328a58b16792cfaccb5