### PR TITLE
Adjust frontend Dockerfile sanitizer workflow

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,10 +2,11 @@
 FROM node:20 AS builder
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./
-COPY frontend/scripts/normalize-package-json.js ./scripts/normalize-package-json.js
-RUN node ./scripts/normalize-package-json.js package.json \
+COPY frontend/scripts/normalize-package-json.js /tmp/normalize-package-json.js
+RUN node /tmp/normalize-package-json.js /app/package.json \
     && npm ci && npm cache clean --force
 COPY frontend/ ./
+RUN node /tmp/normalize-package-json.js /app/package.json
 COPY shared /shared
 
 # Ensure subsequent RUN instructions use bash so pipefail is respected.
@@ -57,8 +58,8 @@ FROM node:20-alpine AS production
 WORKDIR /app
 RUN apk add --no-cache curl
 COPY frontend/package.json frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js ./
-COPY frontend/scripts/normalize-package-json.js ./scripts/normalize-package-json.js
-RUN node ./scripts/normalize-package-json.js package.json \
+COPY frontend/scripts/normalize-package-json.js /tmp/normalize-package-json.js
+RUN node /tmp/normalize-package-json.js /app/package.json \
     && npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary
- copy the package sanitizer script to /tmp in both stages so npm cannot read an unsanitized package.json
- rerun the sanitizer after copying the full frontend so the cleaned package.json persists across layers

## Testing
- docker compose build frontend *(fails: docker not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b23267d083288a96feb3ce738723