### PR TITLE
Import tutorials hooks and bulk services

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -8,6 +8,9 @@ import TutorialsTable from "@/components/dashboard/admin/tutorials/TutorialsTabl
 import BulkActions from "@/components/dashboard/admin/tutorials/BulkActions";
 import PaginationControls from "@/components/dashboard/admin/tutorials/PaginationControls";
 import Stats from "@/components/dashboard/admin/tutorials/Stats";
+import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
+import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
+import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -20,6 +23,8 @@ import {
   toggleTutorialStatus,
   approveTutorial,
   rejectTutorial,
+  bulkApproveTutorials,
+  bulkDeleteTutorials,
 } from "@/services/admin/tutorialService";
 import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";


### PR DESCRIPTION
## Summary
- import the tutorials hooks used by the admin tutorials page
- include the bulk tutorials service helpers in the admin tutorials service import

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee168bd3483289cb51603da5f3ff0