### PR TITLE
Fix online class creation date validation test

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -342,6 +342,18 @@ function CreateOnlineClass() {
       setCurrentStep(2);
     } else {
       // Step 2 validation and submission
+      if (
+        formData.startDate &&
+        formData.endDate &&
+        new Date(formData.endDate) < new Date(formData.startDate)
+      ) {
+        toast.error(
+          t('end_date_after_start_date', {
+            defaultValue: 'End date must be after the start date.',
+          })
+        );
+        return;
+      }
       if (!formData.lessons.length) {
         toast.error(t('add_at_least_one_lesson'));
         return;

--- a/frontend/tests/pages/dashboard/admin/online-classes/create.test.js
+++ b/frontend/tests/pages/dashboard/admin/online-classes/create.test.js
@@ -12,6 +12,7 @@ const mockCreateClassLesson = jest.fn();
 const mockUser = {
   id: 'user-1',
   full_name: 'Test Instructor',
+  role: 'instructor',
 };
 
 jest.mock('next/router', () => ({
@@ -54,6 +55,19 @@ jest.mock('@/services/admin/classTagService', () => ({
 
 jest.mock('@/services/admin/planService', () => ({
   fetchPlanIdentifiers: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/services/admin/instructorService', () => ({
+  fetchAllInstructors: jest.fn().mockResolvedValue({
+    instructors: [
+      {
+        id: 'user-1',
+        full_name: 'Test Instructor',
+        email: 'instructor@example.com',
+      },
+    ],
+    meta: { hasNextPage: false },
+  }),
 }));
 
 jest.mock('@/services/admin/classService', () => ({
@@ -115,9 +129,6 @@ describe('CreateOnlineClass date validation', () => {
     });
     fireEvent.change(screen.getByPlaceholderText('price_label'), {
       target: { value: '100' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('lesson_count_label'), {
-      target: { value: '1' },
     });
   };
 


### PR DESCRIPTION
## Summary
- remove the obsolete lesson count interaction from the admin online class creation test
- stub instructor fetching in the test so the happy path can proceed without network calls
- add an end date validation in the create online class page to surface the expected error message

## Testing
- npm test -- tests/pages/dashboard/admin/online-classes/create.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d80f2992c4832891dfe47ca0fd0091