### PR TITLE
Fix installer API boolean parsing

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -13,7 +13,10 @@ const toBool = (value) => {
     return value;
   }
   if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase();
+    const normalized = value
+      .trim()
+      .replace(/^['"]+|['"]+$/g, '')
+      .toLowerCase();
     if (!normalized) {
       return false;
     }


### PR DESCRIPTION
## Summary
- strip surrounding quotes when interpreting INSTALL_API_ENABLED/ENABLE_INSTALL values
- ensure quoted truthy strings enable the installer API

## Testing
- TEST_DATABASE_URL=postgres://user:pass@localhost:5432/db npm test -- installApi

------
https://chatgpt.com/codex/tasks/task_e_68d43034cb5883289974b391a8050bd1