### PR TITLE
Update robots sitemap URL to include uploads path

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ npm --prefix frontend install
       `backend/src/seeds`. A raw SQL snapshot of the schema is also available
       at `database/schema.sql` for reference.
 
+      The SEO settings seed now publishes the sitemap at
+      `${BASE_URL}/uploads/seo/sitemap.xml`. Re-run the seeds after upgrading
+      to this release so deployments advertise the updated robots.txt
+      location.
+
    Seeding is meant for development environments only and should not be executed in production.
 
    If `ADMIN_INITIAL_PASSWORD` or `SUPERADMIN_INITIAL_PASSWORD` are not set in

--- a/backend/src/seeds/06_seo_settings_seed.js
+++ b/backend/src/seeds/06_seo_settings_seed.js
@@ -42,7 +42,7 @@ exports.seed = async function (knex) {
       { path: '/contact', include: true, priority: 0.6, freq: 'monthly' },
     ],
     robots:
-      `User-agent: *\nDisallow: /dashboard/\nDisallow: /admin/\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml`,
+      `User-agent: *\nDisallow: /dashboard/\nDisallow: /admin/\nAllow: /\n\nSitemap: ${BASE_URL}/uploads/seo/sitemap.xml`,
     openGraph: {
       '/': {
         title: 'SkillBridge | Launch Your Tech Career',

--- a/frontend/src/components/admin/settings/seo/RobotsEditor.js
+++ b/frontend/src/components/admin/settings/seo/RobotsEditor.js
@@ -7,7 +7,7 @@ export default function RobotsEditor({ config, update }) {
   const { t } = useTranslation("dashboard", { keyPrefix: "seoPage.robots" });
   const fallbackUrl = process.env.NEXT_PUBLIC_SITE_URL ||
     (typeof window !== "undefined" ? window.location.origin : "");
-  const defaultContent = `User-agent: *\nDisallow: /dashboard/\nDisallow: /admin/\nAllow: /\n\nSitemap: ${fallbackUrl}/sitemap.xml`;
+  const defaultContent = `User-agent: *\nDisallow: /dashboard/\nDisallow: /admin/\nAllow: /\n\nSitemap: ${fallbackUrl}/uploads/seo/sitemap.xml`;
 
   const [content, setContent] = useState(config.robots || defaultContent);
   const [saved, setSaved] = useState(false);


### PR DESCRIPTION
## Summary
- point the admin robots.txt editor default sitemap to the uploads/seo directory
- align the SEO seed robots entry with the new sitemap location
- document the need to rerun seeds so deployments publish the updated robots URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70667f8cc8328ba6526e87b2d0d38