### PR TITLE
Add installer guidance and Codecanyon key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ When Step&nbsp;2 (“Configuration”) becomes available, gather the following v
 - PostgreSQL connection URL, database user, and password.
 - SMTP host, port, username, and password for transactional email.
 - The default “from” email address and public-facing application name.
+- (Optional) Your Codecanyon purchase/subscription key for license verification.
 - A logo to brand the UI (upload a PNG/JPG/SVG up to 5&nbsp;MB or provide an HTTPS logo URL).
 - The email and password for the first administrator.
 

--- a/backend/scripts/apply-install-config.js
+++ b/backend/scripts/apply-install-config.js
@@ -269,6 +269,7 @@ const applyConfiguration = async () => {
         encoding: (process.env.INSTALL_LOGO_FILE_ENCODING || 'base64').toLowerCase(),
       };
     })(),
+    codecanyonKey: (process.env.CODECANYON_SUBSCRIPTION_KEY || '').trim(),
   };
 
   const envUpdates = {
@@ -287,6 +288,10 @@ const applyConfiguration = async () => {
     ENABLE_INSTALL: 'false',
     INSTALL_API_ENABLED: 'false',
   };
+
+  if (config.codecanyonKey) {
+    envUpdates.CODECANYON_SUBSCRIPTION_KEY = config.codecanyonKey;
+  }
 
   await upsertEnvValues(envPath, envUpdates);
 

--- a/backend/scripts/apply-installer-config.js
+++ b/backend/scripts/apply-installer-config.js
@@ -222,6 +222,7 @@ function buildEnvUpdates(config) {
   const updates = {};
   if (config.appName) updates.APP_NAME = config.appName;
   if (config.supportEmail) updates.SUPPORT_EMAIL = config.supportEmail;
+  if (config.codecanyonKey) updates.CODECANYON_SUBSCRIPTION_KEY = config.codecanyonKey;
   if (config.smtp) {
     if (config.smtp.host) updates.SMTP_HOST = config.smtp.host;
     if (config.smtp.port) updates.SMTP_PORT = config.smtp.port;

--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -77,6 +77,10 @@ const buildInstallerConfig = (body) => {
     config.logoUrl = body.logoUrl;
   }
 
+  if (body.codecanyonKey) {
+    config.codecanyonKey = body.codecanyonKey;
+  }
+
   return config;
 };
 
@@ -105,6 +109,7 @@ exports.runInstall = async (req, res) => {
     smtpFromEmail,
     smtpFromName,
     logoUrl,
+    codecanyonKey,
   } = req.body;
 
   if (!adminEmail || !adminPassword) {
@@ -156,6 +161,10 @@ exports.runInstall = async (req, res) => {
       START_DEV_SERVICES: 'false',
       MODE: process.env.MODE || 'development',
     };
+
+    if (codecanyonKey) {
+      env.CODECANYON_SUBSCRIPTION_KEY = codecanyonKey;
+    }
 
     const { stdout, stderr } = await runScript('install', { env });
     markAdminExists();

--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -111,6 +111,9 @@ const installSchema = z
     adminPassword: z.string().min(8),
     appName: z.string().trim().min(1),
     supportEmail: z.string().trim().email(),
+    codecanyonKey: optionalTrimmed.refine((value) => !value || value.length >= 6, {
+      message: 'Codecanyon key must be at least 6 characters.',
+    }),
     logoUrl: optionalUrl,
     smtpHost: z.string().trim().min(1),
     smtpPort: z

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -265,6 +265,7 @@ location ^~ /install/ {
    - A PostgreSQL connection string, database user, and database password.
    - SMTP host, port, username, and password so SkillBridge can deliver transactional email.
    - The default “from” email address used for outbound messages.
+   - (Optional) Your Codecanyon purchase or subscription key so future updates can validate the license.
    - The public application display name.
    - Either a logo image upload (PNG/JPG/SVG up to 5&nbsp;MB) or an HTTPS URL to an existing logo.
    - The admin email and password for the first administrator.

--- a/install/index.html
+++ b/install/index.html
@@ -176,6 +176,14 @@
     <section id="step-prereq" class="mb-8 step-container step-visible" aria-hidden="false">
       <h2 class="text-xl font-semibold mb-2">Step 1: Prerequisite Check</h2>
       <p class="text-sm text-gray-600">We’ll verify that your environment meets the requirements before continuing.</p>
+      <div class="mt-3 rounded-md border-l-4 border-yellow-400 bg-yellow-50 p-3 text-sm text-yellow-800">
+        <p class="font-semibold">Before you begin</p>
+        <p>
+          Ensure the backend service has <code>ENABLE_INSTALL=true</code> and
+          <code>INSTALL_API_ENABLED=true</code>, then sign in with an administrator account. If
+          <code>INSTALL_SETUP_SECRET</code> is configured, enter it below.
+        </p>
+      </div>
       <div id="setupSecretWrapper" class="mt-4 max-w-md">
         <label class="block">
           <span class="block font-medium">Setup Secret (if required)</span>
@@ -231,6 +239,24 @@
               class="mt-1 w-full rounded border border-gray-300 p-2 focus:border-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-200"
             />
             <p class="mt-1 hidden text-sm text-red-600" data-field-error="adminPassword"></p>
+          </label>
+        </fieldset>
+
+        <fieldset class="space-y-4">
+          <legend class="text-base font-semibold text-gray-800">License</legend>
+          <label class="block">
+            <span class="block font-medium">Codecanyon Subscription Key (optional)</span>
+            <input
+              type="text"
+              name="codecanyonKey"
+              autocomplete="off"
+              placeholder="Purchase or subscription code"
+              class="mt-1 w-full rounded border border-gray-300 p-2 focus:border-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-200"
+            />
+            <span class="mt-1 block text-xs text-gray-500">
+              Store your Envato/Codecanyon key so future updates can verify the license automatically.
+            </span>
+            <p class="mt-1 hidden text-sm text-red-600" data-field-error="codecanyonKey"></p>
           </label>
         </fieldset>
 

--- a/install/install.js
+++ b/install/install.js
@@ -580,6 +580,7 @@ document.addEventListener('DOMContentLoaded', () => {
       adminPassword: String(formData.get('adminPassword') ?? ''),
       appName: sanitize(formData.get('appName')),
       supportEmail: sanitize(formData.get('supportEmail')),
+      codecanyonKey: sanitize(formData.get('codecanyonKey')),
       branding: {
         logoUrl: sanitize(formData.get('logoUrl')),
         logoFile: null,
@@ -668,6 +669,10 @@ document.addEventListener('DOMContentLoaded', () => {
       issues.push({ field: 'logoFile', message: 'Uploaded logo must be 2 MB or smaller.' });
     }
 
+    if (configuration.codecanyonKey && configuration.codecanyonKey.length < 6) {
+      issues.push({ field: 'codecanyonKey', message: 'Codecanyon key should be at least 6 characters.' });
+    }
+
     return issues;
   }
 
@@ -701,6 +706,10 @@ document.addEventListener('DOMContentLoaded', () => {
       if (typeof File !== 'undefined' && logoFile instanceof File && logoFile.size > 0) {
         payload.set('logoFile', logoFile, logoFile.name);
       }
+    }
+
+    if (configuration.codecanyonKey) {
+      payload.set('codecanyonKey', configuration.codecanyonKey);
     }
 
     return payload;


### PR DESCRIPTION
## Summary
- add on-page guidance to the installer and capture an optional Codecanyon subscription key during configuration
- persist the supplied key through the installer API and config scripts so it is written to backend environment files
- document the new field and prerequisites in the README and installation guide

## Testing
- npm --prefix backend test -- installApi
- npm --prefix backend test -- install.controller

------
https://chatgpt.com/codex/tasks/task_e_68d3d4f4a5a88328af8cb922f9175be1