### PR TITLE
Fix InstructorDashboard auth store import

### DIFF
--- a/frontend/src/components/instructors/InstructorDashboard.js
+++ b/frontend/src/components/instructors/InstructorDashboard.js
@@ -34,7 +34,7 @@ import {
 } from "@/services/instructor/classService";
 import { fetchInstructorTutorials } from "@/services/instructor/tutorialService";
 import { instructorDashboardMocks } from "@/mocks/data";
-import { useAuthStore } from "@/store/auth/authStore";
+import useAuthStore from "@/store/auth/authStore";
 
 const localizer = momentLocalizer(moment);
 


### PR DESCRIPTION
## Summary
- correct the InstructorDashboard auth store import to use the default export

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cff229c040832892ca91ccef5f19b7