### PR TITLE
Fix media upload state handling in admin class creation

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -30,7 +30,6 @@ import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
 import FloatingInput from '@/components/shared/FloatingInput';
 import { toDateTimeISO } from '@/utils/date';
-import useMediaUploader from '@/hooks/useMediaUploader';
 
 const ReactQuill = dynamic(() => import('react-quill'), {
   ssr: false,
@@ -77,6 +76,9 @@ function CreateOnlineClass() {
   const [allTags, setAllTags] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
   const [tagInput, setTagInput] = useState('');
+  const [imageUploading, setImageUploading] = useState(false);
+  const [videoUploading, setVideoUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
 
   const filteredTagSuggestions = useMemo(
     () =>
@@ -145,6 +147,7 @@ function CreateOnlineClass() {
         image: file,
         imagePreview: reader.result
       }));
+      setUploadProgress(100);
       setImageUploading(false);
     };
     reader.onerror = () => {
@@ -168,12 +171,15 @@ function CreateOnlineClass() {
       return;
     }
 
-    setVideoUploading(false);
+    setVideoUploading(true);
+    setUploadProgress(0);
     setFormData((prev) => ({
       ...prev,
       demoVideo: file,
       demoPreview: URL.createObjectURL(file),
     }));
+    setUploadProgress(100);
+    setVideoUploading(false);
   };
 
   const addTag = (tag) => {


### PR DESCRIPTION
## Summary
- add explicit state hooks to track media upload progress in the class creation page
- adjust manual image and video handlers to update the new upload state
- remove the unused `useMediaUploader` import

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d77a44e9f08328840587e9bee6bd72