### PR TITLE
Update installer logo background to brand yellow

### DIFF
--- a/install/logo.svg
+++ b/install/logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
-  <rect width="200" height="40" fill="#4A90E2" />
-  <text x="100" y="26" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#fff">SkillBridge</text>
+  <rect width="200" height="40" fill="#F59E0B" />
+  <text x="100" y="26" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#fff" stroke="#78350F" stroke-width="1" paint-order="stroke fill" stroke-linejoin="round">SkillBridge</text>
 </svg>


### PR DESCRIPTION
## Summary
- update the installer logo background to the brand yellow swatch
- add a subtle outline around the white wordmark to preserve contrast on the warmer background

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d2ea75f4c08328bcf3d1d646f113dd