### PR TITLE
Fix admin classes status filter handling

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -31,6 +31,25 @@ import {
   FaList
 } from "react-icons/fa";
 
+const BACKEND_STATUSES = new Set(["draft", "published", "archived"]);
+
+export const mapStatusFilterToQuery = (filterStatus) => {
+  if (!filterStatus || filterStatus === "All") {
+    return undefined;
+  }
+
+  const normalized = filterStatus.toLowerCase();
+  return BACKEND_STATUSES.has(normalized) ? normalized : undefined;
+};
+
+const shouldApplyScheduleFilter = (filterStatus) => {
+  if (!filterStatus || filterStatus === "All") {
+    return false;
+  }
+
+  return !BACKEND_STATUSES.has(filterStatus.toLowerCase());
+};
+
 export function compareValues(a, b, key) {
   const valA = a[key];
   const valB = b[key];
@@ -75,16 +94,35 @@ export default function AdminClassesTable() {
     const load = async () => {
       setLoading(true);
       try {
+        const statusQuery = mapStatusFilterToQuery(filterStatus);
         const { data, meta } = await fetchAdminClasses({
           page: currentPage,
           limit: itemsPerPage,
           filter: searchTerm,
           approval: filterApproval !== "All" ? filterApproval : undefined,
-          status: filterStatus !== "All" ? filterStatus : undefined,
+          status: statusQuery,
         });
-        setClassList(data.sort((a, b) => (a[sortKey] > b[sortKey] ? 1 : -1)));
-        setTotalPages(meta?.totalPages || 1);
-        setTotalItems(meta?.total || data.length);
+        const filteredData = shouldApplyScheduleFilter(filterStatus)
+          ? data.filter(
+              (cls) =>
+                cls.scheduleStatus?.toLowerCase() ===
+                filterStatus.toLowerCase()
+            )
+          : data;
+        const sortedData = [...filteredData].sort((a, b) =>
+          a[sortKey] > b[sortKey] ? 1 : -1
+        );
+        setClassList(sortedData);
+
+        if (shouldApplyScheduleFilter(filterStatus)) {
+          setTotalItems(filteredData.length);
+          setTotalPages(
+            Math.max(1, Math.ceil(filteredData.length / itemsPerPage))
+          );
+        } else {
+          setTotalPages(meta?.totalPages || 1);
+          setTotalItems(meta?.total ?? data.length);
+        }
       } catch (err) {
         console.error(err);
         toast.error("Failed to load classes");

--- a/frontend/tests/components/AdminClassesStatusFilter.test.js
+++ b/frontend/tests/components/AdminClassesStatusFilter.test.js
@@ -1,0 +1,47 @@
+import api from "@/services/api/api";
+import { fetchAdminClasses } from "@/services/admin/classService";
+import { mapStatusFilterToQuery } from "@/components/admin/online-classes/AdminClassesTable";
+
+jest.mock("@/services/api/api", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(() => Promise.resolve({ data: { data: [], meta: {} } })),
+  },
+}));
+
+describe("AdminClassesTable status filter integration", () => {
+  const scheduleFilters = ["All", "Upcoming", "Ongoing", "Completed"];
+  const backendStatuses = ["draft", "published", "archived", "Published"];
+
+  beforeEach(() => {
+    api.get.mockClear();
+  });
+
+  scheduleFilters.forEach((filter) => {
+    it(`omits the status query parameter when schedule filter "${filter}" is applied`, async () => {
+      await fetchAdminClasses({
+        page: 1,
+        limit: 5,
+        status: mapStatusFilterToQuery(filter),
+      });
+
+      const lastCall = api.get.mock.calls[api.get.mock.calls.length - 1][0];
+      expect(lastCall).toContain("/users/classes/admin?");
+      expect(lastCall).not.toContain("status=");
+    });
+  });
+
+  backendStatuses.forEach((status) => {
+    it(`passes backend status "${status}" through to the API query`, async () => {
+      await fetchAdminClasses({
+        page: 1,
+        limit: 5,
+        status: mapStatusFilterToQuery(status),
+      });
+
+      const lastCall = api.get.mock.calls[api.get.mock.calls.length - 1][0];
+      expect(lastCall).toContain("/users/classes/admin?");
+      expect(lastCall).toContain(`status=${status.toLowerCase()}`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add status filter helper to keep schedule filters client-side
- prevent schedule values from being sent to the admin classes API
- add a regression test that ensures the API URL remains correct for each filter choice

## Testing
- npm test -- AdminClassesStatusFilter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d79a570ed48328829862c71f23cf92