### PR TITLE
Reset per-class state on student class navigation

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/student/online-classes/[id].js
@@ -35,6 +35,12 @@ export default function StudentClassRoom() {
     if (!id) return;
     const controller = new AbortController();
     const { signal } = controller;
+    // Reset per-class state so progress and chat start fresh for each class navigation
+    setCompletedLessons([]);
+    setMessages([]);
+    setChatInput("");
+    setAssignments([]);
+    setScheduleStatus(null);
     const load = async () => {
       try {
         const details = await fetchClassDetails(id, signal);


### PR DESCRIPTION
## Summary
- reset completed lessons and other per-class state when the class id changes so each class starts fresh

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d113c065008328bf500adf753d0149