### PR TITLE
Fix auth store hydration callback usage

### DIFF
--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -6,91 +6,97 @@ import useNotificationStore from "@/store/notifications/notificationStore";
 import useMessageStore from "@/store/messages/messageStore";
 import logger from "@/utils/logger";
 
+let authStoreApi;
+
 const useAuthStore = create(
   persist(
-    (set, get) => ({
-      user: null,
-      accessToken: null,
-      hasHydrated: false,
+    (set, get, api) => {
+      authStoreApi = api;
 
-      setUser: (userData) => set({ user: userData }),
-      setToken: (token) => set({ accessToken: token }),
-      markHydrated: () => set({ hasHydrated: true }),
+      return {
+        user: null,
+        accessToken: null,
+        hasHydrated: false,
 
-      isAuthenticated: () => !!get().accessToken && !!get().user,
+        setUser: (userData) => set({ user: userData }),
+        setToken: (token) => set({ accessToken: token }),
+        markHydrated: () => set({ hasHydrated: true }),
 
-      login: async (credentials) => {
-        logger.log("🔑 authStore.login invoked");
-        const { accessToken, user } = await authService.loginUser(credentials);
-        if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
-          user.avatar_url = null;
-        }
-        set({ accessToken, user });
-        return user;
-      },
+        isAuthenticated: () => !!get().accessToken && !!get().user,
 
-      /**
-       * Log in using an already issued access token.
-       * Stores the token, fetches the profile and notifications.
-       */
-      loginWithToken: async (token) => {
-        set({ accessToken: token });
-        try {
-          const res = await getFullProfile();
-          let user = res.data;
+        login: async (credentials) => {
+          logger.log("🔑 authStore.login invoked");
+          const { accessToken, user } = await authService.loginUser(credentials);
           if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
             user.avatar_url = null;
           }
-          set({ user });
-          const fetchNotifications = useNotificationStore.getState().fetch;
-          fetchNotifications?.();
+          set({ accessToken, user });
           return user;
-        } catch (err) {
-          logger.error("❌ loginWithToken error", { message: err?.message });
-          set({ accessToken: null, user: null });
-        }
-      },
+        },
 
-      refreshUser: async () => {
-        try {
-          const res = await getFullProfile();
-          const fresh = res.data;
-          if (fresh.avatar_url?.startsWith("blob:") || fresh.avatar_url === "null") {
-            fresh.avatar_url = null;
-          }
-          set({ user: fresh });
-          return fresh;
-        } catch (err) {
-          logger.error("❌ refreshUser error", { message: err?.message });
-        }
-      },
-
-      register: async (data) => {
-        await authService.registerUser(data);
-      },
-
-      logout: async (skipRequest = false) => {
-        if (!skipRequest) {
+        /**
+         * Log in using an already issued access token.
+         * Stores the token, fetches the profile and notifications.
+         */
+        loginWithToken: async (token) => {
+          set({ accessToken: token });
           try {
-            await authService.logoutUser();
-          } catch (_) {}
-        }
+            const res = await getFullProfile();
+            let user = res.data;
+            if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
+              user.avatar_url = null;
+            }
+            set({ user });
+            const fetchNotifications = useNotificationStore.getState().fetch;
+            fetchNotifications?.();
+            return user;
+          } catch (err) {
+            logger.error("❌ loginWithToken error", { message: err?.message });
+            set({ accessToken: null, user: null });
+          }
+        },
 
-        // Stop polling intervals when logging out
-        const notifStop = useNotificationStore.getState().stopPolling;
-        const msgStop = useMessageStore.getState().stopPolling;
-        notifStop?.();
-        msgStop?.();
-        localStorage.removeItem("auth");
-        set({ accessToken: null, user: null });
-      },
-    }),
+        refreshUser: async () => {
+          try {
+            const res = await getFullProfile();
+            const fresh = res.data;
+            if (fresh.avatar_url?.startsWith("blob:") || fresh.avatar_url === "null") {
+              fresh.avatar_url = null;
+            }
+            set({ user: fresh });
+            return fresh;
+          } catch (err) {
+            logger.error("❌ refreshUser error", { message: err?.message });
+          }
+        },
+
+        register: async (data) => {
+          await authService.registerUser(data);
+        },
+
+        logout: async (skipRequest = false) => {
+          if (!skipRequest) {
+            try {
+              await authService.logoutUser();
+            } catch (_) {}
+          }
+
+          // Stop polling intervals when logging out
+          const notifStop = useNotificationStore.getState().stopPolling;
+          const msgStop = useMessageStore.getState().stopPolling;
+          notifStop?.();
+          msgStop?.();
+          localStorage.removeItem("auth");
+          set({ accessToken: null, user: null });
+        },
+      };
+    },
     {
       name: "auth",
       onRehydrateStorage: () => {
         return (state) => {
           logger.log("🔥 Zustand hydrated");
-          set({ hasHydrated: true });
+          authStoreApi?.setState({ hasHydrated: true });
         };
       },
     }


### PR DESCRIPTION
## Summary
- capture the auth store's Zustand API when creating the store
- use the stored API inside the hydration callback to mark the store as hydrated

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2f100f1ac8328987f79cfd24c8377