### PR TITLE
Protect admin dashboard pages with admin guard

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -20,8 +20,9 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import Image from "next/image";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdAnalyticsPage({ ad: initialAd, error }) {
+function AdAnalyticsPage({ ad: initialAd, error }) {
   const router = useRouter();
   const { id } = router.query;
   const { t } = useTranslation('dashboard', { keyPrefix: 'adsAnalyticsPage' });
@@ -256,3 +257,5 @@ export async function getServerSideProps({ params, locale, req }) {
     };
   }
 }
+
+export default withAdminGuard(AdAnalyticsPage);

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -6,8 +6,9 @@ import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import AdForm from "@/components/ads/AdForm";
 import { createAd, checkAdTitle } from "@/services/admin/adService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function CreateAdPage() {
+function CreateAdPage() {
   const router = useRouter();
   const { t } = useTranslation("dashboard", { keyPrefix: "adsCreatePage" });
 
@@ -42,3 +43,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(CreateAdPage);

--- a/frontend/src/pages/dashboard/admin/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/edit/[id].js
@@ -9,8 +9,9 @@ import AdForm from "@/components/ads/AdForm";
 import { fetchAdById, updateAd } from "@/services/admin/adService";
 import { fetchPlanFeatures } from "@/services/planFeatureService";
 import useAuthStore from "@/store/auth/authStore";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditAdPage() {
+function EditAdPage() {
   const router = useRouter();
   const { id } = router.query;
   const { t } = useTranslation("dashboard", { keyPrefix: "adsEditPage" });
@@ -76,3 +77,5 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(EditAdPage);

--- a/frontend/src/pages/dashboard/admin/ads/index.js
+++ b/frontend/src/pages/dashboard/admin/ads/index.js
@@ -12,8 +12,9 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import useDebounce from "@/hooks/useDebounce";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminAdsPage() {
+function AdminAdsPage() {
     // ─────────────────────
     // State Management
     // ─────────────────────
@@ -245,3 +246,4 @@ export async function getStaticProps({ locale }) {
     };
 }
 
+export default withAdminGuard(AdminAdsPage);

--- a/frontend/src/pages/dashboard/admin/ads/purchase.js
+++ b/frontend/src/pages/dashboard/admin/ads/purchase.js
@@ -5,8 +5,9 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchAds, purchaseAd } from "@/services/admin/adService";
 import { toast } from "react-toastify";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function PurchaseAdsPage() {
+function PurchaseAdsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "adsPurchasePage" });
   const [ads, setAds] = useState([]);
 
@@ -74,3 +75,5 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(PurchaseAdsPage);

--- a/frontend/src/pages/dashboard/admin/assignments/approve/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/approve/[id].js
@@ -7,8 +7,9 @@ import {
   fetchAssignmentById,
   approveAssignment,
 } from '@/services/admin/assignmentService';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function ApproveAssignmentPage() {
+function ApproveAssignmentPage() {
   const router = useRouter();
   const { id } = router.query;
   const [assignment, setAssignment] = useState(null);
@@ -76,3 +77,5 @@ export default function ApproveAssignmentPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(ApproveAssignmentPage);

--- a/frontend/src/pages/dashboard/admin/assignments/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/edit/[id].js
@@ -3,8 +3,9 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaSave, FaArrowLeft } from 'react-icons/fa';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditAssignmentPage() {
+function EditAssignmentPage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -156,3 +157,5 @@ export default function EditAssignmentPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(EditAssignmentPage);

--- a/frontend/src/pages/dashboard/admin/assignments/index.js
+++ b/frontend/src/pages/dashboard/admin/assignments/index.js
@@ -4,8 +4,9 @@ import Link from 'next/link';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaSearch, FaSync, FaEye, FaTrash, FaCheckCircle, FaTimesCircle, FaEdit } from 'react-icons/fa';
 import { fetchAllAssignments } from '@/services/admin/assignmentService';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminAssignmentsPage() {
+function AdminAssignmentsPage() {
   const [assignments, setAssignments] = useState([]);
   const [search, setSearch] = useState('');
   const [filterStatus, setFilterStatus] = useState('all');
@@ -141,3 +142,5 @@ export default function AdminAssignmentsPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(AdminAssignmentsPage);

--- a/frontend/src/pages/dashboard/admin/assignments/reject/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/reject/[id].js
@@ -7,8 +7,9 @@ import {
   fetchAssignmentById,
   rejectAssignment,
 } from '@/services/admin/assignmentService';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function RejectAssignmentPage() {
+function RejectAssignmentPage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -95,3 +96,5 @@ export default function RejectAssignmentPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(RejectAssignmentPage);

--- a/frontend/src/pages/dashboard/admin/assignments/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/view/[id].js
@@ -8,8 +8,9 @@ import {
   approveAssignment,
   rejectAssignment,
 } from '@/services/admin/assignmentService';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminAssignmentReviewPage() {
+function AdminAssignmentReviewPage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -176,3 +177,5 @@ export default function AdminAssignmentReviewPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(AdminAssignmentReviewPage);

--- a/frontend/src/pages/dashboard/admin/bookings/index.js
+++ b/frontend/src/pages/dashboard/admin/bookings/index.js
@@ -11,8 +11,9 @@ import {
 } from '@/services/admin/bookingService';
 import { API_BASE_URL } from '@/config/config';
 import { toast } from 'react-toastify';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminBookingsPage() {
+function AdminBookingsPage() {
   const [bookings, setBookings] = useState([]);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -152,3 +153,5 @@ export default function AdminBookingsPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(AdminBookingsPage);

--- a/frontend/src/pages/dashboard/admin/certificates/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/certificates/edit/[id].js
@@ -4,8 +4,9 @@ import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
 import { getCertificate, updateCertificate } from "@/services/admin/certificateService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminEditCertificatePage() {
+function AdminEditCertificatePage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -132,3 +133,5 @@ export default function AdminEditCertificatePage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(AdminEditCertificatePage);

--- a/frontend/src/pages/dashboard/admin/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/certificates/index.js
@@ -14,8 +14,9 @@ import {
   rejectCertificate,
   downloadCertificate,
 } from "@/services/admin/certificateService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminCertificatesPage() {
+function AdminCertificatesPage() {
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'adminCertificatesPage' });
 
   const [certificates, setCertificates] = useState([]);
@@ -229,3 +230,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminCertificatesPage);

--- a/frontend/src/pages/dashboard/admin/certificates/issue-manual.js
+++ b/frontend/src/pages/dashboard/admin/certificates/issue-manual.js
@@ -4,8 +4,9 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
 import { useRouter } from "next/router";
 import { issueCertificate } from "@/services/admin/certificateService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function ManualCertificateIssuePage() {
+function ManualCertificateIssuePage() {
   const router = useRouter();
 
   const [studentName, setStudentName] = useState("");
@@ -113,3 +114,5 @@ export default function ManualCertificateIssuePage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(ManualCertificateIssuePage);

--- a/frontend/src/pages/dashboard/admin/certificates/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/certificates/view/[id].js
@@ -9,8 +9,9 @@ import {
   rejectCertificate,
   downloadCertificate,
 } from "@/services/admin/certificateService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function ViewCertificatePage() {
+function ViewCertificatePage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -139,3 +140,5 @@ export default function ViewCertificatePage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(ViewCertificatePage);

--- a/frontend/src/pages/dashboard/admin/community/announcements/index.js
+++ b/frontend/src/pages/dashboard/admin/community/announcements/index.js
@@ -11,8 +11,9 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminAnnouncementsPage() {
+function AdminAnnouncementsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityAnnouncementsPage",
   });
@@ -221,3 +222,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminAnnouncementsPage);

--- a/frontend/src/pages/dashboard/admin/community/contributors/index.js
+++ b/frontend/src/pages/dashboard/admin/community/contributors/index.js
@@ -5,8 +5,9 @@ import { fetchContributors } from "@/services/admin/communityService";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminContributorsPage() {
+function AdminContributorsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityContributorsPage",
   });
@@ -110,3 +111,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminContributorsPage);

--- a/frontend/src/pages/dashboard/admin/community/discussions/[id].js
+++ b/frontend/src/pages/dashboard/admin/community/discussions/[id].js
@@ -11,8 +11,9 @@ import {
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminDiscussionDetailsPage() {
+function AdminDiscussionDetailsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityDiscussionDetailsPage",
   });
@@ -136,3 +137,5 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminDiscussionDetailsPage);

--- a/frontend/src/pages/dashboard/admin/community/discussions/index.js
+++ b/frontend/src/pages/dashboard/admin/community/discussions/index.js
@@ -17,8 +17,9 @@ import {
 import { useTranslation, Trans } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminCommunityDiscussionsPage() {
+function AdminCommunityDiscussionsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityDiscussionsPage",
   });
@@ -185,3 +186,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminCommunityDiscussionsPage);

--- a/frontend/src/pages/dashboard/admin/community/index.js
+++ b/frontend/src/pages/dashboard/admin/community/index.js
@@ -19,6 +19,7 @@ import {
   ResponsiveContainer,
   Legend,
 } from "recharts";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 import { fetchDashboardStats } from "@/services/admin/communityService";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -57,7 +58,7 @@ const StatCard = ({ label, value, color }) => (
   </div>
 );
 
-export default function AdminCommunityDashboard({ initialStats }) {
+function AdminCommunityDashboard({ initialStats }) {
   const { t } = useTranslation("dashboard");
   const [stats, setStats] = useState(initialStats ? {
     totalDiscussions: initialStats.totalDiscussions,
@@ -189,3 +190,5 @@ export default function AdminCommunityDashboard({ initialStats }) {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(AdminCommunityDashboard);

--- a/frontend/src/pages/dashboard/admin/community/reports/index.js
+++ b/frontend/src/pages/dashboard/admin/community/reports/index.js
@@ -5,8 +5,9 @@ import { fetchReports } from "@/services/admin/communityService";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminCommunityReportsPage() {
+function AdminCommunityReportsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityReportsPage",
   });
@@ -97,3 +98,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminCommunityReportsPage);

--- a/frontend/src/pages/dashboard/admin/community/settings.js
+++ b/frontend/src/pages/dashboard/admin/community/settings.js
@@ -10,8 +10,9 @@ import {
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminCommunitySettingsPage() {
+function AdminCommunitySettingsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communitySettingsPage",
   });
@@ -91,3 +92,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminCommunitySettingsPage);

--- a/frontend/src/pages/dashboard/admin/community/tags/index.js
+++ b/frontend/src/pages/dashboard/admin/community/tags/index.js
@@ -12,6 +12,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const slugify = (text) =>
   text
@@ -20,7 +21,7 @@ const slugify = (text) =>
     .replace(/[^\w ]+/g, "")
     .replace(/ +/g, "-");
 
-export default function AdminTagsPage() {
+function AdminTagsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "communityTagsPage" });
   const [tags, setTags] = useState([]);
   const [newTag, setNewTag] = useState("");
@@ -213,3 +214,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminTagsPage);

--- a/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
@@ -3,8 +3,9 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchCouponById, updateCoupon } from "@/services/admin/couponService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditCouponPage() {
+function EditCouponPage() {
   const router = useRouter();
   const { id } = router.query;
   const [code, setCode] = useState("");
@@ -72,3 +73,5 @@ export default function EditCouponPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(EditCouponPage);

--- a/frontend/src/pages/dashboard/admin/coupons/index.js
+++ b/frontend/src/pages/dashboard/admin/coupons/index.js
@@ -3,8 +3,9 @@ import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchCoupons, deleteCoupon } from "@/services/admin/couponService";
 import Link from "next/link";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminCouponsPage() {
+function AdminCouponsPage() {
   const [coupons, setCoupons] = useState([]);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
@@ -126,3 +127,5 @@ export default function AdminCouponsPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(AdminCouponsPage);

--- a/frontend/src/pages/dashboard/admin/coupons/new.js
+++ b/frontend/src/pages/dashboard/admin/coupons/new.js
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 import AdminLayout from "@/components/layouts/AdminLayout";
 import {
@@ -67,7 +68,7 @@ const createCouponSchema = (t) =>
       }
     );
 
-export default function NewCouponPage() {
+function NewCouponPage() {
   const { t, i18n } = useTranslation("dashboard", { keyPrefix: "couponsPage" });
   const router = useRouter();
   const [serverError, setServerError] = useState(null);
@@ -219,3 +220,4 @@ export async function getStaticProps({ locale }) {
   };
 }
 
+export default withAdminGuard(NewCouponPage);

--- a/frontend/src/pages/dashboard/admin/currency/languages/create.js
+++ b/frontend/src/pages/dashboard/admin/currency/languages/create.js
@@ -4,8 +4,9 @@ import { useState } from "react";
 import { useRouter } from "next/router";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
 import logger from "@/utils/logger";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function CreateLanguagePage() {
+function CreateLanguagePage() {
   const router = useRouter();
   const [form, setForm] = useState({
     label: "",
@@ -118,3 +119,5 @@ export default function CreateLanguagePage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(CreateLanguagePage);

--- a/frontend/src/pages/dashboard/admin/currency/languages/index.js
+++ b/frontend/src/pages/dashboard/admin/currency/languages/index.js
@@ -11,6 +11,7 @@ import {
   Trash,
   ArrowLeftRight,
 } from "lucide-react";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const mockLanguages = [
   {
@@ -42,7 +43,7 @@ const mockLanguages = [
   },
 ];
 
-export default function LanguageManagerPage() {
+function LanguageManagerPage() {
   const [languages, setLanguages] = useState(mockLanguages);
 
   const toggleActive = (id) => {
@@ -158,3 +159,5 @@ export default function LanguageManagerPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(LanguageManagerPage);

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -21,12 +21,13 @@ import {
 } from 'react-icons/fa';
 import groupService from '@/services/groupService';
 import { toast } from 'react-toastify';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 // ...imports (same as before)...
 
 // Continue from your existing AdminGroupDetailsPage component
 
-export default function AdminGroupDetailsPage() {
+function AdminGroupDetailsPage() {
   const router = useRouter();
   const { id } = router.query;
   const [group, setGroup] = useState();
@@ -541,3 +542,4 @@ export default function AdminGroupDetailsPage() {
   );
 }
 
+export default withAdminGuard(AdminGroupDetailsPage);

--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -14,6 +14,7 @@ import {
 import groupService from '@/services/groupService';
 import { toast } from 'react-toastify';
 import ConfirmModal from '@/components/common/ConfirmModal';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const imagePool = [
   'https://media.npr.org/assets/img/2012/01/25/newnewearth_wide-e15c88c202099fecf4a9d6f6f0e2a19826d9a26f.jpg?s=1400&c=100&f=jpeg',
@@ -22,7 +23,7 @@ const imagePool = [
 ];
 
 
-export default function AdminGroupsIndex() {
+function AdminGroupsIndex() {
   const [groups, setGroups] = useState([]);
   const [search, setSearch] = useState('');
   const debouncedSearch = useDebounce(search, 500);
@@ -426,3 +427,5 @@ export default function AdminGroupsIndex() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(AdminGroupsIndex);

--- a/frontend/src/pages/dashboard/admin/notifications/index.js
+++ b/frontend/src/pages/dashboard/admin/notifications/index.js
@@ -4,8 +4,9 @@ import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaBell, FaCalendarAlt, FaChalkboardTeacher, FaCheckCircle, FaTimes } from 'react-icons/fa';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import LinkText from '@/components/shared/LinkText';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminNotificationsPage() {
+function AdminNotificationsPage() {
   const [filter, setFilter] = useState('all');
   const notifications = useNotificationStore((state) => state.items);
   const fetchNotifications = useNotificationStore((state) => state.fetch);
@@ -112,3 +113,5 @@ export default function AdminNotificationsPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(AdminNotificationsPage);

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
@@ -12,8 +12,9 @@ import {
   updateClassRule,
   deleteClassRule,
 } from "@/services/admin/classRuleService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function ClassRulesPage() {
+function ClassRulesPage() {
   const router = useRouter();
   const { id } = router.query;
   const { t, i18n } = useTranslation('dashboard');
@@ -92,3 +93,6 @@ export async function getServerSideProps({ locale }) {
   };
 }
 
+const ProtectedClassRulesPage = withAdminGuard(ClassRulesPage);
+ProtectedClassRulesPage.getLayout = ClassRulesPage.getLayout;
+export default ProtectedClassRulesPage;

--- a/frontend/src/pages/dashboard/admin/payments/OverviewTab.js
+++ b/frontend/src/pages/dashboard/admin/payments/OverviewTab.js
@@ -12,6 +12,7 @@ import {
   Tooltip,
   Legend,
 } from "chart.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 ChartJS.register(
   CategoryScale,
@@ -23,7 +24,7 @@ ChartJS.register(
   Legend,
 );
 
-export default function OverviewTab({ transactions = [], methods = [], payouts = [], onViewAll }) {
+function OverviewTab({ transactions = [], methods = [], payouts = [], onViewAll }) {
   const { t } = useTranslation('dashboard');
   // Treat "success" as equivalent to "paid" for older records
   const totalRevenue = transactions
@@ -211,3 +212,5 @@ export default function OverviewTab({ transactions = [], methods = [], payouts =
     </div>
   );
 }
+
+export default withAdminGuard(OverviewTab);

--- a/frontend/src/pages/dashboard/admin/payments/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/payments/edit/[id].js
@@ -1,7 +1,8 @@
 import { useRouter } from 'next/router';
 import PaymentProviderConfig from '@/components/payments/PaymentProviderConfig';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditPaymentProviderDashboard() {
+function EditPaymentProviderDashboard() {
   const { id } = useRouter().query;
 
   return (
@@ -11,3 +12,5 @@ export default function EditPaymentProviderDashboard() {
     </div>
   );
 }
+
+export default withAdminGuard(EditPaymentProviderDashboard);

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -17,6 +17,7 @@ import {
   FaUniversity,
 } from "react-icons/fa";
 import OverviewTab from './OverviewTab';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 import { fetchPayments } from '@/services/admin/paymentService';
 import {
@@ -57,7 +58,7 @@ const defaultConfig = {
 };
 
 
-export default function AdminPaymentsPage() {
+function AdminPaymentsPage() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard');
   const user = useAuthStore((s) => s.user);
@@ -759,3 +760,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminPaymentsPage);

--- a/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
@@ -4,8 +4,9 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
 import PaymentProviderConfig from "@/components/payments/PaymentProviderConfig";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function ConfigurePaymentMethodPage() {
+function ConfigurePaymentMethodPage() {
   const router = useRouter();
   const { id } = router.query;
   const { t } = useTranslation('dashboard');
@@ -29,3 +30,5 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(ConfigurePaymentMethodPage);

--- a/frontend/src/pages/dashboard/admin/payments/methods/create.js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/create.js
@@ -12,6 +12,7 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const useAdminNotice = () => {
   const user = useAuthStore((state) => state.user);
@@ -31,7 +32,7 @@ const useAdminNotice = () => {
   };
 };
 
-export default function CreatePaymentMethodPage() {
+function CreatePaymentMethodPage() {
   const router = useRouter();
   const { t } = useTranslation('dashboard');
   const [form, setForm] = useState({
@@ -191,3 +192,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(CreatePaymentMethodPage);

--- a/frontend/src/pages/dashboard/admin/profile/payment-methods/add.js
+++ b/frontend/src/pages/dashboard/admin/profile/payment-methods/add.js
@@ -1,6 +1,7 @@
 import PaymentMethodForm from '@/components/payments/PaymentMethodForm';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AddPaymentMethodPage() {
+function AddPaymentMethodPage() {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">Add a New Payment Method</h1>
@@ -8,3 +9,5 @@ export default function AddPaymentMethodPage() {
     </div>
   );
 }
+
+export default withAdminGuard(AddPaymentMethodPage);

--- a/frontend/src/pages/dashboard/admin/profile/payment-methods/index.js
+++ b/frontend/src/pages/dashboard/admin/profile/payment-methods/index.js
@@ -1,7 +1,8 @@
 import Link from 'next/link';
 import PaymentMethodList from '@/components/payments/PaymentMethodList';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function SavedPaymentMethodsPage() {
+function SavedPaymentMethodsPage() {
   return (
     <div className="p-6">
       <div className="flex justify-between items-center mb-4">
@@ -16,3 +17,5 @@ export default function SavedPaymentMethodsPage() {
     </div>
   );
 }
+
+export default withAdminGuard(SavedPaymentMethodsPage);

--- a/frontend/src/pages/dashboard/admin/settings/app/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/app/index.js
@@ -14,6 +14,7 @@ import { API_BASE_URL } from "@/config/config";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const defaultConfig = { 
   appName: "", 
@@ -25,7 +26,7 @@ const defaultConfig = {
   contactEmail: ""
 };
 
-export default function AppSettingsPage() {
+function AppSettingsPage() {
   const [config, setConfig] = useState(defaultConfig);
   const [logoFile, setLogoFile] = useState(null);
   const [faviconFile, setFaviconFile] = useState(null);
@@ -396,3 +397,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AppSettingsPage);

--- a/frontend/src/pages/dashboard/admin/settings/blog/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/blog/index.js
@@ -11,8 +11,9 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminBlogManager() {
+function AdminBlogManager() {
   const [posts, setPosts] = useState([]);
   const { t } = useTranslation("dashboard", { keyPrefix: "blogManagerPage" });
 
@@ -232,3 +233,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminBlogManager);

--- a/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
@@ -8,8 +8,9 @@ import {
 } from "@/services/admin/certificateTemplateService";
 import { toSnakeCase } from "@/utils/case";
 import CertificateTemplateForm from "@/components/admin/certificates/CertificateTemplateForm";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditCertificateTemplate() {
+function EditCertificateTemplate() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -60,3 +61,5 @@ export default function EditCertificateTemplate() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(EditCertificateTemplate);

--- a/frontend/src/pages/dashboard/admin/settings/certificates/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/create.js
@@ -3,8 +3,9 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { saveTemplate } from "@/services/admin/certificateTemplateService";
 import CertificateTemplateForm from "@/components/admin/certificates/CertificateTemplateForm";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function CreateCertificateTemplate() {
+function CreateCertificateTemplate() {
   const router = useRouter();
 
   const initialValues = {
@@ -44,3 +45,5 @@ export default function CreateCertificateTemplate() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(CreateCertificateTemplate);

--- a/frontend/src/pages/dashboard/admin/settings/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/index.js
@@ -10,6 +10,7 @@ import {
   FaToggleOn,
   FaToggleOff,
 } from "react-icons/fa";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 import CertificatePreviewModal from "@/components/admin/certificates/CertificatePreviewModal";
 import {
@@ -20,7 +21,7 @@ import {
 } from "@/services/admin/certificateTemplateService";
 import { toast } from "react-toastify";
 
-export default function CertificateTemplatesPage() {
+function CertificateTemplatesPage() {
   const [templates, setTemplates] = useState([]);
   const [previewTemplate, setPreviewTemplate] = useState(null);
 
@@ -157,3 +158,5 @@ export default function CertificateTemplatesPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(CertificateTemplatesPage);

--- a/frontend/src/pages/dashboard/admin/settings/contact/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/contact/index.js
@@ -7,6 +7,7 @@ import { fetchContactConfig, updateContactConfig } from "@/services/admin/contac
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const initialConfig = {
   email: process.env.NEXT_PUBLIC_SUPPORT_EMAIL || "",
@@ -18,7 +19,7 @@ const initialConfig = {
   mapEmbedUrl: "https://maps.google.com/embed?pb=...",
 };
 
-export default function AdminContactSettings() {
+function AdminContactSettings() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'contactPage' });
   const [config, setConfig] = useState(initialConfig);
   const [loading, setLoading] = useState(false);
@@ -149,3 +150,4 @@ export async function getStaticProps({ locale }) {
   };
 }
 
+export default withAdminGuard(AdminContactSettings);

--- a/frontend/src/pages/dashboard/admin/settings/email-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/email-config/index.js
@@ -9,6 +9,7 @@ import { fetchEmailConfig, updateEmailConfig } from "@/services/admin/emailConfi
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const defaultConfig = {
   fromName: "SkillBridge Admin",
@@ -22,7 +23,7 @@ const defaultConfig = {
   method: "smtp",
 };
 
-export default function EmailConfigPage() {
+function EmailConfigPage() {
   const { t } = useTranslation('dashboard');
   const [form, setForm] = useState(defaultConfig);
 
@@ -187,3 +188,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(EmailConfigPage);

--- a/frontend/src/pages/dashboard/admin/settings/faqs/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/faqs/index.js
@@ -7,10 +7,11 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const fetcher = (url) => api.get(url).then((res) => res.data.data);
 
-export default function AdminFaqsPage() {
+function AdminFaqsPage() {
   const { t, i18n } = useTranslation("dashboard", { keyPrefix: "faqsPage" });
   const { data: faqs = [], mutate } = useSWR("/faqs", fetcher);
   const [newFaq, setNewFaq] = useState({ question: "", answer: "" });
@@ -174,3 +175,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminFaqsPage);

--- a/frontend/src/pages/dashboard/admin/settings/footer/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/footer/index.js
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const defaultFooter = {
   about: "SkillBridge connects learners with expert instructors worldwide.",
@@ -35,7 +36,7 @@ const defaultFooter = {
   },
 };
 
-export default function FooterSettingsPage() {
+function FooterSettingsPage() {
   const updateStore = useAppConfigStore((state) => state.update);
   const fetchConfig = useAppConfigStore((state) => state.fetch);
   const [config, setConfig] = useState({});
@@ -294,3 +295,5 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(FooterSettingsPage);

--- a/frontend/src/pages/dashboard/admin/settings/language-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/language-config/index.js
@@ -8,8 +8,9 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import useSWR, { mutate as mutateGlobal } from "swr";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function LanguageConfigPage() {
+function LanguageConfigPage() {
   const { t, i18n } = useTranslation("dashboard");
   const [config, setConfig] = useState({ defaultLanguage: "en" });
   const { data: configData } = useSWR("/app-config", fetchAppConfig, {
@@ -84,3 +85,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(LanguageConfigPage);

--- a/frontend/src/pages/dashboard/admin/settings/languages/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/create.js
@@ -8,11 +8,12 @@ import { createLanguage, getLanguages } from "@/services/languageService";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 // Include the common namespace since it's used across the site
 const predefinedNamespaces = ["common", "auth", "website", "dashboard"];
 
-export default function CreateLanguagePage() {
+function CreateLanguagePage() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'languagesPage' });
   const [form, setForm] = useState({
@@ -276,3 +277,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(CreateLanguagePage);

--- a/frontend/src/pages/dashboard/admin/settings/languages/edit/[code].js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/edit/[code].js
@@ -10,6 +10,7 @@ import { FaArrowLeft, FaSave, FaUpload } from "react-icons/fa";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const fetchTranslations = async (code) => {
   const data = {};
@@ -23,7 +24,7 @@ const fetchTranslations = async (code) => {
 
 const namespaces = ["common", "website", "dashboard", "auth"];
 
-export default function EditLanguagePage() {
+function EditLanguagePage() {
   const router = useRouter();
   const { code } = router.query;
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'languagesPage' });
@@ -323,3 +324,5 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(EditLanguagePage);

--- a/frontend/src/pages/dashboard/admin/settings/languages/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/index.js
@@ -10,10 +10,11 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
 import handleApiError from "@/utils/apiError";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const fetcher = url => api.get(url).then(res => res.data.data);
 
-export default function LanguagesPage() {
+function LanguagesPage() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'languagesPage' });
   const { data: languages, mutate } = useSWR("/languages", fetcher);
@@ -175,3 +176,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(LanguagesPage);

--- a/frontend/src/pages/dashboard/admin/settings/policies/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/policies/index.js
@@ -9,6 +9,7 @@ import DOMPurify from "isomorphic-dompurify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 // ReactQuill (lazy load to avoid SSR issues)
 const ReactQuill = dynamic(() => import("react-quill"), { ssr: false });
@@ -21,7 +22,7 @@ const normalizeTitle = (title) =>
     .toLowerCase()
     .replace(/\b\w/g, (c) => c.toUpperCase());
 
-export default function AdminPoliciesPage() {
+function AdminPoliciesPage() {
   const { t, i18n } = useTranslation("dashboard", { keyPrefix: "policiesPage" });
 
   const defaultPolicies = {
@@ -237,3 +238,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminPoliciesPage);

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
@@ -15,6 +15,7 @@ import useMessageStore from "@/store/messages/messageStore";
 import { createPopupAnnouncement } from "@/services/admin/popupAnnouncementService";
 import { fetchPageList } from "@/services/admin/seoConfigService";
 import PopupPreviewModal from "@/components/admin/settings/PopupPreviewModal";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const RichTextEditor = dynamic(() => import("react-quill"), { ssr: false });
 
@@ -34,7 +35,7 @@ const useAdminNotice = () => {
   };
 };
 
-export default function CreateAnnouncementForm() {
+function CreateAnnouncementForm() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'popupAnnouncementsPage' });
   const notify = useAdminNotice();
@@ -281,3 +282,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(CreateAnnouncementForm);

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/edit/[id].js
@@ -13,10 +13,11 @@ import {
   updatePopupAnnouncement,
 } from "@/services/admin/popupAnnouncementService";
 import { fetchPageList } from "@/services/admin/seoConfigService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const RichTextEditor = dynamic(() => import("react-quill"), { ssr: false });
 
-export default function EditAnnouncementForm() {
+function EditAnnouncementForm() {
   const router = useRouter();
   const { id } = router.query;
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'popupAnnouncementsPage' });
@@ -287,3 +288,4 @@ export async function getServerSideProps({ locale }) {
   };
 }
 
+export default withAdminGuard(EditAnnouncementForm);

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/index.js
@@ -12,8 +12,9 @@ import {
   deletePopupAnnouncement,
 } from "@/services/admin/popupAnnouncementService";
 import PopupPreviewModal from "@/components/admin/settings/PopupPreviewModal";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function PopupAnnouncementsIndex() {
+function PopupAnnouncementsIndex() {
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'popupAnnouncementsPage' });
   const [announcements, setAnnouncements] = useState([]);
   const [previewAnn, setPreviewAnn] = useState(null);
@@ -137,3 +138,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(PopupAnnouncementsIndex);

--- a/frontend/src/pages/dashboard/admin/settings/seo/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/seo/index.js
@@ -20,6 +20,7 @@ import RobotsEditor from "@/components/admin/settings/seo/RobotsEditor";
 import OpenGraphSettings from "@/components/admin/settings/seo/OpenGraphSettings";
 import TwitterCardSettings from "@/components/admin/settings/seo/TwitterCardSettings";
 import AdvancedSEOSettings from "@/components/admin/settings/seo/AdvancedSEOSettings";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const defaultConfig = {
   metaTags: {},
@@ -37,7 +38,7 @@ const defaultConfig = {
   jsonSchema: "",
 };
 
-export default function SEOSettingsPage() {
+function SEOSettingsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "seoPage" });
   const tabs = [
     { key: "overview", label: t("tabs.overview"), icon: <FaGlobe /> },
@@ -113,3 +114,5 @@ export default function SEOSettingsPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(SEOSettingsPage);

--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -11,6 +11,7 @@ import useMessageStore from "@/store/messages/messageStore";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const availableIcons = {
   google: <FaGoogle />,
@@ -89,7 +90,7 @@ const providerHasCredentials = (p) => {
   return p.clientId && p.clientSecret;
 };
 
-export default function SocialLoginSettingsPage() {
+function SocialLoginSettingsPage() {
   const [globalActive, setGlobalActive] = useState(true);
   const [providers, setProviders] = useState(initialProviders);
   const [recaptchaActive, setRecaptchaActive] = useState(true);
@@ -569,3 +570,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(SocialLoginSettingsPage);

--- a/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
@@ -16,6 +16,7 @@ import {
   FaAd,
 } from "react-icons/fa";
 import { SiHuggingface } from "react-icons/si";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 // Modal Components
 import ChatGPTModal from "@/components/admin/integrations/ChatGPTModal";
@@ -27,7 +28,7 @@ import GoogleCalendarModal from "@/components/admin/integrations/GoogleCalendarM
 import GoogleAnalyticsModal from "@/components/admin/integrations/GoogleAnalyticsModal";
 import GoogleAdSenseModal from "@/components/admin/integrations/GoogleAdSenseModal";
 
-export default function ThirdPartyIntegrationsPage() {
+function ThirdPartyIntegrationsPage() {
   const { t } = useTranslation('dashboard');
   const [settings, setSettings] = useState({});
   const [loading, setLoading] = useState(false);
@@ -235,3 +236,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(ThirdPartyIntegrationsPage);

--- a/frontend/src/pages/dashboard/admin/support/analytics/index.js
+++ b/frontend/src/pages/dashboard/admin/support/analytics/index.js
@@ -6,8 +6,9 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { fetchSupportAnalytics } from "@/services/supportService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminSupportAnalytics() {
+function AdminSupportAnalytics() {
   const { t } = useTranslation('dashboard');
   const [stats, setStats] = useState({ open: 0, resolved: 0, closed: 0, avg: '0h' });
   const [chart, setChart] = useState([]);
@@ -71,3 +72,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminSupportAnalytics);

--- a/frontend/src/pages/dashboard/admin/support/index.js
+++ b/frontend/src/pages/dashboard/admin/support/index.js
@@ -8,8 +8,9 @@ import { fetchRecentActivity } from "@/services/supportService";
 import formatRelativeTime from "@/utils/relativeTime";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminSupportHome() {
+function AdminSupportHome() {
   const { t } = useTranslation('dashboard');
   const [activity, setActivity] = useState([]);
 
@@ -117,3 +118,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminSupportHome);

--- a/frontend/src/pages/dashboard/admin/support/tickets/[id].js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/[id].js
@@ -18,8 +18,9 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { FiArrowLeft, FiRefreshCw, FiAlertTriangle, FiCheckCircle, FiMessageSquare, FiUser, FiCalendar, FiTag } from "react-icons/fi";
 import { FaSpinner } from "react-icons/fa";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminTicketDetail() {
+function AdminTicketDetail() {
   const { t } = useTranslation("dashboard");
   const router = useRouter();
   const { id } = router.query;
@@ -282,3 +283,5 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminTicketDetail);

--- a/frontend/src/pages/dashboard/admin/support/tickets/index.js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/index.js
@@ -4,13 +4,14 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { FiSearch, FiFilter, FiRefreshCw, FiPlus, FiCalendar, FiUser } from "react-icons/fi";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import TicketCard from "@/components/support/TicketCard";
 import { fetchAllTickets } from "@/services/supportService";
 
-export default function AdminSupportTicketsPage() {
+function AdminSupportTicketsPage() {
   const [tickets, setTickets] = useState([]);
   const [status, setStatus] = useState("");
   const [priority, setPriority] = useState("");
@@ -311,3 +312,5 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+export default withAdminGuard(AdminSupportTicketsPage);

--- a/frontend/src/pages/dashboard/admin/users/create.js
+++ b/frontend/src/pages/dashboard/admin/users/create.js
@@ -4,8 +4,9 @@ import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import AddUserModal from "@/components/admin/users/AddUserModal";
 import { createUser } from "@/services/admin/userService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function CreateUserPage() {
+function CreateUserPage() {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(true);
 
@@ -24,3 +25,5 @@ export default function CreateUserPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(CreateUserPage);

--- a/frontend/src/pages/dashboard/admin/users/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/users/edit/[id].js
@@ -5,8 +5,9 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import EditUserForm from "@/components/admin/users/EditUserForm";
 import { fetchUserById } from "@/services/admin/userService";
 import { toast } from "react-toastify";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditUserPage() {
+function EditUserPage() {
   const router = useRouter();
   const { id } = router.query;
   const [user, setUser] = useState(null);
@@ -32,3 +33,5 @@ export default function EditUserPage() {
     </AdminLayout>
   );
 }
+
+export default withAdminGuard(EditUserPage);


### PR DESCRIPTION
## Summary
- wrap every admin dashboard page with `withAdminGuard` (or equivalent) so only admin roles can render them
- copy any `getLayout` definitions to the guarded component to keep layouts intact

## Testing
- `npm run lint` *(fails: existing lint errors about missing display names and Next.js img usage outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d02568f4e0832898d4598d32ab3873