### PR TITLE
Localize tutorial creation messaging

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/create.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/create.js
@@ -50,14 +50,14 @@ function CreateTutorialPage() {
       refreshMessages?.();
     } catch (err) {
       console.error(err);
-      const msg = err.response?.data?.message || t('creation_failed');
+      const msg = err.response?.data?.message || t('failed_create');
       toast.error(msg);
     }
   };
 
   const submitTutorial = async (status) => {
     if (tutorialData.chapters.some((ch) => !ch.videoUrl)) {
-      toast.error(t('video_required'));
+      toast.error(t('upload_video_each_lesson'));
       return;
     }
 
@@ -66,7 +66,7 @@ function CreateTutorialPage() {
     try {
       await createTutorial(formData);
       toast.success(
-        status === "draft" ? t('draft_success') : t('submit_success')
+        status === "draft" ? t('draft_saved') : t('submitted_success')
       );
       const msg =
         status === "draft"
@@ -80,7 +80,7 @@ function CreateTutorialPage() {
       if (err.response?.data?.message) {
         toast.error(err.response.data.message);
       } else {
-        toast.error(t('creation_failed'));
+        toast.error(t('failed_create'));
       }
     }
   };
@@ -96,10 +96,10 @@ function CreateTutorialPage() {
         {/* Step Progress */}
         <StepProgressBar
           steps={[
-            t('basic_info'),
-            t('curriculum'),
-            t('media'),
-            t('pricing_publish'),
+            t('step_basic_info'),
+            t('step_curriculum'),
+            t('step_media'),
+            t('step_pricing_publish'),
           ]}
           currentStep={step}
           onStepClick={(s) => {


### PR DESCRIPTION
## Summary
- switch the tutorial creation flow to use the existing `tutorialCreatePage` translation keys for step labels and toast messages
- fall back to the localized `failed_create` string when tutorial creation fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d790e4b5e48328b674fb266de2abd7