### PR TITLE
Preserve backend progress percentage for enrolled classes

### DIFF
--- a/frontend/src/services/classService.js
+++ b/frontend/src/services/classService.js
@@ -23,13 +23,24 @@ const formatBaseClass = (cls) => ({
 const formatEnrolledClass = (cls) => {
   const base = formatBaseClass(cls);
   const { start_date, end_date, status, ...rest } = base;
+  const hasProgress = rest.progress !== undefined && rest.progress !== null;
+  let progress = hasProgress ? Number(rest.progress) : undefined;
+
+  if (!Number.isFinite(progress)) {
+    progress = undefined;
+  }
+
+  if (progress === undefined) {
+    progress = status === "completed" ? 100 : 0;
+  }
+
   return {
     ...rest,
     startDate: start_date,
     endDate: end_date,
     enrollmentStatus: status,
     scheduleStatus: computeScheduleStatus(start_date, end_date),
-    progress: status === "completed" ? 100 : 0,
+    progress,
   };
 };
 


### PR DESCRIPTION
## Summary
- update enrolled class formatting to prefer API-supplied progress values and keep sensible defaults

## Testing
- npm run lint *(fails: existing lint errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68d11393ace483288dc609d62b962a3c