### PR TITLE
Adjust tutorial end index to match paginated slice

### DIFF
--- a/frontend/src/hooks/admin/tutorials/useTutorialFilters.js
+++ b/frontend/src/hooks/admin/tutorials/useTutorialFilters.js
@@ -30,8 +30,12 @@ export default function useTutorialFilters(tutorials, tutorialsPerPage = 10) {
   }, [currentPage, totalPages]);
 
   const startIndex = (currentPage - 1) * tutorialsPerPage;
-  const endIndex = startIndex + tutorialsPerPage;
-  const paginatedTutorials = filteredTutorials.slice(startIndex, endIndex);
+  const tentativeEndIndex = startIndex + tutorialsPerPage;
+  const paginatedTutorials = filteredTutorials.slice(startIndex, tentativeEndIndex);
+  const endIndex = Math.min(
+    startIndex + paginatedTutorials.length,
+    filteredTutorials.length
+  );
 
   const goToPage = (page) => {
     if (page >= 1 && page <= totalPages) {


### PR DESCRIPTION
## Summary
- ensure the tutorials hook calculates an end index that matches the filtered slice so the pagination summary reflects the true range

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cee17aa4bc8328a00a16866f84e655