### PR TITLE
Fix instructor availability hydration handling

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -36,6 +36,7 @@ export default function Header() {
   const isHydrated = mounted && hasHydrated;
   const hydratedUser = isHydrated ? user : null;
   const userRole = hydratedUser?.role?.toLowerCase();
+  const userIsOnline = hydratedUser?.is_online ?? false;
   const { t } = useTranslation("common");
   const { t: tDashboard } = useTranslation("dashboard");
 
@@ -142,8 +143,8 @@ export default function Header() {
       return;
     }
 
-    setAvailable(userOnlineStatus);
-  }, [hasHydrated, userOnlineStatus]);
+    setAvailable(userIsOnline);
+  }, [hasHydrated, userIsOnline]);
 
   // Stop polling when component unmounts
   useEffect(() => {


### PR DESCRIPTION
## Summary
- derive the instructor availability state from the hydrated user object to avoid referencing an undefined variable
- keep the availability toggle in sync with the persisted user record by tracking `hydratedUser.is_online`

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cff452c5ec832892bbf65eaffeb50f