### PR TITLE
Fix local date normalization for admin class scheduling

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -30,7 +30,7 @@ import useScheduleStore from '@/store/schedule/scheduleStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
 import FloatingInput from '@/components/shared/FloatingInput';
-import { toDateTimeISO } from '@/utils/date';
+import { toDateTimeISO, toLocalDateStartISO } from '@/utils/date';
 import nextI18NextConfig from '../../../../../next-i18next.config.js';
 
 const ReactQuill = dynamic(() => import('react-quill'), {
@@ -278,9 +278,9 @@ function CreateOnlineClass() {
         if (formData.level) payload.append('level', formData.level);
         if (formData.language) payload.append('language', formData.language);
         if (formData.startDate)
-          payload.append('start_date', toDateTimeISO(formData.startDate));
+          payload.append('start_date', toLocalDateStartISO(formData.startDate));
         if (formData.endDate)
-          payload.append('end_date', toDateTimeISO(formData.endDate));
+          payload.append('end_date', toLocalDateStartISO(formData.endDate));
 
         payload.append('access_type', formData.accessType);
         if (formData.accessType === 'free') {
@@ -319,7 +319,7 @@ function CreateOnlineClass() {
           {
             id: `class-${newClass.id}`,
             title: `Class: ${newClass.title}`,
-            start: toDateTimeISO(formData.startDate || newClass.start_date),
+            start: toLocalDateStartISO(formData.startDate || newClass.start_date),
           },
           ...formData.lessons.map((l, idx) => ({
             id: `lesson-${newClass.id}-${idx}`,

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -14,6 +14,25 @@ export function toDateTimeISO(value) {
   return Number.isNaN(d.getTime()) ? value : d.toISOString();
 }
 
+export function toLocalDateStartISO(value) {
+  if (!value) return '';
+
+  if (value instanceof Date) {
+    const localStart = new Date(value.getFullYear(), value.getMonth(), value.getDate());
+    return Number.isNaN(localStart.getTime()) ? value : localStart.toISOString();
+  }
+
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value.trim())) {
+    const d = new Date(`${value}T00:00`);
+    return Number.isNaN(d.getTime()) ? value : d.toISOString();
+  }
+
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  const localStart = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  return localStart.toISOString();
+}
+
 export function formatDateTime(value) {
   if (!value) return '';
   const d = new Date(value);

--- a/frontend/tests/utils/date.test.js
+++ b/frontend/tests/utils/date.test.js
@@ -1,0 +1,22 @@
+const timeZones = ['UTC', 'America/Los_Angeles', 'Europe/Berlin', 'Asia/Tokyo'];
+
+describe('toLocalDateStartISO', () => {
+  const originalTZ = process.env.TZ;
+
+  afterAll(() => {
+    process.env.TZ = originalTZ;
+  });
+
+  test.each(timeZones)('preserves calendar day for %s', async (timeZone) => {
+    process.env.TZ = timeZone;
+    jest.resetModules();
+    const { toLocalDateStartISO } = await import('@/utils/date');
+
+    const iso = toLocalDateStartISO('2024-03-21');
+    const result = new Date(iso);
+
+    expect(result.getFullYear()).toBe(2024);
+    expect(result.getMonth()).toBe(2);
+    expect(result.getDate()).toBe(21);
+  });
+});


### PR DESCRIPTION
## Summary
- add a toLocalDateStartISO helper to normalize date-only values while preserving the user's calendar day
- use the helper when submitting class start/end dates and seeding admin dashboard schedule events
- cover the new helper with timezone-aware unit tests to guard against regressions

## Testing
- npm run test -- --runTestsByPath tests/utils/date.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d7a7c0a80083289019efc078c78086