### PR TITLE
Add nginx cors snippet volume mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
+      - ./nginx/snippets/cors.inc:/etc/nginx/snippets/cors.inc:ro
       - ./nginx/snippets/cors_allowed_origin.inc:/etc/nginx/snippets/cors_allowed_origin.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro


### PR DESCRIPTION
## Summary
- mount the cors.inc snippet into the nginx container alongside the other snippet volumes so it can be referenced by the config

## Testing
- `docker compose up -d nginx` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cebde6c768832881aad7261abbea54