### PR TITLE
Normalize instructor class schedule display

### DIFF
--- a/frontend/src/components/instructors/InstructorDashboard.js
+++ b/frontend/src/components/instructors/InstructorDashboard.js
@@ -82,8 +82,17 @@ function InstructorDashboard() {
       if (process.env.NODE_ENV === 'development') {
         const { tutorials, classes, students, assignments, certificates } =
           instructorDashboardMocks;
+        const classesWithSchedule = classes.map((cls) => {
+          const scheduleDisplay = [cls.date, cls.time].filter(Boolean).join(" @ ");
+          return {
+            ...cls,
+            start_date: cls.start_date ?? cls.date ?? "",
+            end_date: cls.end_date ?? "",
+            scheduleDisplay,
+          };
+        });
         setTutorials(tutorials);
-        setClasses(classes);
+        setClasses(classesWithSchedule);
         setStudents(students);
         setAssignments(assignments);
         setCertificates(certificates);
@@ -157,6 +166,22 @@ function InstructorDashboard() {
       fontSize: "0.85rem",
     },
   });
+
+  const getClassScheduleLabel = (cls) => {
+    if (cls.scheduleDisplay) return cls.scheduleDisplay;
+
+    const start = cls.start_date ?? cls.startDate ?? "";
+    const end = cls.end_date ?? cls.endDate ?? "";
+
+    if (start && end) {
+      return start === end ? start : `${start} - ${end}`;
+    }
+
+    if (start) return start;
+    if (end) return end;
+
+    return "--";
+  };
 
   return (
     <InstructorLayout>
@@ -263,7 +288,7 @@ function InstructorDashboard() {
         <li key={cls.id} className="flex justify-between items-center p-3 border rounded">
           <div>
             <h4 className="font-semibold">{cls.title}</h4>
-            <p className="text-sm text-gray-500">{cls.date} @ {cls.time}</p>
+            <p className="text-sm text-gray-500">{getClassScheduleLabel(cls)}</p>
           </div>
           <div className="space-x-2">
             <button className="text-sky-600 hover:underline">{t('edit')}</button>

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -4,8 +4,30 @@ import { toDateInput } from "@/utils/date";
 import { safeEncodeURI } from "@/utils/url";
 import { computeScheduleStatus } from "@/utils/classSchedule";
 
+const normalizeDateValue = (value) => (value ? toDateInput(value) : "");
+
+const buildScheduleDisplay = (start, end, fallbackDate, fallbackTime, startTime) => {
+  if (start && end) {
+    return start === end ? start : `${start} - ${end}`;
+  }
+
+  if (start) {
+    const timePortion = startTime || fallbackTime;
+    return timePortion ? `${start} @ ${timePortion}` : start;
+  }
+
+  if (end) return end;
+
+  const fallbackParts = [fallbackDate, startTime || fallbackTime].filter(Boolean);
+  return fallbackParts.join(" @ ");
+};
+
 const formatClass = (cls) => {
   const { status, ...rest } = cls;
+  const rawStart = cls.start_date ?? cls.startDate ?? "";
+  const rawEnd = cls.end_date ?? cls.endDate ?? "";
+  const startDate = normalizeDateValue(rawStart);
+  const endDate = normalizeDateValue(rawEnd);
   return {
     ...rest,
     publishStatus: status,
@@ -22,8 +44,16 @@ const formatClass = (cls) => {
       : null,
     trending: Boolean(cls.trending),
 
-    start_date: cls.start_date ? toDateInput(cls.start_date) : "",
-    end_date: cls.end_date ? toDateInput(cls.end_date) : "",
+    start_date: startDate,
+    end_date: endDate,
+
+    scheduleDisplay: buildScheduleDisplay(
+      startDate,
+      endDate,
+      cls.date ?? cls.startDate ?? "",
+      cls.time ?? "",
+      cls.start_time ?? cls.startTime ?? "",
+    ),
 
     approvalStatus: cls.moderation_status || "Pending",
     scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),


### PR DESCRIPTION
## Summary
- generate a scheduleDisplay string for instructor classes derived from start and end dates when available
- use the scheduleDisplay helper on the instructor dashboard classes tab and normalize mock class data for development
- fall back to neutral placeholders when no scheduling information is available to avoid undefined text

## Testing
- npx eslint src/components/instructors/InstructorDashboard.js src/services/instructor/classService.js

------
https://chatgpt.com/codex/tasks/task_e_68d0f2c551948328a6e9aba6aa5c3595