### PR TITLE
Protect admin dashboard pages with guard

### DIFF
--- a/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/analytics/[id].js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/admin/ads/analytics/[id].js
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
@@ -21,7 +22,7 @@ import {
 } from "recharts";
 import Image from "next/image";
 
-export default function AdAnalyticsPage({ ad: initialAd, error }) {
+function AdAnalyticsPage({ ad: initialAd, error }) {
   const router = useRouter();
   const { id } = router.query;
   const { t } = useTranslation('dashboard', { keyPrefix: 'adsAnalyticsPage' });
@@ -256,3 +257,7 @@ export async function getServerSideProps({ params, locale, req }) {
     };
   }
 }
+
+const ProtectedAdAnalyticsPage = withAdminGuard(AdAnalyticsPage);
+
+export default ProtectedAdAnalyticsPage;

--- a/frontend/src/pages/dashboard/admin/ads/create.js
+++ b/frontend/src/pages/dashboard/admin/ads/create.js
@@ -6,8 +6,9 @@ import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import AdForm from "@/components/ads/AdForm";
 import { createAd, checkAdTitle } from "@/services/admin/adService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function CreateAdPage() {
+function CreateAdPage() {
   const router = useRouter();
   const { t } = useTranslation("dashboard", { keyPrefix: "adsCreatePage" });
 
@@ -42,3 +43,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedCreateAdPage = withAdminGuard(CreateAdPage);
+
+export default ProtectedCreateAdPage;

--- a/frontend/src/pages/dashboard/admin/ads/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/ads/edit/[id].js
@@ -9,8 +9,9 @@ import AdForm from "@/components/ads/AdForm";
 import { fetchAdById, updateAd } from "@/services/admin/adService";
 import { fetchPlanFeatures } from "@/services/planFeatureService";
 import useAuthStore from "@/store/auth/authStore";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditAdPage() {
+function EditAdPage() {
   const router = useRouter();
   const { id } = router.query;
   const { t } = useTranslation("dashboard", { keyPrefix: "adsEditPage" });
@@ -76,3 +77,7 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+const ProtectedEditAdPage = withAdminGuard(EditAdPage);
+
+export default ProtectedEditAdPage;

--- a/frontend/src/pages/dashboard/admin/ads/index.js
+++ b/frontend/src/pages/dashboard/admin/ads/index.js
@@ -12,8 +12,9 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import useDebounce from "@/hooks/useDebounce";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminAdsPage() {
+function AdminAdsPage() {
     // ─────────────────────
     // State Management
     // ─────────────────────
@@ -245,3 +246,6 @@ export async function getStaticProps({ locale }) {
     };
 }
 
+const ProtectedAdminAdsPage = withAdminGuard(AdminAdsPage);
+
+export default ProtectedAdminAdsPage;

--- a/frontend/src/pages/dashboard/admin/ads/purchase.js
+++ b/frontend/src/pages/dashboard/admin/ads/purchase.js
@@ -5,8 +5,9 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchAds, purchaseAd } from "@/services/admin/adService";
 import { toast } from "react-toastify";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function PurchaseAdsPage() {
+function PurchaseAdsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "adsPurchasePage" });
   const [ads, setAds] = useState([]);
 
@@ -74,3 +75,7 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+const ProtectedPurchaseAdsPage = withAdminGuard(PurchaseAdsPage);
+
+export default ProtectedPurchaseAdsPage;

--- a/frontend/src/pages/dashboard/admin/assignments/approve/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/approve/[id].js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/assignments/approve/[id].js
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
@@ -8,7 +9,7 @@ import {
   approveAssignment,
 } from '@/services/admin/assignmentService';
 
-export default function ApproveAssignmentPage() {
+function ApproveAssignmentPage() {
   const router = useRouter();
   const { id } = router.query;
   const [assignment, setAssignment] = useState(null);
@@ -76,3 +77,7 @@ export default function ApproveAssignmentPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedApproveAssignmentPage = withAdminGuard(ApproveAssignmentPage);
+
+export default ProtectedApproveAssignmentPage;

--- a/frontend/src/pages/dashboard/admin/assignments/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/edit/[id].js
@@ -1,10 +1,11 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/assignments/edit/[id].js
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaSave, FaArrowLeft } from 'react-icons/fa';
 
-export default function EditAssignmentPage() {
+function EditAssignmentPage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -156,3 +157,7 @@ export default function EditAssignmentPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedEditAssignmentPage = withAdminGuard(EditAssignmentPage);
+
+export default ProtectedEditAssignmentPage;

--- a/frontend/src/pages/dashboard/admin/assignments/index.js
+++ b/frontend/src/pages/dashboard/admin/assignments/index.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/assignments/index.js
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
@@ -5,7 +6,7 @@ import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaSearch, FaSync, FaEye, FaTrash, FaCheckCircle, FaTimesCircle, FaEdit } from 'react-icons/fa';
 import { fetchAllAssignments } from '@/services/admin/assignmentService';
 
-export default function AdminAssignmentsPage() {
+function AdminAssignmentsPage() {
   const [assignments, setAssignments] = useState([]);
   const [search, setSearch] = useState('');
   const [filterStatus, setFilterStatus] = useState('all');
@@ -141,3 +142,7 @@ export default function AdminAssignmentsPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedAdminAssignmentsPage = withAdminGuard(AdminAssignmentsPage);
+
+export default ProtectedAdminAssignmentsPage;

--- a/frontend/src/pages/dashboard/admin/assignments/reject/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/reject/[id].js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/assignments/reject/[id].js
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
@@ -8,7 +9,7 @@ import {
   rejectAssignment,
 } from '@/services/admin/assignmentService';
 
-export default function RejectAssignmentPage() {
+function RejectAssignmentPage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -95,3 +96,7 @@ export default function RejectAssignmentPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedRejectAssignmentPage = withAdminGuard(RejectAssignmentPage);
+
+export default ProtectedRejectAssignmentPage;

--- a/frontend/src/pages/dashboard/admin/assignments/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/assignments/view/[id].js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/assignments/[id].js
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
@@ -9,7 +10,7 @@ import {
   rejectAssignment,
 } from '@/services/admin/assignmentService';
 
-export default function AdminAssignmentReviewPage() {
+function AdminAssignmentReviewPage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -176,3 +177,7 @@ export default function AdminAssignmentReviewPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedAdminAssignmentReviewPage = withAdminGuard(AdminAssignmentReviewPage);
+
+export default ProtectedAdminAssignmentReviewPage;

--- a/frontend/src/pages/dashboard/admin/bookings/index.js
+++ b/frontend/src/pages/dashboard/admin/bookings/index.js
@@ -11,8 +11,9 @@ import {
 } from '@/services/admin/bookingService';
 import { API_BASE_URL } from '@/config/config';
 import { toast } from 'react-toastify';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminBookingsPage() {
+function AdminBookingsPage() {
   const [bookings, setBookings] = useState([]);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -152,3 +153,7 @@ export default function AdminBookingsPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedAdminBookingsPage = withAdminGuard(AdminBookingsPage);
+
+export default ProtectedAdminBookingsPage;

--- a/frontend/src/pages/dashboard/admin/certificates/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/certificates/edit/[id].js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/certificates/edit/[id].js
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
@@ -5,7 +6,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
 import { getCertificate, updateCertificate } from "@/services/admin/certificateService";
 
-export default function AdminEditCertificatePage() {
+function AdminEditCertificatePage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -132,3 +133,7 @@ export default function AdminEditCertificatePage() {
     </AdminLayout>
   );
 }
+
+const ProtectedAdminEditCertificatePage = withAdminGuard(AdminEditCertificatePage);
+
+export default ProtectedAdminEditCertificatePage;

--- a/frontend/src/pages/dashboard/admin/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/certificates/index.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // ─────────────────────────────────────
 // 📁 dashboard/admin/certificates/index.js
 // ─────────────────────────────────────
@@ -15,7 +16,7 @@ import {
   downloadCertificate,
 } from "@/services/admin/certificateService";
 
-export default function AdminCertificatesPage() {
+function AdminCertificatesPage() {
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'adminCertificatesPage' });
 
   const [certificates, setCertificates] = useState([]);
@@ -229,3 +230,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminCertificatesPage = withAdminGuard(AdminCertificatesPage);
+
+export default ProtectedAdminCertificatesPage;

--- a/frontend/src/pages/dashboard/admin/certificates/issue-manual.js
+++ b/frontend/src/pages/dashboard/admin/certificates/issue-manual.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/certificates/issue-manual.js
 import { useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
@@ -5,7 +6,7 @@ import { FaSave, FaArrowLeft } from "react-icons/fa";
 import { useRouter } from "next/router";
 import { issueCertificate } from "@/services/admin/certificateService";
 
-export default function ManualCertificateIssuePage() {
+function ManualCertificateIssuePage() {
   const router = useRouter();
 
   const [studentName, setStudentName] = useState("");
@@ -113,3 +114,7 @@ export default function ManualCertificateIssuePage() {
     </AdminLayout>
   );
 }
+
+const ProtectedManualCertificateIssuePage = withAdminGuard(ManualCertificateIssuePage);
+
+export default ProtectedManualCertificateIssuePage;

--- a/frontend/src/pages/dashboard/admin/certificates/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/certificates/view/[id].js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/certificates/view/[id].js
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
@@ -10,7 +11,7 @@ import {
   downloadCertificate,
 } from "@/services/admin/certificateService";
 
-export default function ViewCertificatePage() {
+function ViewCertificatePage() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -139,3 +140,7 @@ export default function ViewCertificatePage() {
     </AdminLayout>
   );
 }
+
+const ProtectedViewCertificatePage = withAdminGuard(ViewCertificatePage);
+
+export default ProtectedViewCertificatePage;

--- a/frontend/src/pages/dashboard/admin/community/announcements/index.js
+++ b/frontend/src/pages/dashboard/admin/community/announcements/index.js
@@ -11,8 +11,9 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminAnnouncementsPage() {
+function AdminAnnouncementsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityAnnouncementsPage",
   });
@@ -221,3 +222,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminAnnouncementsPage = withAdminGuard(AdminAnnouncementsPage);
+
+export default ProtectedAdminAnnouncementsPage;

--- a/frontend/src/pages/dashboard/admin/community/contributors/index.js
+++ b/frontend/src/pages/dashboard/admin/community/contributors/index.js
@@ -5,8 +5,9 @@ import { fetchContributors } from "@/services/admin/communityService";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminContributorsPage() {
+function AdminContributorsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityContributorsPage",
   });
@@ -110,3 +111,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminContributorsPage = withAdminGuard(AdminContributorsPage);
+
+export default ProtectedAdminContributorsPage;

--- a/frontend/src/pages/dashboard/admin/community/discussions/[id].js
+++ b/frontend/src/pages/dashboard/admin/community/discussions/[id].js
@@ -11,8 +11,9 @@ import {
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminDiscussionDetailsPage() {
+function AdminDiscussionDetailsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityDiscussionDetailsPage",
   });
@@ -136,3 +137,7 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminDiscussionDetailsPage = withAdminGuard(AdminDiscussionDetailsPage);
+
+export default ProtectedAdminDiscussionDetailsPage;

--- a/frontend/src/pages/dashboard/admin/community/discussions/index.js
+++ b/frontend/src/pages/dashboard/admin/community/discussions/index.js
@@ -17,8 +17,9 @@ import {
 import { useTranslation, Trans } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminCommunityDiscussionsPage() {
+function AdminCommunityDiscussionsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityDiscussionsPage",
   });
@@ -185,3 +186,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminCommunityDiscussionsPage = withAdminGuard(AdminCommunityDiscussionsPage);
+
+export default ProtectedAdminCommunityDiscussionsPage;

--- a/frontend/src/pages/dashboard/admin/community/index.js
+++ b/frontend/src/pages/dashboard/admin/community/index.js
@@ -23,6 +23,7 @@ import {
 import { fetchDashboardStats } from "@/services/admin/communityService";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 export async function getServerSideProps({ req, locale }) {
   const headers = req.headers.cookie ? { Cookie: req.headers.cookie } : {};
@@ -57,7 +58,7 @@ const StatCard = ({ label, value, color }) => (
   </div>
 );
 
-export default function AdminCommunityDashboard({ initialStats }) {
+function AdminCommunityDashboard({ initialStats }) {
   const { t } = useTranslation("dashboard");
   const [stats, setStats] = useState(initialStats ? {
     totalDiscussions: initialStats.totalDiscussions,
@@ -189,3 +190,7 @@ export default function AdminCommunityDashboard({ initialStats }) {
     </AdminLayout>
   );
 }
+
+const ProtectedAdminCommunityDashboard = withAdminGuard(AdminCommunityDashboard);
+
+export default ProtectedAdminCommunityDashboard;

--- a/frontend/src/pages/dashboard/admin/community/reports/index.js
+++ b/frontend/src/pages/dashboard/admin/community/reports/index.js
@@ -5,8 +5,9 @@ import { fetchReports } from "@/services/admin/communityService";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminCommunityReportsPage() {
+function AdminCommunityReportsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communityReportsPage",
   });
@@ -97,3 +98,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminCommunityReportsPage = withAdminGuard(AdminCommunityReportsPage);
+
+export default ProtectedAdminCommunityReportsPage;

--- a/frontend/src/pages/dashboard/admin/community/settings.js
+++ b/frontend/src/pages/dashboard/admin/community/settings.js
@@ -10,8 +10,9 @@ import {
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminCommunitySettingsPage() {
+function AdminCommunitySettingsPage() {
   const { t } = useTranslation("dashboard", {
     keyPrefix: "communitySettingsPage",
   });
@@ -91,3 +92,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminCommunitySettingsPage = withAdminGuard(AdminCommunitySettingsPage);
+
+export default ProtectedAdminCommunitySettingsPage;

--- a/frontend/src/pages/dashboard/admin/community/tags/index.js
+++ b/frontend/src/pages/dashboard/admin/community/tags/index.js
@@ -12,6 +12,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const slugify = (text) =>
   text
@@ -20,7 +21,7 @@ const slugify = (text) =>
     .replace(/[^\w ]+/g, "")
     .replace(/ +/g, "-");
 
-export default function AdminTagsPage() {
+function AdminTagsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "communityTagsPage" });
   const [tags, setTags] = useState([]);
   const [newTag, setNewTag] = useState("");
@@ -213,3 +214,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminTagsPage = withAdminGuard(AdminTagsPage);
+
+export default ProtectedAdminTagsPage;

--- a/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/coupons/edit/[id].js
@@ -3,8 +3,9 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchCouponById, updateCoupon } from "@/services/admin/couponService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditCouponPage() {
+function EditCouponPage() {
   const router = useRouter();
   const { id } = router.query;
   const [code, setCode] = useState("");
@@ -72,3 +73,7 @@ export default function EditCouponPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedEditCouponPage = withAdminGuard(EditCouponPage);
+
+export default ProtectedEditCouponPage;

--- a/frontend/src/pages/dashboard/admin/coupons/index.js
+++ b/frontend/src/pages/dashboard/admin/coupons/index.js
@@ -3,8 +3,9 @@ import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchCoupons, deleteCoupon } from "@/services/admin/couponService";
 import Link from "next/link";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminCouponsPage() {
+function AdminCouponsPage() {
   const [coupons, setCoupons] = useState([]);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
@@ -126,3 +127,7 @@ export default function AdminCouponsPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedAdminCouponsPage = withAdminGuard(AdminCouponsPage);
+
+export default ProtectedAdminCouponsPage;

--- a/frontend/src/pages/dashboard/admin/coupons/new.js
+++ b/frontend/src/pages/dashboard/admin/coupons/new.js
@@ -13,6 +13,7 @@ import {
   validateCode,
 } from "@/services/admin/couponService";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const createCouponSchema = (t) =>
   z
@@ -67,7 +68,7 @@ const createCouponSchema = (t) =>
       }
     );
 
-export default function NewCouponPage() {
+function NewCouponPage() {
   const { t, i18n } = useTranslation("dashboard", { keyPrefix: "couponsPage" });
   const router = useRouter();
   const [serverError, setServerError] = useState(null);
@@ -219,3 +220,6 @@ export async function getStaticProps({ locale }) {
   };
 }
 
+const ProtectedNewCouponPage = withAdminGuard(NewCouponPage);
+
+export default ProtectedNewCouponPage;

--- a/frontend/src/pages/dashboard/admin/currency/languages/create.js
+++ b/frontend/src/pages/dashboard/admin/currency/languages/create.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/settings/languages/create.js
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState } from "react";
@@ -5,7 +6,7 @@ import { useRouter } from "next/router";
 import { FaSave, FaArrowLeft } from "react-icons/fa";
 import logger from "@/utils/logger";
 
-export default function CreateLanguagePage() {
+function CreateLanguagePage() {
   const router = useRouter();
   const [form, setForm] = useState({
     label: "",
@@ -118,3 +119,7 @@ export default function CreateLanguagePage() {
     </AdminLayout>
   );
 }
+
+const ProtectedCreateLanguagePage = withAdminGuard(CreateLanguagePage);
+
+export default ProtectedCreateLanguagePage;

--- a/frontend/src/pages/dashboard/admin/currency/languages/index.js
+++ b/frontend/src/pages/dashboard/admin/currency/languages/index.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/settings/languages/index.js
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState } from "react";
@@ -42,7 +43,7 @@ const mockLanguages = [
   },
 ];
 
-export default function LanguageManagerPage() {
+function LanguageManagerPage() {
   const [languages, setLanguages] = useState(mockLanguages);
 
   const toggleActive = (id) => {
@@ -158,3 +159,7 @@ export default function LanguageManagerPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedLanguageManagerPage = withAdminGuard(LanguageManagerPage);
+
+export default ProtectedLanguageManagerPage;

--- a/frontend/src/pages/dashboard/admin/groups/[id].js
+++ b/frontend/src/pages/dashboard/admin/groups/[id].js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // Enhanced Admin Group Details Page (Final Polished UI with All Tabs and Overview Enhancements)
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -26,7 +27,7 @@ import { toast } from 'react-toastify';
 
 // Continue from your existing AdminGroupDetailsPage component
 
-export default function AdminGroupDetailsPage() {
+function AdminGroupDetailsPage() {
   const router = useRouter();
   const { id } = router.query;
   const [group, setGroup] = useState();
@@ -541,3 +542,6 @@ export default function AdminGroupDetailsPage() {
   );
 }
 
+const ProtectedAdminGroupDetailsPage = withAdminGuard(AdminGroupDetailsPage);
+
+export default ProtectedAdminGroupDetailsPage;

--- a/frontend/src/pages/dashboard/admin/groups/index.js
+++ b/frontend/src/pages/dashboard/admin/groups/index.js
@@ -14,6 +14,7 @@ import {
 import groupService from '@/services/groupService';
 import { toast } from 'react-toastify';
 import ConfirmModal from '@/components/common/ConfirmModal';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const imagePool = [
   'https://media.npr.org/assets/img/2012/01/25/newnewearth_wide-e15c88c202099fecf4a9d6f6f0e2a19826d9a26f.jpg?s=1400&c=100&f=jpeg',
@@ -22,7 +23,7 @@ const imagePool = [
 ];
 
 
-export default function AdminGroupsIndex() {
+function AdminGroupsIndex() {
   const [groups, setGroups] = useState([]);
   const [search, setSearch] = useState('');
   const debouncedSearch = useDebounce(search, 500);
@@ -426,3 +427,7 @@ export default function AdminGroupsIndex() {
     </AdminLayout>
   );
 }
+
+const ProtectedAdminGroupsIndex = withAdminGuard(AdminGroupsIndex);
+
+export default ProtectedAdminGroupsIndex;

--- a/frontend/src/pages/dashboard/admin/index.js
+++ b/frontend/src/pages/dashboard/admin/index.js
@@ -4,7 +4,6 @@ import { useTranslation } from "next-i18next";
 import nextI18NextConfig from "../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import useAuthStore from "@/store/auth/authStore";
-import withAdminGuard from "@/hooks/withAdminGuard";
 import WelcomeBanner from "@/components/admin/WelcomeBanner";
 import StatsGrid from "@/components/admin/StatsGrid";
 import Link from "next/link";
@@ -22,6 +21,7 @@ import InstructorActivityChart from "@/components/admin/charts/InstructorActivit
 import { fetchRecentAlerts } from "@/services/admin/alertService";
 import { fetchFlaggedMessages } from "@/services/admin/moderationService";
 import { fetchLicenseStatus } from "@/services/admin/licenseService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 function AdminDashboardHome() {
   const { user } = useAuthStore();

--- a/frontend/src/pages/dashboard/admin/notifications/index.js
+++ b/frontend/src/pages/dashboard/admin/notifications/index.js
@@ -4,8 +4,9 @@ import AdminLayout from '@/components/layouts/AdminLayout';
 import { FaBell, FaCalendarAlt, FaChalkboardTeacher, FaCheckCircle, FaTimes } from 'react-icons/fa';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import LinkText from '@/components/shared/LinkText';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminNotificationsPage() {
+function AdminNotificationsPage() {
   const [filter, setFilter] = useState('all');
   const notifications = useNotificationStore((state) => state.items);
   const fetchNotifications = useNotificationStore((state) => state.fetch);
@@ -112,3 +113,7 @@ export default function AdminNotificationsPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedAdminNotificationsPage = withAdminGuard(AdminNotificationsPage);
+
+export default ProtectedAdminNotificationsPage;

--- a/frontend/src/pages/dashboard/admin/offers/new.js
+++ b/frontend/src/pages/dashboard/admin/offers/new.js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { createOffer } from "@/services/admin/offerService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const NewOfferPage = () => {
   const router = useRouter();
@@ -155,4 +156,8 @@ const NewOfferPage = () => {
 
 NewOfferPage.getLayout = (page) => <AdminLayout>{page}</AdminLayout>;
 
-export default NewOfferPage;
+const ProtectedNewOfferPage = withAdminGuard(NewOfferPage);
+
+ProtectedNewOfferPage.getLayout = NewOfferPage.getLayout;
+
+export default ProtectedNewOfferPage;

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
@@ -12,8 +12,9 @@ import {
   updateClassRule,
   deleteClassRule,
 } from "@/services/admin/classRuleService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function ClassRulesPage() {
+function ClassRulesPage() {
   const router = useRouter();
   const { id } = router.query;
   const { t, i18n } = useTranslation('dashboard');
@@ -92,3 +93,8 @@ export async function getServerSideProps({ locale }) {
   };
 }
 
+const ProtectedClassRulesPage = withAdminGuard(ClassRulesPage);
+
+ProtectedClassRulesPage.getLayout = ClassRulesPage.getLayout;
+
+export default ProtectedClassRulesPage;

--- a/frontend/src/pages/dashboard/admin/payments/OverviewTab.js
+++ b/frontend/src/pages/dashboard/admin/payments/OverviewTab.js
@@ -12,6 +12,7 @@ import {
   Tooltip,
   Legend,
 } from "chart.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 ChartJS.register(
   CategoryScale,
@@ -23,7 +24,7 @@ ChartJS.register(
   Legend,
 );
 
-export default function OverviewTab({ transactions = [], methods = [], payouts = [], onViewAll }) {
+function OverviewTab({ transactions = [], methods = [], payouts = [], onViewAll }) {
   const { t } = useTranslation('dashboard');
   // Treat "success" as equivalent to "paid" for older records
   const totalRevenue = transactions
@@ -211,3 +212,7 @@ export default function OverviewTab({ transactions = [], methods = [], payouts =
     </div>
   );
 }
+
+const ProtectedOverviewTab = withAdminGuard(OverviewTab);
+
+export default ProtectedOverviewTab;

--- a/frontend/src/pages/dashboard/admin/payments/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/payments/edit/[id].js
@@ -1,7 +1,8 @@
 import { useRouter } from 'next/router';
 import PaymentProviderConfig from '@/components/payments/PaymentProviderConfig';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditPaymentProviderDashboard() {
+function EditPaymentProviderDashboard() {
   const { id } = useRouter().query;
 
   return (
@@ -11,3 +12,7 @@ export default function EditPaymentProviderDashboard() {
     </div>
   );
 }
+
+const ProtectedEditPaymentProviderDashboard = withAdminGuard(EditPaymentProviderDashboard);
+
+export default ProtectedEditPaymentProviderDashboard;

--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -38,6 +38,7 @@ import useAuthStore from '@/store/auth/authStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
 import useAdminNotice from '@/hooks/useAdminNotice';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 
 const defaultConfig = {
@@ -57,7 +58,7 @@ const defaultConfig = {
 };
 
 
-export default function AdminPaymentsPage() {
+function AdminPaymentsPage() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard');
   const user = useAuthStore((s) => s.user);
@@ -759,3 +760,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminPaymentsPage = withAdminGuard(AdminPaymentsPage);
+
+export default ProtectedAdminPaymentsPage;

--- a/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
@@ -4,8 +4,9 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
 import PaymentProviderConfig from "@/components/payments/PaymentProviderConfig";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function ConfigurePaymentMethodPage() {
+function ConfigurePaymentMethodPage() {
   const router = useRouter();
   const { id } = router.query;
   const { t } = useTranslation('dashboard');
@@ -29,3 +30,7 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+const ProtectedConfigurePaymentMethodPage = withAdminGuard(ConfigurePaymentMethodPage);
+
+export default ProtectedConfigurePaymentMethodPage;

--- a/frontend/src/pages/dashboard/admin/payments/methods/create.js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/create.js
@@ -12,6 +12,7 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const useAdminNotice = () => {
   const user = useAuthStore((state) => state.user);
@@ -31,7 +32,7 @@ const useAdminNotice = () => {
   };
 };
 
-export default function CreatePaymentMethodPage() {
+function CreatePaymentMethodPage() {
   const router = useRouter();
   const { t } = useTranslation('dashboard');
   const [form, setForm] = useState({
@@ -191,3 +192,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedCreatePaymentMethodPage = withAdminGuard(CreatePaymentMethodPage);
+
+export default ProtectedCreatePaymentMethodPage;

--- a/frontend/src/pages/dashboard/admin/plans/create.js
+++ b/frontend/src/pages/dashboard/admin/plans/create.js
@@ -6,8 +6,8 @@ import Link from "next/link";
 import { createPlan } from "@/services/admin/planService";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
-import withAdminGuard from "@/hooks/withAdminGuard";
 import useAuthStore from "@/store/auth/authStore";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 function CreatePlanPage() {
   const router = useRouter();

--- a/frontend/src/pages/dashboard/admin/plans/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/plans/edit/[id].js
@@ -6,8 +6,8 @@ import Link from "next/link";
 import { fetchPlanById, updatePlan } from "@/services/admin/planService";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
-import withAdminGuard from "@/hooks/withAdminGuard";
 import useAuthStore from "@/store/auth/authStore";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 function EditPlanPage() {
   const router = useRouter();

--- a/frontend/src/pages/dashboard/admin/profile/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/profile/certificates/index.js
@@ -1,5 +1,6 @@
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const dummyCertificates = [
   { id: 1, title: "React.js Mastery", date: "Jan 10, 2024", url: "/certificates/react.pdf" },
@@ -36,7 +37,7 @@ const Certificates = () => {
   );
 };
 
-export default Certificates;
+
 
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
@@ -48,3 +49,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedCertificates = withAdminGuard(Certificates);
+
+export default ProtectedCertificates;

--- a/frontend/src/pages/dashboard/admin/profile/change-password.js
+++ b/frontend/src/pages/dashboard/admin/profile/change-password.js
@@ -4,6 +4,7 @@ import { FaLock, FaEye, FaEyeSlash, FaCheckCircle, FaExclamationTriangle, FaArro
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer"; // ✅ Import Footer
 import logger from "@/utils/logger";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const ChangePasswordPage = ({ prevStep }) => {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -166,7 +167,7 @@ const ChangePasswordPage = ({ prevStep }) => {
   );
 };
 
-export default ChangePasswordPage;
+
 
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../next-i18next.config.js';
@@ -178,3 +179,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedChangePasswordPage = withAdminGuard(ChangePasswordPage);
+
+export default ProtectedChangePasswordPage;

--- a/frontend/src/pages/dashboard/admin/profile/orders/[id].js
+++ b/frontend/src/pages/dashboard/admin/profile/orders/[id].js
@@ -4,6 +4,7 @@ import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import { motion } from "framer-motion";
 import { FaCheckCircle, FaTimesCircle, FaRedo, FaDownload, FaSync, FaArrowLeft } from "react-icons/fa";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const OrderDetailsPage = () => {
   const router = useRouter();
@@ -113,7 +114,7 @@ const OrderStatusIcon = ({ status }) => {
   return <span className="bg-red-500 text-white px-3 py-1 rounded-md">Failed</span>;
 };
 
-export default OrderDetailsPage;
+
 
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
@@ -125,3 +126,7 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+const ProtectedOrderDetailsPage = withAdminGuard(OrderDetailsPage);
+
+export default ProtectedOrderDetailsPage;

--- a/frontend/src/pages/dashboard/admin/profile/orders/index.js
+++ b/frontend/src/pages/dashboard/admin/profile/orders/index.js
@@ -4,6 +4,7 @@ import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import { motion } from "framer-motion";
 import { FaCheckCircle, FaTimesCircle, FaRedo, FaSync, FaSort, FaFilter, FaShoppingCart, FaEye } from "react-icons/fa";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const OrdersPage = () => {
   const [orders, setOrders] = useState(null);
@@ -159,7 +160,7 @@ const OrderStatusIcon = ({ status }) => {
   return <FaTimesCircle className="text-red-500 text-lg" />;
 };
 
-export default OrdersPage;
+
 
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
@@ -171,3 +172,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedOrdersPage = withAdminGuard(OrdersPage);
+
+export default ProtectedOrdersPage;

--- a/frontend/src/pages/dashboard/admin/profile/payment-methods/add.js
+++ b/frontend/src/pages/dashboard/admin/profile/payment-methods/add.js
@@ -1,6 +1,7 @@
 import PaymentMethodForm from '@/components/payments/PaymentMethodForm';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AddPaymentMethodPage() {
+function AddPaymentMethodPage() {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">Add a New Payment Method</h1>
@@ -8,3 +9,7 @@ export default function AddPaymentMethodPage() {
     </div>
   );
 }
+
+const ProtectedAddPaymentMethodPage = withAdminGuard(AddPaymentMethodPage);
+
+export default ProtectedAddPaymentMethodPage;

--- a/frontend/src/pages/dashboard/admin/profile/payment-methods/index.js
+++ b/frontend/src/pages/dashboard/admin/profile/payment-methods/index.js
@@ -1,7 +1,8 @@
 import Link from 'next/link';
 import PaymentMethodList from '@/components/payments/PaymentMethodList';
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function SavedPaymentMethodsPage() {
+function SavedPaymentMethodsPage() {
   return (
     <div className="p-6">
       <div className="flex justify-between items-center mb-4">
@@ -16,3 +17,7 @@ export default function SavedPaymentMethodsPage() {
     </div>
   );
 }
+
+const ProtectedSavedPaymentMethodsPage = withAdminGuard(SavedPaymentMethodsPage);
+
+export default ProtectedSavedPaymentMethodsPage;

--- a/frontend/src/pages/dashboard/admin/profile/security-settings/index.js
+++ b/frontend/src/pages/dashboard/admin/profile/security-settings/index.js
@@ -1,6 +1,7 @@
 import Navbar from "@/components/website/sections/Navbar";
 import Footer from "@/components/website/sections/Footer";
 import { useState } from "react";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const SecuritySettings = () => {
   const [password, setPassword] = useState("");
@@ -44,7 +45,7 @@ const SecuritySettings = () => {
   );
 };
 
-export default SecuritySettings;
+
 
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
@@ -56,3 +57,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedSecuritySettings = withAdminGuard(SecuritySettings);
+
+export default ProtectedSecuritySettings;

--- a/frontend/src/pages/dashboard/admin/profile/steps/verification.js
+++ b/frontend/src/pages/dashboard/admin/profile/steps/verification.js
@@ -11,6 +11,7 @@ import {
   confirmEmailOtp,
   confirmPhoneOtp,
 } from "@/services/verificationService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const Verification = ({ onBack = () => {} }) => {
   const router = useRouter();
@@ -187,4 +188,6 @@ const Verification = ({ onBack = () => {} }) => {
   );
 };
 
-export default Verification;
+const ProtectedVerification = withAdminGuard(Verification);
+
+export default ProtectedVerification;

--- a/frontend/src/pages/dashboard/admin/settings/app/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/app/index.js
@@ -14,6 +14,7 @@ import { API_BASE_URL } from "@/config/config";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const defaultConfig = { 
   appName: "", 
@@ -25,7 +26,7 @@ const defaultConfig = {
   contactEmail: ""
 };
 
-export default function AppSettingsPage() {
+function AppSettingsPage() {
   const [config, setConfig] = useState(defaultConfig);
   const [logoFile, setLogoFile] = useState(null);
   const [faviconFile, setFaviconFile] = useState(null);
@@ -396,3 +397,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAppSettingsPage = withAdminGuard(AppSettingsPage);
+
+export default ProtectedAppSettingsPage;

--- a/frontend/src/pages/dashboard/admin/settings/blog/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/blog/index.js
@@ -11,8 +11,9 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminBlogManager() {
+function AdminBlogManager() {
   const [posts, setPosts] = useState([]);
   const { t } = useTranslation("dashboard", { keyPrefix: "blogManagerPage" });
 
@@ -232,3 +233,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminBlogManager = withAdminGuard(AdminBlogManager);
+
+export default ProtectedAdminBlogManager;

--- a/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/[id].js
@@ -8,8 +8,9 @@ import {
 } from "@/services/admin/certificateTemplateService";
 import { toSnakeCase } from "@/utils/case";
 import CertificateTemplateForm from "@/components/admin/certificates/CertificateTemplateForm";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function EditCertificateTemplate() {
+function EditCertificateTemplate() {
   const router = useRouter();
   const { id } = router.query;
 
@@ -60,3 +61,7 @@ export default function EditCertificateTemplate() {
     </AdminLayout>
   );
 }
+
+const ProtectedEditCertificateTemplate = withAdminGuard(EditCertificateTemplate);
+
+export default ProtectedEditCertificateTemplate;

--- a/frontend/src/pages/dashboard/admin/settings/certificates/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/create.js
@@ -3,8 +3,9 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { saveTemplate } from "@/services/admin/certificateTemplateService";
 import CertificateTemplateForm from "@/components/admin/certificates/CertificateTemplateForm";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function CreateCertificateTemplate() {
+function CreateCertificateTemplate() {
   const router = useRouter();
 
   const initialValues = {
@@ -44,3 +45,7 @@ export default function CreateCertificateTemplate() {
     </AdminLayout>
   );
 }
+
+const ProtectedCreateCertificateTemplate = withAdminGuard(CreateCertificateTemplate);
+
+export default ProtectedCreateCertificateTemplate;

--- a/frontend/src/pages/dashboard/admin/settings/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/index.js
@@ -19,8 +19,9 @@ import {
   duplicateTemplate,
 } from "@/services/admin/certificateTemplateService";
 import { toast } from "react-toastify";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function CertificateTemplatesPage() {
+function CertificateTemplatesPage() {
   const [templates, setTemplates] = useState([]);
   const [previewTemplate, setPreviewTemplate] = useState(null);
 
@@ -157,3 +158,7 @@ export default function CertificateTemplatesPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedCertificateTemplatesPage = withAdminGuard(CertificateTemplatesPage);
+
+export default ProtectedCertificateTemplatesPage;

--- a/frontend/src/pages/dashboard/admin/settings/contact/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/contact/index.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/settings/contact.js
 import { useState, useEffect } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
@@ -18,7 +19,7 @@ const initialConfig = {
   mapEmbedUrl: "https://maps.google.com/embed?pb=...",
 };
 
-export default function AdminContactSettings() {
+function AdminContactSettings() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'contactPage' });
   const [config, setConfig] = useState(initialConfig);
   const [loading, setLoading] = useState(false);
@@ -149,3 +150,6 @@ export async function getStaticProps({ locale }) {
   };
 }
 
+const ProtectedAdminContactSettings = withAdminGuard(AdminContactSettings);
+
+export default ProtectedAdminContactSettings;

--- a/frontend/src/pages/dashboard/admin/settings/email-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/email-config/index.js
@@ -9,6 +9,7 @@ import { fetchEmailConfig, updateEmailConfig } from "@/services/admin/emailConfi
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const defaultConfig = {
   fromName: "SkillBridge Admin",
@@ -22,7 +23,7 @@ const defaultConfig = {
   method: "smtp",
 };
 
-export default function EmailConfigPage() {
+function EmailConfigPage() {
   const { t } = useTranslation('dashboard');
   const [form, setForm] = useState(defaultConfig);
 
@@ -187,3 +188,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedEmailConfigPage = withAdminGuard(EmailConfigPage);
+
+export default ProtectedEmailConfigPage;

--- a/frontend/src/pages/dashboard/admin/settings/faqs/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/faqs/index.js
@@ -7,10 +7,11 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const fetcher = (url) => api.get(url).then((res) => res.data.data);
 
-export default function AdminFaqsPage() {
+function AdminFaqsPage() {
   const { t, i18n } = useTranslation("dashboard", { keyPrefix: "faqsPage" });
   const { data: faqs = [], mutate } = useSWR("/faqs", fetcher);
   const [newFaq, setNewFaq] = useState({ question: "", answer: "" });
@@ -174,3 +175,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminFaqsPage = withAdminGuard(AdminFaqsPage);
+
+export default ProtectedAdminFaqsPage;

--- a/frontend/src/pages/dashboard/admin/settings/footer/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/footer/index.js
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const defaultFooter = {
   about: "SkillBridge connects learners with expert instructors worldwide.",
@@ -35,7 +36,7 @@ const defaultFooter = {
   },
 };
 
-export default function FooterSettingsPage() {
+function FooterSettingsPage() {
   const updateStore = useAppConfigStore((state) => state.update);
   const fetchConfig = useAppConfigStore((state) => state.fetch);
   const [config, setConfig] = useState({});
@@ -294,3 +295,7 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+const ProtectedFooterSettingsPage = withAdminGuard(FooterSettingsPage);
+
+export default ProtectedFooterSettingsPage;

--- a/frontend/src/pages/dashboard/admin/settings/language-config/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/language-config/index.js
@@ -8,8 +8,9 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import useSWR, { mutate as mutateGlobal } from "swr";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function LanguageConfigPage() {
+function LanguageConfigPage() {
   const { t, i18n } = useTranslation("dashboard");
   const [config, setConfig] = useState({ defaultLanguage: "en" });
   const { data: configData } = useSWR("/app-config", fetchAppConfig, {
@@ -84,3 +85,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedLanguageConfigPage = withAdminGuard(LanguageConfigPage);
+
+export default ProtectedLanguageConfigPage;

--- a/frontend/src/pages/dashboard/admin/settings/languages/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/create.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/settings/languages/create.js
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState, useEffect } from "react";
@@ -12,7 +13,7 @@ import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 // Include the common namespace since it's used across the site
 const predefinedNamespaces = ["common", "auth", "website", "dashboard"];
 
-export default function CreateLanguagePage() {
+function CreateLanguagePage() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'languagesPage' });
   const [form, setForm] = useState({
@@ -276,3 +277,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedCreateLanguagePage = withAdminGuard(CreateLanguagePage);
+
+export default ProtectedCreateLanguagePage;

--- a/frontend/src/pages/dashboard/admin/settings/languages/edit/[code].js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/edit/[code].js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/settings/languages/edit/[code].js
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -23,7 +24,7 @@ const fetchTranslations = async (code) => {
 
 const namespaces = ["common", "website", "dashboard", "auth"];
 
-export default function EditLanguagePage() {
+function EditLanguagePage() {
   const router = useRouter();
   const { code } = router.query;
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'languagesPage' });
@@ -323,3 +324,7 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+const ProtectedEditLanguagePage = withAdminGuard(EditLanguagePage);
+
+export default ProtectedEditLanguagePage;

--- a/frontend/src/pages/dashboard/admin/settings/languages/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/languages/index.js
@@ -10,10 +10,11 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { toast } from "react-toastify";
 import handleApiError from "@/utils/apiError";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const fetcher = url => api.get(url).then(res => res.data.data);
 
-export default function LanguagesPage() {
+function LanguagesPage() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'languagesPage' });
   const { data: languages, mutate } = useSWR("/languages", fetcher);
@@ -175,3 +176,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedLanguagesPage = withAdminGuard(LanguagesPage);
+
+export default ProtectedLanguagesPage;

--- a/frontend/src/pages/dashboard/admin/settings/policies/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/policies/index.js
@@ -9,6 +9,7 @@ import DOMPurify from "isomorphic-dompurify";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 // ReactQuill (lazy load to avoid SSR issues)
 const ReactQuill = dynamic(() => import("react-quill"), { ssr: false });
@@ -21,7 +22,7 @@ const normalizeTitle = (title) =>
     .toLowerCase()
     .replace(/\b\w/g, (c) => c.toUpperCase());
 
-export default function AdminPoliciesPage() {
+function AdminPoliciesPage() {
   const { t, i18n } = useTranslation("dashboard", { keyPrefix: "policiesPage" });
 
   const defaultPolicies = {
@@ -237,3 +238,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminPoliciesPage = withAdminGuard(AdminPoliciesPage);
+
+export default ProtectedAdminPoliciesPage;

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/create.js
@@ -15,6 +15,7 @@ import useMessageStore from "@/store/messages/messageStore";
 import { createPopupAnnouncement } from "@/services/admin/popupAnnouncementService";
 import { fetchPageList } from "@/services/admin/seoConfigService";
 import PopupPreviewModal from "@/components/admin/settings/PopupPreviewModal";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const RichTextEditor = dynamic(() => import("react-quill"), { ssr: false });
 
@@ -34,7 +35,7 @@ const useAdminNotice = () => {
   };
 };
 
-export default function CreateAnnouncementForm() {
+function CreateAnnouncementForm() {
   const router = useRouter();
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'popupAnnouncementsPage' });
   const notify = useAdminNotice();
@@ -281,3 +282,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedCreateAnnouncementForm = withAdminGuard(CreateAnnouncementForm);
+
+export default ProtectedCreateAnnouncementForm;

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/edit/[id].js
@@ -13,10 +13,11 @@ import {
   updatePopupAnnouncement,
 } from "@/services/admin/popupAnnouncementService";
 import { fetchPageList } from "@/services/admin/seoConfigService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const RichTextEditor = dynamic(() => import("react-quill"), { ssr: false });
 
-export default function EditAnnouncementForm() {
+function EditAnnouncementForm() {
   const router = useRouter();
   const { id } = router.query;
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'popupAnnouncementsPage' });
@@ -287,3 +288,6 @@ export async function getServerSideProps({ locale }) {
   };
 }
 
+const ProtectedEditAnnouncementForm = withAdminGuard(EditAnnouncementForm);
+
+export default ProtectedEditAnnouncementForm;

--- a/frontend/src/pages/dashboard/admin/settings/popup-announcement/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/popup-announcement/index.js
@@ -12,8 +12,9 @@ import {
   deletePopupAnnouncement,
 } from "@/services/admin/popupAnnouncementService";
 import PopupPreviewModal from "@/components/admin/settings/PopupPreviewModal";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function PopupAnnouncementsIndex() {
+function PopupAnnouncementsIndex() {
   const { t, i18n } = useTranslation('dashboard', { keyPrefix: 'popupAnnouncementsPage' });
   const [announcements, setAnnouncements] = useState([]);
   const [previewAnn, setPreviewAnn] = useState(null);
@@ -137,3 +138,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedPopupAnnouncementsIndex = withAdminGuard(PopupAnnouncementsIndex);
+
+export default ProtectedPopupAnnouncementsIndex;

--- a/frontend/src/pages/dashboard/admin/settings/seo/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/seo/index.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/settings/seo/index.js
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState, useEffect } from "react";
@@ -37,7 +38,7 @@ const defaultConfig = {
   jsonSchema: "",
 };
 
-export default function SEOSettingsPage() {
+function SEOSettingsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "seoPage" });
   const tabs = [
     { key: "overview", label: t("tabs.overview"), icon: <FaGlobe /> },
@@ -113,3 +114,7 @@ export default function SEOSettingsPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedSEOSettingsPage = withAdminGuard(SEOSettingsPage);
+
+export default ProtectedSEOSettingsPage;

--- a/frontend/src/pages/dashboard/admin/settings/social_login/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/social_login/index.js
@@ -11,6 +11,7 @@ import useMessageStore from "@/store/messages/messageStore";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 const availableIcons = {
   google: <FaGoogle />,
@@ -89,7 +90,7 @@ const providerHasCredentials = (p) => {
   return p.clientId && p.clientSecret;
 };
 
-export default function SocialLoginSettingsPage() {
+function SocialLoginSettingsPage() {
   const [globalActive, setGlobalActive] = useState(true);
   const [providers, setProviders] = useState(initialProviders);
   const [recaptchaActive, setRecaptchaActive] = useState(true);
@@ -569,3 +570,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedSocialLoginSettingsPage = withAdminGuard(SocialLoginSettingsPage);
+
+export default ProtectedSocialLoginSettingsPage;

--- a/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/thirdParty/index.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/settings/thirdParty.js
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { useState, useEffect } from "react";
@@ -27,7 +28,7 @@ import GoogleCalendarModal from "@/components/admin/integrations/GoogleCalendarM
 import GoogleAnalyticsModal from "@/components/admin/integrations/GoogleAnalyticsModal";
 import GoogleAdSenseModal from "@/components/admin/integrations/GoogleAdSenseModal";
 
-export default function ThirdPartyIntegrationsPage() {
+function ThirdPartyIntegrationsPage() {
   const { t } = useTranslation('dashboard');
   const [settings, setSettings] = useState({});
   const [loading, setLoading] = useState(false);
@@ -235,3 +236,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedThirdPartyIntegrationsPage = withAdminGuard(ThirdPartyIntegrationsPage);
+
+export default ProtectedThirdPartyIntegrationsPage;

--- a/frontend/src/pages/dashboard/admin/support/analytics/index.js
+++ b/frontend/src/pages/dashboard/admin/support/analytics/index.js
@@ -6,8 +6,9 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { fetchSupportAnalytics } from "@/services/supportService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminSupportAnalytics() {
+function AdminSupportAnalytics() {
   const { t } = useTranslation('dashboard');
   const [stats, setStats] = useState({ open: 0, resolved: 0, closed: 0, avg: '0h' });
   const [chart, setChart] = useState([]);
@@ -71,3 +72,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminSupportAnalytics = withAdminGuard(AdminSupportAnalytics);
+
+export default ProtectedAdminSupportAnalytics;

--- a/frontend/src/pages/dashboard/admin/support/index.js
+++ b/frontend/src/pages/dashboard/admin/support/index.js
@@ -8,8 +8,9 @@ import { fetchRecentActivity } from "@/services/supportService";
 import formatRelativeTime from "@/utils/relativeTime";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminSupportHome() {
+function AdminSupportHome() {
   const { t } = useTranslation('dashboard');
   const [activity, setActivity] = useState([]);
 
@@ -117,3 +118,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminSupportHome = withAdminGuard(AdminSupportHome);
+
+export default ProtectedAdminSupportHome;

--- a/frontend/src/pages/dashboard/admin/support/tickets/[id].js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/[id].js
@@ -18,8 +18,9 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { FiArrowLeft, FiRefreshCw, FiAlertTriangle, FiCheckCircle, FiMessageSquare, FiUser, FiCalendar, FiTag } from "react-icons/fi";
 import { FaSpinner } from "react-icons/fa";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminTicketDetail() {
+function AdminTicketDetail() {
   const { t } = useTranslation("dashboard");
   const router = useRouter();
   const { id } = router.query;
@@ -282,3 +283,7 @@ export async function getServerSideProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminTicketDetail = withAdminGuard(AdminTicketDetail);
+
+export default ProtectedAdminTicketDetail;

--- a/frontend/src/pages/dashboard/admin/support/tickets/index.js
+++ b/frontend/src/pages/dashboard/admin/support/tickets/index.js
@@ -9,8 +9,9 @@ import PageHead from "@/components/common/PageHead";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import TicketCard from "@/components/support/TicketCard";
 import { fetchAllTickets } from "@/services/supportService";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
-export default function AdminSupportTicketsPage() {
+function AdminSupportTicketsPage() {
   const [tickets, setTickets] = useState([]);
   const [status, setStatus] = useState("");
   const [priority, setPriority] = useState("");
@@ -311,3 +312,7 @@ export async function getStaticProps({ locale }) {
     },
   };
 }
+
+const ProtectedAdminSupportTicketsPage = withAdminGuard(AdminSupportTicketsPage);
+
+export default ProtectedAdminSupportTicketsPage;

--- a/frontend/src/pages/dashboard/admin/users/create.js
+++ b/frontend/src/pages/dashboard/admin/users/create.js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/users/create.js
 import { useState } from "react";
 import { useRouter } from "next/router";
@@ -5,7 +6,7 @@ import AdminLayout from "@/components/layouts/AdminLayout";
 import AddUserModal from "@/components/admin/users/AddUserModal";
 import { createUser } from "@/services/admin/userService";
 
-export default function CreateUserPage() {
+function CreateUserPage() {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(true);
 
@@ -24,3 +25,7 @@ export default function CreateUserPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedCreateUserPage = withAdminGuard(CreateUserPage);
+
+export default ProtectedCreateUserPage;

--- a/frontend/src/pages/dashboard/admin/users/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/users/edit/[id].js
@@ -1,3 +1,4 @@
+import withAdminGuard from "@/hooks/withAdminGuard";
 // pages/dashboard/admin/users/edit/[id].js
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -6,7 +7,7 @@ import EditUserForm from "@/components/admin/users/EditUserForm";
 import { fetchUserById } from "@/services/admin/userService";
 import { toast } from "react-toastify";
 
-export default function EditUserPage() {
+function EditUserPage() {
   const router = useRouter();
   const { id } = router.query;
   const [user, setUser] = useState(null);
@@ -32,3 +33,7 @@ export default function EditUserPage() {
     </AdminLayout>
   );
 }
+
+const ProtectedEditUserPage = withAdminGuard(EditUserPage);
+
+export default ProtectedEditUserPage;

--- a/frontend/src/pages/dashboard/admin/users/index.js
+++ b/frontend/src/pages/dashboard/admin/users/index.js
@@ -6,9 +6,9 @@ import nextI18NextConfig from "../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import UserList from "@/components/admin/users/UserList";
 import { fetchAllUsers } from "@/services/admin/userService";
-import withAdminGuard from "@/hooks/withAdminGuard";
 import { toast } from "react-toastify";
 import logger from "@/utils/logger";
+import withAdminGuard from "@/hooks/withAdminGuard";
 
 function UsersPage() {
   const { t } = useTranslation("dashboard");


### PR DESCRIPTION
## Summary
- wrap every dashboard admin page with the shared admin guard to block unauthorized visitors
- preserve existing page layouts while introducing the guard wrappers

## Testing
- npm run lint *(fails: pre-existing lint warnings/errors around img usage, missing dependencies, and test component display names)*

------
https://chatgpt.com/codex/tasks/task_e_68d02554a4c48328bb8305cbc27d828b