### PR TITLE
Fix duplicate backend migrations volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,6 @@ services:
       redis:
         condition: service_started
     volumes:
-      - ./backend/src/migrations:/app/src/migrations:ro
       - ./backend/uploads:/app/uploads
       - ./backend/src/migrations:/app/src/migrations:ro
     networks:


### PR DESCRIPTION
## Summary
- remove the duplicate backend migrations volume so it is only mounted once

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b9b9e0e08328a20c74b77cb2b72b