### PR TITLE
Protect license logs admin page with auth guard

### DIFF
--- a/frontend/src/pages/admin/license-logs.js
+++ b/frontend/src/pages/admin/license-logs.js
@@ -1,6 +1,7 @@
 // pages/admin/license-logs.js
 import { useEffect, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import { fetchLicenseLogs } from "@/services/admin/licenseService";
 
 function LicenseLogsPage() {
@@ -52,4 +53,11 @@ LicenseLogsPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
 
-export default LicenseLogsPage;
+const ProtectedLicenseLogsPage = withAuthProtection(LicenseLogsPage, [
+  "admin",
+  "superadmin",
+]);
+
+ProtectedLicenseLogsPage.getLayout = LicenseLogsPage.getLayout;
+
+export default ProtectedLicenseLogsPage;


### PR DESCRIPTION
## Summary
- guard the admin license logs page with the shared withAuthProtection HOC
- ensure the AdminLayout getLayout hook remains attached to the wrapped page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfd113d63c8328b8383d3e47659001