### PR TITLE
Fix blur warning count listener

### DIFF
--- a/frontend/src/pages/dashboard/student/assignments/[id].js
+++ b/frontend/src/pages/dashboard/student/assignments/[id].js
@@ -1,5 +1,5 @@
 // pages/dashboard/student/assignments/[id].js
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import StudentLayout from '@/components/layouts/StudentLayout';
 import { FaExclamationTriangle, FaPlay, FaUpload } from 'react-icons/fa';
@@ -12,6 +12,7 @@ export default function AssignmentSolvePage() {
   const [blurCount, setBlurCount] = useState(0);
   const [file, setFile] = useState(null);
   const [answer, setAnswer] = useState('');
+  const blurCountRef = useRef(0);
 
   useEffect(() => {
     if (id) {
@@ -36,10 +37,13 @@ export default function AssignmentSolvePage() {
   }, [started]);
 
   const handleBlur = () => {
-    setBlurCount(prev => prev + 1);
-    if (blurCount < 2) {
+    const nextCount = blurCountRef.current + 1;
+    blurCountRef.current = nextCount;
+    setBlurCount(nextCount);
+
+    if (nextCount === 1) {
       alert('⚠️ Warning: Please stay focused! Switching tabs or minimizing is not allowed.');
-    } else if (blurCount === 2) {
+    } else if (nextCount === 2) {
       alert('⚠️ Final Warning: One more distraction and the assignment will be flagged!');
     } else {
       alert('🚫 You have exceeded the allowed distractions. Admins will be notified.');


### PR DESCRIPTION
## Summary
- ensure the blur handler uses a ref-backed counter so alerts reflect the latest distraction count
- keep the blur listener lifecycle tied to assignment start state and reuse the updated count for tiered warnings

## Testing
- not run (manual testing required in deployed environment)

------
https://chatgpt.com/codex/tasks/task_e_68d11394aa68832886555d5c2c543336