### PR TITLE
Fix duplicate hasExistingAdmin import

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -3,7 +3,7 @@ const { Router } = require('express');
 const { z } = require('zod');
 const validate = require('../../middleware/validate');
 const logoUpload = require('../appConfig/appLogoUploadMiddleware');
-const { hasExistingAdmin } = require('./install.helpers');
+const installHelpers = require('./install.helpers');
 const controller = require('./install.controller');
 
 const router = Router();
@@ -34,7 +34,7 @@ const respondInstallerLocked = (res, message = 'Installer locked. Provide a vali
 const enforceInstallerGuard = async (req, res, next) => {
   try {
     const bypassCache = process.env.NODE_ENV === 'test';
-    const adminExists = await hasExistingAdmin({ bypassCache });
+    const adminExists = await installHelpers.hasExistingAdmin({ bypassCache });
     const setupSecret = typeof process.env.INSTALL_SETUP_SECRET === 'string'
       ? process.env.INSTALL_SETUP_SECRET.trim()
       : '';


### PR DESCRIPTION
## Summary
- replace the destructured helper import in `install.routes.js` with a single module import to avoid duplicate identifier errors
- update the guard middleware to reference the helper through the module object

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d31df3ad248328acdecc1c02db4af0