### PR TITLE
Ensure issued certificates capture template selection

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.controller.js
@@ -13,6 +13,17 @@ exports.list = async (req, res, next) => {
   }
 };
 
+exports.getActive = async (_req, res, next) => {
+  try {
+    const template = await service.getActiveTemplate();
+    if (!template)
+      return res.status(404).json({ message: "No active certificate template found" });
+    sendSuccess(res, template);
+  } catch (err) {
+    next(err);
+  }
+};
+
 exports.get = async (req, res, next) => {
   try {
     const template = await service.getById(req.params.id);

--- a/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.routes.js
@@ -12,6 +12,7 @@ const upload = require("./certificateTemplateUpload.middleware");
 router.use(verifyToken, isAdmin);
 
 router.get("/", controller.list);
+router.get("/active/default", controller.getActive);
 router.post("/", validate(createTemplate), controller.create);
 router.post("/upload", upload, controller.upload);
 router.get("/:id", controller.get);

--- a/backend/src/modules/certificateTemplates/certificateTemplates.service.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.service.js
@@ -4,6 +4,16 @@ exports.getAll = async () => {
   return db("certificate_templates").select("*").orderBy("created_at", "desc");
 };
 
+exports.getActiveTemplate = async () => {
+  return db("certificate_templates")
+    .where({ active: true })
+    .orderBy([
+      { column: "updated_at", order: "desc" },
+      { column: "created_at", order: "desc" },
+    ])
+    .first();
+};
+
 exports.getById = async (id) => {
   return db("certificate_templates").where({ id }).first();
 };

--- a/backend/src/modules/classes/scores/__tests__/classScore.routes.test.js
+++ b/backend/src/modules/classes/scores/__tests__/classScore.routes.test.js
@@ -47,9 +47,11 @@ describe('class score routes', () => {
 
   test('issue certificate', async () => {
     service.issueCertificate.mockResolvedValue({ id: 'c1' });
-    const res = await request(app).post('/classes/scores/instructor/1/students/u1/issue');
+    const res = await request(app)
+      .post('/classes/scores/instructor/1/students/u1/issue')
+      .send({ templateId: 'tpl-1' });
     expect(res.status).toBe(200);
-    expect(service.issueCertificate).toHaveBeenCalled();
+    expect(service.issueCertificate).toHaveBeenCalledWith('1', 'u1', 'tpl-1');
   });
 
   test('get my score', async () => {

--- a/backend/src/modules/classes/scores/__tests__/classScore.service.test.js
+++ b/backend/src/modules/classes/scores/__tests__/classScore.service.test.js
@@ -1,6 +1,11 @@
 jest.mock('../../../../config/database', () => jest.fn());
+jest.mock('../../../users/tutorials/certificate/certificate.service', () => ({
+  generateCode: jest.fn(() => 'TUT-XXXX'),
+  resolveTemplateId: jest.fn(() => Promise.resolve('tpl-default')),
+}));
 
 const db = require('../../../../config/database');
+const { generateCode, resolveTemplateId } = require('../../../users/tutorials/certificate/certificate.service');
 const service = require('../classScore.service');
 
 describe('calculateForClass', () => {
@@ -36,5 +41,53 @@ describe('calculateForClass', () => {
     ]);
 
     service.calculateForStudent = original;
+  });
+});
+
+describe('issueCertificate', () => {
+  beforeEach(() => {
+    db.mockReset();
+    generateCode.mockClear();
+    resolveTemplateId.mockClear();
+    resolveTemplateId.mockResolvedValue('tpl-default');
+    db.fn = { now: jest.fn(() => 'now') };
+  });
+
+  it('persists certificate with resolved template id', async () => {
+    const insertCert = jest.fn().mockResolvedValue([]);
+    const updateScore = jest.fn().mockResolvedValue([]);
+
+    db.mockImplementation((table) => {
+      if (table === 'certificates') {
+        return {
+          where: () => ({ first: () => Promise.resolve(null) }),
+          insert: insertCert,
+        };
+      }
+      if (table === 'student_class_scores as scs') {
+        return {
+          leftJoin: () => ({
+            where: () => ({
+              andWhere: () => ({ select: () => ({ first: () => Promise.resolve({ passed: true }) }) }),
+            }),
+          }),
+        };
+      }
+      if (table === 'student_class_scores') {
+        return {
+          where: () => ({ update: updateScore }),
+        };
+      }
+      return { where: () => ({ first: () => Promise.resolve(null) }) };
+    });
+
+    const cert = await service.issueCertificate('class-1', 'student-1', 'tpl-custom');
+
+    expect(resolveTemplateId).toHaveBeenCalledWith('tpl-custom');
+    expect(insertCert).toHaveBeenCalledWith(
+      expect.objectContaining({ template_id: 'tpl-default', class_id: 'class-1', user_id: 'student-1' }),
+    );
+    expect(cert.template_id).toBe('tpl-default');
+    expect(updateScore).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/classes/scores/classScore.controller.js
+++ b/backend/src/modules/classes/scores/classScore.controller.js
@@ -13,7 +13,11 @@ exports.listScores = catchAsync(async (req, res) => {
 });
 
 exports.issueCertificate = catchAsync(async (req, res) => {
-  const cert = await service.issueCertificate(req.params.classId, req.params.studentId);
+  const cert = await service.issueCertificate(
+    req.params.classId,
+    req.params.studentId,
+    req.body?.templateId || null,
+  );
   sendSuccess(res, cert, 'Certificate issued');
 });
 

--- a/backend/src/modules/classes/scores/classScore.service.js
+++ b/backend/src/modules/classes/scores/classScore.service.js
@@ -1,6 +1,6 @@
 const db = require('../../../config/database');
 const { v4: uuidv4 } = require('uuid');
-const { generateCode } = require('../../users/tutorials/certificate/certificate.service');
+const { generateCode, resolveTemplateId } = require('../../users/tutorials/certificate/certificate.service');
 
 const getPolicy = async (classId) => {
   const existing = await db('class_scoring_policies').where({ class_id: classId }).first();
@@ -110,7 +110,7 @@ const getStudentScore = async (classId, studentId) => {
   return row;
 };
 
-const issueCertificate = async (classId, studentId) => {
+const issueCertificate = async (classId, studentId, templateId = null) => {
   let cert = await db('certificates').where({ class_id: classId, user_id: studentId }).first();
   if (cert) return cert;
 
@@ -118,12 +118,13 @@ const issueCertificate = async (classId, studentId) => {
   if (!score || !score.passed) {
     throw new Error('Student has not passed');
   }
+  const resolvedTemplateId = await resolveTemplateId(templateId);
   cert = {
     id: uuidv4(),
     user_id: studentId,
     class_id: classId,
     tutorial_id: null,
-    template_id: null,
+    template_id: resolvedTemplateId,
     certificate_code: generateCode().replace('TUT', 'CLS'),
     status: 'issued',
   };

--- a/backend/src/modules/users/tutorials/certificate/__tests__/certificate.service.test.js
+++ b/backend/src/modules/users/tutorials/certificate/__tests__/certificate.service.test.js
@@ -1,10 +1,20 @@
 jest.mock("../../../../../config/database", () => jest.fn());
+jest.mock("../../../../certificateTemplates/certificateTemplates.service", () => ({
+  getActiveTemplate: jest.fn(),
+}));
+
 const db = require("../../../../../config/database");
-const { isUserCompletedTutorial } = require("../certificate.service");
+const templateService = require("../../../../certificateTemplates/certificateTemplates.service");
+const {
+  isUserCompletedTutorial,
+  issueCertificate,
+  resolveTemplateId,
+} = require("../certificate.service");
 
 describe("isUserCompletedTutorial", () => {
   beforeEach(() => {
     db.mockReset();
+    templateService.getActiveTemplate.mockReset();
   });
 
   test("returns true when progress is 100 and all assignments are passed", async () => {
@@ -53,6 +63,44 @@ describe("isUserCompletedTutorial", () => {
 
     const res = await isUserCompletedTutorial("u1", "t1");
     expect(res).toBe(false);
+  });
+});
+
+describe("certificate templates", () => {
+  beforeEach(() => {
+    db.mockReset();
+    templateService.getActiveTemplate.mockReset();
+  });
+
+  test("resolveTemplateId returns provided id", async () => {
+    const id = await resolveTemplateId("tpl-provided");
+    expect(id).toBe("tpl-provided");
+    expect(templateService.getActiveTemplate).not.toHaveBeenCalled();
+  });
+
+  test("resolveTemplateId fetches default when missing", async () => {
+    templateService.getActiveTemplate.mockResolvedValue({ id: "tpl-default" });
+    const id = await resolveTemplateId();
+    expect(id).toBe("tpl-default");
+    expect(templateService.getActiveTemplate).toHaveBeenCalled();
+  });
+
+  test("issueCertificate attaches resolved template id", async () => {
+    templateService.getActiveTemplate.mockResolvedValue({ id: "tpl-default" });
+    const insert = jest.fn().mockResolvedValue([]);
+    db.mockImplementation((table) => {
+      if (table === "certificates") {
+        return { insert };
+      }
+      return {
+        where: () => ({ first: () => Promise.resolve(null) }),
+      };
+    });
+
+    const cert = await issueCertificate({ userId: "u1", tutorialId: "t1" });
+
+    expect(cert.template_id).toBe("tpl-default");
+    expect(insert).toHaveBeenCalledWith(cert);
   });
 });
 

--- a/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
+++ b/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
@@ -58,7 +58,28 @@ describe("generate certificate route", () => {
     );
 
     expect(res.statusCode).toBe(200);
-    expect(service.issueCertificate).toHaveBeenCalled();
+    expect(service.issueCertificate).toHaveBeenCalledWith({
+      tutorialId: TUTORIAL_ID,
+      userId: "user1",
+      templateId: undefined,
+    });
+  });
+
+  test("passes template id from request body", async () => {
+    service.isUserCompletedTutorial.mockResolvedValue(true);
+    service.findExisting.mockResolvedValue(null);
+    service.issueCertificate.mockResolvedValue({ id: "cert1" });
+
+    const res = await request(app)
+      .post(`/api/users/tutorials/certificate/${TUTORIAL_ID}/certificate/generate`)
+      .send({ templateId: "tpl-123" });
+
+    expect(res.statusCode).toBe(200);
+    expect(service.issueCertificate).toHaveBeenCalledWith({
+      tutorialId: TUTORIAL_ID,
+      userId: "user1",
+      templateId: "tpl-123",
+    });
   });
 });
 

--- a/backend/src/modules/users/tutorials/certificate/certificate.service.js
+++ b/backend/src/modules/users/tutorials/certificate/certificate.service.js
@@ -1,5 +1,6 @@
 const db = require("../../../../config/database");
 const { v4: uuidv4 } = require("uuid");
+const templateService = require("../../../certificateTemplates/certificateTemplates.service");
 
 // Generate a unique certificate code
 const generateCode = () => {
@@ -44,14 +45,21 @@ const findExisting = async (userId, tutorialId) => {
     .first();
 };
 
+const resolveTemplateId = async (templateId) => {
+  if (templateId) return templateId;
+  const template = await templateService.getActiveTemplate();
+  return template?.id || null;
+};
+
 // Create a new certificate
 const issueCertificate = async ({ userId, tutorialId, templateId = null }) => {
+  const resolvedTemplateId = await resolveTemplateId(templateId);
   const newCert = {
     id: uuidv4(),
     user_id: userId,
     tutorial_id: tutorialId,
     class_id: null,
-    template_id: templateId,
+    template_id: resolvedTemplateId,
     certificate_code: generateCode(),
     status: "issued"
   };
@@ -64,5 +72,6 @@ module.exports = {
   generateCode,
   isUserCompletedTutorial,
   findExisting,
+  resolveTemplateId,
   issueCertificate,
 };

--- a/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
@@ -22,7 +22,8 @@ exports.generateCertificate = catchAsync(async (req, res) => {
   if (existing) return sendSuccess(res, existing, "Certificate already issued");
 
   // 3. Create new
-  const newCert = await service.issueCertificate({ userId, tutorialId });
+  const { templateId } = req.body || {};
+  const newCert = await service.issueCertificate({ userId, tutorialId, templateId });
 
   // 4. Notify user
   const tutorial = await db("tutorials").where({ id: tutorialId }).first();


### PR DESCRIPTION
## Summary
- add a certificate template service helper and controller route to fetch the active template
- resolve the template id when issuing tutorial and class certificates so records reference the chosen design
- expand route and service tests to cover template selection behaviour

## Testing
- npm test -- --runInBand tutorialCertificate.routes.test.js classScore.routes.test.js classScore.service.test.js certificate.service.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d77c405d788328adcf2a69ba10d4d5