### PR TITLE
Handle cache management without a service worker

### DIFF
--- a/frontend/src/components/pwa/CacheManager.jsx
+++ b/frontend/src/components/pwa/CacheManager.jsx
@@ -24,6 +24,8 @@ export default function CacheManager({
 } = {}) {
   const [status, setStatus] = useState("idle");
   const [ready, setReady] = useState(false);
+  const [hasServiceWorker, setHasServiceWorker] = useState(false);
+  const [serviceWorkerReady, setServiceWorkerReady] = useState(false);
   const [message, setMessage] = useState(null);
   const [clearing, setClearing] = useState(false);
 
@@ -31,9 +33,19 @@ export default function CacheManager({
     if (typeof window === "undefined") return () => {};
     let isMounted = true;
     if ("serviceWorker" in navigator) {
-      navigator.serviceWorker.ready.then(() => {
-        if (isMounted) setReady(true);
-      });
+      setHasServiceWorker(true);
+      navigator.serviceWorker.ready
+        .then(() => {
+          if (!isMounted) return;
+          setServiceWorkerReady(true);
+        })
+        .catch((err) => {
+          console.error("Service worker readiness check failed", err);
+        });
+      if (isMounted) setReady(true);
+    } else {
+      setHasServiceWorker(false);
+      setReady(true);
     }
     return () => {
       isMounted = false;
@@ -47,6 +59,11 @@ export default function CacheManager({
       if (strategy === "A") {
         await Promise.all(warmList.map((url) => fetch(url)));
       } else {
+        if (!serviceWorkerReady) {
+          setStatus("error");
+          setMessage("Service worker not ready");
+          return;
+        }
         const registration = await navigator.serviceWorker.ready;
         registration.active?.postMessage({
           type: "WARM_UP_CACHE",
@@ -66,11 +83,10 @@ export default function CacheManager({
     setClearing(true);
     setMessage(null);
     try {
+      let browserCacheCleared = false;
       if ("caches" in window) {
         await caches.delete(WARM_CACHE);
-      } else {
-        setStatus("error");
-        return;
+        browserCacheCleared = true;
       }
       if (strategy === "B") {
         const registration = await navigator.serviceWorker.ready;
@@ -78,7 +94,11 @@ export default function CacheManager({
       }
       await clearCache();
       setStatus("idle");
-      setMessage("Cache cleared");
+      setMessage(
+        browserCacheCleared
+          ? "Cache cleared"
+          : "Browser cache unavailable; server cache cleared"
+      );
     } catch (err) {
       console.error(err);
       toast.error(i18n.t("dashboard.cache_clear_failed"));
@@ -91,15 +111,21 @@ export default function CacheManager({
 
   if (!ready) return null;
 
+  const showWarmCacheButton = strategy === "A" || hasServiceWorker;
+  const warmCacheDisabled =
+    status === "caching" || (strategy === "B" && !serviceWorkerReady);
+
   return (
     <div>
       <div className="space-x-2">
-        <Button onClick={warmCache} disabled={status === "caching"}>
-          {status === "caching" && "Caching…"}
-          {status === "idle" && "Warm Cache"}
-          {status === "success" && "Cached"}
-          {status === "error" && "Retry"}
-        </Button>
+        {showWarmCacheButton && (
+          <Button onClick={warmCache} disabled={warmCacheDisabled}>
+            {status === "caching" && "Caching…"}
+            {status === "idle" && "Warm Cache"}
+            {status === "success" && "Cached"}
+            {status === "error" && "Retry"}
+          </Button>
+        )}
         <Button
           className="bg-gray-200 text-gray-800"
           onClick={handleClearCache}
@@ -110,6 +136,18 @@ export default function CacheManager({
         </Button>
       </div>
       {message && <p className="text-sm text-gray-600 mt-2">{message}</p>}
+      {!serviceWorkerReady && strategy === "B" && hasServiceWorker && (
+        <p className="text-sm text-gray-600 mt-2">
+          Service worker is still starting up. The warm cache action will be
+          enabled once it is ready.
+        </p>
+      )}
+      {!hasServiceWorker && strategy === "B" && (
+        <p className="text-sm text-gray-600 mt-2">
+          No service worker detected. Warming the cache requires a service
+          worker, but you can still clear the server cache below.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/tests/__tests__/CacheManager.test.jsx
+++ b/frontend/src/tests/__tests__/CacheManager.test.jsx
@@ -42,4 +42,14 @@ describe('CacheManager', () => {
     fireEvent.click(button);
     await screen.findByText('Failed to clear cache');
   });
+
+  it('falls back to server cache clearing when Cache API is unavailable', async () => {
+    delete window.caches;
+    mockClearCache.mockResolvedValue({});
+    render(<CacheManager />);
+    const button = await screen.findByText('Clear Cache');
+    fireEvent.click(button);
+    await waitFor(() => expect(mockClearCache).toHaveBeenCalled());
+    await screen.findByText('Browser cache unavailable; server cache cleared');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure CacheManager hydrates even when no service worker is present and track readiness separately
- disable or message the warm cache action when the service worker is unavailable while keeping clear cache accessible
- continue calling the server-side clear cache endpoint when the Cache API is missing and cover the cases with tests

## Testing
- npm test -- CacheManager.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d02567952883288714d74d02cc1122