### PR TITLE
Add scroll-to-top button to website footer

### DIFF
--- a/frontend/src/components/website/sections/Footer.js
+++ b/frontend/src/components/website/sections/Footer.js
@@ -213,6 +213,19 @@ const Footer = () => {
 
      
 
+      {/* Scroll to Top Button */}
+      {showScroll && (
+        <motion.button
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          onClick={scrollToTop}
+          className="fixed bottom-24 right-8 bg-yellow-500 text-gray-900 p-4 rounded-full shadow-lg hover:bg-yellow-400 transition focus:outline-none focus:ring-2 focus:ring-yellow-300 z-50"
+          aria-label="Scroll to top"
+        >
+          <FaArrowUp size={20} />
+        </motion.button>
+      )}
+
       {/* WhatsApp Button (For Direct Contact) */}
       <motion.a
         whileHover={{ scale: 1.2 }}


### PR DESCRIPTION
## Summary
- add a floating scroll-to-top control to the footer when the page is scrolled
- style the button to match existing floating action elements and trigger smooth scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7014de90c83288639112722268887