### PR TITLE
Ensure health check bypasses API proxy

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -239,20 +239,28 @@ const nextConfig = {
         : false,
   },
   async rewrites() {
-    return [
-      {
-        source: '/api/pgadmin/:path*',
-        destination: `${pgAdminBase}/:path*`,
-      },
-      {
-        source: '/api/:path((?!health(?:/|$)).*)',
-        destination: `${internalApiBase}/:path`,
-      },
-      {
-        source: '/uploads/:path*',
-        destination: `${internalApiBase}/uploads/:path*`,
-      },
-    ];
+    return {
+      beforeFiles: [
+        {
+          source: '/api/health',
+          destination: '/api/health',
+        },
+      ],
+      afterFiles: [
+        {
+          source: '/api/pgadmin/:path*',
+          destination: `${pgAdminBase}/:path*`,
+        },
+        {
+          source: '/api/:path((?!health(?:/|$)).*)',
+          destination: `${internalApiBase}/:path`,
+        },
+        {
+          source: '/uploads/:path*',
+          destination: `${internalApiBase}/uploads/:path*`,
+        },
+      ],
+    };
   },
 };
 


### PR DESCRIPTION
## Summary
- add a beforeFiles rewrite so /api/health is resolved locally before proxy rewrites
- preserve existing proxy rewrites for pgAdmin, API, and uploads

## Testing
- docker-compose build frontend *(fails: docker-compose not available in container)*
- docker compose build frontend *(fails: docker not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf932dc7688328a313f70fedd7eb93