### PR TITLE
Gate auth protection on hydrated state

### DIFF
--- a/frontend/src/hooks/withAuthProtection.js
+++ b/frontend/src/hooks/withAuthProtection.js
@@ -11,7 +11,7 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
       : rolesOrOptions || {};
 
   return function ProtectedPage(props) {
-    const { user, accessToken, logout } = useAuthStore();
+    const { user, accessToken, logout, hasHydrated } = useAuthStore();
     const router = useRouter();
     const [hydrated, setHydrated] = useState(false);
 
@@ -20,27 +20,37 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
     }, []);
 
     useEffect(() => {
-      if (hydrated) {
-        const role = user?.role?.toLowerCase();
-        if (!user) {
-          router.replace("/auth/login");
-        } else if (!accessToken || isTokenExpired(accessToken)) {
-          logout();
-          router.replace("/auth/login");
-        } else if (
-          (allowedRoles.length && !allowedRoles.includes(role)) ||
-          (allowedPerms.length &&
-            role !== "superadmin" &&
-            !allowedPerms.some((p) => user.permissions?.includes(p)))
-        ) {
-          router.replace("/error/403");
-        }
+      if (!hydrated || !hasHydrated) {
+        return;
       }
-    }, [hydrated, user, accessToken]);
+
+      const role = user?.role?.toLowerCase();
+      if (!user) {
+        router.replace("/auth/login");
+      } else if (!accessToken || isTokenExpired(accessToken)) {
+        logout();
+        router.replace("/auth/login");
+      } else if (
+        (allowedRoles.length && !allowedRoles.includes(role)) ||
+        (allowedPerms.length &&
+          role !== "superadmin" &&
+          !allowedPerms.some((p) => user.permissions?.includes(p)))
+      ) {
+        router.replace("/error/403");
+      }
+    }, [
+      hydrated,
+      hasHydrated,
+      user,
+      accessToken,
+      logout,
+      router,
+    ]);
 
     const role = user?.role?.toLowerCase();
     if (
       !hydrated ||
+      !hasHydrated ||
       !user ||
       (allowedRoles.length && !allowedRoles.includes(role)) ||
       (allowedPerms.length &&


### PR DESCRIPTION
## Summary
- read hasHydrated from the auth store when wrapping protected pages
- defer redirects until both the component and auth store hydration complete
- block rendering until hydration and authorization checks succeed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d12e46c31c83289a0a3b4af96eae2d