### PR TITLE
Handle missing admin profile defaults

### DIFF
--- a/backend/src/modules/users/admin/__tests__/admin.controller.test.js
+++ b/backend/src/modules/users/admin/__tests__/admin.controller.test.js
@@ -1,0 +1,68 @@
+jest.mock("../../../../config/database", () => jest.fn());
+
+const db = require("../../../../config/database");
+const { getProfile } = require("../admin.controller");
+
+describe("admin controller - getProfile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createQueryBuilder = (rows) => {
+    return {
+      where: jest.fn().mockReturnThis(),
+      select: jest.fn().mockResolvedValue(rows),
+    };
+  };
+
+  it("returns defaults when admin profile is missing", async () => {
+    const userRow = {
+      id: "user-123",
+      full_name: "Admin User",
+      email: "admin@example.com",
+      phone: "1234567890",
+      gender: "other",
+      date_of_birth: "1990-01-01",
+      avatar_url: "https://example.com/avatar.png",
+      is_email_verified: true,
+      is_phone_verified: false,
+      profile_complete: false,
+      created_at: "2024-01-01T00:00:00.000Z",
+      updated_at: "2024-01-02T00:00:00.000Z",
+    };
+
+    db.mockImplementation((table) => {
+      if (table === "users") {
+        return createQueryBuilder([userRow]);
+      }
+
+      if (table === "admin_profiles") {
+        return createQueryBuilder([]);
+      }
+
+      if (table === "user_social_links") {
+        return createQueryBuilder([]);
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    const req = { user: { id: userRow.id } };
+    const res = { json: jest.fn() };
+
+    await getProfile(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: userRow.id,
+        full_name: userRow.full_name,
+        job_title: null,
+        department: null,
+        identity_doc_url: null,
+        admin_profile_created_at: null,
+        admin_profile_updated_at: null,
+        social_links: [],
+      })
+    );
+  });
+});

--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -49,7 +49,7 @@ exports.getProfile = async (req, res) => {
         "updated_at"
       );
 
-    const [adminProfile] = await db("admin_profiles")
+    const [adminProfile = {}] = await db("admin_profiles")
       .where({ user_id: userId })
       .select("job_title", "department", "identity_doc_url", "created_at", "updated_at");
 
@@ -59,7 +59,11 @@ exports.getProfile = async (req, res) => {
 
     res.json({
       ...user,
-      ...adminProfile,
+      job_title: adminProfile.job_title ?? null,
+      department: adminProfile.department ?? null,
+      identity_doc_url: adminProfile.identity_doc_url ?? null,
+      admin_profile_created_at: adminProfile.created_at ?? null,
+      admin_profile_updated_at: adminProfile.updated_at ?? null,
       social_links: socialLinks,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- guard the admin profile lookup against missing rows and return predictable null defaults for admin-specific fields
- add a unit test to confirm the controller responds successfully when no admin profile exists

## Testing
- npm test -- admin controller *(fails: unrelated suites require JWT/refresh/session secrets in env validation)*

------
https://chatgpt.com/codex/tasks/task_e_68cffd1684cc8328bf0806f4b8a3f4d7