### PR TITLE
Ensure sitemap manager syncs with loaded config

### DIFF
--- a/frontend/src/components/admin/settings/seo/SitemapManager.js
+++ b/frontend/src/components/admin/settings/seo/SitemapManager.js
@@ -1,15 +1,25 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { updateSEOConfig } from "@/services/admin/seoConfigService";
+
+const DEFAULT_PAGE = { path: "/", include: true, priority: 1.0, freq: "daily" };
 
 export default function SitemapManager({ config, update, availablePages }) {
   const { t } = useTranslation("dashboard", { keyPrefix: "seoPage.sitemap" });
   const [pages, setPages] = useState(
     config.sitemap.length
-      ? config.sitemap
-      : [{ path: "/", include: true, priority: 1.0, freq: "daily" }]
+      ? config.sitemap.map((page) => ({ ...page }))
+      : [DEFAULT_PAGE]
   );
+
+  useEffect(() => {
+    if (Array.isArray(config.sitemap) && config.sitemap.length > 0) {
+      setPages(config.sitemap.map((page) => ({ ...page })));
+    } else if (Array.isArray(config.sitemap)) {
+      setPages([DEFAULT_PAGE]);
+    }
+  }, [config.sitemap]);
 
   const changeFreqOptions = ["always", "hourly", "daily", "weekly", "monthly", "yearly", "never"];
 


### PR DESCRIPTION
## Summary
- import useEffect and synchronize the sitemap editor with updates from the fetched settings
- default to a single placeholder row only when the incoming sitemap data is empty
- clone incoming sitemap entries before storing them locally to prevent unintended mutations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d706592fb48328baefb2378d56fb7b