### PR TITLE
Add hydration guard for app config settings

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -10,7 +10,9 @@ import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
 import "@/styles/globals.css";
 import "@/services/api/tokenInterceptor";
 import useAuthStore from "@/store/auth/authStore";
-import useAppConfigStore from "@/store/appConfigStore";
+import useAppConfigStore, {
+  useAppConfigHydrated,
+} from "@/store/appConfigStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import useCallStore from "@/store/call/callStore";
@@ -50,6 +52,7 @@ function MyApp({ Component, pageProps, router }) {
   const fetchConfig = useAppConfigStore((state) => state.fetch);
   const configLoaded = useAppConfigStore((state) => state.loaded);
   const settings = useAppConfigStore((state) => state.settings);
+  const appConfigHydrated = useAppConfigHydrated();
   const startNotifPolling = useNotificationStore((s) => s.startPolling);
   const fetchNotifs = useNotificationStore((s) => s.fetch);
   const startMsgPolling = useMessageStore((s) => s.startPolling);
@@ -157,7 +160,10 @@ function MyApp({ Component, pageProps, router }) {
     return slug.replace(/-/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
   };
 
-  const appName = settings.appName || 'SkillBridge';
+  const appName =
+    appConfigHydrated && settings.appName
+      ? settings.appName
+      : 'SkillBridge';
   const defaultTitle = `${appName} | ${getPageTitle()}`;
 
     return (
@@ -207,10 +213,10 @@ function MyApp({ Component, pageProps, router }) {
             <Head>
               <title>{defaultTitle}</title>
               <meta name="viewport" content="width=device-width, initial-scale=1" />
-              {settings.metaDescription && (
+              {appConfigHydrated && settings.metaDescription && (
                 <meta name="description" content={settings.metaDescription} />
               )}
-              {settings.favicon_url && (
+              {appConfigHydrated && settings.favicon_url && (
                 <link
                   rel="icon"
                   href={`${process.env.NEXT_PUBLIC_API_BASE_URL || '/api'}${settings.favicon_url}`}

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -9,7 +9,7 @@ import { toast } from "react-toastify";
 import { motion } from "framer-motion";
 
 import { API_BASE_URL } from "@/config/config";
-import useAppConfigStore from "@/store/appConfigStore";
+import useAppConfigStore, { useAppConfigHydrated } from "@/store/appConfigStore";
 import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
 import InputField from "@/shared/components/auth/InputField";
 import SocialLogin from "@/shared/components/auth/SocialLogin";
@@ -41,6 +41,7 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const settings = useAppConfigStore((state) => state.settings);
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
+  const appConfigHydrated = useAppConfigHydrated();
   const { executeRecaptcha } = useGoogleReCaptcha() || {};
 
   // ─────────────────────
@@ -172,17 +173,28 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
 
           <img
 
-            src={settings.logo_url
-              ? `${API_BASE_URL}${settings.logo_url}`
-              : "/images/logo.png"}
-            alt={(settings.appName || 'SkillBridge') + ' Logo'}
+            src={
+              appConfigHydrated && settings.logo_url
+                ? `${API_BASE_URL}${settings.logo_url}`
+                : "/images/logo.png"
+            }
+            alt={`${
+              appConfigHydrated && settings.appName
+                ? settings.appName
+                : 'SkillBridge'
+            } Logo`}
             width={80}
             height={80}
             className="rounded-full object-contain"
           />
         </div>
         <h2 className="text-2xl font-bold text-center text-yellow-400 mb-6">
-          {t('welcome', { appName: settings.appName || 'SkillBridge' })}
+          {t('welcome', {
+            appName:
+              appConfigHydrated && settings.appName
+                ? settings.appName
+                : 'SkillBridge',
+          })}
         </h2>
 
         {/* Login Form */}

--- a/frontend/src/store/appConfigStore.js
+++ b/frontend/src/store/appConfigStore.js
@@ -2,28 +2,46 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { getAppConfig } from "@/services/appConfigService";
 
+let storeApi;
+
 const useAppConfigStore = create(
   persist(
-    (set, get) => ({
-      settings: {},
-      loading: false,
-      loaded: false,
-      fetch: async () => {
-        if (get().loading) return;
-        set({ loading: true });
-        try {
-          const data = await getAppConfig();
-          set({ settings: data, loaded: true, loading: false });
-        } catch (_err) {
-          set({ loaded: true, loading: false });
-        }
+    (set, get, api) => {
+      storeApi = api;
+      return {
+        settings: {},
+        loading: false,
+        loaded: false,
+        hasHydrated: false,
+        fetch: async () => {
+          if (get().loading) return;
+          set({ loading: true });
+          try {
+            const data = await getAppConfig();
+            set({ settings: data, loaded: true, loading: false });
+          } catch (_err) {
+            set({ loaded: true, loading: false });
+          }
+        },
+        update: (newSettings) =>
+          set((state) => ({ settings: { ...state.settings, ...newSettings } })),
+        clear: () => set({ settings: {}, loaded: false }),
+      };
+    },
+    {
+      name: "app-config",
+      partialize: ({ hasHydrated, ...state }) => state,
+      onRehydrateStorage: () => {
+        return (_state, _error) => {
+          storeApi?.setState({ hasHydrated: true });
+        };
       },
-      update: (newSettings) =>
-        set((state) => ({ settings: { ...state.settings, ...newSettings } })),
-      clear: () => set({ settings: {}, loaded: false }),
-    }),
-    { name: "app-config" }
+    }
   )
 );
+
+export const selectAppConfigHasHydrated = (state) => state.hasHydrated;
+export const useAppConfigHydrated = () =>
+  useAppConfigStore(selectAppConfigHasHydrated);
 
 export default useAppConfigStore;


### PR DESCRIPTION
## Summary
- add an app-config hydration flag to avoid using persisted settings before client hydration completes
- export a convenience selector for the hydration flag and gate SSR-visible settings usage in the app shell and login page

## Testing
- npm run lint *(fails: numerous pre-existing lint warnings/errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cfee8bc2508328a3fb2097033ed597