### PR TITLE
Improve social login env persistence fallback

### DIFF
--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.service.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.service.js
@@ -44,9 +44,21 @@ function resolveEnvPath() {
   const explicitEnvPath = process.env.SOCIAL_LOGIN_ENV_PATH
     ? path.resolve(process.env.SOCIAL_LOGIN_ENV_PATH)
     : null;
-  const fallbackEnvPath = path.join(os.tmpdir(), 'skillbridge', 'social-login.env');
-  const defaultEnvPath = path.join(__dirname, '../../../.env');
-  const candidates = [explicitEnvPath, defaultEnvPath, fallbackEnvPath].filter(Boolean);
+  const backendRoot = path.join(__dirname, '../../../');
+  const uploadsFallbackEnvPath = path.join(
+    backendRoot,
+    'uploads',
+    'config',
+    'social-login.env'
+  );
+  const tmpFallbackEnvPath = path.join(os.tmpdir(), 'skillbridge', 'social-login.env');
+  const defaultEnvPath = path.join(backendRoot, '.env');
+  const candidates = [
+    explicitEnvPath,
+    defaultEnvPath,
+    uploadsFallbackEnvPath,
+    tmpFallbackEnvPath,
+  ].filter(Boolean);
 
   for (const candidate of candidates) {
     try {
@@ -71,14 +83,14 @@ function resolveEnvPath() {
 
       if (isExplicitEnvPath) {
         logger.warn(
-          'Unable to access SOCIAL_LOGIN_ENV_PATH for social login settings. Falling back to defaults.',
-          error
+          'Unable to access SOCIAL_LOGIN_ENV_PATH for social login settings. Falling back to defaults.'
         );
+        logger.debug('SOCIAL_LOGIN_ENV_PATH error details:', error);
       } else if (isDefaultEnvPath && (error?.code === 'EACCES' || error?.code === 'EPERM')) {
         logger.warn(
-          'Default .env file is not writable for social login settings. Falling back to a temporary location.',
-          error
+          'Default .env file is not writable for social login settings. Falling back to a writable location.'
         );
+        logger.debug('Default .env permission error details:', error);
       }
     }
   }


### PR DESCRIPTION
## Summary
- extend social login env persistence to try a writable uploads/config file before falling back to tmp storage
- downgrade noisy permission warnings by logging details at debug level

## Testing
- npm --prefix backend test *(fails: environment lacks TEST_DATABASE_URL and related services)*

------
https://chatgpt.com/codex/tasks/task_e_68d58c5606248328b51f389e7fdf5441