### PR TITLE
Pass abort controller to tutorial fetch config

### DIFF
--- a/frontend/src/hooks/admin/tutorials/useTutorialsData.js
+++ b/frontend/src/hooks/admin/tutorials/useTutorialsData.js
@@ -16,7 +16,7 @@ export default function useTutorialsData(t) {
       try {
         setLoading(true);
         const [tuts, cats] = await Promise.all([
-          fetchAllTutorials({ signal: controller.signal }),
+          fetchAllTutorials(undefined, undefined, { signal: controller.signal }),
           fetchAllCategories({}, { signal: controller.signal }),
         ]);
         if (!isMounted) return;


### PR DESCRIPTION
## Summary
- update the admin tutorials data hook to pass the abort controller via the fetchAllTutorials config argument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee19d5bd883289439aec01a49d1db