### PR TITLE
Add favorite tutorials sidebar label translations

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1221,6 +1221,7 @@
     "profile": "الملف الشخصي",
     "learning": "التعلم",
     "wishlist": "قائمة الرغبات",
+    "favorite_tutorials": "الدروس المفضلة",
     "instructors_bookings": "المدربون والحجوزات",
     "my_bookings": "حجوزاتي",
     "offers_groups": "العروض والمجموعات",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1235,6 +1235,7 @@
     "profile": "Profile",
     "learning": "Learning",
     "wishlist": "Wishlist",
+    "favorite_tutorials": "Lieblings-Tutorials",
     "instructors_bookings": "Instructors & Bookings",
     "my_bookings": "My Bookings",
     "offers_groups": "Offers & Groups",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1239,6 +1239,7 @@
     "profile": "Profile",
     "learning": "Learning",
     "wishlist": "Wishlist",
+    "favorite_tutorials": "Favorite Tutorials",
     "instructors_bookings": "Instructors & Bookings",
     "my_bookings": "My Bookings",
     "offers_groups": "Offers & Groups",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1221,6 +1221,7 @@
     "profile": "Perfil",
     "learning": "Aprendiendo",
     "wishlist": "Lista de deseos",
+    "favorite_tutorials": "Tutoriales favoritos",
     "instructors_bookings": "Instructores y reservas",
     "my_bookings": "Mis reservas",
     "offers_groups": "Ofertas y grupos",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1221,6 +1221,7 @@
     "profile": "Profil",
     "learning": "Apprentissage",
     "wishlist": "Liste de souhaits",
+    "favorite_tutorials": "Tutoriels favoris",
     "instructors_bookings": "Instructeurs & Réservations",
     "my_bookings": "Mes réservations",
     "offers_groups": "Offres & Groupes",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1221,6 +1221,7 @@
     "profile": "प्रोफ़ाइल",
     "learning": "अधिगम",
     "wishlist": "इच्छा-सूची",
+    "favorite_tutorials": "पसंदीदा ट्यूटोरियल्स",
     "instructors_bookings": "प्रशिक्षक और बुकिंग्स",
     "my_bookings": "मेरी बुकिंग्स",
     "offers_groups": "प्रस्ताव और समूह",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1235,6 +1235,7 @@
     "profile": "Profilo",
     "learning": "Apprendimento",
     "wishlist": "Wishlist",
+    "favorite_tutorials": "Tutorial preferiti",
     "instructors_bookings": "Istruttori e prenotazioni",
     "my_bookings": "Le mie prenotazioni",
     "offers_groups": "Offerte e gruppi",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1221,6 +1221,7 @@
     "profile": "轮廓",
     "learning": "学习",
     "wishlist": "愿望清单",
+    "favorite_tutorials": "收藏教程",
     "instructors_bookings": "讲师和预订",
     "my_bookings": "我的预订",
     "offers_groups": "优惠和团体",


### PR DESCRIPTION
## Summary
- add a Favorite Tutorials link to the student dashboard sidebar in the English locale
- translate the new label across Arabic, German, Spanish, French, Hindi, Italian, and Chinese dashboard locales

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d64d03cc18832883ec354dd98e4b74