### PR TITLE
Normalize category fetch response in admin class creation

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -146,7 +146,14 @@ function CreateOnlineClass() {
 
   useEffect(() => {
     fetchAllCategories({ status: 'active', limit: 100 })
-      .then((res) => setCategories(res || []))
+      .then((res) => {
+        const normalizedCategories = Array.isArray(res?.data)
+          ? res.data
+          : Array.isArray(res)
+            ? res
+            : [];
+        setCategories(normalizedCategories);
+      })
       .catch(() => setCategories([]));
     fetchClassTags()
       .then(setAllTags)


### PR DESCRIPTION
## Summary
- normalize the category fetch response to handle both array and object payloads
- ensure that only array data is stored in state when loading categories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d805bfcff08328b7cd47d727d9b16e