### PR TITLE
Refine admin tutorials pagination and filters

### DIFF
--- a/frontend/src/components/dashboard/admin/tutorials/Filters.js
+++ b/frontend/src/components/dashboard/admin/tutorials/Filters.js
@@ -43,9 +43,9 @@ function Filters({
           }}
           className="p-2.5 border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
         >
-          <option value="All">All Categories</option>
+          <option value="">All Categories</option>
           {categories.map((cat) => (
-            <option key={cat.id} value={cat.name}>
+            <option key={cat.id} value={cat.id}>
               {cat.name}
             </option>
           ))}
@@ -59,7 +59,7 @@ function Filters({
           }}
           className="p-2.5 border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
         >
-          <option value="All">All Status</option>
+          <option value="">All Status</option>
           <option value={TUTORIAL_STATUS.PUBLISHED}>Published</option>
           <option value={TUTORIAL_STATUS.DRAFT}>Draft</option>
         </select>
@@ -72,7 +72,7 @@ function Filters({
           }}
           className="p-2.5 border rounded-lg focus:ring-2 focus:ring-yellow-300 focus:border-yellow-400"
         >
-          <option value="All">All Approval</option>
+          <option value="">All Approval</option>
           <option value="Approved">Approved</option>
           <option value="Pending">Pending</option>
           <option value="Rejected">Rejected</option>
@@ -81,9 +81,9 @@ function Filters({
         <Button
           onClick={() => {
             setSearchQuery("");
-            setFilterCategory("All");
-            setFilterStatus("All");
-            setFilterApproval("All");
+            setFilterCategory("");
+            setFilterStatus("");
+            setFilterApproval("");
             setCurrentPage(1);
           }}
           className="bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-2.5 rounded-lg border border-gray-300"

--- a/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
+++ b/frontend/src/components/dashboard/admin/tutorials/TutorialsTable.js
@@ -70,9 +70,9 @@ function TutorialsTable({
                     <Button
                       onClick={() => {
                         setSearchQuery("");
-                        setFilterCategory("All");
-                        setFilterStatus("All");
-                        setFilterApproval("All");
+                        setFilterCategory("");
+                        setFilterStatus("");
+                        setFilterApproval("");
                         setCurrentPage(1);
                       }}
                       className="mt-4 bg-gray-100 hover:bg-gray-200 text-gray-800"

--- a/frontend/src/hooks/admin/tutorials/useTutorialsData.js
+++ b/frontend/src/hooks/admin/tutorials/useTutorialsData.js
@@ -1,13 +1,58 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { toast } from "react-toastify";
 import { fetchAllCategories } from "@/services/admin/categoryService";
 import { fetchAllTutorials } from "@/services/admin/tutorialService";
 
-export default function useTutorialsData(t) {
+export default function useTutorialsData(
+  t,
+  { page = 1, pageSize = 10, filters = {} } = {},
+) {
   const [tutorials, setTutorials] = useState([]);
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [meta, setMeta] = useState(null);
+
+  const normalizedFilters = useMemo(() => {
+    if (!filters || typeof filters !== "object") return {};
+
+    return Object.entries(filters).reduce((acc, [key, value]) => {
+      if (value === undefined || value === null) return acc;
+
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (!trimmed || trimmed === "All") return acc;
+        acc[key] = trimmed;
+        return acc;
+      }
+
+      acc[key] = value;
+      return acc;
+    }, {});
+  }, [filters]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isMounted = true;
+
+    const loadCategories = async () => {
+      try {
+        const cats = await fetchAllCategories({}, { signal: controller.signal });
+        if (!isMounted) return;
+        setCategories(cats?.data || cats || []);
+      } catch (err) {
+        if (err.name === "AbortError" || err.name === "CanceledError") return;
+        console.error(err);
+        if (isMounted) toast.error(t("load_error"));
+      }
+    };
+
+    loadCategories();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [t]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -16,10 +61,10 @@ export default function useTutorialsData(t) {
     const loadData = async () => {
       try {
         setLoading(true);
-        const [tutorialResponse, cats] = await Promise.all([
-          fetchAllTutorials(undefined, undefined, { signal: controller.signal }),
-          fetchAllCategories({}, { signal: controller.signal }),
-        ]);
+        const tutorialResponse = await fetchAllTutorials(page, pageSize, {
+          signal: controller.signal,
+          params: normalizedFilters,
+        });
         if (!isMounted) return;
         const fetchedTutorials = Array.isArray(tutorialResponse)
           ? tutorialResponse
@@ -28,7 +73,6 @@ export default function useTutorialsData(t) {
           ? null
           : tutorialResponse?.meta || null;
         setTutorials(fetchedTutorials);
-        setCategories(cats?.data || cats || []);
         setMeta(paginationMeta || null);
       } catch (err) {
         if (err.name === "AbortError" || err.name === "CanceledError") return;
@@ -45,7 +89,7 @@ export default function useTutorialsData(t) {
       isMounted = false;
       controller.abort();
     };
-  }, [t]);
+  }, [page, pageSize, normalizedFilters, t]);
 
   return { tutorials, setTutorials, categories, loading, meta, setMeta };
 }

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -1,8 +1,7 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
-import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
 import { Button } from "@/components/ui/button";
 import { FaPlus } from "react-icons/fa";
@@ -35,27 +34,54 @@ import { TUTORIAL_STATUS } from "@/constants/tutorialStatus";
 function AdminTutorialsPage() {
   const { t } = useTranslation("dashboard", { keyPrefix: "tutorialsPage" });
   const router = useRouter();
+  const PAGE_SIZE = 10;
+  const [searchQuery, setSearchQuery] = useState("");
+  const [filterCategory, setFilterCategory] = useState("");
+  const [filterStatus, setFilterStatus] = useState("");
+  const [filterApproval, setFilterApproval] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const filterParams = useMemo(() => {
+    const search = searchQuery.trim();
+    return {
+      ...(search ? { search } : {}),
+      ...(filterStatus ? { status: filterStatus } : {}),
+      ...(filterCategory ? { category: filterCategory } : {}),
+      ...(filterApproval ? { approvalStatus: filterApproval } : {}),
+    };
+  }, [searchQuery, filterStatus, filterCategory, filterApproval]);
+
   const { tutorials, setTutorials, categories, loading, meta, setMeta } =
-    useTutorialsData(t);
+    useTutorialsData(t, {
+      page: currentPage,
+      pageSize: PAGE_SIZE,
+      filters: filterParams,
+    });
 
-  const {
-    searchQuery,
-    setSearchQuery,
-    filterCategory,
-    setFilterCategory,
-    filterStatus,
-    setFilterStatus,
-    filterApproval,
-    setFilterApproval,
-    currentPage,
-    setCurrentPage,
-    filteredTutorials,
-    paginatedTutorials,
-    totalPages,
-    startIndex,
-    goToPage,
-  } = useTutorialFilters(tutorials);
+  const totalResults = meta?.total ?? tutorials.length;
+  const totalPages =
+    meta?.totalPages ?? (totalResults > 0 ? Math.ceil(totalResults / PAGE_SIZE) : 0);
 
+  useEffect(() => {
+    if (totalPages === null || totalPages === undefined) return;
+    if (totalPages === 0) {
+      if (currentPage !== 1) setCurrentPage(1);
+      return;
+    }
+
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [totalPages, currentPage]);
+
+  const goToPage = (page) => {
+    if (!Number.isFinite(page)) return;
+    const maxPages = totalPages > 0 ? totalPages : 1;
+    const nextPage = Math.min(Math.max(page, 1), maxPages);
+    if (nextPage !== currentPage) {
+      setCurrentPage(nextPage);
+    }
+  };
 
   const {
     selectedTutorials,
@@ -63,19 +89,19 @@ function AdminTutorialsPage() {
     toggleSelectOne,
     toggleSelectAll,
     clearSelected,
-  } = useBulkSelection(paginatedTutorials, [
+  } = useBulkSelection(tutorials, [
     searchQuery,
     filterCategory,
     filterStatus,
     filterApproval,
+    currentPage,
   ]);
 
-  const totalResults = filteredTutorials.length;
-  const paginatedCount = paginatedTutorials.length;
+  const startIndex = totalResults === 0 ? 0 : (currentPage - 1) * PAGE_SIZE;
   const displayEndIndex =
     totalResults === 0
       ? 0
-      : Math.min(startIndex + paginatedCount, totalResults);
+      : Math.min(startIndex + tutorials.length, totalResults);
 
   const user = useAuthStore((state) => state.user);
   const refreshNotifications = useNotificationStore((state) => state.fetch);
@@ -381,7 +407,7 @@ function AdminTutorialsPage() {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div className="bg-white p-4 rounded-xl shadow border-l-4 border-green-500">
             <p className="text-gray-600">Total Tutorials</p>
-            <p className="text-2xl font-bold">{tutorials.length}</p>
+            <p className="text-2xl font-bold">{totalResults}</p>
           </div>
           <div className="bg-white p-4 rounded-xl shadow border-l-4 border-yellow-500">
             <p className="text-gray-600">Pending Approval</p>
@@ -406,7 +432,7 @@ function AdminTutorialsPage() {
         {/* TABLE */}
         <div className="bg-white rounded-xl shadow-md overflow-hidden">
           <TutorialsTable
-            paginatedTutorials={paginatedTutorials}
+            paginatedTutorials={tutorials}
             loading={loading}
             selectedTutorials={selectedTutorials}
             toggleSelectAll={toggleSelectAll}


### PR DESCRIPTION
## Summary
- extend the admin tutorials data hook to accept pagination/filter inputs and expose API metadata
- drive the admin tutorials dashboard from the new server-side pagination data and totals
- align filter controls and table reset logic with the API-friendly filter values

## Testing
- npm run lint --prefix frontend *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d79aa638e4832890811908ce159031