### PR TITLE
Update robots editor to reflect fetched config

### DIFF
--- a/frontend/src/components/admin/settings/seo/RobotsEditor.js
+++ b/frontend/src/components/admin/settings/seo/RobotsEditor.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { updateSEOConfig } from "@/services/admin/seoConfigService";
@@ -11,6 +11,14 @@ export default function RobotsEditor({ config, update }) {
 
   const [content, setContent] = useState(config.robots || defaultContent);
   const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (config?.robots) {
+      setContent(config.robots);
+    } else {
+      setContent(defaultContent);
+    }
+  }, [config?.robots, defaultContent]);
 
   const handleSave = async () => {
     const updated = { ...config, robots: content };


### PR DESCRIPTION
## Summary
- import `useEffect` in the robots editor
- sync the editor content with fetched SEO configuration while keeping the default template as a fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7065b982883288d35b7fe5334b53b