### PR TITLE
Fix sidebar hydration guard

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -56,14 +56,17 @@ export default function Sidebar({ role = 'admin' }) {
     setActiveDropdown((prev) => (prev === label ? null : label));
   };
 
-  const shouldUseSettings = isHydrated || appConfigHydrated;
+  const shouldUseSettings = isHydrated && appConfigHydrated;
   const fallbackAppName = 'SkillBridge';
+  const fallbackLogoSrc = logo.src || logo;
   const displayAppName =
     shouldUseSettings && settings?.appName ? settings.appName : fallbackAppName;
   const logoSrc =
     shouldUseSettings && settings?.logo_url
       ? buildUrl(settings.logo_url)
-      : logo.src || logo;
+      : fallbackLogoSrc;
+  const footerBranding =
+    shouldUseSettings && settings?.appName ? settings.appName : fallbackAppName;
 
   return (
     <aside className="w-64 min-h-screen bg-white dark:bg-gray-900 shadow-lg p-6 flex flex-col justify-between">
@@ -160,7 +163,7 @@ export default function Sidebar({ role = 'admin' }) {
       <div className="text-xs text-gray-400 dark:text-gray-500 text-center mt-8">
         &copy;{' '}
         {currentYear ? `${currentYear} ` : ''}
-        {settings?.appName || 'SkillBridge'}
+        {footerBranding}
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- ensure the sidebar waits for both client and store hydration before using app-config settings
- fallback to default branding values until hydrated to keep SSR and client renders aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d81cbd3314832888a1aaec02fbb88b