### PR TITLE
Initialize upload state for admin class creation

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -77,6 +77,9 @@ function CreateOnlineClass() {
   const [allTags, setAllTags] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
   const [tagInput, setTagInput] = useState('');
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [imageUploading, setImageUploading] = useState(false);
+  const [videoUploading, setVideoUploading] = useState(false);
 
   const filteredTagSuggestions = useMemo(
     () =>
@@ -168,12 +171,13 @@ function CreateOnlineClass() {
       return;
     }
 
-    setVideoUploading(false);
+    setVideoUploading(true);
     setFormData((prev) => ({
       ...prev,
       demoVideo: file,
       demoPreview: URL.createObjectURL(file),
     }));
+    setVideoUploading(false);
   };
 
   const addTag = (tag) => {


### PR DESCRIPTION
## Summary
- add dedicated upload state management for the admin online class creation page
- ensure the demo video upload toggles the uploading indicator while preparing previews

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d77a3dcd5883288435ca408ff1d3f3