### PR TITLE
Fix admin tutorials table pagination data

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -384,7 +384,7 @@ function AdminTutorialsPage() {
         {/* TABLE */}
         <div className="bg-white rounded-xl shadow-md overflow-hidden">
           <TutorialsTable
-            paginatedTutorials={tutorials}
+            paginatedTutorials={paginatedTutorials}
             loading={loading}
             selectedTutorials={selectedTutorials}
             toggleSelectAll={toggleSelectAll}


### PR DESCRIPTION
## Summary
- ensure the admin tutorials table receives the paginated tutorial list from the filter hook so filters and pagination drive the table contents

## Testing
- npm run lint *(fails: existing lint errors throughout repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cee16db4d48328b1fdee38f5515769