### PR TITLE
Ensure tutorials fetch uses explicit pagination

### DIFF
--- a/frontend/src/hooks/admin/tutorials/useTutorialsData.js
+++ b/frontend/src/hooks/admin/tutorials/useTutorialsData.js
@@ -16,7 +16,7 @@ export default function useTutorialsData(t) {
       try {
         setLoading(true);
         const [tuts, cats] = await Promise.all([
-          fetchAllTutorials({ signal: controller.signal }),
+          fetchAllTutorials(1, 10, { signal: controller.signal }),
           fetchAllCategories({}, { signal: controller.signal }),
         ]);
         if (!isMounted) return;


### PR DESCRIPTION
## Summary
- update the admin tutorials data hook to call fetchAllTutorials with explicit page and limit arguments so pagination parameters are passed through
- keep the AbortController signal in the fetch configuration to allow request cancellation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee17be5d48328982a4eddd2a37496