### PR TITLE
Ensure Sidebar uses settings only after hydration

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.js
+++ b/frontend/src/components/dashboard/Sidebar.js
@@ -56,7 +56,7 @@ export default function Sidebar({ role = 'admin' }) {
     setActiveDropdown((prev) => (prev === label ? null : label));
   };
 
-  const shouldUseSettings = isHydrated || appConfigHydrated;
+  const shouldUseSettings = isHydrated && appConfigHydrated;
   const fallbackAppName = 'SkillBridge';
   const displayAppName =
     shouldUseSettings && settings?.appName ? settings.appName : fallbackAppName;


### PR DESCRIPTION
## Summary
- ensure the dashboard sidebar only uses persisted settings after the component mounts and the app config store has hydrated

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d81cc98ab8832897693e0c3b16e2d8