### PR TITLE
Handle SSR-safe socket initialization

### DIFF
--- a/frontend/src/components/chat/ChatRoom.js
+++ b/frontend/src/components/chat/ChatRoom.js
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
-import socket from "@/services/socketService";
+import getSocket from "@/services/socketService";
 import { FaPaperPlane, FaSmile } from "react-icons/fa";
+
+const socket = getSocket();
 
 const ChatRoom = ({ username, room }) => {
   const [message, setMessage] = useState("");

--- a/frontend/src/components/chat/ChatWindow.js
+++ b/frontend/src/components/chat/ChatWindow.js
@@ -15,7 +15,9 @@ import {
   togglePinMessage as apiTogglePinMessage,
   startVideoCall,
 } from "@/services/messageService";
-import socket from "@/services/socketService";
+import getSocket from "@/services/socketService";
+
+const socket = getSocket();
 
 const ChatWindow = ({ selectedChat, refreshUsers }) => {
   const router = useRouter();

--- a/frontend/src/components/video-call/ChatDuringCall.js
+++ b/frontend/src/components/video-call/ChatDuringCall.js
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
 import { FaPaperPlane } from "react-icons/fa";
 import { fetchCallMessages, sendCallMessage } from "@/services/videoCallService";
-import socket from "@/services/socketService";
+import getSocket from "@/services/socketService";
+
+const socket = getSocket();
 
 const ChatDuringCall = ({ chatId }) => {
   const [messages, setMessages] = useState([]);

--- a/frontend/src/components/video-call/ParticipantList.js
+++ b/frontend/src/components/video-call/ParticipantList.js
@@ -7,7 +7,9 @@ import {
   removeParticipant,
   makeCoHost,
 } from "@/services/videoCallService";
-import socket from "@/services/socketService";
+import getSocket from "@/services/socketService";
+
+const socket = getSocket();
 
 export default function ParticipantList({ chatId, userRole = "participant" }) {
   const [participants, setParticipants] = useState([]);

--- a/frontend/src/pages/messages/chat.js
+++ b/frontend/src/pages/messages/chat.js
@@ -4,8 +4,10 @@ import Navbar from "@/components/website/sections/Navbar";
 import ChatSidebar from "@/components/chat/ChatSidebar";
 import ChatWindow from "@/components/chat/ChatWindow";
 import CallOverlay from "@/components/video-call/CallOverlay";
-import socket from "@/services/socketService";
+import getSocket from "@/services/socketService";
 import { getUsers, getGroups } from "@/services/messageService";
+
+const socket = getSocket();
 
 const ChatPage = () => {
   const [users, setUsers] = useState([]);

--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -4,7 +4,9 @@ import { getCsrfToken } from "@/services/api/csrf";
 import useCallStore from "@/store/call/callStore";
 import useAuthStore from "@/store/auth/authStore";
 import useMessageStore from "@/store/messages/messageStore";
-import socket from "@/services/socketService";
+import getSocket from "@/services/socketService";
+
+const socket = getSocket();
 
 
 export const getUsers = async () => {

--- a/frontend/src/services/socketService.js
+++ b/frontend/src/services/socketService.js
@@ -2,11 +2,33 @@ import { io } from "socket.io-client";
 
 // Allow overriding the socket server URL via env var, otherwise connect to the
 // same host that served the frontend.
-const SOCKET_SERVER_URL =
-  process.env.NEXT_PUBLIC_SOCKET_URL || "";
+const SOCKET_SERVER_URL = process.env.NEXT_PUBLIC_SOCKET_URL || "";
 
-const socket = io(SOCKET_SERVER_URL, {
-  transports: ["websocket"],
-});
+let socketInstance;
 
-export default socket;
+const noop = () => {};
+
+const socketShim = {
+  on: noop,
+  off: noop,
+  emit: noop,
+  connect: noop,
+  disconnect: noop,
+  once: noop,
+};
+
+export const getSocket = () => {
+  if (typeof window === "undefined") {
+    return socketShim;
+  }
+
+  if (!socketInstance) {
+    socketInstance = io(SOCKET_SERVER_URL, {
+      transports: ["websocket"],
+    });
+  }
+
+  return socketInstance;
+};
+
+export default getSocket;

--- a/frontend/src/store/call/callStore.js
+++ b/frontend/src/store/call/callStore.js
@@ -1,6 +1,8 @@
 import { create } from "zustand";
-import socket from "@/services/socketService";
+import getSocket from "@/services/socketService";
 import useAuthStore from "@/store/auth/authStore";
+
+const socket = getSocket();
 
 const useCallStore = create((set, get) => ({
   incomingCall: null,


### PR DESCRIPTION
## Summary
- lazily instantiate the Socket.IO client only when running in the browser and provide a no-op shim for SSR
- update stores, services, and components to request the socket instance via the new getter

## Testing
- docker compose up --build *(fails: docker not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf933282208328bd5abf5c5ee5a330