### PR TITLE
Fix verification code migration reliability

### DIFF
--- a/backend/src/migrations/20250930130000_alter_verifications_code_to_text.js
+++ b/backend/src/migrations/20250930130000_alter_verifications_code_to_text.js
@@ -2,8 +2,8 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = async function up(knex) {
-  await knex.schema.alterTable("verifications", (table) => {
+exports.up = function up(knex) {
+  return knex.schema.alterTable("verifications", (table) => {
     table.text("code").notNullable().alter();
   });
 };
@@ -12,8 +12,8 @@ exports.up = async function up(knex) {
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.down = async function down(knex) {
-  await knex.schema.alterTable("verifications", (table) => {
+exports.down = function down(knex) {
+  return knex.schema.alterTable("verifications", (table) => {
     table.string("code", 10).notNullable().alter();
   });
 };

--- a/backend/src/migrations/20250930140000_update_verifications_code_to_text.js
+++ b/backend/src/migrations/20250930140000_update_verifications_code_to_text.js
@@ -2,8 +2,8 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = async function up(knex) {
-  await knex.schema.alterTable("verifications", (table) => {
+exports.up = function up(knex) {
+  return knex.schema.alterTable("verifications", (table) => {
     table.text("code").notNullable().alter();
   });
 };
@@ -12,8 +12,8 @@ exports.up = async function up(knex) {
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.down = async function down(knex) {
-  await knex.schema.alterTable("verifications", (table) => {
+exports.down = function down(knex) {
+  return knex.schema.alterTable("verifications", (table) => {
     table.string("code", 255).notNullable().alter();
   });
 };

--- a/backend/src/migrations/20250930150000_verify_verifications_code_text.js
+++ b/backend/src/migrations/20250930150000_verify_verifications_code_text.js
@@ -1,0 +1,39 @@
+/**
+ * Ensure verifications.code can store hashed OTP values by widening it to TEXT
+ * when older deployments still have it capped at VARCHAR(10).
+ *
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo.code;
+
+  if (!codeInfo || codeInfo.type === 'text') {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.text('code').notNullable().alter();
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 10).notNullable().alter();
+  });
+};


### PR DESCRIPTION
## Summary
- ensure the verifications code migration files return their schema changes so knex treats them as completed
- add a guard migration that widens verifications.code to TEXT when older databases still use VARCHAR(10)

## Testing
- npm --prefix frontend run build
- node frontend/scripts/healthcheck.js

------
https://chatgpt.com/codex/tasks/task_e_68d68df82994832895ac30b3a753c945