### PR TITLE
Sync sitemap form state with config updates

### DIFF
--- a/frontend/src/components/admin/settings/seo/SitemapManager.js
+++ b/frontend/src/components/admin/settings/seo/SitemapManager.js
@@ -1,15 +1,27 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { updateSEOConfig } from "@/services/admin/seoConfigService";
 
 export default function SitemapManager({ config, update, availablePages }) {
   const { t } = useTranslation("dashboard", { keyPrefix: "seoPage.sitemap" });
-  const [pages, setPages] = useState(
-    config.sitemap.length
-      ? config.sitemap
-      : [{ path: "/", include: true, priority: 1.0, freq: "daily" }]
+  const defaultPages = () => [
+    { path: "/", include: true, priority: 1.0, freq: "daily" },
+  ];
+
+  const [pages, setPages] = useState(() =>
+    config?.sitemap?.length
+      ? config.sitemap.map((page) => ({ ...page }))
+      : defaultPages()
   );
+
+  useEffect(() => {
+    if (Array.isArray(config?.sitemap) && config.sitemap.length) {
+      setPages(config.sitemap.map((page) => ({ ...page })));
+    } else {
+      setPages(defaultPages());
+    }
+  }, [config?.sitemap]);
 
   const changeFreqOptions = ["always", "hourly", "daily", "weekly", "monthly", "yearly", "never"];
 

--- a/frontend/src/tests/__tests__/SitemapManager.test.jsx
+++ b/frontend/src/tests/__tests__/SitemapManager.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import SitemapManager from "@/components/admin/settings/seo/SitemapManager";
+
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+jest.mock("@/services/admin/seoConfigService", () => ({
+  updateSEOConfig: jest.fn(),
+}));
+
+describe("SitemapManager", () => {
+  it("renders provided sitemap entries immediately", () => {
+    const config = {
+      sitemap: [
+        { path: "/courses", include: true, priority: 0.8, freq: "weekly" },
+        { path: "/blog", include: false, priority: 0.6, freq: "monthly" },
+      ],
+      sitemapUpdated: null,
+    };
+
+    render(
+      <SitemapManager
+        config={config}
+        update={jest.fn()}
+        availablePages={["/courses", "/blog", "/"]}
+      />
+    );
+
+    expect(screen.getByDisplayValue("/courses")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("/blog")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("/")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- reset the sitemap manager form state when config.sitemap updates so hydrated data is shown immediately
- ensure deduplication and validation run against cloned sitemap entries from the latest config
- add a unit test verifying existing sitemap entries render without waiting for interaction

## Testing
- npm test -- SitemapManager.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d70665d084832894c58276d13cdb7e