### PR TITLE
Remove duplicate backend migrations volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,6 @@ services:
     volumes:
       - ./backend/src/migrations:/app/src/migrations:ro
       - ./backend/uploads:/app/uploads
-      - ./backend/src/migrations:/app/src/migrations:ro
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- remove the duplicate backend migrations bind mount from docker-compose.yml so the volume is declared only once

## Testing
- docker compose config *(fails: `docker` command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b9c8ab8883288ded04e9727b6ef4