### PR TITLE
Ensure docs directory is bundled for docs pages

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -224,6 +224,10 @@ const nextConfig = {
   experimental: {
     largePageDataBytes: 256 * 1024,
     externalDir: true,
+    outputFileTracingIncludes: {
+      '/docs': ['./docs/**/*'],
+      '/docs/[slug]': ['./docs/**/*'],
+    },
     turbo: {
       resolveAlias: {
         '@shared': path.resolve(__dirname, '../shared'),


### PR DESCRIPTION
## Summary
- ensure Next.js output file tracing includes the top-level docs directory so the docs pages can load markdown after deployment

## Testing
- npm --prefix frontend run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d82f6540288328bd073d47123766b7