### PR TITLE
Use dynamic import for profile croppers

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -2,6 +2,7 @@
 // File: pages/dashboard/instructor/profile/edit.js
 
 import { useState, useEffect, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -25,7 +26,7 @@ import {
   deleteInstructorDemo,
   toggleInstructorStatus,
 } from "@/services/instructor/instructorService";
-import Cropper from "react-easy-crop";
+const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 import { allowedPlatforms } from "@/utils/socialPlatforms";
 import {

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { z, ZodError } from "zod";
@@ -28,7 +29,7 @@ import {
   FaChevronDown, FaChevronUp, FaTimesCircle, FaGraduationCap,
   FaCheck
 } from "react-icons/fa";
-import Cropper from "react-easy-crop";
+const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 
 export const studentProfileSchema = z.object({


### PR DESCRIPTION
## Summary
- switch the student profile edit page to load `react-easy-crop` via a client-only dynamic import
- do the same dynamic import for the instructor profile edit page to avoid SSR issues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d270a7b1e48328aeec0f61e03e3dfd