### PR TITLE
Fix sitemap priority handling

### DIFF
--- a/backend/src/modules/seoConfig/seoConfig.service.js
+++ b/backend/src/modules/seoConfig/seoConfig.service.js
@@ -73,7 +73,7 @@ exports.generateSitemap = async () => {
     .filter((p) => p.include)
     .map(
       (p) =>
-        `  <url><loc>${baseUrl.replace(/\/$/, "")}${p.path}</loc><changefreq>${p.freq || "weekly"}</changefreq><priority>${p.priority || 0.5}</priority></url>`
+        `  <url><loc>${baseUrl.replace(/\/$/, "")}${p.path}</loc><changefreq>${p.freq || "weekly"}</changefreq><priority>${p.priority ?? 0.5}</priority></url>`
     )
     .join("\n");
 

--- a/backend/tests/seoConfigService.test.js
+++ b/backend/tests/seoConfigService.test.js
@@ -1,0 +1,79 @@
+const path = require('path');
+
+describe('seoConfig service sitemap generation', () => {
+  let service;
+  let fs;
+  let writeFileSync;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    writeFileSync = jest.fn();
+    const mkdirSync = jest.fn();
+    const existsSync = jest.fn().mockReturnValue(true);
+
+    jest.doMock('fs', () => ({
+      existsSync,
+      mkdirSync,
+      writeFileSync,
+      unlinkSync: jest.fn(),
+      writeFile: jest.fn(),
+      readFileSync: jest.fn(),
+      createWriteStream: jest.fn(() => ({
+        on: jest.fn(),
+        write: jest.fn(),
+        end: jest.fn(),
+      })),
+    }));
+
+    jest.doMock('node-fetch', () => jest.fn(() => Promise.resolve()));
+    jest.doMock('../src/utils/frontend', () => ({ frontendBase: 'https://frontend.test' }));
+    jest.doMock('../src/config/database', () => {
+      const chain = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+        update: jest.fn(),
+        insert: jest.fn(),
+      };
+      const mockDb = jest.fn(() => chain);
+      mockDb.fn = { now: jest.fn() };
+      return mockDb;
+    });
+
+    service = require('../src/modules/seoConfig/seoConfig.service');
+    fs = require('fs');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves a 0 priority when regenerating the sitemap', async () => {
+    const settings = {
+      sitemap: [
+        { include: true, path: '/zero', freq: 'daily', priority: 0 },
+        { include: true, path: '/default', freq: undefined },
+      ],
+      baseUrl: 'https://mysite.test/',
+      globalSEO: { autoPingSitemap: false },
+    };
+
+    jest.spyOn(service, 'getSettings').mockResolvedValue(settings);
+    const updateSpy = jest.spyOn(service, 'updateSettings').mockResolvedValue();
+
+    const result = await service.generateSitemap();
+
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    const [filePath, xml] = fs.writeFileSync.mock.calls[0];
+
+    expect(path.basename(filePath)).toBe('sitemap.xml');
+    expect(xml).toContain('<loc>https://mysite.test/zero</loc><changefreq>daily</changefreq><priority>0</priority>');
+    expect(xml).toContain('<loc>https://mysite.test/default</loc><changefreq>weekly</changefreq><priority>0.5</priority>');
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sitemapUpdated: expect.any(String),
+      })
+    );
+    expect(result).toEqual({ url: '/uploads/seo/sitemap.xml', updated: expect.any(String) });
+  });
+});


### PR DESCRIPTION
## Summary
- replace the sitemap priority fallback with a nullish check so explicitly configured zero priorities persist
- add a focused unit test that regenerates the sitemap and verifies a 0 priority is preserved in the XML output

## Testing
- npx jest --runTestsByPath tests/seoConfigService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d7065f05fc832892aaee50e32b7989