### PR TITLE
Ensure frontend Docker build sanitizes package.json safely

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,17 @@
 # Build stage
 FROM node:20 AS builder
+
+COPY frontend/scripts/normalize-package-json.js /tmp/normalize-package-json.js
+COPY frontend/package.json /tmp/package.json
+RUN node /tmp/normalize-package-json.js /tmp/package.json \
+    && cp /tmp/package.json /tmp/sanitized-package.json
+COPY frontend/package-lock.json /app/package-lock.json
+RUN mkdir -p /app \
+    && mv /tmp/package.json /app/package.json
 WORKDIR /app
-COPY frontend/package.json frontend/package-lock.json ./
-COPY frontend/scripts/normalize-package-json.js ./scripts/normalize-package-json.js
-RUN node ./scripts/normalize-package-json.js package.json \
-    && npm ci && npm cache clean --force
+RUN npm ci && npm cache clean --force
 COPY frontend/ ./
+RUN cp /tmp/sanitized-package.json package.json
 COPY shared /shared
 
 # Ensure subsequent RUN instructions use bash so pipefail is respected.
@@ -54,12 +60,19 @@ SHELL ["/bin/sh", "-c"]
 
 # Production stage
 FROM node:20-alpine AS production
-WORKDIR /app
+
 RUN apk add --no-cache curl
-COPY frontend/package.json frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js ./
-COPY frontend/scripts/normalize-package-json.js ./scripts/normalize-package-json.js
-RUN node ./scripts/normalize-package-json.js package.json \
-    && npm ci --omit=dev && npm cache clean --force
+COPY frontend/scripts/normalize-package-json.js /tmp/normalize-package-json.js
+COPY frontend/package.json /tmp/package.json
+RUN node /tmp/normalize-package-json.js /tmp/package.json \
+    && cp /tmp/package.json /tmp/sanitized-package.json
+COPY frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js /app/
+RUN mkdir -p /app \
+    && mv /tmp/package.json /app/package.json
+WORKDIR /app
+RUN npm ci --omit=dev && npm cache clean --force
+COPY frontend/ ./
+RUN cp /tmp/sanitized-package.json package.json
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/scripts ./scripts


### PR DESCRIPTION
## Summary
- run the package.json normalizer from /tmp before setting the working directory in both build stages
- preserve the sanitized package.json after copying the full frontend source tree so npm install uses the cleaned file

## Testing
- docker-compose build frontend *(fails: docker-compose not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b258c7408328ba1cfcbd8be1a8b9