### PR TITLE
Expose certificate template metadata across API and UI

### DIFF
--- a/backend/src/modules/certificates/certificate.utils.js
+++ b/backend/src/modules/certificates/certificate.utils.js
@@ -1,0 +1,74 @@
+const TEMPLATE_SELECT_FIELDS = [
+  "certificate_templates.name as template_name",
+  "certificate_templates.type as template_type",
+  "certificate_templates.font_family as template_font_family",
+  "certificate_templates.title_font as template_title_font",
+  "certificate_templates.border_color as template_border_color",
+  "certificate_templates.logo as template_logo",
+  "certificate_templates.background as template_background",
+  "certificate_templates.show_qr as template_show_qr",
+  "certificate_templates.active as template_active",
+  "certificate_templates.created_at as template_created_at",
+  "certificate_templates.updated_at as template_updated_at",
+];
+
+const TEMPLATE_ALIAS_KEYS = TEMPLATE_SELECT_FIELDS.map((field) => field.split(" as ")[1]);
+
+const applyTemplateJoin = (queryBuilder) =>
+  queryBuilder.leftJoin(
+    "certificate_templates",
+    "certificates.template_id",
+    "certificate_templates.id"
+  );
+
+const buildTemplateFromRow = (row) => {
+  if (!row) return null;
+
+  const templateId = row.template_id ?? row.templateId ?? row["certificates.template_id"];
+
+  if (!templateId) return null;
+
+  const template = {
+    id: templateId,
+    name: row.template_name ?? row.templateName,
+    type: row.template_type ?? row.templateType,
+    font_family: row.template_font_family ?? row.templateFontFamily,
+    title_font: row.template_title_font ?? row.templateTitleFont,
+    border_color: row.template_border_color ?? row.templateBorderColor,
+    logo: row.template_logo ?? row.templateLogo,
+    background: row.template_background ?? row.templateBackground,
+    show_qr: row.template_show_qr ?? row.templateShowQr,
+    active: row.template_active ?? row.templateActive,
+    created_at: row.template_created_at ?? row.templateCreatedAt,
+    updated_at: row.template_updated_at ?? row.templateUpdatedAt,
+  };
+
+  const hasData = Object.values(template).some(
+    (value) => value !== undefined && value !== null
+  );
+
+  return hasData ? template : null;
+};
+
+const formatCertificateRow = (row) => {
+  if (!row) return row;
+
+  const formatted = { ...row };
+  const template = buildTemplateFromRow(row);
+
+  TEMPLATE_ALIAS_KEYS.forEach((key) => {
+    delete formatted[key];
+  });
+
+  if (template) {
+    formatted.template = template;
+  }
+
+  return formatted;
+};
+
+module.exports = {
+  TEMPLATE_SELECT_FIELDS,
+  applyTemplateJoin,
+  formatCertificateRow,
+};

--- a/backend/src/modules/certificates/certificates.controller.js
+++ b/backend/src/modules/certificates/certificates.controller.js
@@ -4,6 +4,7 @@
 const service = require("./certificates.service");
 const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
+const AppError = require("../../utils/AppError");
 
 /**
  * List all certificates
@@ -12,4 +13,15 @@ exports.list = catchAsync(async (req, res) => {
   const { page = 1, limit = 10 } = req.query;
   const certificates = await service.getAll({ page, limit });
   sendSuccess(res, certificates);
+});
+
+exports.getById = catchAsync(async (req, res) => {
+  const { id } = req.params;
+  const certificate = await service.getById(id);
+
+  if (!certificate) {
+    throw new AppError("Certificate not found", 404);
+  }
+
+  sendSuccess(res, certificate);
 });

--- a/backend/src/modules/certificates/certificates.routes.js
+++ b/backend/src/modules/certificates/certificates.routes.js
@@ -8,5 +8,6 @@ const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware")
 router.use(verifyToken, isAdmin);
 
 router.get("/", ctrl.list);
+router.get("/:id", ctrl.getById);
 
 module.exports = router;

--- a/backend/src/modules/certificates/certificates.service.js
+++ b/backend/src/modules/certificates/certificates.service.js
@@ -2,6 +2,11 @@
  * Certificate admin service
  */
 const db = require("../../config/database");
+const {
+  TEMPLATE_SELECT_FIELDS,
+  applyTemplateJoin,
+  formatCertificateRow,
+} = require("./certificate.utils");
 
 /**
  * Fetch all certificates with related student and class info
@@ -12,15 +17,42 @@ const { parsePagination } = require("../../utils/pagination");
 exports.getAll = async ({ page = 1, limit = 10 } = {}) => {
   const { limit: lim, offset } = parsePagination({ page, limit });
 
-  return db("certificates")
+  const query = db("certificates")
     .leftJoin("users", "certificates.user_id", "users.id")
-    .leftJoin("online_classes", "certificates.class_id", "online_classes.id")
+    .leftJoin("online_classes", "certificates.class_id", "online_classes.id");
+
+  applyTemplateJoin(query);
+
+  const rows = await query
     .select(
       "certificates.*",
       "users.full_name as student_name",
-      "online_classes.title as class_name"
+      "online_classes.title as class_name",
+      ...TEMPLATE_SELECT_FIELDS
     )
     .orderBy("certificates.created_at", "desc")
     .offset(offset)
     .limit(lim);
+
+  return rows.map(formatCertificateRow);
+};
+
+exports.getById = async (id) => {
+  const query = db("certificates")
+    .leftJoin("users", "certificates.user_id", "users.id")
+    .leftJoin("online_classes", "certificates.class_id", "online_classes.id");
+
+  applyTemplateJoin(query);
+
+  const row = await query
+    .select(
+      "certificates.*",
+      "users.full_name as student_name",
+      "online_classes.title as class_name",
+      ...TEMPLATE_SELECT_FIELDS
+    )
+    .where("certificates.id", id)
+    .first();
+
+  return formatCertificateRow(row);
 };

--- a/backend/src/modules/users/tutorials/certificate/certificate.service.js
+++ b/backend/src/modules/users/tutorials/certificate/certificate.service.js
@@ -1,5 +1,10 @@
 const db = require("../../../../config/database");
 const { v4: uuidv4 } = require("uuid");
+const {
+  TEMPLATE_SELECT_FIELDS,
+  applyTemplateJoin,
+  formatCertificateRow,
+} = require("../../../certificates/certificate.utils");
 
 // Generate a unique certificate code
 const generateCode = () => {
@@ -38,10 +43,27 @@ const isUserCompletedTutorial = async (userId, tutorialId) => {
 };
 
 // Check if certificate already exists
+const buildTemplateAwareQuery = () => {
+  const query = db("certificates");
+  applyTemplateJoin(query);
+  return query.select("certificates.*", ...TEMPLATE_SELECT_FIELDS);
+};
+
 const findExisting = async (userId, tutorialId) => {
-  return await db("certificates")
-    .where({ user_id: userId, tutorial_id: tutorialId })
+  const row = await buildTemplateAwareQuery()
+    .where("certificates.user_id", userId)
+    .where("certificates.tutorial_id", tutorialId)
     .first();
+
+  return formatCertificateRow(row);
+};
+
+const findById = async (id) => {
+  const row = await buildTemplateAwareQuery()
+    .where("certificates.id", id)
+    .first();
+
+  return formatCertificateRow(row);
 };
 
 // Create a new certificate
@@ -64,5 +86,6 @@ module.exports = {
   generateCode,
   isUserCompletedTutorial,
   findExisting,
+  findById,
   issueCertificate,
 };

--- a/backend/src/modules/users/tutorials/certificate/certificatePublic.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/certificatePublic.controller.js
@@ -2,22 +2,32 @@ const db = require("../../../../config/database");
 const catchAsync = require("../../../../utils/catchAsync");
 const { sendSuccess } = require("../../../../utils/response");
 const AppError = require("../../../../utils/AppError");
+const {
+  TEMPLATE_SELECT_FIELDS,
+  applyTemplateJoin,
+  formatCertificateRow,
+} = require("../../../certificates/certificate.utils");
 
 exports.verifyByCode = catchAsync(async (req, res) => {
   const { code } = req.params;
 
-  const cert = await db("certificates")
+  const query = db("certificates")
     .leftJoin("users", "users.id", "certificates.user_id")
-    .leftJoin("tutorials", "tutorials.id", "certificates.tutorial_id")
+    .leftJoin("tutorials", "tutorials.id", "certificates.tutorial_id");
+
+  applyTemplateJoin(query);
+
+  const cert = await query
     .select(
       "certificates.*",
       "users.full_name as user_name",
-      "tutorials.title as tutorial_title"
+      "tutorials.title as tutorial_title",
+      ...TEMPLATE_SELECT_FIELDS
     )
     .where("certificates.certificate_code", code)
     .first();
 
   if (!cert) throw new AppError("Certificate not found", 404);
 
-  sendSuccess(res, cert, "Certificate verified");
+  sendSuccess(res, formatCertificateRow(cert), "Certificate verified");
 });

--- a/frontend/src/pages/dashboard/instructor/certificates/preview/[id].js
+++ b/frontend/src/pages/dashboard/instructor/certificates/preview/[id].js
@@ -1,9 +1,89 @@
 // pages/dashboard/instructor/certificates/preview/[id].js
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import QRCode from "react-qr-code";
 import { getCertificate } from "@/services/instructor/certificateService";
+
+const FALLBACK_BACKGROUND = "/images/paper-texture.png";
+const FALLBACK_LOGO = "/images/certificate/logo.png";
+const FALLBACK_BORDER_COLOR = "#FACC15";
+const FALLBACK_FONT_FAMILY = "Georgia, serif";
+const FALLBACK_TITLE_FONT = "'Great Vibes', cursive";
+
+const firstDefined = (...values) =>
+  values.find((value) => value !== undefined && value !== null && value !== "");
+
+const sanitizeAsset = (value, fallback) =>
+  typeof value === "string" && value.trim().length > 0 ? value : fallback;
+
+const deriveTemplateSettings = (certificate) => {
+  const template = certificate?.template ?? {};
+
+  const borderColor =
+    firstDefined(
+      template.border_color,
+      template.borderColor,
+      certificate?.border_color,
+      certificate?.borderColor,
+      FALLBACK_BORDER_COLOR
+    ) || FALLBACK_BORDER_COLOR;
+
+  const fontFamily =
+    firstDefined(
+      template.font_family,
+      template.fontFamily,
+      certificate?.font_family,
+      certificate?.fontFamily,
+      FALLBACK_FONT_FAMILY
+    ) || FALLBACK_FONT_FAMILY;
+
+  const titleFont =
+    firstDefined(
+      template.title_font,
+      template.titleFont,
+      certificate?.title_font,
+      certificate?.titleFont,
+      FALLBACK_TITLE_FONT
+    ) || FALLBACK_TITLE_FONT;
+
+  const background = sanitizeAsset(
+    firstDefined(
+      template.background,
+      template.backgroundUrl,
+      certificate?.background,
+      certificate?.backgroundImage
+    ),
+    FALLBACK_BACKGROUND
+  );
+
+  const logo = sanitizeAsset(
+    firstDefined(
+      template.logo,
+      template.logoUrl,
+      certificate?.logo,
+      certificate?.logoUrl
+    ),
+    FALLBACK_LOGO
+  );
+
+  const showQrPreference = firstDefined(
+    template.show_qr,
+    template.showQr,
+    certificate?.show_qr,
+    certificate?.showQR
+  );
+
+  return {
+    borderColor,
+    fontFamily,
+    titleFont,
+    background,
+    logo,
+    accentColor: borderColor,
+    showQR: showQrPreference === undefined ? true : Boolean(showQrPreference),
+  };
+};
 
 export default function CertificatePreviewPage() {
   const router = useRouter();
@@ -12,6 +92,11 @@ export default function CertificatePreviewPage() {
   const [certificate, setCertificate] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+
+  const templateSettings = useMemo(
+    () => deriveTemplateSettings(certificate),
+    [certificate]
+  );
 
   useEffect(() => {
     const load = async () => {
@@ -34,6 +119,32 @@ export default function CertificatePreviewPage() {
   if (loading) return <div className="text-gray-700 p-10">Loading certificate...</div>;
   if (error) return <div className="text-red-500 p-10">{error}</div>;
   if (!certificate) return null;
+
+  const {
+    borderColor,
+    fontFamily,
+    titleFont,
+    background,
+    logo,
+    accentColor,
+    showQR,
+  } = templateSettings;
+
+  const formattedIssueDate = certificate.issueDate
+    ? new Date(certificate.issueDate).toLocaleDateString()
+    : "N/A";
+
+  const certificateSerial = certificate.id
+    ? certificate.id.slice(0, 6).toUpperCase()
+    : "------";
+
+  const verificationUrl = firstDefined(
+    certificate.verificationUrl,
+    certificate.verification_url,
+    certificate.verificationLink,
+    certificate.verification_link,
+    certificate.id ? `https://yourplatform.com/certificate/verify/${certificate.id}` : ""
+  );
 
   return (
     <InstructorLayout>
@@ -67,21 +178,28 @@ export default function CertificatePreviewPage() {
         {/* ✅ Print Area */}
         <div className="certificate-print-area">
           {/* Certificate Card */}
-          <div className="w-full max-w-4xl bg-white border-[12px] border-yellow-400 rounded-2xl p-12 text-center shadow-2xl relative" style={{
-            backgroundImage: "url('/images/paper-texture.png')",
-            backgroundSize: "cover",
-            backgroundRepeat: "no-repeat",
-            backgroundPosition: "center",
-            fontFamily: "Georgia, serif",
-          }}>
+          <div
+            className="w-full max-w-4xl bg-white border-[12px] rounded-2xl p-12 text-center shadow-2xl relative"
+            style={{
+              backgroundImage: `url('${background}')`,
+              backgroundSize: "cover",
+              backgroundRepeat: "no-repeat",
+              backgroundPosition: "center",
+              fontFamily,
+              borderColor,
+            }}
+          >
 
             {/* Logo inside certificate */}
             <div className="w-full flex justify-center mb-4">
-              <img src="/images/certificate/logo.png" alt="SkillBridge Logo" className="w-32" />
+              <img src={logo} alt="SkillBridge Logo" className="w-32" />
             </div>
 
             {/* Certificate Title */}
-            <h1 className="text-5xl font-bold text-yellow-600 mb-8" style={{ fontFamily: "'Great Vibes', cursive" }}>
+            <h1
+              className="text-5xl font-bold mb-8"
+              style={{ fontFamily: titleFont, color: accentColor }}
+            >
               Certificate of Completion
             </h1>
 
@@ -102,15 +220,15 @@ export default function CertificatePreviewPage() {
 
             {/* Issue Date and Serial */}
             <p className="text-sm text-gray-500 mb-2">
-              Issued on: <strong>{new Date(certificate.issueDate).toLocaleDateString()}</strong>
+              Issued on: <strong>{formattedIssueDate}</strong>
             </p>
             <p className="text-sm text-gray-500 mb-8">
-              Serial Number: <strong>CERT-{certificate.id.slice(0, 6).toUpperCase()}</strong>
+              Serial Number: <strong>CERT-{certificateSerial}</strong>
             </p>
 
             {/* Bottom Signature / QR Section */}
             <div className="flex justify-between items-center px-8 mt-10">
-              
+
               {/* Instructor Signature */}
               <div className="text-center">
                 <p className="text-sm text-gray-500">Instructor</p>
@@ -119,12 +237,14 @@ export default function CertificatePreviewPage() {
               </div>
 
               {/* QR Code */}
-              <div className="text-center">
-                <div className="bg-white p-2 rounded-lg inline-block">
-                  <QRCode value={`https://yourplatform.com/certificate/verify/${certificate.id}`} size={80} />
+              {showQR && verificationUrl && (
+                <div className="text-center">
+                  <div className="bg-white p-2 rounded-lg inline-block">
+                    <QRCode value={verificationUrl} size={80} />
+                  </div>
+                  <p className="text-[10px] text-gray-500 mt-1">Scan to Verify</p>
                 </div>
-                <p className="text-[10px] text-gray-500 mt-1">Scan to Verify</p>
-              </div>
+              )}
 
               {/* Platform Signature */}
               <div className="text-center">
@@ -140,7 +260,8 @@ export default function CertificatePreviewPage() {
         {/* ✅ Print Button */}
         <button
           onClick={() => window.print()}
-          className="mt-8 bg-yellow-500 hover:bg-yellow-600 text-black font-bold py-2 px-6 rounded-lg shadow-md"
+          className="mt-8 text-black font-bold py-2 px-6 rounded-lg shadow-md"
+          style={{ backgroundColor: accentColor }}
         >
           📄 Print Certificate
         </button>
@@ -149,7 +270,3 @@ export default function CertificatePreviewPage() {
     </InstructorLayout>
   );
 }
-// iomportant NotebookTabs
-
-
-// we did admin certifcate templats so it pulled from it

--- a/frontend/src/services/admin/certificateService.js
+++ b/frontend/src/services/admin/certificateService.js
@@ -2,6 +2,10 @@
 // Admin Certificates API helpers
 // ─────────────────────────────────────────────────────────
 import api from "@/services/api/api";
+import {
+  normalizeCertificate,
+  normalizeCertificates,
+} from "@/services/certificates/transformers";
 
 /**
  * Fetch all certificates for admin
@@ -10,37 +14,37 @@ export const fetchAllCertificates = async (page = 1, limit = 10) => {
   const { data } = await api.get("/certificates/admin", {
     params: { page, limit },
   });
-  return data?.data ?? [];
+  return normalizeCertificates(data?.data);
 };
 
 /** Fetch single certificate details */
 export const getCertificate = async (id) => {
   const { data } = await api.get(`/certificates/admin/${id}`);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };
 
 /** Approve certificate */
 export const approveCertificate = async (id) => {
   const { data } = await api.patch(`/certificates/admin/${id}/approve`);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };
 
 /** Reject certificate */
 export const rejectCertificate = async (id) => {
   const { data } = await api.patch(`/certificates/admin/${id}/reject`);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };
 
 /** Issue certificate manually */
 export const issueCertificate = async (payload) => {
   const { data } = await api.post("/certificates/admin", payload);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };
 
 /** Update certificate */
 export const updateCertificate = async (id, payload) => {
   const { data } = await api.put(`/certificates/admin/${id}`, payload);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };
 
 /** Download certificate */

--- a/frontend/src/services/certificates/transformers.js
+++ b/frontend/src/services/certificates/transformers.js
@@ -1,0 +1,127 @@
+const firstDefined = (...values) =>
+  values.find((value) => value !== undefined && value !== null);
+
+const buildTemplate = (certificate = {}) => {
+  const baseTemplate =
+    certificate.template && Object.keys(certificate.template).length
+      ? { ...certificate.template }
+      : {};
+
+  const template = {
+    id: firstDefined(baseTemplate.id, certificate.template_id, certificate.templateId),
+    name: firstDefined(baseTemplate.name, certificate.template_name, certificate.templateName),
+    type: firstDefined(baseTemplate.type, certificate.template_type, certificate.templateType),
+    font_family: firstDefined(
+      baseTemplate.font_family,
+      baseTemplate.fontFamily,
+      certificate.template_font_family,
+      certificate.templateFontFamily,
+      certificate.font_family,
+      certificate.fontFamily
+    ),
+    title_font: firstDefined(
+      baseTemplate.title_font,
+      baseTemplate.titleFont,
+      certificate.template_title_font,
+      certificate.templateTitleFont,
+      certificate.title_font,
+      certificate.titleFont
+    ),
+    border_color: firstDefined(
+      baseTemplate.border_color,
+      baseTemplate.borderColor,
+      certificate.template_border_color,
+      certificate.templateBorderColor,
+      certificate.border_color,
+      certificate.borderColor
+    ),
+    logo: firstDefined(
+      baseTemplate.logo,
+      baseTemplate.logoUrl,
+      certificate.template_logo,
+      certificate.templateLogo,
+      certificate.logo,
+      certificate.logoUrl
+    ),
+    background: firstDefined(
+      baseTemplate.background,
+      baseTemplate.backgroundUrl,
+      certificate.template_background,
+      certificate.templateBackground,
+      certificate.background,
+      certificate.backgroundImage
+    ),
+    show_qr: firstDefined(
+      baseTemplate.show_qr,
+      baseTemplate.showQr,
+      certificate.template_show_qr,
+      certificate.templateShowQr,
+      certificate.show_qr,
+      certificate.showQR
+    ),
+    active: firstDefined(
+      baseTemplate.active,
+      certificate.template_active,
+      certificate.templateActive
+    ),
+    created_at: firstDefined(
+      baseTemplate.created_at,
+      certificate.template_created_at,
+      certificate.templateCreatedAt
+    ),
+    updated_at: firstDefined(
+      baseTemplate.updated_at,
+      certificate.template_updated_at,
+      certificate.templateUpdatedAt
+    ),
+  };
+
+  const hasData = Object.values(template).some(
+    (value) => value !== undefined && value !== null
+  );
+
+  return hasData ? template : undefined;
+};
+
+export const normalizeCertificate = (certificate) => {
+  if (!certificate) return certificate;
+
+  const normalized = { ...certificate };
+
+  const ensureField = (key, ...fallbacks) => {
+    if (normalized[key] !== undefined && normalized[key] !== null) {
+      return;
+    }
+
+    const value = firstDefined(...fallbacks);
+    if (value !== undefined) {
+      normalized[key] = value;
+    }
+  };
+
+  ensureField("studentName", certificate.student_name);
+  ensureField(
+    "courseTitle",
+    certificate.course_title,
+    certificate.className,
+    certificate.class_name
+  );
+  ensureField("className", certificate.class_name, normalized.courseTitle);
+  ensureField("issueDate", certificate.issue_date, certificate.issued_at);
+  ensureField("status", certificate.status_text);
+  ensureField("instructorName", certificate.instructor_name);
+  ensureField("platformName", certificate.platform_name);
+  ensureField("grade", certificate.final_grade);
+
+  const template = buildTemplate(certificate);
+  if (template) {
+    normalized.template = template;
+  }
+
+  return normalized;
+};
+
+export const normalizeCertificates = (items) => {
+  if (!Array.isArray(items)) return [];
+  return items.map(normalizeCertificate);
+};

--- a/frontend/src/services/instructor/certificateService.js
+++ b/frontend/src/services/instructor/certificateService.js
@@ -2,15 +2,19 @@
 // Instructor Certificates API helpers
 // ─────────────────────────────────────────────────────────
 import api from "@/services/api/api";
+import {
+  normalizeCertificate,
+  normalizeCertificates,
+} from "@/services/certificates/transformers";
 
 export const fetchCertificates = async () => {
   const { data } = await api.get("/certificates/instructor");
-  return data?.data ?? [];
+  return normalizeCertificates(data?.data);
 };
 
 export const getCertificate = async (id) => {
   const { data } = await api.get(`/certificates/instructor/${id}`);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };
 
 export const deleteCertificate = async (id) => {
@@ -19,7 +23,7 @@ export const deleteCertificate = async (id) => {
 
 export const issueCertificate = async (payload) => {
   const { data } = await api.post("/certificates/instructor", payload);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };
 
 export const downloadCertificate = async (id) => {

--- a/frontend/src/services/student/certificateService.js
+++ b/frontend/src/services/student/certificateService.js
@@ -2,15 +2,19 @@
 // Student Certificates API helpers
 // ─────────────────────────────────────────────────────────
 import api from "@/services/api/api";
+import {
+  normalizeCertificate,
+  normalizeCertificates,
+} from "@/services/certificates/transformers";
 
 export const fetchCertificates = async () => {
   const { data } = await api.get("/certificates/student");
-  return data?.data ?? [];
+  return normalizeCertificates(data?.data);
 };
 
 export const getCertificate = async (id) => {
   const { data } = await api.get(`/certificates/student/${id}`);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };
 
 export const downloadCertificate = async (id) => {
@@ -22,10 +26,10 @@ export const downloadCertificate = async (id) => {
 
 export const issueCertificate = async (id) => {
   const { data } = await api.patch(`/certificates/student/${id}/issue`);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };
 
 export const revokeCertificate = async (id) => {
   const { data } = await api.patch(`/certificates/student/${id}/revoke`);
-  return data?.data;
+  return normalizeCertificate(data?.data);
 };


### PR DESCRIPTION
## Summary
- join certificate templates when querying certificates and expose the template payload through the admin and tutorial certificate services
- normalize certificate API responses on the frontend and feed template styling data into the instructor preview view with fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d77c4b12808328a57c49ad9d9d03bf