### PR TITLE
Normalize social link URLs and cover null values

### DIFF
--- a/frontend/src/tests/__tests__/socialLinksMapping.test.js
+++ b/frontend/src/tests/__tests__/socialLinksMapping.test.js
@@ -22,6 +22,17 @@ describe('toSocialLinksArray', () => {
     ]);
   });
 
+  test('ignores nullish or non-string social link values without throwing', () => {
+    const links = {
+      linkedin: null,
+      website: undefined,
+      github: 0,
+    };
+
+    expect(() => toSocialLinksArray(links)).not.toThrow();
+    expect(toSocialLinksArray(links)).toEqual([]);
+  });
+
   test('ignores nullish social link values', () => {
     const links = {
       twitter: 'https://x.com/user',

--- a/frontend/src/utils/socialLinks.js
+++ b/frontend/src/utils/socialLinks.js
@@ -1,21 +1,10 @@
 export const toSocialLinksArray = (links = {}) =>
   Object.entries(links || {}).reduce((acc, [platform, url]) => {
-    if (url === null || url === undefined) {
-      return acc;
-    }
+    const normalizedUrl = typeof url === "string" ? url : "";
+    const trimmed = normalizedUrl.trim();
 
-    let normalizedUrl = url;
-
-    if (typeof normalizedUrl !== "string") {
-      normalizedUrl = String(normalizedUrl);
-    }
-
-    if (typeof normalizedUrl === "string") {
-      const trimmed = normalizedUrl.trim();
-
-      if (trimmed !== "") {
-        acc.push({ platform, url: trimmed });
-      }
+    if (trimmed !== "") {
+      acc.push({ platform, url: trimmed });
     }
 
     return acc;


### PR DESCRIPTION
## Summary
- normalize social link URLs so non-string values are treated as blank entries
- add regression coverage ensuring null, undefined, and non-string links are ignored without errors

## Testing
- npm test -- socialLinksMapping.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0034491408328894888e4aae7ee52