### PR TITLE
Fix frontend healthcheck host header

### DIFF
--- a/frontend/scripts/docker-healthcheck.mjs
+++ b/frontend/scripts/docker-healthcheck.mjs
@@ -12,6 +12,8 @@ if (!Number.isFinite(port) || port <= 0) {
   process.exit(1);
 }
 
+const hostHeader = port === 80 || port === 443 ? host : `${host}:${port}`;
+
 const requestOptions = {
   host,
   port,
@@ -20,6 +22,7 @@ const requestOptions = {
   headers: {
     Accept: 'application/json',
     'User-Agent': 'skillbridge-frontend-healthcheck',
+    Host: hostHeader,
   },
   timeout: timeoutMs,
 };

--- a/frontend/scripts/healthcheck.js
+++ b/frontend/scripts/healthcheck.js
@@ -14,6 +14,7 @@ function parsePositiveInt(value, fallback) {
 
 const host = process.env.HEALTHCHECK_HOST || DEFAULT_HOST;
 const port = parsePositiveInt(process.env.PORT, 3000);
+const hostHeader = port === 80 || port === 443 ? host : `${host}:${port}`;
 const protocol = (process.env.HEALTHCHECK_PROTOCOL || DEFAULT_PROTOCOL).toLowerCase();
 const path = process.env.HEALTHCHECK_PATH || DEFAULT_PATH;
 const timeout = parsePositiveInt(process.env.HEALTHCHECK_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
@@ -40,7 +41,7 @@ const request = client.get(
     headers: {
       'User-Agent': 'skillbridge-frontend-healthcheck',
       Accept: 'application/json',
-      Host: host,
+      Host: hostHeader,
     },
   },
   (response) => {


### PR DESCRIPTION
## Summary
- ensure both frontend health-check scripts include the port when building the Host header so HTTP/1.1 semantics are respected

## Testing
- npm test -- --runTestsByPath tests/health.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3eb2aad488328846d5b15ba1f9692