### PR TITLE
Preserve ISO class schedule timestamps

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/edit/[id].js
@@ -22,6 +22,7 @@ import { fetchAdminClassById, updateAdminClass } from '@/services/admin/classSer
 import { fetchPlanIdentifiers } from '@/services/admin/planService';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
+import { toDateInput } from '@/utils/date';
 
 function EditClassPage() {
   const router = useRouter();
@@ -54,8 +55,12 @@ function EditClassPage() {
           setFormData({
             title: data.title || '',
             instructor: data.instructor || '',
-            start_date: data.start_date || '',
-            end_date: data.end_date || '',
+            start_date:
+              data.startDateInput ||
+              (data.start_date ? toDateInput(data.start_date) : ''),
+            end_date:
+              data.endDateInput ||
+              (data.end_date ? toDateInput(data.end_date) : ''),
             category: data.category_id || '',
             price: data.price || '',
             status: data.status || '',

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/edit.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/edit.js
@@ -17,6 +17,7 @@ import {
 import { fetchAllCategories } from '@/services/instructor/categoryService';
 import { fetchClassTags } from '@/services/instructor/classTagService';
 import useAuthStore from '@/store/auth/authStore';
+import { toDateInput } from '@/utils/date';
 
 const ReactQuill = dynamic(() => import('react-quill'), {
   ssr: false,
@@ -96,8 +97,12 @@ function EditInstructorClass() {
             level: data.level || '',
             language: data.language || '',
             description: data.description || '',
-            startDate: data.start_date || '',
-            endDate: data.end_date || '',
+            startDate:
+              data.startDateInput ||
+              (data.start_date ? toDateInput(data.start_date) : ''),
+            endDate:
+              data.endDateInput ||
+              (data.end_date ? toDateInput(data.end_date) : ''),
             price: data.price ?? '',
             maxStudents: data.max_students ?? '',
             isFree: data.price === 0,

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -21,8 +21,11 @@ const formatClass = (cls) => {
       : null,
     trending: Boolean(cls.trending),
 
-    start_date: cls.start_date ? toDateInput(cls.start_date) : "",
-    end_date: cls.end_date ? toDateInput(cls.end_date) : "",
+    start_date: cls.start_date ?? null,
+    end_date: cls.end_date ?? null,
+
+    startDateInput: cls.start_date ? toDateInput(cls.start_date) : "",
+    endDateInput: cls.end_date ? toDateInput(cls.end_date) : "",
 
     approvalStatus: cls.moderation_status || "Pending",
     scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -22,8 +22,11 @@ const formatClass = (cls) => {
       : null,
     trending: Boolean(cls.trending),
 
-    start_date: cls.start_date ? toDateInput(cls.start_date) : "",
-    end_date: cls.end_date ? toDateInput(cls.end_date) : "",
+    start_date: cls.start_date ?? null,
+    end_date: cls.end_date ?? null,
+
+    startDateInput: cls.start_date ? toDateInput(cls.start_date) : "",
+    endDateInput: cls.end_date ? toDateInput(cls.end_date) : "",
 
     approvalStatus: cls.moderation_status || "Pending",
     scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),


### PR DESCRIPTION
## Summary
- keep raw ISO timestamps for instructor/admin class services and expose helper date-input strings
- update instructor and admin online class edit pages to derive date-only values for form controls

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f2bd37a88328b16d66459fd95d65