### PR TITLE
Fix instructor availability state hydration

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -137,13 +137,15 @@ export default function Header() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  const hydratedUserOnlineStatus = hydratedUser?.is_online ?? false;
+
   useEffect(() => {
-    if (!hasHydrated) {
+    if (!isHydrated) {
       return;
     }
 
-    setAvailable(userOnlineStatus);
-  }, [hasHydrated, userOnlineStatus]);
+    setAvailable(hydratedUserOnlineStatus);
+  }, [isHydrated, hydratedUserOnlineStatus]);
 
   // Stop polling when component unmounts
   useEffect(() => {


### PR DESCRIPTION
## Summary
- derive the instructor availability flag in the dashboard header from the hydrated user object
- ensure the availability state syncs only once auth data has hydrated

## Testing
- npm run lint *(fails: existing lint warnings/errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cff446cb348328be60e5808c73f840