### PR TITLE
Refactor instructor schedule to reuse class fetch

### DIFF
--- a/frontend/src/components/instructors/InstructorDashboard.js
+++ b/frontend/src/components/instructors/InstructorDashboard.js
@@ -52,6 +52,7 @@ function InstructorDashboard() {
   const [events, setEvents] = useState([]);
   const [tutorials, setTutorials] = useState([]);
   const [classes, setClasses] = useState([]);
+  const [classesLoaded, setClassesLoaded] = useState(false);
   const [students, setStudents] = useState([]);
   const [assignments, setAssignments] = useState([]);
   const [certificates, setCertificates] = useState([]);
@@ -76,23 +77,8 @@ function InstructorDashboard() {
       }
     }
     loadStats();
-    async function loadEvents() {
-      if (!user?.id) return;
-      try {
-        const data = await fetchInstructorScheduleEvents(user.id);
-        const parsed = data.map((e) => ({
-          ...e,
-          start: new Date(e.start),
-          ...(e.end ? { end: new Date(e.end) } : {}),
-        }));
-        setEvents(parsed);
-      } catch (err) {
-        console.error('Failed to load schedule events', err);
-      }
-    }
-    loadEvents();
-
     async function loadLists() {
+      setClassesLoaded(false);
       if (process.env.NODE_ENV === 'development') {
         const { tutorials, classes, students, assignments, certificates } =
           instructorDashboardMocks;
@@ -101,6 +87,7 @@ function InstructorDashboard() {
         setStudents(students);
         setAssignments(assignments);
         setCertificates(certificates);
+        setClassesLoaded(true);
         return;
       }
 
@@ -112,10 +99,12 @@ function InstructorDashboard() {
       }
 
       try {
-        const cls = await fetchInstructorClasses();
+        const cls = await fetchInstructorClasses(user?.id);
         setClasses(cls);
       } catch (err) {
         console.error('Failed to load classes', err);
+      } finally {
+        setClassesLoaded(true);
       }
 
       // Students, assignments and certificates would be fetched through
@@ -123,6 +112,30 @@ function InstructorDashboard() {
     }
     loadLists();
   }, [user?.id]);
+
+  useEffect(() => {
+    if (!user?.id || !classesLoaded) return;
+
+    let isMounted = true;
+    async function loadEvents() {
+      try {
+        const data = await fetchInstructorScheduleEvents(user.id, classes);
+        const parsed = data.map((e) => ({
+          ...e,
+          start: new Date(e.start),
+          ...(e.end ? { end: new Date(e.end) } : {}),
+        }));
+        if (isMounted) setEvents(parsed);
+      } catch (err) {
+        console.error('Failed to load schedule events', err);
+      }
+    }
+
+    loadEvents();
+    return () => {
+      isMounted = false;
+    };
+  }, [user?.id, classesLoaded, classes]);
 
   const cardStyle = "bg-white shadow-sm border rounded-2xl p-5 hover:shadow-md transition duration-300";
   const tabButtonStyle = (tab) =>

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -32,9 +32,11 @@ const formatClass = (cls) => {
 
 export const fetchInstructorClasses = async (instructorId) => {
   // Fetch only classes belonging to the specified instructor
-  const { data } = await api.get("/users/classes/instructor/my", {
-    params: { instructorId },
-  });
+  const requestConfig = instructorId ? { params: { instructorId } } : {};
+  const { data } = await api.get(
+    "/users/classes/instructor/my",
+    requestConfig,
+  );
   const list = data?.data ?? [];
   return list.map(formatClass);
 };
@@ -109,8 +111,13 @@ export const deleteClassAssignment = async (assignmentId) => {
 
 // Fetch upcoming schedule events for the current instructor
 // Combines class start dates and lesson times
-export const fetchInstructorScheduleEvents = async (instructorId) => {
-  const classes = await fetchInstructorClasses(instructorId);
+export const fetchInstructorScheduleEvents = async (
+  instructorId,
+  providedClasses,
+) => {
+  const classes = Array.isArray(providedClasses)
+    ? providedClasses
+    : await fetchInstructorClasses(instructorId);
   const now = new Date();
   const events = [];
 


### PR DESCRIPTION
## Summary
- reuse the instructor dashboard's class list when requesting schedule events so classes are only fetched once
- allow `fetchInstructorScheduleEvents` to accept a pre-fetched class list and avoid issuing redundant `/instructor/my` requests

## Testing
- npm --prefix frontend run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e62c051883289f37f33ce556aa7e