### PR TITLE
Fix student profile validation translations

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -35,7 +35,7 @@ import getCroppedImg from "@/utils/cropImage";
 export const studentProfileSchema = z.object({
   full_name: z.string().min(3, "full_name_min"),
   phone: z.string().refine((val) => isValidPhoneNumber(val, getUserCountry()), {
-    message: "invalid_phone_number",
+    message: "invalid_phone",
   }),
   gender: z.enum(['male', 'female']),
   date_of_birth: z.string().refine(val => !isNaN(Date.parse(val)), {
@@ -88,6 +88,22 @@ export default function StudentProfileEdit() {
   const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
   const [tempAvatar, setTempAvatar] = useState(null);
   const [tempFileName, setTempFileName] = useState("");
+
+  const translateValidationMessage = useCallback(
+    (key) => {
+      if (!key) return "";
+      const nested = t(`validation.${key}`, { defaultValue: "" });
+      if (typeof nested === "string" && nested.trim().length > 0) {
+        return nested;
+      }
+      const direct = t(key, { defaultValue: "" });
+      if (typeof direct === "string" && direct.trim().length > 0) {
+        return direct;
+      }
+      return key;
+    },
+    [t]
+  );
 
   useEffect(() => {
     if (!hasHydrated) return;
@@ -281,11 +297,11 @@ const handleAvatarSelect = (e) => {
       if (err instanceof ZodError) {
         err.errors.forEach((error) => {
           const key = error.path.join(".");
-          errs[key] = t(error.message);
+          errs[key] = translateValidationMessage(error.message);
         });
         setErrors(errs);
         if (err.errors?.length) {
-          toast.error(t(err.errors[0].message));
+          toast.error(translateValidationMessage(err.errors[0].message));
         } else {
           toast.error(t('fix_errors'));
         }


### PR DESCRIPTION
## Summary
- add a helper to translate student profile validation error codes with sensible fallbacks
- align the phone validation error key with existing locale entries to prevent null translations

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d58c852c5c8328b6c9cf73f8f1e25f