### PR TITLE
Normalize student topics before profile update

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -60,6 +60,37 @@ const safeString = (value, fallback = "") => {
   }
 };
 
+const normalizeTopics = (topics) => {
+  if (Array.isArray(topics)) {
+    return topics
+      .map((topic) => (typeof topic === "string" ? topic.trim() : ""))
+      .filter((topic) => topic.length > 0);
+  }
+
+  if (typeof topics === "string") {
+    const trimmed = topics.trim();
+    if (!trimmed) return [];
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((topic) => (typeof topic === "string" ? topic.trim() : ""))
+          .filter((topic) => topic.length > 0);
+      }
+    } catch (err) {
+      // Ignore JSON parse errors and fall back to comma-separated parsing
+    }
+
+    return trimmed
+      .split(",")
+      .map((topic) => topic.trim())
+      .filter((topic) => topic.length > 0);
+  }
+
+  return [];
+};
+
 export default function StudentProfileEdit() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'studentProfilePage' });
   const router = useRouter();
@@ -148,7 +179,7 @@ export default function StudentProfileEdit() {
           gender: gender || "male",
           date_of_birth: date_of_birth?.split("T")[0] || "",
           education_level: student?.education_level || "",
-          topics: student?.topics || [],
+          topics: normalizeTopics(student?.topics),
           learning_goals: student?.learning_goals || "",
           socialLinks: socialMap,
           avatar_url,
@@ -295,9 +326,11 @@ const handleAvatarSelect = (e) => {
             allowedPlatforms.some((p) => p.name === platform) && url.trim() !== ""
         )
       );
+      const normalizedTopics = normalizeTopics(formData.topics);
 
       studentProfileSchema.parse({
         ...formData,
+        topics: normalizedTopics,
         socialLinks: Object.keys(sanitizedLinks).length ? sanitizedLinks : undefined,
       });
       setErrors({});
@@ -333,6 +366,7 @@ const handleAvatarSelect = (e) => {
       setIsSubmitting(true);
       logger.log("[StudentProfileEdit] Submitting form", formData);
       const social_links = toSocialLinksArray(formData.socialLinks);
+      const normalizedTopics = normalizeTopics(formData.topics);
 
       const payload = {
         full_name: formData.full_name,
@@ -340,7 +374,7 @@ const handleAvatarSelect = (e) => {
         gender: formData.gender,
         date_of_birth: formData.date_of_birth,
         education_level: formData.education_level,
-        topics: formData.topics,
+        topics: normalizedTopics,
         learning_goals: formData.learning_goals,
         social_links,
       };

--- a/frontend/tests/studentProfileEdit.topics.test.js
+++ b/frontend/tests/studentProfileEdit.topics.test.js
@@ -1,0 +1,146 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import StudentProfileEdit from "@/pages/dashboard/student/profile/edit";
+import {
+  getStudentProfile as mockGetStudentProfile,
+  updateStudentProfile as mockUpdateStudentProfile,
+} from "@/services/student/studentService";
+
+const mockPush = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock("next/dynamic", () => () => () => null);
+
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key, opts) => opts?.defaultValue ?? key,
+  }),
+}));
+
+jest.mock("react-toastify", () => {
+  const toast = {
+    error: jest.fn(),
+    success: jest.fn(),
+    promise: jest.fn((promise) => promise),
+  };
+  return { toast };
+});
+
+jest.mock("@/components/layouts/StudentLayout", () => ({ children }) => <div>{children}</div>);
+
+jest.mock("@/services/student/studentService", () => ({
+  getStudentProfile: jest.fn(),
+  updateStudentProfile: jest.fn(),
+  uploadStudentAvatar: jest.fn(),
+  uploadStudentIdentity: jest.fn(),
+}));
+
+jest.mock("@/store/auth/authStore", () => {
+  const setUser = jest.fn();
+  const logout = jest.fn();
+  return {
+    __esModule: true,
+    default: jest.fn(() => ({
+      user: { id: 42, role: "student" },
+      logout,
+      hasHydrated: true,
+      setUser,
+    })),
+  };
+});
+
+const notificationFetch = jest.fn();
+jest.mock("@/store/notifications/notificationStore", () => ({
+  __esModule: true,
+  default: jest.fn((selector) => selector({ fetch: notificationFetch })),
+}));
+
+const messageFetch = jest.fn();
+jest.mock("@/store/messages/messageStore", () => ({
+  __esModule: true,
+  default: jest.fn((selector) => selector({ fetch: messageFetch })),
+}));
+
+jest.mock("@/services/notificationService", () => ({
+  createNotification: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/services/messageService", () => ({
+  sendChatMessage: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/utils/socialLinks", () => ({
+  toSocialLinksArray: jest.fn(() => []),
+}));
+
+jest.mock("@/utils/socialPlatforms", () => ({
+  allowedPlatforms: [],
+  defaultPlatformIcon: { Icon: () => null, className: "" },
+}));
+
+jest.mock("@/utils/logger", () => ({
+  log: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock("@/utils/getUserCountry", () => ({
+  getUserCountry: jest.fn(() => "US"),
+}));
+
+jest.mock("libphonenumber-js", () => ({
+  isValidPhoneNumber: jest.fn(() => true),
+}));
+
+describe("StudentProfileEdit topics normalization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("submits normalized topics array when profile topics are provided as a string", async () => {
+    const apiTopicsString = '["AI","Blockchain"]';
+    const normalizedResponse = {
+      full_name: "Test Student",
+      phone: "+14155552671",
+      gender: "male",
+      date_of_birth: "2000-01-01T00:00:00.000Z",
+      avatar_url: null,
+      student: {
+        education_level: "Bachelor",
+        topics: ["AI", "Blockchain"],
+        learning_goals: "Become an expert",
+      },
+      social_links: [],
+    };
+
+    mockGetStudentProfile.mockResolvedValue(normalizedResponse);
+    mockGetStudentProfile.mockResolvedValueOnce({
+      ...normalizedResponse,
+      student: {
+        ...normalizedResponse.student,
+        topics: apiTopicsString,
+      },
+    });
+
+    mockUpdateStudentProfile.mockResolvedValue({});
+
+    render(<StudentProfileEdit />);
+
+    await waitFor(() => {
+      expect(mockGetStudentProfile).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await screen.findByDisplayValue("Test Student")).toBeInTheDocument();
+
+    const saveButton = await screen.findByRole("button", { name: "save_changes" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateStudentProfile).toHaveBeenCalledWith(
+        expect.objectContaining({ topics: ["AI", "Blockchain"] })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize student profile topics into arrays when loading and submitting the edit form
- ensure the update payload uses the normalized topics structure expected by the schema
- add a regression test covering profiles that return a string-based topics list

## Testing
- npm test -- studentProfileEdit.topics.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d64ffa00b88328b7e271f69de1b959