### PR TITLE
Fix frontend healthcheck host header definition

### DIFF
--- a/frontend/scripts/healthcheck.js
+++ b/frontend/scripts/healthcheck.js
@@ -14,7 +14,6 @@ function parsePositiveInt(value, fallback) {
 
 const host = process.env.HEALTHCHECK_HOST || DEFAULT_HOST;
 const port = parsePositiveInt(process.env.PORT, 3000);
-const hostHeader = port === 80 || port === 443 ? host : `${host}:${port}`;
 const protocol = (process.env.HEALTHCHECK_PROTOCOL || DEFAULT_PROTOCOL).toLowerCase();
 const path = process.env.HEALTHCHECK_PATH || DEFAULT_PATH;
 const timeout = parsePositiveInt(process.env.HEALTHCHECK_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);


### PR DESCRIPTION
## Summary
- remove the duplicate host header declaration in the frontend healthcheck script to avoid a syntax error during the container health probe

## Testing
- npm run lint -- scripts/healthcheck.js *(fails: existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d412a42a5c8328b05575f63855b3c3