### PR TITLE
Add favorite tutorials label to student sidebar locales

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1220,6 +1220,7 @@
     "account": "الحساب",
     "profile": "الملف الشخصي",
     "learning": "التعلم",
+    "favorite_tutorials": "الدروس المفضلة",
     "wishlist": "قائمة الرغبات",
     "instructors_bookings": "المدربون والحجوزات",
     "my_bookings": "حجوزاتي",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1234,6 +1234,7 @@
     "account": "Account",
     "profile": "Profile",
     "learning": "Learning",
+    "favorite_tutorials": "Lieblings-Tutorials",
     "wishlist": "Wishlist",
     "instructors_bookings": "Instructors & Bookings",
     "my_bookings": "My Bookings",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1238,6 +1238,7 @@
     "account": "Account",
     "profile": "Profile",
     "learning": "Learning",
+    "favorite_tutorials": "Favorite Tutorials",
     "wishlist": "Wishlist",
     "instructors_bookings": "Instructors & Bookings",
     "my_bookings": "My Bookings",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1220,6 +1220,7 @@
     "account": "Cuenta",
     "profile": "Perfil",
     "learning": "Aprendiendo",
+    "favorite_tutorials": "Tutoriales favoritos",
     "wishlist": "Lista de deseos",
     "instructors_bookings": "Instructores y reservas",
     "my_bookings": "Mis reservas",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1220,6 +1220,7 @@
     "account": "Compte",
     "profile": "Profil",
     "learning": "Apprentissage",
+    "favorite_tutorials": "Tutoriels favoris",
     "wishlist": "Liste de souhaits",
     "instructors_bookings": "Instructeurs & Réservations",
     "my_bookings": "Mes réservations",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1220,6 +1220,7 @@
     "account": "खाता",
     "profile": "प्रोफ़ाइल",
     "learning": "अधिगम",
+    "favorite_tutorials": "पसंदीदा ट्यूटोरियल",
     "wishlist": "इच्छा-सूची",
     "instructors_bookings": "प्रशिक्षक और बुकिंग्स",
     "my_bookings": "मेरी बुकिंग्स",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1234,6 +1234,7 @@
     "account": "Account",
     "profile": "Profilo",
     "learning": "Apprendimento",
+    "favorite_tutorials": "Tutorial preferiti",
     "wishlist": "Wishlist",
     "instructors_bookings": "Istruttori e prenotazioni",
     "my_bookings": "Le mie prenotazioni",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1220,6 +1220,7 @@
     "account": "帐户",
     "profile": "轮廓",
     "learning": "学习",
+    "favorite_tutorials": "收藏教程",
     "wishlist": "愿望清单",
     "instructors_bookings": "讲师和预订",
     "my_bookings": "我的预订",


### PR DESCRIPTION
## Summary
- add the missing `favorite_tutorials` sidebar label across each student locale file
- provide translated or English copy for all supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d64cfde1888328b7a47832001eb8b3