### PR TITLE
Fix sidebar year hydration mismatch

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -17,11 +17,17 @@ export default function Sidebar({ role = 'admin' }) {
   const { t } = useTranslation('dashboard');
   const [activeDropdown, setActiveDropdown] = useState(null);
   const [isHydrated, setIsHydrated] = useState(false);
+  const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
   const settings = useAppConfigStore((state) => state.settings);
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
 
   useEffect(() => {
     setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    const year = new Date().getFullYear();
+    setCurrentYear((prevYear) => (prevYear !== year ? year : prevYear));
   }, []);
 
   useEffect(() => {
@@ -142,7 +148,7 @@ export default function Sidebar({ role = 'admin' }) {
       </div>
 
       <div className="text-xs text-gray-400 dark:text-gray-500 text-center mt-8">
-        &copy; {new Date().getFullYear()} {settings.appName || 'SkillBridge'}
+        &copy; {currentYear} {settings.appName || 'SkillBridge'}
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- initialize the sidebar footer year with a stable value during SSR/CSR hydration
- update the year after mount only when it changes to avoid mismatches

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ced4c23c288328961cfb87aaabedc1