### PR TITLE
Fix Node script invocation in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,16 +2,7 @@
 FROM node:20 AS builder
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./
-RUN node -e '
-const fs = require("fs");
-const path = "package.json";
-const sanitize = (input) => input
-  .replace(/\ufeff/g, "")
-  .replace(/\u00a0/g, " ");
-const cleaned = sanitize(fs.readFileSync(path, "utf8"));
-const parsed = JSON.parse(cleaned);
-fs.writeFileSync(path, `${JSON.stringify(parsed, null, 2)}\n`);
-' \
+RUN node -e "const fs = require('fs'); const path = 'package.json'; const sanitize = (input) => input.replace(/\\ufeff/g, '').replace(/\\u00a0/g, ' '); const cleaned = sanitize(fs.readFileSync(path, 'utf8')); const parsed = JSON.parse(cleaned); fs.writeFileSync(path, JSON.stringify(parsed, null, 2) + '\\n');" \
     && npm ci && npm cache clean --force
 COPY frontend/ ./
 COPY shared /shared
@@ -65,16 +56,7 @@ FROM node:20-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache curl
 COPY frontend/package.json frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js ./
-RUN node -e '
-const fs = require("fs");
-const path = "package.json";
-const sanitize = (input) => input
-  .replace(/\ufeff/g, "")
-  .replace(/\u00a0/g, " ");
-const cleaned = sanitize(fs.readFileSync(path, "utf8"));
-const parsed = JSON.parse(cleaned);
-fs.writeFileSync(path, `${JSON.stringify(parsed, null, 2)}\n`);
-' \
+RUN node -e "const fs = require('fs'); const path = 'package.json'; const sanitize = (input) => input.replace(/\\ufeff/g, '').replace(/\\u00a0/g, ' '); const cleaned = sanitize(fs.readFileSync(path, 'utf8')); const parsed = JSON.parse(cleaned); fs.writeFileSync(path, JSON.stringify(parsed, null, 2) + '\\n');" \
     && npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary
- inline the Node sanitization script in the frontend Dockerfile to avoid Docker parser errors
- apply the same quoting adjustment to both build and production stages so docker build no longer fails

## Testing
- not run (docker command unavailable in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7ac8c37688328b3b97e4c1fcded58