### PR TITLE
Fix installer submission response parsing

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -480,11 +480,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const responseText = await res.text();
       let data;
-      if (bodyText) {
+      if (responseText) {
         try {
-          data = JSON.parse(bodyText);
+          data = JSON.parse(responseText);
         } catch {
-          data = { output: bodyText };
+          data = { output: responseText };
         }
       } else {
         data = {};
@@ -522,7 +522,7 @@ document.addEventListener('DOMContentLoaded', () => {
           ? data.output
           : typeof data.log === 'string'
             ? data.log
-            : bodyText;
+            : responseText;
 
       if (installOutput) {
         installOutput.classList.remove('text-gray-700', 'text-green-700', 'text-red-700');


### PR DESCRIPTION
## Summary
- ensure the installer submission handler parses the string returned by `res.text()`
- use the same response text as the fallback log output so errors always display

## Testing
- manual verification of installer success flow in browser
- manual verification of installer failure flow in browser

------
https://chatgpt.com/codex/tasks/task_e_68d2c634c1d48328b74d021229526552