### PR TITLE
Add instructor selection to online class creation

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -137,6 +137,11 @@
   "fill_required_fields": "يرجى تعبئة جميع الحقول المطلوبة",
   "complete_lesson_details": "يرجى استكمال تفاصيل الدرس",
   "user_info_unavailable": "معلومات المستخدم غير متاحة",
+  "select_instructor_placeholder": "اختر مدربًا",
+  "loading_instructors": "جارٍ تحميل المدربين...",
+  "select_instructor_required": "يرجى اختيار مدرب",
+  "selected_instructor_display": "المدرب المختار: {{name}}",
+  "instructors_load_failed": "تعذر تحميل المدربين",
   "step_of_total": "الخطوة {{current}} من {{total}}",
   "preview_alt": "معاينة",
   "dashboardPage": {

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -137,6 +137,11 @@
   "fill_required_fields": "Please fill in all required fields",
   "complete_lesson_details": "Please complete all lesson details",
   "user_info_unavailable": "User information unavailable",
+  "select_instructor_placeholder": "Wählen Sie einen Dozenten",
+  "loading_instructors": "Dozenten werden geladen...",
+  "select_instructor_required": "Bitte wählen Sie einen Dozenten aus",
+  "selected_instructor_display": "Ausgewählter Dozent: {{name}}",
+  "instructors_load_failed": "Dozenten konnten nicht geladen werden",
   "step_of_total": "Step {{current}} of {{total}}",
   "preview_alt": "Preview",
   "dashboardPage": {

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -137,6 +137,11 @@
   "fill_required_fields": "Please fill in all required fields",
   "complete_lesson_details": "Please complete all lesson details",
   "user_info_unavailable": "User information unavailable",
+  "select_instructor_placeholder": "Select an instructor",
+  "loading_instructors": "Loading instructors...",
+  "select_instructor_required": "Please select an instructor",
+  "selected_instructor_display": "Selected instructor: {{name}}",
+  "instructors_load_failed": "Failed to load instructors",
   "step_of_total": "Step {{current}} of {{total}}",
   "preview_alt": "Preview",
   "dashboardPage": {

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -137,6 +137,11 @@
   "fill_required_fields": "Complete todos los campos requeridos",
   "complete_lesson_details": "Complete todos los detalles de la lección",
   "user_info_unavailable": "Información del usuario no disponible",
+  "select_instructor_placeholder": "Selecciona un instructor",
+  "loading_instructors": "Cargando instructores...",
+  "select_instructor_required": "Por favor selecciona un instructor",
+  "selected_instructor_display": "Instructor seleccionado: {{name}}",
+  "instructors_load_failed": "No se pudieron cargar los instructores",
   "step_of_total": "Paso {{actual}} de {{Total}}",
   "preview_alt": "Avance",
   "dashboardPage": {

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -137,6 +137,11 @@
   "fill_required_fields": "Veuillez remplir tous les champs requis",
   "complete_lesson_details": "Veuillez compléter tous les détails de la leçon",
   "user_info_unavailable": "Informations utilisateur indisponibles",
+  "select_instructor_placeholder": "Sélectionnez un instructeur",
+  "loading_instructors": "Chargement des instructeurs...",
+  "select_instructor_required": "Veuillez sélectionner un instructeur",
+  "selected_instructor_display": "Instructeur sélectionné : {{name}}",
+  "instructors_load_failed": "Échec du chargement des instructeurs",
   "step_of_total": "Étape {{current}} sur {{total}}",
   "preview_alt": "Aperçu",
   "dashboardPage": {

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -137,6 +137,11 @@
   "fill_required_fields": "कृपया सभी अपेक्षित फ़ील्ड को भरें",
   "complete_lesson_details": "कृपया सभी पाठ विवरण पूरा करें",
   "user_info_unavailable": "उपयोगकर्ता जानकारी अनुपलब्ध है",
+  "select_instructor_placeholder": "किसी प्रशिक्षक का चयन करें",
+  "loading_instructors": "प्रशिक्षक लोड हो रहे हैं...",
+  "select_instructor_required": "कृपया एक प्रशिक्षक चुनें",
+  "selected_instructor_display": "चयनित प्रशिक्षक: {{name}}",
+  "instructors_load_failed": "प्रशिक्षकों को लोड नहीं किया जा सका",
   "step_of_total": "{{total}} का चरण {{current}}",
   "preview_alt": "पूर्व दर्शन",
   "dashboardPage": {

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -137,6 +137,11 @@
   "fill_required_fields": "Si prega di compilare tutti i campi richiesti",
   "complete_lesson_details": "Si prega di completare tutti i dettagli della lezione",
   "user_info_unavailable": "Informazioni sull'utente non disponibile",
+  "select_instructor_placeholder": "Seleziona un istruttore",
+  "loading_instructors": "Caricamento istruttori...",
+  "select_instructor_required": "Seleziona un istruttore",
+  "selected_instructor_display": "Istruttore selezionato: {{name}}",
+  "instructors_load_failed": "Impossibile caricare gli istruttori",
   "step_of_total": "Passaggio {{current}} di {{total}}",
   "preview_alt": "Anteprima",
   "dashboardPage": {

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -137,6 +137,11 @@
   "fill_required_fields": "请填写所有必填字段",
   "complete_lesson_details": "请完成所有课程详情",
   "user_info_unavailable": "用户信息不可用",
+  "select_instructor_placeholder": "选择讲师",
+  "loading_instructors": "正在加载讲师...",
+  "select_instructor_required": "请选择一位讲师",
+  "selected_instructor_display": "已选择的讲师：{{name}}",
+  "instructors_load_failed": "无法加载讲师",
   "step_of_total": "第 {{current}} 步，共 {{total}} 步",
   "preview_alt": "预览",
   "dashboardPage": {

--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -25,12 +25,14 @@ import { createAdminClass } from '@/services/admin/classService';
 import { fetchClassTags } from '@/services/admin/classTagService';
 import { createClassLesson } from '@/services/instructor/classService';
 import { fetchPlanIdentifiers } from '@/services/admin/planService';
+import { fetchAllInstructors } from '@/services/admin/instructorService';
 import useAuthStore from '@/store/auth/authStore';
 import useScheduleStore from '@/store/schedule/scheduleStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
 import FloatingInput from '@/components/shared/FloatingInput';
 import { toDateTimeISO } from '@/utils/date';
+import { getNormalizedRoles } from '@/utils/auth/roleUtils';
 import nextI18NextConfig from '../../../../../next-i18next.config.js';
 
 const ReactQuill = dynamic(() => import('react-quill'), {
@@ -52,7 +54,6 @@ function CreateOnlineClass() {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     title: '',
-    instructor: user?.full_name || '',
     category: '',
     level: '',
     language: '',
@@ -82,6 +83,10 @@ function CreateOnlineClass() {
   const [isImageUploading, setIsImageUploading] = useState(false);
   const [isVideoUploading, setIsVideoUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
+  const [instructorOptions, setInstructorOptions] = useState([]);
+  const [selectedInstructorId, setSelectedInstructorId] = useState('');
+  const [selectedInstructorName, setSelectedInstructorName] = useState('');
+  const [isLoadingInstructors, setIsLoadingInstructors] = useState(false);
 
   const demoPreview = formData.demoPreview;
 
@@ -119,10 +124,77 @@ function CreateOnlineClass() {
   }, []);
 
   useEffect(() => {
-    if (user?.full_name) {
-      setFormData((prev) => ({ ...prev, instructor: user.full_name }));
+    let isMounted = true;
+
+    const loadInstructors = async () => {
+      setIsLoadingInstructors(true);
+      try {
+        const { instructors: data } = await fetchAllInstructors(1, 100);
+        if (!isMounted) return;
+        let mapped = (data ?? []).map((inst) => ({
+          id: inst.id,
+          name: inst.full_name || inst.username || inst.email?.split('@')[0] || `#${inst.id}`,
+        }));
+        if (user?.id && !mapped.some((inst) => String(inst.id) === String(user.id))) {
+          mapped = [
+            ...mapped,
+            {
+              id: user.id,
+              name: user.full_name || user.username || user.email?.split('@')[0] || `#${user.id}`,
+            },
+          ];
+        }
+        setInstructorOptions(mapped);
+      } catch (error) {
+        if (isMounted) {
+          console.error('Failed to load instructors', error);
+          toast.error(t('instructors_load_failed', { defaultValue: 'Failed to load instructors' }));
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoadingInstructors(false);
+        }
+      }
+    };
+
+    loadInstructors();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [t, user]);
+
+  const normalizedRoles = useMemo(() => getNormalizedRoles(user), [user]);
+  const isInstructorUser = normalizedRoles.includes('instructor');
+
+  useEffect(() => {
+    if (!isInstructorUser || !user?.id || selectedInstructorId) {
+      return;
     }
-  }, [user]);
+    const match = instructorOptions.find((inst) => String(inst.id) === String(user.id));
+    if (match) {
+      setSelectedInstructorId(String(match.id));
+      setSelectedInstructorName(match.name);
+    }
+  }, [instructorOptions, isInstructorUser, selectedInstructorId, user]);
+
+  useEffect(() => {
+    if (!selectedInstructorId) {
+      setSelectedInstructorName('');
+      return;
+    }
+    const match = instructorOptions.find((inst) => String(inst.id) === String(selectedInstructorId));
+    if (match && match.name !== selectedInstructorName) {
+      setSelectedInstructorName(match.name);
+    }
+  }, [instructorOptions, selectedInstructorId, selectedInstructorName]);
+
+  const handleInstructorChange = (e) => {
+    const { value } = e.target;
+    setSelectedInstructorId(value);
+    const match = instructorOptions.find((inst) => String(inst.id) === String(value));
+    setSelectedInstructorName(match?.name || '');
+  };
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -239,6 +311,10 @@ function CreateOnlineClass() {
         toast.error(t('fill_required_fields'));
         return;
       }
+      if (!selectedInstructorId) {
+        toast.error(t('select_instructor_required', { defaultValue: 'Please select an instructor' }));
+        return;
+      }
       setFormData(prev => ({
         ...prev,
         lessons: Array.from({ length: count }, () => ({
@@ -266,13 +342,17 @@ function CreateOnlineClass() {
         toast.error(t('user_info_unavailable'));
         return;
       }
+      if (!selectedInstructorId) {
+        toast.error(t('select_instructor_required', { defaultValue: 'Please select an instructor' }));
+        return;
+      }
       try {
         setIsSubmitting(true);
         setIsServerUploading(true);
         setUploadProgress(0);
 
         const payload = new FormData();
-        payload.append('instructor_id', user?.id);
+        payload.append('instructor_id', selectedInstructorId);
         payload.append('title', formData.title);
         if (formData.description) payload.append('description', formData.description);
         if (formData.level) payload.append('level', formData.level);
@@ -388,13 +468,42 @@ function CreateOnlineClass() {
                         value={formData.title}
                         onChange={handleChange}
                       />
-                      <FloatingInput
-                        label={t('instructor_name_label')}
-                        name="instructor"
-                        value={formData.instructor}
-                        onChange={handleChange}
-                        disabled
-                      />
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                          {t('instructor_name_label')}
+                        </label>
+                        <div className="relative">
+                          <select
+                            name="instructor"
+                            value={selectedInstructorId}
+                            onChange={handleInstructorChange}
+                            disabled={isLoadingInstructors}
+                            className="w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500 text-sm pr-10"
+                          >
+                            <option value="">
+                              {isLoadingInstructors
+                                ? t('loading_instructors', { defaultValue: 'Loading instructors...' })
+                                : t('select_instructor_placeholder', { defaultValue: 'Select an instructor' })}
+                            </option>
+                            {instructorOptions.map((inst) => (
+                              <option key={inst.id} value={inst.id}>
+                                {inst.name}
+                              </option>
+                            ))}
+                          </select>
+                          {isLoadingInstructors && (
+                            <FaSpinner className="absolute right-3 top-1/2 -translate-y-1/2 animate-spin text-yellow-500" />
+                          )}
+                        </div>
+                        {selectedInstructorName && (
+                          <p className="mt-1 text-xs text-gray-500">
+                            {t('selected_instructor_display', {
+                              name: selectedInstructorName,
+                              defaultValue: `Selected instructor: ${selectedInstructorName}`,
+                            })}
+                          </p>
+                        )}
+                      </div>
 
                       <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">


### PR DESCRIPTION
## Summary
- load instructor options from the admin instructor service when creating an online class
- replace the disabled instructor field with a selectable instructor dropdown and validate the choice
- add translations for the instructor selector helper text and errors across locales

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a7bf2f688328b9b3cce27afa3c0a