### PR TITLE
Prefer docker compose plugin in installer

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -3,7 +3,7 @@ const { Router } = require('express');
 const { z } = require('zod');
 const validate = require('../../middleware/validate');
 const logoUpload = require('../appConfig/appLogoUploadMiddleware');
-const { hasExistingAdmin } = require('./install.helpers');
+const installHelpers = require('./install.helpers');
 const controller = require('./install.controller');
 
 const router = Router();
@@ -34,7 +34,7 @@ const respondInstallerLocked = (res, message = 'Installer locked. Provide a vali
 const enforceInstallerGuard = async (req, res, next) => {
   try {
     const bypassCache = process.env.NODE_ENV === 'test';
-    const adminExists = await hasExistingAdmin({ bypassCache });
+    const adminExists = await installHelpers.hasExistingAdmin({ bypassCache });
     const setupSecret = typeof process.env.INSTALL_SETUP_SECRET === 'string'
       ? process.env.INSTALL_SETUP_SECRET.trim()
       : '';

--- a/install.sh
+++ b/install.sh
@@ -41,12 +41,12 @@ load_env_file() {
 }
 
 run_compose() {
-  if command -v docker-compose >/dev/null 2>&1; then
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  elif command -v docker-compose >/dev/null 2>&1; then
     DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-0} \
       COMPOSE_DOCKER_CLI_BUILD=${COMPOSE_DOCKER_CLI_BUILD:-0} \
       docker-compose "$@"
-  elif command -v docker >/dev/null 2>&1; then
-    docker compose "$@"
   else
     echo "Docker is required but not installed." >&2
     return 1


### PR DESCRIPTION
## Summary
- update the installer helper to prefer the modern `docker compose` plugin before falling back to legacy docker-compose

## Testing
- bash -n install.sh

------
https://chatgpt.com/codex/tasks/task_e_68d31245fa0c8328a99b8eb4723c69ca