### PR TITLE
Fix instructor class fetch call

### DIFF
--- a/frontend/src/components/instructors/InstructorDashboard.js
+++ b/frontend/src/components/instructors/InstructorDashboard.js
@@ -104,6 +104,8 @@ function InstructorDashboard() {
         return;
       }
 
+      if (!user?.id) return;
+
       try {
         const tuts = await fetchInstructorTutorials();
         setTutorials(tuts);
@@ -112,7 +114,7 @@ function InstructorDashboard() {
       }
 
       try {
-        const cls = await fetchInstructorClasses();
+        const cls = await fetchInstructorClasses(user.id);
         setClasses(cls);
       } catch (err) {
         console.error('Failed to load classes', err);


### PR DESCRIPTION
## Summary
- guard instructor dashboard class fetching until the authenticated instructor id is available
- pass the instructor id to fetchInstructorClasses so the backend receives the correct identifier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0e6272c0083289b0e472a70cf625d