### PR TITLE
Make AI recommendations component accept prop list

### DIFF
--- a/frontend/src/components/dashboard/AIRecommendations.js
+++ b/frontend/src/components/dashboard/AIRecommendations.js
@@ -3,21 +3,25 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
 
-const recommendedCourses = [
+const defaultRecommendedCourses = [
   { id: 4, title: "Advanced JavaScript", category: "JavaScript" },
   { id: 5, title: "Python for Data Science", category: "Data Science" },
   { id: 6, title: "Blockchain & NFTs", category: "Blockchain" },
 ];
 
-const AIRecommendations = () => {
+const AIRecommendations = ({ recommendedCourses }) => {
   const { t } = useTranslation('dashboard');
+  const coursesToDisplay =
+    recommendedCourses && recommendedCourses.length > 0
+      ? recommendedCourses
+      : defaultRecommendedCourses;
   return (
     <div className="mt-8">
       <h2 className="text-2xl font-semibold text-yellow-400 mb-4">
         {t('dashboardPage.ai_recommendations_title')}
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-        {recommendedCourses.map((course) => (
+        {coursesToDisplay.map((course) => (
           <motion.div
             key={course.id}
             className="bg-gray-800 p-4 rounded-lg shadow-lg"

--- a/frontend/src/tests/__tests__/AIRecommendations.test.js
+++ b/frontend/src/tests/__tests__/AIRecommendations.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AIRecommendations from '../../components/dashboard/AIRecommendations';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }) => <a href={href}>{children}</a>,
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('framer-motion', () => {
+  const React = require('react');
+  const MockComponent = React.forwardRef(({ children, whileHover, ...rest }, ref) => (
+    <div ref={ref} {...rest}>
+      {children}
+    </div>
+  ));
+
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: () => MockComponent,
+      }
+    ),
+  };
+});
+
+describe('AIRecommendations', () => {
+  it('renders courses provided through props', () => {
+    const recommendedCourses = [
+      { id: 1, title: 'Course One', category: 'Category One' },
+      { id: 2, title: 'Course Two', category: 'Category Two' },
+    ];
+
+    render(<AIRecommendations recommendedCourses={recommendedCourses} />);
+
+    recommendedCourses.forEach((course) => {
+      expect(screen.getByText(course.title)).toBeInTheDocument();
+      expect(
+        screen.getByText(`dashboardPage.category: ${course.category}`)
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow the AIRecommendations dashboard widget to consume recommended courses via props with a static fallback
- add a unit test to ensure the component renders the provided courses

## Testing
- npm test -- --runTestsByPath src/tests/__tests__/AIRecommendations.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cfee9910a883289132e0a0d74743fa