### PR TITLE
Reset payment provider form while loading new provider

### DIFF
--- a/frontend/src/components/payments/PaymentProviderConfig.js
+++ b/frontend/src/components/payments/PaymentProviderConfig.js
@@ -23,6 +23,19 @@ export default function PaymentProviderConfig({ providerId }) {
 
   useEffect(() => {
     if (!providerId) return;
+
+    setLoading(true);
+    setSettings('{}');
+    setForm({});
+
+    if (providerId === 'paypal') {
+      setForm({ client_id: '', client_secret: '', mode: 'sandbox' });
+    } else if (providerId === 'stripe') {
+      setForm({ publishable_key: '', secret_key: '' });
+    } else if (providerId === 'coinbase') {
+      setForm({ api_key: '', api_secret: '' });
+    }
+
     const load = async () => {
       try {
         if (providerId === 'paypal') {


### PR DESCRIPTION
## Summary
- ensure the payment provider config view restores its loading state when the selected provider changes
- reset form and settings placeholders while fetching new provider data to prevent stale values from flashing

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d0255e476883288e269247cf38b910