### PR TITLE
Validate online class end date before submission

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -369,6 +369,22 @@ function CreateOnlineClass() {
         );
         return;
       }
+      const startDateValue = formData.startDate ? new Date(formData.startDate) : null;
+      const endDateValue = formData.endDate ? new Date(formData.endDate) : null;
+      if (
+        endDateValue &&
+        startDateValue &&
+        !Number.isNaN(startDateValue.getTime()) &&
+        !Number.isNaN(endDateValue.getTime()) &&
+        endDateValue < startDateValue
+      ) {
+        toast.error(
+          t('end_date_after_start', {
+            defaultValue: 'End date must be after the start date.',
+          })
+        );
+        return;
+      }
       try {
         setIsSubmitting(true);
         setIsServerUploading(true);


### PR DESCRIPTION
## Summary
- add client-side validation to ensure the end date is not before the start date during online class creation
- display a translated toast error and halt submission when the date range is invalid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80e5ea38c8328b04d79c77ec3e4d8