### PR TITLE
Localize admin welcome banner

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -5,6 +5,8 @@
     "admin_dashboard": "لوحة تحكم المدير"
   },
   "welcome_admin": "مرحباً، أيها المشرف",
+  "welcome_banner_greeting": "مرحباً، {{name}} 👋",
+  "welcome_banner_today": "اليوم هو {{date}}",
   "users": "المستخدمون",
   "settings": "الإعدادات (JSON)",
   "language_manager": "مدير اللغة",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -5,6 +5,8 @@
     "admin_dashboard": "Admin-Dashboard"
   },
   "welcome_admin": "Willkommen, Admin",
+  "welcome_banner_greeting": "Willkommen, {{name}} 👋",
+  "welcome_banner_today": "Heute ist {{date}}",
   "users": "Benutzer",
   "settings": "Einstellungen (JSON)",
   "language_manager": "Sprachverwaltung",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -5,6 +5,8 @@
     "admin_dashboard": "Admin Dashboard"
   },
   "welcome_admin": "Welcome, Admin",
+  "welcome_banner_greeting": "Welcome, {{name}} 👋",
+  "welcome_banner_today": "Today is {{date}}",
   "users": "Users",
   "settings": "Settings (JSON)",
   "language_manager": "Language Manager",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -5,6 +5,8 @@
     "admin_dashboard": "Panel de Administrador"
   },
   "welcome_admin": "Bienvenido, administrador",
+  "welcome_banner_greeting": "Bienvenido/a, {{name}} 👋",
+  "welcome_banner_today": "Hoy es {{date}}",
   "users": "Usuarios",
   "settings": "Configuración (JSON)",
   "language_manager": "Administrador de idiomas",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -5,6 +5,8 @@
     "admin_dashboard": "Tableau Admin"
   },
   "welcome_admin": "Bienvenue, Administrateur",
+  "welcome_banner_greeting": "Bienvenue, {{name}} 👋",
+  "welcome_banner_today": "Nous sommes le {{date}}",
   "users": "Utilisateurs",
   "settings": "Paramètres (JSON)",
   "language_manager": "Gestionnaire de langue",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -5,6 +5,8 @@
     "admin_dashboard": "व्यवस्थापक डैशबोर्ड"
   },
   "welcome_admin": "स्वागत है, व्यवस्थापक",
+  "welcome_banner_greeting": "स्वागत है, {{name}} 👋",
+  "welcome_banner_today": "आज {{date}} है",
   "users": "उपयोगकर्ता",
   "settings": "सेटिंग्स (JSON)",
   "language_manager": "भाषा प्रबंधक",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -5,6 +5,8 @@
     "admin_dashboard": "Dashboard amministratore"
   },
   "welcome_admin": "Benvenuto, amministratore",
+  "welcome_banner_greeting": "Benvenuto/a, {{name}} 👋",
+  "welcome_banner_today": "Oggi è {{date}}",
   "users": "Utenti",
   "settings": "Impostazioni (JSON)",
   "language_manager": "Direttore linguistico",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -5,6 +5,8 @@
     "admin_dashboard": "管理仪表板"
   },
   "welcome_admin": "管理员欢迎您",
+  "welcome_banner_greeting": "欢迎，{{name}} 👋",
+  "welcome_banner_today": "今天是{{date}}",
   "users": "用户",
   "settings": "设置（JSON）",
   "language_manager": "语言管理",

--- a/frontend/src/components/admin/WelcomeBanner.js
+++ b/frontend/src/components/admin/WelcomeBanner.js
@@ -1,17 +1,41 @@
 // components/admin/WelcomeBanner.js
+import { useTranslation } from "next-i18next";
+
+const localeFallbacks = {
+  ar: "ar-SA",
+  de: "de-DE",
+  en: "en-US",
+  es: "es-ES",
+  fr: "fr-FR",
+  hi: "hi-IN",
+  it: "it-IT",
+  zh: "zh-CN",
+};
+
 export default function WelcomeBanner({ name = "Admin" }) {
-    const today = new Date().toLocaleDateString("en-US", {
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  
-    return (
-      <div className="bg-white p-6 rounded-xl shadow">
-        <h1 className="text-2xl font-bold text-gray-800">Welcome, {name} 👋</h1>
-        <p className="text-sm text-gray-500">Today is {today}</p>
-      </div>
-    );
-  }
+  const { t, i18n } = useTranslation("dashboard");
+
+  const language = i18n?.language || "en";
+  const [baseLanguage] = language.split("-");
+  const locale =
+    localeFallbacks[language] || localeFallbacks[baseLanguage] || language;
+
+  const today = new Date().toLocaleDateString(locale, {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="bg-white p-6 rounded-xl shadow">
+      <h1 className="text-2xl font-bold text-gray-800">
+        {t("welcome_banner_greeting", { name })}
+      </h1>
+      <p className="text-sm text-gray-500">
+        {t("welcome_banner_today", { date: today })}
+      </p>
+    </div>
+  );
+}
   


### PR DESCRIPTION
## Summary
- localize the admin welcome banner strings in the dashboard namespace
- format the date using the current translation language with sensible locale fallbacks

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd12247408328851e46adf6dd901b