### PR TITLE
Normalize role handling across auth flows

### DIFF
--- a/frontend/src/components/auth/IncompleteAlertModal.js
+++ b/frontend/src/components/auth/IncompleteAlertModal.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import useAuthStore from "@/store/auth/authStore";
 import { useRouter } from "next/router";
 import profileRoutes from "@/constants/profileRoutes";
+import { getNormalizedRoles, getPrimaryRole } from "@/utils/auth/roleUtils";
 
 export default function IncompleteAlertModal() {
   const { user } = useAuthStore();
@@ -12,7 +13,9 @@ export default function IncompleteAlertModal() {
     if (!user) return;
 
     // 🎯 Only show for Student or Instructor roles
-    const isRelevantRole = user.role === "Student" || user.role === "Instructor";
+    const normalizedRoles = getNormalizedRoles(user);
+    const isRelevantRole =
+      normalizedRoles.includes("student") || normalizedRoles.includes("instructor");
 
     const needsProfile = !user.profile_complete || !user.is_email_verified || !user.is_phone_verified;
 
@@ -32,7 +35,7 @@ export default function IncompleteAlertModal() {
         </p>
         <button
           onClick={() => {
-            const path = profileRoutes[user.role?.toLowerCase()] || "/auth/login";
+            const path = profileRoutes[getPrimaryRole(user)] || "/auth/login";
             router.push(path);
           }}
           className="bg-yellow-500 px-4 py-2 rounded text-gray-900 font-semibold"

--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -24,6 +24,7 @@ import LinkText from "@/components/shared/LinkText";
 import { buildUrl } from "@/utils/url";
 
 import profileRoutes from "@/constants/profileRoutes";
+import { getPrimaryRole } from "@/utils/auth/roleUtils";
 
 export default function Header() {
   const user = useAuthStore((state) => state.user);
@@ -34,7 +35,7 @@ export default function Header() {
   const isHydrated = mounted && hasHydrated;
   const hydratedUser = isHydrated ? user : null;
   const userOnlineStatus = hydratedUser?.is_online ?? false;
-  const userRole = hydratedUser?.role?.toLowerCase();
+  const userRole = getPrimaryRole(hydratedUser);
   const userIsOnline = hydratedUser?.is_online ?? false;
   const { t } = useTranslation("common");
   const { t: tDashboard } = useTranslation("dashboard");
@@ -73,7 +74,8 @@ export default function Header() {
   });
 
   const profileLink =
-    profileRoutes[userRole] || `/dashboard/${userRole}/profile/edit`;
+    (userRole && profileRoutes[userRole]) ||
+    (userRole ? `/dashboard/${userRole}/profile/edit` : "/dashboard/profile/edit");
 
   useEffect(() => {
     setMounted(true);

--- a/frontend/src/components/website/sections/Navbar.js
+++ b/frontend/src/components/website/sections/Navbar.js
@@ -35,6 +35,7 @@ import { getCurrencies } from "@/services/currencyService";
 import { buildUrl } from "@/utils/url";
 
 import profileRoutes from "@/constants/profileRoutes";
+import { getPrimaryRole } from "@/utils/auth/roleUtils";
 
 const fetcher = (url) => api.get(url).then((res) => res.data.data);
 const currencyFetcher = () => getCurrencies();
@@ -68,7 +69,7 @@ const Navbar = () => {
 
   const { profile, fetchProfile, clearAdmin } = useAdminStore();
   const router = useRouter();
-  const userRole = user?.role?.toLowerCase();
+  const userRole = getPrimaryRole(user);
 
   const { items: cartItems, fetchCart, clearCart } = useCartStore();
   const cartHydrated = useCartStore.persist?.hasHydrated?.() ?? true;
@@ -91,7 +92,7 @@ const Navbar = () => {
 
   const storesHydrated = authHydrated && cartHydrated;
   const hydratedUser = storesHydrated && isClient ? user : null;
-  const hydratedUserRole = hydratedUser?.role?.toLowerCase();
+  const hydratedUserRole = getPrimaryRole(hydratedUser);
   const hydratedCartItems = storesHydrated && isClient ? cartItems : [];
 
   const { i18n, t } = useTranslation("common");

--- a/frontend/src/hooks/RequireProfileCompletion.js
+++ b/frontend/src/hooks/RequireProfileCompletion.js
@@ -4,11 +4,12 @@ import { useRouter } from "next/router";
 import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
 import profileRoutes from "@/constants/profileRoutes";
+import { getPrimaryRole } from "@/utils/auth/roleUtils";
 
 export default function RequireProfileCompletion({ children }) {
   const { user } = useAuthStore();
   const router = useRouter();
-  const userRole = user?.role?.toLowerCase();
+  const userRole = getPrimaryRole(user);
 
   useEffect(() => {
     if (user && user.profile_complete === false) {

--- a/frontend/src/hooks/withAuthProtection.js
+++ b/frontend/src/hooks/withAuthProtection.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import useAuthStore from "@/store/auth/authStore";
 import { isTokenExpired } from "@/utils/auth/tokenUtils";
+import { getNormalizedRoles } from "@/utils/auth/roleUtils";
 
 export default function withAuthProtection(Component, rolesOrOptions = []) {
   const { roles: allowedRoles = [], permissions: allowedPerms = [] } =
@@ -24,16 +25,19 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
         return;
       }
 
-      const role = user?.role?.toLowerCase();
+      const normalizedRoles = getNormalizedRoles(user);
       if (!user) {
         router.replace("/auth/login");
       } else if (!accessToken || isTokenExpired(accessToken)) {
         logout();
         router.replace("/auth/login");
       } else if (
-        (allowedRoles.length && !allowedRoles.includes(role)) ||
+        (allowedRoles.length &&
+          !allowedRoles.some((allowedRole) =>
+            normalizedRoles.includes(allowedRole)
+          )) ||
         (allowedPerms.length &&
-          role !== "superadmin" &&
+          !normalizedRoles.includes("superadmin") &&
           !allowedPerms.some((p) => user.permissions?.includes(p)))
       ) {
         router.replace("/error/403");
@@ -47,15 +51,20 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
       router,
     ]);
 
-    const role = user?.role?.toLowerCase();
+    const normalizedRoles = getNormalizedRoles(user);
+    const hasAllowedRole =
+      !allowedRoles.length ||
+      allowedRoles.some((allowedRole) => normalizedRoles.includes(allowedRole));
+    const hasRequiredPerms =
+      !allowedPerms.length ||
+      normalizedRoles.includes("superadmin") ||
+      allowedPerms.some((p) => user?.permissions?.includes(p));
     if (
       !hydrated ||
       !hasHydrated ||
       !user ||
-      (allowedRoles.length && !allowedRoles.includes(role)) ||
-      (allowedPerms.length &&
-        role !== "superadmin" &&
-        !allowedPerms.some((p) => user.permissions?.includes(p)))
+      !hasAllowedRole ||
+      !hasRequiredPerms
     ) {
       return null;
     }

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -29,6 +29,7 @@ import { handleError } from "@/utils/error";
 import { loginSchema as createLoginSchema } from "@/utils/auth/validationSchemas";
 import { isTokenExpired } from "@/utils/auth/tokenUtils";
 import profileRoutes from "@/constants/profileRoutes";
+import { getPrimaryRole } from "@/utils/auth/roleUtils";
 
 function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading }) {
   const router = useRouter();
@@ -70,12 +71,12 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
     }
 
     if (user.profile_complete === false) {
-      const rolePath = profileRoutes[user.role?.toLowerCase()] || "/website";
+      const rolePath = profileRoutes[getPrimaryRole(user)] || "/website";
       router.replace(rolePath);
     } else {
       router.replace("/website");
     }
-  }, [hasHydrated, user, accessToken, logout]);
+  }, [hasHydrated, user, accessToken, logout, router]);
 
   useEffect(() => {
     fetchAppConfig();
@@ -133,9 +134,10 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
       toast.success(t("login_successful"));
       fetchNotifications();
 
+      const primaryRole = getPrimaryRole(loggedInUser);
       const targetPath =
         loggedInUser.profile_complete === false
-          ? profileRoutes[loggedInUser.role?.toLowerCase()] || "/website"
+          ? profileRoutes[primaryRole] || "/website"
           : "/website";
 
       // 🚀 Redirect after a short delay so the toast is visible

--- a/frontend/src/pages/dashboard/admin/profile/edit.js
+++ b/frontend/src/pages/dashboard/admin/profile/edit.js
@@ -12,6 +12,7 @@ import { isValidPhoneNumber } from "libphonenumber-js";
 import { getUserCountry } from "@/utils/getUserCountry";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
+import { getNormalizedRoles } from "@/utils/auth/roleUtils";
 import dynamic from "next/dynamic";
 import {
   FaSpinner,
@@ -167,8 +168,8 @@ function ProfileEditTemplate() {
       };
     }
 
-    const role = user.role?.toLowerCase();
-    if (role !== "admin" && role !== "superadmin") {
+    const normalizedRoles = getNormalizedRoles(user);
+    if (!normalizedRoles.includes("admin") && !normalizedRoles.includes("superadmin")) {
       setLoadingProfile(false);
       return () => {
         isMounted = false;

--- a/frontend/src/utils/auth/roleUtils.js
+++ b/frontend/src/utils/auth/roleUtils.js
@@ -1,0 +1,35 @@
+const normalizeRole = (role) => {
+  if (role == null) {
+    return "";
+  }
+
+  return String(role).toLowerCase().replace(/\s+/g, "");
+};
+
+export const getNormalizedRoles = (user) => {
+  if (!user) {
+    return [];
+  }
+
+  const roles = Array.isArray(user.roles) && user.roles.length > 0
+    ? user.roles
+    : [user.role];
+
+  const normalized = roles
+    .map(normalizeRole)
+    .filter((role) => Boolean(role));
+
+  return Array.from(new Set(normalized));
+};
+
+export const getPrimaryRole = (user) => {
+  const normalizedRoles = getNormalizedRoles(user);
+
+  if (normalizedRoles.includes("superadmin")) {
+    return "superadmin";
+  }
+
+  return normalizedRoles[0];
+};
+
+export default getNormalizedRoles;


### PR DESCRIPTION
## Summary
- add a role utility to normalize role names from both `user.role` and `user.roles`
- update auth protection, profile hydration, and navigation flows to rely on normalized roles
- ensure login and profile completion redirects route superadmins into the admin profile experience

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f0fcda508328952965644920df15