### PR TITLE
Protect admin moderation page

### DIFF
--- a/frontend/src/pages/admin/moderation.js
+++ b/frontend/src/pages/admin/moderation.js
@@ -1,8 +1,9 @@
 // pages/admin/moderation.js
 import AdminLayout from "@/components/layouts/AdminLayout";
 import MessageFlagLog from "@/components/admin/security/MessageFlagLog";
+import withAuthProtection from "@/hooks/withAuthProtection";
 
-export default function ModerationPage() {
+function ModerationPage() {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-6">🛡️ Moderation Center</h1>
@@ -17,3 +18,5 @@ export default function ModerationPage() {
 ModerationPage.getLayout = function getLayout(page) {
   return <AdminLayout>{page}</AdminLayout>;
 };
+
+export default withAuthProtection(ModerationPage, ["admin", "superadmin"]);


### PR DESCRIPTION
## Summary
- import the shared withAuthProtection helper in the admin moderation page
- wrap the moderation page export so only admin and superadmin roles can access it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfd7aee1c08328b101380b729a3e54