### PR TITLE
Fix installer API gating to respect config

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const { Router } = require('express');
 const { z } = require('zod');
+const config = require('../../config/env');
 const validate = require('../../middleware/validate');
 const logoUpload = require('../appConfig/appLogoUploadMiddleware');
 const { hasExistingAdmin: resolveHasExistingAdminStatus } = require('./install.helpers');
@@ -48,7 +49,12 @@ const toBool = (value) => {
 };
 
 const requireInstallApiEnabled = (req, res, next) => {
-  if (toBool(process.env.INSTALL_API_ENABLED) || toBool(process.env.ENABLE_INSTALL)) {
+  if (
+    (typeof config.INSTALL_API_ENABLED === 'boolean' && config.INSTALL_API_ENABLED) ||
+    (typeof config.ENABLE_INSTALL === 'boolean' && config.ENABLE_INSTALL) ||
+    toBool(process.env.INSTALL_API_ENABLED) ||
+    toBool(process.env.ENABLE_INSTALL)
+  ) {
     return next();
   }
   return res.status(403).json({ message: 'Installer API disabled' });

--- a/backend/tests/installApi.test.js
+++ b/backend/tests/installApi.test.js
@@ -3,6 +3,15 @@ const path = require('path');
 const fs = require('fs');
 const request = require('supertest');
 
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret';
+process.env.REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET || 'test-refresh-secret';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-session-secret';
+process.env.TEST_DATABASE_URL =
+  process.env.TEST_DATABASE_URL || 'postgres://user:pass@localhost:5432/test-db';
+process.env.ENABLE_INSTALL = process.env.ENABLE_INSTALL || 'false';
+process.env.INSTALL_API_ENABLED = process.env.INSTALL_API_ENABLED || 'false';
+
 jest.mock('child_process', () => {
   const util = require('util');
 


### PR DESCRIPTION
## Summary
- ensure the installer API middleware honors sanitized config booleans and runtime overrides
- initialize required env defaults in the install API tests so the config module can load during Jest runs

## Testing
- npm test -- installApi

------
https://chatgpt.com/codex/tasks/task_e_68d435584efc8328a56165492e4f1900