### PR TITLE
Add FAQ storage and service compatibility improvements

### DIFF
--- a/backend/src/migrations/20251010120000_create_faqs_table.js
+++ b/backend/src/migrations/20251010120000_create_faqs_table.js
@@ -1,0 +1,12 @@
+exports.up = function (knex) {
+  return knex.schema.createTable('faqs', (table) => {
+    table.increments('id').primary();
+    table.string('question', 500).notNullable();
+    table.text('answer').notNullable();
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('faqs');
+};

--- a/backend/src/modules/faqs/faqs.service.js
+++ b/backend/src/modules/faqs/faqs.service.js
@@ -1,6 +1,15 @@
 const db = require("../../config/database");
 
+const clientName = db?.client?.config?.client;
+const isSqlite = clientName === "sqlite3";
+
 exports.create = async (data) => {
+  if (isSqlite) {
+    const [id] = await db("faqs").insert(data);
+    const row = await db("faqs").where({ id }).first();
+    return row;
+  }
+
   const [row] = await db("faqs").insert(data).returning("*");
   return row;
 };
@@ -14,6 +23,17 @@ exports.getById = (id) => {
 };
 
 exports.update = async (id, data) => {
+  if (isSqlite) {
+    const updated = await db("faqs")
+      .where({ id })
+      .update({ ...data, updated_at: db.fn.now() });
+
+    if (!updated) return null;
+
+    const row = await db("faqs").where({ id }).first();
+    return row;
+  }
+
   const [row] = await db("faqs")
     .where({ id })
     .update({ ...data, updated_at: db.fn.now() })


### PR DESCRIPTION
## Summary
- add a migration that creates the faqs table with question, answer, and timestamp columns
- update the FAQ service to gracefully handle SQLite connections when inserting or updating records

## Testing
- npm --prefix backend test *(fails: suite requires TEST_DATABASE_URL and other pre-existing backend fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f825f0e88328b0f9baa56beae4a7