### PR TITLE
Ensure backend container always has verification migrations

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,8 +9,22 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 # Copy the backend source along with the installer assets so the
 # production image can serve /install even when the container is built
-# independently of the repository root.
+# independently of the repository root. Copy the migrations directory
+# explicitly to guarantee that new migration files are always included in
+# the build context.
 COPY backend/ ./
+COPY backend/src/migrations/ ./src/migrations/
+# Fail the build immediately if the critical verification migrations are
+# missing from the build context. This prevents publishing an image that
+# cannot run `knex migrate:latest` because Knex validates the migrations list
+# against the database history.
+RUN set -eux; \
+    ls -1 src/migrations > /dev/null; \
+    for migration in \
+      src/migrations/20250926123707_alter_verifications_code_to_text.js \
+      src/migrations/20250926124314_alter_verifications_code_to_text.js; do \
+        test -f "${migration}"; \
+    done
 COPY install ./install
 COPY install.sh ./install.sh
 COPY scripts/check_prereqs.sh ./scripts/check_prereqs.sh

--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -118,6 +118,28 @@ prepare_upload_dirs() {
   chown -R node:node /app/uploads
 }
 
+ensure_required_migrations() {
+  missing_files=""
+  for migration in \
+    /app/src/migrations/20250926123707_alter_verifications_code_to_text.js \
+    /app/src/migrations/20250926124314_alter_verifications_code_to_text.js; do
+    if [ ! -f "$migration" ]; then
+      missing_files="${missing_files}\n  $(basename "$migration")"
+    fi
+  done
+
+  if [ -n "$missing_files" ]; then
+    cat >&2 <<EOF
+ERROR: The backend container is missing the following critical migration files:${missing_files}
+
+This usually means the backend image was built without copying backend/src/migrations.
+Rebuild the backend image (for example: 'docker compose build backend' or
+'docker-compose build backend') and then redeploy with 'docker compose up -d'.
+EOF
+    exit 1
+  fi
+}
+
 main() {
   ensure_upload_permissions
 
@@ -133,6 +155,7 @@ main() {
 
   if [ "$1" = "node" ] && [ "${2:-}" = "src/server.js" ]; then
     if should_run_migrations; then
+      ensure_required_migrations
       run_as_node npx knex migrate:latest
     else
       echo "Skipping automatic database migrations because RUN_DB_MIGRATIONS=${RUN_DB_MIGRATIONS}."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       redis:
         condition: service_started
     volumes:
+      - ./backend/src/migrations:/app/src/migrations:ro
       - ./backend/uploads:/app/uploads
     networks:
       - app-network


### PR DESCRIPTION
## Summary
- mount the backend migrations directory into the container at runtime so cached images still expose the verification migrations
- add an entrypoint guard that aborts startup with guidance if the critical verification migrations are missing inside the container

## Testing
- not run (docker is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6ac402a108328a80be289fcce4a94