### PR TITLE
Fix frontend health rewrite

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -245,7 +245,7 @@ const nextConfig = {
         destination: `${pgAdminBase}/:path*`,
       },
       {
-        source: '/api/:path((?!health$).*)',
+        source: '/api/:path((?!health(?:/|$)).*)',
         destination: `${internalApiBase}/:path`,
       },
       {


### PR DESCRIPTION
## Summary
- update the frontend rewrite rule so requests to `/api/health` (and nested paths) are always handled locally

## Testing
- npm run lint *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8886e1e88328963808acfa514c40