### PR TITLE
Copy docs into frontend Docker image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p /app \
 WORKDIR /app
 RUN npm ci && npm cache clean --force
 COPY frontend/ ./
+COPY docs ./docs
 RUN cp /tmp/sanitized-package.json package.json
 COPY shared /shared
 
@@ -72,6 +73,7 @@ RUN mkdir -p /app \
 WORKDIR /app
 RUN npm ci --omit=dev && npm cache clean --force
 COPY frontend/ ./
+COPY docs ./docs
 RUN cp /tmp/sanitized-package.json package.json
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary
- copy the repository docs directory into the builder image so static generation can read markdown
- include docs in the production image to ship compiled documentation alongside the app

## Testing
- docker compose build frontend *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8382c401483288b9d9e5840de07ad