### PR TITLE
Improve admin class student detail data

### DIFF
--- a/backend/src/modules/classes/enrollments/classEnrollment.service.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.service.js
@@ -73,15 +73,105 @@ exports.getPhonesByClass = async (class_id) => {
 
 // Get a single student's enrollment details in a class
 exports.getStudent = async (class_id, user_id) => {
-  return db("class_enrollments as ce")
+  const enrollment = await db("class_enrollments as ce")
     .join("users as u", "ce.user_id", "u.id")
     .where({ "ce.class_id": class_id, "ce.user_id": user_id })
     .select(
       "u.id",
       "u.full_name",
       "u.email",
+      "u.phone",
       "ce.status",
       "ce.enrolled_at"
     )
     .first();
+
+  if (!enrollment) {
+    return null;
+  }
+
+  const [lessonRows, attendanceRows, scoreRow] = await Promise.all([
+    db("class_lessons")
+      .where({ class_id })
+      .orderBy("order", "asc")
+      .select("id", "title", "order"),
+    db("class_attendance as ca")
+      .leftJoin("class_lessons as cl", "ca.lesson_id", "cl.id")
+      .where({ "ca.class_id": class_id, "ca.user_id": user_id })
+      .select(
+        "ca.id",
+        "ca.lesson_id",
+        "ca.attended",
+        "ca.timestamp",
+        "cl.title as lesson_title"
+      )
+      .orderBy("ca.timestamp", "asc"),
+    db("student_class_scores as scs")
+      .leftJoin("certificates as c", function () {
+        this.on("c.class_id", "=", "scs.class_id").andOn(
+          "c.user_id",
+          "=",
+          "scs.student_id"
+        );
+      })
+      .where({ "scs.class_id": class_id, "scs.student_id": user_id })
+      .select(
+        "scs.assignment_score",
+        "scs.attendance_score",
+        "scs.final_exam_score",
+        "scs.total_score",
+        "scs.passed",
+        "scs.certificate_issued",
+        "scs.issued_at",
+        "c.id as certificate_id"
+      )
+      .first(),
+  ]);
+
+  const lessons = Array.isArray(lessonRows)
+    ? lessonRows.map((lesson) => ({
+        id: lesson.id,
+        title: lesson.title,
+        order: lesson.order,
+      }))
+    : [];
+
+  const attendance = Array.isArray(attendanceRows)
+    ? attendanceRows.map((record) => ({
+        id: record.id,
+        lessonId: record.lesson_id,
+        lessonTitle: record.lesson_title,
+        attended: Boolean(record.attended),
+        timestamp: record.timestamp,
+      }))
+    : [];
+
+  const certificate = scoreRow
+    ? {
+        issued:
+          Boolean(scoreRow.certificate_issued) || Boolean(scoreRow.certificate_id),
+        issuedAt: scoreRow.issued_at,
+        certificateId: scoreRow.certificate_id,
+        passed: Boolean(scoreRow.passed),
+        totalScore: scoreRow.total_score,
+        assignmentScore: scoreRow.assignment_score,
+        attendanceScore: scoreRow.attendance_score,
+        finalExamScore: scoreRow.final_exam_score,
+      }
+    : null;
+
+  return {
+    id: enrollment.id,
+    full_name: enrollment.full_name,
+    name: enrollment.full_name,
+    email: enrollment.email,
+    phone: enrollment.phone,
+    status: enrollment.status,
+    enrolled_at: enrollment.enrolled_at,
+    lessons,
+    attendance,
+    notes: [],
+    certificate,
+    certificateIssued: certificate?.issued ?? false,
+  };
 };

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
@@ -40,11 +40,18 @@ function ManageStudentInClassPage() {
     return <div className="p-6">{t('studentDetailPage.student_not_found')}</div>;
   }
 
+  const lessonList = Array.isArray(student.lessons) ? student.lessons : [];
+  const attendanceRecords = Array.isArray(student.attendance)
+    ? student.attendance
+    : [];
+  const notes = Array.isArray(student.notes) ? student.notes : [];
+  const certificate = student.certificate ?? null;
+
   return (
     <div className="p-6 space-y-6" dir={i18n.dir()}>
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold text-gray-800">
-          🧑‍🎓 {t('studentDetailPage.title')}: {student.name}
+          🧑‍🎓 {t('studentDetailPage.title')}: {student.full_name ?? student.name}
         </h1>
         <Link
           href={`/dashboard/admin/online-classes/${id}/students`}
@@ -59,49 +66,104 @@ function ManageStudentInClassPage() {
       <div className="bg-white shadow rounded-xl p-6 border space-y-6">
         <div className="grid md:grid-cols-2 gap-6">
           <div>
-            <p><strong>Name:</strong> {student.name}</p>
+            <p><strong>Name:</strong> {student.full_name ?? student.name}</p>
             <p><strong>Email:</strong> {student.email}</p>
             <p><strong>Status:</strong> {student.status}</p>
           </div>
           <div>
-            <p><strong>Certificate:</strong> {student.certificateIssued ? "✅ Issued" : "❌ Not Issued"}</p>
+            <p>
+              <strong>Certificate:</strong>{' '}
+              {student.certificateIssued ? '✅ Issued' : '❌ Not Issued'}
+            </p>
+            {certificate && (
+              <ul className="mt-2 text-sm text-gray-600 space-y-1">
+                <li>
+                  <strong>
+                    {t('studentDetailPage.passed_label', { defaultValue: 'Passed' })}:
+                  </strong>{' '}
+                  {certificate.passed ? '✅' : '⏳'}
+                </li>
+                {typeof certificate.totalScore === 'number' && (
+                  <li>
+                    <strong>
+                      {t('studentDetailPage.total_score', { defaultValue: 'Total Score' })}:
+                    </strong>{' '}
+                    {certificate.totalScore}
+                  </li>
+                )}
+                {certificate.issuedAt && (
+                  <li>
+                    <strong>
+                      {t('studentDetailPage.issued_at', { defaultValue: 'Issued At' })}:
+                    </strong>{' '}
+                    {new Date(certificate.issuedAt).toLocaleString()}
+                  </li>
+                )}
+              </ul>
+            )}
           </div>
         </div>
 
-        <div>
-          <h2 className="text-lg font-semibold text-gray-700 mb-2">📚 Lesson Progress</h2>
-          <ul className="space-y-2">
-            {student.lessons.map((lesson, i) => (
-              <li key={i} className="flex justify-between items-center bg-gray-50 p-3 rounded">
-                <span>{lesson.title}</span>
-                <span className="text-sm">
-                  {lesson.completed ? "✅ Completed" : "⏳ In Progress"} — Test: {lesson.testScore ?? "N/A"}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
+        {lessonList.length > 0 && (
+          <div>
+            <h2 className="text-lg font-semibold text-gray-700 mb-2">📚 Lesson Progress</h2>
+            <ul className="space-y-2">
+              {lessonList.map((lesson) => (
+                <li
+                  key={lesson.id ?? lesson.title}
+                  className="flex justify-between items-center bg-gray-50 p-3 rounded"
+                >
+                  <span>
+                    {lesson.order ? `${lesson.order}. ` : ''}
+                    {lesson.title}
+                  </span>
+                  <span className="text-sm text-gray-600">
+                    {lesson.completed
+                      ? '✅ Completed'
+                      : lesson.completed === false
+                      ? '⏳ In Progress'
+                      : t('studentDetailPage.progress_unknown', {
+                          defaultValue: 'Progress unavailable',
+                        })}
+                    {typeof lesson.testScore !== 'undefined' && (
+                      <span className="ml-1">
+                        — Test: {lesson.testScore ?? 'N/A'}
+                      </span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
-        <div>
-          <h2 className="text-lg font-semibold text-gray-700 mb-2">📅 Attendance</h2>
-          <ul className="space-y-2">
-            {student.attendance.map((record, i) => (
-              <li key={i} className="flex justify-between items-center text-sm bg-gray-100 p-2 rounded">
-                <span>{record.lesson}</span>
-                <span>{record.attended ? "✔ Present" : "— Absent"}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
+        {attendanceRecords.length > 0 && (
+          <div>
+            <h2 className="text-lg font-semibold text-gray-700 mb-2">📅 Attendance</h2>
+            <ul className="space-y-2">
+              {attendanceRecords.map((record) => (
+                <li
+                  key={record.id ?? `${record.lessonId}-${record.timestamp}`}
+                  className="flex justify-between items-center text-sm bg-gray-100 p-2 rounded"
+                >
+                  <span>{record.lessonTitle ?? record.lesson}</span>
+                  <span>{record.attended ? '✔ Present' : '— Absent'}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
-        <div>
-          <h2 className="text-lg font-semibold text-gray-700 mb-2">📝 Notes</h2>
-          <ul className="list-disc list-inside text-sm text-gray-600">
-            {student.notes.map((note, i) => (
-              <li key={i}>{note}</li>
-            ))}
-          </ul>
-        </div>
+        {notes.length > 0 && (
+          <div>
+            <h2 className="text-lg font-semibold text-gray-700 mb-2">📝 Notes</h2>
+            <ul className="list-disc list-inside text-sm text-gray-600">
+              {notes.map((note, i) => (
+                <li key={i}>{note}</li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         <div className="pt-4 flex gap-3">
           <button className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 text-sm">


### PR DESCRIPTION
## Summary
- update the admin student detail page to rely on the actual API fields and guard optional collections before rendering
- expand the enrollment service to include lessons, attendance, and certificate metadata for a class student

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d77a3f468883288d7a40cb8b8a8d75