### PR TITLE
Sync sitemap manager with config updates

### DIFF
--- a/frontend/src/components/admin/settings/seo/SitemapManager.js
+++ b/frontend/src/components/admin/settings/seo/SitemapManager.js
@@ -1,15 +1,31 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { updateSEOConfig } from "@/services/admin/seoConfigService";
 
+const createDefaultPage = () => ({
+  path: "/",
+  include: true,
+  priority: 1.0,
+  freq: "daily",
+});
+
 export default function SitemapManager({ config, update, availablePages }) {
   const { t } = useTranslation("dashboard", { keyPrefix: "seoPage.sitemap" });
-  const [pages, setPages] = useState(
-    config.sitemap.length
+  const [pages, setPages] = useState(() =>
+    Array.isArray(config?.sitemap) && config.sitemap.length
       ? config.sitemap
-      : [{ path: "/", include: true, priority: 1.0, freq: "daily" }]
+      : [createDefaultPage()]
   );
+
+  useEffect(() => {
+    if (!Array.isArray(config?.sitemap) || config.sitemap.length === 0) {
+      setPages([createDefaultPage()]);
+      return;
+    }
+
+    setPages(config.sitemap);
+  }, [config?.sitemap]);
 
   const changeFreqOptions = ["always", "hourly", "daily", "weekly", "monthly", "yearly", "never"];
 


### PR DESCRIPTION
## Summary
- import useEffect and keep sitemap manager state aligned with the latest config
- default sitemap table rows to an empty baseline when configuration is missing or empty

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d70673ef148328b69b6aee2b91c1c0