### PR TITLE
Fix auth store selector usage in dashboard header

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -26,10 +26,8 @@ import { buildUrl } from "@/utils/url";
 import profileRoutes from "@/constants/profileRoutes";
 
 export default function Header() {
-  const { user, hasHydrated } = useAuthStore((state) => ({
-    user: state.user,
-    hasHydrated: state.hasHydrated,
-  }));
+  const user = useAuthStore((state) => state.user);
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
   const logout = useAuthStore((state) => state.logout);
   const setUser = useAuthStore((state) => state.setUser);
   const [mounted, setMounted] = useState(false);


### PR DESCRIPTION
## Summary
- update the dashboard header to read the auth store's user and hydration flags through separate selectors so the component no longer re-renders endlessly

## Testing
- npm run lint *(fails: existing lint errors across the project unrelated to this change)*
- npm run test *(fails: existing failing suites unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ca9e57a48328b583ff6def1f8c86