### PR TITLE
Fix admin class media uploader destructuring

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -100,25 +100,22 @@ function CreateOnlineClass() {
   const [hasMoreInstructors, setHasMoreInstructors] = useState(false);
   const [loadingInstructors, setLoadingInstructors] = useState(false);
 
-  const mediaUploader = useMediaUploader({
-    t,
-    onError: (message) => toast.error(message),
-    onImageSelect: (file, preview) =>
-      setFormData((prev) => ({ ...prev, image: file, imagePreview: preview })),
-    onVideoSelect: (file, preview) =>
-      setFormData((prev) => ({ ...prev, demoVideo: file, demoPreview: preview })),
-  });
-
   const {
     uploadProgress = 0,
+    imageUploading: isImageUploading = false,
+    videoUploading: isVideoUploading = false,
     handleImageUpload: mediaImageUpload,
     handleVideoUpload: mediaVideoUpload,
-    setUploadProgress = () => {},
-    imageUploading: rawImageUploading = false,
-    videoUploading: rawVideoUploading = false,
-  } = mediaUploader ?? {};
-  const isImageUploading = Boolean(rawImageUploading);
-  const isVideoUploading = Boolean(rawVideoUploading);
+    setUploadProgress,
+  } =
+    useMediaUploader({
+      t,
+      onError: (message) => toast.error(message),
+      onImageSelect: (file, preview) =>
+        setFormData((prev) => ({ ...prev, image: file, imagePreview: preview })),
+      onVideoSelect: (file, preview) =>
+        setFormData((prev) => ({ ...prev, demoVideo: file, demoPreview: preview })),
+    }) ?? {};
 
   const priceValue = useMemo(() => {
     const parsed = Number.parseFloat(formData.price);


### PR DESCRIPTION
## Summary
- destructure the media uploader hook with defaulted upload progress and aliased uploading flags
- remove redundant boolean conversions and continue passing through upload handlers

## Testing
- npm run lint *(fails: existing warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8199d1a4483289f35e8503a463658