### PR TITLE
Fix installer API gating when env loaded via config

### DIFF
--- a/backend/src/modules/install/install.routes.js
+++ b/backend/src/modules/install/install.routes.js
@@ -5,6 +5,7 @@ const validate = require('../../middleware/validate');
 const logoUpload = require('../appConfig/appLogoUploadMiddleware');
 const { hasExistingAdmin: resolveHasExistingAdminStatus } = require('./install.helpers');
 const controller = require('./install.controller');
+require('../../config/env');
 
 const router = Router();
 
@@ -47,8 +48,11 @@ const toBool = (value) => {
   return false;
 };
 
+const isInstallerEnabled = () =>
+  toBool(process.env.INSTALL_API_ENABLED) || toBool(process.env.ENABLE_INSTALL);
+
 const requireInstallApiEnabled = (req, res, next) => {
-  if (toBool(process.env.INSTALL_API_ENABLED) || toBool(process.env.ENABLE_INSTALL)) {
+  if (isInstallerEnabled()) {
     return next();
   }
   return res.status(403).json({ message: 'Installer API disabled' });


### PR DESCRIPTION
## Summary
- ensure the install routes bootstrap the backend env parser so .env flags are loaded before checking installer availability
- centralize the installer enabled check so ENABLE_INSTALL and INSTALL_API_ENABLED truthy values continue to allow access

## Testing
- npm test --prefix backend installApi.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d435584efc8328a56165492e4f1900