### PR TITLE
Use alias for next-i18next config import

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -5,7 +5,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import nextI18NextConfig from "@/../next-i18next.config.js";
 import { toast } from "react-toastify";
 import { z, ZodError } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";


### PR DESCRIPTION
## Summary
- adjust the admin profile edit page to import the Next.js i18n configuration via the existing src alias so it resolves correctly

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfa525f18083288107e70e566cb444