### PR TITLE
Fix student dashboard class link path

### DIFF
--- a/frontend/src/pages/dashboard/student/index.js
+++ b/frontend/src/pages/dashboard/student/index.js
@@ -149,7 +149,7 @@ function StudentDashboardHome() {
                   {t("next_session")}: {cls.nextSession}
                 </p>
                 <a
-                  href={`/dashboard/student/classes/${cls.id}`}
+                  href={`/dashboard/student/online-classes/${cls.id}`}
                   className="inline-block mt-2 text-sm text-blue-600 hover:underline"
                 >
                   {t("view_class")}


### PR DESCRIPTION
## Summary
- point the student dashboard class tile to the existing online class route to match the dynamic page

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f2c8090c8328831fd1d50076df8f