### PR TITLE
Handle inline comments when enabling installer API

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -8,18 +8,38 @@ const controller = require('./install.controller');
 
 const router = Router();
 
+const BOOLEAN_TRUTHY_VALUES = new Set(['true', '1', 'yes', 'on']);
+
+const normalizeBooleanEnvValue = (raw) => {
+  if (typeof raw === 'boolean') {
+    return raw;
+  }
+  if (typeof raw === 'number') {
+    return raw === 1;
+  }
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+
+  const withoutComments = raw
+    .replace(/[;#].*$/, '')
+    .trim();
+
+  if (!withoutComments) {
+    return undefined;
+  }
+
+  const firstToken = withoutComments.split(/\s+/)[0].toLowerCase();
+  if (!firstToken) {
+    return undefined;
+  }
+
+  return BOOLEAN_TRUTHY_VALUES.has(firstToken);
+};
+
 const toBool = (value) => {
-  if (typeof value === 'boolean') {
-    return value;
-  }
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase();
-    if (!normalized) {
-      return false;
-    }
-    return ['true', '1', 'yes', 'on'].includes(normalized);
-  }
-  return false;
+  const normalized = normalizeBooleanEnvValue(value);
+  return typeof normalized === 'boolean' ? normalized : false;
 };
 
 const requireInstallApiEnabled = (req, res, next) => {

--- a/backend/tests/installApi.test.js
+++ b/backend/tests/installApi.test.js
@@ -141,6 +141,15 @@ describe('GET /api/install/prereqs', () => {
     expect(res.body).toEqual({ ok: true, allPassed: true });
   });
 
+  it('allows enabling via truthy values that include inline comments', async () => {
+    process.env.INSTALL_API_ENABLED = 'true # enable installer';
+
+    const res = await request(app).get('/api/install/prereqs');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, allPassed: true });
+  });
+
 
   it('executes the prerequisite script and returns its JSON output', async () => {
     mockHasExistingAdmin.mockResolvedValue(false);


### PR DESCRIPTION
## Summary
- make the installer API guard tolerant of inline comments and numeric values in boolean env vars
- cover the new parsing behaviour with an install API test

## Testing
- TEST_DATABASE_URL=postgresql://localhost/test JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test npm test -- installApi

------
https://chatgpt.com/codex/tasks/task_e_68d43034cb5883289974b391a8050bd1