### PR TITLE
Increase global rate limit ceiling for dashboard bursts

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -20,6 +20,9 @@ any are missing:
 - Database connection details – either provide a full connection string via `DATABASE_URL`/`PRODUCTION_DATABASE_URL` (and `TEST_DATABASE_URL` when running tests) or set the individual `POSTGRES_*` variables so the server can build one automatically.
 - `BACKEND_PORT` – port for the HTTP server
 - `SESSION_SECRET` – session cookie signing secret
+- `GLOBAL_RATE_LIMIT_MAX` – optional ceiling for the shared rate limiter (defaults to 1000). Increase this if dashboards or other
+  authenticated flows legitimately send large bursts of requests; lowering it again risks reintroducing HTTP 429 responses when
+  admins keep multiple monitoring tabs open.
 
 Provide these variables via a `.env` file or the hosting environment.
 

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -8,6 +8,11 @@ dotenvExpand.expand(myEnv);
 const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   BACKEND_PORT: z.coerce.number().default(5002),
+  GLOBAL_RATE_LIMIT_MAX: z.coerce
+    .number()
+    .int()
+    .min(100, 'GLOBAL_RATE_LIMIT_MAX must allow at least 100 requests')
+    .default(1000),
   JWT_SECRET: z
     .string()
     .trim()
@@ -234,6 +239,7 @@ const getDatabaseUrl = (targetEnv = env.NODE_ENV) => DATABASE_URLS[targetEnv];
 module.exports = {
   NODE_ENV: env.NODE_ENV,
   BACKEND_PORT: env.BACKEND_PORT,
+  GLOBAL_RATE_LIMIT_MAX: env.GLOBAL_RATE_LIMIT_MAX,
   JWT_SECRET: env.JWT_SECRET,
   REFRESH_TOKEN_SECRET: env.REFRESH_TOKEN_SECRET,
   SESSION_SECRET: env.SESSION_SECRET,

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -152,10 +152,13 @@ app.use(session(sessionOptions));
 
 app.use(csrf);
 
-// Apply rate limiting to all requests
+// Apply rate limiting to all requests. Allow the ceiling to be tuned via
+// GLOBAL_RATE_LIMIT_MAX so that heavy dashboard usage does not trigger 429s.
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs
+  max: config.GLOBAL_RATE_LIMIT_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
   skip: (req) => {
     const path = req.path || req.url;
     return path === '/api/health' || path === '/api/health/';

--- a/backend/tests/healthRateLimit.test.js
+++ b/backend/tests/healthRateLimit.test.js
@@ -2,7 +2,7 @@ const request = require('supertest');
 
 jest.setTimeout(10000);
 
-function loadServer() {
+function loadServer({ rateLimitMax } = {}) {
   jest.resetModules();
   jest.doMock('../src/routes', () => {
     const express = require('express');
@@ -11,6 +11,9 @@ function loadServer() {
       res.status(200).json({ status: 'ok' });
     });
     router.get('/api/normal', (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    router.get('/api/dashboard/overview', (_req, res) => {
       res.status(200).json({ ok: true });
     });
     return router;
@@ -23,6 +26,11 @@ function loadServer() {
   process.env.REFRESH_TOKEN_SECRET = 'test';
   process.env.SESSION_SECRET = 'test';
   process.env.TEST_DATABASE_URL = 'postgresql://localhost/testdb';
+  if (rateLimitMax !== undefined) {
+    process.env.GLOBAL_RATE_LIMIT_MAX = String(rateLimitMax);
+  } else {
+    delete process.env.GLOBAL_RATE_LIMIT_MAX;
+  }
   delete process.env.REDIS_URL;
   return require('../src/server');
 }
@@ -35,11 +43,12 @@ function closeServer(serverInstance) {
   if (serverInstance && typeof serverInstance.close === 'function') {
     serverInstance.close();
   }
+  delete process.env.GLOBAL_RATE_LIMIT_MAX;
 }
 
 describe('global rate limiter', () => {
   it('limits repeated requests to non-health endpoints', async () => {
-    const { app, server } = loadServer();
+    const { app, server } = loadServer({ rateLimitMax: 100 });
     try {
       const agent = request(app);
 
@@ -64,6 +73,22 @@ describe('global rate limiter', () => {
         const res = await agent.get('/api/health');
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ status: 'ok' });
+      }
+    } finally {
+      closeServer(server);
+    }
+  });
+
+  it('allows bursty dashboard traffic under the higher default limit', async () => {
+    const { app, server } = loadServer();
+    try {
+      const agent = request(app);
+
+      for (let i = 0; i < 250; i += 1) {
+        const res = await agent.get('/api/dashboard/overview');
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ ok: true });
+        expect(res.status).not.toBe(429);
       }
     } finally {
       closeServer(server);


### PR DESCRIPTION
## Summary
- allow the shared Express rate limiter ceiling to be configured with GLOBAL_RATE_LIMIT_MAX so dashboards can burst beyond 100 requests
- document the new environment knob and keep defaults high enough to avoid accidental 429s
- extend the rate limit integration tests to cover both enforcement at a lowered ceiling and successful dashboard bursts at the default

## Testing
- npm test -- healthRateLimit

------
https://chatgpt.com/codex/tasks/task_e_68cece63b07c83289acded3c5b0f7b01