### PR TITLE
Use debounced search for admin groups fetch

### DIFF
--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -78,10 +78,10 @@ export default function AdminGroupsIndex() {
 
   useEffect(() => {
     groupService
-      .getAllGroups(search, statusFilter)
+      .getAllGroups(debouncedSearch, statusFilter)
       .then((data) => setGroups(sortGroups(data)))
       .catch(() => setGroups([]));
-  }, [search, statusFilter]);
+  }, [debouncedSearch, statusFilter]);
 
   useEffect(() => {
     setGroups((prev) => sortGroups(prev));


### PR DESCRIPTION
## Summary
- use the debounced search term when fetching groups in the admin dashboard
- ensure the fetch effect only depends on the debounced value and status filter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d02557f9ac8328983eb56aa235c04c