### PR TITLE
Add access type to online classes

### DIFF
--- a/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
@@ -1,0 +1,13 @@
+exports.up = async function (knex) {
+  await knex.schema.alterTable('online_classes', (table) => {
+    table.enu('access_type', ['paid', 'free']).notNullable().defaultTo('paid');
+  });
+
+  await knex('online_classes').update({ access_type: 'paid' });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable('online_classes', (table) => {
+    table.dropColumn('access_type');
+  });
+};

--- a/backend/src/modules/classes/__tests__/class.service.test.js
+++ b/backend/src/modules/classes/__tests__/class.service.test.js
@@ -38,6 +38,7 @@ describe.skip('class.service tag aggregation', () => {
       table.float('price');
       table.string('status');
       table.string('moderation_status');
+      table.string('access_type').notNullable().defaultTo('paid');
       table.uuid('instructor_id').references('users.id');
       table.integer('category_id').references('categories.id');
       table.integer('max_students');
@@ -75,8 +76,26 @@ describe.skip('class.service tag aggregation', () => {
     await mockDb('users').insert({ id: instructorId, full_name: 'Teacher' });
     await mockDb('categories').insert({ id: 1, name: 'Cat' });
     await mockDb('online_classes').insert([
-      { id: class1Id, title: 'C1', slug: 'c1', instructor_id: instructorId, category_id: 1, status: 'draft', moderation_status: 'Pending' },
-      { id: class2Id, title: 'C2', slug: 'c2', instructor_id: instructorId, category_id: 1, status: 'draft', moderation_status: 'Pending' },
+      {
+        id: class1Id,
+        title: 'C1',
+        slug: 'c1',
+        instructor_id: instructorId,
+        category_id: 1,
+        status: 'draft',
+        moderation_status: 'Pending',
+        access_type: 'paid',
+      },
+      {
+        id: class2Id,
+        title: 'C2',
+        slug: 'c2',
+        instructor_id: instructorId,
+        category_id: 1,
+        status: 'draft',
+        moderation_status: 'Pending',
+        access_type: 'paid',
+      },
     ]);
     await mockDb('class_tags').insert([
       { id: 1, name: 'Tag1', slug: 'tag1' },

--- a/backend/src/modules/classes/attendance/__tests__/classAttendance.service.test.js
+++ b/backend/src/modules/classes/attendance/__tests__/classAttendance.service.test.js
@@ -21,6 +21,7 @@ beforeAll(async () => {
   await db.schema.createTable('online_classes', table => {
     table.uuid('id').primary();
     table.string('title');
+    table.string('access_type').defaultTo('paid');
   });
   await db.schema.createTable('class_enrollments', table => {
     table.uuid('class_id');
@@ -43,7 +44,7 @@ beforeAll(async () => {
   const classId = 'class1';
   const lesson1 = 'lesson1';
   const lesson2 = 'lesson2';
-  await db('online_classes').insert({ id: classId, title: 'Class' });
+  await db('online_classes').insert({ id: classId, title: 'Class', access_type: 'paid' });
   await db('class_lessons').insert([
     { id: lesson1, class_id: classId, title: 'L1' },
     { id: lesson2, class_id: classId, title: 'L2' },

--- a/backend/tests/certificatesService.test.js
+++ b/backend/tests/certificatesService.test.js
@@ -40,6 +40,7 @@ describe('certificate templates and certificates integration', () => {
     await mockDb.schema.createTable('online_classes', (table) => {
       table.uuid('id').primary();
       table.string('title');
+      table.string('access_type').notNullable().defaultTo('paid');
     });
 
     await mockDb.schema.createTable('certificates', (table) => {
@@ -152,7 +153,7 @@ describe('certificate templates and certificates integration', () => {
     const classId = uuidv4();
 
     await mockDb('users').insert({ id: userId, full_name: 'Jane Student' });
-    await mockDb('online_classes').insert({ id: classId, title: 'Physics 101' });
+    await mockDb('online_classes').insert({ id: classId, title: 'Physics 101', access_type: 'paid' });
     await mockDb('certificate_templates').insert({
       id: templateId,
       name: 'Class Template',

--- a/backend/tests/studentCheckoutTransaction.test.js
+++ b/backend/tests/studentCheckoutTransaction.test.js
@@ -3,7 +3,7 @@ jest.mock('../src/config/database', () => {
   const rollbackSpy = jest.fn();
 
   const data = {
-    online_classes: [{ id: 'c1' }],
+    online_classes: [{ id: 'c1', access_type: 'paid' }],
     class_enrollments: [],
     cart_items: [{ user_id: 'u1', item_id: 'c1' }],
     payments: [],


### PR DESCRIPTION
## Summary
- add a migration that introduces the `access_type` enum on `online_classes` and backfills existing rows
- update Jest fixtures that create `online_classes` records so they populate the new column

## Testing
- npm test -- --runTestsByPath src/modules/classes/__tests__/class.service.test.js (skipped suite)
- npm test -- --runTestsByPath tests/certificatesService.test.js *(fails: existing ReferenceError in certificates.service.js: rows is not defined)*
- npm test -- --runTestsByPath tests/studentCheckoutTransaction.test.js
- TEST_DATABASE_URL=postgresql://localhost:5432/skillbridge NODE_ENV=test JWT_SECRET=dummy REFRESH_TOKEN_SECRET=dummy SESSION_SECRET=dummy npm run knex:migrate *(fails: no PostgreSQL server available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8214bbe488328b227f0f99334a55a