### PR TITLE
Fix category selection normalization in BasicInfoStep

### DIFF
--- a/frontend/src/components/tutorials/create/BasicInfoStep.js
+++ b/frontend/src/components/tutorials/create/BasicInfoStep.js
@@ -227,8 +227,9 @@ export default function BasicInfoStep({ tutorialData, setTutorialData, onNext, c
           className="w-full p-2 border rounded mt-1"
           value={tutorialData.category}
           onChange={(e) => {
-            const selected = categories.find((c) => c.id === e.target.value);
-            handleChange("category", e.target.value);
+            const { value } = e.target;
+            const selected = categories.find((c) => String(c.id) === value);
+            handleChange("category", value);
             handleChange("categoryName", selected ? selected.name : "");
           }}
         >


### PR DESCRIPTION
## Summary
- normalize the category comparison when handling selection changes
- ensure the category identifier and display name stay in sync after choosing a category

## Testing
- npm run test -- ReviewStep *(fails: no matching tests found)*
- npm run test -- --passWithNoTests *(fails: existing suite has unrelated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d79abc3414832884e2daaa53e519e8