### PR TITLE
Handle admin dashboard stats errors

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -352,6 +352,11 @@ exports.uploadIdentityDoc = async (req, res) => {
  * @access Admin
  */
 exports.getDashboardStats = async (_req, res) => {
-  const data = await require("./admin.service").getDashboardStats();
-  res.status(200).json({ data });
+  try {
+    const data = await require("./admin.service").getDashboardStats();
+    res.status(200).json({ data });
+  } catch (error) {
+    logger.error("Failed to fetch dashboard stats:", error);
+    res.status(500).json({ message: "Failed to fetch dashboard stats" });
+  }
 };


### PR DESCRIPTION
## Summary
- wrap the admin dashboard stats controller in error handling to log failures
- return a 500 response when the stats service throws while preserving the success response structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfd7b1513083288a87dc66f46de2dc