### PR TITLE
Fix admin instructors hydration guard

### DIFF
--- a/frontend/src/pages/dashboard/admin/instructors/index.js
+++ b/frontend/src/pages/dashboard/admin/instructors/index.js
@@ -3,6 +3,7 @@ import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../next-i18next.config.js';
 import AdminLayout from '@/components/layouts/AdminLayout';
+import { useAuthStore } from '@/store/auth/authStore';
 import InstructorCard from '@/components/admin/instructors/InstructorCard';
 import FilterBar from '@/components/admin/instructors/FilterBar';
 import BulkActions from '@/components/admin/instructors/BulkActions';
@@ -19,6 +20,7 @@ import withAdminGuard from '@/hooks/withAdminGuard';
 function AdminInstructorsPage() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'instructorsPage' });
   const { t: tCommon } = useTranslation('common');
+  const { hasHydrated } = useAuthStore();
   const [instructors, setInstructors] = useState([]);
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState('name');


### PR DESCRIPTION
## Summary
- import the auth store into the admin instructors page
- read the hasHydrated flag from the auth store to prevent blank screen while loading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfe14fd4288328b07449d6915c8c17