### PR TITLE
Fix admin class creation category fetch handling

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -108,7 +108,7 @@ function CreateOnlineClass() {
 
   useEffect(() => {
     fetchAllCategories({ status: 'active', limit: 100 })
-      .then((res) => setCategories(res?.data || []))
+      .then((res) => setCategories(res || []))
       .catch(() => setCategories([]));
     fetchClassTags()
       .then(setAllTags)


### PR DESCRIPTION
## Summary
- store the categories array response directly when loading active categories in the admin class creation page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d79a6075748328ba8f8703ededa298