### PR TITLE
Fix duplicate license service import

### DIFF
--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -8,7 +8,6 @@ const { markAdminExists, refreshAdminPresence } = require('./install.helpers');
 const { validatePurchaseCode } = require('../../services/licenseService');
 const appConfigService = require('../appConfig/appConfig.service');
 const emailConfigService = require('../emailConfig/emailConfig.service');
-const { validatePurchaseCode } = require('../../services/licenseService');
 
 const execFileAsync = util.promisify(execFile);
 const fsPromises = fs.promises;


### PR DESCRIPTION
## Summary
- remove duplicated validatePurchaseCode import from install controller to avoid runtime syntax errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d420c439108328bcc3f9951a62f980