### PR TITLE
Fix Sidebar SSR hydration for footer year

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -17,7 +17,7 @@ export default function Sidebar({ role = 'admin' }) {
   const { t } = useTranslation('dashboard');
   const [activeDropdown, setActiveDropdown] = useState(null);
   const [isHydrated, setIsHydrated] = useState(false);
-  const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
+  const [currentYear, setCurrentYear] = useState(null);
   const settings = useAppConfigStore((state) => state.settings);
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
 
@@ -148,7 +148,9 @@ export default function Sidebar({ role = 'admin' }) {
       </div>
 
       <div className="text-xs text-gray-400 dark:text-gray-500 text-center mt-8">
-        &copy; {currentYear} {settings?.appName || 'SkillBridge'}
+        &copy;{' '}
+        {currentYear ? `${currentYear} ` : ''}
+        {settings?.appName || 'SkillBridge'}
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- initialize the sidebar's current year state with a stable null value so SSR markup matches the client
- populate the year inside a client-side effect and render the footer without it until the value is set

## Testing
- npm run dev *(fails: GET /dashboard/student/profile/edit 500 due to existing duplicate default export error)*

------
https://chatgpt.com/codex/tasks/task_e_68d658ceb34083288ef0aaed35711154