### PR TITLE
Guard social link trimming against non-string values

### DIFF
--- a/frontend/src/tests/__tests__/socialLinksMapping.test.js
+++ b/frontend/src/tests/__tests__/socialLinksMapping.test.js
@@ -35,6 +35,19 @@ describe('toSocialLinksArray', () => {
     ]);
   });
 
+  test('ignores non-string social link values', () => {
+    const links = {
+      twitter: 'https://x.com/user',
+      facebook: { handle: 'user' },
+      instagram: 1234,
+    };
+
+    expect(() => toSocialLinksArray(links)).not.toThrow();
+    expect(toSocialLinksArray(links)).toEqual([
+      { platform: 'twitter', url: 'https://x.com/user' },
+    ]);
+  });
+
   test('admin payload mapping remains stable for valid values', () => {
     const sanitizedData = {
       full_name: 'Admin User',

--- a/frontend/src/utils/socialLinks.js
+++ b/frontend/src/utils/socialLinks.js
@@ -4,18 +4,14 @@ export const toSocialLinksArray = (links = {}) =>
       return acc;
     }
 
-    let normalizedUrl = url;
-
-    if (typeof normalizedUrl !== "string") {
-      normalizedUrl = String(normalizedUrl);
+    if (typeof url !== "string") {
+      return acc;
     }
 
-    if (typeof normalizedUrl === "string") {
-      const trimmed = normalizedUrl.trim();
+    const trimmed = url.trim();
 
-      if (trimmed !== "") {
-        acc.push({ platform, url: trimmed });
-      }
+    if (trimmed !== "") {
+      acc.push({ platform, url: trimmed });
     }
 
     return acc;


### PR DESCRIPTION
## Summary
- ensure `toSocialLinksArray` only trims string URLs and skips other value types
- extend social links mapping test coverage to confirm non-string inputs are ignored

## Testing
- npm test -- socialLinksMapping.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0033761908328aee880e0a54752c0