### PR TITLE
Fix sidebar hydration by deferring config store render

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -18,8 +18,8 @@ export default function Sidebar({ role = 'admin' }) {
   const [activeDropdown, setActiveDropdown] = useState(null);
   const [isHydrated, setIsHydrated] = useState(false);
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
-  const settings = useAppConfigStore((state) => state.settings);
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
+  const [settings, setSettings] = useState({ appName: 'SkillBridge', logo_url: null });
 
   useEffect(() => {
     setIsHydrated(true);
@@ -31,7 +31,21 @@ export default function Sidebar({ role = 'admin' }) {
   }, []);
 
   useEffect(() => {
+    setSettings((prev) => ({ ...prev, ...useAppConfigStore.getState().settings }));
+    const unsubscribe = useAppConfigStore.subscribe(
+      (state) => state.settings,
+      (newSettings) => {
+        setSettings((prev) => ({ ...prev, ...newSettings }));
+      }
+    );
+
     fetchAppConfig();
+
+    return () => {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
   }, [fetchAppConfig]);
 
   const handleClearCache = async () => {


### PR DESCRIPTION
## Summary
- initialize sidebar config with static defaults and subscribe to store updates after mount
- avoid hydration mismatches from persisted app settings while still fetching latest config
- keep copyright year stable between server and client renders

## Testing
- npm run lint *(fails: existing lint warnings and errors throughout project)*

------
https://chatgpt.com/codex/tasks/task_e_68ced11893bc8328a03b5c90d7c54fb1