### PR TITLE
Fix OTP verification code storage

### DIFF
--- a/backend/src/migrations/20250721120000_alter_verifications_code_length.js
+++ b/backend/src/migrations/20250721120000_alter_verifications_code_length.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable("verifications", (table) => {
+    table.text("code").notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable("verifications", (table) => {
+    table.string("code", 10).notNullable().alter();
+  });
+};


### PR DESCRIPTION
## Summary
- allow longer verification codes by altering the column to text so bcrypt hashes fit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d67e0dddc48328b80caf9813d0d173