### PR TITLE
Add Envato license verification to installer

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -7,6 +7,7 @@ const logger = require('../../utils/logger');
 const { markAdminExists, refreshAdminPresence } = require('./install.helpers');
 const appConfigService = require('../appConfig/appConfig.service');
 const emailConfigService = require('../emailConfig/emailConfig.service');
+const { validatePurchaseCode } = require('../../services/licenseService');
 
 const execFileAsync = util.promisify(execFile);
 const fsPromises = fs.promises;
@@ -114,6 +115,26 @@ exports.runInstall = async (req, res) => {
 
   if (!adminEmail || !adminPassword) {
     return res.status(400).json({ ok: false, message: 'Admin email and password are required.' });
+  }
+
+  if (codecanyonKey) {
+    try {
+      const forwardedHost = (req.get('x-forwarded-host') || '').split(',')[0]?.trim();
+      const hostHeader = (req.get('host') || '').trim();
+      const domain = forwardedHost || hostHeader || req.hostname;
+      const licenseResult = await validatePurchaseCode(codecanyonKey, domain);
+      if (!licenseResult?.valid) {
+        const message = licenseResult?.message || 'Codecanyon license verification failed.';
+        const statusCode = /unable to verify/i.test(message) ? 502 : 400;
+        logger.warn('Codecanyon license verification rejected during install', { message });
+        return res.status(statusCode).json({ ok: false, message });
+      }
+    } catch (error) {
+      logger.error('Codecanyon license verification error during install', error);
+      return res
+        .status(502)
+        .json({ ok: false, message: 'Unable to verify Codecanyon license key. Please try again later.' });
+    }
   }
 
   const uploadedLogoRelative = req.file ? `/uploads/app/${req.file.filename}` : undefined;

--- a/install/index.html
+++ b/install/index.html
@@ -257,6 +257,7 @@
               Store your Envato/Codecanyon key so future updates can verify the license automatically.
             </span>
             <p class="mt-1 hidden text-sm text-red-600" data-field-error="codecanyonKey"></p>
+            <p class="mt-1 hidden text-sm text-green-600" data-field-success="codecanyonKey"></p>
           </label>
         </fieldset>
 

--- a/install/install.js
+++ b/install/install.js
@@ -235,6 +235,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const backToConfigBtn = document.getElementById('backToConfigBtn');
   const setupSecretInput = document.getElementById('setupSecretInput');
   const setupSecretError = document.getElementById('setupSecretError');
+  const codecanyonInput = configForm ? configForm.querySelector('[name="codecanyonKey"]') : null;
 
   const SECRET_STORAGE_KEY = 'skillbridge-install-setup-secret';
   const secretState = { value: '' };
@@ -342,7 +343,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const fieldErrors = new Map();
+  const fieldSuccesses = new Map();
   let submittedConfig = null;
+  const licenseVerificationCache = { code: '', result: null };
 
   function getFieldErrorElement(name) {
     if (fieldErrors.has(name)) {
@@ -350,6 +353,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const el = configForm ? configForm.querySelector(`[data-field-error="${name}"]`) : null;
     fieldErrors.set(name, el || null);
+    return el || null;
+  }
+
+  function getFieldSuccessElement(name) {
+    if (fieldSuccesses.has(name)) {
+      return fieldSuccesses.get(name);
+    }
+    const el = configForm ? configForm.querySelector(`[data-field-success="${name}"]`) : null;
+    fieldSuccesses.set(name, el || null);
     return el || null;
   }
 
@@ -558,6 +570,10 @@ document.addEventListener('DOMContentLoaded', () => {
       el.textContent = '';
       el.classList.add('hidden');
     });
+    configForm.querySelectorAll('[data-field-success]').forEach((el) => {
+      el.textContent = '';
+      el.classList.add('hidden');
+    });
   }
 
   function setFieldError(name, message) {
@@ -567,11 +583,41 @@ document.addEventListener('DOMContentLoaded', () => {
       field.setAttribute('aria-invalid', 'true');
       field.classList.add('border-red-400', 'focus:border-red-500', 'focus:ring-red-200');
     }
+    clearFieldSuccess(name);
     const errorEl = getFieldErrorElement(name);
     if (errorEl) {
       errorEl.textContent = message;
       errorEl.classList.remove('hidden');
     }
+  }
+
+  function setFieldSuccess(name, message) {
+    const field = configForm ? configForm.querySelector(`[name="${name}"]`) : null;
+    if (field) {
+      field.removeAttribute('aria-invalid');
+      field.classList.remove('border-red-400', 'focus:border-red-500', 'focus:ring-red-200');
+    }
+    const successEl = getFieldSuccessElement(name);
+    if (!successEl) return;
+    const errorEl = getFieldErrorElement(name);
+    if (errorEl) {
+      errorEl.textContent = '';
+      errorEl.classList.add('hidden');
+    }
+    if (message) {
+      successEl.textContent = message;
+      successEl.classList.remove('hidden');
+    } else {
+      successEl.textContent = '';
+      successEl.classList.add('hidden');
+    }
+  }
+
+  function clearFieldSuccess(name) {
+    const successEl = getFieldSuccessElement(name);
+    if (!successEl) return;
+    successEl.textContent = '';
+    successEl.classList.add('hidden');
   }
 
   function collectConfiguration(formData) {
@@ -715,6 +761,80 @@ document.addEventListener('DOMContentLoaded', () => {
     return payload;
   }
 
+  async function verifyCodecanyonLicense(code) {
+    const payload = { purchase_code: code };
+    if (typeof window !== 'undefined') {
+      const domain = window.location?.hostname || window.location?.host;
+      if (domain) {
+        payload.domain = domain;
+      }
+    }
+
+    try {
+      const res = await fetch('/api/license/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const text = await res.text();
+      let data = {};
+      if (text) {
+        try {
+          data = JSON.parse(text);
+        } catch (_err) {
+          data = {};
+        }
+      }
+      const success = res.ok && (data.success !== false);
+      if (success) {
+        return {
+          ok: true,
+          message: typeof data.message === 'string' && data.message.trim()
+            ? data.message.trim()
+            : 'License verified successfully.',
+        };
+      }
+      const message = typeof data.message === 'string' && data.message.trim()
+        ? data.message.trim()
+        : typeof data.error === 'string' && data.error.trim()
+          ? data.error.trim()
+          : 'Unable to verify the Codecanyon license key.';
+      return { ok: false, message };
+    } catch (error) {
+      return {
+        ok: false,
+        message: `Unable to verify the Codecanyon license key. ${error.message}`,
+      };
+    }
+  }
+
+  async function ensureLicenseVerified(codecanyonKey) {
+    const sanitized = sanitize(codecanyonKey);
+    if (!sanitized) {
+      licenseVerificationCache.code = '';
+      licenseVerificationCache.result = null;
+      return { ok: true, message: '' };
+    }
+
+    if (
+      licenseVerificationCache.code === sanitized &&
+      licenseVerificationCache.result &&
+      licenseVerificationCache.result.ok
+    ) {
+      return licenseVerificationCache.result;
+    }
+
+    const result = await verifyCodecanyonLicense(sanitized);
+    if (result.ok) {
+      licenseVerificationCache.code = sanitized;
+      licenseVerificationCache.result = result;
+    } else {
+      licenseVerificationCache.code = '';
+      licenseVerificationCache.result = null;
+    }
+    return result;
+  }
+
   function showCompletion(result) {
     if (!completionCard) return;
     const messageFromApi =
@@ -779,6 +899,24 @@ document.addEventListener('DOMContentLoaded', () => {
         firstField.focus();
       }
       return;
+    }
+
+    if (configuration.codecanyonKey) {
+      const licenseResult = await ensureLicenseVerified(configuration.codecanyonKey);
+      if (!licenseResult.ok) {
+        setFieldError('codecanyonKey', licenseResult.message);
+        showError(licenseResult.message);
+        const field = configForm.querySelector('[name="codecanyonKey"]');
+        if (field && typeof field.focus === 'function') {
+          field.focus();
+        }
+        return;
+      }
+      setFieldSuccess('codecanyonKey', licenseResult.message || 'License verified successfully.');
+    } else {
+      clearFieldSuccess('codecanyonKey');
+      licenseVerificationCache.code = '';
+      licenseVerificationCache.result = null;
     }
 
     submittedConfig = configuration;
@@ -920,6 +1058,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (configForm) {
     configForm.addEventListener('submit', handleInstallSubmit);
+  }
+
+  if (codecanyonInput) {
+    codecanyonInput.addEventListener('input', () => {
+      licenseVerificationCache.code = '';
+      licenseVerificationCache.result = null;
+      clearFieldSuccess('codecanyonKey');
+      const field = codecanyonInput;
+      field.removeAttribute('aria-invalid');
+      field.classList.remove('border-red-400', 'focus:border-red-500', 'focus:ring-red-200');
+      const errorEl = getFieldErrorElement('codecanyonKey');
+      if (errorEl) {
+        errorEl.textContent = '';
+        errorEl.classList.add('hidden');
+      }
+    });
   }
 
   if (backToConfigBtn) {


### PR DESCRIPTION
## Summary
- enforce Codecanyon license verification during installation by calling the existing Envato validation service
- add client-side license verification flow with success messaging and field state resets in the installer UI
- show a dedicated success message area beside the Codecanyon key field

## Testing
- npm test *(fails: numerous pre-existing suites require database configuration and other fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eb2aad488328846d5b15ba1f9692