### PR TITLE
Handle backend validation errors in admin profile edit

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -404,7 +404,32 @@ function ProfileEditTemplate() {
       await fetchMessages();
       router.push("/dashboard/admin/profile/steps/verification");
     } catch (err) {
-      toast.error(err.message || t('profile_update_failed'));
+      const responseData = err?.response?.data;
+      const backendErrors = Array.isArray(responseData?.errors)
+        ? responseData.errors
+        : [];
+
+      if (backendErrors.length) {
+        const formattedErrors = backendErrors.reduce((acc, current) => {
+          if (current?.field) {
+            acc[current.field] = current?.message || t('fix_errors');
+          }
+          return acc;
+        }, {});
+
+        setErrors((prev) => ({
+          ...prev,
+          ...formattedErrors,
+        }));
+      }
+
+      const fallbackMessage = t('profile_update_failed');
+      const errorMessage =
+        (typeof responseData === 'string'
+          ? responseData
+          : responseData?.message) || err?.message || fallbackMessage;
+
+      toast.error(errorMessage);
       console.error("Profile update error:", err);
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
## Summary
- surface backend validation error messages from admin profile updates
- populate form field error state with server-provided validation details
- prefer API-provided failure messages when showing the update toast

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cee159c450832893db1373b9a0a094