### PR TITLE
Update ongoing status labels for student online classes

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/index.js
+++ b/frontend/src/pages/dashboard/student/online-classes/index.js
@@ -30,12 +30,12 @@ export default function MyEnrolledClassesPage() {
 
   const statusLabels = {
     all: t('studentOnlineClassesPage.status_all'),
-    live: t('studentOnlineClassesPage.status_live'),
+    ongoing: t('studentOnlineClassesPage.status_live'),
     upcoming: t('studentOnlineClassesPage.status_upcoming'),
     completed: t('studentOnlineClassesPage.status_completed')
   };
   const scheduleStatusLabels = {
-    Live: t('studentOnlineClassesPage.status_live'),
+    Ongoing: t('studentOnlineClassesPage.status_live'),
     Upcoming: t('studentOnlineClassesPage.status_upcoming'),
     Completed: t('studentOnlineClassesPage.status_completed')
   };
@@ -174,7 +174,7 @@ export default function MyEnrolledClassesPage() {
                 <p className="text-xs text-gray-500 mb-2">{t('studentOnlineClassesPage.progress_completed', { progress: cls.progress || 0 })}</p>
 
                 <span className={`inline-block px-3 py-1 text-xs font-medium rounded-full mb-2 ${
-                  cls.scheduleStatus === 'Live'
+                  cls.scheduleStatus === 'Ongoing'
                     ? 'bg-green-100 text-green-800'
                     : cls.scheduleStatus === 'Upcoming'
                     ? 'bg-yellow-100 text-yellow-800'


### PR DESCRIPTION
## Summary
- add an ongoing label in the student dashboard status filters so it maps to the live translation
- align schedule status labels and chip styling to check for the Ongoing status returned by computeScheduleStatus

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e624e6d48328b197036e3eb5cb34