### PR TITLE
Sync robots editor textarea with saved config

### DIFF
--- a/frontend/src/components/admin/settings/seo/RobotsEditor.js
+++ b/frontend/src/components/admin/settings/seo/RobotsEditor.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "next-i18next";
 import { updateSEOConfig } from "@/services/admin/seoConfigService";
@@ -11,6 +11,10 @@ export default function RobotsEditor({ config, update }) {
 
   const [content, setContent] = useState(config.robots || defaultContent);
   const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setContent(config.robots || defaultContent);
+  }, [config.robots, defaultContent]);
 
   const handleSave = async () => {
     const updated = { ...config, robots: content };


### PR DESCRIPTION
## Summary
- import `useEffect` into the robots editor component
- keep the textarea content in sync with the loaded SEO robots configuration

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d70674ec98832893432ef689a82585