### PR TITLE
Fix deterministic date formatting in admin student pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/[studentId].js
@@ -9,6 +9,7 @@ import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchClassStudent } from "@/services/admin/classService";
 import withAuthProtection from "@/hooks/withAuthProtection";
+import { formatDateWithLocale } from "@/utils/date";
 
 function ManageStudentInClassPage() {
   const { id, studentId } = useRouter().query;
@@ -96,7 +97,13 @@ function ManageStudentInClassPage() {
                     <strong>
                       {t('studentDetailPage.issued_at', { defaultValue: 'Issued At' })}:
                     </strong>{' '}
-                    {new Date(certificate.issuedAt).toLocaleString()}
+                    {formatDateWithLocale(certificate.issuedAt, {
+                      locale: i18n.language,
+                      options: {
+                        dateStyle: 'medium',
+                        timeStyle: 'short',
+                      },
+                    })}
                   </li>
                 )}
               </ul>

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/students/index.js
@@ -8,6 +8,7 @@ import nextI18NextConfig from "../../../../../../../next-i18next.config.js";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import { fetchClassStudents } from "@/services/admin/classService";
 import withAuthProtection from "@/hooks/withAuthProtection";
+import { formatDateWithLocale } from "@/utils/date";
 
 function ClassStudentsPage() {
   const { id } = useRouter().query;
@@ -82,7 +83,9 @@ function ClassStudentsPage() {
                   <td className="border p-2">{stu.email}</td>
                   <td className="border p-2 text-center">{stu.status}</td>
                   <td className="border p-2 text-center">
-                    {new Date(stu.enrolled_at).toLocaleDateString()}
+                    {formatDateWithLocale(stu.enrolled_at, {
+                      locale: i18n.language,
+                    })}
                   </td>
                 </tr>
               ))}

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -19,3 +19,29 @@ export function formatDateTime(value) {
   const d = new Date(value);
   return Number.isNaN(d.getTime()) ? value : format(d, 'yyyy-MM-dd HH:mm');
 }
+
+export function formatDateWithLocale(
+  value,
+  { locale, options, fallback = '—' } = {}
+) {
+  if (!value) return fallback;
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return fallback;
+  }
+
+  const locales = locale ? [locale, 'en-US'] : 'en-US';
+  const formatOptions = {
+    dateStyle: 'medium',
+    timeZone: 'UTC',
+    ...options,
+  };
+
+  try {
+    return new Intl.DateTimeFormat(locales, formatOptions).format(date);
+  } catch (error) {
+    console.error('Failed to format date', error);
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared helper to format dates with a stable locale/time zone fallback
- update the admin student list and detail pages to use the deterministic formatter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d81c6aa438832880fa24190b0b014e