### PR TITLE
Retry admin cache clear with refreshed CSRF token

### DIFF
--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -1,5 +1,33 @@
 import api from "@/services/api/api";
-export const clearCache = async () => {
-  const { data } = await api.post("/admin/cache/clear");
+import { ensureCsrfToken, getCsrfToken } from "@/services/api/csrf";
+
+const requestClearCache = async (csrfToken) => {
+  if (!csrfToken) {
+    throw new Error("CSRF token unavailable");
+  }
+
+  const { data } = await api.post("/admin/cache/clear", null, {
+    headers: { "x-csrf-token": csrfToken },
+  });
+
   return data;
+};
+
+const prepareCsrfToken = async () => {
+  await ensureCsrfToken();
+  return getCsrfToken();
+};
+
+export const clearCache = async () => {
+  try {
+    const initialToken = await prepareCsrfToken();
+    return await requestClearCache(initialToken);
+  } catch (error) {
+    if (error?.response?.status !== 403) {
+      throw error;
+    }
+
+    const refreshedToken = await prepareCsrfToken();
+    return requestClearCache(refreshedToken);
+  }
 };


### PR DESCRIPTION
## Summary
- wrap the admin cache clear request so it reuses a prepared CSRF token or refreshes it on 403 errors
- surface a clear error when no CSRF token can be issued instead of sending a doomed request

## Testing
- npx eslint src/services/admin/cacheService.js

------
https://chatgpt.com/codex/tasks/task_e_68d54718e1588328ad558849eaaeaddf