### PR TITLE
Copy docs directory into frontend container images

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,7 @@ RUN npm ci && npm cache clean --force
 COPY frontend/ ./
 RUN cp /tmp/sanitized-package.json package.json
 COPY shared /shared
+COPY docs ./docs
 
 # Ensure subsequent RUN instructions use bash so pipefail is respected.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -74,6 +75,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 COPY frontend/ ./
 RUN cp /tmp/sanitized-package.json package.json
 COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/docs ./docs
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /shared /shared


### PR DESCRIPTION
## Summary
- copy the repository docs directory into the frontend build stage so Next.js can access Markdown during static generation
- carry the docs directory into the production image to support runtime Markdown access

## Testing
- docker compose build frontend *(fails: `docker` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83833a8d08328b6defcbd324e10f3