### PR TITLE
Fix robots.txt editor hydration and add regression tests

### DIFF
--- a/frontend/src/components/admin/settings/seo/RobotsEditor.js
+++ b/frontend/src/components/admin/settings/seo/RobotsEditor.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { updateSEOConfig } from "@/services/admin/seoConfigService";
@@ -9,8 +9,21 @@ export default function RobotsEditor({ config, update }) {
     (typeof window !== "undefined" ? window.location.origin : "");
   const defaultContent = `User-agent: *\nDisallow: /dashboard/\nDisallow: /admin/\nAllow: /\n\nSitemap: ${fallbackUrl}/sitemap.xml`;
 
-  const [content, setContent] = useState(config.robots || defaultContent);
+  const robotsContent = config?.robots;
+  const hasStoredRobots = robotsContent !== null && robotsContent !== undefined;
+
+  const [content, setContent] = useState(
+    hasStoredRobots ? robotsContent : defaultContent,
+  );
   const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (robotsContent !== null && robotsContent !== undefined) {
+      setContent(robotsContent);
+    } else {
+      setContent(defaultContent);
+    }
+  }, [robotsContent, defaultContent]);
 
   const handleSave = async () => {
     const updated = { ...config, robots: content };

--- a/frontend/tests/components/admin/settings/seo/RobotsEditor.test.js
+++ b/frontend/tests/components/admin/settings/seo/RobotsEditor.test.js
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import RobotsEditor from '@/components/admin/settings/seo/RobotsEditor';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('@/services/admin/seoConfigService', () => ({
+  updateSEOConfig: jest.fn().mockResolvedValue({}),
+}));
+
+describe('RobotsEditor', () => {
+  it('hydrates textarea content when config.robots updates', async () => {
+    const update = jest.fn();
+    const initialConfig = { robots: 'User-agent: initial' };
+    const updatedConfig = { robots: 'User-agent: updated' };
+
+    const { rerender } = render(<RobotsEditor config={initialConfig} update={update} />);
+
+    expect(screen.getByRole('textbox')).toHaveValue(initialConfig.robots);
+
+    rerender(<RobotsEditor config={updatedConfig} update={update} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue(updatedConfig.robots);
+    });
+  });
+
+  it('displays saved feedback after successful save', async () => {
+    const update = jest.fn();
+    const config = { robots: 'User-agent: initial' };
+
+    render(<RobotsEditor config={config} update={update} />);
+
+    fireEvent.click(screen.getByText('save'));
+
+    await waitFor(() => {
+      expect(screen.getByText('saved')).toBeInTheDocument();
+    });
+
+    expect(update).toHaveBeenCalledWith({ robots: config.robots });
+  });
+});


### PR DESCRIPTION
## Summary
- hydrate the robots.txt editor from incoming config updates before falling back to the default template
- ensure save feedback continues to display after successful persistence
- add regression tests covering prop rehydration and save feedback behavior

## Testing
- npm test -- RobotsEditor

------
https://chatgpt.com/codex/tasks/task_e_68d70666b7c883288ed552cf4d324ca2