### PR TITLE
Fix demo video URLs in admin and instructor views

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -6,7 +6,6 @@ import withAuthProtection from "@/hooks/withAuthProtection";
 import Link from "next/link";
 import { fetchAdminClassById } from "@/services/admin/classService";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
-import { safeEncodeURI } from "@/utils/url";
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../../next-i18next.config.js';
@@ -82,7 +81,7 @@ function AdminClassDetailPage() {
           <h3 className="text-sm font-medium text-gray-700">{t('adminClassDetailPage.class_demo_video')}</h3>
                 </div>
                 <CustomVideoPlayer
-                  videos={[{ src: safeEncodeURI(details.demo_video_url) }]}
+                  videos={[{ src: details.demo_video_url }]}
                 />
               </div>
             )}

--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
@@ -4,7 +4,6 @@ import Link from "next/link";
 import InstructorLayout from "@/components/layouts/InstructorLayout";
 import { fetchInstructorClassById } from "@/services/instructor/classService";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
-import { safeEncodeURI } from "@/utils/url";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import DOMPurify from "isomorphic-dompurify";
 
@@ -47,7 +46,7 @@ function InstructorClassDetailPage() {
           )}
           {details?.demo_video_url && (
             <div className="mt-4">
-              <CustomVideoPlayer videos={[{ src: safeEncodeURI(details.demo_video_url) }]} />
+              <CustomVideoPlayer videos={[{ src: details.demo_video_url }]} />
             </div>
           )}
 

--- a/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
+++ b/frontend/src/pages/dashboard/instructor/tutorials/[id]/view.js
@@ -13,7 +13,6 @@ import {
   FaRegComments,
 } from "react-icons/fa";
 import CustomVideoPlayer from "@/components/shared/CustomVideoPlayer";
-import { safeEncodeURI } from "@/utils/url";
 import ProgressChecklistModal from '@/components/tutorials/ProgressChecklistModal';
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { toast } from "react-toastify";
@@ -255,7 +254,7 @@ export default function ViewTutorialPage() {
           <h2 className="text-xl sm:text-2xl font-semibold text-gray-700 mb-2">{t("dashboard:tutorialViewPage.preview")}</h2>
           {tutorial.preview ? (
             <CustomVideoPlayer
-              videos={[{ src: safeEncodeURI(tutorial.preview) }]}
+              videos={[{ src: tutorial.preview }]}
             />
           ) : (
             <div className="w-full h-48 bg-gray-200 rounded-lg flex items-center justify-center text-gray-500">


### PR DESCRIPTION
## Summary
- pass demo and preview video URLs directly to the shared CustomVideoPlayer in admin/instructor dashboards
- drop the extra safeEncodeURI wrapping so reserved characters are preserved for playback

## Testing
- npm run lint *(aborted locally due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68d79a64c5f48328a1fe11f40b4aa89c