### PR TITLE
Fix category payload handling in admin class creation page

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -146,8 +146,20 @@ function CreateOnlineClass() {
 
   useEffect(() => {
     fetchAllCategories({ status: 'active', limit: 100 })
-      .then((res) => setCategories(res || []))
-      .catch(() => setCategories([]));
+      .then((res) => {
+        if (Array.isArray(res?.data)) {
+          setCategories(res.data);
+        } else if (Array.isArray(res)) {
+          setCategories(res);
+        } else {
+          console.warn('Unexpected categories payload format', res);
+          setCategories([]);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to fetch categories', err);
+        setCategories([]);
+      });
     fetchClassTags()
       .then(setAllTags)
       .catch(() => setAllTags([]));


### PR DESCRIPTION
## Summary
- ensure the admin class creation page only stores array data from the categories API response
- add defensive logging and reset when the payload has an unexpected shape

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d800eabd808328b39c46840801c4cb