### PR TITLE
Fix installer dependency helpers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -226,6 +226,14 @@ install_backend_dependencies() {
   fi
 }
 
+ensure_backend_upload_dir() {
+  local uploads_dir="$REPO_ROOT/backend/uploads/app"
+  if [[ ! -d "$uploads_dir" ]]; then
+    echo "Creating backend uploads directory at $uploads_dir"
+    mkdir -p "$uploads_dir"
+  fi
+}
+
 CLI_MODE=${1:-}
 CLI_DOMAIN=${2:-}
 
@@ -235,12 +243,6 @@ ensure_env_file "$REPO_ROOT/backend/.env.production.example" "$REPO_ROOT/backend
 ensure_env_file "$REPO_ROOT/frontend/.env.local.example" "$REPO_ROOT/frontend/.env.local"
 
 load_env_file "$REPO_ROOT/.env"
-
-UPLOADS_DIR="$REPO_ROOT/backend/uploads/app"
-if [[ ! -d "$UPLOADS_DIR" ]]; then
-  echo "Creating backend uploads directory at $UPLOADS_DIR"
-  mkdir -p "$UPLOADS_DIR"
-fi
 
 MODE=${CLI_MODE:-${MODE:-}}
 
@@ -305,7 +307,7 @@ if [[ "$MODE" == "production" ]]; then
 fi
 
 ensure_backend_upload_dir
-install_node_dependencies "$REPO_ROOT/backend"
+install_backend_dependencies
 
 if [[ "$MODE" == "production" ]]; then
   if docker_available; then


### PR DESCRIPTION
## Summary
- add an ensure_backend_upload_dir helper and reuse the existing directory creation logic
- replace the missing install_node_dependencies call with the existing install_backend_dependencies helper

## Testing
- START_DEV_SERVICES=false ADMIN_EMAIL=test@example.com ADMIN_PASSWORD=Password123! DATABASE_URL=postgres://user:pass@localhost:5432/db DATABASE_USER=user DATABASE_PASSWORD=pass SMTP_HOST=localhost SMTP_PORT=1025 SMTP_USER=smtp SMTP_PASS=pass DEFAULT_FROM_EMAIL=no-reply@example.com APP_DISPLAY_NAME=Skillbridge ./install.sh development

------
https://chatgpt.com/codex/tasks/task_e_68d82b0114cc8328bc331dbd3158deba