### PR TITLE
Remove duplicate backend migration volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,6 @@ services:
     volumes:
       - ./backend/src/migrations:/app/src/migrations:ro
       - ./backend/uploads:/app/uploads
-      - ./backend/src/migrations:/app/src/migrations:ro
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- remove the duplicate readonly migrations volume mount from the backend service in docker-compose.yml

## Testing
- docker compose config *(fails: docker not installed in container)*
- docker-compose config *(fails: docker-compose not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b9bfa2e88328ab82d5d794da981c