### PR TITLE
Persist social login settings in writable storage

### DIFF
--- a/backend/data/.gitignore
+++ b/backend/data/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated social login env file
+social-login.env

--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -59,6 +59,9 @@ ensure_upload_permissions() {
   done
 
   chown -R node:node /app/uploads
+
+  mkdir -p /app/data
+  chown -R node:node /app/data
 }
 
 url_encode() {

--- a/backend/src/modules/socialLoginConfig/socialLoginConfig.service.js
+++ b/backend/src/modules/socialLoginConfig/socialLoginConfig.service.js
@@ -44,9 +44,10 @@ function resolveEnvPath() {
   const explicitEnvPath = process.env.SOCIAL_LOGIN_ENV_PATH
     ? path.resolve(process.env.SOCIAL_LOGIN_ENV_PATH)
     : null;
-  const fallbackEnvPath = path.join(os.tmpdir(), 'skillbridge', 'social-login.env');
+  const persistentEnvPath = path.join(__dirname, '../../../data/social-login.env');
   const defaultEnvPath = path.join(__dirname, '../../../.env');
-  const candidates = [explicitEnvPath, defaultEnvPath, fallbackEnvPath].filter(Boolean);
+  const fallbackEnvPath = path.join(os.tmpdir(), 'skillbridge', 'social-login.env');
+  const candidates = [explicitEnvPath, defaultEnvPath, persistentEnvPath, fallbackEnvPath].filter(Boolean);
 
   for (const candidate of candidates) {
     try {
@@ -76,7 +77,7 @@ function resolveEnvPath() {
         );
       } else if (isDefaultEnvPath && (error?.code === 'EACCES' || error?.code === 'EPERM')) {
         logger.warn(
-          'Default .env file is not writable for social login settings. Falling back to a temporary location.',
+          'Default .env file is not writable for social login settings. Falling back to an internal storage location.',
           error
         );
       }


### PR DESCRIPTION
## Summary
- allow the social login settings writer to use a persistent data directory when the root .env file is not writable
- ensure the backend container prepares the /app/data directory with node ownership
- add a gitignored storage directory for the generated social login environment file

## Testing
- npm test -- socialLoginConfig

------
https://chatgpt.com/codex/tasks/task_e_68d58c5606248328b51f389e7fdf5441