### PR TITLE
Track server upload state for instructor class submissions

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -56,6 +56,7 @@ function CreateOnlineClass() {
     lessonCount: ''
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isServerUploading, setIsServerUploading] = useState(false);
   const [categories, setCategories] = useState([]);
   const [tagSuggestions, setTagSuggestions] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
@@ -206,7 +207,7 @@ function CreateOnlineClass() {
       }
       try {
         setIsSubmitting(true);
-        setVideoUploading(true);
+        setIsServerUploading(true);
         setUploadProgress(0);
 
         const payload = new FormData();
@@ -271,7 +272,7 @@ function CreateOnlineClass() {
         toast.error(error.response?.data?.message || 'Upload failed. Please try again.');
       } finally {
         setIsSubmitting(false);
-        setVideoUploading(false);
+        setIsServerUploading(false);
       }
     }
   };
@@ -569,7 +570,7 @@ function CreateOnlineClass() {
                       <div className="border-2 border-dashed border-gray-300 rounded-lg p-4 text-center">
                         <label className="cursor-pointer">
                           <div className="flex flex-col items-center justify-center space-y-2">
-                            {videoUploading ? (
+                            {videoUploading || isServerUploading ? (
                               <>
                                 <FaSpinner className="animate-spin text-yellow-500 text-2xl" />
                                 <p className="text-sm text-gray-600">Uploading... {uploadProgress}%</p>


### PR DESCRIPTION
## Summary
- add a dedicated server upload state to the instructor class creation page
- ensure the server upload state drives the video upload spinner during long submissions
- replace direct video upload flag toggling with the new server upload tracking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d78a577c3c8328b3dee1361b2bbe9c