### PR TITLE
Ensure social platform icons have fallbacks and add regression test

### DIFF
--- a/frontend/src/components/instructor/profile/SocialLinksSection.js
+++ b/frontend/src/components/instructor/profile/SocialLinksSection.js
@@ -1,25 +1,34 @@
-import { allowedPlatforms } from "@/utils/socialPlatforms";
+import { allowedPlatforms, defaultPlatformIcon } from "@/utils/socialPlatforms";
 
 export default function SocialLinksSection({ socialLinks, onChange, t }) {
   return (
     <div>
       <label className="block text-sm font-medium mb-2">{t('social_links')}</label>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {allowedPlatforms.map(({ name, Icon, className }) => (
-          <div key={name} className="bg-gray-50 p-3 rounded-lg">
-            <label className="text-sm flex items-center gap-2 font-medium mb-1">
-              <Icon className={className} /> {name.charAt(0).toUpperCase() + name.slice(1)}
-            </label>
-            <input
-              type="text"
-              name={name}
-              value={socialLinks[name] || ""}
-              onChange={(e) => onChange({ ...socialLinks, [name]: e.target.value })}
-              placeholder={`https://${name}.com/yourprofile`}
-              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-yellow-500 focus:border-yellow-500"
-            />
-          </div>
-        ))}
+        {allowedPlatforms.map(({ name, Icon, className }) => {
+          const IconComponent = Icon || defaultPlatformIcon.Icon;
+          if (!IconComponent) {
+            return null;
+          }
+          const iconClassName = className || defaultPlatformIcon.className;
+
+          return (
+            <div key={name} className="bg-gray-50 p-3 rounded-lg">
+              <label className="text-sm flex items-center gap-2 font-medium mb-1">
+                <IconComponent className={iconClassName} />
+                {name.charAt(0).toUpperCase() + name.slice(1)}
+              </label>
+              <input
+                type="text"
+                name={name}
+                value={socialLinks[name] || ""}
+                onChange={(e) => onChange({ ...socialLinks, [name]: e.target.value })}
+                placeholder={`https://${name}.com/yourprofile`}
+                className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-yellow-500 focus:border-yellow-500"
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/profile/steps/SocialLinks.js
+++ b/frontend/src/components/profile/steps/SocialLinks.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
-import { allowedPlatforms } from "@/utils/socialPlatforms";
+import { allowedPlatforms, defaultPlatformIcon } from "@/utils/socialPlatforms";
 
 const SocialLinks = ({ formData, setFormData, onNext, onBack }) => {
   const [errors, setErrors] = useState({});
@@ -29,29 +29,37 @@ const SocialLinks = ({ formData, setFormData, onNext, onBack }) => {
       <h2 className="text-2xl font-bold mb-4 text-yellow-500">Connect Your Social Profiles</h2>
       <p className="text-gray-400 mb-4 text-sm">Link your professional profiles to enhance credibility.</p>
 
-      {allowedPlatforms.map(({ name, Icon, className }) => (
-        <div key={name} className="mb-4">
-          <label className="block text-sm font-medium">
-            {`${name.charAt(0).toUpperCase() + name.slice(1)} Profile`}
-          </label>
-          <div className="flex items-center bg-gray-700 rounded-lg p-2">
-            <Icon className={className} />
-            <input
-              type="text"
-              name={name}
-              value={formData.socialLinks[name] || ""}
-              onChange={handleChange}
-              className="w-full p-2 bg-gray-700 text-white border-none focus:outline-none ml-3"
-              placeholder={
-                name === 'website'
-                  ? 'https://yourwebsite.com'
-                  : `https://${name}.com`
-              }
-            />
+      {allowedPlatforms.map(({ name, Icon, className }) => {
+        const IconComponent = Icon || defaultPlatformIcon.Icon;
+        if (!IconComponent) {
+          return null;
+        }
+        const iconClassName = className || defaultPlatformIcon.className;
+
+        return (
+          <div key={name} className="mb-4">
+            <label className="block text-sm font-medium">
+              {`${name.charAt(0).toUpperCase() + name.slice(1)} Profile`}
+            </label>
+            <div className="flex items-center bg-gray-700 rounded-lg p-2">
+              <IconComponent className={iconClassName} />
+              <input
+                type="text"
+                name={name}
+                value={formData.socialLinks[name] || ""}
+                onChange={handleChange}
+                className="w-full p-2 bg-gray-700 text-white border-none focus:outline-none ml-3"
+                placeholder={
+                  name === 'website'
+                    ? 'https://yourwebsite.com'
+                    : `https://${name}.com`
+                }
+              />
+            </div>
+            {errors[name] && <p className="text-red-500 text-xs mt-1">{errors[name]}</p>}
           </div>
-          {errors[name] && <p className="text-red-500 text-xs mt-1">{errors[name]}</p>}
-        </div>
-      ))}
+        );
+      })}
 
       {/* ✅ Navigation Buttons */}
       <div className="flex justify-between mt-6">

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -35,7 +35,7 @@ import { API_BASE_URL } from "@/config/config";
 const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 import { toSocialLinksArray } from "@/utils/socialLinks";
-import { allowedPlatforms } from "@/utils/socialPlatforms";
+import { allowedPlatforms, defaultPlatformIcon } from "@/utils/socialPlatforms";
 
 // Add service imports as needed, e.g., getProfile, updateProfile, uploadAvatar, etc.
 
@@ -670,38 +670,46 @@ function ProfileEditTemplate() {
             </div>
             {expanded.social && (
               <div className="p-4 space-y-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {allowedPlatforms.map(({ name, Icon, className }) => (
-                  <div key={name}>
-                    <label className="block text-sm font-medium mb-1 flex items-center gap-2">
-                      <Icon className={`${className} w-4 h-4`} />
-                      {name.charAt(0).toUpperCase() + name.slice(1)}
-                    </label>
-                    <input
-                      type="text"
-                      name={name}
-                      value={formData.socialLinks[name] || ""}
-                      onChange={(e) => {
-                        const { value } = e.target;
-                        setFormData((prev) => ({
-                          ...prev,
-                          socialLinks: { ...prev.socialLinks, [name]: value },
-                        }));
-                        setErrors((prev) => ({ ...prev, [`socialLinks.${name}`]: null }));
-                      }}
-                      placeholder={
-                        name === 'website'
-                          ? 'https://yourwebsite.com'
-                          : `https://${name}.com/yourprofile`
-                      }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                    />
-                    {errors[`socialLinks.${name}`] && (
-                      <p className="text-red-500 text-sm mt-1">
-                        {errors[`socialLinks.${name}`]}
-                      </p>
-                    )}
-                  </div>
-                ))}
+                {allowedPlatforms.map(({ name, Icon, className }) => {
+                  const IconComponent = Icon || defaultPlatformIcon.Icon;
+                  if (!IconComponent) {
+                    return null;
+                  }
+                  const iconClassName = className || defaultPlatformIcon.className;
+
+                  return (
+                    <div key={name}>
+                      <label className="block text-sm font-medium mb-1 flex items-center gap-2">
+                        <IconComponent className={`${iconClassName} w-4 h-4`} />
+                        {name.charAt(0).toUpperCase() + name.slice(1)}
+                      </label>
+                      <input
+                        type="text"
+                        name={name}
+                        value={formData.socialLinks[name] || ""}
+                        onChange={(e) => {
+                          const { value } = e.target;
+                          setFormData((prev) => ({
+                            ...prev,
+                            socialLinks: { ...prev.socialLinks, [name]: value },
+                          }));
+                          setErrors((prev) => ({ ...prev, [`socialLinks.${name}`]: null }));
+                        }}
+                        placeholder={
+                          name === 'website'
+                            ? 'https://yourwebsite.com'
+                            : `https://${name}.com/yourprofile`
+                        }
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                      />
+                      {errors[`socialLinks.${name}`] && (
+                        <p className="text-red-500 text-sm mt-1">
+                          {errors[`socialLinks.${name}`]}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/frontend/src/pages/dashboard/instructor/profile/steps/SocialLinks.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/SocialLinks.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
-import { allowedPlatforms } from "@/utils/socialPlatforms";
+import { allowedPlatforms, defaultPlatformIcon } from "@/utils/socialPlatforms";
 
 const SocialLinks = ({
   formData = {},
@@ -36,29 +36,37 @@ const SocialLinks = ({
       <h2 className="text-2xl font-bold mb-4 text-yellow-500">Connect Your Social Profiles</h2>
       <p className="text-gray-400 mb-4 text-sm">Link your professional profiles to enhance credibility.</p>
 
-      {allowedPlatforms.map(({ name, Icon, className }) => (
-        <div key={name} className="mb-4">
-          <label className="block text-sm font-medium">
-            {`${name.charAt(0).toUpperCase() + name.slice(1)} Profile`}
-          </label>
-          <div className="flex items-center bg-gray-700 rounded-lg p-2">
-            <Icon className={className} />
-            <input
-              type="text"
-              name={name}
-              value={socialLinks[name] || ""}
-              onChange={handleChange}
-              className="w-full p-2 bg-gray-700 text-white border-none focus:outline-none ml-3"
-              placeholder={
-                name === 'website'
-                  ? 'https://yourwebsite.com'
-                  : `https://${name}.com`
-              }
-            />
+      {allowedPlatforms.map(({ name, Icon, className }) => {
+        const IconComponent = Icon || defaultPlatformIcon.Icon;
+        if (!IconComponent) {
+          return null;
+        }
+        const iconClassName = className || defaultPlatformIcon.className;
+
+        return (
+          <div key={name} className="mb-4">
+            <label className="block text-sm font-medium">
+              {`${name.charAt(0).toUpperCase() + name.slice(1)} Profile`}
+            </label>
+            <div className="flex items-center bg-gray-700 rounded-lg p-2">
+              <IconComponent className={iconClassName} />
+              <input
+                type="text"
+                name={name}
+                value={socialLinks[name] || ""}
+                onChange={handleChange}
+                className="w-full p-2 bg-gray-700 text-white border-none focus:outline-none ml-3"
+                placeholder={
+                  name === 'website'
+                    ? 'https://yourwebsite.com'
+                    : `https://${name}.com`
+                }
+              />
+            </div>
+            {errors[name] && <p className="text-red-500 text-xs mt-1">{errors[name]}</p>}
           </div>
-          {errors[name] && <p className="text-red-500 text-xs mt-1">{errors[name]}</p>}
-        </div>
-      ))}
+        );
+      })}
 
       {/* ✅ Navigation Buttons */}
       <div className="flex justify-between mt-6">

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -21,7 +21,7 @@ import { createNotification } from "@/services/notificationService";
 import { sendChatMessage } from "@/services/messageService";
 import logger from "@/utils/logger";
 import { toSocialLinksArray } from "@/utils/socialLinks";
-import { allowedPlatforms } from "@/utils/socialPlatforms";
+import { allowedPlatforms, defaultPlatformIcon } from "@/utils/socialPlatforms";
 import {
   FaUpload, FaTrash, FaFilePdf, FaSpinner,
   FaUserCircle, FaIdCard, FaGlobe,
@@ -673,27 +673,35 @@ const handleAvatarSelect = (e) => {
 
               {expanded.social && (
                 <div className="p-4 space-y-4">
-                  {allowedPlatforms.map(({ name, Icon, className }) => (
-                    <div key={name}>
-                      <label className="block text-sm font-medium text-gray-700 mb-1 flex items-center">
-                        <Icon className={`w-4 h-4 mr-2 ${className}`} />
-                        {t(`${name}_label`)}
-                      </label>
-                      <input
-                        type="text"
-                        name={name}
-                        value={formData.socialLinks[name] || ""}
-                        onChange={handleSocialChange}
-                        placeholder={t(`${name}_placeholder`)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500"
-                      />
-                      {errors[`socialLinks.${name}`] && (
-                        <p className="text-red-500 text-sm mt-1">
-                          {errors[`socialLinks.${name}`]}
-                        </p>
-                      )}
-                    </div>
-                  ))}
+                  {allowedPlatforms.map(({ name, Icon, className }) => {
+                    const IconComponent = Icon || defaultPlatformIcon.Icon;
+                    if (!IconComponent) {
+                      return null;
+                    }
+                    const iconClassName = className || defaultPlatformIcon.className;
+
+                    return (
+                      <div key={name}>
+                        <label className="block text-sm font-medium text-gray-700 mb-1 flex items-center">
+                          <IconComponent className={`w-4 h-4 mr-2 ${iconClassName}`} />
+                          {t(`${name}_label`)}
+                        </label>
+                        <input
+                          type="text"
+                          name={name}
+                          value={formData.socialLinks[name] || ""}
+                          onChange={handleSocialChange}
+                          placeholder={t(`${name}_placeholder`)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500"
+                        />
+                        {errors[`socialLinks.${name}`] && (
+                          <p className="text-red-500 text-sm mt-1">
+                            {errors[`socialLinks.${name}`]}
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/frontend/src/pages/dashboard/student/profile/steps/SocialLinks.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/SocialLinks.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
-import { allowedPlatforms } from "@/utils/socialPlatforms";
+import { allowedPlatforms, defaultPlatformIcon } from "@/utils/socialPlatforms";
 
 const SocialLinks = ({
   formData = {},
@@ -38,32 +38,40 @@ const SocialLinks = ({
         Add any public links you'd like to showcase (optional).
       </p>
 
-      {allowedPlatforms.map(({ name, Icon, className }) => (
-        <div key={name} className="mb-4">
-          <label htmlFor={name} className="block text-sm font-medium text-gray-800 mb-1">
-            {name.charAt(0).toUpperCase() + name.slice(1)}
-          </label>
-          <div className="flex items-center border border-gray-300 rounded-lg px-3 py-2 bg-white">
-            <Icon className={`${className}`} />
-            <input
-              id={name}
-              type="text"
-              name={name}
-              value={socialLinks[name] || ""}
-              onChange={handleChange}
-              placeholder={
-                name === 'website'
-                  ? 'https://yourwebsite.com'
-                  : `https://${name}.com`
-              }
-              className="ml-3 w-full bg-transparent text-sm text-gray-800 focus:outline-none focus:ring-1 focus:ring-yellow-500"
-            />
+      {allowedPlatforms.map(({ name, Icon, className }) => {
+        const IconComponent = Icon || defaultPlatformIcon.Icon;
+        if (!IconComponent) {
+          return null;
+        }
+        const iconClassName = className || defaultPlatformIcon.className;
+
+        return (
+          <div key={name} className="mb-4">
+            <label htmlFor={name} className="block text-sm font-medium text-gray-800 mb-1">
+              {name.charAt(0).toUpperCase() + name.slice(1)}
+            </label>
+            <div className="flex items-center border border-gray-300 rounded-lg px-3 py-2 bg-white">
+              <IconComponent className={iconClassName} />
+              <input
+                id={name}
+                type="text"
+                name={name}
+                value={socialLinks[name] || ""}
+                onChange={handleChange}
+                placeholder={
+                  name === 'website'
+                    ? 'https://yourwebsite.com'
+                    : `https://${name}.com`
+                }
+                className="ml-3 w-full bg-transparent text-sm text-gray-800 focus:outline-none focus:ring-1 focus:ring-yellow-500"
+              />
+            </div>
+            {errors[name] && (
+              <p className="text-red-500 text-xs mt-1">{errors[name]}</p>
+            )}
           </div>
-          {errors[name] && (
-            <p className="text-red-500 text-xs mt-1">{errors[name]}</p>
-          )}
-        </div>
-      ))}
+        );
+      })}
 
       {/* Navigation Buttons */}
       <div className="flex justify-between mt-8">

--- a/frontend/src/tests/__tests__/socialPlatformsFallback.test.js
+++ b/frontend/src/tests/__tests__/socialPlatformsFallback.test.js
@@ -1,0 +1,30 @@
+const React = require('react');
+const { render, screen } = require('@testing-library/react');
+
+describe('social platform icon fallbacks', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('renders fallback icon when an unknown platform is provided', () => {
+    jest.isolateModules(() => {
+      jest.doMock('@shared/socialPlatforms.json', () => ['linkedin', 'mystery'], { virtual: true });
+
+      const { allowedPlatforms, defaultPlatformIcon } = require('@/utils/socialPlatforms');
+      const SocialLinksSection = require('@/components/instructor/profile/SocialLinksSection').default;
+
+      const fallbackEntry = allowedPlatforms.find((platform) => platform.name === 'mystery');
+      expect(fallbackEntry).toBeDefined();
+      expect(fallbackEntry.Icon).toBe(defaultPlatformIcon.Icon);
+      expect(fallbackEntry.className).toBe(defaultPlatformIcon.className);
+
+      render(
+        <SocialLinksSection socialLinks={{}} onChange={() => {}} t={(value) => value} />
+      );
+
+      expect(screen.getByText('Mystery')).toBeInTheDocument();
+      expect(screen.getAllByRole('textbox')).toHaveLength(2);
+    });
+  });
+});

--- a/frontend/src/utils/socialPlatforms.js
+++ b/frontend/src/utils/socialPlatforms.js
@@ -9,6 +9,11 @@ import {
   FaGlobe,
 } from "react-icons/fa";
 
+export const defaultPlatformIcon = {
+  Icon: FaGlobe,
+  className: "text-gray-500",
+};
+
 const iconMap = {
   linkedin: { Icon: FaLinkedin, className: "text-blue-600" },
   github: { Icon: FaGithub, className: "text-gray-800" },
@@ -21,7 +26,7 @@ const iconMap = {
 
 export const allowedPlatforms = platformNames.map((name) => ({
   name,
-  ...iconMap[name],
+  ...(iconMap[name] || defaultPlatformIcon),
 }));
 
 export const socialPlatforms = platformNames;


### PR DESCRIPTION
## Summary
- add a default platform icon fallback when mapping social platforms
- guard all social link renderers against missing icon configurations
- add a regression test that mocks an unknown social platform and verifies the UI renders

## Testing
- npm test -- socialPlatformsFallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cffeb9d47c8328abccca7081524296