### PR TITLE
Add template selection for certificate issuance

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.service.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.service.js
@@ -27,6 +27,21 @@ exports.remove = async (id) => {
   return deleted;
 };
 
+exports.getActiveTemplateId = async () => {
+  const activeTemplate = await db("certificate_templates")
+    .where({ active: true })
+    .orderBy("updated_at", "desc")
+    .first();
+
+  if (activeTemplate) return activeTemplate.id;
+
+  const fallbackTemplate = await db("certificate_templates")
+    .orderBy("created_at", "desc")
+    .first();
+
+  return fallbackTemplate ? fallbackTemplate.id : null;
+};
+
 exports.toggleStatus = async (id) => {
   const [row] = await db("certificate_templates")
     .where({ id })

--- a/backend/src/modules/classes/scores/__tests__/classScore.routes.test.js
+++ b/backend/src/modules/classes/scores/__tests__/classScore.routes.test.js
@@ -47,9 +47,11 @@ describe('class score routes', () => {
 
   test('issue certificate', async () => {
     service.issueCertificate.mockResolvedValue({ id: 'c1' });
-    const res = await request(app).post('/classes/scores/instructor/1/students/u1/issue');
+    const res = await request(app)
+      .post('/classes/scores/instructor/1/students/u1/issue')
+      .set('x-certificate-template-id', 'tmpl2');
     expect(res.status).toBe(200);
-    expect(service.issueCertificate).toHaveBeenCalled();
+    expect(service.issueCertificate).toHaveBeenCalledWith('1', 'u1', 'tmpl2');
   });
 
   test('get my score', async () => {

--- a/backend/src/modules/classes/scores/classScore.controller.js
+++ b/backend/src/modules/classes/scores/classScore.controller.js
@@ -13,7 +13,19 @@ exports.listScores = catchAsync(async (req, res) => {
 });
 
 exports.issueCertificate = catchAsync(async (req, res) => {
-  const cert = await service.issueCertificate(req.params.classId, req.params.studentId);
+  const templateId =
+    req.body?.templateId ??
+    req.body?.template_id ??
+    req.query?.templateId ??
+    req.query?.template_id ??
+    req.headers?.['x-certificate-template-id'] ??
+    req.headers?.['x-template-id'] ??
+    null;
+  const cert = await service.issueCertificate(
+    req.params.classId,
+    req.params.studentId,
+    templateId,
+  );
   sendSuccess(res, cert, 'Certificate issued');
 });
 

--- a/backend/src/modules/classes/scores/classScore.service.js
+++ b/backend/src/modules/classes/scores/classScore.service.js
@@ -1,6 +1,7 @@
 const db = require('../../../config/database');
 const { v4: uuidv4 } = require('uuid');
 const { generateCode } = require('../../users/tutorials/certificate/certificate.service');
+const certificateTemplatesService = require('../../certificateTemplates/certificateTemplates.service');
 
 const getPolicy = async (classId) => {
   const existing = await db('class_scoring_policies').where({ class_id: classId }).first();
@@ -110,7 +111,7 @@ const getStudentScore = async (classId, studentId) => {
   return row;
 };
 
-const issueCertificate = async (classId, studentId) => {
+const issueCertificate = async (classId, studentId, templateId = null) => {
   let cert = await db('certificates').where({ class_id: classId, user_id: studentId }).first();
   if (cert) return cert;
 
@@ -118,12 +119,16 @@ const issueCertificate = async (classId, studentId) => {
   if (!score || !score.passed) {
     throw new Error('Student has not passed');
   }
+  const resolvedTemplateId =
+    templateId != null
+      ? templateId
+      : await certificateTemplatesService.getActiveTemplateId();
   cert = {
     id: uuidv4(),
     user_id: studentId,
     class_id: classId,
     tutorial_id: null,
-    template_id: null,
+    template_id: resolvedTemplateId,
     certificate_code: generateCode().replace('TUT', 'CLS'),
     status: 'issued',
   };

--- a/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
+++ b/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
@@ -41,9 +41,9 @@ describe("generate certificate route", () => {
   test("returns 403 when tutorial is not fully completed", async () => {
     service.isUserCompletedTutorial.mockResolvedValue(false);
 
-    const res = await request(app).post(
-      `/api/users/tutorials/certificate/${TUTORIAL_ID}/certificate/generate`,
-    );
+    const res = await request(app)
+      .post(`/api/users/tutorials/certificate/${TUTORIAL_ID}/certificate/generate`)
+      .set('x-certificate-template-id', 'tmpl1');
 
     expect(res.statusCode).toBe(403);
   });
@@ -51,14 +51,18 @@ describe("generate certificate route", () => {
   test("issues certificate when requirements are met", async () => {
     service.isUserCompletedTutorial.mockResolvedValue(true);
     service.findExisting.mockResolvedValue(null);
-    service.issueCertificate.mockResolvedValue({ id: "cert1" });
+    service.issueCertificate.mockResolvedValue({ id: 'cert1' });
 
-    const res = await request(app).post(
-      `/api/users/tutorials/certificate/${TUTORIAL_ID}/certificate/generate`,
-    );
+    const res = await request(app)
+      .post(`/api/users/tutorials/certificate/${TUTORIAL_ID}/certificate/generate`)
+      .set('x-certificate-template-id', 'tmpl1');
 
     expect(res.statusCode).toBe(200);
-    expect(service.issueCertificate).toHaveBeenCalled();
+    expect(service.issueCertificate).toHaveBeenCalledWith({
+      userId: 'user1',
+      tutorialId: TUTORIAL_ID,
+      templateId: 'tmpl1',
+    });
   });
 });
 

--- a/backend/src/modules/users/tutorials/certificate/certificate.service.js
+++ b/backend/src/modules/users/tutorials/certificate/certificate.service.js
@@ -1,5 +1,6 @@
 const db = require("../../../../config/database");
 const { v4: uuidv4 } = require("uuid");
+const certificateTemplatesService = require("../../../certificateTemplates/certificateTemplates.service");
 
 // Generate a unique certificate code
 const generateCode = () => {
@@ -46,12 +47,17 @@ const findExisting = async (userId, tutorialId) => {
 
 // Create a new certificate
 const issueCertificate = async ({ userId, tutorialId, templateId = null }) => {
+  const resolvedTemplateId =
+    templateId != null
+      ? templateId
+      : await certificateTemplatesService.getActiveTemplateId();
+
   const newCert = {
     id: uuidv4(),
     user_id: userId,
     tutorial_id: tutorialId,
     class_id: null,
-    template_id: templateId,
+    template_id: resolvedTemplateId,
     certificate_code: generateCode(),
     status: "issued"
   };

--- a/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
@@ -22,7 +22,16 @@ exports.generateCertificate = catchAsync(async (req, res) => {
   if (existing) return sendSuccess(res, existing, "Certificate already issued");
 
   // 3. Create new
-  const newCert = await service.issueCertificate({ userId, tutorialId });
+  const templateId =
+    req.body?.templateId ??
+    req.body?.template_id ??
+    req.query?.templateId ??
+    req.query?.template_id ??
+    req.headers?.["x-certificate-template-id"] ??
+    req.headers?.["x-template-id"] ??
+    null;
+
+  const newCert = await service.issueCertificate({ userId, tutorialId, templateId });
 
   // 4. Notify user
   const tutorial = await db("tutorials").where({ id: tutorialId }).first();


### PR DESCRIPTION
## Summary
- add a helper to resolve the active certificate template with a fallback option
- persist the resolved template id when issuing tutorial and class certificates and flow controllers forward explicit template choices
- extend route tests to cover template id propagation for tutorial and class certificate issuance

## Testing
- npm test -- tutorialCertificate.routes.test.js --runInBand
- npm test -- classScore.routes.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d77c431be4832887f74101c6763e8f