### PR TITLE
Fix admin instructors hydration check

### DIFF
--- a/frontend/src/pages/dashboard/admin/instructors/index.js
+++ b/frontend/src/pages/dashboard/admin/instructors/index.js
@@ -7,6 +7,7 @@ import InstructorCard from '@/components/admin/instructors/InstructorCard';
 import FilterBar from '@/components/admin/instructors/FilterBar';
 import BulkActions from '@/components/admin/instructors/BulkActions';
 import InstructorDetailsModal from '@/components/admin/instructors/InstructorDetailsModal';
+import useAuthStore from '@/store/auth/authStore';
 import {
   fetchAllInstructors,
   updateInstructorStatus,
@@ -19,6 +20,7 @@ import withAdminGuard from '@/hooks/withAdminGuard';
 function AdminInstructorsPage() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'instructorsPage' });
   const { t: tCommon } = useTranslation('common');
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
   const [instructors, setInstructors] = useState([]);
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState('name');


### PR DESCRIPTION
## Summary
- import the auth store into the admin instructors page
- read the hydration flag from the auth store before the guard uses it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfe1b7a23483288758160563b5e25d