### PR TITLE
Ensure primary role uses highest privilege

### DIFF
--- a/backend/src/middleware/auth/authMiddleware.js
+++ b/backend/src/middleware/auth/authMiddleware.js
@@ -5,7 +5,7 @@ const {
   addToken: addTokenToStore,
   isTokenBlacklisted,
 } = require("../../services/tokenBlacklistService");
-const { normalizeRole, isAdminRole } = require("../../utils/role");
+const { normalizeRole, isAdminRole, resolvePrimaryRole } = require("../../utils/role");
 
 
 /**
@@ -47,6 +47,7 @@ const verifyToken = async (req, res, next) => {
     }
     const roles = await userModel.getUserRoles(decoded.id);
     const userRoles = roles.length ? roles : [user.role];
+    const primaryRole = resolvePrimaryRole(userRoles, user.role);
     let permissions = await userModel.getUserPermissions(decoded.id);
     if (userRoles.map((r) => normalizeRole(r)).includes("superadmin")) {
       permissions = await userModel.getAllPermissionCodes();
@@ -56,7 +57,7 @@ const verifyToken = async (req, res, next) => {
       ...decoded,
       ...safeUser,
       roles: userRoles,
-      role: userRoles[0],
+      role: primaryRole,
       permissions,
     };
     next();

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -21,6 +21,7 @@ const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
 const { addToken } = require("../../../services/tokenBlacklistService");
 const verificationService = require("../../verify/verify.service");
+const { resolvePrimaryRole } = require("../../../utils/role");
 const {
   REFRESH_TOKEN_EXPIRES_IN,
   REFRESH_TOKEN_MAX_AGE,
@@ -318,9 +319,10 @@ exports.loginUser = async ({ email, password, ip }) => {
   const roles = await userModel.getUserRoles(user.id);
   const permissions = await userModel.getUserPermissions(user.id);
   const tokenRoles = roles.length ? roles : [user.role];
+  const primaryRole = resolvePrimaryRole(tokenRoles, user.role);
   const accessToken = generateAccessToken({
     id: user.id,
-    role: tokenRoles[0],
+    role: primaryRole,
     roles: tokenRoles,
   });
   const refreshToken = await issueRefreshToken(user.id, tokenRoles);
@@ -335,7 +337,11 @@ exports.loginUser = async ({ email, password, ip }) => {
     logger.error("Failed to create login notification", err);
   }
   const safeUser = sanitizeUserUtil(user);
-  return { accessToken, refreshToken, user: { ...safeUser, roles, permissions } };
+  return {
+    accessToken,
+    refreshToken,
+    user: { ...safeUser, role: primaryRole, roles, permissions },
+  };
 };
 
 /**
@@ -361,9 +367,10 @@ function generateRefreshToken(payload, jti) {
 
 async function issueRefreshToken(userId, roles = []) {
   const roleArr = Array.isArray(roles) ? roles : [roles];
+  const primaryRole = resolvePrimaryRole(roleArr);
   const jti = uuidv4();
   const token = generateRefreshToken(
-    { id: userId, role: roleArr[0], roles: roleArr },
+    { id: userId, role: primaryRole, roles: roleArr },
     jti
   );
   const tokenHash = await bcrypt.hash(token, SALT_ROUNDS);
@@ -394,7 +401,8 @@ exports.verifyRefreshToken = async (token) => {
   const match = await bcrypt.compare(token, row.token_hash);
   if (!match) throw new Error("Invalid refresh token");
   const roles = decoded.roles || (decoded.role ? [decoded.role] : []);
-  return { ...decoded, roles, role: roles[0] };
+  const primaryRole = resolvePrimaryRole(roles, decoded.role);
+  return { ...decoded, roles, role: primaryRole };
 };
 
 exports.rotateRefreshToken = async (token) => {

--- a/backend/src/modules/auth/services/socialAuth.service.js
+++ b/backend/src/modules/auth/services/socialAuth.service.js
@@ -3,6 +3,7 @@ const userModel = require("../../users/user.model");
 const { generateAccessToken, issueRefreshToken } = require("./auth.service");
 const AppError = require("../../../utils/AppError");
 const sanitizeUser = require("../utils/sanitizeUser");
+const { resolvePrimaryRole } = require("../../../utils/role");
 
 const SALT_ROUNDS = 12;
 
@@ -56,13 +57,14 @@ exports.loginOrRegister = async ({
 
   const roles = await userModel.getUserRoles(user.id);
   const tokenRoles = roles.length ? roles : [user.role];
+  const primaryRole = resolvePrimaryRole(tokenRoles, user.role);
   const accessToken = generateAccessToken({
     id: user.id,
-    role: tokenRoles[0],
+    role: primaryRole,
     roles: tokenRoles,
   });
   const refreshToken = await issueRefreshToken(user.id, tokenRoles);
 
-  const safeUser = sanitizeUser({ ...user, roles });
+  const safeUser = sanitizeUser({ ...user, role: primaryRole, roles });
   return { accessToken, refreshToken, user: safeUser };
 };

--- a/backend/src/utils/role.js
+++ b/backend/src/utils/role.js
@@ -1,3 +1,5 @@
+const ROLE_PRIORITY = ["superadmin", "admin", "instructor", "student"];
+
 const normalizeRole = (role) =>
   typeof role === "string" ? role.toLowerCase().replace(/\s+/g, "") : "";
 
@@ -8,7 +10,30 @@ const isAdminRole = (roles = []) => {
     .some((r) => ["admin", "superadmin"].includes(r));
 };
 
+const resolvePrimaryRole = (roles = [], fallback) => {
+  const arr = (Array.isArray(roles) ? roles : [roles]).filter(Boolean);
+  if (!arr.length) {
+    return fallback;
+  }
+
+  const normalized = arr.map((role) => ({
+    original: role,
+    normalized: normalizeRole(role),
+  }));
+
+  for (const desired of ROLE_PRIORITY) {
+    const match = normalized.find((entry) => entry.normalized === desired);
+    if (match) {
+      return match.original;
+    }
+  }
+
+  return normalized[0]?.original ?? fallback;
+};
+
 module.exports = {
   normalizeRole,
   isAdminRole,
+  resolvePrimaryRole,
+  ROLE_PRIORITY,
 };

--- a/backend/tests/authPrimaryRole.test.js
+++ b/backend/tests/authPrimaryRole.test.js
@@ -1,0 +1,146 @@
+const jwt = require('jsonwebtoken');
+
+jest.mock('../src/config/database', () => {
+  const mockInsert = jest.fn().mockResolvedValue();
+  const handler = jest.fn((table) => {
+    if (table === 'refresh_tokens') {
+      return { insert: mockInsert };
+    }
+    return {
+      where: jest.fn().mockReturnThis(),
+      whereIn: jest.fn().mockReturnThis(),
+      join: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockReturnThis(),
+      returning: jest.fn().mockResolvedValue([]),
+      andWhere: jest.fn().mockReturnThis(),
+      andWhereRaw: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      count: jest.fn().mockReturnThis(),
+      del: jest.fn().mockReturnThis(),
+      insert: jest.fn().mockReturnThis(),
+    };
+  });
+  handler.transaction = jest.fn(async (cb) => cb(handler));
+  handler.fn = { now: jest.fn() };
+  handler.raw = jest.fn();
+  handler.mockInsert = mockInsert;
+  return handler;
+});
+
+jest.mock('../src/services/tokenBlacklistService', () => ({
+  addToken: jest.fn(),
+  isTokenBlacklisted: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock('../src/modules/users/user.model', () => ({
+  findByEmail: jest.fn(),
+  findById: jest.fn(),
+  updateUser: jest.fn(),
+  getUserRoles: jest.fn(),
+  getUserPermissions: jest.fn(),
+  getAllPermissionCodes: jest.fn(),
+}));
+
+jest.mock('../src/modules/notifications/notifications.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('../src/modules/messages/messages.service', () => ({
+  createMessage: jest.fn(),
+}));
+
+jest.mock('../src/services/smsService', () => ({
+  sendSMS: jest.fn(),
+}));
+
+jest.mock('../src/utils/logger.js', () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+}));
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn().mockResolvedValue('hash'),
+  compare: jest.fn().mockResolvedValue(true),
+}));
+
+process.env.JWT_SECRET = 'testsecret';
+process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
+
+const authService = require('../src/modules/auth/services/auth.service');
+const authMiddleware = require('../src/middleware/auth/authMiddleware');
+const userModel = require('../src/modules/users/user.model');
+
+describe('primary role resolution', () => {
+  const baseUser = {
+    id: 99,
+    email: 'admin@example.com',
+    password_hash: 'hashedpw',
+    role: 'Student',
+    status: 'active',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.JWT_SECRET = 'testsecret';
+    process.env.REFRESH_TOKEN_SECRET = 'refreshsecret';
+    userModel.findByEmail.mockResolvedValue({ ...baseUser });
+    userModel.findById.mockResolvedValue({ ...baseUser });
+    userModel.updateUser.mockResolvedValue();
+    userModel.getUserRoles.mockResolvedValue(['Student', 'SuperAdmin']);
+    userModel.getUserPermissions.mockResolvedValue([]);
+    userModel.getAllPermissionCodes.mockResolvedValue(['perm']);
+  });
+
+  it('returns the elevated role in login payload and tokens', async () => {
+    const result = await authService.loginUser({
+      email: baseUser.email,
+      password: 'Password1!',
+    });
+
+    expect(result.user.role).toBe('SuperAdmin');
+    expect(result.user.roles).toEqual(['Student', 'SuperAdmin']);
+
+    const decodedAccess = jwt.verify(result.accessToken, process.env.JWT_SECRET);
+    expect(decodedAccess.role).toBe('SuperAdmin');
+    expect(decodedAccess.roles).toEqual(['Student', 'SuperAdmin']);
+
+    const decodedRefresh = jwt.verify(
+      result.refreshToken,
+      process.env.REFRESH_TOKEN_SECRET,
+    );
+    expect(decodedRefresh.role).toBe('SuperAdmin');
+    expect(decodedRefresh.roles).toEqual(['Student', 'SuperAdmin']);
+  });
+
+  it('preserves admin access for elevated users during middleware checks', async () => {
+    const { accessToken } = await authService.loginUser({
+      email: baseUser.email,
+      password: 'Password1!',
+    });
+
+    const req = {
+      headers: { authorization: `Bearer ${accessToken}` },
+      cookies: {},
+    };
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn().mockReturnThis();
+    const res = { status, json };
+    const next = jest.fn();
+
+    await authMiddleware.verifyToken(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user.role).toBe('SuperAdmin');
+    expect(req.user.roles).toEqual(['Student', 'SuperAdmin']);
+
+    const adminNext = jest.fn();
+    const adminRes = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    authMiddleware.isAdmin(req, adminRes, adminNext);
+    expect(adminNext).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- resolve a canonical primary role based on highest privilege for authentication payloads and tokens
- update login and middleware flows to publish the elevated role while leaving roles arrays intact
- add regression coverage proving elevated roles are surfaced and preserve admin access

## Testing
- npm test -- authPrimaryRole.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2f0ff1e2883289663d315a5b9d7bf