### PR TITLE
Add API base URL fallback for instructor class media

### DIFF
--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -1,4 +1,5 @@
 import api from "@/services/api/api";
+import { API_BASE_URL } from "@/config/config";
 import { toDateInput } from "@/utils/date";
 import { safeEncodeURI } from "@/utils/url";
 import { computeScheduleStatus } from "@/utils/classSchedule";
@@ -9,15 +10,15 @@ const formatClass = (cls) => {
     ...rest,
     publishStatus: status,
     cover_image: cls.cover_image
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`
       : null,
     demo_video_url: cls.demo_video_url
       ? safeEncodeURI(
-          `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
+          `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.demo_video_url}`,
         )
       : null,
     instructor_image: cls.instructor_image
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.instructor_image}`
       : null,
     trending: Boolean(cls.trending),
 


### PR DESCRIPTION
## Summary
- import the shared API_BASE_URL configuration into the instructor class service
- wrap instructor media URLs with the same API base URL fallback as the student class service
- keep safeEncodeURI surrounding the full demo video URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0e6b1a0688328a7416f4be36bdb37