### PR TITLE
Fix duplicate nginx volume entry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,6 @@ services:
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
       - ./nginx/snippets/cors.inc:/etc/nginx/snippets/cors.inc:ro
       - ./nginx/snippets/cors_allowed_origin.inc:/etc/nginx/snippets/cors_allowed_origin.inc:ro
-      - ./nginx/snippets/cors.inc:/etc/nginx/snippets/cors.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:


### PR DESCRIPTION
## Summary
- remove the duplicate nginx CORS snippet volume entry from docker-compose to satisfy compose validation

## Testing
- docker-compose config *(fails: docker-compose not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cec33ff79083288d51833e19b44d31