### PR TITLE
Fix zero grade display in student assignments

### DIFF
--- a/frontend/src/pages/dashboard/student/assignments/index.js
+++ b/frontend/src/pages/dashboard/student/assignments/index.js
@@ -64,7 +64,10 @@ export default function AssignmentDashboard() {
                           : 'bg-yellow-100 text-yellow-800'
                       }`}
                     >
-                      {assignment.status} {assignment.grade && `| Grade: ${assignment.grade}`}
+                      {assignment.status}{' '}
+                      {assignment.grade !== undefined &&
+                        assignment.grade !== null &&
+                        `| Grade: ${assignment.grade}`}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- update the student assignment status pill to explicitly detect defined grades instead of relying on truthiness
- ensure grades render correctly even when the backend omits the field or provides a zero value

## Testing
- node -e 'const assignment={grade:0,status:"Graded"}; const hasGrade=assignment.grade!==undefined&&assignment.grade!==null; const output=`${assignment.status}${hasGrade?` | Grade: ${assignment.grade}`:""}`; console.log(output);'

------
https://chatgpt.com/codex/tasks/task_e_68d1138a821c8328bcb0f134e881f226