### PR TITLE
Fix admin profile edit page alias error

### DIFF
--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "baseUrl": "src",
     "paths": {
-      "@/*": ["*"],
-      "@shared/*": ["../../shared/*"]
+      "@/*": ["*"]
     }
   }
 }

--- a/frontend/src/components/dashboard/admin/tutorials/Filters.js
+++ b/frontend/src/components/dashboard/admin/tutorials/Filters.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { FaSearch } from "react-icons/fa";
 import { Button } from "@/components/ui/button";
-import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/constants/tutorialStatus";
 
 function Filters({
   searchQuery,

--- a/frontend/src/components/dashboard/admin/tutorials/Stats.js
+++ b/frontend/src/components/dashboard/admin/tutorials/Stats.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/constants/tutorialStatus";
 
 function Stats({ tutorials }) {
   return (

--- a/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
+++ b/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/constants/tutorialStatus";
 import { FaSpinner, FaSearch, FaEdit, FaTrash } from "react-icons/fa";
 
 function TutorialsTable({

--- a/frontend/src/constants/socialPlatforms.js
+++ b/frontend/src/constants/socialPlatforms.js
@@ -1,0 +1,11 @@
+export const SOCIAL_PLATFORMS = Object.freeze([
+  'linkedin',
+  'github',
+  'twitter',
+  'youtube',
+  'facebook',
+  'instagram',
+  'website',
+]);
+
+export default SOCIAL_PLATFORMS;

--- a/frontend/src/constants/tutorialStatus.js
+++ b/frontend/src/constants/tutorialStatus.js
@@ -1,0 +1,7 @@
+export const TUTORIAL_STATUS = Object.freeze({
+  DRAFT: 'draft',
+  PUBLISHED: 'published',
+  ARCHIVED: 'archived',
+});
+
+export default TUTORIAL_STATUS;

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -30,7 +30,7 @@ import { sendChatMessage } from "@/services/messageService";
 import useAuthStore from "@/store/auth/authStore";
 import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
-import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/constants/tutorialStatus";
 
 function AdminTutorialsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "tutorialsPage" });

--- a/frontend/src/pages/dashboard/instructor/tutorials/index.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/index.js
@@ -4,7 +4,7 @@ import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../next-i18next.config.js";
-import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/constants/tutorialStatus";
 import {
   FaPlus,
   FaEdit,

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -2,7 +2,7 @@
 // Admin specific API calls for managing tutorials
 
 import api from "@/services/api/api";
-import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/constants/tutorialStatus";
 
 /**
  * Create a new tutorial as an admin or instructor.

--- a/frontend/src/services/instructor/tutorialService.js
+++ b/frontend/src/services/instructor/tutorialService.js
@@ -1,6 +1,6 @@
 import api from "@/services/api/api";
 import { API_BASE_URL } from "@/config/config";
-import { TUTORIAL_STATUS } from "@shared/tutorialStatus";
+import { TUTORIAL_STATUS } from "@/constants/tutorialStatus";
 
 const formatBase = (tut) => ({
   ...tut,

--- a/frontend/src/tests/__tests__/socialPlatformsFallback.test.js
+++ b/frontend/src/tests/__tests__/socialPlatformsFallback.test.js
@@ -9,7 +9,11 @@ describe('social platform icon fallbacks', () => {
 
   test('renders fallback icon when an unknown platform is provided', () => {
     jest.isolateModules(() => {
-      jest.doMock('@shared/socialPlatforms.json', () => ['linkedin', 'mystery'], { virtual: true });
+      jest.doMock(
+        '@/constants/socialPlatforms',
+        () => ['linkedin', 'mystery'],
+        { virtual: true },
+      );
 
       const { allowedPlatforms, defaultPlatformIcon } = require('@/utils/socialPlatforms');
       const SocialLinksSection = require('@/components/instructor/profile/SocialLinksSection').default;

--- a/frontend/src/utils/socialPlatforms.js
+++ b/frontend/src/utils/socialPlatforms.js
@@ -1,4 +1,4 @@
-import platformNames from "@shared/socialPlatforms.json";
+import SOCIAL_PLATFORMS from "@/constants/socialPlatforms";
 import {
   FaLinkedin,
   FaGithub,
@@ -24,9 +24,9 @@ const iconMap = {
   website: { Icon: FaGlobe, className: "text-green-600" },
 };
 
-export const allowedPlatforms = platformNames.map((name) => ({
+export const allowedPlatforms = SOCIAL_PLATFORMS.map((name) => ({
   name,
   ...(iconMap[name] || defaultPlatformIcon),
 }));
 
-export const socialPlatforms = platformNames;
+export const socialPlatforms = SOCIAL_PLATFORMS;


### PR DESCRIPTION
## Summary
- add local constants for social platforms and tutorial status so the admin profile edit page no longer relies on the failing `@shared` alias
- update tutorial-related pages, services, and components to reference the new constants
- adjust the social platforms utility and accompanying test to use the new constants while keeping path config tidy

## Testing
- npm test -- --runTestsByPath src/tests/__tests__/socialPlatformsFallback.test.js
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1432ef8848328a75fc94230616b11