### PR TITLE
Adjust frontend Dockerfile sanitization context

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,8 @@
 FROM node:20 AS builder
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./
-COPY frontend/scripts/normalize-package-json.js ./scripts/normalize-package-json.js
-RUN node ./scripts/normalize-package-json.js package.json \
+COPY frontend/scripts/normalize-package-json.js /tmp/normalize-package-json.js
+RUN node /tmp/normalize-package-json.js package.json \
     && npm ci && npm cache clean --force
 COPY frontend/ ./
 COPY shared /shared
@@ -57,8 +57,8 @@ FROM node:20-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache curl
 COPY frontend/package.json frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js ./
-COPY frontend/scripts/normalize-package-json.js ./scripts/normalize-package-json.js
-RUN node ./scripts/normalize-package-json.js package.json \
+COPY frontend/scripts/normalize-package-json.js /tmp/normalize-package-json.js
+RUN node /tmp/normalize-package-json.js package.json \
     && npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary
- invoke the package.json sanitizer from outside /app in both build and production stages to avoid Node parsing invalid package metadata before cleanup

## Testing
- docker compose build frontend *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b1a77b348328b5cf988722c88f77