### PR TITLE
Ensure verification codes use text columns

### DIFF
--- a/backend/src/migrations/20250709192133_create_verifications_table.js
+++ b/backend/src/migrations/20250709192133_create_verifications_table.js
@@ -15,7 +15,7 @@ exports.up = function(knex) {
       .inTable('users')
       .onDelete('CASCADE');
     table.string('type').notNullable(); // 'email' or 'phone'
-    table.string('code', 10).notNullable();
+    table.text('code').notNullable();
     table.timestamp('expires_at').notNullable();
     table.boolean('verified').defaultTo(false);
     table.timestamp('created_at').defaultTo(knex.fn.now());

--- a/backend/src/migrations/20250930140000_update_verifications_code_to_text.js
+++ b/backend/src/migrations/20250930140000_update_verifications_code_to_text.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable("verifications", (table) => {
+    table.text("code").notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable("verifications", (table) => {
+    table.string("code", 10).notNullable().alter();
+  });
+};

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -18,6 +18,17 @@ CREATE TABLE IF NOT EXISTS cart_items (
   UNIQUE (user_id, item_id)
 );
 
+-- verifications table
+CREATE TABLE IF NOT EXISTS verifications (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type VARCHAR NOT NULL,
+  code TEXT NOT NULL,
+  expires_at TIMESTAMP NOT NULL,
+  verified BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 -- book_reviews table
 CREATE TABLE IF NOT EXISTS book_reviews (
   id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- change the initial verifications table migration to create the code column as text
- add a follow-up migration to alter existing databases to the new text column type
- refresh the schema documentation to reflect the text-based verification code

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d694156b488328968599756535be2c