### PR TITLE
Refactor dashboard links to animated anchors

### DIFF
--- a/frontend/src/components/dashboard/AIRecommendations.js
+++ b/frontend/src/components/dashboard/AIRecommendations.js
@@ -3,6 +3,8 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
 
+const MotionLink = motion(Link);
+
 const defaultRecommendedCourses = [
   { id: 4, title: "Advanced JavaScript", category: "JavaScript" },
   { id: 5, title: "Python for Data Science", category: "Data Science" },
@@ -31,14 +33,13 @@ const AIRecommendations = ({ recommendedCourses }) => {
             <p className="text-gray-300">
               {t('dashboardPage.category')}: {course.category}
             </p>
-            <Link href={`/dashboard/course/${course.id}`}>
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                className="mt-4 bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
-              >
-                {t('dashboardPage.view_course')}
-              </motion.button>
-            </Link>
+            <MotionLink
+              href={`/dashboard/course/${course.id}`}
+              whileHover={{ scale: 1.05 }}
+              className="mt-4 inline-flex items-center justify-center bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
+            >
+              {t('dashboardPage.view_course')}
+            </MotionLink>
           </motion.div>
         ))}
       </div>

--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -11,6 +11,8 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../next-i18next.config.js";
 
+const MotionLink = motion(Link);
+
 const allCourses = [
   { id: 1, title: "Mastering React.js", category: "JavaScript", progress: 80 },
   {
@@ -80,14 +82,13 @@ const DashboardPage = () => {
                   style={{ width: `${course.progress}%` }}
                 />
               </div>
-              <Link href={`/dashboard/course/${course.id}`}>
-                <motion.button
-                  whileHover={{ scale: 1.05 }}
-                  className="mt-4 bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
-                >
-                  {t('dashboardPage.continue_learning')}
-                </motion.button>
-              </Link>
+              <MotionLink
+                href={`/dashboard/course/${course.id}`}
+                whileHover={{ scale: 1.05 }}
+                className="mt-4 inline-flex items-center justify-center bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
+              >
+                {t('dashboardPage.continue_learning')}
+              </MotionLink>
             </motion.div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- replace Link-wrapped motion buttons in the student dashboard with a MotionLink helper so the DOM renders a single focusable anchor
- update AI course recommendations to reuse the MotionLink helper while keeping existing hover animations and styling

## Testing
- npm run lint *(fails: pre-existing warnings and errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e6af54b88328aa383358e34c0509