### PR TITLE
Improve installer prerequisite error feedback

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -565,15 +565,27 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
+      const normalized = normalizePrereqResponse(data);
+
       if (!res.ok) {
+        if (normalized.requirements.length || normalized.rawText) {
+          renderRequirements(normalized.requirements, normalized.rawText);
+        }
+
         const message =
-          data?.message || data?.error || INSTALLER_DISABLED_GUIDANCE;
+          data?.message ||
+          data?.error ||
+          normalized.summary ||
+          INSTALLER_DISABLED_GUIDANCE;
+
         showError(message);
-        setSummary('Unable to verify prerequisites.', 'error');
+        setSummary(
+          normalized.summary || 'Unable to verify prerequisites.',
+          normalized.allPassing ? 'success' : 'error'
+        );
         return;
       }
 
-      const normalized = normalizePrereqResponse(data);
       renderRequirements(normalized.requirements, normalized.rawText);
       setSummary(normalized.summary, normalized.allPassing ? 'success' : 'error');
 


### PR DESCRIPTION
## Summary
- surface prerequisite script output when the installer API responds with an error
- avoid falling back to the generic "API disabled" guidance when requirements simply fail

## Testing
- not run (frontend-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d435584efc8328a56165492e4f1900