### PR TITLE
Allow password reset OTP reuse within validity

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -43,6 +43,25 @@ const OTP_ATTEMPT_PREFIX = "otpAttempt:";
 const OTP_MAX_ATTEMPTS = 5;
 const OTP_LOCK_TIME = 15 * 60 * 1000; // 15 minutes
 
+async function getActivePasswordResetRequests(userId) {
+  return db("password_resets")
+    .where({ user_id: userId, used: false })
+    .andWhere("expires_at", ">", new Date())
+    .orderBy("created_at", "desc")
+    .select("*");
+}
+
+async function findMatchingResetRecord(records, code) {
+  for (const record of records) {
+    if (!record?.code_hash) continue;
+    const match = await bcrypt.compare(code, record.code_hash);
+    if (match) {
+      return record;
+    }
+  }
+  return null;
+}
+
 function getAttemptKey(email, ip) {
   return `${LOGIN_ATTEMPT_PREFIX}${email}${ip ? `:${ip}` : ""}`;
 }
@@ -470,19 +489,14 @@ exports.verifyOtp = async ({ email, code }) => {
     );
   }
 
-  const record = await db("password_resets")
-    .where({ user_id: user.id, used: false })
-    .andWhere("expires_at", ">", new Date())
-    .orderBy("created_at", "desc")
-    .first();
-
-  if (!record) {
+  const activeResets = await getActivePasswordResetRequests(user.id);
+  if (!activeResets.length) {
     await recordFailedOtpAttempt(user.id);
     throw new AppError("Invalid or expired OTP", 400);
   }
 
-  const match = await bcrypt.compare(code, record.code_hash);
-  if (!match) {
+  const matchingRecord = await findMatchingResetRecord(activeResets, code);
+  if (!matchingRecord) {
     await recordFailedOtpAttempt(user.id);
     throw new AppError("Invalid or expired OTP", 400);
   }
@@ -513,19 +527,14 @@ exports.resetPassword = async ({ email, code, new_password, accessToken }) => {
     throw new AppError("Too many failed OTP attempts. Try again later.", 429);
   }
 
-  const resetRecord = await db("password_resets")
-    .where({ user_id: user.id, used: false })
-    .andWhere("expires_at", ">", new Date())
-    .orderBy("created_at", "desc")
-    .first();
-
-  if (!resetRecord) {
+  const activeResets = await getActivePasswordResetRequests(user.id);
+  if (!activeResets.length) {
     await recordFailedOtpAttempt(user.id);
     throw new AppError("Invalid or expired OTP", 400);
   }
 
-  const match = await bcrypt.compare(code, resetRecord.code_hash);
-  if (!match) {
+  const matchingRecord = await findMatchingResetRecord(activeResets, code);
+  if (!matchingRecord) {
     await recordFailedOtpAttempt(user.id);
     throw new AppError("Invalid or expired OTP", 400);
   }
@@ -538,7 +547,7 @@ exports.resetPassword = async ({ email, code, new_password, accessToken }) => {
   const hashed = await bcrypt.hash(new_password, SALT_ROUNDS);
   await db("users").where({ id: user.id }).update({ password_hash: hashed });
 
-  await db("password_resets").where({ id: resetRecord.id }).update({ used: true });
+  await db("password_resets").where({ id: matchingRecord.id }).update({ used: true });
 
   // Revoke all refresh tokens for this user
   await db("refresh_tokens").where({ user_id: user.id }).del();

--- a/backend/tests/authResetPasswordService.test.js
+++ b/backend/tests/authResetPasswordService.test.js
@@ -3,7 +3,7 @@ jest.mock('../src/config/database', () => {
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
-    first: jest.fn().mockResolvedValue({ id: 1, code_hash: 'otp_hash' }),
+    select: jest.fn().mockResolvedValue([{ id: 1, code_hash: 'otp_hash' }]),
     update: jest.fn().mockResolvedValue(),
   };
 
@@ -73,6 +73,8 @@ const { addToken } = require('../src/services/tokenBlacklistService');
 describe('resetPassword service', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    const { passwordResetsTable } = db.__tables;
+    passwordResetsTable.select.mockResolvedValue([{ id: 1, code_hash: 'otp_hash' }]);
   });
 
   it('sends notification but not self message', async () => {
@@ -165,5 +167,70 @@ describe('resetPassword service', () => {
           'Password reset succeeded, but the security notification could not be recorded.',
       },
     ]);
+  });
+
+  it('accepts a valid OTP that is not the newest record', async () => {
+    const { passwordResetsTable } = db.__tables;
+
+    userModel.findByEmail.mockResolvedValue({
+      id: 3,
+      email: 'multi@example.com',
+      password_hash: 'old_hash',
+    });
+
+    passwordResetsTable.select.mockResolvedValueOnce([
+      { id: 10, code_hash: 'old_hash_value' },
+      { id: 11, code_hash: 'otp_hash' },
+    ]);
+
+    bcrypt.compare
+      .mockResolvedValueOnce(false) // first record mismatch
+      .mockResolvedValueOnce(true) // second record match
+      .mockResolvedValueOnce(false); // new password differs from old
+
+    bcrypt.hash.mockResolvedValue('new_hash');
+
+    await authService.resetPassword({
+      email: 'multi@example.com',
+      code: '654321',
+      new_password: 'Another1!',
+    });
+
+    // Ensure the matching record was marked as used
+    expect(passwordResetsTable.where).toHaveBeenCalledWith({ id: 11 });
+    expect(passwordResetsTable.update).toHaveBeenCalledWith({ used: true });
+  });
+});
+
+describe('verifyOtp service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { passwordResetsTable } = db.__tables;
+    passwordResetsTable.select.mockResolvedValue([{ id: 1, code_hash: 'otp_hash' }]);
+  });
+
+  it('returns true when a non-latest OTP matches', async () => {
+    const { passwordResetsTable } = db.__tables;
+
+    userModel.findByEmail.mockResolvedValue({
+      id: 5,
+      email: 'verify@example.com',
+    });
+
+    passwordResetsTable.select.mockResolvedValueOnce([
+      { id: 21, code_hash: 'first_hash' },
+      { id: 22, code_hash: 'otp_hash' },
+    ]);
+
+    bcrypt.compare
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    const result = await authService.verifyOtp({
+      email: 'verify@example.com',
+      code: '222222',
+    });
+
+    expect(result).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- allow password reset verification to consider any active OTP for a user instead of only the most recent record
- reuse the matching OTP record during password reset so it can be marked as used when the password change succeeds
- expand auth reset password tests to cover multiple OTP records and add coverage for the verifyOtp helper logic

## Testing
- JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test npm test -- --runTestsByPath tests/authResetPasswordService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cec8dd60248328abb21af2f6af995f