### PR TITLE
Adjust backend Docker runtime permissions

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,12 +9,11 @@ COPY ./ ./
 # Production stage
 FROM node:20-alpine
 WORKDIR /app
-RUN apk add --no-cache curl netcat-openbsd postgresql-client && \
+RUN apk add --no-cache curl netcat-openbsd postgresql-client su-exec && \
     (id -u node 2>/dev/null || adduser -S node)
 COPY --from=builder /app ./
 RUN chmod +x scripts/wait-for-db.sh scripts/docker-entrypoint.sh && \
     chown -R node:node /app
 EXPOSE 5002
-USER node
 ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
 CMD ["node", "src/server.js"]

--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -50,6 +50,11 @@ should_wait_for_db() {
   return 1
 }
 
+prepare_upload_dirs() {
+  mkdir -p /app/uploads/app /app/uploads/languages
+  chown -R node:node /app/uploads
+}
+
 main() {
   derive_database_url
 
@@ -67,9 +72,11 @@ main() {
     else
       echo "Skipping automatic database migrations because RUN_DB_MIGRATIONS=${RUN_DB_MIGRATIONS}."
     fi
+
+    prepare_upload_dirs
   fi
 
-  exec "$@"
+  exec su-exec node "$@"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- install su-exec in the backend image so the container can drop privileges at runtime
- prepare upload directories in the entrypoint before starting the server and drop to the node user with su-exec

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cefc2219cc8328a7367401e073a433