### PR TITLE
Add access type persistence and fix instructor uploader flag

### DIFF
--- a/backend/src/migrations/20251031120000_add_access_type_column_to_online_classes.js
+++ b/backend/src/migrations/20251031120000_add_access_type_column_to_online_classes.js
@@ -1,0 +1,19 @@
+exports.up = async function (knex) {
+  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
+  if (!hasColumn) {
+    await knex.schema.alterTable('online_classes', (table) => {
+      table.string('access_type').notNullable().defaultTo('paid');
+    });
+  }
+
+  await knex('online_classes').whereNull('access_type').update({ access_type: 'paid' });
+};
+
+exports.down = async function (knex) {
+  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
+  if (hasColumn) {
+    await knex.schema.alterTable('online_classes', (table) => {
+      table.dropColumn('access_type');
+    });
+  }
+};

--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -203,6 +203,26 @@ describe('Class routes', () => {
     expect(res.body.data.access_type).toBe('free');
   });
 
+  test('instructor class creation defaults access_type to paid when omitted', async () => {
+    const created = {
+      id: '2',
+      instructor_id: 'test-user',
+      title: 'Paid Class',
+      access_type: 'paid',
+    };
+    service.createClass.mockResolvedValue(created);
+
+    const res = await request(app)
+      .post('/classes/instructor')
+      .send({ title: 'Paid Class' });
+
+    expect(res.statusCode).toBe(200);
+    expect(service.createClass).toHaveBeenCalledWith(
+      expect.objectContaining({ access_type: 'paid' })
+    );
+    expect(res.body.data.access_type).toBe('paid');
+  });
+
   test('instructor cannot create class when feature disabled', async () => {
     planService.getPlanById.mockResolvedValueOnce({
       id: 'plan1',

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -3,7 +3,17 @@ const ClassModel = require("./class.model");
 const { parsePagination } = require("../../utils/pagination");
 
 exports.createClass = async (data) => {
-  return ClassModel.create(data);
+  const normalizedAccessType =
+    typeof data?.access_type === "string" && ["paid", "free"].includes(data.access_type)
+      ? data.access_type
+      : "paid";
+
+  const payload = {
+    ...data,
+    access_type: normalizedAccessType,
+  };
+
+  return ClassModel.create(payload);
 };
 
 exports.countPublishedClasses = async (instructorId) => {

--- a/frontend/src/pages/dashboard/instructor/online-classes/create.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/create.js
@@ -88,13 +88,12 @@ function CreateOnlineClass() {
 
   const {
     uploadProgress = 0,
+    imageUploading: isImageUploading = false,
+    videoUploading: isVideoUploading = false,
     handleImageUpload: mediaImageUpload = () => {},
     handleVideoUpload: mediaVideoUpload = () => {},
     setUploadProgress = () => {},
   } = mediaUploader ?? {};
-
-  const isImageUploading = Boolean(mediaUploader?.imageUploading);
-  const isVideoUploading = Boolean(mediaUploader?.videoUploading);
 
   useEffect(() => {
     fetchAllCategories({ status: 'active', limit: 100 })


### PR DESCRIPTION
## Summary
- add a migration to ensure online classes include an access_type column defaulting to paid
- normalize access_type before persisting classes and extend route tests to cover the default case
- fix the instructor class creation page to use the media uploader state that already exists

## Testing
- npm test -- class.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8203315408328938d5d7c949435b8