### PR TITLE
Add missing verifications code migrations

### DIFF
--- a/backend/src/migrations/20250926123707_alter_verifications_code_to_text.js
+++ b/backend/src/migrations/20250926123707_alter_verifications_code_to_text.js
@@ -1,0 +1,38 @@
+/**
+ * Expand the verifications.code column so hashed OTPs fit without truncation.
+ *
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo.code;
+
+  if (codeInfo && codeInfo.maxLength && Number(codeInfo.maxLength) >= 255) {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 255).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 10).notNullable().alter();
+  });
+};

--- a/backend/src/migrations/20250926124314_alter_verifications_code_to_text.js
+++ b/backend/src/migrations/20250926124314_alter_verifications_code_to_text.js
@@ -1,0 +1,38 @@
+/**
+ * Migrate verifications.code to TEXT to permanently remove length constraints.
+ *
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo.code;
+
+  if (codeInfo && codeInfo.type === 'text') {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.text('code').notNullable().alter();
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 255).notNullable().alter();
+  });
+};


### PR DESCRIPTION
## Summary
- restore the two verifications.code migrations that production expects
- make the migrations idempotent and include safe down migrations for rollback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a6c984fc83288030ee043718dfe0