### PR TITLE
Document docker-compose ContainerConfig workaround

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,11 @@
 # Environment variables for docker-compose development
+# Docker Compose build settings
+# docker-compose v1 can raise a `KeyError: 'ContainerConfig'` when recreating
+# services that were built with BuildKit. Disabling BuildKit keeps compatibility
+# with the legacy image metadata format expected by docker-compose.
+DOCKER_BUILDKIT=0
+COMPOSE_DOCKER_CLI_BUILD=0
+
 POSTGRES_USER=skillbridge_user
 POSTGRES_PASSWORD=skillbridge_pass
 POSTGRES_DB=skillbridge_db

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Example environment variables for docker-compose development
 # Copy this file to `.env` and replace placeholder values with your own.
 
+# Docker Compose build settings
+# Docker Compose v1 can raise a `KeyError: 'ContainerConfig'` when recreating
+# services built with BuildKit. Disabling BuildKit keeps the legacy image
+# metadata that docker-compose expects.
+DOCKER_BUILDKIT=0
+COMPOSE_DOCKER_CLI_BUILD=0
+
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=change_me
 POSTGRES_DB=eduSkillbridge

--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ npm --prefix frontend install
    docker-compose up --build
    ```
 
+   If `docker-compose` exits with `KeyError: 'ContainerConfig'`, set
+   `DOCKER_BUILDKIT=0` and `COMPOSE_DOCKER_CLI_BUILD=0` in your `.env`
+   file (both are included in `.env.example`). This disables BuildKit for
+   compose v1 so images retain the legacy metadata structure expected by
+   older docker-compose releases.
+
 4. Visit `http://localhost:3000` to access the frontend when running locally. The API will be available at `http://localhost:5002/api`.
 
 For detailed instructions see [docs/installation.md](docs/installation.md).


### PR DESCRIPTION
## Summary
- disable BuildKit by default in the project `.env` files to avoid docker-compose v1 `ContainerConfig` errors when rebuilding containers
- explain the workaround in the README quick start so developers know how to resolve the issue if it occurs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cef166d0208328a1811e48bce209f6