### PR TITLE
Add CORS snippet volume to nginx service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,7 @@ services:
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
       - ./nginx/snippets/cors_allowed_origin.inc:/etc/nginx/snippets/cors_allowed_origin.inc:ro
+      - ./nginx/snippets/cors.inc:/etc/nginx/snippets/cors.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:


### PR DESCRIPTION
## Summary
- mount the nginx cors snippet into the nginx container as read-only so it is available at runtime

## Testing
- ⚠️ `docker compose up nginx --no-deps -d` *(fails: `docker` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cebdeb97188328954601f11dd88378