### PR TITLE
Use paginated tutorials in admin table

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -384,7 +384,7 @@ function AdminTutorialsPage() {
         {/* TABLE */}
         <div className="bg-white rounded-xl shadow-md overflow-hidden">
           <TutorialsTable
-            paginatedTutorials={tutorials}
+            paginatedTutorials={paginatedTutorials}
             loading={loading}
             selectedTutorials={selectedTutorials}
             toggleSelectAll={toggleSelectAll}


### PR DESCRIPTION
## Summary
- pass the paginated tutorials slice from the filter hook into the admin tutorials table so the UI renders the current page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee18ae30c8328b72df3f43b322aab