### PR TITLE
Handle lesson creation failures during admin class creation

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -82,6 +82,7 @@ function CreateOnlineClass() {
   const [isImageUploading, setIsImageUploading] = useState(false);
   const [isVideoUploading, setIsVideoUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
+  const [failedLessonIndices, setFailedLessonIndices] = useState([]);
 
   const demoPreview = formData.demoPreview;
 
@@ -248,6 +249,7 @@ function CreateOnlineClass() {
           start_time: ''
         }))
       }));
+      setFailedLessonIndices([]);
       setCurrentStep(2);
     } else {
       // Step 2 validation and submission
@@ -270,6 +272,7 @@ function CreateOnlineClass() {
         setIsSubmitting(true);
         setIsServerUploading(true);
         setUploadProgress(0);
+        setFailedLessonIndices([]);
 
         const payload = new FormData();
         payload.append('instructor_id', user?.id);
@@ -304,16 +307,38 @@ function CreateOnlineClass() {
           setUploadProgress(percent);
         });
 
-        await Promise.all(
+        const lessonResults = await Promise.allSettled(
           formData.lessons.map(async (lesson) => {
             const lessonData = new FormData();
             lessonData.append('title', lesson.title);
             if (lesson.duration) lessonData.append('duration', lesson.duration);
             if (lesson.resource) lessonData.append('resource', lesson.resource);
             lessonData.append('start_time', toDateTimeISO(lesson.start_time));
-            return createClassLesson(newClass.id, lessonData).catch(() => null);
+            return createClassLesson(newClass.id, lessonData);
           })
         );
+
+        const failedIndices = lessonResults.reduce((acc, result, index) => {
+          if (result.status === 'rejected') {
+            acc.push(index);
+          }
+          return acc;
+        }, []);
+
+        if (failedIndices.length) {
+          setFailedLessonIndices(failedIndices);
+          toast.error(
+            t('lesson_creation_failed', {
+              count: failedIndices.length,
+              indices: failedIndices.map((idx) => idx + 1).join(', '),
+              defaultValue: `Failed to create ${failedIndices.length} lesson(s). Please review highlighted lessons (${failedIndices
+                .map((idx) => idx + 1)
+                .join(', ')}).`,
+            })
+          );
+          setCurrentStep(2);
+          return;
+        }
 
         const events = [
           {
@@ -716,10 +741,12 @@ function CreateOnlineClass() {
                       {t('lesson_plan')}
                     </h2>
 
-                    {formData.lessons.map((lesson, index) => (
+                    {formData.lessons.map((lesson, index) => {
+                      const lessonHasError = failedLessonIndices.includes(index);
+                      return (
                       <div
                         key={index}
-                        className="border border-gray-200 rounded-lg p-4 bg-gray-50"
+                        className={`border rounded-lg p-4 ${lessonHasError ? 'border-red-300 bg-red-50' : 'border-gray-200 bg-gray-50'}`}
                       >
                         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
                           <div>
@@ -733,6 +760,7 @@ function CreateOnlineClass() {
                                 const updated = [...formData.lessons];
                                 updated[index].title = e.target.value;
                                 setFormData(prev => ({ ...prev, lessons: updated }));
+                                setFailedLessonIndices((prev) => prev.filter((i) => i !== index));
                               }}
                               className="w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500 text-sm"
                               placeholder={t('lesson_title_placeholder')}
@@ -750,6 +778,7 @@ function CreateOnlineClass() {
                                 const updated = [...formData.lessons];
                                 updated[index].duration = e.target.value;
                                 setFormData(prev => ({ ...prev, lessons: updated }));
+                                setFailedLessonIndices((prev) => prev.filter((i) => i !== index));
                               }}
                               className="w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500 text-sm"
                               placeholder={t('duration_placeholder')}
@@ -767,6 +796,7 @@ function CreateOnlineClass() {
                                 const updated = [...formData.lessons];
                                 updated[index].start_time = e.target.value;
                                 setFormData(prev => ({ ...prev, lessons: updated }));
+                                setFailedLessonIndices((prev) => prev.filter((i) => i !== index));
                               }}
                               className="w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500 text-sm"
                             />
@@ -784,6 +814,7 @@ function CreateOnlineClass() {
                                   const updated = [...formData.lessons];
                                   updated[index].resource = e.target.files[0];
                                   setFormData(prev => ({ ...prev, lessons: updated }));
+                                  setFailedLessonIndices((prev) => prev.filter((i) => i !== index));
                                 }}
                                 className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                               />
@@ -796,8 +827,17 @@ function CreateOnlineClass() {
                             </div>
                           </div>
                         </div>
+                        {lessonHasError && (
+                          <p className="mt-3 text-sm text-red-600">
+                            {t('lesson_failed_hint', {
+                              number: index + 1,
+                              defaultValue: `Lesson ${index + 1} failed to save. Please review the details and try again.`,
+                            })}
+                          </p>
+                        )}
                       </div>
-                    ))}
+                    );
+                    })}
                   </div>
                 )}
               </motion.div>


### PR DESCRIPTION
## Summary
- surface lesson creation failures by tracking rejected promises when creating an online class
- block redirects and highlight specific lessons so admins can correct and retry submissions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a7a937688328a12fee0decf4f88f