### PR TITLE
Fix admin avatar upload user id scope

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -258,7 +258,6 @@ exports.updateAvatar = async (req, res) => {
       return res.status(400).json({ message: "No image uploaded" });
     }
 
-    const userId = req.params.id;
     const { avatar_url: oldAvatar } = await db("users")
       .where({ id: userId })
       .first("avatar_url");

--- a/backend/tests/adminAvatarController.test.js
+++ b/backend/tests/adminAvatarController.test.js
@@ -35,7 +35,7 @@ describe('admin controller updateAvatar', () => {
       json: jest.fn(),
     };
 
-    await controller.updateAvatar(req, res);
+    await expect(controller.updateAvatar(req, res)).resolves.toBeUndefined();
 
     expect(res.status).not.toHaveBeenCalled();
     expect(mockDb).toHaveBeenCalledWith('users');
@@ -68,7 +68,7 @@ describe('admin controller updateAvatar', () => {
       json: jest.fn(),
     };
 
-    await controller.updateAvatar(req, res);
+    await expect(controller.updateAvatar(req, res)).resolves.toBeUndefined();
 
     expect(res.status).toHaveBeenCalledWith(403);
     expect(res.json).toHaveBeenCalledWith({ message: 'Forbidden' });


### PR DESCRIPTION
## Summary
- use the request param user id for all admin avatar update operations and logging
- expand the admin avatar controller tests to assert the upload resolves without throwing

## Testing
- npm test --prefix backend adminAvatarController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cfa691739c8328ae7cc67bb8c0cb24