### PR TITLE
Allow Tailwind CDN in CSP

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -62,8 +62,8 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        scriptSrc: ["'self'", "'unsafe-inline'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
+        scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.tailwindcss.com"],
+        styleSrc: ["'self'", "'unsafe-inline'", "https://cdn.tailwindcss.com"],
       },
     },
     crossOriginEmbedderPolicy: false,


### PR DESCRIPTION
## Summary
- allow the Tailwind CDN in the Helmet content security policy configuration so the install page can load its script and styles

## Testing
- npm run start *(fails: missing JWT_SECRET, REFRESH_TOKEN_SECRET, SESSION_SECRET environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68d39d0dd1bc8328918b743e32a9d124