### PR TITLE
Fix down migration for password_resets code column

### DIFF
--- a/backend/src/migrations/20250718000000_remove_code_from_password_resets.js
+++ b/backend/src/migrations/20250718000000_remove_code_from_password_resets.js
@@ -5,7 +5,11 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.alterTable('password_resets', function(table) {
-    table.string('code', 10).notNullable();
-  });
+  return knex.schema
+    .alterTable('password_resets', function(table) {
+      table.string('code', 10).defaultTo('').notNullable();
+    })
+    .then(function() {
+      return knex.raw('ALTER TABLE password_resets ALTER COLUMN code DROP DEFAULT');
+    });
 };


### PR DESCRIPTION
## Summary
- ensure the password_resets down migration repopulates the code column with a safe default
- drop the temporary default after existing rows have been updated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3e5c697208328bc4f882955b9b457