### PR TITLE
Fix admin pages hydration guard

### DIFF
--- a/frontend/src/pages/dashboard/admin/instructors/index.js
+++ b/frontend/src/pages/dashboard/admin/instructors/index.js
@@ -14,6 +14,7 @@ import {
 } from '@/services/admin/instructorService';
 import { toast } from 'react-toastify';
 import withAdminGuard from '@/hooks/withAdminGuard';
+import useAuthStore from '@/store/auth/authStore';
 
 
 function AdminInstructorsPage() {
@@ -29,6 +30,7 @@ function AdminInstructorsPage() {
   const [hasMore, setHasMore] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [loading, setLoading] = useState(true);
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
 
   useEffect(() => {
     const loadData = async () => {

--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -7,10 +7,12 @@ import { createPlan } from "@/services/admin/planService";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import withAdminGuard from "@/hooks/withAdminGuard";
+import useAuthStore from "@/store/auth/authStore";
 
 function CreatePlanPage() {
   const router = useRouter();
   const { t } = useTranslation('dashboard', { keyPrefix: 'plansPage' });
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
 
   const [form, setForm] = useState({
     name: "",

--- a/frontend/src/pages/dashboard/admin/plans/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/plans/edit/[id].js
@@ -7,11 +7,13 @@ import { fetchPlanById, updatePlan } from "@/services/admin/planService";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import withAdminGuard from "@/hooks/withAdminGuard";
+import useAuthStore from "@/store/auth/authStore";
 
 function EditPlanPage() {
   const router = useRouter();
   const { t } = useTranslation('dashboard', { keyPrefix: 'plansPage' });
   const { id } = router.query;
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
 
   const [form, setForm] = useState(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- import the authentication store in the affected admin dashboard pages
- initialize the hydration flag from the store before hydration guards run

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe220b6b48328b3b27a6a8a8507a1