### PR TITLE
Handle category service response safely

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -146,7 +146,14 @@ function CreateOnlineClass() {
 
   useEffect(() => {
     fetchAllCategories({ status: 'active', limit: 100 })
-      .then((res) => setCategories(res || []))
+      .then((res) => {
+        const list = Array.isArray(res?.data)
+          ? res.data
+          : Array.isArray(res)
+            ? res
+            : [];
+        setCategories(list);
+      })
       .catch(() => setCategories([]));
     fetchClassTags()
       .then(setAllTags)
@@ -582,7 +589,7 @@ function CreateOnlineClass() {
                           className="w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500 text-sm"
                         >
                           <option value="">{t('select_category')}</option>
-                          {categories.map((cat) => (
+                          {(Array.isArray(categories) ? categories : []).map((cat) => (
                             <option key={cat.id} value={cat.id}>
                               {cat.name}
                             </option>


### PR DESCRIPTION
## Summary
- normalize the admin online class category fetch to accept both wrapped and raw arrays
- guard the category select from mapping non-array values to avoid runtime errors

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d8021b92688328a5e5c78a8706e407