### PR TITLE
Fix installer asset paths to absolute URLs

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>SkillBridge Installer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="/install/styles.css" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     .step-container {
@@ -387,6 +387,6 @@
       </div>
     </section>
   </main>
-  <script src="install.js" defer></script>
+  <script src="/install/install.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the installer HTML to reference its CSS and JS with absolute `/install` paths so they resolve when the page is loaded from `/install`

## Testing
- curl http://127.0.0.1:8000/install/styles.css
- curl http://127.0.0.1:8000/install/install.js

------
https://chatgpt.com/codex/tasks/task_e_68d39d6f2dac83288aa3a6d622b229be