### PR TITLE
Document Compose v2 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ npm --prefix frontend install
      # e.g. http://localhost:3000,https://example.com. Defaults to http://localhost:3000
      # REDIS_URL should point to your Redis instance for session persistence
      # set it to your frontend's domain if different and omit any trailing slash
-     # When using docker-compose make sure the value does
+     # When using Docker Compose make sure the value does
      # not include an extra "FRONTEND_URL=" prefix.
      # Optionally set ADMIN_INITIAL_PASSWORD and SUPERADMIN_INITIAL_PASSWORD
      # to control the seeded admin credentials
@@ -136,14 +136,15 @@ npm --prefix frontend install
 3. Build and launch the entire stack:
 
    ```bash
-   docker-compose up --build
+   docker compose up --build
    ```
 
-   If `docker-compose` exits with `KeyError: 'ContainerConfig'`, set
-   `DOCKER_BUILDKIT=0` and `COMPOSE_DOCKER_CLI_BUILD=0` in your `.env`
-   file (both are included in `.env.example`). This disables BuildKit for
-   compose v1 so images retain the legacy metadata structure expected by
-   older docker-compose releases.
+   If the legacy `docker-compose` v1 CLI exits with `KeyError: 'ContainerConfig'`,
+   upgrade to Docker Compose V2 and use the `docker compose` command. If
+   upgrading immediately is not possible, set `DOCKER_BUILDKIT=0` and
+   `COMPOSE_DOCKER_CLI_BUILD=0` in your `.env` file (both are included in
+   `.env.example`) to disable BuildKit so legacy docker-compose releases
+   can run the stack.
 
 4. Visit `http://localhost:3000` to access the frontend when running locally. The API will be available at `http://localhost:5002/api`.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ referenced in `nginx/conf.d/ssl.conf`.
   APP_DOMAIN=yourdomain.com
   FRONTEND_URL=https://${APP_DOMAIN},http://147.93.121.45
   # Do not prefix with "FRONTEND_URL=" when using
-  # docker-compose environment variables.
+  # Docker Compose environment variables.
     ```
 
    For production deployments, Docker Compose also loads variables from

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -158,7 +158,7 @@ cd ..
 Start all services with Docker Compose:
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 The containers expose the following URLs:
@@ -232,14 +232,14 @@ To deploy SkillBridge for real users on a remote host:
 4. **Run database migrations and seeds** before starting the containers:
 
    ```bash
-   docker-compose run --rm backend npm run migrate
-   docker-compose run --rm backend npm run seed
+   docker compose run --rm backend npm run migrate
+   docker compose run --rm backend npm run seed
    ```
 
 5. **Build and start the containers** in detached mode:
 
    ```bash
-   docker-compose up -d --build
+   docker compose up -d --build
    ```
 
 6. **Verify the deployment** by visiting `https://<your-domain>` in a browser. The API will be available at `https://<your-domain>/api`.
@@ -248,5 +248,5 @@ For updates, pull the latest changes and rebuild:
 
 ```bash
 git pull
-docker-compose up -d --build
+docker compose up -d --build
 ```

--- a/scripts/check_prereqs.sh
+++ b/scripts/check_prereqs.sh
@@ -59,24 +59,40 @@ else
   add_requirement "docker" "Docker" "fail" "Docker CLI not found."
 fi
 
-docker_compose_status=false
-if command -v docker-compose >/dev/null 2>&1; then
+compose_message="Docker Compose not found. Install Docker Compose V2 (the \"docker compose\" plugin)."
+compose_status="fail"
+
+extract_major_version() {
+  echo "$1" | sed -E 's/^v?([0-9]+).*/\1/'
+}
+
+if [ "$docker_present" = true ] && docker compose version >/dev/null 2>&1; then
+  COMPOSE_VERSION=$(docker compose version --short 2>/dev/null || docker compose version 2>/dev/null | head -n 1)
+  COMPOSE_MAJOR=$(extract_major_version "$COMPOSE_VERSION")
+  if [[ "$COMPOSE_MAJOR" =~ ^[0-9]+$ && "$COMPOSE_MAJOR" -ge 2 ]]; then
+    compose_status="pass"
+    if [ -n "$COMPOSE_VERSION" ]; then
+      compose_message="Docker Compose plugin ${COMPOSE_VERSION}"
+    else
+      compose_message="Docker Compose plugin detected."
+    fi
+  else
+    compose_status="fail"
+    compose_message="Docker Compose plugin ${COMPOSE_VERSION:-unknown} detected. Version 2 or newer is required."
+  fi
+elif command -v docker-compose >/dev/null 2>&1; then
   COMPOSE_VERSION=$(docker-compose --version 2>/dev/null || true)
-  if [ -n "$COMPOSE_VERSION" ]; then
-    add_requirement "docker_compose" "Docker Compose" "pass" "$COMPOSE_VERSION"
+  COMPOSE_MAJOR=$(extract_major_version "$COMPOSE_VERSION")
+  if [[ "$COMPOSE_MAJOR" =~ ^[0-9]+$ && "$COMPOSE_MAJOR" -ge 2 ]]; then
+    compose_status="pass"
+    compose_message="${COMPOSE_VERSION:-docker-compose command available.}"
   else
-    add_requirement "docker_compose" "Docker Compose" "pass" "docker-compose command available."
+    compose_status="fail"
+    compose_message="Legacy docker-compose ${COMPOSE_VERSION:-version unknown} detected. Install Docker Compose V2 and use the 'docker compose' command to avoid errors such as KeyError: 'ContainerConfig'."
   fi
-elif [ "$docker_present" = true ] && docker compose version >/dev/null 2>&1; then
-  COMPOSE_VERSION=$(docker compose version 2>/dev/null | head -n 1)
-  if [ -n "$COMPOSE_VERSION" ]; then
-    add_requirement "docker_compose" "Docker Compose" "pass" "$COMPOSE_VERSION"
-  else
-    add_requirement "docker_compose" "Docker Compose" "pass" "Docker Compose plugin available."
-  fi
-else
-  add_requirement "docker_compose" "Docker Compose" "fail" "Docker Compose not found."
 fi
+
+add_requirement "docker_compose" "Docker Compose" "$compose_status" "$compose_message"
 
 # Verify Git
 if command -v git >/dev/null 2>&1; then

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -4,11 +4,14 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-# Determine docker compose command
-if command -v docker-compose >/dev/null 2>&1; then
+# Determine docker compose command, preferring the v2 plugin
+if docker compose version >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
   DOCKER_COMPOSE="docker-compose"
 else
-  DOCKER_COMPOSE="docker compose"
+  echo "Docker Compose is required but not installed. Install the Docker Compose plugin (v2)." >&2
+  exit 1
 fi
 
 if [ -n "$($DOCKER_COMPOSE ps -q backend 2>/dev/null)" ]; then


### PR DESCRIPTION
## Summary
- prefer the Docker Compose v2 plugin in helper scripts and fail fast when it is missing
- update prerequisite checks to flag legacy docker-compose and mention the ContainerConfig error
- refresh documentation to use the `docker compose` command and advise upgrading from Compose v1

## Testing
- ./scripts/check_prereqs.sh

------
https://chatgpt.com/codex/tasks/task_e_68d131c0770483288fdc057f3a9048ad