### PR TITLE
Improve installer automation and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ensure `bash`, `curl`, `docker`, and the Docker Compose V2 plugin (the `docker c
 curl -sSL https://raw.githubusercontent.com/eduskillbridge/SkillBridge/main/install.sh | bash
 ```
 
-The script validates prerequisites, copies example env files, builds and starts the Docker containers, and can seed the database for development setups when `SEED_DB=true`. After it completes, the app is available at `http://localhost:3000`.
+The script validates prerequisites, copies example env files, installs backend npm dependencies, ensures the uploads directory exists, builds and starts the Docker containers, and can seed the database for development setups when `SEED_DB=true`. After it completes, the app is available at `http://localhost:3000`. Set `SKIP_BACKEND_NPM_INSTALL=true` to reuse preinstalled backend dependencies.
 
 > **Note:** Always review the script before piping it into `bash` to verify it comes from a trusted source.
 ## Installer
@@ -50,7 +50,7 @@ When Step&nbsp;2 (“Configuration”) becomes available, gather the following v
 - SMTP host, port, username, and password for transactional email.
 - The default “from” email address and public-facing application name.
 - (Optional) Your Codecanyon purchase/subscription key for license verification.
-- A logo to brand the UI (upload a PNG/JPG/SVG up to 5&nbsp;MB or provide an HTTPS logo URL).
+- A logo to brand the UI (upload a PNG/JPG/SVG up to 2&nbsp;MB or provide an HTTPS logo URL).
 - The email and password for the first administrator.
 
 The installer writes these values to `backend/.env`, stores the logo under `backend/uploads/app/`, seeds branding/email settings in the database, and then provisions the admin account.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,12 +32,20 @@ non-interactive use (for example in CI pipelines). Optional flags include:
 - `SEED_DB=true` &mdash; run `npm --prefix backend run seed` after migrations.
 - `START_DEV_SERVICES=false` &mdash; skip the automatic `docker compose up` step in
   development mode if you prefer to start services yourself.
+- `SKIP_BACKEND_NPM_INSTALL=true` &mdash; skip the automatic `npm --prefix backend install`
+  step when you manage dependencies separately.
 
 In production mode, the script ensures Docker services are running before it
 executes database migrations. In development mode it starts the compose stack in
 detached mode unless you opt out with `START_DEV_SERVICES=false`. Any migration
 or seeding errors halt the script before the admin user creation step so you can
 address the problem immediately.
+
+Before running migrations the script installs backend dependencies with
+`npm --prefix backend install` so the Node.js helper scripts are available and
+creates `backend/uploads/app/` if it is missing. Use
+`SKIP_BACKEND_NPM_INSTALL=true` if dependencies are already installed and you
+prefer to reuse them.
 
 ### Backend
 
@@ -267,7 +275,7 @@ location ^~ /install/ {
    - The default “from” email address used for outbound messages.
    - (Optional) Your Codecanyon purchase or subscription key so future updates can validate the license.
    - The public application display name.
-   - Either a logo image upload (PNG/JPG/SVG up to 5&nbsp;MB) or an HTTPS URL to an existing logo.
+   - Either a logo image upload (PNG/JPG/SVG up to 2&nbsp;MB) or an HTTPS URL to an existing logo.
    - The admin email and password for the first administrator.
 7. Run the installer to apply the configuration. The script updates `backend/.env`, writes the selected logo to `backend/uploads/app/`, seeds the branding/email settings in the database, and finally provisions the administrator account.
 

--- a/install.sh
+++ b/install.sh
@@ -112,11 +112,43 @@ docker_available() {
   return 1
 }
 
-MODE=${1:-}
-DOMAIN=${2:-}
-ADMIN_EMAIL="${ADMIN_EMAIL:-}"
-ADMIN_PASSWORD="${ADMIN_PASSWORD:-}"
-INSTALL_CONFIG_PATH="${INSTALL_CONFIG_PATH:-}"
+install_backend_dependencies() {
+  local skip="${SKIP_BACKEND_NPM_INSTALL:-false}"
+  case "$skip" in
+    1|true|TRUE|yes|YES|on|ON)
+      echo "Skipping backend dependency installation (SKIP_BACKEND_NPM_INSTALL=$skip)."
+      return 0
+      ;;
+  esac
+
+  echo "Installing backend dependencies (npm install)..."
+  if ! npm --prefix "$REPO_ROOT/backend" install; then
+    echo "Failed to install backend dependencies." >&2
+    exit 1
+  fi
+}
+
+CLI_MODE=${1:-}
+CLI_DOMAIN=${2:-}
+
+ensure_env_file "$REPO_ROOT/.env.example" "$REPO_ROOT/.env"
+ensure_env_file "$REPO_ROOT/backend/.env.example" "$REPO_ROOT/backend/.env"
+ensure_env_file "$REPO_ROOT/backend/.env.production.example" "$REPO_ROOT/backend/.env.production"
+ensure_env_file "$REPO_ROOT/frontend/.env.local.example" "$REPO_ROOT/frontend/.env.local"
+
+load_env_file "$REPO_ROOT/.env"
+
+UPLOADS_DIR="$REPO_ROOT/backend/uploads/app"
+if [[ ! -d "$UPLOADS_DIR" ]]; then
+  echo "Creating backend uploads directory at $UPLOADS_DIR"
+  mkdir -p "$UPLOADS_DIR"
+fi
+
+MODE=${CLI_MODE:-${MODE:-}}
+
+load_env_file "$REPO_ROOT/backend/.env"
+
+DOMAIN=${CLI_DOMAIN:-${DOMAIN:-}}
 
 if [[ -z "$MODE" ]]; then
   if [[ -t 0 ]]; then
@@ -139,6 +171,11 @@ if [[ "$MODE" == "production" && -z "$DOMAIN" ]]; then
     echo "Domain is required for production" >&2
     exit 1
   fi
+fi
+
+if [[ "$MODE" == "production" ]]; then
+  load_env_file "$REPO_ROOT/backend/.env.production"
+  DOMAIN=${CLI_DOMAIN:-${DOMAIN:-}}
 fi
 
 if [[ "$MODE" == "production" ]]; then
@@ -179,6 +216,10 @@ elif [[ "$START_DEV_SERVICES" == "true" ]]; then
 else
   echo "Skipping automatic startup of development services."
 fi
+
+ADMIN_EMAIL="${ADMIN_EMAIL:-}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-}"
+INSTALL_CONFIG_PATH="${INSTALL_CONFIG_PATH:-}"
 
 if [[ -z "$ADMIN_EMAIL" ]]; then
   if [[ -t 0 ]]; then
@@ -232,6 +273,8 @@ for required in DATABASE_URL DATABASE_USER DATABASE_PASSWORD SMTP_HOST SMTP_PORT
 
   require_env_var "$required"
 done
+
+install_backend_dependencies
 
 export \
   ADMIN_EMAIL \


### PR DESCRIPTION
## Summary
- ensure the installer copies env templates, creates the uploads directory, and installs backend dependencies with an opt-out flag
- document the new automation behaviour and lower the documented logo upload size to match the UI limit
- update the README to highlight the dependency install, uploads directory provisioning, and 2 MB logo cap

## Testing
- bash -n install.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3e20980c88328a5e120ab74a04ee4