### PR TITLE
Handle aborting admin profile load

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -107,14 +107,18 @@ function ProfileEditTemplate() {
 
   useEffect(() => {
     let isMounted = true;
+    const controller = new AbortController();
 
-    if (!hasHydrated) return () => {
-      isMounted = false;
-    };
+    if (!hasHydrated)
+      return () => {
+        isMounted = false;
+        controller.abort();
+      };
     if (!user) {
       if (isMounted) setLoadingProfile(false);
       return () => {
         isMounted = false;
+        controller.abort();
       };
     }
     const role = user.role?.toLowerCase();
@@ -122,6 +126,7 @@ function ProfileEditTemplate() {
       if (isMounted) setLoadingProfile(false);
       return () => {
         isMounted = false;
+        controller.abort();
       };
     }
 
@@ -186,6 +191,7 @@ function ProfileEditTemplate() {
           socialLinks: socialMap,
         }));
       } catch (err) {
+        if (err?.name === "AbortError") return;
         if (!isMounted) return;
         toast.error(t('load_profile_failed'));
         console.error("Profile load error:", err);
@@ -199,6 +205,7 @@ function ProfileEditTemplate() {
 
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, [hasHydrated, user, fetchNotifications, fetchMessages]);
 


### PR DESCRIPTION
## Summary
- create an AbortController for the admin profile load effect and abort it on cleanup
- skip toast notifications when the request is cancelled during unmount

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec8e9281883288c055ee45a418b49