### PR TITLE
Fix hostHeader declaration in frontend healthcheck script

### DIFF
--- a/frontend/scripts/healthcheck.js
+++ b/frontend/scripts/healthcheck.js
@@ -25,7 +25,7 @@ const defaultPorts = new Map([
 ]);
 
 const defaultPortForProtocol = defaultPorts.get(protocol);
-hostHeader = defaultPortForProtocol && port === defaultPortForProtocol ? host : `${host}:${port}`;
+const hostHeader = defaultPortForProtocol && port === defaultPortForProtocol ? host : `${host}:${port}`;
 
 const allowedProtocols = new Set(['http', 'https']);
 if (!allowedProtocols.has(protocol)) {


### PR DESCRIPTION
## Summary
- declare the `hostHeader` constant before it is used in the frontend healthcheck script to avoid implicit globals

## Testing
- HEALTHCHECK_HOST=127.0.0.1 PORT=3000 node frontend/scripts/healthcheck.js

------
https://chatgpt.com/codex/tasks/task_e_68d69a7aa708832891dc9d60bda52cc3