### PR TITLE
Protect admin create user page with guard

### DIFF
--- a/frontend/src/pages/dashboard/admin/users/create.js
+++ b/frontend/src/pages/dashboard/admin/users/create.js
@@ -1,11 +1,14 @@
 // pages/dashboard/admin/users/create.js
 import { useState } from "react";
 import { useRouter } from "next/router";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import AddUserModal from "@/components/admin/users/AddUserModal";
+import withAdminGuard from "@/hooks/withAdminGuard";
 import { createUser } from "@/services/admin/userService";
 
-export default function CreateUserPage() {
+function CreateUserPage() {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(true);
 
@@ -23,4 +26,14 @@ export default function CreateUserPage() {
       <AddUserModal isOpen={isOpen} onClose={handleClose} onSubmit={handleSubmit} />
     </AdminLayout>
   );
+}
+
+export default withAdminGuard(CreateUserPage);
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["dashboard", "auth"], nextI18NextConfig)),
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- wrap the admin create user page with the existing admin guard
- load the dashboard/auth translation namespaces so the modal still receives i18n strings

## Testing
- npx eslint src/pages/dashboard/admin/users/create.js

------
https://chatgpt.com/codex/tasks/task_e_68d0254f2eac8328a3e68ecd63efcf40