### PR TITLE
Fix category fetch handling

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -108,7 +108,7 @@ function CreateOnlineClass() {
 
   useEffect(() => {
     fetchAllCategories({ status: 'active', limit: 100 })
-      .then((res) => setCategories(res?.data || []))
+      .then((res) => setCategories(res || []))
       .catch(() => setCategories([]));
     fetchClassTags()
       .then(setAllTags)


### PR DESCRIPTION
## Summary
- update the admin online class creation page to store the fetched category array directly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d79a5a9d04832881f51cc1890cf5e1