### PR TITLE
Guard admin class rule controls until auth hydration

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -84,11 +84,20 @@ export default function AdminClassesTable() {
   const [loading, setLoading] = useState(false);
   const [totalPages, setTotalPages] = useState(1);
   const [totalItems, setTotalItems] = useState(0);
+  const [isMounted, setIsMounted] = useState(false);
   const user = useAuthStore((state) => state.user);
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
   const { t } = useTranslation('dashboard');
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
-  const canManageRules = user?.permissions?.includes('ADD_ONLINE_CLASS_RULE');
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const canManageRules =
+    isMounted &&
+    hasHydrated &&
+    !!user?.permissions?.includes('ADD_ONLINE_CLASS_RULE');
 
   useEffect(() => {
     const load = async () => {


### PR DESCRIPTION
## Summary
- subscribe to the auth store hydration flag and a client-side mount check in the admin classes table
- gate the Manage Rules actions behind both hydration guards to avoid hydration-time permission lookups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82132419483289b646b9fd1d3e1ef