### PR TITLE
Protect admin payments pages with guard

### DIFF
--- a/frontend/src/pages/dashboard/admin/payments/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/payments/edit/[id].js
@@ -1,7 +1,8 @@
 import { useRouter } from 'next/router';
 import PaymentProviderConfig from '@/components/payments/PaymentProviderConfig';
+import withAdminGuard from '@/hooks/withAdminGuard';
 
-export default function EditPaymentProviderDashboard() {
+function EditPaymentProviderDashboard() {
   const { id } = useRouter().query;
 
   return (
@@ -11,3 +12,5 @@ export default function EditPaymentProviderDashboard() {
     </div>
   );
 }
+
+export default withAdminGuard(EditPaymentProviderDashboard);

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAdminGuard from "@/hooks/withAdminGuard";
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../next-i18next.config.js';
@@ -57,7 +58,7 @@ const defaultConfig = {
 };
 
 
-export default function AdminPaymentsPage() {
+function AdminPaymentsPage() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard');
   const user = useAuthStore((s) => s.user);
@@ -759,3 +760,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminPaymentsPage);

--- a/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
@@ -1,11 +1,12 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAdminGuard from "@/hooks/withAdminGuard";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
 import PaymentProviderConfig from "@/components/payments/PaymentProviderConfig";
 
-export default function ConfigurePaymentMethodPage() {
+function ConfigurePaymentMethodPage() {
   const router = useRouter();
   const { id } = router.query;
   const { t } = useTranslation('dashboard');
@@ -29,3 +30,5 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(ConfigurePaymentMethodPage);

--- a/frontend/src/pages/dashboard/admin/payments/methods/create.js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/create.js
@@ -1,4 +1,5 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
+import withAdminGuard from "@/hooks/withAdminGuard";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
@@ -31,7 +32,7 @@ const useAdminNotice = () => {
   };
 };
 
-export default function CreatePaymentMethodPage() {
+function CreatePaymentMethodPage() {
   const router = useRouter();
   const { t } = useTranslation('dashboard');
   const [form, setForm] = useState({
@@ -191,3 +192,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(CreatePaymentMethodPage);


### PR DESCRIPTION
## Summary
- wrap admin payments dashboard and management pages with the withAdminGuard HOC
- preserve existing admin layout usage so pages still render within AdminLayout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0255c88c08328905cdbe360aaf6d8