### PR TITLE
Handle currency strings in instructor pricing validation

### DIFF
--- a/backend/src/modules/users/instructor/instructor.service.js
+++ b/backend/src/modules/users/instructor/instructor.service.js
@@ -75,6 +75,24 @@ const normalizeUrl = (url = "") => {
   return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
 };
 
+const parsePricingValue = (pricing) => {
+  if (pricing === undefined || pricing === null) return NaN;
+  if (typeof pricing === "number") return pricing;
+  if (typeof pricing === "string") {
+    const trimmed = pricing.trim();
+    if (!trimmed) return NaN;
+    const [firstToken] = trimmed.split(/\s+/);
+    const numeric = parseFloat(firstToken);
+    if (!Number.isNaN(numeric)) {
+      return numeric;
+    }
+    const fallback = parseFloat(trimmed);
+    return Number.isNaN(fallback) ? NaN : fallback;
+  }
+  const numeric = Number(pricing);
+  return Number.isNaN(numeric) ? NaN : numeric;
+};
+
 // 🔹 Update instructor user data, profile data, and social links in a transaction
 const updateInstructorProfile = async (
   userId,
@@ -115,7 +133,7 @@ const updateInstructorProfile = async (
   const hasValidPricing =
     instructorData.pricing !== undefined &&
     instructorData.pricing !== null &&
-    Number(instructorData.pricing) > 0;
+    parsePricingValue(instructorData.pricing) > 0;
   const hasInstructorFields =
     Array.isArray(instructorData.expertise) &&
     instructorData.expertise.length > 0 &&

--- a/backend/tests/instructorProfileService.test.js
+++ b/backend/tests/instructorProfileService.test.js
@@ -104,6 +104,21 @@ describe('instructor.service updateInstructorProfile', () => {
     expect(user2.profile_complete).toBe(false);
   });
 
+  it('accepts pricing strings containing amount and currency', async () => {
+    const userId = uuidv4();
+    await mockDb('users').insert({ id: userId });
+
+    await service.updateInstructorProfile(
+      userId,
+      { full_name: 'Currency Price', phone: '123', gender: 'male', date_of_birth: '1990-01-01' },
+      { experience: 5, expertise: ['Math'], bio: 'Teacher', pricing: '100 USD' },
+      [{ platform: 'facebook', url: 'facebook.com/currencyprice' }]
+    );
+
+    const user = await mockDb('users').where({ id: userId }).first();
+    expect(user.profile_complete).toBe(true);
+  });
+
   it('marks profile as incomplete when pricing is missing or zero', async () => {
     const userId1 = uuidv4();
     await mockDb('users').insert({ id: userId1 });


### PR DESCRIPTION
## Summary
- parse instructor pricing strings to extract the numeric amount before validating profile completeness
- add a unit test to confirm pricing values with currency text still result in a complete profile

## Testing
- npm test -- instructorProfileService

------
https://chatgpt.com/codex/tasks/task_e_68d678e4839c8328aaeade428dd249de