### PR TITLE
Allow AIRecommendations to render provided course list

### DIFF
--- a/frontend/src/components/dashboard/AIRecommendations.js
+++ b/frontend/src/components/dashboard/AIRecommendations.js
@@ -3,21 +3,25 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
 
-const recommendedCourses = [
+const defaultRecommendedCourses = [
   { id: 4, title: "Advanced JavaScript", category: "JavaScript" },
   { id: 5, title: "Python for Data Science", category: "Data Science" },
   { id: 6, title: "Blockchain & NFTs", category: "Blockchain" },
 ];
 
-const AIRecommendations = () => {
+const AIRecommendations = ({ recommendedCourses }) => {
   const { t } = useTranslation('dashboard');
+  const coursesToRender =
+    Array.isArray(recommendedCourses) && recommendedCourses.length > 0
+      ? recommendedCourses
+      : defaultRecommendedCourses;
   return (
     <div className="mt-8">
       <h2 className="text-2xl font-semibold text-yellow-400 mb-4">
         {t('dashboardPage.ai_recommendations_title')}
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-        {recommendedCourses.map((course) => (
+        {coursesToRender.map((course) => (
           <motion.div
             key={course.id}
             className="bg-gray-800 p-4 rounded-lg shadow-lg"

--- a/frontend/src/tests/__tests__/AIRecommendations.test.js
+++ b/frontend/src/tests/__tests__/AIRecommendations.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AIRecommendations from '@/components/dashboard/AIRecommendations';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }) => <a href={href}>{children}</a>,
+}));
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, whileHover, ...props }) => <div {...props}>{children}</div>,
+    button: ({ children, whileHover, ...props }) => (
+      <button {...props}>{children}</button>
+    ),
+  },
+}));
+
+describe('AIRecommendations', () => {
+  it('renders provided recommended courses', () => {
+    const courses = [
+      { id: 1, title: 'Test Course 1', category: 'Category A' },
+      { id: 2, title: 'Test Course 2', category: 'Category B' },
+    ];
+
+    render(<AIRecommendations recommendedCourses={courses} />);
+
+    courses.forEach((course) => {
+      expect(screen.getByText(course.title)).toBeInTheDocument();
+      expect(
+        screen.getByText(`dashboardPage.category: ${course.category}`)
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow the AIRecommendations dashboard component to accept a recommendedCourses prop and fall back to the default list when none is provided
- replace the internal iteration to use the provided/fallback list and add a Jest test covering the rendered courses

## Testing
- npm test -- AIRecommendations

------
https://chatgpt.com/codex/tasks/task_e_68cfeeb98cbc8328a6e5fca9833cb23e