### PR TITLE
Add license verification endpoint with demo support

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,8 @@ REFRESH_TOKEN_SECRET=your_refresh_token_secret
 # Maximum upload size for blog images in bytes
 MAX_BLOG_IMAGE_BYTES=10485760
 CLOUDINARY_API_KEY=your_key
+# Envato API token for purchase code verification
+ENVATO_TOKEN=your_envato_api_token_here
 # SMTP configuration
 # Port 587 uses STARTTLS; keep SMTP_SECURE=false for this port.
 # For TLS-over-SSL use port 465 and set SMTP_SECURE=true.

--- a/backend/src/migrations/20250924120000_create_licenses.js
+++ b/backend/src/migrations/20250924120000_create_licenses.js
@@ -1,0 +1,51 @@
+exports.up = async function up(knex) {
+  const hasLicensesTable = await knex.schema.hasTable('licenses');
+
+  if (!hasLicensesTable) {
+    await knex.schema.createTable('licenses', (table) => {
+      table.increments('id').primary();
+      table.string('purchase_code').unique().notNullable();
+      table.string('domain').nullable();
+      table.timestamp('verified_at').nullable();
+      table.string('status').defaultTo('active');
+      table.timestamp('created_at').defaultTo(knex.fn.now());
+      table.timestamp('updated_at').defaultTo(knex.fn.now());
+    });
+    return;
+  }
+
+  const hasVerifiedAt = await knex.schema.hasColumn('licenses', 'verified_at');
+  if (!hasVerifiedAt) {
+    await knex.schema.alterTable('licenses', (table) => {
+      table.timestamp('verified_at').nullable();
+    });
+  }
+
+  await knex.schema.alterTable('licenses', (table) => {
+    table.string('domain').nullable().alter();
+  });
+};
+
+exports.down = async function down(knex) {
+  const hasLicensesTable = await knex.schema.hasTable('licenses');
+  if (!hasLicensesTable) {
+    return;
+  }
+
+  const hasEmailColumn = await knex.schema.hasColumn('licenses', 'email');
+  if (!hasEmailColumn) {
+    await knex.schema.dropTable('licenses');
+    return;
+  }
+
+  const hasVerifiedAt = await knex.schema.hasColumn('licenses', 'verified_at');
+  if (hasVerifiedAt) {
+    await knex.schema.alterTable('licenses', (table) => {
+      table.dropColumn('verified_at');
+    });
+  }
+
+  await knex.schema.alterTable('licenses', (table) => {
+    table.string('domain').notNullable().alter();
+  });
+};

--- a/backend/src/modules/license/license.controller.js
+++ b/backend/src/modules/license/license.controller.js
@@ -1,5 +1,28 @@
 const fetch = (...args) => import('node-fetch').then(({ default: f }) => f(...args));
 const service = require('./license.service');
+const { validatePurchaseCode } = require('../../services/licenseService');
+
+/**
+ * POST /api/license/verify
+ * Validate a purchase code during installation.
+ */
+exports.verifyPurchaseCode = async (req, res, next) => {
+  const { purchase_code, domain } = req.body;
+  try {
+    if (!purchase_code) {
+      return res.status(400).json({ error: 'Purchase code required' });
+    }
+
+    const result = await validatePurchaseCode(purchase_code, domain);
+    if (result.valid) {
+      return res.json({ success: true, message: result.message });
+    }
+
+    return res.status(400).json({ success: false, message: result.message });
+  } catch (err) {
+    return next(err);
+  }
+};
 
 /**
  * POST /api/license/activate

--- a/backend/src/modules/license/license.routes.js
+++ b/backend/src/modules/license/license.routes.js
@@ -5,6 +5,7 @@ const validate = require('../../middleware/validate');
 const { verifyToken, isAdmin } = require('../../middleware/auth/authMiddleware');
 const validator = require('./license.validator');
 
+router.post('/verify', controller.verifyPurchaseCode);
 router.post('/activate', validate(validator.activate), controller.activateLicense);
 router.post('/validate', validate(validator.validate), controller.validateLicense);
 router.post('/deactivate', validate(validator.deactivate), controller.deactivateLicense);

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -19,6 +19,7 @@ router.use('/api/admin/cache', require('./cache.routes'));
 router.use('/api/messages/config', require('../modules/messagesConfig/messagesConfig.routes'));
 router.use('/api/social-login/config', require('../modules/socialLoginConfig/socialLoginConfig.routes'));
 router.use('/api/app-config', require('../modules/appConfig/appConfig.routes'));
+router.use('/api/license', require('../modules/license/license.routes'));
 router.use('/api/third-party-config', require('../modules/thirdPartyConfig/thirdPartyConfig.routes'));
 router.use('/api/google-analytics', require('../modules/googleAnalytics/googleAnalytics.routes'));
 router.use('/api/adsense', require('../modules/adsense/adsense.routes'));

--- a/backend/src/services/licenseService.js
+++ b/backend/src/services/licenseService.js
@@ -1,0 +1,36 @@
+const axios = require('axios');
+const db = require('../config/database');
+
+// Axios is kept in place for the future Envato API integration.
+void axios;
+
+async function validatePurchaseCode(code, domain) {
+  if (code === 'DEMO-CODE-1234') {
+    const existing = await db('licenses').where({ purchase_code: code }).first();
+    const now = new Date();
+    const payload = {
+      verified_at: now,
+      status: 'active',
+      ...(domain !== undefined ? { domain: domain || null } : {}),
+    };
+
+    if (existing) {
+      await db('licenses').where({ id: existing.id }).update(payload);
+    } else {
+      await db('licenses').insert({
+        purchase_code: code,
+        domain: domain || null,
+        email: 'demo@placeholder.invalid',
+        status: 'active',
+        verified_at: now,
+        created_at: now,
+      });
+    }
+
+    return { valid: true, message: 'Demo license accepted' };
+  }
+
+  return { valid: false, message: 'Invalid purchase code' };
+}
+
+module.exports = { validatePurchaseCode };

--- a/frontend/src/services/licenseService.js
+++ b/frontend/src/services/licenseService.js
@@ -1,0 +1,10 @@
+import api from "@/services/api/api";
+
+export async function verifyLicense(purchaseCode, domain) {
+  const payload = {
+    purchase_code: purchaseCode,
+    ...(domain ? { domain } : {}),
+  };
+  const { data } = await api.post("/license/verify", payload);
+  return data;
+}


### PR DESCRIPTION
## Summary
- add a migration that ensures the licenses table supports nullable domains and a verified_at timestamp
- create a backend license verification service and route that accepts a demo purchase code while preparing for Envato integration
- expose the verification endpoint to the frontend along with a simple installer-facing API helper and document the Envato token env var

## Testing
- npm --prefix backend test -- --runTestsByPath tests/installRoute.test.js *(fails: installer template missing expected `id="configForm"` marker in current tree)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d8fd7ba483289ea6289b699331ef