### PR TITLE
Use client-only dynamic import for react-easy-crop in profile pages

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -10,6 +10,7 @@ import { toast } from "react-toastify";
 import { z, ZodError } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import { getUserCountry } from "@/utils/getUserCountry";
+import dynamic from "next/dynamic";
 import { API_BASE_URL } from "@/config/config";
 import { getCurrencies } from "@/services/currencyService";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
@@ -25,7 +26,7 @@ import {
   deleteInstructorDemo,
   toggleInstructorStatus,
 } from "@/services/instructor/instructorService";
-import Cropper from "react-easy-crop";
+const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 import { allowedPlatforms } from "@/utils/socialPlatforms";
 import {

--- a/frontend/src/pages/dashboard/instructor/profile/steps/PersonalDetails.js
+++ b/frontend/src/pages/dashboard/instructor/profile/steps/PersonalDetails.js
@@ -1,7 +1,9 @@
 import { useState, useCallback, useEffect } from "react";
-import Cropper from "react-easy-crop";
+import dynamic from "next/dynamic";
 import getCroppedImg from "@/utils/cropImage"; // Helper function for cropping
 import { FaUpload, FaTimesCircle, FaCrop, FaCheck } from "react-icons/fa";
+
+const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 
 const PersonalDetails = ({
   formData = {},

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { z, ZodError } from "zod";
@@ -28,7 +29,7 @@ import {
   FaChevronDown, FaChevronUp, FaTimesCircle, FaGraduationCap,
   FaCheck
 } from "react-icons/fa";
-import Cropper from "react-easy-crop";
+const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 
 export const studentProfileSchema = z.object({

--- a/frontend/src/pages/dashboard/student/profile/steps/PersonalDetails.js
+++ b/frontend/src/pages/dashboard/student/profile/steps/PersonalDetails.js
@@ -1,7 +1,9 @@
 import { useState, useCallback, useEffect } from "react";
-import Cropper from "react-easy-crop";
+import dynamic from "next/dynamic";
 import getCroppedImg from "@/utils/cropImage";
 import { FaUpload, FaTimesCircle, FaCrop, FaCheck } from "react-icons/fa";
+
+const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 
 const PersonalDetails = ({
   formData = {},


### PR DESCRIPTION
## Summary
- replace the react-easy-crop default import with a client-only dynamic import across the student and instructor profile edit and personal details pages
- keep the existing conditional rendering around the Cropper component so it only mounts when the cropper modal is shown

## Testing
- npm run dev
- Visited /dashboard/student/profile/edit, /dashboard/student/profile/steps/PersonalDetails, /dashboard/instructor/profile/edit, and /dashboard/instructor/profile/steps/PersonalDetails without seeing a "window is not defined" error


------
https://chatgpt.com/codex/tasks/task_e_68d2708aebb48328b4152259b99c6b43