### PR TITLE
Handle invalid notifications payload

### DIFF
--- a/frontend/src/store/notifications/__tests__/notificationStore.test.js
+++ b/frontend/src/store/notifications/__tests__/notificationStore.test.js
@@ -1,0 +1,32 @@
+import useNotificationStore from '@/store/notifications/notificationStore';
+import { getNotifications } from '@/services/notificationService';
+
+jest.mock('@/services/notificationService', () => ({
+  getNotifications: jest.fn(),
+  markNotificationAsRead: jest.fn(),
+  deleteNotification: jest.fn(),
+}));
+
+const resetStore = () => {
+  useNotificationStore.setState({ items: [], loading: false, poller: null });
+};
+
+describe('notificationStore.fetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStore();
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['non-array object', { data: [] }],
+  ])('treats %s responses as empty arrays', async (_, response) => {
+    getNotifications.mockResolvedValueOnce(response);
+
+    await expect(useNotificationStore.getState().fetch()).resolves.toBeUndefined();
+
+    expect(useNotificationStore.getState().items).toEqual([]);
+    expect(useNotificationStore.getState().loading).toBe(false);
+  });
+});

--- a/frontend/src/store/notifications/notificationStore.js
+++ b/frontend/src/store/notifications/notificationStore.js
@@ -22,7 +22,8 @@ const useNotificationStore = create((set, get) => ({
     set({ loading: true });
     try {
       const data = await getNotifications();
-      const filtered = data.filter(
+      const notifications = Array.isArray(data) ? data : [];
+      const filtered = notifications.filter(
         (n) => !(n.read && n.read_at && new Date() - new Date(n.read_at) > HOUR_MS)
       );
       const prevUnread = get().items.filter((n) => !n.read).length;


### PR DESCRIPTION
## Summary
- guard the notification store fetcher against non-array API responses before filtering
- add regression tests ensuring fetch handles null or object payloads without crashing

## Testing
- npm test -- notificationStore

------
https://chatgpt.com/codex/tasks/task_e_68d2df12d5ac83288377507b39f2860e