### PR TITLE
Add build guard for verification migrations

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,8 +9,22 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 # Copy the backend source along with the installer assets so the
 # production image can serve /install even when the container is built
-# independently of the repository root.
+# independently of the repository root. Copy the migrations directory
+# explicitly to guarantee that new migration files are always included in
+# the build context.
 COPY backend/ ./
+COPY backend/src/migrations/ ./src/migrations/
+# Fail the build immediately if the critical verification migrations are
+# missing from the build context. This prevents publishing an image that
+# cannot run `knex migrate:latest` because Knex validates the migrations list
+# against the database history.
+RUN set -eux; \
+    ls -1 src/migrations > /dev/null; \
+    for migration in \
+      src/migrations/20250926123707_alter_verifications_code_to_text.js \
+      src/migrations/20250926124314_alter_verifications_code_to_text.js; do \
+        test -f "${migration}"; \
+    done
 COPY install ./install
 COPY install.sh ./install.sh
 COPY scripts/check_prereqs.sh ./scripts/check_prereqs.sh


### PR DESCRIPTION
## Summary
- ensure the backend Docker build copies the migrations directory with trailing slashes
- add a build-time check so the image build fails if the verification migrations are missing from the context

## Testing
- docker build -f backend/Dockerfile -t skillbridge-backend:latest . *(fails: docker is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ac402a108328a80be289fcce4a94