### PR TITLE
Move i18next imports to top of course dashboard

### DIFF
--- a/frontend/src/pages/dashboard/course/[id].js
+++ b/frontend/src/pages/dashboard/course/[id].js
@@ -4,6 +4,8 @@ import Footer from "@/components/website/sections/Footer";
 import CourseProgress from "@/components/classes/CourseProgress";
 import dynamic from "next/dynamic";
 import { motion } from "framer-motion";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../../next-i18next.config.js";
 
 import { Star, Play, Pause, Volume2, VolumeX, Expand, Minimize, FastForward, Gauge, Lock, Send, CheckCircle } from "lucide-react";
 
@@ -272,9 +274,6 @@ const CourseDashboard = () => {
 };
 
 export default CourseDashboard;
-
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import nextI18NextConfig from '../../../../next-i18next.config.js';
 
 export async function getServerSideProps({ locale }) {
   return {


### PR DESCRIPTION
## Summary
- relocate the next-i18next imports to the top of the course dashboard page so they are grouped with the other import statements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0e6ae486c8328925e1c1a117674f3