### PR TITLE
Handle tutorial status toggle response

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -94,12 +94,27 @@ function AdminTutorialsPage() {
         toast.error("Tutorial not found");
         return;
       }
-      await toggleTutorialStatus(id);
-      const newStatus =
+      const updated = await toggleTutorialStatus(id);
+      if (!updated) {
+        toast.error(t("update_failed"));
+        return;
+      }
+
+      const toggledStatus =
         existing.status === TUTORIAL_STATUS.PUBLISHED
           ? TUTORIAL_STATUS.DRAFT
           : TUTORIAL_STATUS.PUBLISHED;
-      const target = { ...existing, status: newStatus };
+
+      const resolvedStatus = updated.status ?? toggledStatus;
+      const moderationStatus =
+        updated.moderation_status ?? existing.approvalStatus ?? "Pending";
+
+      const target = {
+        ...existing,
+        status: resolvedStatus,
+        approvalStatus: moderationStatus,
+        rejectionReason: null,
+      };
       setTutorials((prev) =>
         prev.map((tut) =>
           tut.id === id

--- a/frontend/src/services/admin/tutorialService.js
+++ b/frontend/src/services/admin/tutorialService.js
@@ -74,7 +74,17 @@ export const permanentlyDeleteTutorial = async (id) => {
 
 export const toggleTutorialStatus = async (id) => {
   const { data } = await api.patch(`/users/tutorials/admin/${id}/status`);
-  return data?.data;
+  const payload = data?.data;
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const { status = null, moderation_status = null } = payload;
+
+  return {
+    status,
+    moderation_status,
+  };
 };
 
 export const approveTutorial = async (id) => {


### PR DESCRIPTION
## Summary
- update the admin tutorial toggle flow to use the API response for status and moderation state
- normalize the toggle service to return a structured payload for callers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79aa12f088328880e47be788fdcf8