### PR TITLE
Restore verification migrations at container startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,8 +9,22 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 # Copy the backend source along with the installer assets so the
 # production image can serve /install even when the container is built
-# independently of the repository root.
+# independently of the repository root. Copy the migrations directory
+# explicitly to guarantee that new migration files are always included in
+# the build context.
 COPY backend/ ./
+COPY backend/src/migrations/ ./src/migrations/
+# Fail the build immediately if the critical verification migrations are
+# missing from the build context. This prevents publishing an image that
+# cannot run `knex migrate:latest` because Knex validates the migrations list
+# against the database history.
+RUN set -eux; \
+    ls -1 src/migrations > /dev/null; \
+    for migration in \
+      src/migrations/20250926123707_alter_verifications_code_to_text.js \
+      src/migrations/20250926124314_alter_verifications_code_to_text.js; do \
+        test -f "${migration}"; \
+    done
 COPY install ./install
 COPY install.sh ./install.sh
 COPY scripts/check_prereqs.sh ./scripts/check_prereqs.sh

--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -118,6 +118,164 @@ prepare_upload_dirs() {
   chown -R node:node /app/uploads
 }
 
+restore_verification_migration_to_string() {
+  cat <<'EOF'
+/**
+ * Expand the verifications.code column so hashed OTPs fit without truncation.
+ *
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo && columnInfo.code;
+
+  if (!codeInfo) {
+    return;
+  }
+
+  if (codeInfo.type === 'text') {
+    return;
+  }
+
+  if (codeInfo.maxLength && Number(codeInfo.maxLength) >= 255) {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 255).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo && columnInfo.code;
+
+  if (!codeInfo || codeInfo.type === 'text') {
+    return;
+  }
+
+  if (codeInfo.maxLength && Number(codeInfo.maxLength) <= 10) {
+    return;
+  }
+
+  const hasLongCodes = await knex('verifications')
+    .whereRaw('char_length(code) > 10')
+    .first();
+
+  if (hasLongCodes) {
+    throw new Error(
+      'Cannot shrink verifications.code to length 10 because data longer than 10 characters exists.'
+    );
+  }
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 10).notNullable().alter();
+  });
+};
+EOF
+}
+
+restore_verification_migration_to_text() {
+  cat <<'EOF'
+/**
+ * Migrate verifications.code to TEXT to permanently remove length constraints.
+ *
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo && columnInfo.code;
+
+  if (!codeInfo) {
+    return;
+  }
+
+  if (codeInfo.type === 'text') {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.text('code').notNullable().alter();
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo && columnInfo.code;
+
+  if (!codeInfo || codeInfo.type !== 'text') {
+    return;
+  }
+
+  const hasLongCodes = await knex('verifications')
+    .whereRaw('char_length(code) > 255')
+    .first();
+
+  if (hasLongCodes) {
+    throw new Error(
+      'Cannot shrink verifications.code to length 255 because data longer than 255 characters exists.'
+    );
+  }
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 255).notNullable().alter();
+  });
+};
+EOF
+}
+
+restore_required_migrations() {
+  local_base="src/migrations"
+  mkdir -p "$local_base"
+
+  for migration in \
+    20250926123707_alter_verifications_code_to_text.js \
+    20250926124314_alter_verifications_code_to_text.js; do
+    if [ -f "$local_base/$migration" ]; then
+      continue
+    fi
+
+    echo "WARNING: Missing $local_base/$migration inside the container. Restoring from embedded copy." >&2
+
+    case "$migration" in
+      20250926123707_alter_verifications_code_to_text.js)
+        restore_verification_migration_to_string > "$local_base/$migration"
+        ;;
+      20250926124314_alter_verifications_code_to_text.js)
+        restore_verification_migration_to_text > "$local_base/$migration"
+        ;;
+    esac
+  done
+}
+
 main() {
   ensure_upload_permissions
 
@@ -133,6 +291,7 @@ main() {
 
   if [ "$1" = "node" ] && [ "${2:-}" = "src/server.js" ]; then
     if should_run_migrations; then
+      restore_required_migrations
       run_as_node npx knex migrate:latest
     else
       echo "Skipping automatic database migrations because RUN_DB_MIGRATIONS=${RUN_DB_MIGRATIONS}."


### PR DESCRIPTION
## Summary
- add runtime safeguards in the backend Docker entrypoint to recreate the two critical verification migrations if they are missing inside the container
- invoke the safeguard before running automatic migrations so `npx knex migrate:latest` always has the full migration list available

## Testing
- bash -n backend/scripts/docker-entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6ac402a108328a80be289fcce4a94