### PR TITLE
Enable SkillBridge installer API

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,2 +1,4 @@
 APP_DOMAIN=eduskillbridge.net
 FRONTEND_URL=https://eduskillbridge.net,https://www.eduskillbridge.net
+ENABLE_INSTALL=true
+INSTALL_API_ENABLED=true


### PR DESCRIPTION
## Summary
- set ENABLE_INSTALL and INSTALL_API_ENABLED to true in the backend environment to allow the installer to run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4241e96e48328a029d7c5a0425843