### PR TITLE
Handle admin profile edit hydration state

### DIFF
--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -523,6 +523,10 @@ function ProfileEditTemplate() {
   };
 
 
+  if (!mounted) {
+    return null;
+  }
+
   if (!isHydrated || loadingProfile) {
     return (
       <div className="flex justify-center items-center h-64">


### PR DESCRIPTION
## Summary
- render nothing on the admin profile edit page until the component mounts to match the server output
- keep the loading spinner for hydration/profile fetch states but only show it after mount

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d12e56892c8328b52eab487cd4a5d3