### PR TITLE
Ensure admin cache clear includes CSRF token

### DIFF
--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -1,5 +1,11 @@
 import api from "@/services/api/api";
+import { ensureCsrfToken } from "@/services/api/csrf";
+
 export const clearCache = async () => {
-  const { data } = await api.post("/admin/cache/clear");
+  const headers = {};
+  const csrfToken = await ensureCsrfToken();
+  if (csrfToken) headers["x-csrf-token"] = csrfToken;
+
+  const { data } = await api.post("/admin/cache/clear", null, { headers });
   return data;
 };


### PR DESCRIPTION
## Summary
- ensure the admin cache clear service fetches a CSRF token before sending the request
- include the token in the request headers so protected endpoints succeed

## Testing
- npx eslint src/services/admin/cacheService.js


------
https://chatgpt.com/codex/tasks/task_e_68d54718e1588328ad558849eaaeaddf