### PR TITLE
Fix installer response parsing variable reference

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -385,11 +385,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch('/api/install/prereqs', { cache: 'no-store' });
       const bodyText = await res.text();
       let data;
-      if (bodyText) {
+      if (responseText) {
         try {
-          data = JSON.parse(bodyText);
+          data = JSON.parse(responseText);
         } catch {
-          data = { output: bodyText };
+          data = { output: responseText };
         }
       } else {
         data = {};
@@ -480,11 +480,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const responseText = await res.text();
       let data;
-      if (bodyText) {
+      if (responseText) {
         try {
-          data = JSON.parse(bodyText);
+          data = JSON.parse(responseText);
         } catch {
-          data = { output: bodyText };
+          data = { output: responseText };
         }
       } else {
         data = {};
@@ -522,7 +522,7 @@ document.addEventListener('DOMContentLoaded', () => {
           ? data.output
           : typeof data.log === 'string'
             ? data.log
-            : bodyText;
+            : responseText;
 
       if (installOutput) {
         installOutput.classList.remove('text-gray-700', 'text-green-700', 'text-red-700');


### PR DESCRIPTION
## Summary
- replace references to an undefined variable in the installer submission handler with the captured response text
- ensure install output rendering falls back to the raw response text when structured data is unavailable

## Testing
- started a static server and exercised the installer page with a headless browser to confirm errors render without crashing

------
https://chatgpt.com/codex/tasks/task_e_68d2c632a86883289f8de76d0a532760