### PR TITLE
Fix nginx CORS logic to avoid invalid nested if directives

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,6 @@ services:
       - ./nginx/snippets/common_locations.inc:/etc/nginx/snippets/common_locations.inc:ro
       - ./nginx/snippets/cors.inc:/etc/nginx/snippets/cors.inc:ro
       - ./nginx/snippets/cors_allowed_origin.inc:/etc/nginx/snippets/cors_allowed_origin.inc:ro
-      - ./nginx/snippets/cors.inc:/etc/nginx/snippets/cors.inc:ro
       - ./nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:

--- a/nginx/snippets/common_locations.inc
+++ b/nginx/snippets/common_locations.inc
@@ -10,16 +10,6 @@
 
   # Serve Next.js static assets directly from the frontend service
   location ^~ /_next/static/ {
-    set $cors_allowed_origin "";
-    if ($allowed_origins != "") {
-      set $allowed_origins_list ",$allowed_origins,";
-      if ($http_origin != "") {
-        if ($allowed_origins_list ~ ",$http_origin,") {
-          set $cors_allowed_origin $http_origin;
-        }
-      }
-    }
-
     proxy_pass http://frontend:3000;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -33,17 +23,6 @@
 
   # Forward Socket.IO traffic to backend and enable WebSocket upgrades
   location /socket.io/ {
-    set $cors_allowed_origin "";
-    if ($allowed_origins != "") {
-      set $allowed_origins_list ",$allowed_origins,";
-      if ($http_origin != "") {
-        if ($allowed_origins_list ~ ",$http_origin,") {
-          set $cors_allowed_origin $http_origin;
-        }
-      }
-    }
-
-
     proxy_pass http://backend:5002;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -56,16 +35,6 @@
   }
 
   location ^~ /api/ {
-    set $cors_allowed_origin "";
-    if ($allowed_origins != "") {
-      set $allowed_origins_list ",$allowed_origins,";
-      if ($http_origin != "") {
-        if ($allowed_origins_list ~ ",$http_origin,") {
-          set $cors_allowed_origin $http_origin;
-        }
-      }
-    }
-
     # forward API requests without rewriting the path
     proxy_pass http://backend:5002;
     proxy_http_version 1.1;

--- a/nginx/snippets/cors.inc
+++ b/nginx/snippets/cors.inc
@@ -1,15 +1,22 @@
     proxy_hide_header Access-Control-Allow-Origin;
     set $cors_allowed_origin "";
-    if ($allowed_origins != "") {
-        set $allowed_origins_list ",$allowed_origins,";
-        if ($http_origin != "") {
-            set $normalized_origin ",$http_origin,";
-            if ($allowed_origins_list ~ $normalized_origin) {
-                set $cors_allowed_origin $http_origin;
-            }
-        }
+    set $normalized_origin "__no_origin__";
+    set $origin_match "";
+
+    if ($http_origin != "") {
+        set $normalized_origin ",$http_origin,";
     }
+
+    if ($allowed_origins_list != "") {
+        set $origin_match $allowed_origins_list;
+    }
+
+    if ($origin_match ~ $normalized_origin) {
+        set $cors_allowed_origin $http_origin;
+    }
+
     if ($cors_allowed_origin != "") {
         add_header Access-Control-Allow-Origin $cors_allowed_origin always;
     }
+
     add_header Access-Control-Allow-Credentials true always;


### PR DESCRIPTION
## Summary
- refactor the shared nginx CORS snippet to remove nested `if` directives that nginx refuses to load
- rely on the shared snippet for CORS handling in common locations to keep the configuration consistent

## Testing
- docker-compose config *(fails: docker-compose is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cec33ff79083288d51833e19b44d31