### PR TITLE
Fix docs installation link closing tag

### DIFF
--- a/frontend/src/pages/docs/index.js
+++ b/frontend/src/pages/docs/index.js
@@ -343,7 +343,7 @@ export default function DocumentationLandingPage() {
                     >
                       <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                     </svg>
-                  </Link>
+                  </a>
                 </div>
               </article>
             </div>


### PR DESCRIPTION
## Summary
- fix the closing tag for the installation docs anchor on the docs landing page to use </a>

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e4209eec8328a3eae8e3f6f05678