### PR TITLE
Remove duplicate fs import from install API test

### DIFF
--- a/backend/tests/installApi.test.js
+++ b/backend/tests/installApi.test.js
@@ -2,7 +2,6 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const request = require('supertest');
-const fs = require('fs');
 
 jest.mock('child_process', () => {
   const util = require('util');


### PR DESCRIPTION
## Summary
- remove the duplicate `fs` import declaration in `backend/tests/installApi.test.js`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d31aceaa448328bbe84c01e34d82ed