### PR TITLE
Guard notification creation by user or admin

### DIFF
--- a/backend/src/modules/notifications/__tests__/notifications.controller.test.js
+++ b/backend/src/modules/notifications/__tests__/notifications.controller.test.js
@@ -1,0 +1,37 @@
+const AppError = require("../../../utils/AppError");
+
+jest.mock("../notifications.service", () => ({
+  createNotification: jest.fn().mockResolvedValue({ id: 123 }),
+}));
+
+const controller = require("../notifications.controller");
+const service = require("../notifications.service");
+
+describe("notifications.controller.create", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects attempts to create notifications for another user without admin rights", async () => {
+    const req = {
+      body: { user_id: "target-user", type: "info", message: "Hello" },
+      user: { id: "requesting-user", roles: ["student"] },
+    };
+    const res = {};
+
+    let capturedError;
+    await new Promise((resolve) => {
+      controller.create(req, res, (err) => {
+        capturedError = err;
+        resolve();
+      });
+    });
+
+    expect(service.createNotification).not.toHaveBeenCalled();
+    expect(capturedError).toBeInstanceOf(AppError);
+    expect(capturedError.statusCode).toBe(403);
+    expect(capturedError.message).toBe(
+      "Unauthorized to create notifications for other users"
+    );
+  });
+});

--- a/backend/src/modules/notifications/notifications.controller.js
+++ b/backend/src/modules/notifications/notifications.controller.js
@@ -2,6 +2,7 @@ const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
 const service = require("./notifications.service");
+const { isAdminRole } = require("../../utils/role");
 
 exports.getMyNotifications = catchAsync(async (req, res) => {
   const data = await service.getUserNotifications(req.user.id);
@@ -19,6 +20,11 @@ exports.create = catchAsync(async (req, res) => {
   if (!user_id || !type || !message) {
     throw new AppError("Missing fields", 400);
   }
+  const isAdmin = isAdminRole(req.user?.roles || req.user?.role);
+  if (!isAdmin && String(req.user.id) !== String(user_id)) {
+    throw new AppError("Unauthorized to create notifications for other users", 403);
+  }
+
   const note = await service.createNotification({ user_id, type, message });
   sendSuccess(res, note, "Notification created");
 });


### PR DESCRIPTION
## Summary
- ensure notification creation requires the requester to be the target user or hold an admin role
- add a unit test covering unauthorized attempts to create notifications for other users

## Testing
- npm test -- notifications.controller.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0f0b88cac8328be76d282a60a8956