### PR TITLE
Document backend image rebuild requirement for new migrations

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -155,6 +155,20 @@ npm --prefix backend run migrate
 Running migrations separately keeps `startServer()` lightweight and ensures the
 database schema matches the application's expectations.
 
+> **Important:** Docker Compose no longer bind-mounts `backend/src/migrations`.
+> When a release adds new migration files (for example the critical verification
+> migrations `20250926123707` and `20250926124314`), rebuild the backend image so
+> the container sees the updated migration directory before running `npm --prefix
+> backend run migrate`:
+>
+> ```bash
+> docker compose build backend && docker compose up -d backend
+> ```
+>
+> Otherwise the running container will still contain the previous migration set
+> and Knex will report **"The migration directory is corrupt..."** because it
+> cannot find the new files.
+
 ## Preserve uploaded media
 
 The admin panel lets you upload a logo and favicon under


### PR DESCRIPTION
## Summary
- warn operators that new backend migration files require rebuilding the backend image because the directory is no longer bind-mounted
- include the rebuild command referencing the verification migrations and the Knex "migration directory is corrupt" warning for context

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68d6bb4f67808328a5771b221cbedff2