### PR TITLE
Use relative asset URLs on install page

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>SkillBridge Installer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="./styles.css" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     .step-container {
@@ -387,6 +387,6 @@
       </div>
     </section>
   </main>
-  <script src="install.js" defer></script>
+  <script src="./install.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the install page HTML to load its CSS and JavaScript with directory-relative URLs so assets resolve correctly when served from /install

## Testing
- python3 -m http.server 8000
- playwright script to load http://127.0.0.1:8000/install/

------
https://chatgpt.com/codex/tasks/task_e_68d39d0e185c83288dbd9db4e9e9a90e