### PR TITLE
Fix duplicate default export in student profile edit

### DIFF
--- a/frontend/src/pages/dashboard/student/profile/edit.js
+++ b/frontend/src/pages/dashboard/student/profile/edit.js
@@ -96,7 +96,7 @@ const normalizeTopics = (value) => {
   return toTrimmedArray([value]);
 };
 
-export default function StudentProfileEdit() {
+function StudentProfileEdit() {
   const { t } = useTranslation('dashboard', { keyPrefix: 'studentProfilePage' });
   const router = useRouter();
   const { user, logout, hasHydrated, setUser, refreshUser } = useAuthStore();


### PR DESCRIPTION
## Summary
- convert the student profile edit page component to a named function so it can be wrapped without double default exports
- keep the authentication HOC as the sole default export to restore successful frontend builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d697a3c8a48328a260b00c6f6ad89e