### PR TITLE
Add end date validation to admin online class creation

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -145,6 +145,7 @@
   "image_preview_failed": "فشل تحميل معاينة الصورة.",
   "video_size_exceeded": "يجب أن يكون الفيديو أقل من 100 ميجابايت",
   "fill_required_fields": "يرجى تعبئة جميع الحقول المطلوبة",
+  "end_date_after_start": "يجب أن يكون تاريخ الانتهاء بعد تاريخ البدء.",
   "complete_lesson_details": "يرجى استكمال تفاصيل الدرس",
   "add_at_least_one_lesson": "يرجى إضافة درس واحد على الأقل قبل الإرسال.",
   "user_info_unavailable": "معلومات المستخدم غير متاحة",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -145,6 +145,7 @@
   "image_preview_failed": "Failed to load image preview.",
   "video_size_exceeded": "Video must be less than 100MB",
   "fill_required_fields": "Please fill in all required fields",
+  "end_date_after_start": "Das Enddatum muss nach dem Startdatum liegen.",
   "complete_lesson_details": "Please complete all lesson details",
   "add_at_least_one_lesson": "Bitte fügen Sie vor dem Absenden mindestens eine Lektion hinzu.",
   "user_info_unavailable": "User information unavailable",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -145,6 +145,7 @@
   "image_preview_failed": "Failed to load image preview.",
   "video_size_exceeded": "Video must be less than 100MB",
   "fill_required_fields": "Please fill in all required fields",
+  "end_date_after_start": "End date must be after the start date.",
   "complete_lesson_details": "Please complete all lesson details",
   "add_at_least_one_lesson": "Please add at least one lesson before submitting.",
   "user_info_unavailable": "User information unavailable",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -145,6 +145,7 @@
   "image_preview_failed": "No se pudo cargar la vista previa de la imagen.",
   "video_size_exceeded": "El video debe ser menos de 100 MB",
   "fill_required_fields": "Complete todos los campos requeridos",
+  "end_date_after_start": "La fecha de finalización debe ser posterior a la fecha de inicio.",
   "complete_lesson_details": "Complete todos los detalles de la lección",
   "add_at_least_one_lesson": "Agrega al menos una lección antes de enviar.",
   "user_info_unavailable": "Información del usuario no disponible",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -145,6 +145,7 @@
   "image_preview_failed": "Échec du chargement de l'aperçu de l'image.",
   "video_size_exceeded": "La vidéo doit faire moins de 100MB",
   "fill_required_fields": "Veuillez remplir tous les champs requis",
+  "end_date_after_start": "La date de fin doit être postérieure à la date de début.",
   "complete_lesson_details": "Veuillez compléter tous les détails de la leçon",
   "add_at_least_one_lesson": "Veuillez ajouter au moins une leçon avant de soumettre.",
   "user_info_unavailable": "Informations utilisateur indisponibles",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -145,6 +145,7 @@
   "image_preview_failed": "छवि पूर्वावलोकन लोड करने में विफल।",
   "video_size_exceeded": "वीडियो 100mb से कम होना चाहिए",
   "fill_required_fields": "कृपया सभी अपेक्षित फ़ील्ड को भरें",
+  "end_date_after_start": "समापन तिथि प्रारंभ तिथि के बाद होनी चाहिए।",
   "complete_lesson_details": "कृपया सभी पाठ विवरण पूरा करें",
   "add_at_least_one_lesson": "सबमिट करने से पहले कम से कम एक पाठ जोड़ें।",
   "user_info_unavailable": "उपयोगकर्ता जानकारी अनुपलब्ध है",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -145,6 +145,7 @@
   "image_preview_failed": "Impossibile caricare l'anteprima dell'immagine.",
   "video_size_exceeded": "Il video deve essere inferiore a 100 MB",
   "fill_required_fields": "Si prega di compilare tutti i campi richiesti",
+  "end_date_after_start": "La data di fine deve essere successiva alla data di inizio.",
   "complete_lesson_details": "Si prega di completare tutti i dettagli della lezione",
   "add_at_least_one_lesson": "Aggiungi almeno una lezione prima di inviare.",
   "user_info_unavailable": "Informazioni sull'utente non disponibile",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -145,6 +145,7 @@
   "image_preview_failed": "加载图片预览失败",
   "video_size_exceeded": "视频必须小于 100MB",
   "fill_required_fields": "请填写所有必填字段",
+  "end_date_after_start": "结束日期必须晚于开始日期。",
   "complete_lesson_details": "请完成所有课程详情",
   "add_at_least_one_lesson": "提交前请至少添加一节课。",
   "user_info_unavailable": "用户信息不可用",

--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -329,6 +329,23 @@ function CreateOnlineClass() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    const parseDate = (value) => {
+      if (!value) return null;
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    };
+
+    const startDateValue = parseDate(formData.startDate);
+    const endDateValue = parseDate(formData.endDate);
+
+    if (startDateValue && endDateValue && endDateValue < startDateValue) {
+      toast.error(
+        t('end_date_after_start', {
+          defaultValue: 'End date must be after the start date.',
+        })
+      );
+      return;
+    }
     if (currentStep === 1) {
       if (!formData.title || !formData.startDate) {
         toast.error(t('fill_required_fields'));

--- a/frontend/src/tests/pages/dashboard/admin/online-classes/create.test.jsx
+++ b/frontend/src/tests/pages/dashboard/admin/online-classes/create.test.jsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { toast } from "react-toastify";
+
+import { CreateOnlineClass } from "@/pages/dashboard/admin/online-classes/create";
+
+const pushMock = jest.fn();
+const addEventsMock = jest.fn();
+const fetchNotificationsMock = jest.fn();
+const fetchMessagesMock = jest.fn();
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+typeof window !== "undefined" && (window.HTMLElement.prototype.scrollIntoView = jest.fn());
+
+jest.mock("next/dynamic", () => () => (props) => <div data-testid="dynamic" {...props} />);
+
+jest.mock("react-quill", () => ({
+  __esModule: true,
+  default: () => <div data-testid="react-quill" />,
+}));
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...rest }) => <div {...rest}>{children}</div>,
+  },
+  AnimatePresence: ({ children }) => <>{children}</>,
+}));
+
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key, options) => options?.defaultValue ?? key,
+    i18n: { dir: () => "ltr" },
+  }),
+}));
+
+jest.mock("@/hooks/withAuthProtection", () => ({
+  __esModule: true,
+  default: (component) => component,
+}));
+
+jest.mock("@/components/layouts/AdminLayout", () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/shared/FloatingInput", () => ({
+  __esModule: true,
+  default: ({ label, name, value = "", onChange, type = "text" }) => (
+    <label>
+      <span>{label}</span>
+      <input
+        aria-label={label}
+        name={name}
+        value={value}
+        onChange={onChange}
+        type={type}
+      />
+    </label>
+  ),
+}));
+
+jest.mock("@/hooks/useMediaUploader", () => ({
+  __esModule: true,
+  default: () => ({
+    uploadProgress: 0,
+    imageUploading: false,
+    videoUploading: false,
+    handleImageUpload: jest.fn(),
+    handleVideoUpload: jest.fn(),
+    setUploadProgress: jest.fn(),
+  }),
+}));
+
+const useAuthStoreMock = jest.fn(() => ({ user: { id: "admin-1" } }));
+jest.mock("@/store/auth/authStore", () => ({
+  __esModule: true,
+  default: (...args) => useAuthStoreMock(...args),
+}));
+
+jest.mock("@/store/schedule/scheduleStore", () => ({
+  __esModule: true,
+  default: (selector) => (selector ? selector({ addEvents: addEventsMock }) : { addEvents: addEventsMock }),
+}));
+
+jest.mock("@/store/notifications/notificationStore", () => ({
+  __esModule: true,
+  default: (selector) => (selector ? selector({ fetch: fetchNotificationsMock }) : { fetch: fetchNotificationsMock }),
+}));
+
+jest.mock("@/store/messages/messageStore", () => ({
+  __esModule: true,
+  default: (selector) => (selector ? selector({ fetch: fetchMessagesMock }) : { fetch: fetchMessagesMock }),
+}));
+
+jest.mock("@/services/admin/categoryService", () => ({
+  fetchAllCategories: jest.fn().mockResolvedValue({ data: [] }),
+}));
+
+jest.mock("@/services/admin/classService", () => ({
+  createAdminClass: jest.fn().mockResolvedValue({ id: "class-1", title: "Test" }),
+}));
+
+jest.mock("@/services/admin/classTagService", () => ({
+  fetchClassTags: jest.fn().mockResolvedValue({ data: [] }),
+}));
+
+jest.mock("@/services/instructor/classService", () => ({
+  createClassLesson: jest.fn(),
+}));
+
+jest.mock("@/services/admin/planService", () => ({
+  fetchPlanIdentifiers: jest.fn().mockResolvedValue({ data: [] }),
+}));
+
+jest.mock("@/services/admin/instructorService", () => ({
+  fetchAllInstructors: jest.fn().mockResolvedValue({
+    instructors: [],
+    meta: { hasNextPage: false },
+  }),
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+describe("CreateOnlineClass date validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("prevents progressing when the end date is before the start date", async () => {
+    render(<CreateOnlineClass />);
+
+    fireEvent.change(screen.getByLabelText("class_title_label"), { target: { value: "Sample Class" } });
+    fireEvent.change(screen.getByLabelText("start_date_label"), { target: { value: "2024-01-10" } });
+    fireEvent.change(screen.getByLabelText("end_date_label"), { target: { value: "2024-01-09" } });
+
+    const form = screen.getByRole("button", { name: "next" }).closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("End date must be after the start date.");
+    });
+  });
+
+  it("allows progressing when the end date is after the start date", async () => {
+    render(<CreateOnlineClass />);
+
+    fireEvent.change(screen.getByLabelText("class_title_label"), { target: { value: "Sample Class" } });
+    fireEvent.change(screen.getByLabelText("start_date_label"), { target: { value: "2024-01-10" } });
+    fireEvent.change(screen.getByLabelText("end_date_label"), { target: { value: "2024-01-11" } });
+
+    const form = screen.getByRole("button", { name: "next" }).closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(screen.getByText("lesson_plan")).toBeInTheDocument();
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- validate the admin online class form so end dates cannot precede the start date
- add the translated toast message for the new validation error
- add unit tests that cover both invalid and valid end-date submissions

## Testing
- npm test -- --runTestsByPath src/tests/pages/dashboard/admin/online-classes/create.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d80f284d748328bd2ac6d884f08438