### PR TITLE
Fix admin tutorials data loading

### DIFF
--- a/frontend/src/hooks/admin/tutorials/useTutorialsData.js
+++ b/frontend/src/hooks/admin/tutorials/useTutorialsData.js
@@ -16,12 +16,18 @@ export default function useTutorialsData(t) {
     const loadData = async () => {
       try {
         setLoading(true);
-        const [tuts, cats] = await Promise.all([
+        const [tutorialResponse, cats] = await Promise.all([
           fetchAllTutorials(undefined, undefined, { signal: controller.signal }),
           fetchAllCategories({}, { signal: controller.signal }),
         ]);
         if (!isMounted) return;
-        setTutorials(tuts);
+        const fetchedTutorials = Array.isArray(tutorialResponse)
+          ? tutorialResponse
+          : tutorialResponse?.tutorials || [];
+        const paginationMeta = Array.isArray(tutorialResponse)
+          ? null
+          : tutorialResponse?.meta || null;
+        setTutorials(fetchedTutorials);
         setCategories(cats?.data || cats || []);
         setMeta(paginationMeta || null);
       } catch (err) {


### PR DESCRIPTION
## Summary
- parse the admin tutorials API response correctly before updating state
- retain compatibility with array-only responses while still storing pagination metadata

## Testing
- `npm run lint` *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cef6dc09f483288297a5f96d159128