### PR TITLE
Restore missing verification migrations

### DIFF
--- a/backend/src/migrations/20250926123707_alter_verifications_code_to_text.js
+++ b/backend/src/migrations/20250926123707_alter_verifications_code_to_text.js
@@ -1,0 +1,66 @@
+/**
+ * Expand the verifications.code column so hashed OTPs fit without truncation.
+ *
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo && columnInfo.code;
+
+  if (!codeInfo) {
+    return;
+  }
+
+  if (codeInfo.type === 'text') {
+    return;
+  }
+
+  if (codeInfo.maxLength && Number(codeInfo.maxLength) >= 255) {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 255).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo && columnInfo.code;
+
+  if (!codeInfo || codeInfo.type === 'text') {
+    return;
+  }
+
+  if (codeInfo.maxLength && Number(codeInfo.maxLength) <= 10) {
+    return;
+  }
+
+  const hasLongCodes = await knex('verifications')
+    .whereRaw('char_length(code) > 10')
+    .first();
+
+  if (hasLongCodes) {
+    throw new Error(
+      'Cannot shrink verifications.code to length 10 because data longer than 10 characters exists.'
+    );
+  }
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 10).notNullable().alter();
+  });
+};

--- a/backend/src/migrations/20250926124314_alter_verifications_code_to_text.js
+++ b/backend/src/migrations/20250926124314_alter_verifications_code_to_text.js
@@ -1,0 +1,58 @@
+/**
+ * Migrate verifications.code to TEXT to permanently remove length constraints.
+ *
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo && columnInfo.code;
+
+  if (!codeInfo) {
+    return;
+  }
+
+  if (codeInfo.type === 'text') {
+    return;
+  }
+
+  await knex.schema.alterTable('verifications', (table) => {
+    table.text('code').notNullable().alter();
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  const hasTable = await knex.schema.hasTable('verifications');
+  if (!hasTable) {
+    return;
+  }
+
+  const columnInfo = await knex('verifications').columnInfo();
+  const codeInfo = columnInfo && columnInfo.code;
+
+  if (!codeInfo || codeInfo.type !== 'text') {
+    return;
+  }
+
+  const hasLongCodes = await knex('verifications')
+    .whereRaw('char_length(code) > 255')
+    .first();
+
+  if (hasLongCodes) {
+    throw new Error(
+      'Cannot shrink verifications.code to length 255 because data longer than 255 characters exists.'
+    );
+  }
+  await knex.schema.alterTable('verifications', (table) => {
+    table.string('code', 255).notNullable().alter();
+  });
+};


### PR DESCRIPTION
## Summary
- restore the archived migrations that expand and convert `verifications.code`
- ensure knex can locate the historical migration files that already ran in production

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e1e6a6308328a6bd8dde356b1714