### PR TITLE
Handle legacy refresh token hashes

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -1,6 +1,7 @@
 const logger = require('../../../utils/logger.js');
 const redisClient = require("../../../utils/redisClient");
 const bcrypt = require("bcrypt");
+const crypto = require("crypto");
 const jwt = require("jsonwebtoken");
 const { v4: uuidv4 } = require("uuid");
 const userModel = require("../../users/user.model");
@@ -43,6 +44,72 @@ const LOGIN_ATTEMPT_PREFIX = "failedLogin:";
 const OTP_ATTEMPT_PREFIX = "otpAttempt:";
 const OTP_MAX_ATTEMPTS = 5;
 const OTP_LOCK_TIME = 15 * 60 * 1000; // 15 minutes
+
+// Bcrypt only hashes the first 72 bytes of input which can silently truncate
+// long refresh tokens. To avoid rejecting valid tokens we migrate to a SHA-256
+// based hash (stored as base64) while still accepting legacy bcrypt hashes
+// stored in the database. We also support the interim SHA-256 hex strings
+// produced during the initial rollout. Once those tokens expire naturally we
+// can remove the fallbacks.
+const BCRYPT_HASH_PREFIXES = ["$2a$", "$2b$", "$2y$"];
+
+const hashRefreshToken = (token) =>
+  crypto.createHash("sha256").update(token).digest();
+
+const encodeRefreshTokenHash = (buffer) => buffer.toString("base64");
+
+const decodeRefreshTokenHash = (storedHash) => {
+  if (!storedHash) return null;
+
+  // Preferred encoding going forward is base64 to guarantee shorter strings
+  try {
+    const base64Buffer = Buffer.from(storedHash, "base64");
+    if (base64Buffer.length === 32) {
+      return base64Buffer;
+    }
+  } catch (err) {
+    logger.debug("Failed to decode base64 refresh token hash", err);
+  }
+
+  // Legacy SHA-256 hashes stored as lowercase hex (introduced in previous fix)
+  try {
+    const hexBuffer = Buffer.from(storedHash, "hex");
+    if (hexBuffer.length === 32) {
+      return hexBuffer;
+    }
+  } catch (err) {
+    logger.debug("Failed to decode hex refresh token hash", err);
+  }
+
+  return null;
+};
+
+async function compareRefreshToken(token, storedHash) {
+  if (!storedHash) return false;
+
+  if (BCRYPT_HASH_PREFIXES.some((prefix) => storedHash.startsWith(prefix))) {
+    try {
+      return await bcrypt.compare(token, storedHash);
+    } catch (err) {
+      logger.warn("Failed to compare legacy bcrypt refresh token hash", err);
+      return false;
+    }
+  }
+
+  const tokenBuffer = hashRefreshToken(token);
+  const storedBuffer = decodeRefreshTokenHash(storedHash);
+
+  if (!storedBuffer || storedBuffer.length !== tokenBuffer.length) {
+    return false;
+  }
+
+  try {
+    return crypto.timingSafeEqual(tokenBuffer, storedBuffer);
+  } catch (err) {
+    logger.warn("Failed to compare refresh token hash", err);
+    return false;
+  }
+}
 
 async function getActivePasswordResetRequests(userId) {
   return db("password_resets")
@@ -374,7 +441,7 @@ async function issueRefreshToken(userId, roles = []) {
     { id: userId, role: primaryRole, roles: roleArr },
     jti
   );
-  const tokenHash = await bcrypt.hash(token, SALT_ROUNDS);
+  const tokenHash = encodeRefreshTokenHash(hashRefreshToken(token));
   const expiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE);
   await db("refresh_tokens").insert({
     id: jti,
@@ -399,7 +466,7 @@ exports.verifyRefreshToken = async (token) => {
   if (!row || row.revoked_at || row.expires_at < new Date()) {
     throw new Error("Invalid refresh token");
   }
-  const match = await bcrypt.compare(token, row.token_hash);
+  const match = await compareRefreshToken(token, row.token_hash);
   if (!match) throw new Error("Invalid refresh token");
   const roles = decoded.roles || (decoded.role ? [decoded.role] : []);
   const primaryRole = resolvePrimaryRole(roles, decoded.role);


### PR DESCRIPTION
## Summary
- store SHA-256 refresh token hashes using a base64 encoding to avoid column length truncation issues
- add decoding logic that supports base64 and legacy hex encodings alongside existing bcrypt fallbacks when validating refresh tokens

## Testing
- not run (tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d7a38ac3f88328b5e9527faa24ddb1