### PR TITLE
Add demo license verification endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,7 +68,7 @@ STRIPE_SECRET_KEY=your_stripe_secret_key
 # Default ad duration in days; defaults to 0
 DEFAULT_AD_DURATION_DAYS=0
 # Envato API token used for license verification
-ENVATO_TOKEN=your_envato_token
+ENVATO_TOKEN=your_envato_api_token_here
 
 # OAuth provider credentials
 GITHUB_CLIENT_ID=your_github_client_id

--- a/backend/src/migrations/20250924120000_update_licenses_table.js
+++ b/backend/src/migrations/20250924120000_update_licenses_table.js
@@ -1,0 +1,73 @@
+const isPostgres = (knex) => {
+  const client = knex?.client?.config?.client;
+  return client === 'pg' || client === 'postgres' || client === 'postgresql';
+};
+
+exports.up = async function (knex) {
+  const hasLicenses = await knex.schema.hasTable('licenses');
+
+  if (!hasLicenses) {
+    await knex.schema.createTable('licenses', (table) => {
+      table.increments('id').primary();
+      table.string('purchase_code').unique().notNullable();
+      table.string('domain').nullable();
+      table.timestamp('verified_at').nullable();
+      table.string('status').defaultTo('active');
+    });
+    return;
+  }
+
+  const hasVerifiedAt = await knex.schema.hasColumn('licenses', 'verified_at');
+  if (!hasVerifiedAt) {
+    await knex.schema.alterTable('licenses', (table) => {
+      table.timestamp('verified_at').nullable();
+    });
+  }
+
+  if (isPostgres(knex)) {
+    await knex.raw('ALTER TABLE licenses ALTER COLUMN domain DROP NOT NULL');
+    try {
+      await knex.raw('ALTER TABLE licenses ALTER COLUMN email DROP NOT NULL');
+    } catch (error) {
+      if (error && error.message && !error.message.includes('email')) {
+        throw error;
+      }
+    }
+  }
+};
+
+exports.down = async function (knex) {
+  const hasLicenses = await knex.schema.hasTable('licenses');
+  if (!hasLicenses) {
+    return;
+  }
+
+  const hasVerifiedAt = await knex.schema.hasColumn('licenses', 'verified_at');
+  if (hasVerifiedAt) {
+    await knex.schema.alterTable('licenses', (table) => {
+      table.dropColumn('verified_at');
+    });
+  }
+
+  if (isPostgres(knex)) {
+    try {
+      await knex.raw('ALTER TABLE licenses ALTER COLUMN domain SET NOT NULL');
+    } catch (error) {
+      if (!error || !error.message || !error.message.includes('does not exist')) {
+        throw error;
+      }
+    }
+
+    try {
+      await knex.raw('ALTER TABLE licenses ALTER COLUMN email SET NOT NULL');
+    } catch (error) {
+      if (
+        !error ||
+        !error.message ||
+        (!error.message.includes('does not exist') && !error.message.includes('email'))
+      ) {
+        throw error;
+      }
+    }
+  }
+};

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -49,6 +49,7 @@ router.use('/api/faqs', require('../modules/faqs/faqs.routes'));
 router.use('/api/support', require('../modules/support/support.routes'));
 router.use('/api/tickets', require('../modules/tickets/tickets.routes'));
 router.use('/api/media', require('../modules/media/media.routes'));
+router.use('/api/license', require('./license.routes'));
 router.use('/api/book-categories', require('../modules/bookCategories/bookCategories.routes'));
 router.use('/api/books', require('../modules/books/book.routes'));
 router.use('/api/instructor/books', require('../modules/books/instructorBook.routes'));

--- a/backend/src/routes/license.routes.js
+++ b/backend/src/routes/license.routes.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const { validatePurchaseCode } = require('../services/licenseService');
+
+router.post('/verify', async (req, res) => {
+  try {
+    const { purchase_code: purchaseCode, domain } = req.body || {};
+    if (!purchaseCode) {
+      return res.status(400).json({ error: 'Purchase code required' });
+    }
+
+    const result = await validatePurchaseCode(purchaseCode, domain);
+    if (result.valid) {
+      return res.json({ success: true, message: result.message });
+    }
+
+    return res.status(400).json({ success: false, message: result.message });
+  } catch (error) {
+    return res.status(500).json({ error: 'License check failed' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/services/licenseService.js
+++ b/backend/src/services/licenseService.js
@@ -1,0 +1,49 @@
+const axios = require('axios');
+const db = require('../config/database');
+
+let hasEmailColumnCache;
+async function hasEmailColumn() {
+  if (typeof hasEmailColumnCache === 'boolean') {
+    return hasEmailColumnCache;
+  }
+  try {
+    hasEmailColumnCache = await db.schema.hasColumn('licenses', 'email');
+  } catch (error) {
+    hasEmailColumnCache = false;
+  }
+  return hasEmailColumnCache;
+}
+
+async function validatePurchaseCode(code, domain) {
+  if (code === 'DEMO-CODE-1234') {
+    const now = new Date();
+    const existing = await db('licenses').where({ purchase_code: code }).first();
+    const payload = {
+      purchase_code: code,
+      domain: domain || null,
+      verified_at: now,
+      status: 'active',
+    };
+
+    if (await hasEmailColumn()) {
+      payload.email = 'demo@example.com';
+    }
+
+    if (existing) {
+      await db('licenses').where({ id: existing.id }).update(payload);
+    } else {
+      await db('licenses').insert(payload);
+    }
+
+    return { valid: true, message: 'Demo license accepted' };
+  }
+
+  // const response = await axios.get(
+  //   `https://api.envato.com/v3/market/author/sale?code=${code}`,
+  //   { headers: { Authorization: `Bearer ${process.env.ENVATO_TOKEN}` } }
+  // );
+
+  return { valid: false, message: 'Invalid purchase code' };
+}
+
+module.exports = { validatePurchaseCode };

--- a/frontend/src/services/licenseService.js
+++ b/frontend/src/services/licenseService.js
@@ -1,0 +1,9 @@
+import api from "@/services/api/api";
+
+export async function verifyLicense(purchaseCode, domain) {
+  const { data } = await api.post("/license/verify", {
+    purchase_code: purchaseCode,
+    domain,
+  });
+  return data;
+}


### PR DESCRIPTION
## Summary
- ensure the `licenses` table exists with `verified_at` support and relax Postgres constraints when available
- add a demo-oriented license verification service and `/api/license/verify` endpoint wired into the router
- provide a frontend helper for the installer flow and document the Envato token placeholder

## Testing
- `npm test -- --runTestsByPath` *(fails: numerous existing suites require full database/payment configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d8fd7ba483289ea6289b699331ef