### PR TITLE
Avoid deleting remote avatar URLs

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -272,11 +272,16 @@ exports.updateAvatar = async (req, res) => {
       .where({ id: userId })
       .update({ avatar_url: filePath, updated_at: new Date() });
 
-    if (oldAvatar) {
-      const oldPath = path.join(__dirname, "../../../../", oldAvatar);
-      fs.unlink(oldPath, (err) =>
-        err && logger.error("Failed to remove old avatar", { userId, err })
-      );
+    const isRemoteUrl = (url) => typeof url === "string" && /^https?:\/\//i.test(url);
+
+    if (oldAvatar && !isRemoteUrl(oldAvatar)) {
+      const sanitizedOldAvatar = oldAvatar.replace(/^\/+/, "");
+      const oldPath = path.join(process.cwd(), sanitizedOldAvatar);
+      fs.unlink(oldPath, (err) => {
+        if (err && err.code !== "ENOENT") {
+          logger.error("Failed to remove old avatar", { userId, err });
+        }
+      });
     }
 
     res.json({ message: "Avatar updated", avatar_url: filePath });
@@ -303,14 +308,17 @@ exports.deleteAvatar = async (req, res) => {
       return res.status(404).json({ message: "User not found" });
     }
 
-    if (user.avatar_url) {
+    const isRemoteUrl = (url) => typeof url === "string" && /^https?:\/\//i.test(url);
+
+    if (user.avatar_url && !isRemoteUrl(user.avatar_url)) {
       const filePath = path.join(
-        __dirname,
-        "../../../../",
-        user.avatar_url.replace(/^\//, "")
+        process.cwd(),
+        user.avatar_url.replace(/^\/+/, "")
       );
       fs.unlink(filePath, (err) => {
-        if (err) logger.error(err);
+        if (err && err.code !== "ENOENT") {
+          logger.error(err);
+        }
       });
     }
 

--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -230,9 +230,16 @@ exports.updateAvatar = async (req, res) => {
 
         await db("users").where({ id: req.user.id }).update({ avatar_url: avatarUrl });
 
-        if (oldAvatar) {
-            const oldPath = path.join(__dirname, "../../../../", oldAvatar);
-            fs.unlink(oldPath, (error) => error && logger.error("Failed to remove old avatar:", error));
+        const isRemoteUrl = (url) => typeof url === "string" && /^https?:\/\//i.test(url);
+
+        if (oldAvatar && !isRemoteUrl(oldAvatar)) {
+            const sanitizedOldAvatar = oldAvatar.replace(/^\/+/, "");
+            const oldPath = path.join(process.cwd(), sanitizedOldAvatar);
+            fs.unlink(oldPath, (error) => {
+                if (error && error.code !== "ENOENT") {
+                    logger.error("Failed to remove old avatar:", error);
+                }
+            });
         }
 
         res.json({ avatar_url: avatarUrl });

--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -123,12 +123,16 @@ exports.updateAvatar = async (req, res) => {
       .where({ id: req.user.id })
       .update({ avatar_url: avatarUrl });
 
-    if (oldAvatar) {
-      const sanitizedOldAvatar = oldAvatar.replace(/^\//, "");
+    const isRemoteUrl = (url) => typeof url === "string" && /^https?:\/\//i.test(url);
+
+    if (oldAvatar && !isRemoteUrl(oldAvatar)) {
+      const sanitizedOldAvatar = oldAvatar.replace(/^\/+/, "");
       const oldPath = path.join(process.cwd(), sanitizedOldAvatar);
-      fs.unlink(oldPath, (err) =>
-        err && logger.error("Failed to remove old avatar:", err)
-      );
+      fs.unlink(oldPath, (err) => {
+        if (err && err.code !== "ENOENT") {
+          logger.error("Failed to remove old avatar:", err);
+        }
+      });
     }
 
     res.json({ avatar_url: avatarUrl });


### PR DESCRIPTION
## Summary
- guard the student, instructor, and admin avatar updaters against remote avatar URLs before unlinking files
- skip unlink errors when the file is missing to avoid noisy ENOENT logs during avatar updates

## Testing
- npm test *(fails: many suites require additional database/env setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d585cb7adc8328b9fc772ae17183b5