### PR TITLE
Fix assignment date handling on student online class page

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/student/online-classes/[id].js
@@ -135,31 +135,49 @@ export default function StudentClassRoom() {
           <p className="text-gray-400">No assignments available for this class.</p>
         ) : (
           <ul className="space-y-4">
-            {assignments.map((assignment) => (
-              <li key={assignment.id} className="flex justify-between items-center bg-gray-700 px-4 py-3 rounded hover:bg-gray-600">
-                <div>
-                  <div className="flex items-center space-x-2">
-                    <p className="font-semibold">{assignment.title}</p>
-                    {assignment.createdAt && Date.now() - new Date(assignment.createdAt).getTime() < 3 * 24 * 60 * 60 * 1000 && (
-                      <span className="bg-green-500 text-black text-xs px-2 py-0.5 rounded">New</span>
+            {assignments.map((assignment) => {
+              const createdAtDate = assignment.createdAt
+                ? new Date(assignment.createdAt)
+                : null;
+              const isNew =
+                createdAtDate &&
+                !Number.isNaN(createdAtDate.getTime()) &&
+                Date.now() - createdAtDate.getTime() < 3 * 24 * 60 * 60 * 1000;
+              const dueDate = assignment.dueDate ? new Date(assignment.dueDate) : null;
+              const dueDateLabel =
+                dueDate && !Number.isNaN(dueDate.getTime())
+                  ? dueDate.toLocaleDateString()
+                  : "No due date";
+
+              return (
+                <li
+                  key={assignment.id}
+                  className="flex justify-between items-center bg-gray-700 px-4 py-3 rounded hover:bg-gray-600"
+                >
+                  <div>
+                    <div className="flex items-center space-x-2">
+                      <p className="font-semibold">{assignment.title}</p>
+                      {isNew && (
+                        <span className="bg-green-500 text-black text-xs px-2 py-0.5 rounded">New</span>
+                      )}
+                    </div>
+                    <small className="text-gray-400">Due: {dueDateLabel}</small>
+                  </div>
+                  <div>
+                    {assignment.status === 'Pending' ? (
+                      <button
+                        onClick={() => router.push(`/dashboard/student/assignments/${assignment.id}`)}
+                        className="text-sm bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-600"
+                      >
+                        Start
+                      </button>
+                    ) : (
+                      <span className="text-xs text-green-400 font-semibold">{assignment.status}</span>
                     )}
                   </div>
-                  <small className="text-gray-400">Due: {new Date(assignment.dueDate).toLocaleDateString()}</small>
-                </div>
-                <div>
-                  {assignment.status === 'Pending' ? (
-                    <button
-                      onClick={() => router.push(`/dashboard/student/assignments/${assignment.id}`)}
-                      className="text-sm bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-600"
-                    >
-                      Start
-                    </button>
-                  ) : (
-                    <span className="text-xs text-green-400 font-semibold">{assignment.status}</span>
-                  )}
-                </div>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -83,9 +83,16 @@ export const fetchClassLessons = async (classId, signal) => {
   return extractData(res);
 };
 
+const formatAssignment = (assignment) => ({
+  ...assignment,
+  createdAt: assignment.createdAt ?? assignment.created_at ?? null,
+  dueDate: assignment.dueDate ?? assignment.due_date ?? null,
+});
+
 export const fetchClassAssignments = async (classId, signal) => {
   const res = await api.get(`/users/classes/assignments/class/${classId}`, { signal });
-  return extractData(res);
+  const list = extractData(res);
+  return Array.isArray(list) ? list.map(formatAssignment) : [];
 };
 
 export const fetchMyClassAssignments = async () => {


### PR DESCRIPTION
## Summary
- map assignment API responses to include camelCase date fields before storing in state
- guard the student online class assignments renderer against missing or invalid dates to prevent Invalid Date output

## Testing
- npm run lint *(fails: existing lint warnings/errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f2c90fd483288259a7463304ca6c