### PR TITLE
Fix wait-for-db script to target database name

### DIFF
--- a/backend/scripts/wait-for-db.sh
+++ b/backend/scripts/wait-for-db.sh
@@ -6,7 +6,7 @@ SLEEP_SECONDS=${DB_WAIT_INTERVAL_SECONDS:-2}
 
 resolve_from_database_url() {
   key="$1"
-  node -e "const value = new URL(process.argv[1]); const map = { host: value.hostname || 'db', port: value.port || '5432', user: value.username || 'postgres', password: value.password || '' }; process.stdout.write(map['$key']);" "$DATABASE_URL"
+  node -e "const value = new URL(process.argv[1]); const map = { host: value.hostname || 'db', port: value.port || '5432', user: value.username || 'postgres', password: value.password || '', database: value.pathname && value.pathname !== '/' ? value.pathname.slice(1) : '' }; process.stdout.write(map['$key']);" "$DATABASE_URL"
 }
 
 if [ -n "${DATABASE_URL:-}" ]; then
@@ -14,12 +14,15 @@ if [ -n "${DATABASE_URL:-}" ]; then
   DB_PORT=$(resolve_from_database_url port)
   DB_USER=$(resolve_from_database_url user)
   DB_PASSWORD=$(resolve_from_database_url password)
+  DB_NAME=$(resolve_from_database_url database)
 else
   DB_HOST=${POSTGRES_HOST:-db}
   DB_PORT=${POSTGRES_PORT:-5432}
   DB_USER=${POSTGRES_USER:-postgres}
   DB_PASSWORD=${POSTGRES_PASSWORD:-}
 fi
+
+DB_NAME=${DB_NAME:-${POSTGRES_DB:-postgres}}
 
 if [ -n "$DB_PASSWORD" ]; then
   export PGPASSWORD="$DB_PASSWORD"
@@ -29,7 +32,7 @@ attempt=0
 
 if command -v pg_isready >/dev/null 2>&1; then
   while true; do
-    if output=$(pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" 2>&1); then
+    if output=$(pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" 2>&1); then
       break
     fi
 
@@ -41,11 +44,11 @@ if command -v pg_isready >/dev/null 2>&1; then
       exit 1
     fi
 
-    echo "Waiting for database at $DB_HOST:$DB_PORT (attempt ${attempt}/${MAX_ATTEMPTS})... $output"
+    echo "Waiting for database at $DB_HOST:$DB_PORT (database $DB_NAME) (attempt ${attempt}/${MAX_ATTEMPTS})... $output"
     sleep "$SLEEP_SECONDS"
   done
 else
-  echo "pg_isready not available; falling back to TCP probe for $DB_HOST:$DB_PORT."
+  echo "pg_isready not available; falling back to TCP probe for $DB_HOST:$DB_PORT (database $DB_NAME)."
   while true; do
     if nc -z "$DB_HOST" "$DB_PORT"; then
       break
@@ -58,7 +61,7 @@ else
       exit 1
     fi
 
-    echo "Waiting for database port $DB_PORT on $DB_HOST (attempt ${attempt}/${MAX_ATTEMPTS})..."
+    echo "Waiting for database port $DB_PORT on $DB_HOST (database $DB_NAME) (attempt ${attempt}/${MAX_ATTEMPTS})..."
     sleep "$SLEEP_SECONDS"
   done
 fi


### PR DESCRIPTION
## Summary
- parse the database name from DATABASE_URL in the wait-for-db helper
- default to POSTGRES_DB when the URL omits a database and reuse it in status logs
- ensure pg_isready explicitly targets the intended database

## Testing
- docker compose up -d db backend *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68cebdecd59c8328b35fe0bb118d0e4e