### PR TITLE
Include common namespace for student profile edit translations

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -898,7 +898,11 @@ export default withAuthProtection(StudentProfileEdit, ['student']);
 export async function getServerSideProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+      ...(await serverSideTranslations(
+        locale,
+        ['dashboard', 'common'],
+        nextI18NextConfig
+      )),
     },
   };
 }


### PR DESCRIPTION
## Summary
- ensure the student profile edit page preloads both dashboard and common translation namespaces to match layout components

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d658d93a3c83288fca5d9695f54780