### PR TITLE
Fix tutorials pagination data flow

### DIFF
--- a/frontend/src/components/dashboard/admin/tutorials/PaginationControls.js
+++ b/frontend/src/components/dashboard/admin/tutorials/PaginationControls.js
@@ -9,6 +9,10 @@ function PaginationControls({
   endIndex,
   totalResults,
 }) {
+  const safeTotalResults = Number.isFinite(totalResults) && totalResults > 0 ? totalResults : 0;
+  const displayStart = safeTotalResults === 0 ? 0 : Math.min(startIndex + 1, safeTotalResults);
+  const displayEnd = safeTotalResults === 0 ? 0 : Math.min(endIndex, safeTotalResults);
+
   const renderPageNumbers = () => {
     const pages = [];
     const maxPagesToShow = 5;
@@ -56,9 +60,9 @@ function PaginationControls({
   return (
     <div className="px-6 py-4 border-t border-gray-100 flex flex-col sm:flex-row items-center justify-between">
       <div className="text-sm text-gray-700 mb-4 sm:mb-0">
-        Showing <span className="font-medium">{startIndex + 1}</span> to{' '}
-        <span className="font-medium">{endIndex}</span> of{' '}
-        <span className="font-medium">{totalResults}</span> results
+        Showing <span className="font-medium">{displayStart}</span> to{' '}
+        <span className="font-medium">{displayEnd}</span> of{' '}
+        <span className="font-medium">{safeTotalResults}</span> results
       </div>
 
       <div className="flex items-center space-x-2">

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -384,7 +384,7 @@ function AdminTutorialsPage() {
         {/* TABLE */}
         <div className="bg-white rounded-xl shadow-md overflow-hidden">
           <TutorialsTable
-            paginatedTutorials={tutorials}
+            paginatedTutorials={paginatedTutorials}
             loading={loading}
             selectedTutorials={selectedTutorials}
             toggleSelectAll={toggleSelectAll}
@@ -400,14 +400,14 @@ function AdminTutorialsPage() {
             setCurrentPage={setCurrentPage}
             onEdit={(id) => router.push(`/dashboard/admin/tutorials/${id}/edit`)}
           />
-          {meta.total > 0 && !loading && (
+          {filteredTutorials.length > 0 && !loading && (
             <PaginationControls
               currentPage={currentPage}
               totalPages={totalPages}
               goToPage={goToPage}
               startIndex={startIndex}
               endIndex={endIndex}
-              totalResults={meta.total || 0}
+              totalResults={filteredTutorials.length}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- pass the paginated tutorials slice and filtered counts into the admin tutorials table and pagination controls
- clamp the pagination footer display to the filtered result totals for accurate ranges

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cee19c46cc83288a8b85588d1b9337