### PR TITLE
Add migration to allow longer verification codes

### DIFF
--- a/backend/src/migrations/20250930121000_alter_verifications_code_to_text.js
+++ b/backend/src/migrations/20250930121000_alter_verifications_code_to_text.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('verifications', (table) => {
+    table.text('code').notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 255).notNullable().alter();
+  });
+};


### PR DESCRIPTION
## Summary
- add a knex migration that alters the verifications.code column to use the text type so bcrypt hashes fit

## Testing
- npm run knex:migrate *(fails: backend configuration requires JWT, refresh token, and session secrets in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6870715748328b92d5fbecd11dbfc