### PR TITLE
Secure install API with setup secret guard

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -2,9 +2,7 @@ const router = require('express').Router();
 const controller = require('./install.controller');
 const { verifyToken, isAdmin } = require('../../middleware/auth/authMiddleware');
 const validate = require('../../middleware/validate');
-const userModel = require('../users/user.model');
 const { z } = require('zod');
-const { hasExistingAdmin } = require('./install.helpers');
 
 // Guard installation endpoints behind an environment flag to prevent accidental
 // exposure in production deployments.
@@ -16,35 +14,18 @@ const requireInstallApiEnabled = (req, res, next) => {
 };
 
 router.use(requireInstallApiEnabled);
-const determineAdminPresence = async () => {
-  try {
-    const bypassCache = process.env.NODE_ENV === 'test';
-    return await hasExistingAdmin({ bypassCache });
-  } catch (error) {
-    if (process.env.NODE_ENV === 'test') {
-      try {
-        const admins = await userModel.findAdmins();
-        return Array.isArray(admins) && admins.length > 0;
-      } catch (fallbackError) {
-        throw fallbackError;
-      }
-    }
-
-    throw error;
-  }
-};
-
 const enforceInstallerGuard = async (req, res, next) => {
   try {
     const setupSecret =
       typeof process.env.INSTALL_SETUP_SECRET === 'string'
         ? process.env.INSTALL_SETUP_SECRET.trim()
         : '';
-    const adminExists = await determineAdminPresence();
-    const requireAuth = adminExists || (setupSecret.length > 0 && req.method === 'GET');
 
-    if (!requireAuth) {
-      return next();
+    if (setupSecret.length > 0) {
+      const providedSecret = req.get('x-install-setup-secret');
+      if (typeof providedSecret === 'string' && providedSecret === setupSecret) {
+        return next();
+      }
     }
 
     return verifyToken(req, res, (err) => {

--- a/backend/tests/installApi.test.js
+++ b/backend/tests/installApi.test.js
@@ -21,6 +21,25 @@ jest.mock('../src/modules/users/user.model', () => ({
   findAdmins: (...args) => mockFindAdmins(...args),
 }));
 
+const mockRefreshAdminPresence = jest.fn().mockResolvedValue(false);
+const mockMarkAdminExists = jest.fn();
+
+jest.mock('../src/modules/install/install.helpers', () => ({
+  refreshAdminPresence: (...args) => mockRefreshAdminPresence(...args),
+  markAdminExists: (...args) => mockMarkAdminExists(...args),
+}));
+
+const ensureEnv = (key, fallback) => {
+  if (!process.env[key]) {
+    process.env[key] = fallback;
+  }
+};
+
+ensureEnv('JWT_SECRET', 'test-jwt-secret');
+ensureEnv('REFRESH_TOKEN_SECRET', 'test-refresh-secret');
+ensureEnv('SESSION_SECRET', 'test-session-secret');
+ensureEnv('TEST_DATABASE_URL', 'postgres://user:pass@localhost:5432/testdb');
+
 const { execFile } = require('child_process');
 const { router } = require('../src/modules/install/install.routes');
 const controller = require('../src/modules/install/install.controller');
@@ -31,6 +50,7 @@ app.use('/api/install', router);
 
 afterEach(() => {
   delete process.env.INSTALL_API_ENABLED;
+  delete process.env.INSTALL_SETUP_SECRET;
   jest.clearAllMocks();
 });
 
@@ -70,11 +90,14 @@ describe('/api/install/prereqs', () => {
     expect(mockIsAdmin).toHaveBeenCalledTimes(1);
   });
 
-  it('allows unauthenticated access when no admins exist', async () => {
+  it('allows access with setup secret when no admins exist', async () => {
     process.env.INSTALL_API_ENABLED = 'true';
+    process.env.INSTALL_SETUP_SECRET = 's3cret';
     mockFindAdmins.mockResolvedValue([]);
 
-    const res = await request(app).get('/api/install/prereqs');
+    const res = await request(app)
+      .get('/api/install/prereqs')
+      .set('x-install-setup-secret', 's3cret');
 
     expect(res.status).toBe(200);
     expect(execFile).toHaveBeenCalled();
@@ -117,6 +140,7 @@ describe('/api/install/prereqs', () => {
 describe('/api/install/run', () => {
   it('passes credentials to the installer environment', async () => {
     process.env.INSTALL_API_ENABLED = 'true';
+    process.env.INSTALL_SETUP_SECRET = 's3cret';
     const adminEmail = 'admin@example.com';
     const adminPassword = 'super-secret';
     const envKey = 'INSTALLER_EXISTING_ENV';
@@ -142,6 +166,7 @@ describe('/api/install/run', () => {
     try {
       const res = await request(app)
         .post('/api/install/run')
+        .set('x-install-setup-secret', 's3cret')
         .send({ adminEmail, adminPassword });
 
       expect(res.status).toBe(200);
@@ -177,11 +202,47 @@ describe('runInstall controller', () => {
 });
 
 describe('/api/install/run', () => {
-  it('passes sanitized credentials to the install script via environment', async () => {
+  it('rejects POST attempts without the setup secret when configured', async () => {
     process.env.INSTALL_API_ENABLED = 'true';
+    process.env.INSTALL_SETUP_SECRET = 's3cret';
+    mockFindAdmins.mockResolvedValue([]);
+    mockVerifyToken.mockImplementation((req, res) =>
+      res.status(401).json({ message: 'Missing or malformed token' })
+    );
 
     const res = await request(app)
       .post('/api/install/run')
+      .send({ adminEmail: 'admin@example.com', adminPassword: 'password123' });
+
+    expect(res.status).toBe(401);
+    expect(execFile).not.toHaveBeenCalled();
+    expect(mockVerifyToken).toHaveBeenCalledTimes(1);
+    expect(mockIsAdmin).not.toHaveBeenCalled();
+  });
+
+  it('allows POST attempts when the correct setup secret is provided', async () => {
+    process.env.INSTALL_API_ENABLED = 'true';
+    process.env.INSTALL_SETUP_SECRET = 's3cret';
+    mockFindAdmins.mockResolvedValue([]);
+
+    const res = await request(app)
+      .post('/api/install/run')
+      .set('x-install-setup-secret', 's3cret')
+      .send({ adminEmail: 'admin@example.com', adminPassword: 'password123' });
+
+    expect(res.status).toBe(200);
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+    expect(mockIsAdmin).not.toHaveBeenCalled();
+  });
+
+  it('passes sanitized credentials to the install script via environment', async () => {
+    process.env.INSTALL_API_ENABLED = 'true';
+    process.env.INSTALL_SETUP_SECRET = 's3cret';
+
+    const res = await request(app)
+      .post('/api/install/run')
+      .set('x-install-setup-secret', 's3cret')
       .send({
         adminEmail: '  admin@example.com  \n',
         adminPassword: '  pass\nword  ',


### PR DESCRIPTION
## Summary
- require a matching x-install-setup-secret header or authenticated admin for all install API requests
- accept setup secrets via header comparison against INSTALL_SETUP_SECRET
- expand install API Jest coverage to exercise secret-protected GET and POST scenarios

## Testing
- npm test -- installApi.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2f0d41a0c832899e0ce8ecf0560cf