### PR TITLE
Fix backend upload permissions in Docker entrypoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,12 +9,11 @@ COPY ./ ./
 # Production stage
 FROM node:20-alpine
 WORKDIR /app
-RUN apk add --no-cache curl netcat-openbsd postgresql-client && \
+RUN apk add --no-cache curl netcat-openbsd postgresql-client su-exec && \
     (id -u node 2>/dev/null || adduser -S node)
 COPY --from=builder /app ./
 RUN chmod +x scripts/wait-for-db.sh scripts/docker-entrypoint.sh && \
     chown -R node:node /app
 EXPOSE 5002
-USER node
 ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
 CMD ["node", "src/server.js"]

--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -1,6 +1,66 @@
 #!/bin/sh
 set -eu
 
+run_as_node() {
+  if [ "$(id -u)" -eq 0 ]; then
+    exec_cmd="su-exec"
+    if ! command -v "$exec_cmd" >/dev/null 2>&1; then
+      echo "ERROR: $exec_cmd not found. Ensure it is installed in the container image." >&2
+      exit 1
+    fi
+    "$exec_cmd" node "$@"
+  else
+    "$@"
+  fi
+}
+
+ensure_upload_permissions() {
+  if [ "$(id -u)" -ne 0 ]; then
+    return
+  fi
+
+  upload_dirs="
+/app/uploads
+/app/uploads/ads
+/app/uploads/admin
+/app/uploads/admin/avatars
+/app/uploads/admin/identity
+/app/uploads/app
+/app/uploads/avatars
+/app/uploads/avatars/instructor
+/app/uploads/avatars/student
+/app/uploads/books
+/app/uploads/certificateTemplates
+/app/uploads/certificates
+/app/uploads/certificates/instructor
+/app/uploads/chat
+/app/uploads/currencies
+/app/uploads/demo-videos
+/app/uploads/demos
+/app/uploads/demos/instructor
+/app/uploads/groups
+/app/uploads/identity
+/app/uploads/identity/student
+/app/uploads/invoices
+/app/uploads/languages
+/app/uploads/payment-methods
+/app/uploads/payment-receipts
+/app/uploads/seo
+/app/uploads/support_attachments
+/app/uploads/ticket_attachments
+/app/uploads/tutorials
+/app/uploads/tutorials/chapters
+/app/uploads/tutorials/chapters/instructor
+/app/uploads/tutorials/chapters/student
+"
+
+  for dir in $upload_dirs; do
+    mkdir -p "$dir"
+  done
+
+  chown -R node:node /app/uploads
+}
+
 url_encode() {
   node -e "process.stdout.write(encodeURIComponent(process.argv[1] ?? ''));" "$1"
 }
@@ -51,6 +111,8 @@ should_wait_for_db() {
 }
 
 main() {
+  ensure_upload_permissions
+
   derive_database_url
 
   if [ "$#" -eq 0 ]; then
@@ -63,10 +125,14 @@ main() {
 
   if [ "$1" = "node" ] && [ "${2:-}" = "src/server.js" ]; then
     if should_run_migrations; then
-      npx knex migrate:latest
+      run_as_node npx knex migrate:latest
     else
       echo "Skipping automatic database migrations because RUN_DB_MIGRATIONS=${RUN_DB_MIGRATIONS}."
     fi
+  fi
+
+  if [ "$(id -u)" -eq 0 ]; then
+    exec su-exec node "$@"
   fi
 
   exec "$@"


### PR DESCRIPTION
## Summary
- install su-exec in the backend image so the entrypoint can drop privileges after fixing permissions
- extend the Docker entrypoint to create the uploads subdirectories, chown them when running as root, and then exec the app as the node user

## Testing
- npm test -- --runTestsByPath tests/appConfigRoutes.test.js
- docker build -t skillbridge-backend-test backend *(fails: docker CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cefc17370c8328883e927b8749c73f