### PR TITLE
Fix frontend healthcheck host header reassignment

### DIFF
--- a/frontend/scripts/healthcheck.js
+++ b/frontend/scripts/healthcheck.js
@@ -14,7 +14,7 @@ function parsePositiveInt(value, fallback) {
 
 const host = process.env.HEALTHCHECK_HOST || DEFAULT_HOST;
 const port = parsePositiveInt(process.env.PORT, 3000);
-const hostHeader = port === 80 || port === 443 ? host : `${host}:${port}`;
+let hostHeader = port === 80 || port === 443 ? host : `${host}:${port}`;
 const protocol = (process.env.HEALTHCHECK_PROTOCOL || DEFAULT_PROTOCOL).toLowerCase();
 const path = process.env.HEALTHCHECK_PATH || DEFAULT_PATH;
 const timeout = parsePositiveInt(process.env.HEALTHCHECK_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
@@ -26,8 +26,7 @@ const defaultPorts = new Map([
 ]);
 
 const defaultPortForProtocol = defaultPorts.get(protocol);
-const hostHeader =
-  defaultPortForProtocol && port === defaultPortForProtocol ? host : `${host}:${port}`;
+hostHeader = defaultPortForProtocol && port === defaultPortForProtocol ? host : `${host}:${port}`;
 
 const allowedProtocols = new Set(['http', 'https']);
 if (!allowedProtocols.has(protocol)) {


### PR DESCRIPTION
## Summary
- avoid redeclaring the `hostHeader` constant inside the frontend healthcheck script to prevent syntax errors

## Testing
- npm run lint *(fails: existing lint errors and warnings in the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68d412a42a5c8328b05575f63855b3c3