### PR TITLE
Add dynamic certificate template previews

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
@@ -23,6 +23,16 @@ exports.get = async (req, res, next) => {
   }
 };
 
+exports.preview = async (req, res, next) => {
+  try {
+    const preview = await service.getPreview(req.params.id);
+    if (!preview) return res.status(404).json({ message: "Template not found" });
+    sendSuccess(res, preview);
+  } catch (err) {
+    next(err);
+  }
+};
+
 exports.create = async (req, res, next) => {
   try {
     const template = await service.create(req.body);

--- a/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
@@ -14,6 +14,7 @@ router.use(verifyToken, isAdmin);
 router.get("/", controller.list);
 router.post("/", validate(createTemplate), controller.create);
 router.post("/upload", upload, controller.upload);
+router.get("/:id/preview", controller.preview);
 router.get("/:id", controller.get);
 router.put("/:id", validate(updateTemplate), controller.update);
 router.patch("/:id/toggle", controller.toggle);

--- a/backend/src/modules/certificateTemplates/certificateTemplates.service.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.service.js
@@ -49,3 +49,75 @@ exports.duplicate = async (id) => {
   const [row] = await db("certificate_templates").insert(newTemplate).returning("*");
   return row;
 };
+
+const buildFallbackPreview = (template) => {
+  const now = new Date();
+  const safeId = template?.id ? template.id : `preview-${now.getTime()}`;
+  const baseCourseName = template?.name ? `${template.name} Course` : "Sample Course";
+  const safePlatform = process.env.APP_NAME || "SkillBridge";
+
+  return {
+    id: safeId,
+    studentName: "Sample Student",
+    courseName: baseCourseName,
+    issueDate: now.toISOString(),
+    instructor: "Sample Instructor",
+    platformName: safePlatform,
+    grade: "A+",
+    certificateCode: `PREVIEW-${String(safeId).slice(0, 8).toUpperCase()}`,
+  };
+};
+
+exports.getPreview = async (id) => {
+  const template = await exports.getById(id);
+  if (!template) return null;
+
+  const certificate = await db("certificates as c")
+    .leftJoin("users as student", "c.user_id", "student.id")
+    .leftJoin("tutorials as tut", "c.tutorial_id", "tut.id")
+    .leftJoin("online_classes as cls", "c.class_id", "cls.id")
+    .leftJoin("users as tut_instructor", "tut.instructor_id", "tut_instructor.id")
+    .leftJoin("users as cls_instructor", "cls.instructor_id", "cls_instructor.id")
+    .select(
+      "c.id as certificate_id",
+      "c.certificate_code",
+      "c.created_at",
+      "student.full_name as student_name",
+      "tut.title as tutorial_title",
+      "cls.title as class_title",
+      "tut_instructor.full_name as tutorial_instructor_name",
+      "cls_instructor.full_name as class_instructor_name"
+    )
+    .where("c.template_id", id)
+    .orderBy("c.created_at", "desc")
+    .first();
+
+  if (!certificate) {
+    return buildFallbackPreview(template);
+  }
+
+  const issueDate = certificate.created_at instanceof Date
+    ? certificate.created_at.toISOString()
+    : new Date(certificate.created_at || Date.now()).toISOString();
+
+  const platformName = process.env.APP_NAME || "SkillBridge";
+
+  return {
+    id: certificate.certificate_id,
+    studentName: certificate.student_name || "Sample Student",
+    courseName:
+      certificate.tutorial_title ||
+      certificate.class_title ||
+      (template.name ? `${template.name} Course` : "Sample Course"),
+    issueDate,
+    instructor:
+      certificate.tutorial_instructor_name ||
+      certificate.class_instructor_name ||
+      "Sample Instructor",
+    platformName,
+    grade: "A+",
+    certificateCode:
+      certificate.certificate_code ||
+      `PREVIEW-${String(certificate.certificate_id).slice(0, 8).toUpperCase()}`,
+  };
+};

--- a/frontend/src/components/admin/certificates/CertificatePreviewModal.js
+++ b/frontend/src/components/admin/certificates/CertificatePreviewModal.js
@@ -1,24 +1,89 @@
+import { useEffect, useMemo, useState } from "react";
 import { FaTimes } from "react-icons/fa";
 import QRCode from "react-qr-code";
+import { getTemplatePreview } from "@/services/admin/certificateTemplateService";
 
 const isTemplateAsset = (url) =>
   typeof url === "string" &&
   url.startsWith("/api/uploads/certificateTemplates/");
 
-export default function CertificatePreviewModal({ template, onClose, mockData }) {
-  if (!template) return null;
+const buildFallbackPreview = (template) => {
+  const now = new Date();
+  const safeId = template?.id || `preview-${now.getTime()}`;
+  const courseName = template?.name ? `${template.name} Course` : "Sample Course";
+  const platformName = process.env.NEXT_PUBLIC_APP_NAME || "SkillBridge";
 
-  const defaultData = {
-    id: "ABC123",
-    studentName: "Student Name",
-    courseName: "Course Title",
-    issueDate: new Date().toISOString().split("T")[0],
-    instructor: "Instructor Name",
-    platformName: "Platform Name",
+  return {
+    id: safeId,
+    studentName: "Sample Student",
+    courseName,
+    issueDate: now.toISOString(),
+    instructor: "Sample Instructor",
+    platformName,
     grade: "A+",
+    certificateCode: `PREVIEW-${String(safeId).slice(0, 8).toUpperCase()}`,
   };
+};
 
-  const data = { ...defaultData, ...(mockData || {}) };
+export default function CertificatePreviewModal({
+  template,
+  onClose,
+  previewData,
+  loadingPreview = false,
+}) {
+  const [data, setData] = useState(previewData ?? null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setData(previewData ?? null);
+  }, [previewData]);
+
+  useEffect(() => {
+    if (!template) {
+      setData(null);
+      return;
+    }
+
+    if (previewData) return;
+
+    if (!template.id) {
+      setData(buildFallbackPreview(template));
+      return;
+    }
+
+    let mounted = true;
+    setIsLoading(true);
+
+    getTemplatePreview(template.id)
+      .then((payload) => {
+        if (!mounted) return;
+        if (payload) {
+          setData(payload);
+        } else {
+          setData(buildFallbackPreview(template));
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to load certificate preview", err);
+        if (mounted) setData(buildFallbackPreview(template));
+      })
+      .finally(() => {
+        if (mounted) setIsLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [template, previewData]);
+
+  const resolvedData = useMemo(() => {
+    if (!template) return null;
+    return data ?? buildFallbackPreview(template);
+  }, [data, template]);
+
+  if (!template || !resolvedData) return null;
+
+  const effectiveLoading = loadingPreview || isLoading;
 
   const {
     border_color,
@@ -44,6 +109,8 @@ export default function CertificatePreviewModal({ template, onClose, mockData })
     ? logo
     : "/images/certificate/logo.png";
 
+  const serialValue = (resolvedData.certificateCode || `CERT-${String(resolvedData.id).slice(0, 6)}`).toUpperCase();
+
   return (
     <div className="fixed inset-0 bg-gradient-to-br from-black/80 to-black/60 flex items-center justify-center z-50">
       <div className="relative w-full max-w-5xl max-h-[90vh] bg-white rounded-2xl shadow-2xl p-6 overflow-auto border border-gray-200">
@@ -66,6 +133,11 @@ export default function CertificatePreviewModal({ template, onClose, mockData })
             fontFamily,
           }}
         >
+          {effectiveLoading && (
+            <div className="absolute inset-0 bg-white/70 backdrop-blur-sm flex items-center justify-center z-20 rounded-xl">
+              <span className="text-gray-600 font-semibold">Loading preview...</span>
+            </div>
+          )}
           {/* Logo */}
           <div className="flex justify-center mb-6">
             <img src={safeLogo} alt="Logo" className="w-32" />
@@ -81,23 +153,27 @@ export default function CertificatePreviewModal({ template, onClose, mockData })
 
           <p className="text-lg text-gray-700 mb-1">This certifies that</p>
 
-          <h2 className="text-4xl font-extrabold text-gray-800 mb-4">{data.studentName}</h2>
+          <h2 className="text-4xl font-extrabold text-gray-800 mb-4">
+            {resolvedData.studentName}
+          </h2>
 
           <p className="text-lg text-gray-700 mb-1">has successfully completed</p>
 
-          <h3 className="text-2xl italic text-gray-700 mb-6">"{data.courseName}"</h3>
+          <h3 className="text-2xl italic text-gray-700 mb-6">
+            "{resolvedData.courseName}"
+          </h3>
 
-          {data.grade && (
+          {resolvedData.grade && (
             <p className="text-lg text-gray-600 mb-4">
-              Final Grade: <span className="text-green-600 font-bold text-2xl">{data.grade}</span>
+              Final Grade: <span className="text-green-600 font-bold text-2xl">{resolvedData.grade}</span>
             </p>
           )}
 
           <p className="text-sm text-gray-500 mb-1">
-            Issued on: <strong>{new Date(data.issueDate).toLocaleDateString()}</strong>
+            Issued on: <strong>{new Date(resolvedData.issueDate).toLocaleDateString()}</strong>
           </p>
           <p className="text-sm text-gray-500 mb-6">
-            Serial Number: <strong>CERT-{data.id.slice(0, 6).toUpperCase()}</strong>
+            Serial Number: <strong>{serialValue}</strong>
           </p>
 
           {/* Footer Row */}
@@ -105,7 +181,7 @@ export default function CertificatePreviewModal({ template, onClose, mockData })
             {/* Instructor Signature */}
             <div className="text-center">
               <p className="text-sm text-gray-500">Instructor</p>
-              <h4 className="font-bold text-gray-700">{data.instructor}</h4>
+              <h4 className="font-bold text-gray-700">{resolvedData.instructor}</h4>
               <img
                 src="/images/certificate/instructor-signature.png"
                 alt="Instructor Signature"
@@ -118,7 +194,7 @@ export default function CertificatePreviewModal({ template, onClose, mockData })
               <div className="text-center">
                 <div className="bg-white border border-gray-200 p-2 rounded-md inline-block shadow-sm">
                   <QRCode
-                    value={`https://yourplatform.com/certificate/verify/${data.id}`}
+                    value={`https://yourplatform.com/certificate/verify/${resolvedData.id}`}
                     size={80}
                   />
                 </div>
@@ -129,7 +205,7 @@ export default function CertificatePreviewModal({ template, onClose, mockData })
             {/* Platform Signature */}
             <div className="text-center">
               <p className="text-sm text-gray-500">Issued by</p>
-              <h4 className="font-bold text-gray-700">{data.platformName}</h4>
+              <h4 className="font-bold text-gray-700">{resolvedData.platformName}</h4>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/dashboard/admin/settings/certificates/index.js
+++ b/frontend/src/pages/dashboard/admin/settings/certificates/index.js
@@ -18,12 +18,15 @@ import {
   deleteTemplate,
   toggleTemplateStatus,
   duplicateTemplate,
+  getTemplatePreview,
 } from "@/services/admin/certificateTemplateService";
 import { toast } from "react-toastify";
 
 function CertificateTemplatesPage() {
   const [templates, setTemplates] = useState([]);
   const [previewTemplate, setPreviewTemplate] = useState(null);
+  const [previewData, setPreviewData] = useState(null);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
 
   useEffect(() => {
     refresh();
@@ -71,6 +74,30 @@ function CertificateTemplatesPage() {
       console.error("Failed to duplicate template", err);
       toast.error("Failed to duplicate template");
     }
+  };
+
+  const openPreview = async (template) => {
+    setPreviewTemplate(template);
+    setPreviewData(null);
+
+    if (!template?.id) return;
+
+    setIsPreviewLoading(true);
+    try {
+      const payload = await getTemplatePreview(template.id);
+      setPreviewData(payload);
+    } catch (err) {
+      console.error("Failed to load preview", err);
+      toast.error("Failed to load preview data");
+    } finally {
+      setIsPreviewLoading(false);
+    }
+  };
+
+  const closePreview = () => {
+    setPreviewTemplate(null);
+    setPreviewData(null);
+    setIsPreviewLoading(false);
   };
 
   return (
@@ -132,7 +159,7 @@ function CertificateTemplatesPage() {
                       <button onClick={() => handleDuplicate(template.id)}>
                         <FaClone title="Duplicate" />
                       </button>
-                      <button onClick={() => setPreviewTemplate(template)}>
+                      <button onClick={() => openPreview(template)}>
                         <FaEye title="Preview" />
                       </button>
                       <button
@@ -151,7 +178,9 @@ function CertificateTemplatesPage() {
         {previewTemplate && (
           <CertificatePreviewModal
             template={previewTemplate}
-            onClose={() => setPreviewTemplate(null)}
+            previewData={previewData}
+            loadingPreview={isPreviewLoading}
+            onClose={closePreview}
           />
         )}
       </div>

--- a/frontend/src/services/admin/certificateTemplateService.js
+++ b/frontend/src/services/admin/certificateTemplateService.js
@@ -11,6 +11,11 @@ export const getTemplate = async (id) => {
   return res.data?.data || null;
 };
 
+export const getTemplatePreview = async (id) => {
+  const res = await api.get(`/certificate-templates/${id}/preview`);
+  return res.data?.data || null;
+};
+
 export const saveTemplate = async (template) => {
   const res = await api.post(
     "/certificate-templates",


### PR DESCRIPTION
## Summary
- add a certificate template preview endpoint that returns representative learner data by joining related tables and falling back to synthetic values
- expose a frontend helper for fetching template previews and update the preview modal to consume dynamic data
- load preview payloads when opening templates in the admin settings page so previews render live values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d77c3e5d708328b8d549916d382fde