### PR TITLE
Enforce end date validation when creating online classes

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -135,6 +135,7 @@
   "image_preview_failed": "فشل تحميل معاينة الصورة.",
   "video_size_exceeded": "يجب أن يكون الفيديو أقل من 100 ميجابايت",
   "fill_required_fields": "يرجى تعبئة جميع الحقول المطلوبة",
+  "end_date_before_start": "لا يمكن أن يكون تاريخ الانتهاء أسبق من تاريخ البدء.",
   "complete_lesson_details": "يرجى استكمال تفاصيل الدرس",
   "user_info_unavailable": "معلومات المستخدم غير متاحة",
   "step_of_total": "الخطوة {{current}} من {{total}}",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -135,6 +135,7 @@
   "image_preview_failed": "Failed to load image preview.",
   "video_size_exceeded": "Video must be less than 100MB",
   "fill_required_fields": "Please fill in all required fields",
+  "end_date_before_start": "Das Enddatum darf nicht vor dem Startdatum liegen.",
   "complete_lesson_details": "Please complete all lesson details",
   "user_info_unavailable": "User information unavailable",
   "step_of_total": "Step {{current}} of {{total}}",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -135,6 +135,7 @@
   "image_preview_failed": "Failed to load image preview.",
   "video_size_exceeded": "Video must be less than 100MB",
   "fill_required_fields": "Please fill in all required fields",
+  "end_date_before_start": "End date cannot be earlier than start date.",
   "complete_lesson_details": "Please complete all lesson details",
   "user_info_unavailable": "User information unavailable",
   "step_of_total": "Step {{current}} of {{total}}",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -135,6 +135,7 @@
   "image_preview_failed": "No se pudo cargar la vista previa de la imagen.",
   "video_size_exceeded": "El video debe ser menos de 100 MB",
   "fill_required_fields": "Complete todos los campos requeridos",
+  "end_date_before_start": "La fecha de finalización no puede ser anterior a la fecha de inicio.",
   "complete_lesson_details": "Complete todos los detalles de la lección",
   "user_info_unavailable": "Información del usuario no disponible",
   "step_of_total": "Paso {{actual}} de {{Total}}",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -135,6 +135,7 @@
   "image_preview_failed": "Échec du chargement de l'aperçu de l'image.",
   "video_size_exceeded": "La vidéo doit faire moins de 100MB",
   "fill_required_fields": "Veuillez remplir tous les champs requis",
+  "end_date_before_start": "La date de fin ne peut pas être antérieure à la date de début.",
   "complete_lesson_details": "Veuillez compléter tous les détails de la leçon",
   "user_info_unavailable": "Informations utilisateur indisponibles",
   "step_of_total": "Étape {{current}} sur {{total}}",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -135,6 +135,7 @@
   "image_preview_failed": "छवि पूर्वावलोकन लोड करने में विफल।",
   "video_size_exceeded": "वीडियो 100mb से कम होना चाहिए",
   "fill_required_fields": "कृपया सभी अपेक्षित फ़ील्ड को भरें",
+  "end_date_before_start": "समाप्ति तिथि प्रारंभ तिथि से पहले नहीं हो सकती।",
   "complete_lesson_details": "कृपया सभी पाठ विवरण पूरा करें",
   "user_info_unavailable": "उपयोगकर्ता जानकारी अनुपलब्ध है",
   "step_of_total": "{{total}} का चरण {{current}}",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -135,6 +135,7 @@
   "image_preview_failed": "Impossibile caricare l'anteprima dell'immagine.",
   "video_size_exceeded": "Il video deve essere inferiore a 100 MB",
   "fill_required_fields": "Si prega di compilare tutti i campi richiesti",
+  "end_date_before_start": "La data di fine non può essere precedente alla data di inizio.",
   "complete_lesson_details": "Si prega di completare tutti i dettagli della lezione",
   "user_info_unavailable": "Informazioni sull'utente non disponibile",
   "step_of_total": "Passaggio {{current}} di {{total}}",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -135,6 +135,7 @@
   "image_preview_failed": "加载图片预览失败",
   "video_size_exceeded": "视频必须小于 100MB",
   "fill_required_fields": "请填写所有必填字段",
+  "end_date_before_start": "结束日期不能早于开始日期。",
   "complete_lesson_details": "请完成所有课程详情",
   "user_info_unavailable": "用户信息不可用",
   "step_of_total": "第 {{current}} 步，共 {{total}} 步",

--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -126,10 +126,31 @@ function CreateOnlineClass() {
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
-    setFormData((prev) => ({
-      ...prev,
-      [name]: type === 'checkbox' ? checked : value
-    }));
+    setFormData((prev) => {
+      const nextValue = type === 'checkbox' ? checked : value;
+
+      if (name === 'startDate') {
+        let adjustedEndDate = prev.endDate;
+        if (
+          adjustedEndDate &&
+          nextValue &&
+          new Date(adjustedEndDate) < new Date(nextValue)
+        ) {
+          adjustedEndDate = nextValue;
+        }
+
+        return {
+          ...prev,
+          [name]: nextValue,
+          endDate: adjustedEndDate,
+        };
+      }
+
+      return {
+        ...prev,
+        [name]: nextValue,
+      };
+    });
   };
 
   const handleImageUpload = (e) => {
@@ -266,6 +287,19 @@ function CreateOnlineClass() {
         toast.error(t('user_info_unavailable'));
         return;
       }
+      if (formData.startDate && formData.endDate) {
+        const start = new Date(formData.startDate);
+        const end = new Date(formData.endDate);
+        if (end < start) {
+          toast.error(
+            t('end_date_before_start', {
+              defaultValue: 'End date cannot be earlier than start date.',
+            })
+          );
+          return;
+        }
+      }
+
       try {
         setIsSubmitting(true);
         setIsServerUploading(true);
@@ -507,6 +541,7 @@ function CreateOnlineClass() {
                         name="endDate"
                         value={formData.endDate}
                         onChange={handleChange}
+                        min={formData.startDate || undefined}
                       />
 
                       <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- prevent admins from submitting online classes when the end date precedes the start date
- keep the end date in sync with the chosen start date and set an input minimum to reinforce the rule
- add a localized `end_date_before_start` message across dashboard locales

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a7bc246c8328ba68a92050f1ba8e