### PR TITLE
Fix next-i18next config import for admin online classes page

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -33,7 +33,7 @@ import useMessageStore from '@/store/messages/messageStore';
 import FloatingInput from '@/components/shared/FloatingInput';
 import { toDateTimeISO } from '@/utils/date';
 import useMediaUploader from '@/hooks/useMediaUploader';
-import nextI18NextConfig from '../../../../../next-i18next.config.js';
+import nextI18NextConfig from '@/../next-i18next.config.js';
 
 const ReactQuill = dynamic(() => import('react-quill'), {
   ssr: false,


### PR DESCRIPTION
## Summary
- update the admin online class creation page to resolve next-i18next config from the frontend root so translations load without module resolution errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80b9388b08328a1f5264358a564d9