### PR TITLE
Add admin avatar removal toast translations

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -592,6 +592,8 @@
     "invalid_image_type": "يُسمح بملفات الصور فقط.",
     "avatar_upload_failed": "فشل رفع الصورة الشخصية",
     "avatar_crop_failed": "فشل قص الصورة الرمزية",
+    "avatar_remove_success": "تمت إزالة الصورة الرمزية بنجاح!",
+    "avatar_remove_failed": "فشل إزالة الصورة الرمزية",
     "profile_update_success": "تم تحديث الملف الشخصي بنجاح!",
     "profile_update_failed": "فشل تحديث الملف الشخصي",
     "full_name_min": "يجب أن يكون الاسم الكامل 3 أحرف على الأقل",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -606,6 +606,8 @@
     "avatar_max_size": "Max size 10 MB",
     "invalid_image_type": "Only image files are allowed.",
     "avatar_upload_failed": "Failed to upload avatar",
+    "avatar_remove_success": "Avatar erfolgreich entfernt!",
+    "avatar_remove_failed": "Avatar konnte nicht entfernt werden",
     "profile_update_success": "Profile updated successfully!",
     "profile_update_failed": "Failed to update profile",
     "full_name_min": "Full name must be at least 3 characters",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -612,6 +612,8 @@
     "invalid_image_type": "Only image files are allowed.",
     "avatar_upload_failed": "Failed to upload avatar",
     "avatar_crop_failed": "Failed to crop avatar",
+    "avatar_remove_success": "Avatar removed successfully!",
+    "avatar_remove_failed": "Failed to remove avatar",
     "profile_update_success": "Profile updated successfully!",
     "profile_update_failed": "Failed to update profile",
     "full_name_min": "Full name must be at least 3 characters",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -592,6 +592,8 @@
     "invalid_image_type": "Solo se permiten archivos de imagen.",
     "avatar_upload_failed": "No se pudo subir avatar",
     "avatar_crop_failed": "No se pudo recortar el avatar",
+    "avatar_remove_success": "¡Avatar eliminado con éxito!",
+    "avatar_remove_failed": "No se pudo eliminar el avatar",
     "profile_update_success": "Perfil actualizado con éxito!",
     "profile_update_failed": "No se pudo actualizar el perfil",
     "full_name_min": "El nombre completo debe ser al menos 3 caracteres",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -592,6 +592,8 @@
     "invalid_image_type": "Seuls les fichiers image sont autorisés.",
     "avatar_upload_failed": "Échec du téléversement de l'avatar",
     "avatar_crop_failed": "Échec du recadrage de l'avatar",
+    "avatar_remove_success": "Avatar supprimé avec succès !",
+    "avatar_remove_failed": "Échec de la suppression de l'avatar",
     "profile_update_success": "Profil mis à jour avec succès !",
     "profile_update_failed": "Échec de la mise à jour du profil",
     "full_name_min": "Le nom complet doit comporter au moins 3 caractères",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -592,6 +592,8 @@
     "invalid_image_type": "केवल छवि फ़ाइलों की अनुमति है।",
     "avatar_upload_failed": "अवतार अपलोड करने में विफल",
     "avatar_crop_failed": "अवतार क्रॉप विफल हुआ",
+    "avatar_remove_success": "अवतार सफलतापूर्वक हटाया गया!",
+    "avatar_remove_failed": "अवतार हटाने में विफल",
     "profile_update_success": "प्रोफ़ाइल सफलतापूर्वक अपडेट किया गया!",
     "profile_update_failed": "प्रोफ़ाइल अपडेट करने में विफल",
     "full_name_min": "पूरा नाम कम से कम 3 अक्षर होना चाहिए",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -606,6 +606,8 @@
     "invalid_image_type": "Sono consentiti solo i file di immagine.",
     "avatar_upload_failed": "Impossibile caricare Avatar",
     "avatar_crop_failed": "Ritaglio avatar non riuscito",
+    "avatar_remove_success": "Avatar rimosso con successo!",
+    "avatar_remove_failed": "Impossibile rimuovere l'avatar",
     "profile_update_success": "Profilo aggiornato correttamente!",
     "profile_update_failed": "Impossibile aggiornare il profilo",
     "full_name_min": "Il nome completo deve essere almeno 3 caratteri",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -592,6 +592,8 @@
     "invalid_image_type": "只允许图片文件。",
     "avatar_upload_failed": "无法上传头像",
     "avatar_crop_failed": "头像裁剪失败",
+    "avatar_remove_success": "头像已成功移除！",
+    "avatar_remove_failed": "移除头像失败",
     "profile_update_success": "个人资料成功更新了！",
     "profile_update_failed": "无法更新个人资料",
     "full_name_min": "全名必须至少为3个字符",


### PR DESCRIPTION
## Summary
- add avatar removal success and failure translations to the admin profile page locale strings across all supported languages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cec9f9cce88328a2e6089f2aefe443