### PR TITLE
Prevent installer from launching docker in app container

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  setupFiles: ['<rootDir>/jest.setup.js'],
 };

--- a/backend/jest.setup.js
+++ b/backend/jest.setup.js
@@ -1,0 +1,3 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret';
+process.env.REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET || 'test-refresh-secret';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-session-secret';

--- a/backend/src/modules/install/__tests__/install.controller.test.js
+++ b/backend/src/modules/install/__tests__/install.controller.test.js
@@ -1,0 +1,65 @@
+jest.mock('child_process', () => ({
+  execFile: jest.fn(),
+}));
+
+jest.mock('../../../utils/logger', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+jest.mock('../../appConfig/appConfig.service', () => ({
+  getSettings: jest.fn().mockResolvedValue({}),
+  updateSettings: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../../emailConfig/emailConfig.service', () => ({
+  getSettings: jest.fn().mockResolvedValue({}),
+  updateSettings: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../install.helpers', () => ({
+  markAdminExists: jest.fn(),
+  refreshAdminPresence: jest.fn().mockResolvedValue(),
+}));
+
+const { execFile } = require('child_process');
+
+const flushPromises = () => new Promise(setImmediate);
+
+describe('install.controller runInstall', () => {
+  beforeEach(() => {
+    delete process.env.MODE;
+    execFile.mockReset();
+    execFile.mockImplementation((file, args, options, callback) => {
+      callback(null, '', '');
+    });
+  });
+
+  it('passes START_DEV_SERVICES=false to the installer script', async () => {
+    const { runInstall } = require('../install.controller');
+
+    const req = {
+      body: {
+        adminEmail: 'admin@example.com',
+        adminPassword: 'supersecret',
+        appName: 'SkillBridge',
+      },
+    };
+
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn();
+    const res = { status, json };
+
+    await runInstall(req, res);
+    await flushPromises();
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+    const call = execFile.mock.calls[0];
+    const options = call[2];
+    expect(options).toBeDefined();
+    expect(options.env).toMatchObject({
+      START_DEV_SERVICES: 'false',
+      MODE: 'development',
+    });
+  });
+});

--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -153,6 +153,8 @@ exports.runInstall = async (req, res) => {
       ADMIN_EMAIL: adminEmail,
       ADMIN_PASSWORD: adminPassword,
       INSTALL_CONFIG_PATH: configPath,
+      START_DEV_SERVICES: 'false',
+      MODE: process.env.MODE || 'development',
     };
 
     const { stdout, stderr } = await runScript('install', { env });

--- a/install.sh
+++ b/install.sh
@@ -43,14 +43,29 @@ load_env_file() {
 run_compose() {
   if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
     docker compose "$@"
-  elif command -v docker-compose >/dev/null 2>&1; then
+    return $?
+  fi
+
+  if command -v docker-compose >/dev/null 2>&1; then
     DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-0} \
       COMPOSE_DOCKER_CLI_BUILD=${COMPOSE_DOCKER_CLI_BUILD:-0} \
       docker-compose "$@"
-  else
-    echo "Docker is required but not installed." >&2
-    return 1
+    return $?
   fi
+
+  return 127
+}
+
+docker_available() {
+  if command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v docker-compose >/dev/null 2>&1; then
+    return 0
+  fi
+
+  return 1
 }
 
 MODE=${1:-}
@@ -98,16 +113,24 @@ COMPOSE_FILE="$REPO_ROOT/docker-compose.yml"
 START_DEV_SERVICES=${START_DEV_SERVICES:-true}
 
 if [[ "$MODE" == "production" ]]; then
-  echo "Ensuring Docker services are running before migrations..."
-  if ! run_compose -f "$COMPOSE_FILE" up -d; then
-    echo "Failed to start Docker services required for production." >&2
-    exit 1
+  if docker_available; then
+    echo "Ensuring Docker services are running before migrations..."
+    if ! run_compose -f "$COMPOSE_FILE" up -d; then
+      echo "Failed to start Docker services required for production." >&2
+      exit 1
+    fi
+  else
+    echo "Docker CLI not available; skipping compose startup for production mode." >&2
   fi
 elif [[ "$START_DEV_SERVICES" == "true" ]]; then
-  echo "Starting development services with docker compose (detached)..."
-  if ! run_compose -f "$COMPOSE_FILE" up --build -d; then
-    echo "Failed to start development Docker services." >&2
-    exit 1
+  if docker_available; then
+    echo "Starting development services with docker compose (detached)..."
+    if ! run_compose -f "$COMPOSE_FILE" up --build -d; then
+      echo "Failed to start development Docker services." >&2
+      exit 1
+    fi
+  else
+    echo "Docker CLI not available; skipping development compose startup."
   fi
 else
   echo "Skipping automatic startup of development services."


### PR DESCRIPTION
## Summary
- ensure the backend installer controller sets START_DEV_SERVICES=false and defaults MODE to development when invoking install.sh
- make install.sh skip docker compose startup if no Docker CLI is available
- add Jest setup defaults for auth secrets and cover the new controller behavior with a focused unit test

## Testing
- npm test -- install.controller

------
https://chatgpt.com/codex/tasks/task_e_68d317a7139483288bf7926300e6648e