### PR TITLE
Fix nginx config for CORS handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
+      - ./nginx/snippets/cors_allowed_origin.inc:/etc/nginx/snippets/cors_allowed_origin.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:

--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -1,17 +1,8 @@
-  # Determine if the request Origin is allowed based on a comma-separated
-  # list supplied via the ALLOWED_ORIGINS environment variable.
-  # Example: "https://foo.com,https://bar.com"
-  set $cors_allowed_origin "";
-  if ($allowed_origins != "") {
-    set $allowed_origins_list ",$allowed_origins,";
-    if ($http_origin != "") {
-      if ($allowed_origins_list ~ ",$http_origin,") {
-        set $cors_allowed_origin $http_origin;
-      }
-    }
-  }
-
   location / {
+    # Determine if the request Origin is allowed based on a comma-separated
+    # list supplied via the ALLOWED_ORIGINS environment variable.
+    # Example: "https://foo.com,https://bar.com"
+    include /etc/nginx/snippets/cors_allowed_origin.inc;
     proxy_pass http://frontend:3000;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -28,6 +19,7 @@
 
   # Serve Next.js static assets directly from the frontend service
   location ^~ /_next/static/ {
+    include /etc/nginx/snippets/cors_allowed_origin.inc;
     proxy_pass http://frontend:3000;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -46,6 +38,7 @@
 
   # Forward Socket.IO traffic to backend and enable WebSocket upgrades
   location /socket.io/ {
+    include /etc/nginx/snippets/cors_allowed_origin.inc;
     proxy_pass http://backend:5002;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -63,6 +56,7 @@
   }
 
   location ^~ /api/ {
+    include /etc/nginx/snippets/cors_allowed_origin.inc;
     # forward API requests without rewriting the path
     proxy_pass http://backend:5002;
     proxy_http_version 1.1;

--- a/nginx/snippets/cors_allowed_origin.inc
+++ b/nginx/snippets/cors_allowed_origin.inc
@@ -1,0 +1,10 @@
+    set $cors_allowed_origin "";
+    set $allowed_origins_list "";
+    if ($allowed_origins != "") {
+      set $allowed_origins_list ",$allowed_origins,";
+      if ($http_origin != "") {
+        if ($allowed_origins_list ~ ",$http_origin,") {
+          set $cors_allowed_origin $http_origin;
+        }
+      }
+    }


### PR DESCRIPTION
## Summary
- move the CORS origin evaluation into a reusable snippet that runs inside each location block
- include the new snippet from every proxied location so nginx no longer rejects the configuration
- mount the additional snippet in the nginx service so the container can load it

## Testing
- `docker-compose config` *(fails: command not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceadcb0f188328a58b16792cfaccb5