### PR TITLE
Handle relative API bases when joining URLs

### DIFF
--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -3,8 +3,40 @@ import { extractData } from "@/services/api/helpers";
 import { API_BASE_URL } from "@/config/config";
 import { joinUrl } from "@/utils/url";
 
+const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//;
+
+function resolveAssetBase() {
+  const explicitBase = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+
+  if (ABSOLUTE_URL_REGEX.test(explicitBase || "")) {
+    return explicitBase;
+  }
+
+  if (typeof window === "undefined") {
+    const internalBase = process.env.INTERNAL_API_BASE_URL;
+    if (ABSOLUTE_URL_REGEX.test(internalBase || "")) {
+      return internalBase;
+    }
+
+    const appDomain = process.env.APP_DOMAIN;
+    if (appDomain) {
+      const isLocalhost = /^localhost(:\d+)?$/i.test(appDomain);
+      const protocol = isLocalhost ? "http" : "https";
+      const normalizedDomain = appDomain.replace(/\/+$/, "");
+      const relative = explicitBase
+        ? explicitBase.startsWith("/")
+          ? explicitBase
+          : `/${explicitBase}`
+        : "";
+      return `${protocol}://${normalizedDomain}${relative}`;
+    }
+  }
+
+  return explicitBase;
+}
+
 export const formatTutorial = (tut) => {
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL;
+  const baseUrl = resolveAssetBase();
   const thumbnailPath = tut.thumbnail_url || tut.cover_image;
   const previewPath = tut.preview_video;
 

--- a/frontend/src/tests/__tests__/urlUtils.node.test.js
+++ b/frontend/src/tests/__tests__/urlUtils.node.test.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+import { joinUrl } from "../../utils/url";
+import { formatTutorial } from "../../services/tutorialService";
+
+describe("joinUrl in node environment", () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    delete process.env.INTERNAL_API_BASE_URL;
+    delete process.env.APP_DOMAIN;
+  });
+
+  it("derives origin from INTERNAL_API_BASE_URL for relative bases", () => {
+    process.env.INTERNAL_API_BASE_URL = "http://backend:5002/api";
+
+    expect(joinUrl("/api", "img.png")).toBe("http://backend:5002/api/img.png");
+  });
+
+  it("uses APP_DOMAIN when available to build absolute URLs", () => {
+    process.env.APP_DOMAIN = "example.com";
+
+    expect(joinUrl("/api", "img.png")).toBe("https://example.com/api/img.png");
+  });
+
+  it("falls back to relative joining when no origin is available", () => {
+    expect(joinUrl("/api", "img.png")).toBe("/api/img.png");
+  });
+});
+
+describe("formatTutorial server-side URL handling", () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    delete process.env.INTERNAL_API_BASE_URL;
+    delete process.env.APP_DOMAIN;
+  });
+
+  it("prefers INTERNAL_API_BASE_URL when public base is relative", () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "/api";
+    process.env.INTERNAL_API_BASE_URL = "http://backend:5002/api";
+
+    const formatted = formatTutorial({ thumbnail_url: "img.png" });
+
+    expect(formatted.thumbnail).toBe("http://backend:5002/api/img.png");
+  });
+
+  it("derives protocol from APP_DOMAIN when internal base is missing", () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "/api";
+    process.env.APP_DOMAIN = "example.com";
+
+    const formatted = formatTutorial({ preview_video: "clip.mp4" });
+
+    expect(formatted.preview).toBe("https://example.com/api/clip.mp4");
+  });
+});

--- a/frontend/src/utils/url.js
+++ b/frontend/src/utils/url.js
@@ -6,6 +6,61 @@ const RAW_API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 // static asset URLs point to the server root regardless of API prefix.
 const API_BASE = RAW_API_BASE.replace(/\/api.*$/, "");
 
+const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//;
+
+function isAbsoluteUrl(value) {
+  return typeof value === "string" && ABSOLUTE_URL_REGEX.test(value);
+}
+
+function getFallbackOrigin() {
+  if (typeof window !== "undefined" && window?.location?.origin) {
+    return window.location.origin;
+  }
+
+  const internalBase = process.env.INTERNAL_API_BASE_URL;
+  if (isAbsoluteUrl(internalBase)) {
+    return new URL(internalBase).origin;
+  }
+
+  const publicBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (isAbsoluteUrl(publicBase)) {
+    return new URL(publicBase).origin;
+  }
+
+  const appDomain = process.env.APP_DOMAIN;
+  if (appDomain) {
+    const isLocalhost = /^localhost(:\d+)?$/i.test(appDomain);
+    const protocol = isLocalhost ? "http" : "https";
+    return `${protocol}://${appDomain}`;
+  }
+
+  return null;
+}
+
+function joinPaths(base, path) {
+  if (!base) {
+    if (!path) return "";
+    return path.startsWith("/") ? path : `/${path}`;
+  }
+
+  if (!path) {
+    return base;
+  }
+
+  const baseEndsWithSlash = base.endsWith("/");
+  const pathStartsWithSlash = path.startsWith("/");
+
+  if (baseEndsWithSlash && pathStartsWithSlash) {
+    return base + path.slice(1);
+  }
+
+  if (!baseEndsWithSlash && !pathStartsWithSlash) {
+    return `${base}/${path}`;
+  }
+
+  return base + path;
+}
+
 export function safeEncodeURI(url) {
   return encodeURI(url).replace(/#/g, "%23");
 }
@@ -20,5 +75,39 @@ export function buildUrl(path) {
 }
 
 export function joinUrl(base, path) {
-  return new URL(path, base).href;
+  if (!path) {
+    return base || "";
+  }
+
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  let effectiveBase = base;
+
+  if (!isAbsoluteUrl(effectiveBase)) {
+    const origin = getFallbackOrigin();
+    if (origin) {
+      const combined = joinPaths(effectiveBase, path);
+      const normalizedPath = combined.startsWith("/")
+        ? combined
+        : `/${combined}`;
+      return `${origin.replace(/\/+$/, "")}${normalizedPath}`;
+    }
+
+    return joinPaths(effectiveBase, path);
+  }
+
+  try {
+    const baseForUrl =
+      typeof effectiveBase === "string" && effectiveBase.length > 0
+        ? effectiveBase.endsWith("/") || /[?#]$/.test(effectiveBase)
+          ? effectiveBase
+          : `${effectiveBase}/`
+        : effectiveBase;
+
+    return new URL(path, baseForUrl).href;
+  } catch (error) {
+    return joinPaths(effectiveBase, path);
+  }
 }


### PR DESCRIPTION
## Summary
- add robust helpers in url utilities to derive an absolute origin before joining paths
- resolve tutorial asset base URLs server-side by preferring internal API or app domain fallbacks
- cover absolute and relative join scenarios with new node-environment unit tests

## Testing
- npm test -- --runTestsByPath src/tests/__tests__/tutorialService.test.js src/tests/__tests__/urlUtils.node.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf917fda48832881bb1cce8dba14d4