### PR TITLE
Fix duplicate dynamic import in instructor profile edit page

### DIFF
--- a/frontend/src/pages/dashboard/instructor/profile/edit.js
+++ b/frontend/src/pages/dashboard/instructor/profile/edit.js
@@ -11,7 +11,6 @@ import { toast } from "react-toastify";
 import { z, ZodError } from "zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import { getUserCountry } from "@/utils/getUserCountry";
-import dynamic from "next/dynamic";
 import { API_BASE_URL } from "@/config/config";
 import { getCurrencies } from "@/services/currencyService";
 import InstructorLayout from "@/components/layouts/InstructorLayout";


### PR DESCRIPTION
## Summary
- remove the duplicate `next/dynamic` import from the instructor profile edit page so the module only declares it once

## Testing
- npm run lint (fails: existing lint errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68d2c0f839d08328bb4b44ba181e3cdc