### PR TITLE
Add student profile translation coverage across locales

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -2085,6 +2085,7 @@
     "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
+    "fix_errors": "Please fix the highlighted errors before continuing.",
     "load_failed": "Failed to load profile data",
     "image_size_error": "Image size should be less than 10MB",
     "avatar_invalid_type": "Only image files are allowed",
@@ -2104,7 +2105,8 @@
       "full_name_min": "Full name must be at least 3 characters",
       "invalid_phone": "Invalid phone number",
       "invalid_date": "Invalid date format",
-      "education_required": "Education level is required"
+      "education_required": "Education level is required",
+      "url_invalid": "Please enter a valid URL"
     }
   },
   "studentOnlineClassesPage": {

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -2102,6 +2102,7 @@
     "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
+    "fix_errors": "Please fix the highlighted errors before continuing.",
     "load_failed": "Failed to load profile data",
     "image_size_error": "Image size should be less than 10MB",
     "avatar_invalid_type": "Only image files are allowed",
@@ -2121,7 +2122,8 @@
       "full_name_min": "Full name must be at least 3 characters",
       "invalid_phone": "Invalid phone number",
       "invalid_date": "Invalid date format",
-      "education_required": "Education level is required"
+      "education_required": "Education level is required",
+      "url_invalid": "Please enter a valid URL"
     }
   },
   "studentOnlineClassesPage": {

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -2102,6 +2102,7 @@
     "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
+    "fix_errors": "Please fix the highlighted errors before continuing.",
     "load_failed": "Failed to load profile data",
     "image_size_error": "Image size should be less than 10MB",
     "avatar_invalid_type": "Only image files are allowed",
@@ -2121,7 +2122,8 @@
       "full_name_min": "Full name must be at least 3 characters",
       "invalid_phone": "Invalid phone number",
       "invalid_date": "Invalid date format",
-      "education_required": "Education level is required"
+      "education_required": "Education level is required",
+      "url_invalid": "Please enter a valid URL"
     }
   },
   "studentOnlineClassesPage": {

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -2088,6 +2088,7 @@
     "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
+    "fix_errors": "Please fix the highlighted errors before continuing.",
     "load_failed": "Failed to load profile data",
     "image_size_error": "Image size should be less than 10MB",
     "avatar_invalid_type": "Only image files are allowed",
@@ -2107,7 +2108,8 @@
       "full_name_min": "Full name must be at least 3 characters",
       "invalid_phone": "Invalid phone number",
       "invalid_date": "Invalid date format",
-      "education_required": "Education level is required"
+      "education_required": "Education level is required",
+      "url_invalid": "Please enter a valid URL"
     }
   },
   "studentOnlineClassesPage": {

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -2085,6 +2085,7 @@
     "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
+    "fix_errors": "Please fix the highlighted errors before continuing.",
     "load_failed": "Failed to load profile data",
     "image_size_error": "Image size should be less than 10MB",
     "avatar_invalid_type": "Only image files are allowed",
@@ -2104,7 +2105,8 @@
       "full_name_min": "Full name must be at least 3 characters",
       "invalid_phone": "Invalid phone number",
       "invalid_date": "Invalid date format",
-      "education_required": "Education level is required"
+      "education_required": "Education level is required",
+      "url_invalid": "Please enter a valid URL"
     }
   },
   "studentOnlineClassesPage": {

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -2088,6 +2088,7 @@
     "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
+    "fix_errors": "Please fix the highlighted errors before continuing.",
     "load_failed": "Failed to load profile data",
     "image_size_error": "Image size should be less than 10MB",
     "avatar_invalid_type": "Only image files are allowed",
@@ -2107,7 +2108,8 @@
       "full_name_min": "Full name must be at least 3 characters",
       "invalid_phone": "Invalid phone number",
       "invalid_date": "Invalid date format",
-      "education_required": "Education level is required"
+      "education_required": "Education level is required",
+      "url_invalid": "Please enter a valid URL"
     }
   },
   "studentOnlineClassesPage": {

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -2102,6 +2102,7 @@
     "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
+    "fix_errors": "Please fix the highlighted errors before continuing.",
     "load_failed": "Failed to load profile data",
     "image_size_error": "Image size should be less than 10MB",
     "avatar_invalid_type": "Only image files are allowed",
@@ -2121,7 +2122,8 @@
       "full_name_min": "Full name must be at least 3 characters",
       "invalid_phone": "Invalid phone number",
       "invalid_date": "Invalid date format",
-      "education_required": "Education level is required"
+      "education_required": "Education level is required",
+      "url_invalid": "Please enter a valid URL"
     }
   },
   "studentOnlineClassesPage": {

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -2057,6 +2057,7 @@
     "upload": "Upload",
     "saving": "Saving...",
     "save_changes": "Save Changes",
+    "fix_errors": "Please fix the highlighted errors before continuing.",
     "load_failed": "Failed to load profile data",
     "image_size_error": "Image size should be less than 10MB",
     "avatar_invalid_type": "Only image files are allowed",
@@ -2076,7 +2077,8 @@
       "full_name_min": "Full name must be at least 3 characters",
       "invalid_phone": "Invalid phone number",
       "invalid_date": "Invalid date format",
-      "education_required": "Education level is required"
+      "education_required": "Education level is required",
+      "url_invalid": "Please enter a valid URL"
     }
   },
   "studentOnlineClassesPage": {

--- a/frontend/src/tests/__tests__/studentProfileTranslations.test.js
+++ b/frontend/src/tests/__tests__/studentProfileTranslations.test.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('studentProfilePage translations', () => {
+  const localesDir = path.join(__dirname, '../../../public/locales');
+  const locales = fs.readdirSync(localesDir);
+
+  it('should include fix_errors in all locales', () => {
+    const missing = [];
+
+    locales.forEach((locale) => {
+      const filePath = path.join(localesDir, locale, 'dashboard.json');
+      const translations = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      const studentProfile = translations.studentProfilePage;
+
+      if (!studentProfile || !Object.prototype.hasOwnProperty.call(studentProfile, 'fix_errors')) {
+        missing.push(locale);
+      }
+    });
+
+    expect(missing).toEqual([]);
+  });
+
+  it('should include validation.url_invalid in all locales', () => {
+    const missing = [];
+
+    locales.forEach((locale) => {
+      const filePath = path.join(localesDir, locale, 'dashboard.json');
+      const translations = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      const validation = translations.studentProfilePage?.validation;
+
+      if (!validation || !Object.prototype.hasOwnProperty.call(validation, 'url_invalid')) {
+        missing.push(locale);
+      }
+    });
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `fix_errors` helper text to the student profile page translations for every locale
- add `validation.url_invalid` to the student profile page translations for every locale
- introduce a Jest test to ensure each locale includes the new student profile keys

## Testing
- npm test -- --runTestsByPath src/tests/__tests__/studentProfileTranslations.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6500ac198832883d9b5853edcffe3