### PR TITLE
Guard admin dashboard rendering until user is loaded

### DIFF
--- a/frontend/src/pages/dashboard/admin/index.js
+++ b/frontend/src/pages/dashboard/admin/index.js
@@ -93,7 +93,7 @@ function AdminDashboardHome() {
     }
   }, [hydrated]);
 
-  if (!hydrated) {
+  if (!hydrated || !user) {
     return null;
   }
 
@@ -109,7 +109,7 @@ function AdminDashboardHome() {
 
   return (
     <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 space-y-10">
-      <WelcomeBanner name={user.full_name || "Admin"} />
+      <WelcomeBanner name={user?.full_name ?? "Admin"} />
 
       {/* Alerts Summary */}
       <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- prevent the admin dashboard page from rendering before the auth store has provided a user
- default the welcome banner name to the user's full name when available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfd112615883289a0a94deb4bad7f5