### PR TITLE
Clear auth cookies when refresh token rotation fails

### DIFF
--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -10,6 +10,14 @@ const authMiddleware = require("../../../middleware/auth/authMiddleware");
 // 🔧 Cookie options used in login and logout
 const { refreshCookieOptions, csrfCookieOptions } = require("../../../utils/cookie");
 
+const omitCookieExpiry = (options = {}) => {
+  const { maxAge, expires, ...rest } = options;
+  return rest;
+};
+
+const refreshCookieClearOptions = omitCookieExpiry(refreshCookieOptions);
+const csrfCookieClearOptions = omitCookieExpiry(csrfCookieOptions);
+
 /**
  * @desc Register a new user
  * @access Public
@@ -145,7 +153,11 @@ exports.refreshToken = catchAsync(async (req, res) => {
     response.json({ message: "Token refreshed", accessToken });
   } catch (err) {
     logger.error("❌ Refresh token error:", err.message);
-    return res.status(401).json({ message: "Invalid or expired refresh token" });
+    return res
+      .clearCookie("refreshToken", refreshCookieClearOptions)
+      .clearCookie("csrfToken", csrfCookieClearOptions)
+      .status(401)
+      .json({ message: "Invalid or expired refresh token" });
   }
 });
 
@@ -172,8 +184,8 @@ exports.logout = catchAsync(async (req, res) => {
     await authMiddleware.addTokenToBlacklist(access);
   }
   res
-    .clearCookie("refreshToken", refreshCookieOptions)
-    .clearCookie("csrfToken", csrfCookieOptions)
+    .clearCookie("refreshToken", refreshCookieClearOptions)
+    .clearCookie("csrfToken", csrfCookieClearOptions)
     .json({ message: "Logged out successfully" });
 });
 

--- a/backend/tests/authRefreshRoutes.test.js
+++ b/backend/tests/authRefreshRoutes.test.js
@@ -109,6 +109,9 @@ describe('POST /api/auth/refresh', () => {
 
     expect(res.status).toBe(401);
     expect(res.body.message).toMatch(/invalid or expired/i);
+    const clearedCookies = res.headers['set-cookie'] || [];
+    expect(clearedCookies.some((cookie) => cookie.startsWith('refreshToken=;'))).toBe(true);
+    expect(clearedCookies.some((cookie) => cookie.startsWith('csrfToken=;'))).toBe(true);
   });
 
   it('rejects refresh without CSRF token', async () => {


### PR DESCRIPTION
## Summary
- avoid reusing cookie maxAge when clearing auth cookies by deriving expiry-free options once
- clear refresh and csrf cookies when refresh token rotation fails to prevent invalid tokens from persisting
- update refresh route tests to assert cookies are cleared on invalid tokens

## Testing
- npm test -- authRefreshRoutes

------
https://chatgpt.com/codex/tasks/task_e_68d7edbb5ea08328acb8e41d07c47d4b