### PR TITLE
Normalize certificate API responses to camelCase

### DIFF
--- a/frontend/src/services/admin/certificateService.js
+++ b/frontend/src/services/admin/certificateService.js
@@ -2,6 +2,14 @@
 // Admin Certificates API helpers
 // ─────────────────────────────────────────────────────────
 import api from "@/services/api/api";
+import { toCamelCase } from "@/utils/case";
+
+const mapCertificateResponse = (payload) => {
+  if (payload === undefined || payload === null) {
+    return payload;
+  }
+  return toCamelCase(payload);
+};
 
 /**
  * Fetch all certificates for admin
@@ -10,37 +18,38 @@ export const fetchAllCertificates = async (page = 1, limit = 10) => {
   const { data } = await api.get("/certificates/admin", {
     params: { page, limit },
   });
-  return data?.data ?? [];
+  const certificates = data?.data ?? [];
+  return mapCertificateResponse(certificates) ?? [];
 };
 
 /** Fetch single certificate details */
 export const getCertificate = async (id) => {
   const { data } = await api.get(`/certificates/admin/${id}`);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };
 
 /** Approve certificate */
 export const approveCertificate = async (id) => {
   const { data } = await api.patch(`/certificates/admin/${id}/approve`);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };
 
 /** Reject certificate */
 export const rejectCertificate = async (id) => {
   const { data } = await api.patch(`/certificates/admin/${id}/reject`);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };
 
 /** Issue certificate manually */
 export const issueCertificate = async (payload) => {
   const { data } = await api.post("/certificates/admin", payload);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };
 
 /** Update certificate */
 export const updateCertificate = async (id, payload) => {
   const { data } = await api.put(`/certificates/admin/${id}`, payload);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };
 
 /** Download certificate */

--- a/frontend/src/services/instructor/certificateService.js
+++ b/frontend/src/services/instructor/certificateService.js
@@ -2,15 +2,24 @@
 // Instructor Certificates API helpers
 // ─────────────────────────────────────────────────────────
 import api from "@/services/api/api";
+import { toCamelCase } from "@/utils/case";
+
+const mapCertificateResponse = (payload) => {
+  if (payload === undefined || payload === null) {
+    return payload;
+  }
+  return toCamelCase(payload);
+};
 
 export const fetchCertificates = async () => {
   const { data } = await api.get("/certificates/instructor");
-  return data?.data ?? [];
+  const certificates = data?.data ?? [];
+  return mapCertificateResponse(certificates) ?? [];
 };
 
 export const getCertificate = async (id) => {
   const { data } = await api.get(`/certificates/instructor/${id}`);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };
 
 export const deleteCertificate = async (id) => {
@@ -19,7 +28,7 @@ export const deleteCertificate = async (id) => {
 
 export const issueCertificate = async (payload) => {
   const { data } = await api.post("/certificates/instructor", payload);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };
 
 export const downloadCertificate = async (id) => {

--- a/frontend/src/services/student/certificateService.js
+++ b/frontend/src/services/student/certificateService.js
@@ -2,15 +2,24 @@
 // Student Certificates API helpers
 // ─────────────────────────────────────────────────────────
 import api from "@/services/api/api";
+import { toCamelCase } from "@/utils/case";
+
+const mapCertificateResponse = (payload) => {
+  if (payload === undefined || payload === null) {
+    return payload;
+  }
+  return toCamelCase(payload);
+};
 
 export const fetchCertificates = async () => {
   const { data } = await api.get("/certificates/student");
-  return data?.data ?? [];
+  const certificates = data?.data ?? [];
+  return mapCertificateResponse(certificates) ?? [];
 };
 
 export const getCertificate = async (id) => {
   const { data } = await api.get(`/certificates/student/${id}`);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };
 
 export const downloadCertificate = async (id) => {
@@ -22,10 +31,10 @@ export const downloadCertificate = async (id) => {
 
 export const issueCertificate = async (id) => {
   const { data } = await api.patch(`/certificates/student/${id}/issue`);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };
 
 export const revokeCertificate = async (id) => {
   const { data } = await api.patch(`/certificates/student/${id}/revoke`);
-  return data?.data;
+  return mapCertificateResponse(data?.data);
 };

--- a/frontend/src/utils/case.js
+++ b/frontend/src/utils/case.js
@@ -13,3 +13,17 @@ export const toSnakeCase = (obj) => {
   }
   return obj;
 };
+
+export const toCamelCase = (obj) => {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => toCamelCase(item));
+  }
+  if (obj && typeof obj === "object" && obj.constructor === Object) {
+    return Object.entries(obj).reduce((acc, [key, value]) => {
+      const camelKey = key.replace(/_([a-z0-9])/g, (_, char) => char.toUpperCase());
+      acc[camelKey] = toCamelCase(value);
+      return acc;
+    }, {});
+  }
+  return obj;
+};


### PR DESCRIPTION
## Summary
- add a shared toCamelCase helper for transforming API payloads
- normalize admin, student, and instructor certificate service responses to camelCase so pages can consume live data

## Testing
- npm run lint *(fails: existing lint warnings/errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d77dacbf7c8328945e8d7288a3db44