### PR TITLE
Include docs directory in frontend Docker images

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p /app \
 WORKDIR /app
 RUN npm ci && npm cache clean --force
 COPY frontend/ ./
+COPY docs ./docs
 RUN cp /tmp/sanitized-package.json package.json
 COPY shared /shared
 
@@ -72,9 +73,11 @@ RUN mkdir -p /app \
 WORKDIR /app
 RUN npm ci --omit=dev && npm cache clean --force
 COPY frontend/ ./
+COPY docs ./docs
 RUN cp /tmp/sanitized-package.json package.json
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
+COPY --from=builder /app/docs ./docs
 COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /shared /shared
 RUN addgroup -S app && adduser -S -G app app && chown -R app:app /app


### PR DESCRIPTION
## Summary
- ensure the frontend build stage copies the repository docs directory so static generation can access markdown content
- propagate the docs artifacts into the production image by copying them from the builder layer

## Testing
- docker compose build frontend *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83814f0e48328b244e77bc97e953a