### PR TITLE
Align social link validation message with translations

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -53,7 +53,7 @@ export const profileSchema = z.object({
   // Social links validated as URLs; allow empty strings so optional fields don't fail validation
   // Additionally ensure provided keys correspond to allowed platforms
   socialLinks: z
-    .record(z.string().url("invalid_url").or(z.literal("")))
+    .record(z.string().url("url_invalid").or(z.literal("")))
     .refine(
       (links) =>
         Object.keys(links).every((key) =>

--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -68,7 +68,7 @@ export const instructorProfileSchema = (country) => z.object({
       message: "bio_max_words",
     }),
   socialLinks: z
-    .record(z.string().url("invalid_url").or(z.literal("")))
+    .record(z.string().url("url_invalid").or(z.literal("")))
     .optional(),
 })
   .superRefine((data, ctx) => {

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -45,7 +45,7 @@ export const studentProfileSchema = z.object({
   learning_goals: z.string().optional(),
   // Social links validated as URLs but allow empty strings for optional entries
   socialLinks: z
-    .record(z.string().url("invalid_url").or(z.literal("")))
+    .record(z.string().url("url_invalid").or(z.literal("")))
     .optional(),
 });
 

--- a/frontend/src/tests/__tests__/profileSchemaSocialLinks.test.js
+++ b/frontend/src/tests/__tests__/profileSchemaSocialLinks.test.js
@@ -23,7 +23,7 @@ describe('profile schema socialLinks URL validation', () => {
     try {
       adminProfileSchema.parse(data);
     } catch (err) {
-      expect(err.errors[0].message).toBe('invalid_url');
+      expect(err.errors[0].message).toBe('url_invalid');
     }
   });
 
@@ -37,7 +37,7 @@ describe('profile schema socialLinks URL validation', () => {
     try {
       instructorProfileSchema('US').parse(data);
     } catch (err) {
-      expect(err.errors[0].message).toBe('invalid_url');
+      expect(err.errors[0].message).toBe('url_invalid');
     }
   });
 
@@ -51,7 +51,7 @@ describe('profile schema socialLinks URL validation', () => {
     try {
       studentProfileSchema.parse(data);
     } catch (err) {
-      expect(err.errors[0].message).toBe('invalid_url');
+      expect(err.errors[0].message).toBe('url_invalid');
     }
   });
 });

--- a/frontend/src/utils/validation/adminProfileSchema.js
+++ b/frontend/src/utils/validation/adminProfileSchema.js
@@ -18,6 +18,6 @@ export const adminProfileSchema = z.object({
   job_title: z.string().min(2, "Job title is required"),
   department: z.string().min(2, "Department is required"),
   socialLinks: z
-    .record(z.string().url("invalid_url"))
+    .record(z.string().url("url_invalid"))
     .optional(), // optional dictionary { platform: url }
 });


### PR DESCRIPTION
## Summary
- switch dashboard profile social link validators to use the existing `url_invalid` translation key
- update the shared admin profile validation schema accordingly
- adjust profile schema unit test expectations to match the new key

## Testing
- npm test -- profileSchemaSocialLinks

------
https://chatgpt.com/codex/tasks/task_e_68cec9fdca408328a84f2ee50847acc3