### PR TITLE
Handle media upload flags safely in admin class create

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -113,10 +113,12 @@ function CreateOnlineClass() {
     uploadProgress = 0,
     handleImageUpload: mediaImageUpload,
     handleVideoUpload: mediaVideoUpload,
-    setUploadProgress,
+    setUploadProgress = () => {},
+    imageUploading: rawImageUploading = false,
+    videoUploading: rawVideoUploading = false,
   } = mediaUploader ?? {};
-  const isImageUploading = Boolean(mediaUploader?.imageUploading);
-  const isVideoUploading = Boolean(mediaUploader?.videoUploading);
+  const isImageUploading = Boolean(rawImageUploading);
+  const isVideoUploading = Boolean(rawVideoUploading);
 
   const priceValue = useMemo(() => {
     const parsed = Number.parseFloat(formData.price);


### PR DESCRIPTION
## Summary
- ensure the admin online class create page defaults media upload flags to booleans before use
- guard setUploadProgress with a no-op fallback so submission does not throw when the hook fails

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8171bb7508328a3838d4cd96e58ce