### PR TITLE
Refactor class rule modal to single text field

### DIFF
--- a/frontend/src/components/admin/online-classes/rules/RuleList.js
+++ b/frontend/src/components/admin/online-classes/rules/RuleList.js
@@ -32,16 +32,18 @@ export default function RuleList({ rules = [], onAdd, onUpdate, onDelete, canMan
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
-              <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Title</th>
-              <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Description</th>
-              {canManage && <th className="px-4 py-2 text-right text-sm font-medium text-gray-700">Actions</th>}
+              <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Rule</th>
+              {canManage && (
+                <th className="px-4 py-2 text-right text-sm font-medium text-gray-700">Actions</th>
+              )}
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {rules.map((rule) => (
               <tr key={rule.id}>
-                <td className="px-4 py-2">{rule.title}</td>
-                <td className="px-4 py-2">{rule.description}</td>
+                <td className="px-4 py-2 whitespace-pre-line">
+                  {rule.text || [rule.title, rule.description].filter(Boolean).join("\n")}
+                </td>
                 {canManage && (
                   <td className="px-4 py-2 text-right space-x-2">
                     <button
@@ -64,7 +66,7 @@ export default function RuleList({ rules = [], onAdd, onUpdate, onDelete, canMan
               <tr>
                 <td
                   className="px-4 py-4 text-center text-gray-500"
-                  colSpan={canManage ? 3 : 2}
+                  colSpan={canManage ? 2 : 1}
                 >
                   No rules found
                 </td>

--- a/frontend/src/components/admin/online-classes/rules/RuleModal.js
+++ b/frontend/src/components/admin/online-classes/rules/RuleModal.js
@@ -3,19 +3,23 @@ import Modal from "@/components/common/Modal";
 import { Button } from "@/components/ui/button";
 
 export default function RuleModal({ isOpen, onClose, initialData, onSave }) {
-  const [form, setForm] = useState({ title: "", description: "" });
+  const [text, setText] = useState(initialData?.text || "");
 
   useEffect(() => {
     if (initialData) {
-      setForm({ title: initialData.title || "", description: initialData.description || "" });
+      const legacyText = [initialData.title, initialData.description]
+        .filter(Boolean)
+        .join("\n")
+        .trim();
+      setText(initialData.text || legacyText || "");
     } else {
-      setForm({ title: "", description: "" });
+      setText("");
     }
   }, [initialData]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    onSave?.(form);
+    onSave?.({ text });
     onClose();
   };
 
@@ -27,22 +31,13 @@ export default function RuleModal({ isOpen, onClose, initialData, onSave }) {
     >
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium mb-1">Title</label>
-          <input
-            type="text"
-            value={form.title}
-            onChange={(e) => setForm({ ...form, title: e.target.value })}
-            className="w-full border border-gray-300 rounded px-3 py-2"
-            required
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">Description</label>
+          <label className="block text-sm font-medium mb-1">Rule</label>
           <textarea
-            value={form.description}
-            onChange={(e) => setForm({ ...form, description: e.target.value })}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
             className="w-full border border-gray-300 rounded px-3 py-2"
-            rows={3}
+            rows={4}
+            required
           />
         </div>
         <div className="flex justify-end gap-2">

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
@@ -36,18 +36,18 @@ function ClassRulesPage() {
       .finally(() => setLoading(false));
   }, [id]);
 
-  const handleAdd = async (payload) => {
+  const handleAdd = async ({ text }) => {
     try {
-      const created = await createClassRule(id, payload);
+      const created = await createClassRule(id, { text });
       if (created) setRules((prev) => [...prev, created]);
     } catch (err) {
       console.error('Failed to create rule', err);
     }
   };
 
-  const handleUpdate = async (ruleId, payload) => {
+  const handleUpdate = async (ruleId, { text }) => {
     try {
-      const updated = await updateClassRule(id, ruleId, payload);
+      const updated = await updateClassRule(id, ruleId, { text });
       if (updated) setRules((prev) => prev.map((r) => (r.id === ruleId ? updated : r)));
     } catch (err) {
       console.error('Failed to update rule', err);


### PR DESCRIPTION
## Summary
- update the admin class rule modal to capture a single rule text field and submit `{ text }`
- simplify the rules table to display the combined rule text with legacy fallbacks
- align the page handlers with the API by passing `{ text }` to create and update service calls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79a5257808328bc82be95f85b48bc