### PR TITLE
Fix create online class submit button rendering

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -790,9 +790,14 @@ function CreateOnlineClass() {
                   <>
                     <FaSpinner className="animate-spin mr-2" />
                     {t('server_upload_in_progress', { defaultValue: 'Server upload in progress...' })}
-                  </div>
+                  </>
+                ) : (
+                  <>
+                    <FaCheck className="mr-2" />
+                    {t('create_class')}
+                  </>
                 )}
-              </div>
+              </button>
             </div>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- repair the create-online-class submit button so the loading state fragment closes correctly and the idle state shows a label with an icon

## Testing
- npm run lint -- --fix *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d790fdd6e8832888b9ff0ba1a2e56e