### PR TITLE
Add cors snippet bind mount to nginx service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
+      - ./nginx/snippets/cors.inc:/etc/nginx/snippets/cors.inc:ro
       - ./nginx/snippets/cors_allowed_origin.inc:/etc/nginx/snippets/cors_allowed_origin.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro


### PR DESCRIPTION
## Summary
- mount the nginx cors.inc snippet into the container via docker compose

## Testing
- not run (docker not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_68cebde1b9308328ab8fc3f2f593931e