### PR TITLE
Restrict notification creation to admins

### DIFF
--- a/backend/src/modules/notifications/notifications.controller.js
+++ b/backend/src/modules/notifications/notifications.controller.js
@@ -2,6 +2,7 @@ const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
 const service = require("./notifications.service");
+const { isAdminRole } = require("../../utils/role");
 
 exports.getMyNotifications = catchAsync(async (req, res) => {
   const data = await service.getUserNotifications(req.user.id);
@@ -15,11 +16,19 @@ exports.markRead = catchAsync(async (req, res) => {
 });
 
 exports.create = catchAsync(async (req, res) => {
-  const { user_id, type, message } = req.body || {};
-  if (!user_id || !type || !message) {
+  const { user_id: bodyUserId, type, message } = req.body || {};
+  const isAdmin = isAdminRole(req.user.roles || req.user.role);
+  const targetUserId = isAdmin ? bodyUserId : req.user.id;
+
+  if (!targetUserId || !type || !message) {
     throw new AppError("Missing fields", 400);
   }
-  const note = await service.createNotification({ user_id, type, message });
+
+  const note = await service.createNotification({
+    user_id: targetUserId,
+    type,
+    message,
+  });
   sendSuccess(res, note, "Notification created");
 });
 

--- a/backend/src/modules/notifications/notifications.routes.js
+++ b/backend/src/modules/notifications/notifications.routes.js
@@ -1,12 +1,12 @@
 const express = require("express");
 const router = express.Router();
 const controller = require("./notifications.controller");
-const { verifyToken } = require("../../middleware/auth/authMiddleware");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
 
 router.use(verifyToken);
 
 router.get("/", controller.getMyNotifications);
-router.post("/", controller.create);
+router.post("/", isAdmin, controller.create);
 router.patch("/:id/read", controller.markRead);
 router.delete("/:id", controller.remove);
 


### PR DESCRIPTION
## Summary
- gate the notification creation route behind the admin authorization middleware
- prevent non-admin users from spoofing the notification recipient by defaulting to the authenticated user

## Testing
- npm test -- --runTestsByPath src/modules/notifications *(fails: no notification-specific tests are defined)*
- JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test npm test -- --passWithNoTests *(fails: broader suite requires extensive test fixtures and environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f0c96dbc8328bc3a1a404cc5a55f