### PR TITLE
Fix back navigation handlers in tutorial edit wizard

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/[id]/edit.js
@@ -144,7 +144,7 @@ function EditTutorialPage() {
             tutorialData={tutorialData}
             setTutorialData={setTutorialData}
             onNext={onNext}
-            onPrev={onPrev}
+            onBack={onPrev}
           />
         )}
         {step === 3 && (
@@ -152,13 +152,13 @@ function EditTutorialPage() {
             tutorialData={tutorialData}
             setTutorialData={setTutorialData}
             onNext={onNext}
-            onPrev={onPrev}
+            onBack={onPrev}
           />
         )}
         {step === 4 && (
             <ReviewStep
               tutorialData={tutorialData}
-              onPrev={onPrev}
+              onBack={onPrev}
               actionLabel="Save Changes"
               onPublish={async () => {
                 const formData = buildTutorialFormData(tutorialData);


### PR DESCRIPTION
## Summary
- update the edit tutorial wizard to pass the `onBack` handler to Curriculum, Media, and Review steps so they receive the expected prop
- ensure step navigation wiring stays consistent by reusing the existing `onPrev` function as the back handler

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79abad99083289c004b782940eda5