### PR TITLE
Add migration to alter verifications code column to text

### DIFF
--- a/backend/src/migrations/20250930130000_alter_verifications_code_to_text.js
+++ b/backend/src/migrations/20250930130000_alter_verifications_code_to_text.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable("verifications", (table) => {
+    table.text("code").notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable("verifications", (table) => {
+    table.string("code", 10).notNullable().alter();
+  });
+};


### PR DESCRIPTION
## Summary
- add a new Knex migration that alters the verifications.code column to use a text data type
- provide a reversible down migration that restores the previous varchar(10) definition

## Testing
- `npm run knex:migrate` *(fails: requires JWT_SECRET, REFRESH_TOKEN_SECRET, and SESSION_SECRET environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68d6870f5858832891396868f32c087a