### PR TITLE
Declare host header constant in frontend healthcheck

### DIFF
--- a/frontend/scripts/healthcheck.js
+++ b/frontend/scripts/healthcheck.js
@@ -25,7 +25,7 @@ const defaultPorts = new Map([
 ]);
 
 const defaultPortForProtocol = defaultPorts.get(protocol);
-hostHeader = defaultPortForProtocol && port === defaultPortForProtocol ? host : `${host}:${port}`;
+const hostHeader = defaultPortForProtocol && port === defaultPortForProtocol ? host : `${host}:${port}`;
 
 const allowedProtocols = new Set(['http', 'https']);
 if (!allowedProtocols.has(protocol)) {


### PR DESCRIPTION
## Summary
- declare the host header computation in the frontend healthcheck script as a constant to avoid creating implicit globals

## Testing
- docker compose build frontend *(fails: docker not available in environment)*
- docker compose up -d *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69876e2088328a94d8493145aa2ef