### PR TITLE
Handle Axios cancellation in admin profile load

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -189,7 +189,13 @@ function ProfileEditTemplate() {
           socialLinks: socialMap,
         }));
       } catch (err) {
-        if (err?.name === "AbortError") return;
+        if (
+          err?.name === "AbortError" ||
+          err?.code === "ERR_CANCELED" ||
+          err?.name === "CanceledError"
+        ) {
+          return;
+        }
         toast.error(t("load_profile_failed"));
         console.error("Profile load error:", err);
       } finally {


### PR DESCRIPTION
## Summary
- guard the admin profile loader against Axios cancellation errors and skip error handling when triggered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfa528e34c8328aca6bf07d660b512