### PR TITLE
Fix verification code column length

### DIFF
--- a/backend/src/migrations/20250715120000_alter_verifications_code_length.js
+++ b/backend/src/migrations/20250715120000_alter_verifications_code_length.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.alterTable("verifications", (table) => {
+    table.string("code", 255).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable("verifications", (table) => {
+    table.string("code", 10).notNullable().alter();
+  });
+};


### PR DESCRIPTION
## Summary
- increase the verifications.code column length so hashed OTP values can be stored without errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d67cfa32148328bcc30187e0447db5