### PR TITLE
Enhance website scroll section tracking

### DIFF
--- a/frontend/src/pages/website/index.js
+++ b/frontend/src/pages/website/index.js
@@ -40,19 +40,64 @@ export default function Home() {
   }
   const [currentSection, setCurrentSection] = useState(0);
   const [scrollProgress, setScrollProgress] = useState(0);
+  const getSectionElements = () =>
+    sectionRefs.current
+      .map((ref) =>
+        ref && typeof ref === "object" && Object.prototype.hasOwnProperty.call(ref, "current")
+          ? ref.current
+          : ref
+      )
+      .filter(Boolean);
   // Intentionally no console logs to avoid leaking user data
 
   // Track scrolling position
   useEffect(() => {
     let ticking = false;
+
+    const updateScrollState = () => {
+      const scrollY = typeof window.scrollY === "number" ? window.scrollY : 0;
+      const docElement = document.documentElement;
+      const rawDocHeight = docElement.scrollHeight - window.innerHeight;
+      const docHeight = rawDocHeight > 0 ? rawDocHeight : 0;
+      const progress = docHeight > 0 ? (scrollY / docHeight) * 100 : 0;
+      setScrollProgress(Number.isFinite(progress) ? progress : 0);
+
+      const sectionElements = getSectionElements();
+      if (!sectionElements.length) {
+        setCurrentSection(0);
+        return;
+      }
+
+      if (typeof window.IntersectionObserver === "undefined") {
+        const viewportMid = window.innerHeight / 2;
+        let activeIndex = 0;
+        let smallestDistance = Infinity;
+
+        sectionElements.forEach((section, index) => {
+          if (!section || typeof section.getBoundingClientRect !== "function") {
+            return;
+          }
+
+          const rect = section.getBoundingClientRect();
+          const top = rect?.top ?? 0;
+          const bottom = rect?.bottom ?? top;
+          const center = top + (bottom - top) / 2;
+          const distance = Math.abs(center - viewportMid);
+
+          if (distance < smallestDistance) {
+            smallestDistance = distance;
+            activeIndex = index;
+          }
+        });
+
+        setCurrentSection(activeIndex);
+      }
+    };
+
     const handleScroll = () => {
       if (!ticking) {
         window.requestAnimationFrame(() => {
-          const scrollY = window.scrollY;
-          const docHeight =
-            document.documentElement.scrollHeight - window.innerHeight;
-          const progress = (scrollY / docHeight) * 100;
-          setScrollProgress(progress);
+          updateScrollState();
           ticking = false;
         });
         ticking = true;
@@ -60,30 +105,97 @@ export default function Home() {
     };
 
     window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+    updateScrollState();
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [sections.length]);
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.IntersectionObserver === "undefined"
+    ) {
+      return undefined;
+    }
+
+    const sectionElements = getSectionElements();
+    if (!sectionElements.length) {
+      return undefined;
+    }
+
+    const observer = new window.IntersectionObserver(
+      (entries) => {
+        const visibleEntries = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+
+        if (visibleEntries.length > 0) {
+          const targetIndex = sectionElements.findIndex(
+            (element) => element === visibleEntries[0].target
+          );
+          if (targetIndex !== -1) {
+            setCurrentSection(targetIndex);
+            return;
+          }
+        }
+
+        const viewportMid = window.innerHeight / 2;
+        let closestIndex = 0;
+        let smallestDistance = Infinity;
+
+        sectionElements.forEach((section, index) => {
+          if (!section || typeof section.getBoundingClientRect !== "function") {
+            return;
+          }
+
+          const rect = section.getBoundingClientRect();
+          const top = rect?.top ?? 0;
+          const bottom = rect?.bottom ?? top;
+          const center = top + (bottom - top) / 2;
+          const distance = Math.abs(center - viewportMid);
+
+          if (distance < smallestDistance) {
+            smallestDistance = distance;
+            closestIndex = index;
+          }
+        });
+
+        setCurrentSection(closestIndex);
+      },
+      { threshold: [0.25, 0.5, 0.75, 1] }
+    );
+
+    sectionElements.forEach((section) => observer.observe(section));
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [sections.length]);
 
   // Smooth scrolling to sections
   const scrollToSection = (index) => {
-    const ref = sectionRefs.current[index];
-    if (ref && ref.current) {
-      ref.current.scrollIntoView({ behavior: "smooth" });
+    const refOrElement = sectionRefs.current[index];
+    const element =
+      refOrElement &&
+      typeof refOrElement === "object" &&
+      Object.prototype.hasOwnProperty.call(refOrElement, "current")
+        ? refOrElement.current
+        : refOrElement;
+
+    if (element && typeof element.scrollIntoView === "function") {
+      element.scrollIntoView({ behavior: "smooth" });
       setCurrentSection(index);
     }
   };
 
   return (
-    <div className="overflow-x-hidden">
+    <div className="overflow-x-hidden" data-current-section={currentSection}>
       <Navbar />
       <IncompleteAlertModal />
 
       {sections.map(({ component: Component, props }, index) => (
-        <section
-          key={index}
-          ref={(el) => {
-            sectionRefs.current[index] = el;
-          }}
-        >
+        <section key={index} ref={sectionRefs.current[index]}>
           <Component {...props} />
         </section>
       ))}
@@ -99,14 +211,22 @@ export default function Home() {
       {/* Smooth Scroll Buttons */}
       <div className="fixed bottom-8 right-8 z-50 gap-4 hidden md:flex md:flex-col">
         {currentSection > 0 && (
-          <motion.button whileHover={{ scale: 1.2 }} onClick={() => scrollToSection(currentSection - 1)}
-            className="bg-gray-800 text-white p-3 rounded-full shadow-lg hover:bg-gray-700 transition">
+          <motion.button
+            aria-label="Scroll to previous section"
+            whileHover={{ scale: 1.2 }}
+            onClick={() => scrollToSection(currentSection - 1)}
+            className="bg-gray-800 text-white p-3 rounded-full shadow-lg hover:bg-gray-700 transition"
+          >
             <FaArrowUp size={20} />
           </motion.button>
         )}
         {currentSection < sections.length - 1 && (
-          <motion.button whileHover={{ scale: 1.2 }} onClick={() => scrollToSection(currentSection + 1)}
-            className="bg-yellow-500 text-gray-900 p-3 rounded-full shadow-lg hover:bg-yellow-600 transition">
+          <motion.button
+            aria-label="Scroll to next section"
+            whileHover={{ scale: 1.2 }}
+            onClick={() => scrollToSection(currentSection + 1)}
+            className="bg-yellow-500 text-gray-900 p-3 rounded-full shadow-lg hover:bg-yellow-600 transition"
+          >
             <FaArrowDown size={20} />
           </motion.button>
         )}

--- a/frontend/src/tests/__tests__/WebsiteHomeScroll.test.js
+++ b/frontend/src/tests/__tests__/WebsiteHomeScroll.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
 import Home from '../../pages/website/index';
 
 function createMock(name) {
@@ -30,10 +30,10 @@ jest.mock('framer-motion', () => {
   const React = require('react');
   return {
     motion: {
-      div: React.forwardRef(({ children, ...props }, ref) => (
+      div: React.forwardRef(({ children, whileHover, ...props }, ref) => (
         <div ref={ref} {...props}>{children}</div>
       )),
-      button: React.forwardRef(({ children, ...props }, ref) => (
+      button: React.forwardRef(({ children, whileHover, ...props }, ref) => (
         <button ref={ref} {...props}>{children}</button>
       )),
     },
@@ -45,8 +45,51 @@ jest.mock('next-i18next', () => ({
 }));
 
 describe('Home page section scrolling', () => {
-  test('clicking the down arrow scrolls to the next section', () => {
-    const { container } = render(<Home />);
+  const originalIntersectionObserver = window.IntersectionObserver;
+  let observers = [];
+
+  beforeEach(() => {
+    observers = [];
+    Object.defineProperty(window, 'IntersectionObserver', {
+      configurable: true,
+      writable: true,
+      value: jest.fn((callback, options) => {
+        const observer = {
+          callback,
+          options,
+          elements: [],
+          observe(element) {
+            this.elements.push(element);
+          },
+          unobserve: jest.fn(),
+          disconnect: jest.fn(),
+        };
+        observers.push(observer);
+        return observer;
+      }),
+    });
+  });
+
+  afterEach(() => {
+    observers = [];
+    if (originalIntersectionObserver) {
+      Object.defineProperty(window, 'IntersectionObserver', {
+        configurable: true,
+        writable: true,
+        value: originalIntersectionObserver,
+      });
+    } else {
+      delete window.IntersectionObserver;
+    }
+  });
+
+  test('clicking the down arrow scrolls to the next section', async () => {
+    let renderResult;
+    await act(async () => {
+      renderResult = render(<Home />);
+    });
+
+    const { container } = renderResult;
     const sections = container.querySelectorAll('section');
     expect(sections.length).toBeGreaterThan(1);
 
@@ -58,5 +101,117 @@ describe('Home page section scrolling', () => {
     fireEvent.click(button);
 
     expect(scrollSpy).toHaveBeenCalled();
+  });
+
+  test('scrolling updates the available navigation buttons', async () => {
+    let renderResult;
+    await act(async () => {
+      renderResult = render(<Home />);
+    });
+
+    const { container } = renderResult;
+    const sections = container.querySelectorAll('section');
+    expect(sections.length).toBeGreaterThan(2);
+
+    const originalInnerHeight = window.innerHeight;
+    const innerHeightDescriptor = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      get: () => 1000,
+    });
+
+    const originalScrollHeight = document.documentElement.scrollHeight;
+    const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(document.documentElement, 'scrollHeight');
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      configurable: true,
+      get: () => 6000,
+    });
+
+    const originalScrollY = window.scrollY;
+    const scrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY');
+    let scrollYValue = 0;
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      get: () => scrollYValue,
+      set: (value) => {
+        scrollYValue = value;
+      },
+    });
+
+    const originalRAF = window.requestAnimationFrame;
+    window.requestAnimationFrame = (cb) => cb();
+
+    const setActiveSection = async (activeIndex) => {
+      await waitFor(() => {
+        expect(observers[0]?.elements.length).toBe(sections.length);
+      });
+
+      const observer = observers[0];
+      scrollYValue = activeIndex * 1000;
+      const entries = observer.elements.map((element, index) => {
+        const baseTop = (index - activeIndex) * 1000;
+        const top = baseTop;
+        const bottom = top + 1000;
+
+        if (typeof element.getBoundingClientRect !== 'function') {
+          element.getBoundingClientRect = () => ({ top, bottom });
+        }
+
+        return {
+          target: element,
+          isIntersecting: index === activeIndex,
+          intersectionRatio: index === activeIndex ? 1 : 0,
+          boundingClientRect: { top, bottom },
+        };
+      });
+
+      await act(async () => {
+        observer.callback(entries, observer);
+      });
+    };
+
+    const root = container.querySelector('[data-current-section]');
+    expect(root).not.toBeNull();
+
+    await setActiveSection(0);
+    expect(container.querySelectorAll('[aria-label="Scroll to previous section"]').length).toBe(0);
+    expect(container.querySelectorAll('[aria-label="Scroll to next section"]').length).toBe(1);
+    expect(root?.getAttribute('data-current-section')).toBe('0');
+
+    await setActiveSection(1);
+    expect(root?.getAttribute('data-current-section')).toBe('1');
+    expect(container.querySelectorAll('[aria-label="Scroll to previous section"]').length).toBe(1);
+    expect(container.querySelectorAll('[aria-label="Scroll to next section"]').length).toBe(1);
+
+    await setActiveSection(sections.length - 1);
+    expect(container.querySelectorAll('[aria-label="Scroll to previous section"]').length).toBe(1);
+    expect(container.querySelectorAll('[aria-label="Scroll to next section"]').length).toBe(0);
+    expect(root?.getAttribute('data-current-section')).toBe(String(sections.length - 1));
+    window.requestAnimationFrame = originalRAF;
+    if (scrollYDescriptor) {
+      Object.defineProperty(window, 'scrollY', scrollYDescriptor);
+    } else {
+      Object.defineProperty(window, 'scrollY', {
+        configurable: true,
+        get: () => originalScrollY,
+        set: () => {},
+      });
+    }
+    if (scrollHeightDescriptor) {
+      Object.defineProperty(document.documentElement, 'scrollHeight', scrollHeightDescriptor);
+    } else {
+      Object.defineProperty(document.documentElement, 'scrollHeight', {
+        configurable: true,
+        get: () => originalScrollHeight,
+      });
+    }
+    if (innerHeightDescriptor) {
+      Object.defineProperty(window, 'innerHeight', innerHeightDescriptor);
+    } else {
+      Object.defineProperty(window, 'innerHeight', {
+        configurable: true,
+        get: () => originalInnerHeight,
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- compute scroll progress and active section with a dedicated helper and add an IntersectionObserver to update the active section when sections enter the viewport
- add accessibility labels to the navigation buttons and expose the current section for testing purposes
- expand the website home scroll test to simulate IntersectionObserver updates and verify button visibility across sections

## Testing
- npm test -- WebsiteHomeScroll.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d700fbd0448328b35a3a4fc8183aa5