### PR TITLE
Improve package.json sanitizer structural repairs

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,12 +2,12 @@
 FROM node:20 AS builder
 
 COPY frontend/scripts/normalize-package-json.js /tmp/normalize-package-json.js
-COPY frontend/package.json /tmp/package.json
-RUN node /tmp/normalize-package-json.js /tmp/package.json \
-    && cp /tmp/package.json /tmp/sanitized-package.json
+COPY frontend/package.json /tmp/input/package.json
+RUN node /tmp/normalize-package-json.js /tmp/input/package.json \
+    && cp /tmp/input/package.json /tmp/sanitized-package.json
 COPY frontend/package-lock.json /app/package-lock.json
 RUN mkdir -p /app \
-    && mv /tmp/package.json /app/package.json
+    && mv /tmp/input/package.json /app/package.json
 WORKDIR /app
 RUN npm ci && npm cache clean --force
 COPY frontend/ ./
@@ -63,12 +63,12 @@ FROM node:20-alpine AS production
 
 RUN apk add --no-cache curl
 COPY frontend/scripts/normalize-package-json.js /tmp/normalize-package-json.js
-COPY frontend/package.json /tmp/package.json
-RUN node /tmp/normalize-package-json.js /tmp/package.json \
-    && cp /tmp/package.json /tmp/sanitized-package.json
+COPY frontend/package.json /tmp/input/package.json
+RUN node /tmp/normalize-package-json.js /tmp/input/package.json \
+    && cp /tmp/input/package.json /tmp/sanitized-package.json
 COPY frontend/package-lock.json frontend/next.config.mjs frontend/next-i18next.config.js /app/
 RUN mkdir -p /app \
-    && mv /tmp/package.json /app/package.json
+    && mv /tmp/input/package.json /app/package.json
 WORKDIR /app
 RUN npm ci --omit=dev && npm cache clean --force
 COPY frontend/ ./

--- a/frontend/scripts/normalize-package-json.js
+++ b/frontend/scripts/normalize-package-json.js
@@ -47,18 +47,73 @@ try {
 
 const { output: cleaned, applied } = sanitize(raw);
 
+function attemptStructuralRepairs(input) {
+  let output = input;
+  let scriptOverrides = null;
+
+  const duplicateScriptsPattern = /("scripts"\s*:\s*{[\s\S]*?}\s*,\s*\n)(\s*"dev"\s*:\s*"[^"]*",?\s*\n\s*"build"\s*:\s*"[^"]*",?\s*\n\s*"start"\s*:\s*"[^"]*",?\s*\n\s*"lint"\s*:\s*"[^"]*",?\s*\n\s*"test"\s*:\s*"[^"]*"\s*,?\s*\n)(\s*},)/m;
+  const redundantClosingPattern = /},\s*\n\s*},/m;
+
+  const match = output.match(duplicateScriptsPattern);
+  if (match) {
+    const [, prefix, duplicateBlock, suffix] = match;
+    scriptOverrides = {};
+    const entryPattern = /"([^"]+)"\s*:\s*"([^"]*)"/g;
+    let entryMatch;
+    while ((entryMatch = entryPattern.exec(duplicateBlock)) !== null) {
+      const [, key, value] = entryMatch;
+      scriptOverrides[key] = value;
+    }
+    output = output.replace(duplicateScriptsPattern, `${prefix}${suffix}`);
+  }
+
+  if (redundantClosingPattern.test(output)) {
+    output = output.replace(redundantClosingPattern, '},\n');
+  }
+
+  return { output, scriptOverrides };
+}
+
 let parsed;
+let normalizedCandidate = cleaned;
+let repairDetails = null;
 try {
-  parsed = JSON.parse(cleaned);
-} catch (error) {
-  console.error(`Failed to parse JSON from ${targetPath}.`);
-  console.error('A sanitized preview of the file is shown below to aid debugging:\n');
-  const preview = cleaned
-    .split('\n')
-    .slice(0, 20)
-    .join('\n');
-  console.error(preview);
-  throw error;
+  parsed = JSON.parse(normalizedCandidate);
+} catch (initialError) {
+  repairDetails = attemptStructuralRepairs(cleaned);
+  normalizedCandidate = repairDetails.output;
+  if (normalizedCandidate !== cleaned) {
+    try {
+      parsed = JSON.parse(normalizedCandidate);
+      if (repairDetails.scriptOverrides && parsed && typeof parsed === 'object') {
+        parsed.scripts = {
+          ...(parsed.scripts || {}),
+          ...repairDetails.scriptOverrides,
+        };
+      }
+      console.warn(
+        `Applied structural repairs to ${path.basename(targetPath)} to resolve duplicated sections.`,
+      );
+    } catch (retryError) {
+      console.error(`Failed to parse JSON from ${targetPath}.`);
+      console.error('A sanitized preview of the file is shown below to aid debugging:\n');
+      const preview = cleaned
+        .split('\n')
+        .slice(0, 20)
+        .join('\n');
+      console.error(preview);
+      throw retryError;
+    }
+  } else {
+    console.error(`Failed to parse JSON from ${targetPath}.`);
+    console.error('A sanitized preview of the file is shown below to aid debugging:\n');
+    const preview = cleaned
+      .split('\n')
+      .slice(0, 20)
+      .join('\n');
+    console.error(preview);
+    throw initialError;
+  }
 }
 
 const normalized = JSON.stringify(parsed, null, 2) + '\n';


### PR DESCRIPTION
## Summary
- enhance the normalization script to strip duplicated script blocks before parsing and capture overrides from the newer definitions
- ensure redundant closing braces are removed and latest script commands are preserved when repairs are applied

## Testing
- node frontend/scripts/normalize-package-json.js frontend/package.json

------
https://chatgpt.com/codex/tasks/task_e_68d7b12ab56c8328a129941dc0e191a6