### PR TITLE
Update admin profile social link validation message

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -53,7 +53,7 @@ export const profileSchema = z.object({
   // Social links validated as URLs; allow empty strings so optional fields don't fail validation
   // Additionally ensure provided keys correspond to allowed platforms
   socialLinks: z
-    .record(z.string().url("invalid_url").or(z.literal("")))
+    .record(z.string().url("url_invalid").or(z.literal("")))
     .refine(
       (links) =>
         Object.keys(links).every((key) =>


### PR DESCRIPTION
## Summary
- update the admin profile form schema to use the shared `url_invalid` translation key for social link validation

## Testing
- npm run lint *(fails: existing lint errors and warnings across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cec9f318648328a31f86ffae51bac2