### PR TITLE
Fix hydration for instructor availability in dashboard header

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -36,6 +36,7 @@ export default function Header() {
   const isHydrated = mounted && hasHydrated;
   const hydratedUser = isHydrated ? user : null;
   const userRole = hydratedUser?.role?.toLowerCase();
+  const hydratedOnlineStatus = hydratedUser?.is_online ?? false;
   const { t } = useTranslation("common");
   const { t: tDashboard } = useTranslation("dashboard");
 
@@ -142,8 +143,8 @@ export default function Header() {
       return;
     }
 
-    setAvailable(userOnlineStatus);
-  }, [hasHydrated, userOnlineStatus]);
+    setAvailable(hydratedOnlineStatus);
+  }, [hasHydrated, hydratedOnlineStatus]);
 
   // Stop polling when component unmounts
   useEffect(() => {


### PR DESCRIPTION
## Summary
- derive the hydrated online status from the hydrated user object
- ensure the hydration-aware effect tracks and applies the online status safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff44ce8448328a409ae278a12007a