### PR TITLE
Fix CSRF token fetch for admin cache clear

### DIFF
--- a/frontend/src/services/api/csrf.js
+++ b/frontend/src/services/api/csrf.js
@@ -12,7 +12,14 @@ export const ensureCsrfToken = async () => {
   let token = getCsrfToken();
   if (!token) {
     try {
-      await api.get("/csrf-token");
+      // Use a relative URL so Axios appends it to the configured base URL.
+      // A leading slash causes Axios to treat the path as absolute, which
+      // skips the `/api` prefix in production and prevents the backend CSRF
+      // route from being hit. That leaves the csrfToken cookie unset and the
+      // next POST request fails with a 403. Using a relative path ensures we
+      // always call `/api/csrf-token`, allowing the server to issue the
+      // expected cookie before we retry the protected request.
+      await api.get("csrf-token");
     } catch (e) {
       // The route may not exist; we only care about the cookie.
     }


### PR DESCRIPTION
## Summary
- ensure the frontend CSRF helper hits the backend `/api/csrf-token` endpoint by using a relative path
- document the reasoning in code comments to avoid future regressions when fetching CSRF tokens

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d5745cde708328bf78826851d86ef7