### PR TITLE
Enable Tailwind dark mode and update release checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -11,5 +11,6 @@ Use this checklist to verify the repository is clean before creating a release p
 - [ ] Run frontend tests with `npm test` from the `frontend` directory.
 - [ ] Review documentation for accuracy and completeness.
 - [ ] Verify the application builds successfully.
+- [ ] Verify the light/dark mode toggle in the dashboard header switches themes without visual regressions.
 
 Following this checklist helps keep release packages lean and reliable.

--- a/frontend/tailwind.config.mjs
+++ b/frontend/tailwind.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 const config = {
+  darkMode: "class",
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- enable class-based dark mode selectors in the Tailwind configuration
- document a manual check for the dashboard header light/dark mode toggle in the release checklist

## Testing
- npm run dev
- npm test -- --watch=false *(fails: multiple pre-existing frontend test failures, e.g., missing i18next setup in InstructorTutorialsPage.test and missing subscriptionService mock in InstructorSettingsPage.test)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e6a55dc0832894fd12b9e9807e60