### PR TITLE
Use shared cache helper for sidebar toast

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -7,7 +7,7 @@ import { useState, useEffect } from 'react';
 import useAppConfigStore from '@/store/appConfigStore';
 import logo from '@/shared/assets/images/login/logo.png';
 import { buildUrl } from '@/utils/url';
-import { clearCache } from '@/services/admin/cacheService';
+import { clearCache as clearCacheWithToast } from '@/utils/cache';
 import { adminNavLinks } from './SidebarLinks/adminLinks';
 import { instructorNavLinks } from './SidebarLinks/instructorLinks';
 import { studentNavLinks } from './SidebarLinks/studentLinks';
@@ -36,7 +36,7 @@ export default function Sidebar({ role = 'admin' }) {
 
   const handleClearCache = async () => {
     try {
-      await clearCache();
+      await clearCacheWithToast();
     } catch (err) {
       console.error('Failed to clear cache', err);
     }

--- a/frontend/src/services/admin/cacheService.js
+++ b/frontend/src/services/admin/cacheService.js
@@ -6,7 +6,8 @@ const requestClearCache = async (csrfToken) => {
     throw new Error("CSRF token unavailable");
   }
 
-  const { data } = await api.post("/admin/cache/clear", null, {
+  // Use a relative path so Axios preserves the configured `/api` prefix.
+  const { data } = await api.post("admin/cache/clear", null, {
     headers: { "x-csrf-token": csrfToken },
   });
 

--- a/frontend/src/services/api/csrf.js
+++ b/frontend/src/services/api/csrf.js
@@ -12,7 +12,14 @@ export const ensureCsrfToken = async () => {
   let token = getCsrfToken();
   if (!token) {
     try {
-      await api.get("/csrf-token");
+      // Use a relative URL so Axios appends it to the configured base URL.
+      // A leading slash causes Axios to treat the path as absolute, which
+      // skips the `/api` prefix in production and prevents the backend CSRF
+      // route from being hit. That leaves the csrfToken cookie unset and the
+      // next POST request fails with a 403. Using a relative path ensures we
+      // always call `/api/csrf-token`, allowing the server to issue the
+      // expected cookie before we retry the protected request.
+      await api.get("csrf-token");
     } catch (e) {
       // The route may not exist; we only care about the cookie.
     }


### PR DESCRIPTION
## Summary
- use the cache utility helper in the dashboard sidebar so the admin clear cache button triggers toast notifications

## Testing
- npm run lint *(fails: numerous pre-existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5745cde708328bf78826851d86ef7