### PR TITLE
Fix SSR-safe payment provider edit heading

### DIFF
--- a/frontend/src/pages/admin/payments/edit/[id].js
+++ b/frontend/src/pages/admin/payments/edit/[id].js
@@ -5,11 +5,18 @@ import PaymentProviderConfig from '@/components/payments/PaymentProviderConfig';
 export default function EditPaymentProviderPage() {
   const router = useRouter();
   const { id } = router.query;
+  const isStringId = typeof id === 'string' && id.length > 0;
+  const heading = isStringId ? id.toUpperCase() : '...';
+  const shouldRenderConfig = router.isReady && isStringId;
 
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Configure {id?.toUpperCase()} Settings</h1>
-      <PaymentProviderConfig providerId={id} />
+      <h1 className="text-2xl font-bold mb-4">Configure {heading} Settings</h1>
+      {shouldRenderConfig ? (
+        <PaymentProviderConfig providerId={id} />
+      ) : (
+        <div className="h-24 rounded bg-gray-100" aria-busy="true" aria-live="polite" />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- stabilize the payment provider edit heading by rendering a placeholder until the id is available
- defer PaymentProviderConfig rendering until router readiness and id availability to avoid hydration mismatches
- add a lightweight loading placeholder for the configuration panel while awaiting the provider id

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*
- npm run dev *(manual verification via Playwright script that /admin/payments/edit/stripe hydrates without console errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cfadfb6dd48328a3baadb09de89fe2