### PR TITLE
Fix nginx cors logic to avoid top-level if

### DIFF
--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -1,17 +1,17 @@
-  # Determine if the request Origin is allowed based on a comma-separated
-  # list supplied via the ALLOWED_ORIGINS environment variable.
-  # Example: "https://foo.com,https://bar.com"
-  set $cors_allowed_origin "";
-  if ($allowed_origins != "") {
-    set $allowed_origins_list ",$allowed_origins,";
-    if ($http_origin != "") {
-      if ($allowed_origins_list ~ ",$http_origin,") {
-        set $cors_allowed_origin $http_origin;
+  location / {
+    # Determine if the request Origin is allowed based on a comma-separated
+    # list supplied via the ALLOWED_ORIGINS environment variable.
+    # Example: "https://foo.com,https://bar.com"
+    set $cors_allowed_origin "";
+    if ($allowed_origins != "") {
+      set $allowed_origins_list ",$allowed_origins,";
+      if ($http_origin != "") {
+        if ($allowed_origins_list ~ ",$http_origin,") {
+          set $cors_allowed_origin $http_origin;
+        }
       }
     }
-  }
 
-  location / {
     proxy_pass http://frontend:3000;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -28,6 +28,16 @@
 
   # Serve Next.js static assets directly from the frontend service
   location ^~ /_next/static/ {
+    set $cors_allowed_origin "";
+    if ($allowed_origins != "") {
+      set $allowed_origins_list ",$allowed_origins,";
+      if ($http_origin != "") {
+        if ($allowed_origins_list ~ ",$http_origin,") {
+          set $cors_allowed_origin $http_origin;
+        }
+      }
+    }
+
     proxy_pass http://frontend:3000;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -46,6 +56,16 @@
 
   # Forward Socket.IO traffic to backend and enable WebSocket upgrades
   location /socket.io/ {
+    set $cors_allowed_origin "";
+    if ($allowed_origins != "") {
+      set $allowed_origins_list ",$allowed_origins,";
+      if ($http_origin != "") {
+        if ($allowed_origins_list ~ ",$http_origin,") {
+          set $cors_allowed_origin $http_origin;
+        }
+      }
+    }
+
     proxy_pass http://backend:5002;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -63,6 +83,16 @@
   }
 
   location ^~ /api/ {
+    set $cors_allowed_origin "";
+    if ($allowed_origins != "") {
+      set $allowed_origins_list ",$allowed_origins,";
+      if ($http_origin != "") {
+        if ($allowed_origins_list ~ ",$http_origin,") {
+          set $cors_allowed_origin $http_origin;
+        }
+      }
+    }
+
     # forward API requests without rewriting the path
     proxy_pass http://backend:5002;
     proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
- move the CORS origin validation logic inside each location block in the shared nginx snippet
- ensure headers are still applied consistently without relying on a top-level `if`

## Testing
- docker-compose run --rm nginx nginx -t *(fails: command not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceadcb0f188328a58b16792cfaccb5