### PR TITLE
Document docker-compose v1 workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,16 @@ npm --prefix frontend install
    ```
 
    If the legacy `docker-compose` v1 CLI exits with `KeyError: 'ContainerConfig'`,
-   upgrade to Docker Compose V2 and use the `docker compose` command. If
-   upgrading immediately is not possible, set `DOCKER_BUILDKIT=0` and
+   upgrade to Docker Compose V2 and use the `docker compose` command. The
+   repository also includes [`scripts/run-compose.sh`](scripts/run-compose.sh),
+   which automatically prefers the V2 plugin and falls back to the standalone
+   binary so you can run:
+
+   ```bash
+   ./scripts/run-compose.sh up --build
+   ```
+
+   If upgrading immediately is not possible, set `DOCKER_BUILDKIT=0` and
    `COMPOSE_DOCKER_CLI_BUILD=0` in your `.env` file (both are included in
    `.env.example`) to disable BuildKit so legacy docker-compose releases
    can run the stack.

--- a/scripts/run-compose.sh
+++ b/scripts/run-compose.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  exec docker compose "$@"
+elif command -v docker-compose >/dev/null 2>&1; then
+  exec docker-compose "$@"
+else
+  echo "Error: Docker Compose is not installed." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- document the docker-compose v1 `ContainerConfig` failure and point readers to the new compose wrapper script
- add a helper script that prefers the Compose V2 plugin while keeping compatibility with the legacy binary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6de5876f08328b50f8d015ad8b689