### PR TITLE
Fix admin class media URLs to use fallback base

### DIFF
--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -1,4 +1,5 @@
 import api from "@/services/api/api";
+import { API_BASE_URL } from "@/config/config";
 import { toDateInput } from "@/utils/date";
 import { safeEncodeURI } from "@/utils/url";
 import { computeScheduleStatus } from "@/utils/classSchedule";
@@ -9,15 +10,19 @@ const formatClass = (cls) => {
     ...rest,
     publishStatus: status,
     cover_image: cls.cover_image
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.cover_image}`
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`
       : null,
     demo_video_url: cls.demo_video_url
       ? safeEncodeURI(
-          `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.demo_video_url}`,
+          `${
+            process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL
+          }${cls.demo_video_url}`,
         )
       : null,
     instructor_image: cls.instructor_image
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}${cls.instructor_image}`
+      ? `${
+          process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL
+        }${cls.instructor_image}`
       : null,
     trending: Boolean(cls.trending),
 


### PR DESCRIPTION
## Summary
- import the shared API_BASE_URL constant into the admin class service
- update admin class media URL builders to fall back to the configured API base when the env var is missing

## Testing
- npm test -- AdminClassDetailSanitization

------
https://chatgpt.com/codex/tasks/task_e_68d79a61fe6c8328a21670b06903a828