### PR TITLE
Improve installer prerequisite checks

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,6 +30,32 @@ For deployments, Docker Compose additionally reads `backend/.env.production`.
 Copy `backend/.env.production.example` to `backend/.env.production` and fill in
 production database credentials and JWT secrets.
 
+Set the display name that should appear in installer prompts and outbound
+emails so the branding check passes:
+
+```
+APP_NAME=SkillBridge
+```
+
+If you plan to disable transactional email during setup, set
+`DISABLE_EMAILS=true`. Otherwise, provide SMTP credentials so the installer can
+verify connectivity up front:
+
+```
+SMTP_HOST=smtp.mailtrap.io
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password
+```
+
+Create the uploads directory that stores logos and favicons and ensure it is
+writable by the backend service user:
+
+```bash
+mkdir -p backend/uploads/app
+```
+
 Edit `backend/.env` and provide your secrets. `FRONTEND_URL` must match the
 exact origin (scheme, host, and port) where the frontend will run to avoid
 CORS errors. Separate multiple origins with commas, for example:
@@ -195,6 +221,12 @@ location ^~ /install/ {
 3. Rebuild and start the containers if they are running.
 4. Log in with an administrator account.
 5. Visit `http://localhost:5002/install` (or your domain's `/install`) and verify the page lists the prerequisite checks.
+
+   The prerequisite card now verifies that PostgreSQL is reachable using the
+   credentials in `.env`, confirms SMTP settings (or acknowledges that
+   `DISABLE_EMAILS=true` is set), checks that `APP_NAME` is defined, and ensures
+   `backend/uploads/app` is writable for logo uploads. Address any failures the
+   installer reports before continuing.
 
 Whether you run SkillBridge directly from the monorepo or from the packaged
 container image, the backend automatically serves the installer assets. During

--- a/install/install.js
+++ b/install/install.js
@@ -226,6 +226,7 @@ document.addEventListener('DOMContentLoaded', () => {
       requirements = payload.requirements.map((req, index) => {
         const id = req?.id || req?.key || req?.name || `requirement-${index}`;
         const label = req?.label || req?.name || FRIENDLY_LABELS[id] || formatKey(id);
+        const rawStatus = typeof req?.status === 'string' ? req.status.toLowerCase() : '';
         const value = req?.ok ?? req?.passed ?? req?.status ?? req?.value ?? req?.isMet ?? false;
         const passed =
           typeof value === 'boolean'
@@ -234,7 +235,8 @@ document.addEventListener('DOMContentLoaded', () => {
               ? ['ok', 'pass', 'passed', 'true', 'ready'].includes(value.toLowerCase())
               : Boolean(value);
         const details = req?.details || req?.message || req?.hint || '';
-        return { id, label, passed, details };
+        const status = rawStatus === 'warn' ? 'warn' : passed ? 'pass' : 'fail';
+        return { id, label, passed, details, status };
       });
     } else {
       const ignoreKeys = new Set(['ok', 'summary', 'message', 'output', 'requirements']);
@@ -244,31 +246,41 @@ document.addEventListener('DOMContentLoaded', () => {
           const label = FRIENDLY_LABELS[key] || formatKey(key);
           let passed = false;
           let details = '';
+          let rawStatus = typeof value?.status === 'string' ? value.status.toLowerCase() : '';
           if (typeof value === 'boolean') {
             passed = value;
+            rawStatus = value ? 'pass' : 'fail';
           } else if (typeof value === 'string') {
             const lowered = value.toLowerCase();
             passed = ['ok', 'pass', 'passed', 'true', 'ready', 'success'].includes(lowered);
             if (!passed && lowered.length) {
               details = value;
             }
+            rawStatus = lowered;
           } else if (typeof value === 'number') {
             passed = value > 0;
+            rawStatus = passed ? 'pass' : 'fail';
           } else if (typeof value === 'object') {
             if (typeof value.ok === 'boolean') {
               passed = value.ok;
+              rawStatus = value.ok ? 'pass' : rawStatus;
             } else if (typeof value.passed === 'boolean') {
               passed = value.passed;
+              rawStatus = value.passed ? 'pass' : rawStatus;
             } else if (typeof value.status === 'string') {
               passed = ['ok', 'pass', 'passed', 'ready', 'success'].includes(value.status.toLowerCase());
+              rawStatus = value.status.toLowerCase();
             } else if (typeof value.value === 'boolean') {
               passed = value.value;
+              rawStatus = value.value ? 'pass' : rawStatus;
             } else if (typeof value.isMet === 'boolean') {
               passed = value.isMet;
+              rawStatus = value.isMet ? 'pass' : rawStatus;
             }
             details = value.message || value.details || value.hint || '';
           }
-          return { id: key, label, passed, details };
+          const status = rawStatus === 'warn' ? 'warn' : passed ? 'pass' : 'fail';
+          return { id: key, label, passed, details, status };
         });
     }
 
@@ -315,15 +327,35 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     requirements.forEach((req) => {
+      const normalizedStatus = req.status || (req.passed ? 'pass' : 'fail');
+      const statusStyles = {
+        pass: {
+          wrapper: 'border-green-200 bg-green-50 text-green-800',
+          icon: 'text-green-600',
+          symbol: '✓',
+        },
+        warn: {
+          wrapper: 'border-amber-200 bg-amber-50 text-amber-800',
+          icon: 'text-amber-500',
+          symbol: '⚠',
+        },
+        fail: {
+          wrapper: 'border-red-200 bg-red-50 text-red-700',
+          icon: 'text-red-600',
+          symbol: '!',
+        },
+      };
+      const style = statusStyles[normalizedStatus] || statusStyles[req.passed ? 'pass' : 'fail'];
+
       const wrapper = document.createElement('div');
       wrapper.className = [
         'flex items-start gap-3 rounded border p-3 text-sm transition-colors duration-300',
-        req.passed ? 'border-green-200 bg-green-50 text-green-800' : 'border-red-200 bg-red-50 text-red-700',
+        style.wrapper,
       ].join(' ');
 
       const icon = document.createElement('span');
-      icon.className = `mt-0.5 text-base ${req.passed ? 'text-green-600' : 'text-red-600'}`;
-      icon.textContent = req.passed ? '✓' : '!';
+      icon.className = `mt-0.5 text-base ${style.icon}`;
+      icon.textContent = style.symbol;
       icon.setAttribute('aria-hidden', 'true');
 
       const content = document.createElement('div');

--- a/scripts/check_prereqs.sh
+++ b/scripts/check_prereqs.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 requirements=()
 all_ok=true
+ENV_FILES=("$REPO_ROOT/.env" "$REPO_ROOT/backend/.env" "$REPO_ROOT/backend/.env.local" "$REPO_ROOT/backend/.env.production")
+PYTHON_BIN="$(command -v python3 || command -v python || true)"
 
 escape_json() {
   local s="${1-}"
@@ -16,19 +21,282 @@ escape_json() {
 
 add_requirement() {
   local id="$1"
-  local name="$2"
+  local label="$2"
   local status="$3"
   local message="$4"
 
-  local escaped_name
-  escaped_name=$(escape_json "$name")
+  local escaped_label
+  escaped_label=$(escape_json "$label")
   local escaped_message
   escaped_message=$(escape_json "$message")
 
-  requirements+=("{\"id\":\"$id\",\"name\":\"$escaped_name\",\"status\":\"$status\",\"message\":\"$escaped_message\"}")
+  local passed="false"
+  case "$status" in
+    pass|PASS|ok|OK|ready|READY)
+      passed="true"
+      status="pass"
+      ;;
+    warn|WARN|warning|WARNING)
+      status="warn"
+      ;;
+    *)
+      status="fail"
+      ;;
+  esac
 
-  if [ "$status" != "pass" ]; then
+  requirements+=(
+    "{\"id\":\"$id\",\"label\":\"$escaped_label\",\"status\":\"$status\",\"passed\":$passed,\"message\":\"$escaped_message\"}"
+  )
+
+  if [ "$passed" != "true" ]; then
     all_ok=false
+  fi
+}
+
+trim_whitespace() {
+  local value="$1"
+  value="${value#${value%%[![:space:]]*}}"
+  value="${value%${value##*[![:space:]]}}"
+  echo "$value"
+}
+
+lookup_env_file_value() {
+  local key="$1"
+  shift
+  local file line raw_key value
+  for file in "$@"; do
+    [ -f "$file" ] || continue
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line%%$'\r'}"
+      line=$(trim_whitespace "$line")
+      [ -n "$line" ] || continue
+      case "$line" in
+        \#*) continue ;;
+      esac
+      if [[ "$line" == export* ]]; then
+        line=${line#export}
+        line=$(trim_whitespace "$line")
+      fi
+      raw_key=${line%%=*}
+      raw_key=$(trim_whitespace "$raw_key")
+      [ "$raw_key" = "$key" ] || continue
+      value=${line#*=}
+      value=$(trim_whitespace "$value")
+      case "$value" in
+        "\""*"\"") value=${value:1:-1} ;;
+        "'"*"'") value=${value:1:-1} ;;
+      esac
+      echo "$value"
+      return 0
+    done <"$file"
+  done
+  return 1
+}
+
+get_env_value() {
+  local key="$1"
+  local value="${!key-}"
+  if [ -n "$value" ]; then
+    echo "$value"
+    return 0
+  fi
+  lookup_env_file_value "$key" "${ENV_FILES[@]}" || true
+}
+
+join_by() {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
+check_smtp_configuration() {
+  local disable
+  disable=$(get_env_value "DISABLE_EMAILS")
+  if [ -n "$disable" ]; then
+    local normalized_disable
+    normalized_disable=$(echo "$disable" | tr '[:upper:]' '[:lower:]')
+    if [ "$normalized_disable" = "true" ]; then
+      add_requirement "smtp_env" "SMTP configuration" "pass" "Email delivery is disabled (DISABLE_EMAILS=true); SMTP credentials are optional."
+      return
+    fi
+  fi
+
+  local required=("SMTP_HOST" "SMTP_PORT" "SMTP_USER" "SMTP_PASS")
+  local missing=()
+  local smtp_host=""
+  local smtp_port=""
+  local smtp_user=""
+  local value
+  local var
+
+  for var in "${required[@]}"; do
+    value=$(get_env_value "$var")
+    if [ -n "$value" ]; then
+      case "$var" in
+        SMTP_HOST) smtp_host="$value" ;;
+        SMTP_PORT) smtp_port="$value" ;;
+        SMTP_USER) smtp_user="$value" ;;
+      esac
+    else
+      missing+=("$var")
+    fi
+  done
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    add_requirement "smtp_env" "SMTP configuration" "fail" "Missing variables: $(join_by ', ' "${missing[@]}"). Provide SMTP credentials or set DISABLE_EMAILS=true to bypass email delivery during installation."
+    return
+  fi
+
+  if ! [[ "$smtp_port" =~ ^[0-9]+$ ]]; then
+    add_requirement "smtp_env" "SMTP configuration" "fail" "SMTP_PORT must be a numeric port. Current value: ${smtp_port}."
+    return
+  fi
+
+  local message="SMTP credentials detected for ${smtp_host}:${smtp_port}."
+  if [ -n "$smtp_user" ]; then
+    message+=" Username ${smtp_user} will be used for authentication."
+  fi
+
+  add_requirement "smtp_env" "SMTP configuration" "pass" "$message"
+}
+
+check_single_env() {
+  local id="$1"
+  local label="$2"
+  local key="$3"
+  local value
+  value=$(get_env_value "$key")
+
+  if [ -n "$value" ]; then
+    add_requirement "$id" "$label" "pass" "$key is set."
+  else
+    add_requirement "$id" "$label" "fail" "$key is missing. Define it in backend/.env or your runtime environment so the installer can apply your branding."
+  fi
+}
+
+parse_database_url() {
+  local url="$1"
+  if [ -z "$url" ] || [ -z "$PYTHON_BIN" ]; then
+    return 1
+  fi
+
+  "$PYTHON_BIN" - "$url" <<'PY'
+import sys
+from urllib.parse import urlparse
+
+url = sys.argv[1]
+parsed = urlparse(url)
+if not parsed.scheme:
+    sys.exit(0)
+
+host = parsed.hostname or ''
+port = parsed.port or ''
+user = parsed.username or ''
+password = parsed.password or ''
+database = (parsed.path or '').lstrip('/')
+
+print(f"HOST={host}")
+print(f"PORT={port}")
+print(f"USER={user}")
+print(f"PASSWORD={password}")
+print(f"DATABASE={database}")
+PY
+}
+
+check_database_connection() {
+  local db_url host port user password database
+  local parse_output
+
+  db_url=$(get_env_value "DATABASE_URL")
+  if [ -z "$db_url" ]; then
+    db_url=$(get_env_value "PRODUCTION_DATABASE_URL")
+  fi
+
+  if [ -n "$db_url" ]; then
+    if [ -n "$PYTHON_BIN" ]; then
+      parse_output=$(parse_database_url "$db_url" || true)
+      if [ -n "$parse_output" ]; then
+        while IFS='=' read -r key value; do
+          case "$key" in
+            HOST) [ -n "$value" ] && host="$value" ;;
+            PORT) [ -n "$value" ] && port="$value" ;;
+            USER) [ -n "$value" ] && user="$value" ;;
+            PASSWORD) password="$value" ;;
+            DATABASE) [ -n "$value" ] && database="$value" ;;
+          esac
+        done <<<"$parse_output"
+      fi
+    else
+      add_requirement "database_connection" "Database connectivity" "fail" "DATABASE_URL is defined but Python is unavailable to parse it. Install Python 3 or provide discrete DATABASE_* variables."
+      return
+    fi
+  fi
+
+  host="${host:-$(get_env_value "DATABASE_HOST")}" \
+    || host="${host:-$(get_env_value "POSTGRES_HOST")}" || true
+  port="${port:-$(get_env_value "DATABASE_PORT")}" \
+    || port="${port:-$(get_env_value "POSTGRES_PORT")}" || true
+  user="${user:-$(get_env_value "DATABASE_USER")}" \
+    || user="${user:-$(get_env_value "POSTGRES_USER")}" || true
+  password="${password:-$(get_env_value "DATABASE_PASSWORD")}" \
+    || password="${password:-$(get_env_value "POSTGRES_PASSWORD")}" || true
+  database="${database:-$(get_env_value "DATABASE_NAME")}" \
+    || database="${database:-$(get_env_value "POSTGRES_DB")}" || true
+
+  if [ -z "$host" ] || [ -z "$user" ] || [ -z "$database" ]; then
+    add_requirement "database_connection" "Database connectivity" "fail" "Database configuration is incomplete. Provide host, user, and database name via DATABASE_URL or the DATABASE_*/POSTGRES_* variables."
+    return
+  fi
+
+  if [ -z "$port" ]; then
+    port=5432
+  fi
+
+  local connection_message
+  local status="pass"
+
+  if command -v psql >/dev/null 2>&1; then
+    if timeout 10 env PGPASSWORD="$password" PGCONNECT_TIMEOUT=5 PSQLRC=/dev/null psql \
+      --no-password --tuples-only --quiet --command "SELECT 1" \
+      --host "$host" --port "$port" --username "$user" --dbname "$database" >/dev/null 2>&1; then
+      connection_message="Successfully authenticated with PostgreSQL at $host:$port as $user."
+    else
+      status="fail"
+      connection_message="Failed to authenticate with PostgreSQL at $host:$port using the provided credentials. Verify the server is running and the username/password are correct."
+    fi
+  else
+    if timeout 5 bash -c "cat < /dev/null > /dev/tcp/$host/$port" >/dev/null 2>&1; then
+      connection_message="PostgreSQL at $host:$port is reachable. Install psql to validate credentials automatically, or test manually using the same environment variables."
+      if [ -z "$password" ]; then
+        connection_message+=" No database password was detected; set DATABASE_PASSWORD or POSTGRES_PASSWORD if your server requires one."
+      fi
+    else
+      status="fail"
+      connection_message="Unable to reach PostgreSQL at $host:$port. Check that the host is correct, the service is running, and firewalls permit the connection."
+    fi
+  fi
+
+  add_requirement "database_connection" "Database connectivity" "$status" "$connection_message"
+}
+
+check_logo_path() {
+  local logo_dir="$REPO_ROOT/backend/uploads/app"
+  if [ ! -d "$logo_dir" ]; then
+    add_requirement "logo_path" "Logo upload directory" "fail" "${logo_dir} does not exist. Create the directory and ensure the backend service can write to it."
+    return
+  fi
+
+  if [ ! -w "$logo_dir" ]; then
+    add_requirement "logo_path" "Logo upload directory" "fail" "${logo_dir} exists but is not writable. Adjust permissions (e.g., chown/chmod) so the backend can store branding assets."
+    return
+  fi
+
+  local tmp_file="$logo_dir/.write-test-$$"
+  if touch "$tmp_file" 2>/dev/null; then
+    rm -f "$tmp_file"
+    add_requirement "logo_path" "Logo upload directory" "pass" "${logo_dir} is writable."
+  else
+    add_requirement "logo_path" "Logo upload directory" "fail" "${logo_dir} is present but a write test failed. Review filesystem permissions and available disk space."
   fi
 }
 
@@ -106,6 +374,11 @@ else
   add_requirement "git" "Git" "fail" "Git executable not found."
 fi
 
+check_database_connection
+check_smtp_configuration
+check_single_env "app_name" "Application name" "APP_NAME"
+check_logo_path
+
 if [ "$all_ok" = true ]; then
   SUMMARY="All prerequisites met."
 else
@@ -124,6 +397,7 @@ OVERALL=$([ "$all_ok" = true ] && echo "true" || echo "false")
 
 printf '{'
 printf '"ok": %s,' "$OVERALL"
+printf '"allPassed": %s,' "$OVERALL"
 printf '"summary": "%s",' "$SUMMARY_ESCAPED"
 printf '"requirements": [%s]' "$joined"
 printf '}'


### PR DESCRIPTION
## Summary
- extend the prerequisite script to validate database connectivity, SMTP configuration, application name, and logo upload permissions while returning structured status data
- update the installer UI parser to respect the new status metadata and highlight pass/fail/warn states
- document the extra environment setup and installer checks in the installation guide

## Testing
- ./scripts/check_prereqs.sh > /tmp/prereq.json


------
https://chatgpt.com/codex/tasks/task_e_68d2f8a422e48328bbb8b9844424000a