### PR TITLE
Enforce docker compose plugin requirement in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SkillBridge is a full-stack learning platform powered by an Express.js backend a
 
 ## Automated Installation
 
-Ensure `bash`, `curl`, `docker` and `docker compose` are installed on your system.
+Ensure `bash`, `curl`, `docker`, and the Docker Compose V2 plugin (the `docker compose` command) are installed on your system. The installer exits early if only the legacy `docker-compose` binary is present so you can install the plugin or downgrade Docker Engine below version 27 before proceeding.
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/eduskillbridge/SkillBridge/main/install.sh | bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ This document explains how to set up SkillBridge for local development and for h
 - Git
 - Redis or another session store for production deployments
 
-> **Heads up:** The legacy `docker-compose` v1 CLI is incompatible with recent Docker Engine releases and often fails with `KeyError: 'ContainerConfig'` when rebuilding containers. Install Docker Compose V2 and prefer the `docker compose` command. If you cannot upgrade immediately, the installation script now disables BuildKit automatically for the legacy CLI; you can achieve the same effect manually by exporting `DOCKER_BUILDKIT=0` and `COMPOSE_DOCKER_CLI_BUILD=0` before running Compose so v1 can work with older image metadata.
+> **Heads up:** The legacy `docker-compose` v1 CLI is incompatible with recent Docker Engine releases and often fails with `KeyError: 'ContainerConfig'` when rebuilding containers. The installer now refuses to run when only the v1 binary is available so you can address the issue up front. Install the Docker Compose V2 plugin (the `docker compose` command) or downgrade Docker Engine below version&nbsp;27 before running the script.
 
 ## 1. Clone the repository
 

--- a/install.sh
+++ b/install.sh
@@ -67,16 +67,34 @@ derive_postgres_url() {
 }
 
 run_compose() {
-  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
-    docker compose "$@"
-    return $?
+  local server_version=""
+  local engine_major=""
+
+  if command -v docker >/dev/null 2>&1; then
+    if docker compose version >/dev/null 2>&1; then
+      docker compose "$@"
+      return $?
+    fi
+
+    server_version=$(docker version --format '{{.Server.Version}}' 2>/dev/null || true)
+    if [[ -n "$server_version" ]]; then
+      engine_major=${server_version%%.*}
+      if [[ "$engine_major" =~ ^[0-9]+$ ]] && (( engine_major >= 27 )); then
+        echo "Docker Engine $server_version detected but the docker compose plugin is unavailable." >&2
+        echo "Install the Docker Compose plugin (the 'docker compose' command) or downgrade Docker Engine below version 27." >&2
+        return 1
+      fi
+    fi
+
+    echo "Docker is installed but the docker compose plugin is not available." >&2
+    echo "Install the Docker Compose plugin (the 'docker compose' command) to continue." >&2
+    return 1
   fi
 
   if command -v docker-compose >/dev/null 2>&1; then
-    DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-0} \
-      COMPOSE_DOCKER_CLI_BUILD=${COMPOSE_DOCKER_CLI_BUILD:-0} \
-      docker-compose "$@"
-    return $?
+    echo "Only the legacy docker-compose v1 binary was found." >&2
+    echo "Install the Docker Compose plugin (the 'docker compose' command) or downgrade Docker Engine below version 27 to avoid errors such as KeyError: 'ContainerConfig'." >&2
+    return 1
   fi
 
   return 127


### PR DESCRIPTION
## Summary
- detect when only the legacy docker-compose binary is available and stop with a helpful error
- query the Docker Engine version so the installer can prompt for the compose plugin or an engine downgrade before running
- document the compose plugin requirement and the new fail-fast behavior in the README and installation guide

## Testing
- bash -n install.sh

------
https://chatgpt.com/codex/tasks/task_e_68d31ae841d08328aa4cd52a9f143cf4