### PR TITLE
Ensure admin profile edit translations include common namespace

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -829,7 +829,11 @@ export default ClientOnlyProtectedProfileEdit;
 export async function getStaticProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+      ...(await serverSideTranslations(
+        locale,
+        ['common', 'dashboard'],
+        nextI18NextConfig
+      )),
     },
   };
 }


### PR DESCRIPTION
## Summary
- ensure the admin profile edit page preloads the common namespace in addition to dashboard translations so layout strings localize correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d12e4629b08328b12b516daeb7054c