### PR TITLE
Include common translations for admin online classes

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/index.js
@@ -45,7 +45,7 @@ export default ProtectedAdminOnlineClassesPage;
 export async function getStaticProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+      ...(await serverSideTranslations(locale, ['common', 'dashboard'], nextI18NextConfig)),
     },
   };
 }


### PR DESCRIPTION
## Summary
- include the shared `common` namespace when loading translations for the admin online classes page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8213de4088328a8c8ab7c0cdff8de