### PR TITLE
Fix payments overview view-all navigation

### DIFF
--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -337,7 +337,7 @@ export default function AdminPaymentsPage() {
             transactions={transactions}
             methods={methods}
             payouts={payouts}
-            onViewAll={() => router.push("/dashboard/admin/payments/transactions")}
+            onViewAll={() => setActiveTab("transactions")}
           />
         );
 


### PR DESCRIPTION
## Summary
- update the payments overview tab to switch to the Transactions tab locally when "View all" is clicked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0255bb2b083288f22c04034877546