### PR TITLE
Fix duplicate install helper import

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -3,7 +3,7 @@ const { Router } = require('express');
 const { z } = require('zod');
 const validate = require('../../middleware/validate');
 const logoUpload = require('../appConfig/appLogoUploadMiddleware');
-const { hasExistingAdmin } = require('./install.helpers');
+const installHelpers = require('./install.helpers');
 const controller = require('./install.controller');
 
 const router = Router();
@@ -34,7 +34,7 @@ const respondInstallerLocked = (res, message = 'Installer locked. Provide a vali
 const enforceInstallerGuard = async (req, res, next) => {
   try {
     const bypassCache = process.env.NODE_ENV === 'test';
-    const adminExists = await hasExistingAdmin({ bypassCache });
+    const adminExists = await installHelpers.hasExistingAdmin({ bypassCache });
     const setupSecret = typeof process.env.INSTALL_SETUP_SECRET === 'string'
       ? process.env.INSTALL_SETUP_SECRET.trim()
       : '';


### PR DESCRIPTION
## Summary
- replace the destructured import of the install helpers with a namespaced import to avoid redeclaration errors
- update the installer guard to reference the helper through the namespaced module

## Testing
- npm test -- --runTestsByPath src/modules/install/__tests__/install.routes.test.js *(fails: test file missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d31245fa0c8328a99b8eb4723c69ca