### PR TITLE
Default admin profile phone to empty string

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -174,7 +174,7 @@ function ProfileEditTemplate() {
           ...prev,
           full_name,
           email: email || "",
-          phone,
+          phone: phone || "",
           gender: gender || "male",
           date_of_birth: date_of_birth?.split("T")[0] || "",
           avatar_url,


### PR DESCRIPTION
## Summary
- ensure the admin profile form defaults the phone field to an empty string when the API omits it
- rely on the existing zod validation to surface the invalid_phone_number error when the field remains blank

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee16061608328ad6b8e0aed469688