### PR TITLE
Fix shared alias resolution for Turbopack

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -224,6 +224,11 @@ const nextConfig = {
   experimental: {
     largePageDataBytes: 256 * 1024,
     externalDir: true,
+    turbo: {
+      resolveAlias: {
+        '@shared': path.resolve(__dirname, '../shared'),
+      },
+    },
   },
   webpack(config) {
     config.resolve.alias['@shared'] = path.resolve(__dirname, '../shared');


### PR DESCRIPTION
## Summary
- register the `@shared` path alias with Turbopack so shared assets resolve when using the dev server

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d04283d23083288960faf185f69a2c