### PR TITLE
Add server upload state handling to admin class creation

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -71,6 +71,7 @@ function CreateOnlineClass() {
     lessonCount: ''
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isServerUploading, setIsServerUploading] = useState(false);
   const [categories, setCategories] = useState([]);
   const [plans, setPlans] = useState([]);
   const [allTags, setAllTags] = useState([]);
@@ -771,7 +772,8 @@ function CreateOnlineClass() {
                 <button
                   type="button"
                   onClick={() => setCurrentStep(currentStep - 1)}
-                  className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500"
+                  disabled={isSubmitting || isServerUploading}
+                  className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {t('back')}
                 </button>
@@ -781,10 +783,10 @@ function CreateOnlineClass() {
 
               <button
                 type="submit"
-                disabled={isSubmitting}
+                disabled={isSubmitting || isServerUploading}
                 className="inline-flex items-center px-6 py-3 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-yellow-600 hover:bg-yellow-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {isSubmitting ? (
+                {isSubmitting || isServerUploading ? (
                   <>
                     <FaSpinner className="animate-spin mr-2" />
                     {currentStep === 1 ? t('processing') : t('submitting')}


### PR DESCRIPTION
## Summary
- add an `isServerUploading` state to the admin online class creation page
- disable navigation and submission actions while uploads are in progress
- reuse the existing spinner when either submitting or uploading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d78a5ad68c8328986c6653f1dd262f