### PR TITLE
Fix installer API enablement detection

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -8,6 +8,22 @@ const controller = require('./install.controller');
 
 const router = Router();
 
+let cachedConfig;
+const getConfig = () => {
+  if (cachedConfig !== undefined) {
+    return cachedConfig;
+  }
+
+  try {
+    // eslint-disable-next-line global-require
+    cachedConfig = require('../../config/env');
+  } catch (error) {
+    cachedConfig = null;
+  }
+
+  return cachedConfig;
+};
+
 const normalizeBooleanCandidate = (value) => {
   if (typeof value !== 'string') {
     return '';
@@ -47,8 +63,40 @@ const toBool = (value) => {
   return false;
 };
 
+const readExplicitBoolean = (value) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value === 'string' && value.trim() === '') {
+    return null;
+  }
+
+  return toBool(value);
+};
+
+const resolveEnvOverride = () => {
+  const installFlag = readExplicitBoolean(process.env.INSTALL_API_ENABLED);
+  const enableFlag = readExplicitBoolean(process.env.ENABLE_INSTALL);
+
+  if (installFlag === null && enableFlag === null) {
+    return null;
+  }
+
+  return Boolean(installFlag || enableFlag);
+};
+
 const requireInstallApiEnabled = (req, res, next) => {
-  if (toBool(process.env.INSTALL_API_ENABLED) || toBool(process.env.ENABLE_INSTALL)) {
+  const envOverride = resolveEnvOverride();
+  if (envOverride !== null) {
+    if (envOverride) {
+      return next();
+    }
+    return res.status(403).json({ message: 'Installer API disabled' });
+  }
+
+  const config = getConfig();
+  if (config?.INSTALL_API_ENABLED || config?.ENABLE_INSTALL) {
     return next();
   }
   return res.status(403).json({ message: 'Installer API disabled' });


### PR DESCRIPTION
## Summary
- lazily load the backend config when checking the installer middleware to avoid crashes when config is unavailable
- respect sanitized backend config booleans while still honoring explicit runtime environment overrides for enabling/disabling the installer API
- ensure explicit environment values override config defaults without breaking existing fallback behaviour

## Testing
- TEST_DATABASE_URL=postgres://user:pass@localhost:5432/testdb npm test -- installApi

------
https://chatgpt.com/codex/tasks/task_e_68d435584efc8328a56165492e4f1900