### PR TITLE
Fix installer prereq response parsing

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -385,11 +385,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch('/api/install/prereqs', { cache: 'no-store' });
       const bodyText = await res.text();
       let data;
-      if (responseText) {
+      if (bodyText) {
         try {
-          data = JSON.parse(responseText);
+          data = JSON.parse(bodyText);
         } catch {
-          data = { output: responseText };
+          data = { output: bodyText };
         }
       } else {
         data = {};


### PR DESCRIPTION
## Summary
- ensure the installer prerequisite check parses the fetched response body using the existing bodyText variable
- fall back to returning the raw body text when JSON parsing fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2ccc2aa2c83288ea15718d5565cbb