### PR TITLE
Include installer assets in backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,9 +2,16 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache curl netcat-openbsd postgresql-client
-COPY package*.json ./
+
+# Copy the backend package manifests first to leverage Docker layer caching.
+COPY backend/package*.json ./
 RUN npm ci --omit=dev && npm cache clean --force
-COPY ./ ./
+
+# Copy the backend source along with the installer assets so the
+# production image can serve /install even when the container is built
+# independently of the repository root.
+COPY backend/ ./
+COPY install ./install
 
 # Production stage
 FROM node:20-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,8 @@ services:
 
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
     restart: always
     env_file:
       - ./.env


### PR DESCRIPTION
## Summary
- ensure the backend Docker build copies the installer assets so `/install` can be served from the container image
- switch the backend service build context to the repository root so the Dockerfile has access to both backend sources and the installer bundle

## Testing
- `npm test` *(fails: missing JWT_SECRET/REFRESH_TOKEN_SECRET/SESSION_SECRET in test env)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c49d16cc83288d66b8a619ab397e