### PR TITLE
Fix tutorials fetch pagination arguments

### DIFF
--- a/frontend/src/hooks/admin/tutorials/useTutorialsData.js
+++ b/frontend/src/hooks/admin/tutorials/useTutorialsData.js
@@ -16,7 +16,7 @@ export default function useTutorialsData(t) {
       try {
         setLoading(true);
         const [tuts, cats] = await Promise.all([
-          fetchAllTutorials({ signal: controller.signal }),
+          fetchAllTutorials(1, 10, { signal: controller.signal }),
           fetchAllCategories({}, { signal: controller.signal }),
         ]);
         if (!isMounted) return;


### PR DESCRIPTION
## Summary
- pass explicit page and limit values when loading admin tutorials
- ensure the abort controller signal is provided via the config argument

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cee170cfd08328aa22758c22448b49