### PR TITLE
Fix installer asset paths

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>SkillBridge Installer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="/install/styles.css" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     .step-container {
@@ -387,6 +387,6 @@
       </div>
     </section>
   </main>
-  <script src="install.js" defer></script>
+  <script src="/install/install.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update installer HTML to load styles and scripts from absolute /install URLs so assets resolve regardless of trailing slash

## Testing
- python -m http.server 8000
- curl -sSD - http://127.0.0.1:8000/install | head
- curl -sS http://127.0.0.1:8000/install/ | head
- curl -sS http://127.0.0.1:8000/install/styles.css | head
- curl -sS http://127.0.0.1:8000/install/install.js | head

------
https://chatgpt.com/codex/tasks/task_e_68d39d24770c83288346f10667b9839f