### PR TITLE
Fix null strings in student profile edit form

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -117,8 +117,8 @@ export default function StudentProfileEdit() {
         });
 
         setFormData({
-          full_name,
-          phone,
+          full_name: full_name ?? "",
+          phone: phone ?? "",
           gender: gender || "male",
           date_of_birth: date_of_birth?.split("T")[0] || "",
           education_level: student?.education_level || "",


### PR DESCRIPTION
## Summary
- ensure student profile form initializes text fields with empty strings when API returns null values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d58c852c5c8328b6c9cf73f8f1e25f