### PR TITLE
Ensure installer scripts available in Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,10 @@ WORKDIR /app
 RUN apk add --no-cache curl netcat-openbsd postgresql-client su-exec && \
     (id -u node 2>/dev/null || adduser -S node)
 COPY --from=builder /app ./
-RUN chmod +x scripts/wait-for-db.sh scripts/docker-entrypoint.sh
+COPY scripts /scripts
+COPY install.sh /install.sh
+RUN chmod +x scripts/wait-for-db.sh scripts/docker-entrypoint.sh \
+    && chmod +x /scripts/check_prereqs.sh /install.sh
 EXPOSE 5002
 ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
 CMD ["node", "src/server.js"]

--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -12,15 +12,37 @@ const emailConfigService = require('../emailConfig/emailConfig.service');
 const execFileAsync = util.promisify(execFile);
 const fsPromises = fs.promises;
 
+const candidateScriptRoots = [
+  path.resolve(__dirname, '../../../../'),
+  path.resolve(__dirname, '../../../'),
+  process.cwd(),
+];
+
+const resolveInstallerAsset = (relativePath) => {
+  for (const rootDir of candidateScriptRoots) {
+    const candidate = path.resolve(rootDir, relativePath);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return path.resolve(__dirname, '../../../../', relativePath);
+};
+
 const SCRIPTS = {
-  prereqs: path.resolve(__dirname, '../../../../scripts/check_prereqs.sh'),
-  install: path.resolve(__dirname, '../../../../install.sh'),
+  prereqs: () => resolveInstallerAsset('scripts/check_prereqs.sh'),
+  install: () => resolveInstallerAsset('install.sh'),
 };
 
 const runScript = async (scriptKey, { env = {}, args = [] } = {}) => {
-  const scriptPath = SCRIPTS[scriptKey];
+  const scriptResolver = SCRIPTS[scriptKey];
+  const scriptPath = typeof scriptResolver === 'function' ? scriptResolver() : scriptResolver;
   if (!scriptPath) {
     throw new Error(`Unknown installer script: ${scriptKey}`);
+  }
+  if (!fs.existsSync(scriptPath)) {
+    const error = new Error(`Installer script not found: ${scriptPath}`);
+    error.code = 'ENOENT';
+    throw error;
   }
   const mergedEnv = { ...process.env, ...env };
   return execFileAsync(scriptPath, args, { env: mergedEnv, shell: false });


### PR DESCRIPTION
## Summary
- resolve installer script locations dynamically so the API can execute them in different deployment layouts
- fail fast with a clearer error when installer shell scripts are missing
- bundle the prerequisite and install shell scripts into the backend Docker image with executable permissions

## Testing
- `npm test -- installApi` *(fails: Unable to determine database connection string. Provide TEST_DATABASE_URL or matching POSTGRES_/DATABASE_ variables.)*

------
https://chatgpt.com/codex/tasks/task_e_68d4263b9570832889f62252125dac61