### PR TITLE
Improve frontend Docker build JSON normalization

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,8 @@
 FROM node:20 AS builder
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./
-RUN node -e "const fs = require('fs'); const path = 'package.json'; const sanitize = (input) => input.replace(/\\ufeff/g, '').replace(/\\u00a0/g, ' '); const cleaned = sanitize(fs.readFileSync(path, 'utf8')); const parsed = JSON.parse(cleaned); fs.writeFileSync(path, JSON.stringify(parsed, null, 2) + '\\n');" \
+COPY frontend/scripts/normalize-package-json.js ./scripts/normalize-package-json.js
+RUN node ./scripts/normalize-package-json.js package.json \
     && npm ci && npm cache clean --force
 COPY frontend/ ./
 COPY shared /shared
@@ -56,7 +57,8 @@ FROM node:20-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache curl
 COPY frontend/package.json frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js ./
-RUN node -e "const fs = require('fs'); const path = 'package.json'; const sanitize = (input) => input.replace(/\\ufeff/g, '').replace(/\\u00a0/g, ' '); const cleaned = sanitize(fs.readFileSync(path, 'utf8')); const parsed = JSON.parse(cleaned); fs.writeFileSync(path, JSON.stringify(parsed, null, 2) + '\\n');" \
+COPY frontend/scripts/normalize-package-json.js ./scripts/normalize-package-json.js
+RUN node ./scripts/normalize-package-json.js package.json \
     && npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public

--- a/frontend/scripts/normalize-package-json.js
+++ b/frontend/scripts/normalize-package-json.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const targetPath = path.resolve(process.argv[2] || 'package.json');
+
+const REPLACEMENTS = [
+  { pattern: /\ufeff/g, replacement: '', description: 'byte order marks' },
+  { pattern: /\u00a0/g, replacement: ' ', description: 'non-breaking spaces' },
+  { pattern: /[\u200b\u200c\u200d\u2060]/g, replacement: '', description: 'zero-width characters' },
+  { pattern: /[\u2028\u2029]/g, replacement: '\n', description: 'unicode line separators' },
+];
+
+function sanitize(input) {
+  let output = input;
+  const applied = [];
+
+  for (const { pattern, replacement, description } of REPLACEMENTS) {
+    if (pattern.test(output)) {
+      output = output.replace(pattern, replacement);
+      applied.push(description);
+    }
+  }
+
+  // Normalize Windows line endings for consistency.
+  if (/\r\n?/.test(output)) {
+    output = output.replace(/\r\n?/g, '\n');
+    applied.push('carriage returns');
+  }
+
+  return { output, applied };
+}
+
+let raw;
+try {
+  raw = fs.readFileSync(targetPath, 'utf8');
+} catch (error) {
+  console.error(`Unable to read ${targetPath}:`, error.message);
+  process.exitCode = 1;
+  return;
+}
+
+const { output: cleaned, applied } = sanitize(raw);
+
+let parsed;
+try {
+  parsed = JSON.parse(cleaned);
+} catch (error) {
+  console.error(`Failed to parse JSON from ${targetPath}.`);
+  console.error('A sanitized preview of the file is shown below to aid debugging:\n');
+  const preview = cleaned
+    .split('\n')
+    .slice(0, 20)
+    .join('\n');
+  console.error(preview);
+  throw error;
+}
+
+const normalized = JSON.stringify(parsed, null, 2) + '\n';
+
+if (normalized !== raw) {
+  fs.writeFileSync(targetPath, normalized, 'utf8');
+  if (applied.length > 0) {
+    console.warn(`Normalized ${path.basename(targetPath)} by removing ${applied.join(', ')}.`);
+  }
+} else if (applied.length > 0) {
+  // If sanitization changed the file but JSON formatting matched the original,
+  // ensure the sanitized content is persisted.
+  fs.writeFileSync(targetPath, cleaned, 'utf8');
+  console.warn(`Sanitized ${path.basename(targetPath)} by removing ${applied.join(', ')}.`);
+}


### PR DESCRIPTION
## Summary
- add a reusable script to sanitize package.json before dependency installation
- update the frontend Dockerfile to call the sanitizer in both build stages

## Testing
- npm run lint *(fails: existing lint warnings/errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d7adf79204832886768f130f9cef96