### PR TITLE
Fix install helper functions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -226,6 +226,50 @@ install_backend_dependencies() {
   fi
 }
 
+ensure_backend_upload_dir() {
+  local uploads_dir="$REPO_ROOT/backend/uploads/app"
+
+  if [[ -d "$uploads_dir" ]]; then
+    return 0
+  fi
+
+  echo "Creating backend uploads directory at $uploads_dir"
+  if ! mkdir -p "$uploads_dir"; then
+    echo "Failed to create backend uploads directory at $uploads_dir" >&2
+    exit 1
+  fi
+}
+
+install_node_dependencies() {
+  local target_dir=${1:-}
+
+  if [[ -z "$target_dir" ]]; then
+    echo "install_node_dependencies requires a target directory argument." >&2
+    exit 1
+  fi
+
+  if [[ "${NODE_DEPS_INSTALLED:-false}" == "true" ]]; then
+    return 0
+  fi
+
+  case "$target_dir" in
+    "$REPO_ROOT/backend")
+      install_backend_dependencies
+      ;;
+    *)
+      echo "Installing Node dependencies in $target_dir..."
+      if ! npm --prefix "$target_dir" install; then
+        echo "Failed to install Node dependencies in $target_dir." >&2
+        exit 1
+      fi
+      ;;
+  esac
+
+  NODE_DEPS_INSTALLED=true
+}
+
+NODE_DEPS_INSTALLED=false
+
 CLI_MODE=${1:-}
 CLI_DOMAIN=${2:-}
 
@@ -236,11 +280,7 @@ ensure_env_file "$REPO_ROOT/frontend/.env.local.example" "$REPO_ROOT/frontend/.e
 
 load_env_file "$REPO_ROOT/.env"
 
-UPLOADS_DIR="$REPO_ROOT/backend/uploads/app"
-if [[ ! -d "$UPLOADS_DIR" ]]; then
-  echo "Creating backend uploads directory at $UPLOADS_DIR"
-  mkdir -p "$UPLOADS_DIR"
-fi
+ensure_backend_upload_dir
 
 MODE=${CLI_MODE:-${MODE:-}}
 
@@ -304,7 +344,6 @@ if [[ "$MODE" == "production" ]]; then
   load_env_file "$REPO_ROOT/backend/.env.production"
 fi
 
-ensure_backend_upload_dir
 install_node_dependencies "$REPO_ROOT/backend"
 
 if [[ "$MODE" == "production" ]]; then
@@ -388,7 +427,7 @@ for required in DATABASE_URL DATABASE_USER DATABASE_PASSWORD SMTP_HOST SMTP_PORT
   require_env_var "$required"
 done
 
-install_backend_dependencies
+install_node_dependencies "$REPO_ROOT/backend"
 
 export \
   ADMIN_EMAIL \


### PR DESCRIPTION
## Summary
- implement `ensure_backend_upload_dir` to manage the backend uploads directory in one place
- add `install_node_dependencies` wrapper so backend npm installs reuse the existing helper and only run once per invocation

## Testing
- `START_DEV_SERVICES=false ADMIN_EMAIL=test@example.com ADMIN_PASSWORD='Password123!' DATABASE_URL='postgres://user:pass@localhost:5432/db' DATABASE_USER=user DATABASE_PASSWORD=pass SMTP_HOST=localhost SMTP_PORT=1025 SMTP_USER=user SMTP_PASS=pass DEFAULT_FROM_EMAIL='no-reply@example.com' APP_DISPLAY_NAME='SkillBridge' SKIP_BACKEND_NPM_INSTALL=true ./install.sh development` *(fails: apply-install-config requires a reachable database in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82aed58b08328bd2b41b67dff34c4