### PR TITLE
Fix duplicate hasExistingAdmin import

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -3,7 +3,7 @@ const { Router } = require('express');
 const { z } = require('zod');
 const validate = require('../../middleware/validate');
 const logoUpload = require('../appConfig/appLogoUploadMiddleware');
-const installHelpers = require('./install.helpers');
+const { hasExistingAdmin } = require('./install.helpers');
 const controller = require('./install.controller');
 
 const router = Router();
@@ -34,7 +34,7 @@ const respondInstallerLocked = (res, message = 'Installer locked. Provide a vali
 const enforceInstallerGuard = async (req, res, next) => {
   try {
     const bypassCache = process.env.NODE_ENV === 'test';
-    const adminExists = await installHelpers.hasExistingAdmin({ bypassCache });
+    const adminExists = await hasExistingAdmin({ bypassCache });
     const setupSecret = typeof process.env.INSTALL_SETUP_SECRET === 'string'
       ? process.env.INSTALL_SETUP_SECRET.trim()
       : '';


### PR DESCRIPTION
## Summary
- switch the install routes helper import to destructure `hasExistingAdmin`
- call the helper directly to avoid duplicate constant declarations during module loading

## Testing
- npm test *(fails: environment-dependent suites require database config and other services)*

------
https://chatgpt.com/codex/tasks/task_e_68d31c0e9bb88328a249326ef5af74f6