### PR TITLE
Fix AI recommendations link to course dashboard

### DIFF
--- a/frontend/src/components/dashboard/AIRecommendations.js
+++ b/frontend/src/components/dashboard/AIRecommendations.js
@@ -27,7 +27,7 @@ const AIRecommendations = () => {
             <p className="text-gray-300">
               {t('dashboardPage.category')}: {course.category}
             </p>
-            <Link href={`/classes/${course.id}/details`}>
+            <Link href={`/dashboard/course/${course.id}`}>
               <motion.button
                 whileHover={{ scale: 1.05 }}
                 className="mt-4 bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"

--- a/frontend/src/components/dashboard/__tests__/AIRecommendations.test.js
+++ b/frontend/src/components/dashboard/__tests__/AIRecommendations.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AIRecommendations from '@/components/dashboard/AIRecommendations';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, whileHover, ...props }) => (
+      <div {...props}>{children}</div>
+    ),
+    button: ({ children, whileHover, ...props }) => (
+      <button {...props}>{children}</button>
+    ),
+  },
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('AIRecommendations', () => {
+  it('links to the course dashboard page for each recommendation', () => {
+    render(<AIRecommendations />);
+
+    const links = screen.getAllByRole('link', {
+      name: 'dashboardPage.view_course',
+    });
+
+    const expectedCourseIds = [4, 5, 6];
+
+    expectedCourseIds.forEach((id, index) => {
+      expect(links[index]).toHaveAttribute('href', `/dashboard/course/${id}`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- point AI recommendations CTA to the course dashboard route
- add a unit test to ensure each recommendation links to its course dashboard page

## Testing
- npm test -- AIRecommendations

------
https://chatgpt.com/codex/tasks/task_e_68cfee99b21c832888de572cad6f00f9