### PR TITLE
Validate Codecanyon license during installer

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const logger = require('../../utils/logger');
 const { markAdminExists, refreshAdminPresence } = require('./install.helpers');
+const { validatePurchaseCode } = require('../../services/licenseService');
 const appConfigService = require('../appConfig/appConfig.service');
 const emailConfigService = require('../emailConfig/emailConfig.service');
 
@@ -95,6 +96,18 @@ const removeFileIfExists = async (filePath) => {
   }
 };
 
+const extractDomainFromRequest = (req) => {
+  const forwardedHost = (req.get('x-forwarded-host') || '').split(',')[0].trim();
+  if (forwardedHost) {
+    return forwardedHost.split(':')[0];
+  }
+  const hostHeader = (req.get('host') || '').trim();
+  if (hostHeader) {
+    return hostHeader.split(':')[0];
+  }
+  return req.hostname;
+};
+
 exports.runInstall = async (req, res) => {
   const {
     adminEmail,
@@ -118,6 +131,34 @@ exports.runInstall = async (req, res) => {
 
   const uploadedLogoRelative = req.file ? `/uploads/app/${req.file.filename}` : undefined;
   const uploadedLogoAbsolute = req.file ? req.file.path : undefined;
+
+  if (codecanyonKey) {
+    try {
+      const domain = extractDomainFromRequest(req);
+      const { valid, message } = await validatePurchaseCode(codecanyonKey, domain);
+      if (!valid) {
+        if (uploadedLogoAbsolute) {
+          await removeFileIfExists(uploadedLogoAbsolute);
+        }
+        return res.status(400).json({
+          ok: false,
+          message: message || 'Codecanyon purchase code could not be verified.',
+          fieldErrors: {
+            codecanyonKey: message || 'Codecanyon purchase code could not be verified.',
+          },
+        });
+      }
+    } catch (error) {
+      logger.error('Codecanyon license validation failed during install', error);
+      if (uploadedLogoAbsolute) {
+        await removeFileIfExists(uploadedLogoAbsolute);
+      }
+      return res.status(500).json({
+        ok: false,
+        message: 'Unexpected error while validating the Codecanyon purchase code. Please try again.',
+      });
+    }
+  }
 
   let tempDir;
   let configPath;

--- a/install/install.js
+++ b/install/install.js
@@ -870,6 +870,58 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
+      if (res.status === 400) {
+        const highlightFields = [];
+        const registerFieldError = (field, message) => {
+          if (typeof field !== 'string' || !field) return;
+          highlightFields.push(field);
+          setFieldError(field, message || 'Please correct this value.');
+        };
+
+        if (Array.isArray(data?.errors)) {
+          data.errors.forEach((issue) => {
+            if (!issue) return;
+            const path = Array.isArray(issue.path)
+              ? issue.path.find((segment) => typeof segment === 'string')
+              : typeof issue.path === 'string'
+                ? issue.path
+                : undefined;
+            registerFieldError(path, typeof issue.message === 'string' ? issue.message : undefined);
+          });
+        }
+
+        if (data?.fieldErrors && typeof data.fieldErrors === 'object') {
+          Object.entries(data.fieldErrors).forEach(([field, message]) => {
+            registerFieldError(field, typeof message === 'string' ? message : undefined);
+          });
+        }
+
+        const summaryMessage =
+          typeof data?.message === 'string' && data.message.trim().length > 0
+            ? data.message.trim()
+            : 'Installation configuration contains errors. Please review the highlighted fields.';
+
+        showError(summaryMessage);
+        updateStep('config', { preserveProgress: true });
+        backToConfigBtn?.classList.remove('hidden');
+
+        if (installOutput) {
+          installOutput.classList.remove('text-gray-700');
+          installOutput.classList.add('text-red-700');
+          installOutput.textContent = summaryMessage;
+        }
+
+        if (highlightFields.length > 0) {
+          const firstField = configForm.querySelector(`[name="${highlightFields[0]}"]`);
+          if (firstField && typeof firstField.focus === 'function') {
+            firstField.focus();
+          }
+        }
+
+        if (installBtn) installBtn.disabled = false;
+        return;
+      }
+
       const success = typeof data.ok === 'boolean' ? data.ok : res.ok;
       const outputText =
         typeof data.output === 'string' && data.output.trim().length > 0


### PR DESCRIPTION
## Summary
- validate optional Codecanyon purchase code during the installer run and abort on invalid licenses
- surface backend validation errors in the installer UI so fields are highlighted with server feedback

## Testing
- npm test *(fails: requires TEST_DATABASE_URL / other database configuration that is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eb2aad488328846d5b15ba1f9692