### PR TITLE
Preformat instructor join date server-side

### DIFF
--- a/frontend/src/pages/instructors/[id].js
+++ b/frontend/src/pages/instructors/[id].js
@@ -13,7 +13,7 @@ import { fetchPublicInstructorById, fetchInstructorStats } from "@/services/publ
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
 import { safeEncodeURI } from "@/utils/url";
 
-export default function InstructorProfilePage({ initialInstructor, initialStats }) {
+export default function InstructorProfilePage({ initialInstructor, initialStats, joinDate: initialJoinDate }) {
   const { t } = useTranslation("website");
   const router = useRouter();
   const { id } = router.query;
@@ -42,10 +42,7 @@ export default function InstructorProfilePage({ initialInstructor, initialStats 
       <p className="text-gray-500 mt-2">The requested instructor profile does not exist</p>
     </div>
   );
-
-  const joinDate = instructor.created_at
-    ? new Date(instructor.created_at).toLocaleDateString()
-    : null;
+  const joinDateLabel = instructor?.joinDate ?? initialJoinDate ?? null;
 
   const role = user?.role?.toLowerCase();
   let Layout = StudentLayout;
@@ -115,10 +112,10 @@ export default function InstructorProfilePage({ initialInstructor, initialStats 
                     <span>{t('instructor_rating', { count: instructor.rating.toFixed(1) })}</span>
                   </div>
                 )}
-                {joinDate && (
+                {joinDateLabel && (
                   <div className="flex items-center text-gray-600">
                     <IoMdTime className="mr-2 text-yellow-500" />
-                    <span>Joined {joinDate}</span>
+                    <span>Joined {joinDateLabel}</span>
                   </div>
                 )}
               </div>
@@ -203,7 +200,7 @@ export default function InstructorProfilePage({ initialInstructor, initialStats 
   );
 }
 
-export async function getServerSideProps({ params }) {
+export async function getServerSideProps({ params, locale }) {
   const { id } = params;
   try {
     const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
@@ -211,10 +208,19 @@ export async function getServerSideProps({ params }) {
     if (!data) {
       return { props: { initialInstructor: null, initialStats: { classes: 0, tutorials: 0 } } };
     }
+    const joinDate = data?.created_at
+      ? new Intl.DateTimeFormat(locale || "en-US", {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          timeZone: "UTC",
+        }).format(new Date(data.created_at))
+      : null;
     const formatted = {
       ...data,
       avatar_url: data?.avatar_url ? `${API_BASE_URL}${data.avatar_url}` : "/images/profile/user.png",
       demo_video_url: data?.demo_video_url ? `${API_BASE_URL}${data.demo_video_url}` : null,
+      joinDate,
     };
     const stats = await fetchInstructorStats(id);
 
@@ -222,6 +228,7 @@ export async function getServerSideProps({ params }) {
       props: {
         initialInstructor: formatted,
         initialStats: stats || { classes: 0, tutorials: 0 },
+        joinDate,
       },
     };
   } catch (err) {

--- a/frontend/src/tests/pages/instructors/InstructorProfilePage.test.js
+++ b/frontend/src/tests/pages/instructors/InstructorProfilePage.test.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import InstructorProfilePage, { getServerSideProps } from '@/pages/instructors/[id]';
+import { TextEncoder, TextDecoder } from 'util';
+
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+const { renderToString } = require('react-dom/server');
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@/store/auth/authStore', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ user: { role: 'student' } })),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, opts = {}) => {
+      if (key === 'instructor_rating' && opts.count) {
+        return `${opts.count} rating`;
+      }
+      return key;
+    },
+  }),
+}));
+
+jest.mock('react-toastify', () => ({
+  __esModule: true,
+  toast: { info: jest.fn() },
+}));
+
+jest.mock('@/components/layouts/StudentLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div data-testid="student-layout">{children}</div>,
+}));
+
+jest.mock('@/components/layouts/AdminLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div data-testid="admin-layout">{children}</div>,
+}));
+
+jest.mock('@/components/layouts/InstructorLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div data-testid="instructor-layout">{children}</div>,
+}));
+
+jest.mock('@/components/student/instructors/BookingRequestModal', () => ({
+  __esModule: true,
+  default: ({ onClose }) => (
+    <div>
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/shared/CustomVideoPlayer', () => ({
+  __esModule: true,
+  default: () => <div data-testid="video-player" />,
+}));
+
+jest.mock('@/services/public/instructorService', () => ({
+  fetchPublicInstructorById: jest.fn(),
+  fetchInstructorStats: jest.fn(),
+}));
+
+const { useRouter } = require('next/router');
+const { fetchPublicInstructorById, fetchInstructorStats } = require('@/services/public/instructorService');
+
+describe('InstructorProfilePage SSR join date consistency', () => {
+  beforeEach(() => {
+    useRouter.mockReturnValue({
+      query: { id: '1' },
+      push: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reuses the server-formatted join date string during client render', async () => {
+    fetchPublicInstructorById.mockResolvedValue({
+      id: '1',
+      full_name: 'Test Instructor',
+      avatar_url: '/avatar.png',
+      created_at: '2023-01-15T12:34:56Z',
+      expertise: ['Math'],
+      experience: 5,
+      rating: 4.5,
+      bio: 'Biography',
+      email: 'test@example.com',
+      phone: '12345',
+      pricing: '$10',
+      demo_video_url: null,
+      is_online: true,
+    });
+    fetchInstructorStats.mockResolvedValue({ classes: 3, tutorials: 2 });
+
+    const context = { params: { id: '1' }, locale: 'en-GB' };
+    const result = await getServerSideProps(context);
+
+    expect(result.props.joinDate).toBe('15 January 2023');
+
+    const serverHTML = renderToString(<InstructorProfilePage {...result.props} />);
+    expect(serverHTML).toContain(result.props.joinDate);
+
+    render(<InstructorProfilePage {...result.props} />);
+    expect(screen.getByText(`Joined ${result.props.joinDate}`)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- format instructor join dates in `getServerSideProps` using a deterministic UTC formatter
- render the preformatted join date string directly to avoid client-side locale differences
- add a Jest test that checks SSR and client renders share the same join date markup under a mocked locale

## Testing
- npm test -- InstructorProfilePage

------
https://chatgpt.com/codex/tasks/task_e_68cfee8e85908328933d563bd7f1fa19