### PR TITLE
Handle missing analytics data defaults

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -50,7 +50,19 @@ function AnalyticsDashboard() {
   useEffect(() => {
     if (!id) return;
     fetchAdminClassAnalytics(id)
-      .then((data) => setStats(data))
+      .then((data) =>
+        setStats({
+          ...EMPTY_STATS,
+          ...(data ?? {}),
+          revenueBreakdown: {
+            ...EMPTY_STATS.revenueBreakdown,
+            ...(data?.revenueBreakdown ?? {}),
+          },
+          locations: data?.locations ?? EMPTY_STATS.locations,
+          devices: data?.devices ?? EMPTY_STATS.devices,
+          registrationTrend: data?.registrationTrend ?? EMPTY_STATS.registrationTrend,
+        })
+      )
       .catch((err) => {
         console.error("Failed to load analytics", err);
         setStats(EMPTY_STATS);
@@ -65,17 +77,26 @@ function AnalyticsDashboard() {
     );
   }
 
+  const totalStudents = stats.totalStudents ?? 0;
+  const totalRevenue = stats.totalRevenue ?? 0;
+  const totalAttendance = stats.totalAttendance ?? 0;
+  const totalCompleted = stats.completed ?? 0;
+  const revenueBreakdown = stats.revenueBreakdown ?? EMPTY_STATS.revenueBreakdown;
+  const locations = stats.locations ?? EMPTY_STATS.locations;
+  const devices = stats.devices ?? EMPTY_STATS.devices;
+  const registrationTrend = stats.registrationTrend ?? EMPTY_STATS.registrationTrend;
+
   const avgRevenue =
-    stats.totalStudents > 0
-      ? (stats.totalRevenue / stats.totalStudents).toFixed(2)
+    totalStudents > 0
+      ? (totalRevenue / totalStudents).toFixed(2)
       : "0";
   const attendanceRate =
-    stats.totalStudents > 0
-      ? ((stats.totalAttendance / stats.totalStudents) * 100).toFixed(1)
+    totalStudents > 0
+      ? ((totalAttendance / totalStudents) * 100).toFixed(1)
       : "0";
   const completionRate =
-    stats.totalStudents > 0
-      ? ((stats.completed / stats.totalStudents) * 100).toFixed(1)
+    totalStudents > 0
+      ? ((totalCompleted / totalStudents) * 100).toFixed(1)
       : "0";
 
   return (
@@ -87,20 +108,20 @@ function AnalyticsDashboard() {
       <div className="grid md:grid-cols-3 gap-6">
         <div className="bg-white p-6 rounded-xl shadow border">
           <h2 className="text-lg font-semibold text-gray-700 mb-2">👥 {t('classAnalyticsPage.total_enrolled_students')}</h2>
-          <p className="text-3xl font-bold text-green-600">{stats.totalStudents}</p>
+          <p className="text-3xl font-bold text-green-600">{totalStudents}</p>
         </div>
 
         <div className="bg-white p-6 rounded-xl shadow border">
           <h2 className="text-lg font-semibold text-gray-700 mb-2">💰 {t('classAnalyticsPage.total_revenue')}</h2>
-          <p className="text-3xl font-bold text-indigo-600">${stats.totalRevenue}</p>
+          <p className="text-3xl font-bold text-indigo-600">${totalRevenue}</p>
         </div>
 
         <div className="bg-white p-6 rounded-xl shadow border">
           <h2 className="text-lg font-semibold text-gray-700 mb-2">💳 {t('classAnalyticsPage.revenue_breakdown')}</h2>
           <ul className="text-gray-700 space-y-1">
-            <li><strong>{t('classAnalyticsPage.full_payments')}:</strong> {stats.revenueBreakdown.full}</li>
-            <li><strong>{t('classAnalyticsPage.installments')}:</strong> {stats.revenueBreakdown.installments}</li>
-            <li><strong>{t('classAnalyticsPage.free_seats')}:</strong> {stats.revenueBreakdown.free}</li>
+            <li><strong>{t('classAnalyticsPage.full_payments')}:</strong> {revenueBreakdown?.full ?? 0}</li>
+            <li><strong>{t('classAnalyticsPage.installments')}:</strong> {revenueBreakdown?.installments ?? 0}</li>
+            <li><strong>{t('classAnalyticsPage.free_seats')}:</strong> {revenueBreakdown?.free ?? 0}</li>
           </ul>
         </div>
       </div>
@@ -127,8 +148,8 @@ function AnalyticsDashboard() {
           <h2 className="text-lg font-semibold text-gray-700 mb-4">🌍 {t('classAnalyticsPage.top_countries')}</h2>
           <ResponsiveContainer width="100%" height={300}>
             <PieChart>
-              <Pie data={stats.locations} dataKey="value" nameKey="name" outerRadius={100}>
-                {stats.locations.map((entry, index) => (
+              <Pie data={locations} dataKey="value" nameKey="name" outerRadius={100}>
+                {(locations ?? []).map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                 ))}
               </Pie>
@@ -142,8 +163,8 @@ function AnalyticsDashboard() {
           <h2 className="text-lg font-semibold text-gray-700 mb-4">📱 {t('classAnalyticsPage.devices_used')}</h2>
           <ResponsiveContainer width="100%" height={300}>
             <PieChart>
-              <Pie data={stats.devices} dataKey="value" nameKey="name" outerRadius={100}>
-                {stats.devices.map((entry, index) => (
+              <Pie data={devices} dataKey="value" nameKey="name" outerRadius={100}>
+                {(devices ?? []).map((entry, index) => (
                   <Cell key={`cell-dev-${index}`} fill={COLORS[index % COLORS.length]} />
                 ))}
               </Pie>
@@ -157,7 +178,7 @@ function AnalyticsDashboard() {
       <div className="bg-white p-6 rounded-xl shadow border">
         <h2 className="text-lg font-semibold text-gray-700 mb-4">📈 {t('classAnalyticsPage.registration_trend')}</h2>
         <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={stats.registrationTrend}>
+          <BarChart data={registrationTrend}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="date" />
             <YAxis />

--- a/frontend/src/tests/pages/dashboard/admin/online-classes/analytics.test.jsx
+++ b/frontend/src/tests/pages/dashboard/admin/online-classes/analytics.test.jsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+
+const mockRouter = {
+  query: { id: "123" },
+  replace: jest.fn(),
+  push: jest.fn(),
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => mockRouter,
+}));
+
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: { dir: () => "ltr" },
+  }),
+}));
+
+jest.mock("@/hooks/withAuthProtection", () => ({
+  __esModule: true,
+  default: (Component) => Component,
+}));
+
+jest.mock("@/components/layouts/AdminLayout", () => ({
+  __esModule: true,
+  default: ({ children }) => <div data-testid="admin-layout">{children}</div>,
+}));
+
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }) => <div data-testid="responsive">{children}</div>,
+  PieChart: ({ children }) => <div data-testid="pie-chart">{children}</div>,
+  Pie: ({ children }) => <div data-testid="pie">{children}</div>,
+  Cell: () => <div data-testid="cell" />,
+  Legend: () => <div data-testid="legend" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  BarChart: ({ children }) => <div data-testid="bar-chart">{children}</div>,
+  CartesianGrid: () => <div data-testid="grid" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Bar: () => <div data-testid="bar" />,
+}));
+
+const mockFetchAdminClassAnalytics = jest.fn();
+jest.mock("@/services/admin/classService", () => ({
+  fetchAdminClassAnalytics: (...args) => mockFetchAdminClassAnalytics(...args),
+}));
+
+import AnalyticsPage from "@/pages/dashboard/admin/online-classes/[id]/analytics";
+
+describe("Admin class analytics page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchAdminClassAnalytics.mockResolvedValue({ totalStudents: 3 });
+  });
+
+  it("renders with minimal analytics payload", async () => {
+    render(<AnalyticsPage />);
+
+    await waitFor(() => expect(mockFetchAdminClassAnalytics).toHaveBeenCalledWith("123"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText((content) => content.includes("classAnalyticsPage.total_revenue"))
+      ).toBeInTheDocument();
+      expect(screen.getByText("$0")).toBeInTheDocument();
+    });
+
+    const totalStudentsValue = screen.getByText(
+      (content, element) => element?.textContent === "3"
+    );
+    expect(totalStudentsValue).toBeInTheDocument();
+
+    const fullPaymentsRow = screen
+      .getByText((content) => content.includes("classAnalyticsPage.full_payments"))
+      .closest("li");
+    expect(fullPaymentsRow).not.toBeNull();
+    expect(within(fullPaymentsRow).getByText("0")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- merge fetched analytics payloads with EMPTY_STATS and guard nested reads with defaults
- add a regression test covering rendering with a minimal analytics payload

## Testing
- npm test -- src/tests/pages/dashboard/admin/online-classes/analytics.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d77a4643488328875befc01940f92d