### PR TITLE
Install bash for installer scripts and improve errors

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 FROM node:20-alpine AS builder
 WORKDIR /app
-RUN apk add --no-cache curl netcat-openbsd postgresql-client
+RUN apk add --no-cache bash curl netcat-openbsd postgresql-client
 
 # Copy the backend package manifests first to leverage Docker layer caching.
 COPY backend/package*.json ./
@@ -16,10 +16,13 @@ COPY install ./install
 # Production stage
 FROM node:20-alpine
 WORKDIR /app
-RUN apk add --no-cache curl netcat-openbsd postgresql-client su-exec && \
+RUN apk add --no-cache bash curl netcat-openbsd postgresql-client su-exec && \
     (id -u node 2>/dev/null || adduser -S node)
 COPY --from=builder /app ./
-RUN chmod +x scripts/wait-for-db.sh scripts/docker-entrypoint.sh
+COPY scripts /scripts
+COPY install.sh /install.sh
+RUN chmod +x scripts/wait-for-db.sh scripts/docker-entrypoint.sh \
+    && chmod +x /scripts/check_prereqs.sh /install.sh
 EXPOSE 5002
 ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
 CMD ["node", "src/server.js"]

--- a/backend/src/modules/install/install.controller.js
+++ b/backend/src/modules/install/install.controller.js
@@ -12,18 +12,48 @@ const emailConfigService = require('../emailConfig/emailConfig.service');
 const execFileAsync = util.promisify(execFile);
 const fsPromises = fs.promises;
 
+const candidateScriptRoots = [
+  path.resolve(__dirname, '../../../../'),
+  path.resolve(__dirname, '../../../'),
+  process.cwd(),
+];
+
+const resolveInstallerAsset = (relativePath) => {
+  for (const rootDir of candidateScriptRoots) {
+    const candidate = path.resolve(rootDir, relativePath);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return path.resolve(__dirname, '../../../../', relativePath);
+};
+
 const SCRIPTS = {
-  prereqs: path.resolve(__dirname, '../../../../scripts/check_prereqs.sh'),
-  install: path.resolve(__dirname, '../../../../install.sh'),
+  prereqs: () => resolveInstallerAsset('scripts/check_prereqs.sh'),
+  install: () => resolveInstallerAsset('install.sh'),
 };
 
 const runScript = async (scriptKey, { env = {}, args = [] } = {}) => {
-  const scriptPath = SCRIPTS[scriptKey];
+  const scriptResolver = SCRIPTS[scriptKey];
+  const scriptPath = typeof scriptResolver === 'function' ? scriptResolver() : scriptResolver;
   if (!scriptPath) {
     throw new Error(`Unknown installer script: ${scriptKey}`);
   }
+  if (!fs.existsSync(scriptPath)) {
+    const error = new Error(`Installer script not found: ${scriptPath}`);
+    error.code = 'ENOENT';
+    error.installScriptKey = scriptKey;
+    error.installScriptPath = scriptPath;
+    throw error;
+  }
   const mergedEnv = { ...process.env, ...env };
-  return execFileAsync(scriptPath, args, { env: mergedEnv, shell: false });
+  try {
+    return await execFileAsync(scriptPath, args, { env: mergedEnv, shell: false });
+  } catch (error) {
+    error.installScriptKey = scriptKey;
+    error.installScriptPath = scriptPath;
+    throw error;
+  }
 };
 
 const parseInstallerOutput = (stdout, stderr) => {
@@ -52,6 +82,17 @@ exports.checkPrereqs = async (req, res, next) => {
     const stdout = error.stdout || '';
     const stderr = error.stderr || '';
     logger.error('Prerequisite check failed', error);
+    if (error?.code === 'ENOENT') {
+      const scriptPath = error.installScriptPath || error.path || 'installer script';
+      return res.status(500).json({
+        ok: false,
+        code: 'INSTALLER_SCRIPT_MISSING',
+        message: [
+          'Unable to execute prerequisite checker.',
+          `Ensure ${scriptPath} exists and that Bash is available in the environment.`,
+        ].join(' '),
+      });
+    }
     const payload = parseInstallerOutput(stdout, stderr);
     return res.status(500).json(payload);
   }
@@ -300,6 +341,17 @@ exports.runInstall = async (req, res) => {
     await cleanupTempConfig();
     if (uploadedLogoAbsolute) {
       await removeFileIfExists(uploadedLogoAbsolute);
+    }
+    if (error?.code === 'ENOENT') {
+      const scriptPath = error.installScriptPath || error.path || 'installer script';
+      return res.status(500).json({
+        ok: false,
+        code: 'INSTALLER_SCRIPT_MISSING',
+        message: [
+          'Unable to execute installer script.',
+          `Ensure ${scriptPath} exists and that Bash is available in the environment.`,
+        ].join(' '),
+      });
     }
     const payload = parseInstallerOutput(stdout, stderr);
     payload.ok = false;


### PR DESCRIPTION
## Summary
- add bash to both Docker build stages so bundled installer scripts can execute in Alpine-based containers
- surface clearer HTTP 500 responses when prerequisite or install scripts are missing or bash is unavailable, including the resolved script path

## Testing
- `npm test -- installApi` *(fails: Unable to determine database connection string. Provide TEST_DATABASE_URL or matching POSTGRES_/DATABASE_ variables.)*

------
https://chatgpt.com/codex/tasks/task_e_68d4263b9570832889f62252125dac61