### PR TITLE
Add template selection for tutorial certificates

### DIFF
--- a/backend/src/modules/certificateTemplates/certificateTemplates.service.js
+++ b/backend/src/modules/certificateTemplates/certificateTemplates.service.js
@@ -49,3 +49,13 @@ exports.duplicate = async (id) => {
   const [row] = await db("certificate_templates").insert(newTemplate).returning("*");
   return row;
 };
+
+exports.getActiveByType = async (type) => {
+  if (!type) return null;
+
+  return db("certificate_templates")
+    .where({ type })
+    .andWhere({ active: true })
+    .orderBy("updated_at", "desc")
+    .first();
+};

--- a/backend/src/modules/certificates/certificates.service.js
+++ b/backend/src/modules/certificates/certificates.service.js
@@ -15,10 +15,23 @@ exports.getAll = async ({ page = 1, limit = 10 } = {}) => {
   return db("certificates")
     .leftJoin("users", "certificates.user_id", "users.id")
     .leftJoin("online_classes", "certificates.class_id", "online_classes.id")
+    .leftJoin(
+      "certificate_templates as template",
+      "certificates.template_id",
+      "template.id",
+    )
     .select(
       "certificates.*",
       "users.full_name as student_name",
-      "online_classes.title as class_name"
+      "online_classes.title as class_name",
+      "template.name as template_name",
+      "template.type as template_type",
+      "template.font_family as template_font_family",
+      "template.title_font as template_title_font",
+      "template.border_color as template_border_color",
+      "template.logo as template_logo",
+      "template.background as template_background",
+      "template.show_qr as template_show_qr"
     )
     .orderBy("certificates.created_at", "desc")
     .offset(offset)

--- a/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
+++ b/backend/src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js
@@ -58,7 +58,13 @@ describe("generate certificate route", () => {
     );
 
     expect(res.statusCode).toBe(200);
-    expect(service.issueCertificate).toHaveBeenCalled();
+    expect(service.issueCertificate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user1",
+        tutorialId: TUTORIAL_ID,
+        certificateType: "Completion",
+      }),
+    );
   });
 });
 

--- a/backend/src/modules/users/tutorials/certificate/certificate.service.js
+++ b/backend/src/modules/users/tutorials/certificate/certificate.service.js
@@ -1,5 +1,6 @@
 const db = require("../../../../config/database");
 const { v4: uuidv4 } = require("uuid");
+const certificateTemplateService = require("../../../certificateTemplates/certificateTemplates.service");
 
 // Generate a unique certificate code
 const generateCode = () => {
@@ -45,13 +46,24 @@ const findExisting = async (userId, tutorialId) => {
 };
 
 // Create a new certificate
-const issueCertificate = async ({ userId, tutorialId, templateId = null }) => {
+const issueCertificate = async ({
+  userId,
+  tutorialId,
+  templateId = null,
+  certificateType = "Completion",
+}) => {
+  let resolvedTemplateId = templateId;
+  if (!resolvedTemplateId && certificateType) {
+    const activeTemplate = await certificateTemplateService.getActiveByType(certificateType);
+    resolvedTemplateId = activeTemplate?.id || null;
+  }
+
   const newCert = {
     id: uuidv4(),
     user_id: userId,
     tutorial_id: tutorialId,
     class_id: null,
-    template_id: templateId,
+    template_id: resolvedTemplateId,
     certificate_code: generateCode(),
     status: "issued"
   };

--- a/backend/src/modules/users/tutorials/certificate/certificatePublic.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/certificatePublic.controller.js
@@ -9,10 +9,23 @@ exports.verifyByCode = catchAsync(async (req, res) => {
   const cert = await db("certificates")
     .leftJoin("users", "users.id", "certificates.user_id")
     .leftJoin("tutorials", "tutorials.id", "certificates.tutorial_id")
+    .leftJoin(
+      "certificate_templates as template",
+      "certificates.template_id",
+      "template.id",
+    )
     .select(
       "certificates.*",
       "users.full_name as user_name",
-      "tutorials.title as tutorial_title"
+      "tutorials.title as tutorial_title",
+      "template.name as template_name",
+      "template.type as template_type",
+      "template.font_family as template_font_family",
+      "template.title_font as template_title_font",
+      "template.border_color as template_border_color",
+      "template.logo as template_logo",
+      "template.background as template_background",
+      "template.show_qr as template_show_qr"
     )
     .where("certificates.certificate_code", code)
     .first();

--- a/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
+++ b/backend/src/modules/users/tutorials/certificate/tutorialCertificate.controller.js
@@ -6,6 +6,8 @@ const db = require("../../../../config/database");
 const notificationService = require("../../../notifications/notifications.service");
 const { requireUserAndTutorial } = require("../utils");
 
+const TUTORIAL_CERTIFICATE_TYPE = "Completion";
+
 exports.generateCertificate = catchAsync(async (req, res) => {
   const { userId, tutorialId } = requireUserAndTutorial(req);
 
@@ -22,7 +24,11 @@ exports.generateCertificate = catchAsync(async (req, res) => {
   if (existing) return sendSuccess(res, existing, "Certificate already issued");
 
   // 3. Create new
-  const newCert = await service.issueCertificate({ userId, tutorialId });
+  const newCert = await service.issueCertificate({
+    userId,
+    tutorialId,
+    certificateType: TUTORIAL_CERTIFICATE_TYPE,
+  });
 
   // 4. Notify user
   const tutorial = await db("tutorials").where({ id: tutorialId }).first();

--- a/backend/tests/certificatesService.test.js
+++ b/backend/tests/certificatesService.test.js
@@ -1,0 +1,199 @@
+const { newDb } = require('pg-mem');
+const { v4: uuidv4 } = require('uuid');
+
+const db = newDb();
+db.public.registerFunction({ name: 'uuid_generate_v4', returns: 'uuid', implementation: uuidv4 });
+const mockDb = db.adapters.createKnex();
+
+jest.mock('../src/config/database.js', () => mockDb);
+
+const certificateTemplatesService = require('../src/modules/certificateTemplates/certificateTemplates.service');
+const tutorialCertificateService = require('../src/modules/users/tutorials/certificate/certificate.service');
+const certificatesService = require('../src/modules/certificates/certificates.service');
+
+describe('certificate templates and certificates integration', () => {
+  beforeAll(async () => {
+    await mockDb.schema.createTable('certificate_templates', (table) => {
+      table.uuid('id').primary();
+      table.string('name');
+      table.string('type');
+      table.string('font_family');
+      table.string('title_font');
+      table.string('border_color');
+      table.text('logo');
+      table.text('background');
+      table.boolean('show_qr');
+      table.boolean('active');
+      table.timestamps(true, true);
+    });
+
+    await mockDb.schema.createTable('users', (table) => {
+      table.uuid('id').primary();
+      table.string('full_name');
+    });
+
+    await mockDb.schema.createTable('tutorials', (table) => {
+      table.uuid('id').primary();
+      table.string('title');
+    });
+
+    await mockDb.schema.createTable('online_classes', (table) => {
+      table.uuid('id').primary();
+      table.string('title');
+    });
+
+    await mockDb.schema.createTable('certificates', (table) => {
+      table.uuid('id').primary();
+      table.uuid('user_id');
+      table.uuid('tutorial_id');
+      table.uuid('class_id');
+      table.uuid('template_id');
+      table.string('certificate_code');
+      table.string('status');
+      table.timestamp('revoked_at');
+      table.string('reason');
+      table.timestamps(true, true);
+    });
+  });
+
+  afterAll(async () => {
+    await mockDb.destroy();
+  });
+
+  beforeEach(async () => {
+    await mockDb('certificates').del();
+    await mockDb('certificate_templates').del();
+    await mockDb('users').del();
+    await mockDb('tutorials').del();
+    await mockDb('online_classes').del();
+  });
+
+  it('returns the active template for a given type', async () => {
+    const inactiveId = uuidv4();
+    const activeId = uuidv4();
+
+    await mockDb('certificate_templates').insert([
+      {
+        id: inactiveId,
+        name: 'Inactive',
+        type: 'Completion',
+        font_family: 'Roboto',
+        title_font: 'Lora',
+        border_color: '#000000',
+        logo: 'logo-inactive.png',
+        background: 'bg-inactive.png',
+        show_qr: true,
+        active: false,
+        created_at: new Date('2023-01-01T00:00:00Z'),
+        updated_at: new Date('2023-01-01T00:00:00Z'),
+      },
+      {
+        id: activeId,
+        name: 'Active',
+        type: 'Completion',
+        font_family: 'Georgia',
+        title_font: 'Playfair',
+        border_color: '#FFFFFF',
+        logo: 'logo-active.png',
+        background: 'bg-active.png',
+        show_qr: false,
+        active: true,
+        created_at: new Date('2023-02-01T00:00:00Z'),
+        updated_at: new Date('2023-02-02T00:00:00Z'),
+      },
+    ]);
+
+    const activeTemplate = await certificateTemplatesService.getActiveByType('Completion');
+
+    expect(activeTemplate).toBeTruthy();
+    expect(activeTemplate.id).toBe(activeId);
+    expect(activeTemplate.name).toBe('Active');
+  });
+
+  it('stores the active template id when issuing tutorial certificates', async () => {
+    const templateId = uuidv4();
+    const userId = uuidv4();
+    const tutorialId = uuidv4();
+
+    await mockDb('certificate_templates').insert({
+      id: templateId,
+      name: 'Tutorial Template',
+      type: 'Completion',
+      font_family: 'Georgia, serif',
+      title_font: "'Great Vibes', cursive",
+      border_color: '#FACC15',
+      logo: 'logo.png',
+      background: 'bg.png',
+      show_qr: true,
+      active: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    await mockDb('users').insert({ id: userId, full_name: 'Student User' });
+    await mockDb('tutorials').insert({ id: tutorialId, title: 'Tutorial' });
+
+    const certificate = await tutorialCertificateService.issueCertificate({
+      userId,
+      tutorialId,
+      certificateType: 'Completion',
+    });
+
+    expect(certificate.template_id).toBe(templateId);
+
+    const stored = await mockDb('certificates').where({ id: certificate.id }).first();
+    expect(stored).toBeTruthy();
+    expect(stored.template_id).toBe(templateId);
+  });
+
+  it('includes template styling fields when fetching certificates', async () => {
+    const templateId = uuidv4();
+    const userId = uuidv4();
+    const classId = uuidv4();
+
+    await mockDb('users').insert({ id: userId, full_name: 'Jane Student' });
+    await mockDb('online_classes').insert({ id: classId, title: 'Physics 101' });
+    await mockDb('certificate_templates').insert({
+      id: templateId,
+      name: 'Class Template',
+      type: 'Completion',
+      font_family: 'Georgia, serif',
+      title_font: "'Great Vibes', cursive",
+      border_color: '#FACC15',
+      logo: 'logo.png',
+      background: 'bg.png',
+      show_qr: true,
+      active: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    const certificateId = uuidv4();
+    await mockDb('certificates').insert({
+      id: certificateId,
+      user_id: userId,
+      class_id: classId,
+      template_id: templateId,
+      certificate_code: 'CERT-123',
+      status: 'issued',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    const results = await certificatesService.getAll({ page: 1, limit: 10 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      id: certificateId,
+      template_id: templateId,
+      template_name: 'Class Template',
+      template_type: 'Completion',
+      template_font_family: 'Georgia, serif',
+      template_title_font: "'Great Vibes', cursive",
+      template_border_color: '#FACC15',
+      template_logo: 'logo.png',
+      template_background: 'bg.png',
+      template_show_qr: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a helper to fetch the active certificate template by type and leverage it while issuing tutorial certificates
- expand certificate queries to include template styling information for admin and public consumers
- add tests covering template selection, issuance, and template field exposure

## Testing
- npm test -- --runTestsByPath tests/certificatesService.test.js src/modules/users/tutorials/certificate/__tests__/tutorialCertificate.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d77daa9cac8328b381f55c5397634f