### PR TITLE
Cleanup replaced installer logos

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -162,6 +162,7 @@ exports.runInstall = async (req, res) => {
     });
 
     const existingAppSettings = (await appConfigService.getSettings()) || {};
+    const existingLogoUrl = existingAppSettings.logo_url;
     const nextAppSettings = { ...existingAppSettings };
     if (appName) {
       nextAppSettings.appName = appName;
@@ -179,6 +180,15 @@ exports.runInstall = async (req, res) => {
       nextAppSettings.logo_url = logoUrl;
     }
     await appConfigService.updateSettings(nextAppSettings);
+
+    const nextLogoUrl = nextAppSettings.logo_url;
+    const isDifferentLogo = existingLogoUrl && existingLogoUrl !== nextLogoUrl;
+    const wasLocalUpload = typeof existingLogoUrl === 'string' && existingLogoUrl.startsWith('/uploads/app/');
+    if (isDifferentLogo && wasLocalUpload) {
+      const relativePath = existingLogoUrl.replace(/^\/+/, '');
+      const absolutePath = path.join(path.resolve(__dirname, '../../..'), relativePath);
+      await removeFileIfExists(absolutePath);
+    }
 
     const existingEmailSettings = (await emailConfigService.getSettings()) || {};
     const nextEmailSettings = {

--- a/backend/tests/installApi.test.js
+++ b/backend/tests/installApi.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const request = require('supertest');
+const fs = require('fs');
 
 jest.mock('child_process', () => {
   const util = require('util');
@@ -62,6 +63,8 @@ jest.mock('../src/modules/emailConfig/emailConfig.service', () => ({
 const { execFile } = require('child_process');
 const { router } = require('../src/modules/install/install.routes');
 
+const unlinkSpy = jest.spyOn(fs.promises, 'unlink').mockImplementation(async () => {});
+
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -94,6 +97,7 @@ beforeEach(() => {
   mockGetEmailSettings.mockResolvedValue({});
   mockUpdateEmailSettings.mockResolvedValue({});
   execFile.mockClear();
+  unlinkSpy.mockClear();
 });
 
 afterEach(() => {
@@ -215,6 +219,33 @@ describe('POST /api/install/run', () => {
         fromName: payload.smtpFromName,
       })
     );
+  });
+
+  it('removes the previous uploaded logo when a new logo is provided', async () => {
+    const payload = buildPayload();
+    const previousLogo = '/uploads/app/old-logo.png';
+    mockGetAppSettings.mockResolvedValueOnce({ logo_url: previousLogo });
+
+    const res = await postInstall(payload);
+
+    expect(res.status).toBe(200);
+    expect(
+      unlinkSpy.mock.calls.some(([calledPath]) => calledPath.endsWith('uploads/app/old-logo.png'))
+    ).toBe(true);
+  });
+
+  it('skips logo cleanup when the stored logo path is unchanged', async () => {
+    const payload = buildPayload();
+    delete payload.logoUrl;
+    const existingLogo = '/uploads/app/current-logo.png';
+    mockGetAppSettings.mockResolvedValueOnce({ logo_url: existingLogo });
+
+    const res = await postInstall(payload);
+
+    expect(res.status).toBe(200);
+    expect(
+      unlinkSpy.mock.calls.some(([calledPath]) => calledPath.endsWith('uploads/app/current-logo.png'))
+    ).toBe(false);
   });
 
   it('propagates installer failures', async () => {


### PR DESCRIPTION
## Summary
- capture the previous logo_url before updating installer branding settings
- remove superseded logo uploads after settings are saved
- assert installer tests cover logo cleanup for replaced and unchanged paths

## Testing
- npm test -- installApi

------
https://chatgpt.com/codex/tasks/task_e_68d31710b2d48328aca3b859cef48e14