### PR TITLE
feat: render documentation index from repository markdown

### DIFF
--- a/frontend/src/pages/docs/index.js
+++ b/frontend/src/pages/docs/index.js
@@ -1,4 +1,6 @@
 import { useMemo, useState } from 'react';
+import fs from 'fs/promises';
+import path from 'path';
 import Link from 'next/link';
 
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
@@ -8,347 +10,234 @@ import Navbar from '@/components/website/sections/Navbar';
 import PageHead from '@/components/common/PageHead';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 
-const sections = [
-  {
-    id: 'overview',
-    title: 'Overview',
-    blurb: 'Understand what the SkillBridge installation script does and when to use it.',
-    content: (
-      <>
-        <p>
-          The SkillBridge installer script automates the most time-consuming parts of standing up a
-          local or production environment. It copies <code>.env</code> templates, installs dependencies,
-          applies database migrations, seeds demo content (when requested), and provisions the first
-          administrator account. Use it whenever you want a reproducible setup that mirrors the
-          official deployment pipeline.
-        </p>
-        <p>
-          You can run the script in an interactive mode that prompts for values or feed credentials
-          through environment variables for fully unattended installs. The same entry point supports
-          both development and production targets, ensuring consistent behavior across teams.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: 'prerequisites',
-    title: 'Prerequisites',
-    blurb: 'Verify that your workstation or server meets the minimum requirements.',
-    content: (
-      <>
-        <p>Install or verify the following before executing the installer:</p>
-        <ul className="list-disc list-inside space-y-1 text-gray-200">
-          <li>
-            <span className="font-semibold">Node.js 18+</span> – required for running database migrations
-            and seeding scripts.
-          </li>
-          <li>
-            <span className="font-semibold">Docker with the Compose V2 plugin</span> – the script relies on
-            the <code>docker compose</code> command. The legacy <code>docker-compose</code> binary is not supported.
-          </li>
-          <li>
-            <span className="font-semibold">Git</span> – to clone the SkillBridge repository.
-          </li>
-          <li>
-            <span className="font-semibold">Redis (production only)</span> – used for persisting sessions
-            when running the backend in production mode.
-          </li>
-        </ul>
-        <p>
-          Production deployments should also expose the desired domain in DNS and have TLS certificates
-          ready if HTTPS is enforced by your ingress or load balancer.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: 'download',
-    title: 'Download the script',
-    blurb: 'Fetch the latest version of install.sh straight from the repository.',
-    content: (
-      <>
-        <p>Clone the repository and move into the project directory:</p>
-        <pre className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm">
-{`git clone https://github.com/eduskillbridge/SkillBridge.git
-cd Skillbridge`}
-        </pre>
-        <p>
-          Alternatively, grab only the installer for quick experiments by piping it directly to
-          <code>bash</code>:
-        </p>
-        <pre className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm">
-{`curl -fsSL https://raw.githubusercontent.com/eduskillbridge/SkillBridge/main/install.sh | bash`}
-        </pre>
-        <p>
-          The repository approach is recommended for long-lived environments so you can inspect the
-          script, customize configuration files, and commit changes to your own fork if needed.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: 'configure',
-    title: 'Configure environment variables',
-    blurb: 'Provide credentials and settings the installer needs to bootstrap your stack.',
-    content: (
-      <>
-        <p>
-          When the installer runs, it copies every <code>.env.example</code> file to its corresponding
-          <code>.env</code> if it is missing. Adjust the generated files before rerunning the script if you
-          need custom values. The most commonly tuned variables are:
-        </p>
-        <ul className="list-disc list-inside space-y-1 text-gray-200">
-          <li>
-            <code>ADMIN_EMAIL</code> and <code>ADMIN_PASSWORD</code> – used to create the initial admin user.
-          </li>
-          <li>
-            <code>FRONTEND_URL</code> – the URL(s) that are allowed to communicate with the API.
-          </li>
-          <li>
-            <code>DATABASE_URL</code> / <code>DATABASE_USER</code> / <code>DATABASE_PASSWORD</code> – production
-            database connection details when you are not using the bundled Postgres container.
-          </li>
-          <li>
-            <code>SMTP_HOST</code>, <code>SMTP_PORT</code>, <code>SMTP_USER</code>, <code>SMTP_PASS</code> – email
-            credentials so the script can validate outbound mail early.
-          </li>
-        </ul>
-        <p>
-          Pass any of these as environment variables when invoking the installer to avoid interactive
-          prompts in CI/CD pipelines:
-        </p>
-        <pre className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm">
-{`ADMIN_EMAIL=admin@example.com \
-ADMIN_PASSWORD='supersafe' \
-SEED_DB=true \
-bash install.sh --mode production`}
-        </pre>
-        <p>
-          In development mode you can skip automatically starting Docker services by setting
-          <code>START_DEV_SERVICES=false</code>.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: 'run-script',
-    title: 'Run the installer',
-    blurb: 'Execute the script in development or production mode and watch it provision the stack.',
-    content: (
-      <>
-        <p>
-          Execute the script from the repository root. Choose the mode that matches your target
-          environment:
-        </p>
-        <div className="space-y-4">
-          <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
-            <h3 className="text-lg font-semibold text-white mb-2">Development mode</h3>
-            <p className="text-gray-200 mb-3">
-              Spins up the Docker Compose stack in detached mode, runs migrations, and seeds optional
-              demo data when <code>SEED_DB=true</code>.
-            </p>
-            <pre className="bg-black text-gray-100 p-3 rounded-md overflow-x-auto text-sm">
-{`bash install.sh --mode development`}
-            </pre>
-          </div>
-          <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
-            <h3 className="text-lg font-semibold text-white mb-2">Production mode</h3>
-            <p className="text-gray-200 mb-3">
-              Ensures Docker services are running, applies migrations against the production database,
-              and then provisions the admin user.
-            </p>
-            <pre className="bg-black text-gray-100 p-3 rounded-md overflow-x-auto text-sm">
-{`bash install.sh --mode production`}
-            </pre>
-          </div>
-        </div>
-        <p>
-          The script halts immediately if migrations fail so you can resolve the issue before an
-          incomplete deployment progresses further.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: 'post-install',
-    title: 'Post-install checklist',
-    blurb: 'Verify that critical services are online and lock down administrative access.',
-    content: (
-      <>
-        <ul className="list-disc list-inside space-y-1 text-gray-200">
-          <li>Log in using the admin credentials supplied to the installer.</li>
-          <li>
-            Navigate to <code>/admin/settings/general</code> to confirm branding, domains, and contact
-            details.
-          </li>
-          <li>
-            Upload production logos and favicons under <strong>Appearance</strong> so the frontend pulls
-            the correct assets.
-          </li>
-          <li>Review email deliverability by triggering a password reset from the admin dashboard.</li>
-          <li>
-            If running in production, disable the installation API by setting
-            <code>INSTALL_API_ENABLED=false</code> and redeploying the backend service.
-          </li>
-        </ul>
-        <p>
-          When everything checks out, commit your tailored configuration files to a secure repository
-          so the environment can be recreated quickly in the future.
-        </p>
-      </>
-    ),
-
-  },
-  {
-    id: 'troubleshooting',
-    title: 'Troubleshooting tips',
-    blurb: 'Resolve the most common installation issues quickly.',
-    content: (
-      <>
-        <ul className="list-disc list-inside space-y-1 text-gray-200">
-          <li>
-            <strong>Docker Compose version error:</strong> Install the V2 plugin so the
-            <code>docker compose</code> command is available. The script exits early if only the legacy
-            binary is detected.
-          </li>
-          <li>
-            <strong>Migrations fail because the database is unavailable:</strong> Double-check that the
-            Postgres container is running (or that your external database is reachable) before retrying.
-          </li>
-          <li>
-            <strong>SMTP verification fails:</strong> Provide valid credentials or temporarily set
-            <code>DISABLE_EMAILS=true</code> while finishing the rest of the setup.
-          </li>
-          <li>
-            <strong>Admin login issues:</strong> Re-run the installer with a new
-            <code>ADMIN_PASSWORD</code> or reset the password via the API using another admin account.
-          </li>
-        </ul>
-        <p>
-          Check the <code>install.log</code> file generated in the project root whenever the script exits
-          unexpectedly—it captures the complete command output for easier debugging.
-        </p>
-      </>
-    ),
-  },
+const DOCS_DIR_CANDIDATES = [
+  path.join(process.cwd(), 'docs'),
+  path.join(process.cwd(), '..', 'docs'),
+  path.join(process.cwd(), '..', '..', 'docs'),
 ];
 
-export default function DocumentationLandingPage() {
-  const [activeSectionId, setActiveSectionId] = useState(sections[0].id);
+async function resolveDocsDirectory() {
+  for (const candidate of DOCS_DIR_CANDIDATES) {
+    try {
+      const stats = await fs.stat(candidate);
+      if (stats.isDirectory()) {
+        return candidate;
+      }
+    } catch (error) {
+      // Ignore missing directories and continue checking.
+    }
+  }
 
-  const activeSection = useMemo(
-    () => sections.find((section) => section.id === activeSectionId) || sections[0],
-    [activeSectionId],
-  );
+  return null;
+}
+
+function extractMetadata(content, slug) {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const titleMatch = normalized.match(/^#\s+(.+)/m);
+  const fallbackTitle = slug.replace(/[-_]/g, ' ').replace(/\s+/g, ' ').trim();
+  const title = titleMatch ? titleMatch[1].trim() : fallbackTitle || slug;
+
+  const lines = normalized
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) =>
+      line &&
+      !line.startsWith('#') &&
+      !line.startsWith('![') &&
+      !line.startsWith('|') &&
+      !/^[-*]\s/.test(line) &&
+      !line.startsWith('<') &&
+      !line.startsWith('```'),
+    );
+
+  const descriptionSource = lines[0] || '';
+  const description = descriptionSource
+    .replace(/[`*_]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return {
+    title,
+    description,
+  };
+}
+
+async function loadDocsMetadata() {
+  const docsDir = await resolveDocsDirectory();
+  if (!docsDir) {
+    return [];
+  }
+
+  let entries = [];
+  try {
+    entries = await fs.readdir(docsDir, { withFileTypes: true });
+  } catch (error) {
+    console.error('Unable to read documentation directory:', error);
+    return [];
+  }
+
+  const docs = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) {
+      continue;
+    }
+
+    const slug = entry.name.replace(/\.md$/, '');
+    const filePath = path.join(docsDir, entry.name);
+
+    try {
+      const [content, stats] = await Promise.all([
+        fs.readFile(filePath, 'utf8'),
+        fs.stat(filePath),
+      ]);
+      const { title, description } = extractMetadata(content, slug);
+
+      docs.push({
+        slug,
+        title,
+        description,
+        lastUpdated: stats.mtime.toISOString(),
+      });
+    } catch (error) {
+      console.error(`Failed to load documentation file "${entry.name}":`, error);
+    }
+  }
+
+  return docs.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+function formatDate(value) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new Intl.DateTimeFormat('en', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(value));
+  } catch (error) {
+    return null;
+  }
+}
+
+export default function DocumentationLandingPage({ docs = [] }) {
+  const [query, setQuery] = useState('');
+  const [showAll, setShowAll] = useState(false);
+
+  const filteredDocs = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    if (!normalizedQuery) {
+      return docs;
+    }
+
+    return docs.filter((doc) => {
+      const haystack = `${doc.title} ${doc.slug} ${doc.description}`.toLowerCase();
+      return haystack.includes(normalizedQuery);
+    });
+  }, [docs, query]);
+
+  const visibleDocs = showAll ? filteredDocs : filteredDocs.slice(0, 12);
+
   return (
     <>
-      <PageHead title="Installation Guide" description="Install the SkillBridge platform with the bundled setup scripts." />
+      <PageHead title="Documentation" description="Explore the latest SkillBridge guides and references." />
       <Navbar />
 
-      <section className="bg-gradient-to-r from-indigo-900 via-purple-900 to-black text-white py-24 px-6 text-center">
+      <section className="bg-gradient-to-r from-slate-900 via-indigo-950 to-black text-white py-24 px-6 text-center">
         <div className="mx-auto max-w-3xl space-y-6">
-          <h1 className="text-4xl font-bold md:text-5xl">Install SkillBridge</h1>
+          <h1 className="text-4xl font-bold md:text-5xl">SkillBridge Documentation</h1>
           <p className="text-lg text-indigo-100">
-            Follow this guided installation to bootstrap SkillBridge with the unified setup script. Choose a section to learn how
-            to prepare your environment, run the installer, and validate the deployment.
+            Browse every guide shipped with the repository. These pages are generated directly from the Markdown files in the
+            <code className="mx-1 rounded bg-white/10 px-2 py-1 text-sm text-indigo-100">/docs</code> directory so you are always
+            reading the latest version.
           </p>
         </div>
       </section>
 
       <section className="bg-black py-16 px-6">
-        <div className="max-w-6xl mx-auto">
-          <div className="mb-10 text-center text-white">
-            <h2 className="text-3xl font-semibold mb-4">Installation script walkthrough</h2>
-            <p className="text-gray-300">
-              Follow the guided flow below to configure and execute <code>install.sh</code> for any environment.
-            </p>
-          </div>
-
-          <div className="bg-gray-950 border border-gray-800 rounded-2xl shadow-xl overflow-hidden">
-            <div className="flex flex-col md:flex-row">
-              <aside className="md:w-72 border-b md:border-b-0 md:border-r border-gray-800 bg-gray-900/60 p-6">
-                <div className="md:hidden mb-4">
-                  <label htmlFor="docs-section-picker" className="block text-sm font-medium text-gray-300 mb-2">
-                    Jump to section
-                  </label>
-                  <select
-                    id="docs-section-picker"
-                    value={activeSectionId}
-                    onChange={(event) => setActiveSectionId(event.target.value)}
-                    className="w-full bg-gray-900 border border-gray-700 text-gray-100 rounded-lg px-3 py-2"
-                  >
-                    {sections.map((section) => (
-                      <option key={section.id} value={section.id}>
-                        {section.title}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <nav className="hidden md:flex md:flex-col md:gap-2" aria-label="Installation sections">
-                  {sections.map((section) => {
-                    const isActive = section.id === activeSectionId;
-
-                    return (
-                      <button
-                        key={section.id}
-                        type="button"
-                        onClick={() => setActiveSectionId(section.id)}
-                        className={`w-full text-left px-4 py-3 rounded-xl border transition focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 focus:ring-offset-gray-950 ${
-                          isActive
-                            ? 'bg-indigo-600 border-indigo-400 text-white shadow-lg'
-                            : 'bg-gray-900/70 border-gray-800 text-gray-200 hover:bg-gray-800'
-                        }`}
-                      >
-                        <span className="block text-sm uppercase tracking-wide text-gray-300 mb-1">
-                          Step {sections.findIndex((item) => item.id === section.id) + 1}
-                        </span>
-                        <span className="block text-lg font-semibold">{section.title}</span>
-                        <span className="block text-xs text-gray-300 mt-1">{section.blurb}</span>
-                      </button>
-                    );
-                  })}
-                </nav>
-              </aside>
-
-              <article className="flex-1 p-6 md:p-10 text-gray-100">
-                <header className="border-b border-gray-800 pb-6 mb-8">
-                  <p className="text-sm uppercase tracking-wide text-indigo-300">
-                    Step {sections.findIndex((item) => item.id === activeSection.id) + 1}
-                  </p>
-                  <h3 className="text-3xl font-bold text-white mt-2 mb-3">{activeSection.title}</h3>
-                  <p className="text-gray-300 max-w-3xl">{activeSection.blurb}</p>
-                </header>
-
-                <div className="prose prose-invert prose-indigo max-w-none space-y-6">
-                  {activeSection.content}
-                </div>
-
-                <div className="mt-12 border-t border-gray-800 pt-6 flex flex-wrap items-center justify-between gap-4 text-sm text-gray-400">
-                  <span>Need deeper context? Read the full installation reference in our documentation portal.</span>
-                  <a
-                    href="https://eduskillbridge.net/docs"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-2 text-indigo-300 hover:text-indigo-200"
-                  >
-                    Open installation docs
-                    <svg
-                      className="h-4 w-4"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                    </svg>
-                  </a>
-                </div>
-              </article>
+        <div className="max-w-6xl mx-auto space-y-10">
+          <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 className="text-3xl font-semibold text-white">All guides ({filteredDocs.length})</h2>
+              <p className="mt-2 max-w-2xl text-gray-300">
+                Use the search below to quickly jump to install instructions, API references, deployment tips, and more.
+              </p>
+            </div>
+            <div className="w-full md:w-80">
+              <label htmlFor="docs-search" className="sr-only">
+                Search documentation
+              </label>
+              <input
+                id="docs-search"
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search guides"
+                className="w-full rounded-xl border border-indigo-500/40 bg-slate-950/70 px-4 py-3 text-sm text-white placeholder:text-indigo-200 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/80"
+              />
             </div>
           </div>
 
+          {filteredDocs.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-indigo-500/40 bg-slate-950/60 p-12 text-center text-gray-300">
+              <h3 className="text-xl font-semibold text-white">No matches found</h3>
+              <p className="mt-3 text-sm text-gray-400">
+                We couldn't find any documentation matching "{query}". Try a different keyword or clear the search box.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                {visibleDocs.map((doc) => {
+                  const formattedDate = formatDate(doc.lastUpdated);
+
+                  return (
+                    <Link
+                      key={doc.slug}
+                      href={`/docs/${doc.slug}`}
+                      className="group flex h-full flex-col rounded-2xl border border-slate-800 bg-slate-950/80 p-6 shadow-lg transition hover:border-indigo-500/60 hover:shadow-indigo-500/20"
+                    >
+                      <div className="flex-1 space-y-3">
+                        <span className="inline-flex items-center rounded-full border border-indigo-500/40 bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-200">
+                          Guide
+                        </span>
+                        <h3 className="text-xl font-semibold text-white transition group-hover:text-indigo-200">
+                          {doc.title}
+                        </h3>
+                        {doc.description ? (
+                          <p className="text-sm leading-6 text-gray-300 line-clamp-4">{doc.description}</p>
+                        ) : (
+                          <p className="text-sm text-gray-500">Open to read the full guide.</p>
+                        )}
+                      </div>
+
+                      {formattedDate && (
+                        <div className="mt-6 flex items-center justify-between text-xs text-indigo-200/80">
+                          <span>Last updated</span>
+                          <span>{formattedDate}</span>
+                        </div>
+                      )}
+                    </Link>
+                  );
+                })}
+              </div>
+
+              {filteredDocs.length > visibleDocs.length && (
+                <div className="text-center">
+                  <button
+                    type="button"
+                    onClick={() => setShowAll(true)}
+                    className="inline-flex items-center gap-2 rounded-full border border-indigo-500/60 bg-indigo-500/10 px-6 py-3 text-sm font-medium text-indigo-200 transition hover:bg-indigo-500/20"
+                  >
+                    Show all {filteredDocs.length} guides
+                  </button>
+                </div>
+              )}
+            </>
+          )}
         </div>
       </section>
 
@@ -356,17 +245,9 @@ export default function DocumentationLandingPage() {
         <div className="mx-auto max-w-3xl">
           <h2 className="text-3xl font-semibold mb-4">Need more help?</h2>
           <p className="text-indigo-100 mb-6">
-            Browse the full documentation on our website, join the community discussions, or open an issue if you run into trouble during installation.
+            Join the community discussions or open an issue if you run into trouble during installation or customization.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row sm:justify-center">
-            <a
-              href="https://eduskillbridge.net/docs"
-              className="bg-white text-indigo-700 px-6 py-2 rounded shadow hover:bg-gray-100"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Browse docs online
-            </a>
             <a
               href="https://github.com/eduskillbridge/SkillBridge/discussions"
               className="border border-white px-6 py-2 rounded hover:bg-white hover:text-indigo-700"
@@ -374,6 +255,14 @@ export default function DocumentationLandingPage() {
               rel="noopener noreferrer"
             >
               Community Support
+            </a>
+            <a
+              href="https://github.com/eduskillbridge/SkillBridge/issues/new/choose"
+              className="bg-white text-indigo-700 px-6 py-2 rounded shadow hover:bg-gray-100"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open an issue
             </a>
           </div>
         </div>
@@ -385,9 +274,13 @@ export default function DocumentationLandingPage() {
 }
 
 export async function getStaticProps({ locale }) {
+  const docs = await loadDocsMetadata();
+
   return {
     props: {
+      docs,
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
     },
+    revalidate: 300,
   };
 }


### PR DESCRIPTION
## Summary
- load Markdown files from the `/docs` directory when building the documentation landing page
- render searchable cards that link to the statically generated detail pages and show update metadata
- keep i18n support and static regeneration so the index stays current with repository docs

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fbe166a083289c92f23f5f57a072