### PR TITLE
Ensure sidebar branding waits for store hydration

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -56,7 +56,7 @@ export default function Sidebar({ role = 'admin' }) {
     setActiveDropdown((prev) => (prev === label ? null : label));
   };
 
-  const shouldUseSettings = isHydrated || appConfigHydrated;
+  const shouldUseSettings = isHydrated && appConfigHydrated;
   const fallbackAppName = 'SkillBridge';
   const displayAppName =
     shouldUseSettings && settings?.appName ? settings.appName : fallbackAppName;


### PR DESCRIPTION
## Summary
- require both the local mount flag and the Zustand hydration flag before reading persisted branding values in the dashboard sidebar

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d81bd2a3e88328abdd6915236aaf89