### PR TITLE
Handle invalid social link inputs safely

### DIFF
--- a/frontend/src/tests/__tests__/socialLinksMapping.test.js
+++ b/frontend/src/tests/__tests__/socialLinksMapping.test.js
@@ -35,6 +35,29 @@ describe('toSocialLinksArray', () => {
     ]);
   });
 
+  test('skips non-string social link values safely', () => {
+    const links = {
+      twitter: ' https://x.com/user ',
+      facebook: 12345,
+      instagram: { url: 'https://instagram.com/user' },
+      threads: ['https://threads.net/user'],
+      bluesky: true,
+    };
+
+    expect(() => toSocialLinksArray(links)).not.toThrow();
+    expect(toSocialLinksArray(links)).toEqual([
+      { platform: 'twitter', url: 'https://x.com/user' },
+    ]);
+  });
+
+  test('returns empty array when links object is nullish', () => {
+    expect(() => toSocialLinksArray(null)).not.toThrow();
+    expect(toSocialLinksArray(null)).toEqual([]);
+
+    expect(() => toSocialLinksArray(undefined)).not.toThrow();
+    expect(toSocialLinksArray(undefined)).toEqual([]);
+  });
+
   test('admin payload mapping remains stable for valid values', () => {
     const sanitizedData = {
       full_name: 'Admin User',

--- a/frontend/src/utils/socialLinks.js
+++ b/frontend/src/utils/socialLinks.js
@@ -4,18 +4,11 @@ export const toSocialLinksArray = (links = {}) =>
       return acc;
     }
 
-    let normalizedUrl = url;
+    const normalizedUrl = typeof url === "string" ? url : "";
+    const trimmed = normalizedUrl.trim();
 
-    if (typeof normalizedUrl !== "string") {
-      normalizedUrl = String(normalizedUrl);
-    }
-
-    if (typeof normalizedUrl === "string") {
-      const trimmed = normalizedUrl.trim();
-
-      if (trimmed !== "") {
-        acc.push({ platform, url: trimmed });
-      }
+    if (trimmed !== "") {
+      acc.push({ platform, url: trimmed });
     }
 
     return acc;


### PR DESCRIPTION
## Summary
- normalize social link values to strings so only trimmed string URLs are forwarded
- expand socialLinksArray unit tests to cover non-string and nullish cases

## Testing
- npm test -- socialLinksMapping

------
https://chatgpt.com/codex/tasks/task_e_68d0033d840083289a341a530f2f7167