### PR TITLE
Copy docs directory into frontend Docker image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,7 @@ RUN npm ci && npm cache clean --force
 COPY frontend/ ./
 RUN cp /tmp/sanitized-package.json package.json
 COPY shared /shared
+COPY docs ./docs
 
 # Ensure subsequent RUN instructions use bash so pipefail is respected.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -73,6 +74,7 @@ WORKDIR /app
 RUN npm ci --omit=dev && npm cache clean --force
 COPY frontend/ ./
 RUN cp /tmp/sanitized-package.json package.json
+COPY docs ./docs
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/scripts ./scripts


### PR DESCRIPTION
## Summary
- copy the repository docs directory into the frontend build stage so Next.js static generation can read markdown guides
- mirror the docs copy in the production image to keep markdown available during ISR revalidations

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d8381cee208328a295c43e0399df17