### PR TITLE
Fix sidebar footer year hydration

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -17,11 +17,17 @@ export default function Sidebar({ role = 'admin' }) {
   const { t } = useTranslation('dashboard');
   const [activeDropdown, setActiveDropdown] = useState(null);
   const [isHydrated, setIsHydrated] = useState(false);
+  const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
   const settings = useAppConfigStore((state) => state.settings);
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
 
   useEffect(() => {
     setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    const year = new Date().getFullYear();
+    setCurrentYear((prev) => (prev === year ? prev : year));
   }, []);
 
   useEffect(() => {
@@ -142,7 +148,7 @@ export default function Sidebar({ role = 'admin' }) {
       </div>
 
       <div className="text-xs text-gray-400 dark:text-gray-500 text-center mt-8">
-        &copy; {new Date().getFullYear()} {settings.appName || 'SkillBridge'}
+        &copy; {currentYear} {settings.appName || 'SkillBridge'}
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- cache the footer year in state so that the server and first client render match
- update the year after hydration if needed to handle year rollovers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ced4b7fbec8328ad3a8ce8d3745819