### PR TITLE
Fix admin profile i18n config import

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -5,7 +5,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import nextI18NextConfig from "@/../next-i18next.config.js";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
 import { z, ZodError } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";


### PR DESCRIPTION
## Summary
- point the admin profile edit page to the frontend i18n config using a relative path

## Testing
- npm run lint *(fails: pre-existing lint errors about img usage, missing dependencies, and display names)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfa68a691883289cf709ca43be5335