### PR TITLE
Use dynamic Cropper import on dashboard profile pages

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -2,6 +2,7 @@
 // File: pages/dashboard/instructor/profile/edit.js
 
 import { useState, useEffect, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -25,7 +26,7 @@ import {
   deleteInstructorDemo,
   toggleInstructorStatus,
 } from "@/services/instructor/instructorService";
-import Cropper from "react-easy-crop";
+const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 import { allowedPlatforms } from "@/utils/socialPlatforms";
 import {

--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import { z, ZodError } from "zod";
@@ -28,7 +29,7 @@ import {
   FaChevronDown, FaChevronUp, FaTimesCircle, FaGraduationCap,
   FaCheck
 } from "react-icons/fa";
-import Cropper from "react-easy-crop";
+const Cropper = dynamic(() => import("react-easy-crop"), { ssr: false });
 import getCroppedImg from "@/utils/cropImage";
 
 export const studentProfileSchema = z.object({


### PR DESCRIPTION
## Summary
- load `react-easy-crop` with a client-only dynamic import on the student dashboard profile edit page
- apply the same client-only dynamic import on the instructor dashboard profile edit page to match the admin pattern

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2707a16308328bb65eef05cfa2f83