### PR TITLE
Ensure SSR API client uses internal base URL

### DIFF
--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -8,15 +8,81 @@
 import axios from "axios";
 import logger from "@/utils/logger";
 
-// If NEXT_PUBLIC_API_BASE_URL isn't provided, default to a relative path so
-// the frontend works regardless of the domain it's served from. This prevents
-// hard coded production URLs from causing CORS or redirect issues in other
-// environments.
-const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+const isBrowser = typeof window !== "undefined";
+const DEFAULT_SERVER_BASE_URL = "http://localhost:5002/api";
+const publicBaseCandidate = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+const internalBaseCandidate = process.env.INTERNAL_API_BASE_URL;
+
+const pickBaseCandidate = () => {
+  if (!isBrowser && internalBaseCandidate) {
+    return internalBaseCandidate;
+  }
+
+  return publicBaseCandidate;
+};
+
+const ensureAbsoluteUrl = (candidate) => {
+  if (!candidate) {
+    return candidate;
+  }
+
+  if (/^https?:\/\//i.test(candidate)) {
+    return candidate;
+  }
+
+  const tryResolveWithBase = (base) => {
+    try {
+      return new URL(candidate, base).toString();
+    } catch (error) {
+      logger.warn(
+        `Failed to resolve API base URL from "${candidate}" against "${base}": ${error.message}`
+      );
+      return null;
+    }
+  };
+
+  if (isBrowser) {
+    const origin = window?.location?.origin;
+    if (origin) {
+      const resolved = tryResolveWithBase(origin);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    logger.warn(
+      `API base "${candidate}" is not absolute. Falling back to the current browser origin.`
+    );
+    return origin ? tryResolveWithBase(origin) || origin : candidate;
+  }
+
+  const appDomain = process.env.APP_DOMAIN;
+  if (appDomain) {
+    const domainWithProtocol = /^https?:\/\//i.test(appDomain)
+      ? appDomain
+      : `https://${appDomain}`;
+    const resolved = tryResolveWithBase(domainWithProtocol);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  const fallback = internalBaseCandidate && /^https?:\/\//i.test(internalBaseCandidate)
+    ? internalBaseCandidate
+    : DEFAULT_SERVER_BASE_URL;
+
+  logger.warn(
+    `API base "${candidate}" is not absolute and could not be resolved. Falling back to "${fallback}".`
+  );
+
+  return fallback;
+};
+
+const baseURL = ensureAbsoluteUrl(pickBaseCandidate());
 
 // Warn developers if the default domain URL is used in production
 if (
-  typeof window !== "undefined" &&
+  isBrowser &&
   !process.env.NEXT_PUBLIC_API_BASE_URL &&
   window.location.hostname !== "localhost"
 ) {


### PR DESCRIPTION
## Summary
- update the shared Axios client to prefer `INTERNAL_API_BASE_URL` during SSR and fall back to the public base in the browser
- ensure the API base URL is absolute by resolving relative paths against the browser origin or configured domain

## Testing
- `npm --prefix frontend run lint` *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf917fc3ec83289d7dcf97a160cd57