### PR TITLE
Fix duplicate withAdminGuard imports in admin payments pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/payments/index.js
+++ b/frontend/src/pages/dashboard/admin/payments/index.js
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layouts/AdminLayout";
-import withAdminGuard from "@/hooks/withAdminGuard";
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../next-i18next.config.js';

--- a/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/configure/[id].js
@@ -1,5 +1,4 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
-import withAdminGuard from "@/hooks/withAdminGuard";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";

--- a/frontend/src/pages/dashboard/admin/payments/methods/create.js
+++ b/frontend/src/pages/dashboard/admin/payments/methods/create.js
@@ -1,5 +1,4 @@
 import AdminLayout from "@/components/layouts/AdminLayout";
-import withAdminGuard from "@/hooks/withAdminGuard";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { FaSave, FaArrowLeft } from "react-icons/fa";


### PR DESCRIPTION
## Summary
- remove duplicate withAdminGuard imports from admin payment pages that caused "Identifier has already been declared" build errors

## Testing
- npm run lint *(fails: existing lint warnings/errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d036316e7c832896506f28d1be8e62