### PR TITLE
Fix backend entrypoint execution logic

### DIFF
--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -138,16 +138,7 @@ main() {
     prepare_upload_dirs
   fi
 
-  if [ "$(id -u)" -eq 0 ]; then
-    ensure_upload_dirs
-    exec su-exec node "$@"
-  fi
-
-  if [ "$(id -u)" -eq 0 ]; then
-    exec su-exec node "$@"
-  fi
-
-  exec "$@"
+  run_as_node "$@"
 
 }
 


### PR DESCRIPTION
## Summary
- replace the backend entrypoint's manual su-exec calls with the existing run_as_node helper to prevent command-not-found errors

## Testing
- sh -n backend/scripts/docker-entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68cf9c0511f4832883646b04bf9c4201