### PR TITLE
Fix tutorials pagination total results calculation

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -65,6 +65,8 @@ function AdminTutorialsPage() {
     filterApproval,
   ]);
 
+  const totalResults = filteredTutorials.length;
+
   const user = useAuthStore((state) => state.user);
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
@@ -400,14 +402,14 @@ function AdminTutorialsPage() {
             setCurrentPage={setCurrentPage}
             onEdit={(id) => router.push(`/dashboard/admin/tutorials/${id}/edit`)}
           />
-          {meta.total > 0 && !loading && (
+          {totalResults > 0 && !loading && (
             <PaginationControls
               currentPage={currentPage}
               totalPages={totalPages}
               goToPage={goToPage}
               startIndex={startIndex}
               endIndex={endIndex}
-              totalResults={meta.total || 0}
+              totalResults={totalResults}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- derive the total results count for admin tutorials pagination from the filtered tutorials collection
- update pagination rendering and props to use the new total results value instead of an undefined meta object

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee176827883289d662bbb839f6c60