### PR TITLE
Handle missing notification messages safely

### DIFF
--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -67,7 +67,9 @@ export default function Header() {
   const router = useRouter();
 
   const notificationFallbackMessage = t("notification_missing_message", {
-    defaultValue: t("notification", { defaultValue: "Notification" }),
+    defaultValue: t("notification_message_unavailable", {
+      defaultValue: "Notification message unavailable",
+    }),
   });
 
   const profileLink =
@@ -321,9 +323,7 @@ export default function Header() {
                     const message =
                       typeof n?.message === "string" && n.message.trim().length > 0
                         ? n.message
-                        : t("notification_message_unavailable", {
-                            defaultValue: "Notification message unavailable",
-                          });
+                        : notificationFallbackMessage;
 
                     return (
                       <li

--- a/frontend/src/components/dashboard/__tests__/Header.notifications.test.js
+++ b/frontend/src/components/dashboard/__tests__/Header.notifications.test.js
@@ -1,0 +1,155 @@
+import React from "react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key, options) => options?.defaultValue ?? _key,
+  }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }) => (
+    <a href={typeof href === "string" ? href : "#"} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("lucide-react", () => {
+  const React = require("react");
+  const createIcon = (name) =>
+    React.forwardRef(({ children, ...props }, ref) => (
+      <svg ref={ref} data-icon={name} {...props}>
+        {children}
+      </svg>
+    ));
+
+  return {
+    Bell: createIcon("Bell"),
+    ChevronDown: createIcon("ChevronDown"),
+    Mail: createIcon("Mail"),
+    Moon: createIcon("Moon"),
+    Sun: createIcon("Sun"),
+    Search: createIcon("Search"),
+    Home: createIcon("Home"),
+    LogOut: createIcon("LogOut"),
+  };
+});
+
+jest.mock("framer-motion", () => {
+  const React = require("react");
+  return {
+    motion: {
+      div: React.forwardRef(({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>
+          {children}
+        </div>
+      )),
+    },
+    AnimatePresence: ({ children }) => <>{children}</>,
+  };
+});
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+jest.mock("@/services/instructor/instructorService", () => ({
+  toggleInstructorStatus: jest.fn(),
+}));
+
+jest.mock("@/utils/url", () => ({
+  buildUrl: jest.fn((url) => url),
+}));
+
+const mockAuthState = {
+  user: { role: "student", is_online: false },
+  hasHydrated: true,
+  logout: jest.fn(),
+  setUser: jest.fn(),
+};
+
+jest.mock("@/store/auth/authStore", () => {
+  return {
+    __esModule: true,
+    default: jest.fn((selector) => selector(mockAuthState)),
+  };
+});
+
+const mockNotificationState = {
+  items: [
+    { id: "1", message: undefined, read: false },
+  ],
+  fetch: jest.fn().mockResolvedValue(undefined),
+  startPolling: jest.fn(),
+  stopPolling: jest.fn(),
+  markRead: jest.fn(),
+};
+
+jest.mock("@/store/notifications/notificationStore", () => ({
+  __esModule: true,
+  default: jest.fn((selector) => selector(mockNotificationState)),
+}));
+
+const mockMessageState = {
+  items: [],
+  fetch: jest.fn(),
+  startPolling: jest.fn(),
+  stopPolling: jest.fn(),
+  markRead: jest.fn(),
+};
+
+jest.mock("@/store/messages/messageStore", () => ({
+  __esModule: true,
+  default: jest.fn((selector) => selector(mockMessageState)),
+}));
+
+const mockAppConfigState = {
+  settings: {},
+  fetch: jest.fn(),
+};
+
+jest.mock("@/store/appConfigStore", () => ({
+  __esModule: true,
+  default: jest.fn((selector) => selector(mockAppConfigState)),
+}));
+
+import { useRouter } from "next/router";
+import Header from "../Header";
+
+describe("Header notifications", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useRouter.mockReturnValue({
+      pathname: "/dashboard/student",
+      query: {},
+      push: jest.fn(),
+    });
+  });
+
+  it("renders notifications that are missing a message without throwing", async () => {
+    const { container } = render(<Header />);
+
+    expect(() => {
+      const toggle = container.querySelector('[aria-label="Toggle notifications"]');
+      if (toggle) {
+        fireEvent.click(toggle);
+      }
+    }).not.toThrow();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Notification message unavailable")
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/shared/LinkText.js
+++ b/frontend/src/components/shared/LinkText.js
@@ -6,15 +6,15 @@ export default function LinkText({ text }) {
   const safeText =
     typeof text === 'string'
       ? text
-      : text != null && typeof text.toString === 'function'
-        ? text.toString()
-        : '';
+      : text == null
+        ? ''
+        : String(text);
 
-  const parts = safeText.split(urlRegex);
+  const parts = safeText ? safeText.split(urlRegex) : [''];
   return (
     <>
       {parts.map((part, index) => {
-        const isUrl = new RegExp(urlRegex).test(part);
+        const isUrl = urlRegex.test(part);
         return isUrl ? (
           <a
             key={`link-${index}`}

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -31,20 +31,15 @@ const useNotificationStore = create((set, get) => ({
         const diff = unread - prevUnread;
         if (diff === 1) {
           const note = filtered.find((n) => !n.read);
+          const fallbackMessage = i18next.t("new_notification_available", {
+            defaultValue: DEFAULT_LINK_TEXT,
+          });
           const message =
             typeof note?.message === "string" && note.message.trim().length > 0
               ? note.message
-              : null;
+              : fallbackMessage;
 
-          if (message) {
-            toast.info(<LinkText text={message} />);
-          } else {
-            toast.info(
-              i18next.t("new_notification_available", {
-                defaultValue: "You have a new notification",
-              }),
-            );
-          }
+          toast.info(<LinkText text={message} />);
         } else {
           toast.info(i18next.t("you_have_new_notifications", { count: diff }));
         }


### PR DESCRIPTION
## Summary
- Normalize the `LinkText` component input so falsy and non-string values render safely before URL parsing
- Guard dashboard notifications and toast alerts with translated fallback content when `message` is missing
- Add a regression test that renders the dashboard header with a notification lacking a message

## Testing
- `npx jest src/components/shared/__tests__/LinkText.test.js --verbose`
- `npx jest src/components/dashboard/__tests__/Header.notifications.test.js --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68d2d840a5dc83289ea72a1e0ffe4cf0