### PR TITLE
Fix admin profile avatar preview URLs

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -31,12 +31,18 @@ import {
   uploadAdminAvatar,
   deleteAdminAvatar,
 } from "@/services/admin/adminService";
+import { API_BASE_URL } from "@/config/config";
 const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 import { toSocialLinksArray } from "@/utils/socialLinks";
 import { allowedPlatforms } from "@/utils/socialPlatforms";
 
 // Add service imports as needed, e.g., getProfile, updateProfile, uploadAvatar, etc.
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+
+const buildAvatarUrl = (url) =>
+  url ? (url.startsWith("http") ? url : `${BASE_URL}${url}`) : null;
 
 export const profileSchema = z.object({
   full_name: z.string().min(3, "full_name_min"),
@@ -137,9 +143,7 @@ function ProfileEditTemplate() {
       gender: user.gender || "male",
       date_of_birth: user.date_of_birth?.split("T")[0] || "",
       avatar_url: user.avatar_url,
-      avatarPreview: user.avatar_url
-        ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${user.avatar_url}`
-        : null,
+      avatarPreview: buildAvatarUrl(user.avatar_url),
       job_title: user.job_title || "",
       department: user.department || "",
     }));
@@ -178,9 +182,7 @@ function ProfileEditTemplate() {
           gender: gender || "male",
           date_of_birth: date_of_birth?.split("T")[0] || "",
           avatar_url,
-          avatarPreview: avatar_url
-            ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${avatar_url}`
-            : null,
+          avatarPreview: buildAvatarUrl(avatar_url),
           job_title: job_title || "",
           department: department || "",
           socialLinks: socialMap,
@@ -282,7 +284,9 @@ function ProfileEditTemplate() {
       setFormData((prev) => ({
         ...prev,
         avatar_url: res.avatar_url,
-        avatarPreview: `${process.env.NEXT_PUBLIC_API_BASE_URL}${res.avatar_url}?v=${cacheBust}`,
+        avatarPreview: buildAvatarUrl(
+          res.avatar_url ? `${res.avatar_url}?v=${cacheBust}` : null
+        ),
       }));
       setShowCropper(false);
       URL.revokeObjectURL(tempAvatar);
@@ -390,9 +394,7 @@ function ProfileEditTemplate() {
         email: fresh.email || "",
         job_title: fresh.job_title || "",
         department: fresh.department || "",
-        avatarPreview: fresh.avatar_url
-          ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${fresh.avatar_url}`
-          : null,
+        avatarPreview: buildAvatarUrl(fresh.avatar_url),
         socialLinks: (fresh.social_links || []).reduce((acc, cur) => {
           acc[cur.platform] = cur.url;
           return acc;


### PR DESCRIPTION
## Summary
- ensure admin profile page builds avatar preview URLs with configured API base URL fallback
- add helper to normalize relative and absolute avatar URLs across profile load, upload, and refresh flows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cee14eddec832892d192cda70c366d