### PR TITLE
Fix duplicate trimmed constant in social links util

### DIFF
--- a/frontend/src/utils/socialLinks.js
+++ b/frontend/src/utils/socialLinks.js
@@ -3,9 +3,6 @@ export const toSocialLinksArray = (links = {}) =>
     if (url === null || url === undefined) {
       return acc;
     }
-    const normalizedUrl = typeof url === "string" ? url : "";
-    const trimmed = normalizedUrl.trim();
-
     if (typeof url !== "string") {
       return acc;
     }


### PR DESCRIPTION
## Summary
- remove the redundant normalized URL handling in `toSocialLinksArray`
- prevent redeclaration of the `trimmed` constant when reducing social link inputs

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*
- npx eslint src/utils/socialLinks.js


------
https://chatgpt.com/codex/tasks/task_e_68d01870800483289e7b95282796c0cf