### PR TITLE
Add cors snippet bind mount to nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
+      - ./nginx/snippets/cors.inc:/etc/nginx/snippets/cors.inc:ro
       - ./nginx/snippets/cors_allowed_origin.inc:/etc/nginx/snippets/cors_allowed_origin.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro


### PR DESCRIPTION
## Summary
- mount the nginx cors snippet into the container so it is available at runtime

## Testing
- docker compose up -d *(fails: docker not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cebdefa9f083288c7ce3e783304e16