### PR TITLE
Require admin privileges for moderation flags route

### DIFF
--- a/backend/src/modules/moderation/moderation.routes.js
+++ b/backend/src/modules/moderation/moderation.routes.js
@@ -1,9 +1,9 @@
 const express = require("express");
 const router = express.Router();
 const controller = require("./moderation.controller");
-const { verifyToken } = require("../../middleware/auth/authMiddleware");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
 
-router.use(verifyToken);
+router.use(verifyToken, isAdmin);
 router.get("/flags", controller.getFlags);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- import the admin auth middleware in the moderation routes module
- apply the admin guard alongside verifyToken before registering the flags route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfd7ade2408328b958e6f773fc3d36