### PR TITLE
Handle missing notification messages

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -68,6 +68,10 @@ export default function Header() {
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
   const router = useRouter();
 
+  const notificationFallbackMessage = t("notification_missing_message", {
+    defaultValue: t("notification", { defaultValue: "Notification" }),
+  });
+
   const profileLink =
     profileRoutes[userRole] || `/dashboard/${userRole}/profile/edit`;
 
@@ -315,7 +319,10 @@ export default function Header() {
                 className="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50"
               >
                 <ul className="text-sm text-gray-700 dark:text-gray-200 max-h-60 overflow-y-auto divide-y">
-                  {notifications.slice(0, 10).map((n) => (
+                  {notifications.slice(0, 10).map((n) => {
+                    const hasMessage =
+                      typeof n.message === "string" && n.message.trim().length > 0;
+                    return (
                     <li
                       key={n.id}
                       className={`flex justify-between items-center px-4 py-2 transition ${
@@ -324,7 +331,13 @@ export default function Header() {
                           : "bg-yellow-50 dark:bg-gray-600"
                       }`}
                     >
-                      <LinkText text={n.message} />
+                      {hasMessage ? (
+                        <LinkText text={n.message} />
+                      ) : (
+                        <span className="italic text-gray-500">
+                          {notificationFallbackMessage}
+                        </span>
+                      )}
                         {!n.read && (
                           <button
                             onClick={() => markRead(n.id)}
@@ -334,7 +347,8 @@ export default function Header() {
                           </button>
                         )}
                     </li>
-                  ))}
+                    );
+                  })}
                   {notifications.length === 0 && (
                     <li className="px-4 py-2 text-center text-sm text-gray-500">
                       {t('no_notifications')}

--- a/frontend/src/components/shared/LinkText.js
+++ b/frontend/src/components/shared/LinkText.js
@@ -3,7 +3,13 @@ import React from 'react';
 const urlRegex = /(https?:\/\/[^\s]+)/;
 
 export default function LinkText({ text }) {
-  const parts = text.split(urlRegex);
+  const safeText =
+    typeof text === "string"
+      ? text
+      : text != null && typeof text.toString === "function"
+        ? text.toString()
+        : "";
+  const parts = safeText.split(urlRegex);
   return (
     <>
       {parts.map((part, index) =>

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -29,7 +29,15 @@ const useNotificationStore = create((set, get) => ({
         const diff = unread - prevUnread;
         if (diff === 1) {
           const note = filtered.find((n) => !n.read);
-          toast.info(<LinkText text={note.message} />);
+          const message =
+            typeof note?.message === "string" && note.message.trim().length > 0
+              ? note.message
+              : null;
+          if (message) {
+            toast.info(<LinkText text={message} />);
+          } else {
+            toast.info(i18next.t("you_have_new_notifications", { count: diff }));
+          }
         } else {
           toast.info(i18next.t("you_have_new_notifications", { count: diff }));
         }

--- a/frontend/src/tests/__tests__/HeaderNotificationFallback.test.jsx
+++ b/frontend/src/tests/__tests__/HeaderNotificationFallback.test.jsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Header from '@/components/dashboard/Header';
+import LinkText from '@/components/shared/LinkText';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: '/dashboard/student',
+    query: {},
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock('next/link', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: React.forwardRef(function MockLink({ children, href, ...rest }, ref) {
+      return React.createElement('a', { href, ref, ...rest }, children);
+    }),
+  };
+});
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }) => <>{children}</>,
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, options) => options?.defaultValue || key,
+  }),
+}));
+
+jest.mock('@/services/instructor/instructorService', () => ({
+  toggleInstructorStatus: jest.fn(),
+}));
+
+jest.mock('@/components/shared/LinkText', () => {
+  const React = require('react');
+  const mockComponent = jest.fn(({ text }) => <span data-testid="link-text">{text}</span>);
+  return {
+    __esModule: true,
+    default: mockComponent,
+  };
+});
+
+jest.mock('@/store/notifications/notificationStore', () => {
+  const store = {
+    items: [
+      { id: 1, read: false, message: undefined },
+      { id: 2, read: false, message: 'https://example.com' },
+    ],
+    fetch: jest.fn().mockResolvedValue(),
+    startPolling: jest.fn(),
+    stopPolling: jest.fn(),
+    markRead: jest.fn(),
+  };
+  const useStore = jest.fn((selector = (s) => s) => selector(store));
+  useStore.getState = () => store;
+  useStore.setState = (partial) => {
+    const value = typeof partial === 'function' ? partial(store) : partial;
+    Object.assign(store, value);
+  };
+  return {
+    __esModule: true,
+    default: useStore,
+  };
+});
+
+jest.mock('@/store/messages/messageStore', () => {
+  const store = {
+    items: [],
+    fetch: jest.fn().mockResolvedValue(),
+    startPolling: jest.fn(),
+    stopPolling: jest.fn(),
+    markRead: jest.fn(),
+  };
+  const useStore = jest.fn((selector = (s) => s) => selector(store));
+  useStore.getState = () => store;
+  useStore.setState = (partial) => {
+    const value = typeof partial === 'function' ? partial(store) : partial;
+    Object.assign(store, value);
+  };
+  return {
+    __esModule: true,
+    default: useStore,
+  };
+});
+
+jest.mock('@/store/auth/authStore', () => {
+  const store = {
+    user: { role: 'student', is_online: true },
+    hasHydrated: true,
+    logout: jest.fn(),
+    setUser: jest.fn(),
+  };
+  const useStore = jest.fn((selector = (s) => s) => selector(store));
+  useStore.getState = () => store;
+  useStore.setState = (partial) => {
+    const value = typeof partial === 'function' ? partial(store) : partial;
+    Object.assign(store, value);
+  };
+  return {
+    __esModule: true,
+    default: useStore,
+  };
+});
+
+jest.mock('@/store/appConfigStore', () => {
+  const store = {
+    settings: {},
+    fetch: jest.fn().mockResolvedValue(),
+  };
+  const useStore = jest.fn((selector = (s) => s) => selector(store));
+  useStore.getState = () => store;
+  useStore.setState = (partial) => {
+    const value = typeof partial === 'function' ? partial(store) : partial;
+    Object.assign(store, value);
+  };
+  return {
+    __esModule: true,
+    default: useStore,
+  };
+});
+
+describe('Header notification rendering', () => {
+  it('renders fallback message when notification message is missing', () => {
+    render(<Header />);
+
+    fireEvent.click(screen.getByLabelText('Toggle notifications'));
+
+    expect(LinkText).toHaveBeenCalledTimes(1);
+    expect(LinkText.mock.calls[0][0]).toEqual({ text: 'https://example.com' });
+    expect(screen.getByText('Notification')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/__tests__/LinkTextFallback.test.js
+++ b/frontend/src/tests/__tests__/LinkTextFallback.test.js
@@ -1,0 +1,6 @@
+import { render } from '@testing-library/react';
+import LinkText from '@/components/shared/LinkText';
+
+test('LinkText renders safely with undefined text', () => {
+  expect(() => render(<LinkText text={undefined} />)).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- make LinkText resilient to falsy or non-string values
- fall back when notifications omit message content in the dashboard header and toast alerts
- add regression tests covering missing notification messages

## Testing
- npm test -- Fallback

------
https://chatgpt.com/codex/tasks/task_e_68d2ca6536008328adb695484c4f3ef1