### PR TITLE
Fix instructor class upload file type validation

### DIFF
--- a/backend/src/modules/classes/classUploadMiddleware.js
+++ b/backend/src/modules/classes/classUploadMiddleware.js
@@ -27,16 +27,29 @@ const storage = multer.diskStorage({
 const imageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
 const videoTypes = ['video/mp4', 'video/quicktime', 'video/x-matroska', 'video/webm'];
 
-const fileFilter = (_req, file, cb) => {
-  const detectedMime = mime.lookup(file.originalname) || '';
+const normalizeMime = (value) => (value ? value.toLowerCase() : '');
 
+const hasAllowedType = (file, allowedTypes) => {
+  const mimeFromClient = normalizeMime(file.mimetype);
+  const mimeFromName = normalizeMime(mime.lookup(file.originalname));
+
+  if (allowedTypes.includes(mimeFromClient) || allowedTypes.includes(mimeFromName)) {
+    return true;
+  }
+
+  // Some browsers/devices may not send a reliable mimetype. In that case we
+  // fall back to checking the file extension directly.
+  const ext = normalizeMime(path.extname(file.originalname)).replace('.', '');
+  if (!ext) return false;
+  return allowedTypes.some((type) => normalizeMime(mime.extension(type)) === ext);
+};
+
+const fileFilter = (_req, file, cb) => {
   if (file.fieldname === 'cover_image') {
-    if (imageTypes.includes(file.mimetype) && imageTypes.includes(detectedMime))
-      return cb(null, true);
+    if (hasAllowedType(file, imageTypes)) return cb(null, true);
     return cb(new Error('Invalid file type'), false);
   } else if (file.fieldname === 'demo_video') {
-    if (videoTypes.includes(file.mimetype) && videoTypes.includes(detectedMime))
-      return cb(null, true);
+    if (hasAllowedType(file, videoTypes)) return cb(null, true);
     return cb(new Error('Invalid file type'), false);
   }
 


### PR DESCRIPTION
## Summary
- relax the class upload file filter to accept client-provided MIME types, detected MIME types, or extensions
- add normalization helpers so optional uploads no longer fail with false "Invalid file type" errors

## Testing
- npm test -- classUploadMiddleware

------
https://chatgpt.com/codex/tasks/task_e_68d8186461c88328aa083f2b6eacf6ea