### PR TITLE
Fix host header declaration for frontend healthcheck

### DIFF
--- a/frontend/scripts/healthcheck.js
+++ b/frontend/scripts/healthcheck.js
@@ -25,7 +25,8 @@ const defaultPorts = new Map([
 ]);
 
 const defaultPortForProtocol = defaultPorts.get(protocol);
-hostHeader = defaultPortForProtocol && port === defaultPortForProtocol ? host : `${host}:${port}`;
+const hostHeader =
+  defaultPortForProtocol && port === defaultPortForProtocol ? host : `${host}:${port}`;
 
 const allowedProtocols = new Set(['http', 'https']);
 if (!allowedProtocols.has(protocol)) {


### PR DESCRIPTION
## Summary
- declare the frontend healthcheck host header with an explicit constant to avoid implicit globals

## Testing
- docker-compose build frontend *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68d6994a9890832883cf3c153ae5a7b0