### PR TITLE
Fix installer submission response handling

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -480,11 +480,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const responseText = await res.text();
       let data;
-      if (bodyText) {
+      if (responseText) {
         try {
-          data = JSON.parse(bodyText);
+          data = JSON.parse(responseText);
         } catch {
-          data = { output: bodyText };
+          data = { output: responseText };
         }
       } else {
         data = {};
@@ -522,7 +522,7 @@ document.addEventListener('DOMContentLoaded', () => {
           ? data.output
           : typeof data.log === 'string'
             ? data.log
-            : bodyText;
+            : responseText;
 
       if (installOutput) {
         installOutput.classList.remove('text-gray-700', 'text-green-700', 'text-red-700');


### PR DESCRIPTION
## Summary
- update the installer submission handler to parse the fetched response text instead of the stale bodyText variable
- fall back to the same response payload when populating the log output

## Testing
- not run (browser-based installer flow requires a UI environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2c6cdf6448328930003f1b607a057