### PR TITLE
Fix student class progress defaults

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/student/online-classes/[id].js
@@ -67,8 +67,13 @@ export default function StudentClassRoom() {
     }
   };
 
+  const totalLessons = classData?.lessons?.length || 0;
+  const progressPercentage = totalLessons > 0
+    ? (completedLessons.length / totalLessons) * 100
+    : 0;
+
   const showCertificate =
-    classData && classData.lessons && completedLessons.length === classData.lessons.length;
+    classData && totalLessons > 0 && completedLessons.length === totalLessons;
 
   if (!id) return <div className="text-white p-10">Loading class...</div>;
   if (!classData) return <div className="text-red-400 p-10">❌ Class not found</div>;
@@ -85,7 +90,7 @@ export default function StudentClassRoom() {
       <div className="w-full bg-gray-700 rounded-full h-4 mb-6">
         <div
           className="bg-yellow-500 h-4 rounded-full"
-          style={{ width: `${classData.lessons ? (completedLessons.length / classData.lessons.length) * 100 : 0}%` }}
+          style={{ width: `${progressPercentage}%` }}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- guard progress calculations when a class has no lessons
- require at least one lesson before showing the certificate message

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0f2c9b254832894e175b663f24b64