### PR TITLE
Fix instructor pricing parsing for profile completion

### DIFF
--- a/backend/src/modules/users/instructor/instructor.service.js
+++ b/backend/src/modules/users/instructor/instructor.service.js
@@ -112,10 +112,23 @@ const updateInstructorProfile = async (
     instructorData.experience !== undefined &&
     instructorData.experience !== null &&
     Number(instructorData.experience) > 0;
+  const rawPricing = instructorData.pricing;
+  let parsedPricing = null;
+
+  if (typeof rawPricing === "number") {
+    parsedPricing = rawPricing;
+  } else if (typeof rawPricing === "string") {
+    const trimmed = rawPricing.trim();
+    if (trimmed) {
+      const match = trimmed.match(/-?[\d,.]+/);
+      if (match) {
+        parsedPricing = parseFloat(match[0].replace(/,/g, ""));
+      }
+    }
+  }
+
   const hasValidPricing =
-    instructorData.pricing !== undefined &&
-    instructorData.pricing !== null &&
-    Number(instructorData.pricing) > 0;
+    parsedPricing !== null && !Number.isNaN(parsedPricing) && parsedPricing > 0;
   const hasInstructorFields =
     Array.isArray(instructorData.expertise) &&
     instructorData.expertise.length > 0 &&
@@ -139,6 +152,10 @@ const updateInstructorProfile = async (
       .first();
     const data = {
       ...instructorData,
+      pricing:
+        parsedPricing !== null && !Number.isNaN(parsedPricing)
+          ? parsedPricing
+          : null,
       expertise: instructorData.expertise
         ? JSON.stringify(instructorData.expertise)
         : null,

--- a/backend/tests/instructorProfileService.test.js
+++ b/backend/tests/instructorProfileService.test.js
@@ -61,6 +61,21 @@ describe('instructor.service updateInstructorProfile', () => {
     expect(user.profile_complete).toBe(true);
   });
 
+  it('treats pricing strings with currency labels as valid', async () => {
+    const userId = uuidv4();
+    await mockDb('users').insert({ id: userId });
+
+    await service.updateInstructorProfile(
+      userId,
+      { full_name: 'Currency Doe', phone: '123', gender: 'male', date_of_birth: '1990-01-01' },
+      { experience: 5, expertise: ['Math'], bio: 'Teacher', pricing: '100 USD' },
+      [{ platform: 'facebook', url: 'facebook.com/currencydoe' }]
+    );
+
+    const user = await mockDb('users').where({ id: userId }).first();
+    expect(user.profile_complete).toBe(true);
+  });
+
   it('marks profile as incomplete when missing bio', async () => {
     const userId = uuidv4();
     await mockDb('users').insert({ id: userId });
@@ -130,5 +145,18 @@ describe('instructor.service updateInstructorProfile', () => {
 
     const user2 = await mockDb('users').where({ id: userId2 }).first();
     expect(user2.profile_complete).toBe(false);
+
+    const userId3 = uuidv4();
+    await mockDb('users').insert({ id: userId3 });
+
+    await service.updateInstructorProfile(
+      userId3,
+      { full_name: 'Blank Price', phone: '123', gender: 'male', date_of_birth: '1990-01-01' },
+      { experience: 5, expertise: ['Math'], bio: 'Teacher', pricing: '   ' },
+      [{ platform: 'facebook', url: 'facebook.com/blankprice' }]
+    );
+
+    const user3 = await mockDb('users').where({ id: userId3 }).first();
+    expect(user3.profile_complete).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- parse numeric pricing values before validation and persistence in the instructor profile service
- treat blank pricing strings as missing so incomplete profiles stay incomplete
- extend instructor profile service tests to cover currency strings and blank pricing

## Testing
- npm test -- instructorProfileService

------
https://chatgpt.com/codex/tasks/task_e_68d678dfbbc88328bb1737c2bb60ab54