### PR TITLE
Fix identity document preview handling

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -142,6 +142,10 @@ export default function StudentProfileEdit() {
           }
         });
 
+        const identityDocUrl = student?.identity_doc_url
+          ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${student.identity_doc_url}`
+          : null;
+
         setFormData({
           full_name: full_name ?? "",
           phone: phone ?? "",
@@ -154,7 +158,7 @@ export default function StudentProfileEdit() {
           avatar_url,
           avatarPreview: avatar_url ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${avatar_url}` : null,
           identityFile: null,
-          identityPreview: null,
+          identityPreview: identityDocUrl,
         });
       } catch (err) {
         toast.error(t('load_failed'));
@@ -169,7 +173,7 @@ export default function StudentProfileEdit() {
 
   useEffect(() => {
     return () => {
-      if (formData.identityPreview) {
+      if (formData.identityPreview && formData.identityPreview.startsWith("blob:")) {
         URL.revokeObjectURL(formData.identityPreview);
       }
     };
@@ -265,11 +269,17 @@ const handleAvatarSelect = (e) => {
     try {
       setIsUploadingIdentity(true);
       await uploadStudentIdentity(user.id, file);
-      setFormData(prev => ({
-        ...prev,
-        identityFile: file,
-        identityPreview: URL.createObjectURL(file)
-      }));
+      setFormData(prev => {
+        if (prev.identityPreview && prev.identityPreview.startsWith("blob:")) {
+          URL.revokeObjectURL(prev.identityPreview);
+        }
+
+        return {
+          ...prev,
+          identityFile: file,
+          identityPreview: URL.createObjectURL(file)
+        };
+      });
       toast.success(t('id_upload_success'));
     } catch (err) {
       toast.error(t('id_upload_failed'));
@@ -280,7 +290,7 @@ const handleAvatarSelect = (e) => {
 
   const removeIdentity = () => {
     setFormData(prev => {
-      if (prev.identityPreview) {
+      if (prev.identityPreview && prev.identityPreview.startsWith("blob:")) {
         URL.revokeObjectURL(prev.identityPreview);
       }
       return { ...prev, identityFile: null, identityPreview: null };


### PR DESCRIPTION
## Summary
- load stored identity document URLs into the edit profile form so the download link remains available
- avoid revoking remote identity document URLs by only cleaning up locally created blob previews
- refresh identity preview blobs when selecting new files to prevent leaks

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65014ac40832888f139aad016222b