### PR TITLE
Add HTML documentation build output

### DIFF
--- a/docs/README.html
+++ b/docs/README.html
@@ -1,0 +1,527 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SkillBridge Documentation | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html" class="active">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="skillbridge-documentation">SkillBridge Documentation</h1>
+<h2 id="installation">Installation</h2>
+<p>Choose the path that matches your environment:</p>
+<ul>
+<li><a href="./installation.html#deploy-from-the-customer-zip-package">Deploy from the customer ZIP package</a>
+  – ideal for cPanel/FTP hosts and managed servers where you upload a prepared
+  archive from the Memonet portal.</li>
+<li><a href="./installation.html#1-clone-the-repository">Install from Git</a> – clone the
+  repository, run the install script, and manage updates with Git.</li>
+</ul>
+<h3 id="prerequisites">Prerequisites</h3>
+<p>SkillBridge requires the following tools on your workstation or server:</p>
+<ul>
+<li>Node.js 18 or later (npm 9+ is bundled)</li>
+<li>Docker Engine and the Docker Compose <strong>V2</strong> plugin (<code>docker compose</code> command)</li>
+<li>Git</li>
+<li>Redis or another session store for production deployments</li>
+</ul>
+<blockquote>
+<p><strong>Heads up:</strong> The legacy <code>docker-compose</code> v1 CLI is incompatible with recent
+Docker Engine releases and often fails with <code>KeyError: 'ContainerConfig'</code>
+when rebuilding containers. Install the Docker Compose V2 plugin or downgrade
+Docker Engine below version 27 before continuing. As a short-term workaround,
+run <a href="../scripts/run-compose.sh"><code>scripts/run-compose.sh</code></a>, which exports
+<code>DOCKER_API_VERSION=1.43</code> automatically when it has to fall back to the
+legacy binary.</p>
+</blockquote>
+<h3 id="install-the-required-tools">Install the required tools</h3>
+<p>Follow the commands for your operating system to install the prerequisites the
+installer enforces.</p>
+<h4 id="nodejs-18-includes-npm">Node.js 18+ (includes npm)</h4>
+<ul>
+<li><strong>macOS (Homebrew):</strong></li>
+</ul>
+<p><code>bash
+  brew install node@20
+  echo 'export PATH="/opt/homebrew/opt/node@20/bin:$PATH"' &gt;&gt; ~/.zshrc</code></p>
+<ul>
+<li><strong>Ubuntu / Debian:</strong></li>
+</ul>
+<p><code>bash
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+  sudo apt-get install -y nodejs</code></p>
+<ul>
+<li><strong>Windows:</strong> Download the LTS installer from <a href="https://nodejs.org/">nodejs.org</a>,
+  run it, then restart your terminal and confirm with <code>node -v</code>.</li>
+</ul>
+<h4 id="docker-engine-and-docker-compose-v2">Docker Engine and Docker Compose V2</h4>
+<ul>
+<li>
+<p><strong>macOS / Windows:</strong> Install <a href="https://www.docker.com/products/docker-desktop/">Docker Desktop</a>,
+  ensure it is running, and verify with <code>docker --version</code> and
+  <code>docker compose version</code>.</p>
+</li>
+<li>
+<p><strong>Ubuntu / Debian:</strong></p>
+</li>
+</ul>
+<p><code>bash
+  curl -fsSL https://get.docker.com | sh
+  sudo usermod -aG docker $USER
+  newgrp docker
+  sudo mkdir -p /usr/lib/docker/cli-plugins
+  sudo curl -SL "https://github.com/docker/compose/releases/download/v2.24.7/docker-compose-linux-$(uname -m)" \
+    -o /usr/lib/docker/cli-plugins/docker-compose
+  sudo chmod +x /usr/lib/docker/cli-plugins/docker-compose
+  docker --version
+  docker compose version</code></p>
+<p>Docker Desktop already bundles Compose V2; Linux users install the plugin
+  manually as shown above.</p>
+<h4 id="git">Git</h4>
+<ul>
+<li><strong>macOS:</strong> <code>brew install git</code></li>
+<li><strong>Ubuntu / Debian:</strong> <code>sudo apt-get install -y git</code></li>
+<li><strong>Windows:</strong> Install <a href="https://git-scm.com/download/win">Git for Windows</a> and
+  select “Git from the command line” during setup.</li>
+</ul>
+<p>Open a fresh terminal after installing these tools so PATH changes take effect,
+then rerun <code>./install.sh</code> or revisit <code>/install</code> to confirm the checks pass.</p>
+<h3 id="install-from-zip-release">Install from ZIP release</h3>
+<p>If you downloaded the packaged CodeCanyon release (published as <strong>memonet</strong>)
+rather than cloning Git, follow these steps to get the archive running on a
+workstation or live server:</p>
+<ol>
+<li><strong>Upload the ZIP.</strong> Copy the release to the host. For remote servers use
+   <code>scp</code>/<code>rsync</code> (e.g. <code>scp Skillbridge-v1.0.0.zip deploy@example.com:/var/www</code>).</li>
+<li><strong>Extract into <code>Skillbridge/</code>.</strong> Unzip the archive, rename the extracted
+   folder to <code>Skillbridge</code>, and <code>cd</code> into it so <code>install.sh</code>, <code>docker-compose.yml</code>,
+   <code>backend/</code>, and <code>frontend/</code> sit in the project root.</li>
+<li><strong>Fix ownership and permissions.</strong> On Linux change ownership to the deploy
+   user (<code>sudo chown -R deploy:deploy Skillbridge</code>) and ensure helper scripts
+   are executable (<code>chmod +x install.sh scripts/*.sh</code>). Local macOS/Windows
+   users can usually skip the <code>chown</code> step.</li>
+<li><strong>Copy the <code>.env</code> templates.</strong> Duplicate <code>.env.example</code> files for the root,
+   backend (both <code>.env</code> and <code>.env.production</code>), and frontend (<code>frontend/.env.local</code>).
+   Update the values with your domain, database URL, SMTP credentials, and admin
+   account details. See <a href="./deployment.html">deployment.md</a> for production-only
+   settings such as TLS certificates and domain variables.</li>
+<li><strong>Run the installer.</strong> Execute <code>./install.sh</code> from the project root. The
+   script asks whether you are installing locally or in production and applies
+   migrations/seeds automatically. For unattended production use the CLI form
+   (<code>./install.sh production yourdomain.com</code>).</li>
+<li><strong>Start Docker services.</strong> Launch the stack with <code>docker compose up --build</code>
+   for local development or <code>docker compose up -d --build</code> on a live host. If
+   you skip the automated compose step, run the commands manually after the
+   installer exits. When you handle migrations yourself, apply them before
+   serving traffic:</li>
+</ol>
+<p><code>bash
+   docker compose run --rm backend npm run migrate
+   docker compose run --rm backend npm run seed</code></p>
+<p>The dedicated <a href="./installation.html#install-from-zip-release">installation guide</a>
+contains the same workflow with command examples and troubleshooting tips.</p>
+<h3 id="1-clone-the-repository">1. Clone the repository</h3>
+<div class="codehilite"><pre><span></span><code>git<span class="w"> </span>clone<span class="w"> </span>&lt;repo-url&gt;
+<span class="nb">cd</span><span class="w"> </span>Skillbridge
+</code></pre></div>
+
+<h3 id="2-configure-environment-variables">2. Configure environment variables</h3>
+<h4 id="automated-install-script">Automated install script</h4>
+<p>The root <code>install.sh</code> script streamlines both local and production setups. When
+you run it the script:</p>
+<ol>
+<li>Runs <code>scripts/check_prereqs.sh</code> to verify Node.js, npm, Docker, Docker Compose
+   V2, and Git. Fix the issue, acknowledge the warning at the prompt, or set
+   <code>ALLOW_PREREQ_FAILURES=true</code> to continue automatically.</li>
+<li>Copies <code>.env.example</code> files to <code>.env</code> when the target file is missing (root,
+   backend, backend production, and <code>frontend/.env.local</code>).</li>
+<li>Sources the resulting files so migrations, seeds, and helper scripts inherit
+   the configuration.</li>
+<li>Ensures <code>backend/uploads/app</code> exists before branding assets are written.</li>
+</ol>
+<p>Supply <code>ADMIN_EMAIL</code> and <code>ADMIN_PASSWORD</code> via environment variables for
+non-interactive use. Optional flags include:</p>
+<ul>
+<li><code>SEED_DB=true</code> — run <code>npm --prefix backend run seed</code> after migrations.</li>
+<li><code>START_DEV_SERVICES=false</code> — skip the automatic <code>docker compose up</code> step in
+  development mode.</li>
+<li><code>SKIP_BACKEND_NPM_INSTALL=true</code> — skip the automatic backend dependency
+  install step when you manage packages separately.</li>
+</ul>
+<p>In production mode, the script ensures Docker services are running before it
+executes database migrations. In development mode it starts the compose stack in
+detached mode unless you opt out with <code>START_DEV_SERVICES=false</code>.</p>
+<p>Before running migrations the script installs backend dependencies with
+<code>npm --prefix backend install</code> so the Node.js helper scripts are available and
+creates <code>backend/uploads/app/</code> if it is missing.</p>
+<h4 id="backend">Backend</h4>
+<p>Copy the example file and adjust values as needed:</p>
+<div class="codehilite"><pre><span></span><code>cp<span class="w"> </span>backend/.env.example<span class="w"> </span>backend/.env
+</code></pre></div>
+
+<p>For deployments, Docker Compose also reads <code>backend/.env.production</code>. Copy
+<code>backend/.env.production.example</code> to <code>backend/.env.production</code> and fill in
+production database credentials and JWT secrets.</p>
+<p>Set the display name that should appear in installer prompts and outbound
+emails so the branding check passes:</p>
+<div class="codehilite"><pre><span></span><code>APP_NAME=SkillBridge
+</code></pre></div>
+
+<p>If you plan to disable transactional email during setup, set
+<code>DISABLE_EMAILS=true</code>. Otherwise provide SMTP credentials so the installer can
+verify connectivity:</p>
+<div class="codehilite"><pre><span></span><code>SMTP_HOST=smtp.mailtrap.io
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password
+</code></pre></div>
+
+<p>Create the uploads directory that stores logos and favicons and ensure it is
+writable by the backend service user:</p>
+<div class="codehilite"><pre><span></span><code>mkdir<span class="w"> </span>-p<span class="w"> </span>backend/uploads/app
+</code></pre></div>
+
+<p>Edit <code>backend/.env</code> and provide your secrets. <code>FRONTEND_URL</code> must match the
+exact origin (scheme, host, and port) where the frontend will run to avoid CORS
+errors. Separate multiple origins with commas, for example:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">FRONTEND_URL</span><span class="o">=</span>http://localhost:3000,https://example.com
+</code></pre></div>
+
+<p>Leave <code>NODE_ENV</code> unset so cookies work over HTTP locally. If you need
+cross-subdomain cookies without HTTPS, also set:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">COOKIE_SECURE</span><span class="o">=</span><span class="nb">false</span>
+<span class="nv">COOKIE_SAMESITE</span><span class="o">=</span>None
+</code></pre></div>
+
+<p>If additional domains need access to the API, add them to
+<code>EXTRA_CORS_ORIGINS</code> as a comma-separated list of URLs:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">EXTRA_CORS_ORIGINS</span><span class="o">=</span>https://admin.example.com,https://docs.example.com
+</code></pre></div>
+
+<p>Rate limiting defaults to 1,000 requests per IP every 15 minutes. Adjust the
+allowance if your deployment expects heavier bursts of traffic:</p>
+<div class="codehilite"><pre><span></span><code>RATE_LIMIT_MAX=2000
+RATE_LIMIT_WINDOW_MS=300000 # 5 minutes
+</code></pre></div>
+
+<p>A Redis instance (or compatible store) is required to persist sessions in
+production. Set <code>REDIS_URL</code> in <code>backend/.env</code> to point to your Redis server
+(for example <code>redis://localhost:6379</code>).</p>
+<p>The book filter's price range uses configurable defaults:</p>
+<div class="codehilite"><pre><span></span><code>BOOK_PRICE_RANGE_DEFAULT=100
+BOOK_PRICE_RANGE_MAX=500
+</code></pre></div>
+
+<p>These values are read in <code>backend/src/config/books.js</code> and mirrored on the
+frontend via <code>frontend/src/utils/constants.js</code>. When running the frontend
+outside Docker, add the <code>NEXT_PUBLIC_</code> variants to <code>frontend/.env.local</code>:</p>
+<div class="codehilite"><pre><span></span><code>NEXT_PUBLIC_BOOK_PRICE_RANGE_DEFAULT=100
+NEXT_PUBLIC_BOOK_PRICE_RANGE_MAX=500
+</code></pre></div>
+
+<h5 id="installation-api">Installation API</h5>
+<p>The backend exposes protected setup endpoints at <code>/api/install</code> for automated
+deployments. Enable them by setting <code>INSTALL_API_ENABLED=true</code> in
+<code>backend/.env</code> and restarting the backend. Authenticate every request with an
+administrator JWT and provide the configuration payload when invoking
+<code>POST /api/install/run</code>.</p>
+<p>If you configure <code>INSTALL_SETUP_SECRET</code>, clients must also send the same value
+in the <code>X-Install-Setup-Secret</code> header on every installer request. Remove or
+disable the API when setup is complete.</p>
+<h5 id="initial-admin-passwords">Initial admin passwords</h5>
+<p>Set <code>ADMIN_INITIAL_PASSWORD</code> and <code>SUPERADMIN_INITIAL_PASSWORD</code> before running
+seed scripts if you want to control the passwords for the seeded Admin and
+SuperAdmin accounts. When left unset, the seed process generates secure random
+passwords and prints them to the console.</p>
+<h4 id="frontend-optional">Frontend (optional)</h4>
+<p>When using Docker Compose the frontend automatically points to the API on port
+<code>5002</code>. If you start the Next.js app separately, create <code>frontend/.env.local</code>
+and set:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">NEXT_PUBLIC_API_BASE_URL</span><span class="o">=</span>http://localhost:5002/api
+<span class="nv">NEXT_PUBLIC_TRUSTED_ICON_HOSTS</span><span class="o">=</span>yourdomain.com,cdn.yourdomain.com
+</code></pre></div>
+
+<p><code>NEXT_PUBLIC_TRUSTED_ICON_HOSTS</code> defines a comma-separated list of allowed
+hosts for payment method icons. URLs outside this list will fall back to a
+default icon.</p>
+<p>The root <code>.env</code> file defaults <code>NEXT_PUBLIC_API_BASE_URL</code> to
+<code>http://localhost:5002/api</code> so Docker services can reach the backend container
+internally during development. For production builds use
+<code>frontend/.env.production</code> instead and remove or override the root <code>.env</code> so the
+frontend points to your public domain.</p>
+<h3 id="3-install-dependencies-optional">3. Install dependencies (optional)</h3>
+<p>For manual development outside of Docker:</p>
+<div class="codehilite"><pre><span></span><code><span class="nb">cd</span><span class="w"> </span>backend<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>npm<span class="w"> </span>install
+<span class="nb">cd</span><span class="w"> </span>../frontend<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>npm<span class="w"> </span>install
+<span class="nb">cd</span><span class="w"> </span>..
+</code></pre></div>
+
+<h3 id="4-prepare-the-database">4. Prepare the database</h3>
+<p>Run migrations and seed data:</p>
+<div class="codehilite"><pre><span></span><code><span class="nb">cd</span><span class="w"> </span>backend
+npm<span class="w"> </span>run<span class="w"> </span>migrate
+npm<span class="w"> </span>run<span class="w"> </span>seed
+<span class="nb">cd</span><span class="w"> </span>..
+</code></pre></div>
+
+<h3 id="5-launch-the-stack">5. Launch the stack</h3>
+<p>Start all services with Docker Compose:</p>
+<div class="codehilite"><pre><span></span><code>docker<span class="w"> </span>compose<span class="w"> </span>up<span class="w"> </span>--build
+</code></pre></div>
+
+<p>The containers expose the following URLs:</p>
+<ul>
+<li>Frontend: <code>http://localhost:3000</code></li>
+<li>Backend API: <code>http://localhost:5002/api</code></li>
+<li>PostgreSQL: <code>localhost:5432</code></li>
+<li>pgAdmin: <code>http://localhost:5050</code></li>
+<li>Redis: <code>localhost:6379</code></li>
+</ul>
+<p>Once running, open the frontend URL in your browser and create an account or log
+in.</p>
+<h4 id="web-based-installer-optional">Web-based installer (optional)</h4>
+<ol>
+<li>In <code>backend/.env</code>, set <code>ENABLE_INSTALL=true</code> and <code>INSTALL_API_ENABLED=true</code>.</li>
+<li>Configure Nginx to proxy the installer route to the backend:</li>
+</ol>
+<p><code>nginx
+   location ^~ /install/ {
+     proxy_pass http://backend:5002;
+     proxy_http_version 1.1;
+     proxy_set_header Host $host;
+     proxy_set_header X-Real-IP $remote_addr;
+     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+     proxy_set_header X-Forwarded-Proto $scheme;
+   }</code></p>
+<ol start="3">
+<li>Rebuild and start the containers if they are running.</li>
+<li>Log in with an administrator account.</li>
+<li>Visit <code>http://localhost:5002/install</code> (or your domain's <code>/install</code>) and
+   verify the page lists the prerequisite checks.</li>
+<li>Complete the <strong>Configuration</strong> step by supplying database, SMTP, branding,
+   and admin credentials.</li>
+<li>Run the installer. It updates <code>backend/.env</code>, uploads the logo, seeds
+   branding/email settings, and provisions the administrator account.</li>
+</ol>
+<h3 id="6-running-tests">6. Running tests</h3>
+<p>The project includes Jest suites for both the API and the frontend.</p>
+<div class="codehilite"><pre><span></span><code><span class="nb">cd</span><span class="w"> </span>backend<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>npm<span class="w"> </span><span class="nb">test</span>
+<span class="nb">cd</span><span class="w"> </span>../frontend<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>npm<span class="w"> </span><span class="nb">test</span>
+</code></pre></div>
+
+<h3 id="7-hosting-on-a-server">7. Hosting on a server</h3>
+<ol>
+<li>Provision a Linux server and install Docker and Docker Compose V2.</li>
+<li>Clone the repository on the server and configure environment variables as
+   described above.
+   - In <code>backend/.env</code>, set production values such as <code>NODE_ENV=production</code>,
+     <code>FRONTEND_URL=https://&lt;your-domain&gt;</code>, <code>COOKIE_SECURE=true</code>, and
+     <code>COOKIE_SAMESITE=None</code>.
+   - Create <code>frontend/.env.local</code> with
+     <code>NEXT_PUBLIC_API_BASE_URL=https://&lt;your-domain&gt;/api</code>.</li>
+<li>Adjust Nginx for your domain.
+   - Set the <code>APP_DOMAIN</code> environment variable so Nginx and the backend use your
+     domain.
+   - Obtain TLS certificates (for example via Let's Encrypt) and ensure the
+     paths in <code>ssl.conf</code> match the certificate locations.</li>
+<li>Run database migrations and seeds before starting the containers:</li>
+</ol>
+<p><code>bash
+   docker compose run --rm backend npm run migrate
+   docker compose run --rm backend npm run seed</code></p>
+<ol start="5">
+<li>Build and start the containers in detached mode:</li>
+</ol>
+<p><code>bash
+   docker compose up -d --build</code></p>
+<ol start="6">
+<li>Verify the deployment by visiting <code>https://&lt;your-domain&gt;</code> in a browser. The
+   API is available at <code>https://&lt;your-domain&gt;/api</code>.</li>
+</ol>
+<p>For updates, pull the latest changes and rebuild:</p>
+<div class="codehilite"><pre><span></span><code>git<span class="w"> </span>pull
+docker<span class="w"> </span>compose<span class="w"> </span>up<span class="w"> </span>-d<span class="w"> </span>--build
+</code></pre></div>
+
+<h3 id="additional-references">Additional references</h3>
+<ul>
+<li><a href="deployment.html">Deployment Guide</a> — how to deploy SkillBridge.</li>
+<li><a href="architecture.html">Architecture Overview</a> — system components and data flow.</li>
+<li><a href="social-login-setup.html">Social Login Setup</a> — configure OAuth providers.</li>
+</ul>
+<h2 id="administration">Administration</h2>
+<ul>
+<li><a href="admin-alerts.html">Alerts Management</a> — configure system alerts.</li>
+<li><a href="admin-ads-management.html">Ads Management</a> — manage platform advertisements.</li>
+<li><a href="admin-category-management.html">Category Management</a> — organize course categories.</li>
+<li><a href="admin-third-party-integrations.html">Third-Party Integrations</a> — connect external services.</li>
+<li><a href="license-verification.html">License Verification</a> — verify instructor credentials.</li>
+<li><a href="messages-config.html">Messages Configuration</a> — customize message templates.</li>
+<li><a href="coupon-management.html">Coupon Management</a> — define promotional codes.</li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a> — references for payment icons.</li>
+<li><a href="subscription-plan-style.html">Subscription Plan Styles</a> — style subscription options.</li>
+</ul>
+<h2 id="workflows">Workflows</h2>
+<ul>
+<li><a href="book-workflow.html">Book Workflow</a> — process for booking classes.</li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle Workflow</a> — lifecycle of a class.</li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a> — overview of plan coverage.</li>
+<li><a href="student-registration-guide.html">Student Registration Guide</a> — steps for new student sign-up.</li>
+<li><a href="student-enrollment-workflow.html">Student Enrollment Workflow</a> — enroll students into classes.</li>
+</ul>
+<h2 id="reference">Reference</h2>
+<ul>
+<li><a href="api-docs.html">API Documentation</a> — REST API endpoints.</li>
+<li><a href="changelog.html">Changelog</a> — record of notable changes.</li>
+<li><a href="release-checklist.html">Release Checklist</a> — tasks before a release.</li>
+</ul>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/admin-ads-management.html
+++ b/docs/admin-ads-management.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Ads Management | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html" class="active">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="admin-ads-management">Admin Ads Management</h1>
+<p>This page describes how advertisement banners are managed within the admin dashboard.</p>
+<h2 id="backend">Backend</h2>
+<ul>
+<li>Routes and controllers live in <code>backend/src/modules/ads</code>.</li>
+<li>Creating, updating or deleting an ad now sends a notification to the ad creator and to all admin users.</li>
+<li>The <code>GET /api/ads/admin</code> endpoint accepts an optional <code>role</code> query to
+  filter ads targeted to <code>student</code> or <code>instructor</code> roles.</li>
+</ul>
+<h2 id="frontend">Frontend</h2>
+<ul>
+<li>UI pages are located in <code>frontend/src/pages/dashboard/admin/ads</code>.</li>
+<li><code>index.js</code> lists existing ads with filtering and pagination. Actions such as deleting or toggling status display toast notifications and trigger backend notifications.</li>
+<li><code>create.js</code> allows adding new ads with image uploads.</li>
+</ul>
+<p>All actions are backed by <code>frontend/src/services/admin/adService.js</code> which communicates with the API.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/admin-alerts.html
+++ b/docs/admin-alerts.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Alerts | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html" class="active">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="admin-alerts">Admin Alerts</h1>
+<p>The admin alerts page surfaces recent warnings and system errors so administrators can diagnose issues quickly.</p>
+<h2 id="backend">Backend</h2>
+<ul>
+<li><strong>Endpoint:</strong> <code>GET /api/system-errors</code></li>
+<li>Located in <code>backend/src/modules/errorLogs</code>.</li>
+<li>Reads the last 50 lines of <code>logs/error.log</code> and returns them as JSON.</li>
+<li>Route is protected by <code>verifyToken</code> and <code>isAdmin</code> middleware.</li>
+</ul>
+<h2 id="frontend">Frontend</h2>
+<ul>
+<li>Page: <code>frontend/src/pages/admin/alerts.js</code></li>
+<li>Uses a Zustand store to fetch and poll the <code>/api/system-errors</code> endpoint every minute.</li>
+<li>Results are shown with pagination and color-coded severity levels.</li>
+<li>A back button links to the main admin dashboard.</li>
+</ul>
+<p>This feature helps track runtime errors and unusual events in production without server access.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/admin-category-management.html
+++ b/docs/admin-category-management.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Category Management | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html" class="active">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="admin-category-management">Admin Category Management</h1>
+<p>Administrators can organize classes and tutorials into a hierarchical list of categories. Each category may have an optional parent so nested structures like <code>Programming &gt; Web Development &gt; JavaScript</code> are supported.</p>
+<h2 id="backend">Backend</h2>
+<ul>
+<li><strong>Routes:</strong> exposed under <code>/api/users/admin/categories</code> and implemented in <code>backend/src/modules/users/categories</code>.</li>
+<li><code>POST /create</code> – create a new category. Supports uploading an image file via the <code>image</code> form field.</li>
+<li><code>PUT /:id</code> – update name, parent, status or image.</li>
+<li><code>PATCH /:id/status</code> – toggle between <code>active</code> and <code>inactive</code>.</li>
+<li><code>DELETE /:id</code> – remove a category that has no sub‑categories.</li>
+<li><code>GET /</code> – list categories with optional <code>search</code> and <code>status</code> filters.</li>
+<li><code>GET /tree</code> – return categories in a nested structure for dropdowns.</li>
+<li><code>GET /:id</code> – fetch a single category by id.</li>
+</ul>
+<h2 id="frontend">Frontend</h2>
+<ul>
+<li>Pages live in <code>frontend/src/pages/dashboard/admin/categories</code>.</li>
+<li><code>index.js</code> lists categories and allows status toggling or deletion.</li>
+<li><code>create.js</code> provides a form to add a new category.</li>
+<li><code>edit/[id].js</code> edits an existing category.</li>
+<li>Requests are handled through <code>frontend/src/services/admin/categoryService.js</code>.</li>
+<li>Images are previewed client‑side before upload and stored in <code>/uploads/categories</code> on the server.</li>
+</ul>
+<p>See also the seed files under <code>backend/src/seeds</code> for example parent and child categories.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/admin-third-party-integrations.html
+++ b/docs/admin-third-party-integrations.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Third Party Integrations | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html" class="active">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="admin-third-party-integrations">Admin Third Party Integrations</h1>
+<p>SkillBridge lets administrators manage API keys and settings for various third-party services. These include the ChatGPT and Hugging Face AI providers used on the community "Ask" page.</p>
+<blockquote>
+<p><strong>Note:</strong> Google reCAPTCHA configuration is no longer managed here. Administrators can configure reCAPTCHA under the <strong>Social Login</strong> settings page.</p>
+</blockquote>
+<h2 id="backend">Backend</h2>
+<ul>
+<li><strong>Settings storage:</strong> <code>backend/src/modules/thirdPartyConfig</code></li>
+<li><strong>API endpoints:</strong> <code>/api/third-party-config</code> for get and update</li>
+<li><strong>AI endpoint:</strong> <code>/api/ai-assistance</code> implemented in <code>backend/src/modules/ai</code></li>
+<li>AI service reads provider config from the settings record before sending requests.</li>
+</ul>
+<h2 id="frontend">Frontend</h2>
+<ul>
+<li>Admin page: <code>frontend/src/pages/dashboard/admin/settings/thirdParty</code></li>
+<li>Integration modals under <code>frontend/src/components/admin/integrations</code> allow entering API keys for ChatGPT and Hugging Face.</li>
+<li>Saved settings are fetched through <code>frontend/src/services/admin/thirdPartyService.js</code>.</li>
+<li>Community question page <code>frontend/src/pages/community/ask.js</code> calls <code>fetchThirdPartyConfig</code> to list available AI providers for users.</li>
+<li>When no provider has an API key configured the page shows "No AI integrations available".</li>
+</ul>
+<p>After storing keys on the admin page, users can select ChatGPT or Hugging Face from a dropdown on the AI Assistance tab and submit questions powered by the chosen model.</p>
+<h3 id="chatgpt-configuration">ChatGPT Configuration</h3>
+<ol>
+<li>Sign in to your OpenAI account and create an API key.</li>
+<li>In the admin dashboard navigate to <strong>Settings → Third Party</strong> and open the
+   <strong>ChatGPT</strong> modal.</li>
+<li>Paste the key into the <strong>API Key</strong> field. You can configure multiple models
+   by listing their names and default temperatures.</li>
+<li>Click <strong>Add model</strong> in the modal to create additional model rows (e.g.
+   <code>gpt-4</code>, <code>gpt-3.5-turbo</code>). Each question on the Ask page can then choose one
+   of the configured models.</li>
+<li>Click <strong>Save</strong> to persist the settings. The backend will use the selected
+   model when calling the OpenAI Chat Completion API.</li>
+</ol>
+<h3 id="hugging-face-configuration">Hugging Face Configuration</h3>
+<ol>
+<li>Generate an access token in your Hugging Face account: <a href="https://huggingface.co/settings/tokens">https://huggingface.co/settings/tokens</a>.
+   A fine‑grained token with the <code>inference:serverless</code> permission is sufficient.</li>
+<li>In the admin dashboard open <strong>Settings → Third Party</strong> and launch the <strong>Hugging Face</strong> modal.</li>
+<li>Paste the token into the <strong>Access Token</strong> field and specify the desired model
+   endpoint (e.g. <code>gpt2</code> or <code>google/flan-t5-base</code>).</li>
+<li>Click <strong>Save</strong> to store the settings.</li>
+<li>Users can now choose <code>huggingface</code> as the provider when asking AI questions.</li>
+</ol>
+<h3 id="deepseek-configuration">DeepSeek Configuration</h3>
+<ol>
+<li>Generate an API key in your DeepSeek account.</li>
+<li>In the admin dashboard open <strong>Settings → Third Party</strong> and select <strong>DeepSeek</strong>.</li>
+<li>Provide the API key and the desired model name (e.g. <code>deepseek-chat</code>) and optional max tokens such as <code>1024</code>.</li>
+<li>Save the settings to enable DeepSeek. Other providers can be deactivated by toggling them off.</li>
+</ol>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/api-docs.html
+++ b/docs/api-docs.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>API Overview | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html" class="active">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="api-overview">API Overview</h1>
+<p>The backend exposes a REST API under the <code>/api</code> prefix. Below is a brief outline of the main routes. For the complete specification see <code>backend/src/docs/swagger.yaml</code>.</p>
+<h2 id="authentication">Authentication</h2>
+<p><code>/api/auth</code></p>
+<ul>
+<li><code>POST /register</code> – create a new user</li>
+<li><code>POST /login</code> – authenticate and receive tokens</li>
+<li><code>POST /refresh</code> – refresh an access token (refresh token cookies expire after 30 days)</li>
+<li><code>POST /logout</code> – clear the refresh token</li>
+<li><code>POST /request-reset</code> – send a password reset OTP <em>(legacy)</em></li>
+<li><code>POST /forgot-password</code> – send a password reset OTP via email</li>
+<li><code>POST /verify-otp</code> – verify the reset code</li>
+<li><code>POST /reset-password</code> – update the password</li>
+</ul>
+<p><code>POST /login</code> and <code>POST /refresh</code> also issue a <code>csrfToken</code> cookie containing a
+random CSRF token. Clients must mirror this value in the <code>x-csrf-token</code> header
+on subsequent state‑changing requests (POST/PUT/PATCH/DELETE) to satisfy server
+CSRF validation.</p>
+<h2 id="csrf-token">CSRF Token</h2>
+<p><code>GET /api/csrf-token</code> – return a fresh CSRF token cookie. The endpoint responds
+with status <code>204</code> and no body.</p>
+<h2 id="users">Users</h2>
+<p><code>/api/users</code></p>
+<ul>
+<li><code>/categories</code> – browse and manage categories</li>
+<li><code>/tutorials</code> – public tutorial browsing and admin management</li>
+<li><code>/classes</code> – published classes and enrollment</li>
+<li><code>GET /api/users/classes</code> – list published classes</li>
+<li><code>GET /api/users/classes/:id</code> – view details for a published class</li>
+<li><code>POST /api/users/classes/admin</code> – create a class (instructor or admin)</li>
+<li><code>PUT /api/users/classes/admin/:id</code> – update a class</li>
+<li><code>DELETE /api/users/classes/admin/:id</code> – remove a class</li>
+<li><code>GET /api/users/classes/admin/my</code> – list classes for the logged in instructor</li>
+<li><code>/admin</code> – administrator dashboard features</li>
+<li><code>/instructor</code> – instructor tools</li>
+<li><code>/student</code> – student account endpoints</li>
+</ul>
+<h2 id="booking-management">Booking Management</h2>
+<p><code>/api/bookings/admin</code> – CRUD operations for session bookings (admin only).</p>
+<h2 id="payment-management">Payment Management</h2>
+<p><code>/api/payments/admin</code> – CRUD operations for user payments (admin only).</p>
+<p><code>/api/payments/student</code></p>
+<ul>
+<li><code>GET /api/payments/student</code> – list payments for the logged in student</li>
+<li><code>GET /api/payments/student/:id</code> – retrieve a payment belonging to the authenticated student</li>
+</ul>
+<h2 id="community-management">Community Management</h2>
+<p><code>/api/community/admin</code> – manage announcements, reports, tags and settings.</p>
+<h2 id="verification">Verification</h2>
+<p><code>/api/verify</code> – send and confirm OTP codes for email or phone verification.</p>
+<h2 id="health-check">Health Check</h2>
+<p><code>GET /</code> – returns a simple message confirming that the API is running.</p>
+<h2 id="offers">Offers</h2>
+<p><code>/api/offers</code></p>
+<ul>
+<li><code>GET /api/offers</code> – list open offers</li>
+<li><code>POST /api/offers</code> – create a new offer (auth required)</li>
+<li><code>GET /api/offers/:id</code> – view offer details</li>
+<li><code>PUT /api/offers/:id</code> – update an existing offer</li>
+<li><code>DELETE /api/offers/:id</code> – remove an offer</li>
+<li><code>GET /api/offers/:offerId/responses</code> – list responses for an offer</li>
+<li><code>POST /api/offers/:offerId/responses</code> – create a response</li>
+<li><code>GET /api/offers/:offerId/responses/:responseId/messages</code> – list offer messages</li>
+<li><code>POST /api/offers/:offerId/responses/:responseId/messages</code> – send a message</li>
+<li><code>DELETE /api/offers/:offerId/responses/:responseId/messages/:messageId</code> – delete a message you sent</li>
+</ul>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Backend Architecture Overview | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html" class="active">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="backend-architecture-overview">Backend Architecture Overview</h1>
+<p>This project uses a modular Express.js structure. Each user role (Student, Instructor, Admin and SuperAdmin) has its own set of controllers and routes under <code>src/modules/users</code>. Tutorials and their related resources live under <code>src/modules/users/tutorials</code>.</p>
+<p>The valid roles available in the system are <code>Student</code>, <code>Instructor</code>, <code>Admin</code> and <code>SuperAdmin</code>. These values are referenced throughout the codebase and database migrations from a single shared constant.</p>
+<p>Uploaded tutorial assets are stored in role specific folders:</p>
+<div class="codehilite"><pre><span></span><code><span class="n">backend</span><span class="o">/</span><span class="n">uploads</span><span class="o">/</span><span class="n">tutorials</span><span class="o">/</span><span class="n">admin</span><span class="o">/</span>
+<span class="n">backend</span><span class="o">/</span><span class="n">uploads</span><span class="o">/</span><span class="n">tutorials</span><span class="o">/</span><span class="n">instructor</span><span class="o">/</span>
+<span class="n">backend</span><span class="o">/</span><span class="n">uploads</span><span class="o">/</span><span class="n">tutorials</span><span class="o">/</span><span class="n">student</span><span class="o">/</span>
+</code></pre></div>
+
+<p>The upload middleware automatically places files in these folders based on the authenticated user's role.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/book-workflow.html
+++ b/docs/book-workflow.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Book Marketplace Module Workflow | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html" class="active">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="book-marketplace-module-workflow">Book Marketplace Module Workflow</h1>
+<h2 id="module-goal">Module Goal</h2>
+<p>Allow instructors to upload and sell PDF books, and allow students to browse, purchase, and download them. Admin approves books, tracks sales, and configures settings.</p>
+<h2 id="database-schema">Database Schema</h2>
+<h3 id="books">books</h3>
+<ul>
+<li><code>id</code></li>
+<li><code>title</code></li>
+<li><code>short_description</code></li>
+<li><code>detailed_description</code></li>
+<li><code>price</code> (decimal)</li>
+<li><code>pdf_url</code></li>
+<li><code>cover_image_url</code></li>
+<li><code>category_id</code> (FK → categories)</li>
+<li><code>language</code></li>
+<li><code>license_type</code></li>
+<li><code>allow_preview</code></li>
+<li><code>preview_pages</code></li>
+<li><code>instructor_id</code> (FK → users)</li>
+<li><code>status</code> (pending, approved, rejected)</li>
+<li><code>created_at</code></li>
+</ul>
+<h3 id="book_purchases">book_purchases</h3>
+<ul>
+<li><code>id</code></li>
+<li><code>student_id</code> (FK → users)</li>
+<li><code>book_id</code> (FK → books)</li>
+<li><code>price_paid</code></li>
+<li><code>purchased_at</code></li>
+</ul>
+<h3 id="book_categories-optional">book_categories (optional)</h3>
+<ul>
+<li><code>id</code></li>
+<li><code>name</code></li>
+<li><code>slug</code></li>
+<li><code>status</code></li>
+</ul>
+<h2 id="route-map-frontend">Route Map (Frontend)</h2>
+<h3 id="public">Public</h3>
+<ul>
+<li><code>/marketplace/books</code> → Browse books</li>
+<li><code>/marketplace/books/[id]</code> → Book details</li>
+</ul>
+<h3 id="student">Student</h3>
+<ul>
+<li><code>/cart</code> → View cart</li>
+<li><code>/payments/checkout</code> → Pay for books</li>
+<li><code>/dashboard/student/library</code> → Purchased books list (download access)</li>
+</ul>
+<h3 id="instructor">Instructor</h3>
+<ul>
+<li><code>/dashboard/instructor/books</code> → Book list (own)</li>
+<li><code>/dashboard/instructor/books/create</code> → Add new book</li>
+<li><code>/dashboard/instructor/books/[id]/edit</code> → Edit book</li>
+<li><code>/dashboard/instructor/books/analytics</code> → Sales overview</li>
+</ul>
+<h3 id="admin">Admin</h3>
+<ul>
+<li><code>/dashboard/admin/books</code> → View all books</li>
+<li><code>/dashboard/admin/books/pending</code> → Approve/reject</li>
+<li><code>/dashboard/admin/settings/books</code> → Commission %, file rules</li>
+<li><code>/dashboard/admin/books/analytics</code> → Sales statistics</li>
+</ul>
+<h2 id="api-endpoints-backend">API Endpoints (Backend)</h2>
+<h3 id="instructor_1">Instructor</h3>
+<ul>
+<li><code>POST /api/books</code> → Create new book</li>
+<li><code>PUT /api/books/:id</code> → Update book</li>
+<li><code>GET /api/instructor/books</code> → List instructor's books</li>
+<li><code>GET /api/instructor/books/analytics</code> → View sales</li>
+</ul>
+<h3 id="student_1">Student</h3>
+<ul>
+<li><code>GET /api/books</code> → Public book list</li>
+<li><code>GET /api/books/:id</code> → Book details</li>
+<li><code>POST /api/cart</code> → Add to cart</li>
+<li><code>POST /api/checkout</code> → Process purchase</li>
+<li><code>GET /api/library</code> → List purchased books</li>
+<li><code>GET /api/library/download/:bookId</code> → Download secure PDF</li>
+</ul>
+<h3 id="admin_1">Admin</h3>
+<ul>
+<li><code>GET /api/admin/books/pending</code> → Pending list</li>
+<li><code>PATCH /api/admin/books/:id/approve</code> → Approve book</li>
+<li><code>PATCH /api/admin/books/:id/reject</code> → Reject book</li>
+<li><code>GET /api/admin/books/analytics</code> → View stats</li>
+</ul>
+<h2 id="components">Components</h2>
+<ul>
+<li><code>&lt;BookCard /&gt;</code> – Title, price, instructor, thumbnail</li>
+<li><code>&lt;BookForm /&gt;</code> – Form to create/edit book</li>
+<li><code>&lt;BookDetails /&gt;</code> – Full view + “Add to Cart” button</li>
+<li><code>&lt;CartItem /&gt;</code> – Book row in cart with quantity controls</li>
+<li><code>&lt;LibraryItem /&gt;</code> – Book row in student library</li>
+<li><code>&lt;SecureDownload /&gt;</code> – Button for PDF access (with auth token check)</li>
+<li><code>&lt;AdminBookRow /&gt;</code> – Approve/reject actions</li>
+</ul>
+<h2 id="permission-flow">Permission Flow</h2>
+<table>
+<thead>
+<tr>
+<th>Action</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Upload book</td>
+<td>Instructor only</td>
+</tr>
+<tr>
+<td>Approve/reject</td>
+<td>Admin only</td>
+</tr>
+<tr>
+<td>Purchase book</td>
+<td>Student only</td>
+</tr>
+<tr>
+<td>View library</td>
+<td>Student only</td>
+</tr>
+<tr>
+<td>Download book</td>
+<td>Student only (if purchased) and plan feature <code>books_download</code> enabled</td>
+</tr>
+<tr>
+<td>View earnings</td>
+<td>Instructor</td>
+</tr>
+<tr>
+<td>Manage commission/settings</td>
+<td>Admin</td>
+</tr>
+</tbody>
+</table>
+<h2 id="payment-access-flow">Payment &amp; Access Flow</h2>
+<ol>
+<li>Student adds book to cart</li>
+<li>Proceeds to checkout</li>
+<li>After successful payment:
+   - <code>book_purchases</code> entry is created
+   - PDF is added to My Library
+   - Student can access book via secure download route</li>
+</ol>
+<h2 id="notifications-optional-enhancements">Notifications (optional enhancements)</h2>
+<ul>
+<li>Instructor notified when book is approved</li>
+<li>Instructor notified on each new sale</li>
+<li>Admin notified on new book submission</li>
+<li>Student gets confirmation email after purchase</li>
+</ul>
+<h2 id="admin-configuration">Admin Configuration</h2>
+<ul>
+<li>Commission percentage (20% default)</li>
+<li>Max PDF size (e.g., 50MB)</li>
+<li>Toggle book module on/off</li>
+<li>Book categories manager (optional)</li>
+</ul>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Changelog | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html" class="active">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/class-lifecycle-workflow.html
+++ b/docs/class-lifecycle-workflow.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Class Lifecycle &amp; Certificate Workflow | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html" class="active">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="class-lifecycle-certificate-workflow">Class Lifecycle &amp; Certificate Workflow</h1>
+<p>This guide explains the typical steps from creating a live class to issuing a certificate to each student.</p>
+<h2 id="1-instructor-creates-a-class">1. Instructor Creates a Class</h2>
+<ol>
+<li>The instructor logs in and navigates to their dashboard.</li>
+<li>From <strong>Create Class</strong> they provide details like title, schedule, price and max students.</li>
+<li>The backend route <code>POST /api/users/classes/admin</code> stores the class in <code>online_classes</code>.</li>
+<li>Once ready, the instructor publishes the class using <code>PATCH /api/users/classes/admin/:id/status</code>.</li>
+</ol>
+<h2 id="2-students-enroll">2. Students Enroll</h2>
+<ol>
+<li>Students register an account following the <a href="student-registration-guide.html">Student Registration Guide</a>.</li>
+<li>On the class page, a student can <strong>Add to Cart</strong> and complete checkout.</li>
+<li>After payment they are added to <code>class_enrollments</code> and can access the lessons and resources.</li>
+</ol>
+<h2 id="3-assignments-attendance">3. Assignments &amp; Attendance</h2>
+<ol>
+<li>The instructor creates assignments via <code>POST /api/users/classes/assignments/class/:classId</code>.</li>
+<li>Students submit work which is stored in <code>assignment_submissions</code>.</li>
+<li>Attendance for each lesson is recorded through the <code>/attendance</code> endpoints.</li>
+</ol>
+<h2 id="4-scoring">4. Scoring</h2>
+<ol>
+<li>Instructors can define a scoring policy using <code>POST /api/users/classes/scores/policy/:classId</code>.</li>
+<li>The policy sets weights for assignment grades, attendance and a final exam.</li>
+<li><code>GET /api/users/classes/scores/instructor/:classId</code> calculates scores for every enrolled student.</li>
+<li>Each student's results are saved in <code>student_class_scores</code> with the total percentage and pass/fail status.</li>
+</ol>
+<h2 id="5-certificates">5. Certificates</h2>
+<ol>
+<li>When a student passes, the instructor issues a certificate with <code>POST /api/users/classes/scores/instructor/:classId/students/:studentId/issue</code>.</li>
+<li>A new entry is created in <code>certificates</code> linked to the class and student.</li>
+<li>Students can view or download their certificate from the dashboard once issued.</li>
+</ol>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/class-plan-coverage.html
+++ b/docs/class-plan-coverage.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Class Plan Coverage | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html" class="active">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="class-plan-coverage">Class Plan Coverage</h1>
+<p>Classes can be either paid or included for free with specific subscription plans. Two fields control this behaviour:</p>
+<ul>
+<li><code>access_type</code> – defines whether the class requires direct payment or is available through a plan. Values:</li>
+<li><code>paid</code> – students must purchase the class individually.</li>
+<li><code>free</code> – the class is available at no additional cost for members of selected plans.</li>
+<li><code>included_plans</code> – array of plan slugs or IDs that grant free access when <code>access_type</code> is <code>free</code>.</li>
+</ul>
+<p>During class creation or update, admins can select the plans that include the class. The frontend fetches available plan identifiers from <code>/plans/identifiers</code> to populate this list.</p>
+<p>When <code>access_type</code> is <code>free</code>, the class price is automatically set to <code>0</code> on the backend, ensuring students with the listed plans can access it without payment. For all other classes the <code>price</code> field determines the cost.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/coupon-management.html
+++ b/docs/coupon-management.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Coupon Management | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html" class="active">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="coupon-management">Coupon Management</h1>
+<p>This document explains how discount coupons are handled in SkillBridge.</p>
+<h2 id="backend">Backend</h2>
+<ul>
+<li><strong>Routes</strong> live in <code>backend/src/modules/coupons</code>.</li>
+<li>Admins and instructors use <code>/api/coupons/admin</code> for CRUD operations.</li>
+<li><code>GET /api/coupons/code/:code</code> validates a coupon for checkout.</li>
+<li>Coupons include an optional <code>instructor_id</code> so instructors can create their own codes.</li>
+<li><code>starts_at</code> and <code>expires_at</code> define the active window for a coupon.</li>
+<li><code>applies_to</code> (with optional <code>applies_to_id</code>) restricts the coupon to a plan, class or tutorial.</li>
+</ul>
+<h2 id="frontend">Frontend</h2>
+<ul>
+<li>API helpers will be located in <code>frontend/src/services/admin/couponService.js</code> and <code>frontend/src/services/instructor/couponService.js</code>.</li>
+<li>Dashboard pages under <code>frontend/src/pages/dashboard/admin/coupons</code> and <code>frontend/src/pages/dashboard/instructor/coupons</code> will allow managing coupons.</li>
+<li>The checkout page reads promo codes via <code>couponService.validateCode</code> and applies the discount.</li>
+</ul>
+<p>A seed file (<code>07_coupons_seed.js</code>) creates a demo code <code>DISCOUNT10</code> for testing.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/deployment.html
+++ b/docs/deployment.html
@@ -1,0 +1,432 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Deployment Guide | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html" class="active">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="deployment-guide">Deployment Guide</h1>
+<p>Follow these steps to run SkillBridge on a server or production host.</p>
+<h2 id="zip-package-deployments">ZIP package deployments</h2>
+<p>If you received the managed archive from Memonet, follow the
+<a href="./installation.html#deploy-from-the-customer-zip-package">ZIP installation workflow</a>
+to upload the bundle, prepare the environment files, and run the install
+scripts. That section covers cPanel/FTP uploads, SSH-based installs, and
+fallbacks for hosts that cannot run Docker. Use this approach when you do not
+have Git access on the production server or when you prefer to promote a tested
+bundle directly from the customer portal.</p>
+<h2 id="automated-nginx-and-ssl-setup">Automated Nginx and SSL setup</h2>
+<p>After pointing your domain DNS records to the server, run the installation
+wizard to configure Nginx and request Let's Encrypt certificates:</p>
+<div class="codehilite"><pre><span></span><code>./install.sh
+</code></pre></div>
+
+<p>The script prompts for the environment and, in production mode, the domain
+name. To run non-interactively you can provide arguments:</p>
+<div class="codehilite"><pre><span></span><code>./install.sh<span class="w"> </span>production<span class="w"> </span>yourdomain.com
+</code></pre></div>
+
+<p>In either case the script updates the domain placeholders in <code>nginx/conf.d</code>
+and uses <code>certbot</code> (or <code>acme.sh</code>) to generate certificates at the paths
+referenced in <code>nginx/conf.d/ssl.conf</code>.</p>
+<h2 id="configure-environment-variables">Configure environment variables</h2>
+<ol>
+<li><strong>Nginx</strong> – set the <code>ALLOWED_ORIGINS</code> environment variable to a
+   comma-separated list of origins that should be allowed by the reverse
+   proxy (e.g. <code>https://foo.com,https://bar.com</code>). After updating this list
+   reload Nginx so the new value takes effect:</li>
+</ol>
+<p><code>bash
+   docker compose exec nginx nginx -s reload</code></p>
+<ol start="2">
+<li>
+<p><strong>Backend</strong> – copy <code>backend/.env.example</code> to <code>backend/.env</code> and set:
+   - <code>PORT</code> – typically <code>5000</code> unless changed.
+   - <code>APP_DOMAIN</code> – your production domain (e.g. <code>yourdomain.com</code>).
+   - <code>SUPPORT_EMAIL</code> – address used for outbound messages.
+   - <code>FRONTEND_URL</code> – set this to the full URL of your frontend. You can
+     specify multiple domains separated by commas. For example:</p>
+<p><code>bash
+  # Example using a custom domain and server IP
+  APP_DOMAIN=yourdomain.com
+  FRONTEND_URL=https://${APP_DOMAIN},http://147.93.121.45
+  # Do not prefix with "FRONTEND_URL=" when using
+  # Docker Compose environment variables.</code></p>
+</li>
+</ol>
+<p>For production deployments, Docker Compose also loads variables from
+   <code>backend/.env.production</code>. Copy <code>backend/.env.production.example</code> to
+   <code>backend/.env.production</code> and fill in production secrets such as database
+   credentials and JWT keys.</p>
+<p>If the frontend and backend are on different subdomains, also set
+    <code>COOKIE_DOMAIN</code> so the authentication cookie can be shared. Example:</p>
+<div class="codehilite"><pre><span></span><code>```bash
+</code></pre></div>
+
+<p>COOKIE_DOMAIN=.${APP_DOMAIN}
+   ```</p>
+<p>When running over plain HTTP but using different subdomains (e.g. staging
+   environments), also add:</p>
+<p><code>bash
+   COOKIE_SECURE=false
+   COOKIE_SAMESITE=None</code></p>
+<div class="codehilite"><pre><span></span><code><span class="n">To</span><span class="w"> </span><span class="n">enable</span><span class="w"> </span><span class="n">password</span><span class="w"> </span><span class="n">recovery</span><span class="w"> </span><span class="n">via</span><span class="w"> </span><span class="n">email</span><span class="p">,</span><span class="w"> </span><span class="n">provide</span><span class="w"> </span><span class="n">SMTP</span><span class="w"> </span><span class="n">settings</span><span class="w"> </span><span class="ow">or</span>
+<span class="n">configure</span><span class="w"> </span><span class="n">them</span><span class="w"> </span><span class="n">later</span><span class="w"> </span><span class="n">through</span><span class="w"> </span><span class="n">the</span><span class="w"> </span><span class="err">`</span><span class="o">/</span><span class="n">api</span><span class="o">/</span><span class="n">email</span><span class="o">-</span><span class="n">config</span><span class="err">`</span><span class="w"> </span><span class="n">endpoint</span><span class="w"> </span><span class="ow">or</span><span class="w"> </span><span class="n">the</span><span class="w"> </span><span class="n">admin</span>
+<span class="n">dashboard</span><span class="w"> </span><span class="n">at</span><span class="w"> </span><span class="err">`</span><span class="o">/</span><span class="n">dashboard</span><span class="o">/</span><span class="n">admin</span><span class="o">/</span><span class="n">settings</span><span class="o">/</span><span class="n">email</span><span class="o">-</span><span class="n">config</span><span class="err">`</span><span class="o">.</span><span class="w"> </span><span class="n">At</span><span class="w"> </span><span class="n">a</span><span class="w"> </span><span class="n">minimum</span>
+<span class="n">the</span><span class="w"> </span><span class="n">backend</span><span class="w"> </span><span class="n">requires</span><span class="w"> </span><span class="n">the</span><span class="w"> </span><span class="n">following</span><span class="w"> </span><span class="n">variables</span><span class="p">:</span>
+
+<span class="err">```</span><span class="n">bash</span>
+<span class="n">SMTP_HOST</span><span class="o">=</span><span class="n">smtp</span><span class="o">.</span><span class="n">mailtrap</span><span class="o">.</span><span class="n">io</span>
+<span class="n">SMTP_PORT</span><span class="o">=</span><span class="mi">587</span>
+<span class="n">SMTP_SECURE</span><span class="o">=</span><span class="bp">false</span>
+<span class="n">SMTP_USER</span><span class="o">=</span><span class="n">your_smtp_username</span>
+<span class="n">SMTP_PASS</span><span class="o">=</span><span class="n">your_smtp_password</span>
+<span class="err">```</span>
+
+<span class="n">To</span><span class="w"> </span><span class="n">disable</span><span class="w"> </span><span class="n">sending</span><span class="w"> </span><span class="n">emails</span><span class="w"> </span><span class="p">(</span><span class="n">OTP</span><span class="w"> </span><span class="n">codes</span><span class="w"> </span><span class="n">will</span><span class="w"> </span><span class="n">be</span><span class="w"> </span><span class="n">logged</span><span class="w"> </span><span class="n">instead</span><span class="p">),</span><span class="w"> </span><span class="n">set</span><span class="p">:</span>
+
+<span class="err">```</span><span class="n">bash</span>
+<span class="n">DISABLE_EMAILS</span><span class="o">=</span><span class="bp">true</span>
+<span class="err">```</span>
+
+<span class="n">The</span><span class="w"> </span><span class="n">default</span><span class="w"> </span><span class="n">templates</span><span class="w"> </span><span class="n">include</span><span class="w"> </span><span class="n">your</span><span class="w"> </span><span class="n">logo</span><span class="w"> </span><span class="ow">and</span><span class="w"> </span><span class="n">a</span><span class="w"> </span><span class="n">footer</span><span class="o">.</span><span class="w"> </span><span class="n">OTP</span><span class="w"> </span><span class="n">codes</span><span class="w"> </span><span class="n">expire</span>
+
+<span class="n">after</span><span class="w"> </span><span class="o">**</span><span class="mi">15</span><span class="w"> </span><span class="n">minutes</span><span class="o">**.</span><span class="w"> </span><span class="n">You</span><span class="w"> </span><span class="n">can</span><span class="w"> </span><span class="n">customize</span><span class="w"> </span><span class="n">the</span><span class="w"> </span><span class="n">app</span><span class="w"> </span><span class="n">name</span><span class="p">,</span><span class="w"> </span><span class="n">logo</span><span class="w"> </span><span class="ow">and</span><span class="w"> </span><span class="n">contact</span>
+<span class="n">email</span><span class="w"> </span><span class="n">from</span><span class="w"> </span><span class="err">`</span><span class="o">/</span><span class="n">dashboard</span><span class="o">/</span><span class="n">admin</span><span class="o">/</span><span class="n">settings</span><span class="o">/</span><span class="n">app</span><span class="err">`</span><span class="w"> </span><span class="n">so</span><span class="w"> </span><span class="n">outbound</span><span class="w"> </span><span class="n">emails</span><span class="w"> </span><span class="n">show</span><span class="w"> </span><span class="n">your</span>
+<span class="n">branding</span><span class="o">.</span>
+
+
+<span class="n">This</span><span class="w"> </span><span class="n">value</span><span class="w"> </span><span class="k">is</span><span class="w"> </span><span class="n">used</span><span class="w"> </span><span class="k">for</span><span class="w"> </span><span class="n">CORS</span><span class="w"> </span><span class="ow">and</span><span class="w"> </span><span class="n">socket</span><span class="o">.</span><span class="n">io</span><span class="w"> </span><span class="n">connections</span><span class="o">.</span><span class="w"> </span><span class="n">If</span><span class="w"> </span><span class="n">it</span><span class="w"> </span><span class="n">still</span><span class="w"> </span><span class="n">points</span><span class="w"> </span><span class="n">to</span>
+<span class="err">`</span><span class="n">http</span><span class="p">:</span><span class="o">//</span><span class="n">localhost</span><span class="p">:</span><span class="mi">3001</span><span class="err">`</span><span class="w"> </span><span class="n">you</span><span class="w"> </span><span class="n">may</span><span class="w"> </span><span class="n">see</span><span class="w"> </span><span class="err">`</span><span class="n">Network</span><span class="w"> </span><span class="n">Error</span><span class="err">`</span><span class="w"> </span><span class="ow">or</span><span class="w"> </span><span class="n">CORS</span><span class="w"> </span><span class="n">errors</span><span class="w"> </span><span class="n">when</span>
+<span class="n">logging</span><span class="w"> </span><span class="ow">in</span><span class="w"> </span><span class="n">from</span><span class="w"> </span><span class="n">the</span><span class="w"> </span><span class="n">deployed</span><span class="w"> </span><span class="n">site</span><span class="o">.</span>
+</code></pre></div>
+
+<ol start="3">
+<li><strong>Frontend</strong> – for Docker Compose production builds, set variables in
+  <code>frontend/.env.production</code>:</li>
+</ol>
+<div class="codehilite"><pre><span></span><code><span class="nv">APP_DOMAIN</span><span class="o">=</span>yourdomain.com
+<span class="nv">NEXT_PUBLIC_API_BASE_URL</span><span class="o">=</span>https://<span class="si">${</span><span class="nv">APP_DOMAIN</span><span class="si">}</span>/api
+<span class="nv">NEXT_PUBLIC_PGADMIN_URL</span><span class="o">=</span>https://<span class="si">${</span><span class="nv">APP_DOMAIN</span><span class="si">}</span>/pgadmin
+</code></pre></div>
+
+<blockquote>
+<p><strong>Tip:</strong> When <code>APP_DOMAIN</code> is defined you can alternatively set
+<code>NEXT_PUBLIC_API_BASE_URL=/api</code>. During the build the relative value expands
+to <code>https://${APP_DOMAIN}/api</code>, letting reverse proxies expose the API at the
+same origin without hard-coding the domain in your environment file.</p>
+</blockquote>
+<p>Commit only placeholder values. Provide real production settings via
+environment variables or by mounting a <code>.env.production</code> file at deploy time
+so secrets stay out of version control. The root <code>.env</code> is intended for local
+development and defaults <code>NEXT_PUBLIC_API_BASE_URL</code> to
+<code>http://localhost:5002/api</code> for internal container communication. Remove or
+override this file in production so the frontend uses your public HTTPS
+domain.</p>
+<p>Without these variables the frontend defaults to <code>/api</code> which may point to the
+ wrong server when deployed.</p>
+<h3 id="production-example-eduskillbridgenet">Production example: eduskillbridge.net</h3>
+<p>To deploy the official site, copy <code>.env.example</code> to <code>.env</code> and
+<code>backend/.env.production.example</code> to <code>backend/.env.production</code>. Fill in the
+database credentials, JWT and refresh token secrets, and SMTP settings with
+values managed outside of version control. Configure the public URLs:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">APP_DOMAIN</span><span class="o">=</span>eduskillbridge.net
+<span class="nv">FRONTEND_URL</span><span class="o">=</span>https://eduskillbridge.net
+<span class="nv">NEXT_PUBLIC_API_BASE_URL</span><span class="o">=</span>https://eduskillbridge.net/api
+<span class="nv">NEXT_PUBLIC_PGADMIN_URL</span><span class="o">=</span>https://eduskillbridge.net/pgadmin
+<span class="nv">NEXT_PUBLIC_SOCKET_URL</span><span class="o">=</span>wss://eduskillbridge.net
+</code></pre></div>
+
+<p>Keep these files out of git and store the secrets in your hosting
+environment or secrets manager.</p>
+<p>After updating these files, rebuild the Docker images or restart the server so
+that the environment changes take effect.</p>
+<h2 id="run-database-migrations">Run database migrations</h2>
+<p>Before starting the backend server or after pulling updates, apply any pending
+database migrations:</p>
+<div class="codehilite"><pre><span></span><code>npm<span class="w"> </span>--prefix<span class="w"> </span>backend<span class="w"> </span>run<span class="w"> </span>migrate
+</code></pre></div>
+
+<p>Running migrations separately keeps <code>startServer()</code> lightweight and ensures the
+database schema matches the application's expectations.</p>
+<blockquote>
+<p><strong>Important:</strong> Docker Compose no longer bind-mounts <code>backend/src/migrations</code>.
+When a release adds new migration files (for example the critical verification
+migrations <code>20250930160000</code> and <code>20250930160010</code>), rebuild the backend image so
+the container sees the updated migration directory before running <code>npm --prefix
+backend run migrate</code>:</p>
+<p><code>bash
+docker compose build backend &amp;&amp; docker compose up -d backend</code></p>
+<p>Otherwise the running container will still contain the previous migration set
+and Knex will report <strong>"The migration directory is corrupt..."</strong> because it
+cannot find the new files.</p>
+</blockquote>
+<h2 id="preserve-uploaded-media">Preserve uploaded media</h2>
+<p>The admin panel lets you upload a logo and favicon under
+<code>/dashboard/admin/settings/app</code>. These files are stored inside the backend
+container under <code>/app/uploads</code>. To keep them after a container restart, mount the
+<code>backend/uploads</code> folder from the host. In <code>docker-compose.yml</code> add:</p>
+<div class="codehilite"><pre><span></span><code><span class="w">  </span><span class="nt">backend</span><span class="p">:</span>
+<span class="w">    </span><span class="nt">volumes</span><span class="p">:</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">./backend/uploads:/app/uploads</span>
+</code></pre></div>
+
+<p>This ensures custom branding files persist across deployments.</p>
+<h2 id="preserve-database-and-pgadmin-data">Preserve database and pgAdmin data</h2>
+<p>PostgreSQL stores its data in the <code>postgres_data</code> volume and pgAdmin uses
+<code>pgadmin_data</code>. In production, avoid running <code>docker compose down -v</code> as the
+<code>-v</code> flag removes these volumes and wipes the database and pgAdmin settings.
+Use <code>docker compose stop</code> or <code>docker compose down</code> without <code>-v</code> to retain your
+data. Manually deleting the <code>postgres_data</code> or <code>pgadmin_data</code> volumes will also
+erase data. Consider mounting these volumes to external storage or setting up
+regular backups to protect critical information.</p>
+<h2 id="nextjs-image-domains">Next.js image domains</h2>
+<p>Uploads served from the backend domain are now automatically whitelisted for
+Next.js Image. The hostname and port are derived from
+<code>NEXT_PUBLIC_API_BASE_URL</code> at build time.  If you need to allow additional
+domains you can still extend <code>remotePatterns</code> in
+<code>frontend/next.config.mjs</code>.</p>
+<h2 id="troubleshooting">Troubleshooting</h2>
+<h3 id="knex-reports-the-migration-directory-is-corrupt">Knex reports "The migration directory is corrupt"</h3>
+<p>When Compose reuses an older backend image it may not contain the newest
+<code>backend/src/migrations</code> files.  Knex then aborts with errors like:</p>
+<div class="codehilite"><pre><span></span><code><span class="n">The</span><span class="w"> </span><span class="n">migration</span><span class="w"> </span><span class="n">directory</span><span class="w"> </span><span class="k">is</span><span class="w"> </span><span class="n">corrupt</span><span class="p">,</span><span class="w"> </span><span class="n">the</span><span class="w"> </span><span class="n">following</span><span class="w"> </span><span class="n">files</span><span class="w"> </span><span class="n">are</span><span class="w"> </span><span class="n">missing</span><span class="p">:</span>
+<span class="mi">20250930160000</span><span class="n">_alter_verifications_code_to_varchar255</span><span class="o">.</span><span class="n">js</span><span class="p">,</span>
+<span class="mi">20250930160010</span><span class="n">_alter_verifications_code_to_text</span><span class="o">.</span><span class="n">js</span>
+</code></pre></div>
+
+<p>To resolve this:</p>
+<ol>
+<li>Rebuild the backend image so the container bakes in the updated migration
+   list (pass <code>--no-cache</code> if you want to discard any cached layers):</li>
+</ol>
+<p><code>bash
+   docker compose build --no-cache backend &amp;&amp; docker compose up -d backend</code></p>
+<ol start="2">
+<li>Confirm the new container can see the migrations:</li>
+</ol>
+<p><code>bash
+   docker compose exec backend ls /app/src/migrations</code></p>
+<p>The output should include the verification migrations
+   <code>20250930160000_alter_verifications_code_to_varchar255.js</code> and
+   <code>20250930160010_alter_verifications_code_to_text.js</code>.</p>
+<ol start="3">
+<li>Re-run the migration command if it did not execute automatically during the
+   container start-up:</li>
+</ol>
+<p><code>bash
+   docker compose exec backend npm run migrate</code></p>
+<p>If the error persists, stop the backend service and remove the old container so
+Compose cannot reuse it (<code>docker compose rm -fs backend</code>), then repeat the
+build/start steps above.  Always rebuild the backend image after adding or
+renaming migration files because the directory is no longer bind-mounted into
+the container.</p>
+<h3 id="login-page-requests-httplocalhost5002">Login page requests <code>http://localhost:5002</code></h3>
+<p>If you deploy the frontend and see network errors pointing to
+<code>http://localhost:5002/api</code> it means the build did not have
+<code>NEXT_PUBLIC_API_BASE_URL</code> set.  Update <code>frontend/.env.local</code> with the correct
+backend URL and rebuild/restart the frontend container so the new value is
+picked up.</p>
+<h3 id="cors-errors-when-logging-in">CORS errors when logging in</h3>
+<p>If the browser console shows messages like <code>No 'Access-Control-Allow-Origin'</code> or
+<code>ERR_NETWORK</code> during login, your backend is rejecting the frontend's origin.
+Edit <code>backend/.env</code> and ensure the <code>FRONTEND_URL</code> variable lists the exact
+domain of your deployed site without a trailing slash. Include both the
+<code>www</code> and non-<code>www</code> variants if you use them. For example:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">FRONTEND_URL</span><span class="o">=</span>https://<span class="si">${</span><span class="nv">APP_DOMAIN</span><span class="si">}</span>,https://www.<span class="si">${</span><span class="nv">APP_DOMAIN</span><span class="si">}</span>
+</code></pre></div>
+
+<p>Restart the backend so the updated CORS settings take effect.
+If CORS errors occur when requesting a password reset, ensure the FRONTEND_URL contains your frontend's domain. The API only sends CORS headers for domains listed there.
+If you use Nginx or another reverse proxy, ensure it does <strong>not</strong> add its own
+<code>Access-Control-Allow-Origin</code> header. Duplicates will cause browsers to reject
+the response even if both values are identical.</p>
+<h3 id="home-page-shows-failed-to-load-tutorials-or-failed-to-load-categories">Home page shows "Failed to load tutorials" or "Failed to load categories"</h3>
+<p>These messages mean the frontend cannot reach the API. Verify that
+<code>NEXT_PUBLIC_API_BASE_URL</code> in <code>frontend/.env.local</code> points to your backend URL
+including the <code>/api</code> prefix.  Also confirm the backend server is running and
+that the <code>FRONTEND_URL</code> in <code>backend/.env</code> includes your frontend domain.</p>
+<h3 id="login-redirects-repeatedly">Login redirects repeatedly</h3>
+<p>If you briefly see the home page then get bounced back to the login form with
+browser console messages about CORS, your backend is not allowing the
+frontend's origin.  Double check that <code>FRONTEND_URL</code> in <code>backend/.env</code>
+matches the deployed domain exactly and restart the backend.  The
+<code>NEXT_PUBLIC_API_BASE_URL</code> in <code>frontend/.env.local</code> must also point to the
+backend including the <code>/api</code> prefix. When the frontend and API are on
+different subdomains, set <code>COOKIE_DOMAIN</code> in <code>backend/.env</code> to the shared
+base domain (e.g. <code>.${APP_DOMAIN}</code>) so the authentication cookie is
+available to both sites. If the site uses HTTP, also set:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">COOKIE_SECURE</span><span class="o">=</span><span class="nb">false</span>
+<span class="nv">COOKIE_SAMESITE</span><span class="o">=</span>None
+</code></pre></div>
+
+<p>This ensures the refresh token cookie is sent across subdomains without HTTPS.</p>
+<h3 id="failed-to-load-seo-settings-or-network-errors">"Failed to load SEO settings" or network errors</h3>
+<p>If the dashboard displays <strong>"Failed to load SEO settings"</strong> or other
+<code>ERR_NETWORK</code> messages, the frontend is usually pointed at the wrong API or the
+backend is not allowing the frontend's origin.</p>
+<ol>
+<li>Verify <code>NEXT_PUBLIC_API_BASE_URL</code> in your frontend <code>.env.local</code> or
+   <code>.env.production</code> matches your public backend URL with the <code>/api</code> suffix. See
+   the <a href="#production-example-eduskillbridgenet">production example</a> above for a
+   typical value using <code>${APP_DOMAIN}</code>.</li>
+<li>Ensure <code>FRONTEND_URL</code> in <code>backend/.env</code> lists the exact origin of your
+   frontend, including both <code>www</code> and non-<code>www</code> domains if applicable. Refer to
+   the earlier <code>FRONTEND_URL</code> snippet under <strong>Configure environment variables</strong>.</li>
+<li>Check the backend logs or browser console for CORS messages such as
+   <code>No 'Access-Control-Allow-Origin'</code> or <code>Origin ... not allowed by CORS</code> to
+   confirm which domain is being rejected.</li>
+</ol>
+<p>Updating these variables and restarting the affected service should resolve most
+SEO and networking issues.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Installation Guide | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html" class="active">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="installation-guide">Installation Guide</h1>
+<p>This guide walks through the ZIP-based installation workflow for SkillBridge so you can unpack the customer bundle and bring the stack online without cloning the Git repository. Follow these steps when you receive the packaged release from CodeCanyon or the Memonet customer portal.</p>
+<h2 id="1-upload-the-archive">1. Upload the archive</h2>
+<ul>
+<li><strong>Local workstation:</strong> Download the ZIP file and move it into the directory where you want the project to live.</li>
+<li><strong>Remote server:</strong> Copy the archive to the host with a tool such as <code>scp</code> or <code>rsync</code>:</li>
+</ul>
+<p><code>bash
+  scp Skillbridge-v1.0.0.zip deploy@example.com:/var/www</code></p>
+<p>Keep a pristine copy of the downloaded ZIP so you can re-upload clean files later if needed.</p>
+<h2 id="2-extract-and-position-the-project-directory">2. Extract and position the project directory</h2>
+<p>Unzip the package and ensure the project root is named <code>Skillbridge/</code> so the helper scripts can find the expected paths:</p>
+<div class="codehilite"><pre><span></span><code>unzip<span class="w"> </span>Skillbridge-v1.0.0.zip
+mv<span class="w"> </span>Skillbridge-v1.0.0<span class="w"> </span>Skillbridge
+<span class="nb">cd</span><span class="w"> </span>Skillbridge
+</code></pre></div>
+
+<p>The root folder should now contain <code>install.sh</code>, <code>docker-compose.yml</code>, and the <code>backend/</code>, <code>frontend/</code>, and <code>nginx/</code> directories directly under <code>Skillbridge/</code>.</p>
+<p>On Linux servers adjust permissions so your deploy user owns the files and the shell scripts remain executable:</p>
+<div class="codehilite"><pre><span></span><code>sudo<span class="w"> </span>chown<span class="w"> </span>-R<span class="w"> </span>deploy:deploy<span class="w"> </span>Skillbridge
+chmod<span class="w"> </span>+x<span class="w"> </span>install.sh<span class="w"> </span>scripts/*.sh
+</code></pre></div>
+
+<h2 id="3-copy-environment-templates">3. Copy environment templates</h2>
+<p>Duplicate each <code>.env.example</code> file so the backend and frontend can read real configuration values:</p>
+<div class="codehilite"><pre><span></span><code>cp<span class="w"> </span>.env.example<span class="w"> </span>.env
+cp<span class="w"> </span>backend/.env.example<span class="w"> </span>backend/.env
+cp<span class="w"> </span>backend/.env.production.example<span class="w"> </span>backend/.env.production
+cp<span class="w"> </span>frontend/.env.local.example<span class="w"> </span>frontend/.env.local
+</code></pre></div>
+
+<p>Edit the resulting files to match your target environment. Use local URLs (for example <code>http://localhost:5002/api</code>) and <code>COOKIE_SECURE=false</code> for development, then replace them with your public domain, SMTP credentials, and production secrets before going live.</p>
+<h2 id="4-run-the-installer">4. Run the installer</h2>
+<p>From the project root execute the installer. It validates prerequisites, prepares environment files when missing, runs database migrations and seeds, and creates the initial admin user:</p>
+<div class="codehilite"><pre><span></span><code>./install.sh
+</code></pre></div>
+
+<p>For unattended production deployments, pass the target mode and domain (for example <code>./install.sh production yourdomain.com</code>) and supply <code>ADMIN_EMAIL</code> and <code>ADMIN_PASSWORD</code> via environment variables if you need non-interactive credentials.</p>
+<h2 id="5-start-the-services">5. Start the services</h2>
+<p>Start the Docker stack after the installer completes:</p>
+<ul>
+<li><strong>Local development:</strong></li>
+</ul>
+<p><code>bash
+  docker compose up --build</code></p>
+<ul>
+<li><strong>Production host:</strong></li>
+</ul>
+<p><code>bash
+  docker compose up -d --build</code></p>
+<p>When you manage containers manually, remember to run migrations yourself before serving traffic:</p>
+<div class="codehilite"><pre><span></span><code>docker<span class="w"> </span>compose<span class="w"> </span>run<span class="w"> </span>--rm<span class="w"> </span>backend<span class="w"> </span>npm<span class="w"> </span>run<span class="w"> </span>migrate
+docker<span class="w"> </span>compose<span class="w"> </span>run<span class="w"> </span>--rm<span class="w"> </span>backend<span class="w"> </span>npm<span class="w"> </span>run<span class="w"> </span>seed
+</code></pre></div>
+
+<p>Once the services are running you can sign in with the admin credentials you configured during installation and begin configuring SkillBridge.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -1,0 +1,689 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Installation Guide | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html" class="active">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="installation-guide">Installation Guide</h1>
+<p>This document explains how to set up SkillBridge for local development and for hosting the platform on a production server.</p>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul>
+<li><a href="https://nodejs.org/">Node.js</a> 18 or later</li>
+<li><a href="https://www.npmjs.com/">npm</a> 9 or later (bundled with Node.js 18+)</li>
+<li><a href="https://www.docker.com/">Docker</a> and the Docker Compose <strong>V2</strong> plugin (<code>docker compose</code> command)</li>
+<li>Git (only required when cloning or updating from the repository; skip this for packaged ZIP installs)</li>
+<li>Redis or another session store for production deployments</li>
+</ul>
+<blockquote>
+<p><strong>Heads up:</strong> The legacy <code>docker-compose</code> v1 CLI is incompatible with recent Docker Engine releases and often fails with <code>KeyError: 'ContainerConfig'</code> when rebuilding containers. The installer now refuses to run when only the v1 binary is available so you can address the issue up front. Install the Docker Compose V2 plugin (the <code>docker compose</code> command) or downgrade Docker Engine below version&nbsp;27 before running the script. If you are temporarily stuck on the old CLI, use <a href="../scripts/run-compose.sh"><code>scripts/run-compose.sh</code></a> for local commands—the wrapper exports <code>DOCKER_API_VERSION=1.43</code> automatically to avoid the compatibility bug.</p>
+</blockquote>
+<h2 id="install-the-required-tools">Install the required tools</h2>
+<p>Follow the commands for your operating system to install the prerequisites
+that the installer enforces.</p>
+<h3 id="nodejs-18-includes-npm">Node.js 18+ (includes npm)</h3>
+<ul>
+<li><strong>macOS (Homebrew):</strong></li>
+</ul>
+<p><code>bash
+  brew install node@20
+  echo 'export PATH="/opt/homebrew/opt/node@20/bin:$PATH"' &gt;&gt; ~/.zshrc</code></p>
+<ul>
+<li><strong>Ubuntu / Debian:</strong></li>
+</ul>
+<p><code>bash
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+  sudo apt-get install -y nodejs</code></p>
+<ul>
+<li><strong>Windows:</strong> Download the LTS installer from <a href="https://nodejs.org/">nodejs.org</a>
+  and run it, then restart your terminal and confirm with <code>node -v</code>.</li>
+</ul>
+<h3 id="docker-engine-and-docker-compose-v2">Docker Engine and Docker Compose V2</h3>
+<ul>
+<li>
+<p><strong>macOS / Windows:</strong> Install <a href="https://www.docker.com/products/docker-desktop/">Docker Desktop</a>,
+  ensure it is running, and verify with <code>docker --version</code> and
+  <code>docker compose version</code>.</p>
+</li>
+<li>
+<p><strong>Ubuntu / Debian:</strong></p>
+</li>
+</ul>
+<p><code>bash
+  curl -fsSL https://get.docker.com | sh
+  sudo usermod -aG docker $USER
+  newgrp docker
+  sudo mkdir -p /usr/lib/docker/cli-plugins
+  sudo curl -SL "https://github.com/docker/compose/releases/download/v2.24.7/docker-compose-linux-$(uname -m)" \
+    -o /usr/lib/docker/cli-plugins/docker-compose
+  sudo chmod +x /usr/lib/docker/cli-plugins/docker-compose
+  docker --version
+  docker compose version</code></p>
+<p>Docker Desktop already bundles Compose V2; Linux users install the plugin
+  manually as shown above.</p>
+<h3 id="git">Git</h3>
+<ul>
+<li><strong>macOS:</strong> <code>brew install git</code></li>
+<li><strong>Ubuntu / Debian:</strong> <code>sudo apt-get install -y git</code></li>
+<li><strong>Windows:</strong> Install <a href="https://git-scm.com/download/win">Git for Windows</a> and
+  select “Git from the command line” during setup.</li>
+</ul>
+<p>Open a fresh terminal after installing these tools so PATH changes take effect,
+then rerun <code>./install.sh</code> or revisit <code>/install</code> to confirm the checks pass.</p>
+<h2 id="install-from-zip-release">Install from ZIP release</h2>
+<p>If you purchased SkillBridge on CodeCanyon (released as <strong>memonet</strong>), the
+downloadable ZIP already contains the full repository. Use this workflow when
+you would rather upload the packaged build than clone from Git.</p>
+<blockquote>
+<p><strong>Note:</strong> You can skip installing Git for this workflow unless you plan to
+migrate to Git-based updates later.</p>
+</blockquote>
+<ol>
+<li>
+<p><strong>Upload the archive.</strong>
+   - <strong>Local workstation:</strong> download the ZIP and move it into the directory
+     where you want the project to live.
+   - <strong>Remote server:</strong> copy the file to the server with a tool such as <code>scp</code>
+     or <code>rsync</code>:</p>
+<p><code>bash
+ scp Skillbridge-v1.0.0.zip deploy@example.com:/var/www</code></p>
+</li>
+<li>
+<p><strong>Extract and rename the project directory</strong> so the root folder is named
+   <code>Skillbridge/</code>:</p>
+</li>
+</ol>
+<p><code>bash
+   unzip Skillbridge-v1.0.0.zip
+   mv Skillbridge-v1.0.0 Skillbridge
+   cd Skillbridge</code></p>
+<p>The install scripts expect to run from the project root. If the archive
+   extracts to a nested directory, rename or move it until
+   <code>install.sh</code>, <code>docker-compose.yml</code>, <code>backend/</code>, and <code>frontend/</code> sit directly
+   under <code>Skillbridge/</code>.</p>
+<ol start="3">
+<li><strong>Fix file ownership and permissions.</strong> On Linux servers ensure the deploy
+   user owns the files and that the helper scripts are executable:</li>
+</ol>
+<p><code>bash
+   sudo chown -R deploy:deploy Skillbridge
+   chmod +x install.sh scripts/*.sh</code></p>
+<p>Skip the <code>chown</code> step on macOS or Windows if you extracted the archive as
+   your own user.</p>
+<ol start="4">
+<li><strong>Copy the environment templates.</strong> The packaged archive ships with
+   <code>.env.example</code> files so you can bootstrap configuration without Git:</li>
+</ol>
+<p><code>bash
+   cp .env.example .env
+   cp backend/.env.example backend/.env
+   cp backend/.env.production.example backend/.env.production
+   cp frontend/.env.local.example frontend/.env.local</code></p>
+<p>Adjust <code>backend/.env</code> for local development. When preparing a live host also
+   update <code>backend/.env.production</code> and the frontend files with your domain,
+   database, and SMTP credentials. See <a href="./deployment.html">deployment.md</a> for TLS
+   requirements, domain-specific variables, and email guidance.</p>
+<ol start="5">
+<li><strong>Run the installer.</strong> From the project root execute <code>install.sh</code>. The
+   script prompts for environment type and handles prerequisites, migrations,
+   seeds, and the initial admin account.</li>
+</ol>
+<p><code>bash
+   ./install.sh</code></p>
+<p>For unattended production setups you can pass arguments as documented in
+   <a href="./deployment.html">deployment.md</a> (for example
+   <code>./install.sh production yourdomain.com</code>).</p>
+<ol start="6">
+<li>
+<p><strong>Start the containers.</strong>
+   - <strong>Local development:</strong></p>
+<p><code>bash
+ docker compose up --build</code></p>
+</li>
+</ol>
+<ul>
+<li>
+<p><strong>Production host:</strong></p>
+<p><code>bash
+ docker compose up -d --build</code></p>
+</li>
+</ul>
+<p>If you prefer to manage Docker manually, launch the stack after the
+   installer finishes. Review <a href="./deployment.html">deployment.md</a> for production
+   follow-up tasks such as enabling TLS, updating Nginx, and running migrations
+   in detached environments.</p>
+<p>When you bypass the automated installer, apply database changes manually
+   before serving traffic:</p>
+<p><code>bash
+   docker compose run --rm backend npm run migrate
+   docker compose run --rm backend npm run seed</code></p>
+<p>After unpacking a release you can pull future updates from Git or repeat the
+workflow with the next packaged ZIP.</p>
+<h2 id="deploy-from-the-customer-zip-package">Deploy from the customer ZIP package</h2>
+<p>The managed customer bundle distributed by Memonet contains a snapshot of the
+repository (including the backend, frontend, and helper scripts) so you can
+launch SkillBridge without cloning the Git repo. Use this workflow on shared
+hosts where the provider gives you cPanel/FTP access or limited SSH.</p>
+<h3 id="1-download-and-extract-the-archive">1. Download and extract the archive</h3>
+<ol>
+<li>Sign in to the <a href="https://customer.memonet.in/">Memonet customer portal</a>.</li>
+<li>Download the latest <code>skillbridge-&lt;version&gt;.zip</code> release from the “Downloads”
+   section.</li>
+<li>Extract the ZIP on your workstation. The bundle unpacks to a top-level
+   folder with <code>backend/</code>, <code>frontend/</code>, <code>nginx/</code>, the root <code>.env.example</code>, and
+   automation scripts such as <code>install.sh</code>.</li>
+</ol>
+<blockquote>
+<p><strong>Tip:</strong> Keep a pristine copy of the ZIP so you can re-upload files later
+without having to redownload the package.</p>
+</blockquote>
+<h3 id="2-upload-the-bundle-to-your-host">2. Upload the bundle to your host</h3>
+<ul>
+<li><strong>cPanel File Manager:</strong> Upload the ZIP to your hosting account (for example
+  into <code>~/skillbridge</code>), then use the “Extract” action. Ensure the <code>backend/</code>
+  and <code>frontend/</code> directories sit next to each other just like they do locally.</li>
+<li><strong>SFTP/FTP:</strong> Extract the ZIP on your workstation first, then upload the
+  folders and files using a client such as FileZilla or Cyberduck. Preserve the
+  directory structure so relative paths (e.g. <code>backend/uploads/app</code>) continue to
+  work.</li>
+<li><strong>SSH:</strong> Copy the archive with <code>scp</code>/<code>rsync</code>, then run <code>unzip</code> on the server.
+  If your provider enables SSH but not Docker, you can still run the Node.js
+  services directly from this extracted directory.</li>
+</ul>
+<p>When deploying to a subdirectory (e.g. <code>public_html/skillbridge</code>), update any
+reverse-proxy rules so the backend API and Next.js frontend continue to resolve
+correctly at <code>/api</code> and the site root.</p>
+<h3 id="3-copy-environment-files-and-adjust-settings">3. Copy environment files and adjust settings</h3>
+<p>After the upload finishes, duplicate each example environment file so the app
+can read real configuration values:</p>
+<div class="codehilite"><pre><span></span><code>cp<span class="w"> </span>.env.example<span class="w"> </span>.env
+cp<span class="w"> </span>backend/.env.example<span class="w"> </span>backend/.env
+cp<span class="w"> </span>backend/.env.production.example<span class="w"> </span>backend/.env.production
+cp<span class="w"> </span>frontend/.env.local.example<span class="w"> </span>frontend/.env.local
+cp<span class="w"> </span>frontend/.env.production.expanded<span class="w"> </span>frontend/.env.production
+</code></pre></div>
+
+<p>Edit the resulting files with the values that match your target environment:</p>
+<ul>
+<li><strong>Local or staging:</strong> Point <code>DATABASE_URL</code>/<code>PGHOST</code>, <code>REDIS_URL</code>, and
+  <code>NEXT_PUBLIC_API_BASE_URL</code> to services that run on the same machine (for
+  example <code>http://localhost:5002/api</code>). Keep <code>NODE_ENV</code> unset and set
+  <code>COOKIE_SECURE=false</code> so browser cookies work over plain HTTP. You can also
+  list both localhost and your staging URL in <code>FRONTEND_URL</code>.</li>
+<li><strong>Live production:</strong> Replace all localhost URLs with your public domain. Set
+  <code>APP_DOMAIN</code> to your apex domain (for example <code>example.com</code>), update
+  <code>FRONTEND_URL</code> to <code>https://example.com</code>, and point
+  <code>NEXT_PUBLIC_API_BASE_URL</code>/<code>NEXT_PUBLIC_SOCKET_URL</code> to the HTTPS endpoints
+  your reverse proxy exposes. Update SMTP credentials, JWT secrets, and payment
+  keys before inviting real users.</li>
+</ul>
+<p>Uploads for branding (logos and favicons) belong in
+<code>backend/uploads/app/</code>. Create the directory if it does not exist and ensure
+the PHP/Node.js user has write access:</p>
+<div class="codehilite"><pre><span></span><code>mkdir<span class="w"> </span>-p<span class="w"> </span>backend/uploads/app
+chmod<span class="w"> </span><span class="m">775</span><span class="w"> </span>backend/uploads<span class="w"> </span>backend/uploads/app
+</code></pre></div>
+
+<p>If you deploy multiple instances, keep each environment’s <code>.env</code> files outside
+version control and back them up securely alongside the uploaded assets.</p>
+<h3 id="4-run-install-scripts-or-fall-back-to-manual-commands">4. Run install scripts or fall back to manual commands</h3>
+<p>Shared hosting varies widely, so choose the approach that matches what your
+provider allows:</p>
+<ul>
+<li><strong>SSH with Docker support:</strong> Run the same automation as the Git-based
+  workflow. From the extracted root folder execute <code>./install.sh production
+  yourdomain.com</code>. The script checks prerequisites, prepares <code>.env</code> files,
+  brings up Docker containers, and runs database migrations for you.</li>
+<li><strong>SSH without Docker:</strong> Install Node.js 18+ via the host’s package manager or
+  the Node Version Manager (nvm). Then run:</li>
+</ul>
+<p>```bash
+  npm --prefix backend install
+  npm --prefix backend run migrate
+  npm --prefix backend run seed   # optional sample data
+  npm --prefix backend run start  # or use pm2/forever for background processes</p>
+<p>npm --prefix frontend install
+  npm --prefix frontend run build
+  npm --prefix frontend run start
+  ```</p>
+<p>Configure a process manager (PM2, Supervisor, or your provider’s “Node.js
+  App” feature) to keep the backend and frontend running. If the host only
+  allows PHP/Node cron jobs, schedule scripts such as
+  <code>npm --prefix backend run migrate</code> nightly to keep the database schema up to
+  date and use <code>pm2 resurrect</code> in the cron task that restarts services after
+  maintenance windows.
+- <strong>No SSH access:</strong> Use cPanel’s “Setup Node.js App” or “Application Manager”
+  to point to the uploaded backend and frontend directories, then upload the
+  built <code>.next/</code> directory generated locally. When Node.js apps are not
+  supported, deploy the frontend separately on a platform that can host Next.js
+  (Vercel, Netlify, or a Node-capable VPS) and connect it to the backend API
+  running on a server you control.</p>
+<p>Regardless of the method, verify that cron or scheduled tasks run any long-lived
+jobs you rely on, and confirm that outbound ports for SMTP and payment gateways
+are open on your hosting plan.</p>
+<h2 id="1-clone-the-repository">1. Clone the repository</h2>
+<div class="codehilite"><pre><span></span><code>git<span class="w"> </span>clone<span class="w"> </span>&lt;repo-url&gt;
+<span class="nb">cd</span><span class="w"> </span>Skillbridge
+</code></pre></div>
+
+<h2 id="2-configure-environment-variables">2. Configure environment variables</h2>
+<h3 id="automated-install-script">Automated install script</h3>
+<p>The root <code>install.sh</code> script streamlines both local and production setups. When
+you run it the script:</p>
+<ol>
+<li>Runs <code>scripts/check_prereqs.sh</code> to verify the required host tools (Node.js,
+   npm, Docker, Docker Compose V2, and Git). When the check fails you can either fix the
+   problem, acknowledge the warning at the interactive prompt, or set
+   <code>ALLOW_PREREQ_FAILURES=true</code> to continue automatically.</li>
+<li>Copies <code>.env.example</code> files to <code>.env</code> when the target file is missing (root,
+   backend, backend production, and <code>frontend/.env.local</code>).</li>
+<li>Sources the resulting files so migrations, seeds, and helper scripts inherit
+   the configuration.</li>
+<li>Ensures <code>backend/uploads/app</code> exists before branding assets are written.</li>
+</ol>
+<p>Supply <code>ADMIN_EMAIL</code> and <code>ADMIN_PASSWORD</code> via environment variables for
+non-interactive use (for example in CI pipelines). Optional flags include:</p>
+<ul>
+<li><code>SEED_DB=true</code> &mdash; run <code>npm --prefix backend run seed</code> after migrations.</li>
+<li><code>START_DEV_SERVICES=false</code> &mdash; skip the automatic <code>docker compose up</code> step in
+  development mode if you prefer to start services yourself.</li>
+<li><code>SKIP_BACKEND_NPM_INSTALL=true</code> &mdash; skip the automatic <code>npm --prefix backend install</code>
+  step when you manage dependencies separately.</li>
+</ul>
+<p>In production mode, the script ensures Docker services are running before it
+executes database migrations. In development mode it starts the compose stack in
+detached mode unless you opt out with <code>START_DEV_SERVICES=false</code>. Any migration
+or seeding errors halt the script before the admin user creation step so you can
+address the problem immediately.</p>
+<p>Before running migrations the script installs backend dependencies with
+<code>npm --prefix backend install</code> so the Node.js helper scripts are available and
+creates <code>backend/uploads/app/</code> if it is missing. Use
+<code>SKIP_BACKEND_NPM_INSTALL=true</code> if dependencies are already installed and you
+prefer to reuse them.</p>
+<h3 id="backend">Backend</h3>
+<p>Copy the example file and adjust values as needed:</p>
+<div class="codehilite"><pre><span></span><code>cp<span class="w"> </span>backend/.env.example<span class="w"> </span>backend/.env
+</code></pre></div>
+
+<p>For deployments, Docker Compose additionally reads <code>backend/.env.production</code>.
+Copy <code>backend/.env.production.example</code> to <code>backend/.env.production</code> and fill in
+production database credentials and JWT secrets.</p>
+<p>Set the display name that should appear in installer prompts and outbound
+emails so the branding check passes:</p>
+<div class="codehilite"><pre><span></span><code>APP_NAME=SkillBridge
+</code></pre></div>
+
+<p>If you plan to disable transactional email during setup, set
+<code>DISABLE_EMAILS=true</code>. Otherwise, provide SMTP credentials so the installer can
+verify connectivity up front:</p>
+<div class="codehilite"><pre><span></span><code>SMTP_HOST=smtp.mailtrap.io
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password
+</code></pre></div>
+
+<p>Create the uploads directory that stores logos and favicons and ensure it is
+writable by the backend service user:</p>
+<div class="codehilite"><pre><span></span><code>mkdir<span class="w"> </span>-p<span class="w"> </span>backend/uploads/app
+</code></pre></div>
+
+<p>Edit <code>backend/.env</code> and provide your secrets. <code>FRONTEND_URL</code> must match the
+exact origin (scheme, host, and port) where the frontend will run to avoid
+CORS errors. Separate multiple origins with commas, for example:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">FRONTEND_URL</span><span class="o">=</span>http://localhost:3000,https://example.com
+</code></pre></div>
+
+<p>The variable defaults to <code>http://localhost:3000</code>. Leave <code>NODE_ENV</code> unset so
+cookies work over HTTP. If you need cross-subdomain cookies without HTTPS,
+also set:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">COOKIE_SECURE</span><span class="o">=</span><span class="nb">false</span>
+<span class="nv">COOKIE_SAMESITE</span><span class="o">=</span>None
+</code></pre></div>
+
+<p>If additional domains need access to the API, add them to
+<code>EXTRA_CORS_ORIGINS</code> as a comma-separated list of URLs:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">EXTRA_CORS_ORIGINS</span><span class="o">=</span>https://admin.example.com,https://docs.example.com
+</code></pre></div>
+
+<p>These origins are merged with <code>FRONTEND_URL</code> and the default app domain to
+configure CORS.</p>
+<p>Rate limiting defaults to 1,000 requests per IP every 15 minutes. Adjust the
+allowance if your deployment expects heavier bursts of traffic by setting:</p>
+<div class="codehilite"><pre><span></span><code>RATE_LIMIT_MAX=2000
+RATE_LIMIT_WINDOW_MS=300000 # 5 minutes
+</code></pre></div>
+
+<p>Increase or decrease these numbers to match your usage profile. The health
+check endpoint (<code>/api/health</code>) is excluded so uptime probes continue to work
+even when the limit is reached.</p>
+<p>A Redis instance (or compatible store) is required to persist sessions in
+production. Set <code>REDIS_URL</code> in <code>backend/.env</code> to point to your Redis server
+(for example <code>redis://localhost:6379</code>).</p>
+<p>The book filter's price range uses configurable defaults:</p>
+<div class="codehilite"><pre><span></span><code>BOOK_PRICE_RANGE_DEFAULT=100
+BOOK_PRICE_RANGE_MAX=500
+</code></pre></div>
+
+<p>These values are read in <code>backend/src/config/books.js</code> and mirrored on the
+frontend via <code>frontend/src/utils/constants.js</code>. When running the frontend
+outside Docker, add the <code>NEXT_PUBLIC_</code> variants to <code>frontend/.env.local</code>:</p>
+<div class="codehilite"><pre><span></span><code>NEXT_PUBLIC_BOOK_PRICE_RANGE_DEFAULT=100
+NEXT_PUBLIC_BOOK_PRICE_RANGE_MAX=500
+</code></pre></div>
+
+<h3 id="installation-api">Installation API</h3>
+<p>The backend exposes protected setup endpoints at <code>/api/install</code> for automated deployments. They are disabled by default to reduce the attack surface. When you need to run the installer, explicitly enable the endpoints by setting <code>INSTALL_API_ENABLED=true</code> in <code>backend/.env</code> and restarting the backend service so the change takes effect:</p>
+<div class="codehilite"><pre><span></span><code><span class="gh">#</span> backend/.env
+INSTALL_API_ENABLED=true
+</code></pre></div>
+
+<p>Every request to <code>/api/install/*</code> must be authenticated with an administrator token. Log in as an admin (for example via <code>/api/auth/login</code>) and reuse the returned JWT as a <code>Bearer</code> token when calling the installation routes. When invoking <code>POST /api/install/run</code>, include the following JSON body so the installer can persist your configuration before provisioning the admin account:</p>
+<div class="codehilite"><pre><span></span><code><span class="p">{</span>
+<span class="w">  </span><span class="nt">&quot;adminEmail&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;admin@example.com&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;adminPassword&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;super-secret&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;databaseUrl&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;postgres://user:password@db-host:5432/skillbridge&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;databaseUser&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;user&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;databasePassword&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;password&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;smtpHost&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;smtp.example.com&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;smtpPort&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">587</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;smtpUser&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;mailer&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;smtpPassword&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;smtp-password&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;defaultFromEmail&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;notifications@example.com&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;appDisplayName&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SkillBridge&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;logoUrl&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;https://assets.example.com/logo.png&quot;</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<p>You may provide a base64-encoded logo instead of <code>logoUrl</code> by supplying a <code>logoFile</code> object with <code>name</code>, <code>size</code>, <code>type</code>, <code>encoding</code> (<code>base64</code>) and <code>data</code> fields. The API refuses requests that omit both a logo URL and a file. The backend writes these values into <code>backend/.env</code>, uploads the logo to <code>backend/uploads/app/</code>, and seeds the <code>settings</code> table with the default email and branding metadata before creating the admin user.</p>
+<p>If you configure <code>INSTALL_SETUP_SECRET</code> in <code>backend/.env</code>, clients must also send the same value in the <code>X-Install-Setup-Secret</code> header on <strong>every</strong> installer request. The backend trims the configured secret before comparison, so avoid trailing spaces when setting the environment variable. Requests that omit the header or provide the wrong secret receive a <code>403</code> response with an <code>INSTALL_LOCKED</code> error code before the installer runs.</p>
+<p>After you finish the installation or automation tasks, immediately disable the API again by removing the setting or switching it back to <code>false</code> and redeploying/restarting the backend. Leaving the installer enabled in production is not recommended.</p>
+<h3 id="initial-admin-passwords">Initial admin passwords</h3>
+<p>Set <code>ADMIN_INITIAL_PASSWORD</code> and <code>SUPERADMIN_INITIAL_PASSWORD</code> in
+<code>backend/.env</code> before running the seed scripts if you want to control the
+passwords for the seeded Admin and SuperAdmin accounts. When left unset, the
+seed process will generate secure random passwords and print them to the
+console.</p>
+<h3 id="frontend-optional">Frontend (optional)</h3>
+<p>When using Docker Compose the frontend automatically points to the API on port
+<code>5002</code>. If you start the Next.js app separately, create <code>frontend/.env.local</code> and
+set:</p>
+<div class="codehilite"><pre><span></span><code><span class="nv">NEXT_PUBLIC_API_BASE_URL</span><span class="o">=</span>http://localhost:5002/api
+<span class="nv">NEXT_PUBLIC_TRUSTED_ICON_HOSTS</span><span class="o">=</span>yourdomain.com,cdn.yourdomain.com
+</code></pre></div>
+
+<p><code>NEXT_PUBLIC_TRUSTED_ICON_HOSTS</code> defines a comma-separated list of allowed
+hosts for payment method icons. URLs outside this list will fall back to a
+default icon.</p>
+<p>The root <code>.env</code> file defaults <code>NEXT_PUBLIC_API_BASE_URL</code> to
+<code>http://localhost:5002/api</code> so Docker services can reach the backend container
+internally during development. For production builds use
+<code>frontend/.env.production</code> instead and remove or override the root <code>.env</code> so the
+frontend points to your public domain (for example,
+<code>https://yourdomain.com/api</code>).</p>
+<h2 id="3-install-dependencies-optional">3. Install dependencies (optional)</h2>
+<p>For manual development outside of Docker:</p>
+<div class="codehilite"><pre><span></span><code><span class="nb">cd</span><span class="w"> </span>backend<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>npm<span class="w"> </span>install
+<span class="nb">cd</span><span class="w"> </span>../frontend<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>npm<span class="w"> </span>install
+<span class="nb">cd</span><span class="w"> </span>..
+</code></pre></div>
+
+<h2 id="4-prepare-the-database">4. Prepare the database</h2>
+<p>Run migrations and seed data:</p>
+<div class="codehilite"><pre><span></span><code><span class="nb">cd</span><span class="w"> </span>backend
+npm<span class="w"> </span>run<span class="w"> </span>migrate
+npm<span class="w"> </span>run<span class="w"> </span>seed
+<span class="nb">cd</span><span class="w"> </span>..
+</code></pre></div>
+
+<h2 id="5-launch-the-stack">5. Launch the stack</h2>
+<p>Start all services with Docker Compose:</p>
+<div class="codehilite"><pre><span></span><code>docker<span class="w"> </span>compose<span class="w"> </span>up<span class="w"> </span>--build
+</code></pre></div>
+
+<p>The containers expose the following URLs:</p>
+<ul>
+<li>Frontend: <code>http://localhost:3000</code></li>
+<li>Backend API: <code>http://localhost:5002/api</code></li>
+<li>PostgreSQL: <code>localhost:5432</code></li>
+<li>pgAdmin: <code>http://localhost:5050</code></li>
+<li>Redis: <code>localhost:6379</code></li>
+</ul>
+<p>Once running, open the frontend URL in your browser and create an account or log
+in.</p>
+<h3 id="web-based-installer-optional">Web-based installer (optional)</h3>
+<p>The backend ships with a small web-based installer. To use it:</p>
+<ol>
+<li>In <code>backend/.env</code>, set <code>ENABLE_INSTALL=true</code> and <code>INSTALL_API_ENABLED=true</code>.</li>
+<li>Configure Nginx to proxy the installer route to the backend:</li>
+</ol>
+<div class="codehilite"><pre><span></span><code><span class="k">location</span><span class="w"> </span><span class="s">^~</span><span class="w"> </span><span class="s">/install/</span><span class="w"> </span><span class="p">{</span>
+<span class="w">  </span><span class="kn">proxy_pass</span><span class="w"> </span><span class="s">http://backend:5002</span><span class="p">;</span>
+<span class="w">  </span><span class="kn">proxy_http_version</span><span class="w"> </span><span class="mi">1</span><span class="s">.1</span><span class="p">;</span>
+<span class="w">  </span><span class="kn">proxy_set_header</span><span class="w"> </span><span class="s">Host</span><span class="w"> </span><span class="nv">$host</span><span class="p">;</span>
+<span class="w">  </span><span class="kn">proxy_set_header</span><span class="w"> </span><span class="s">X-Real-IP</span><span class="w"> </span><span class="nv">$remote_addr</span><span class="p">;</span>
+<span class="w">  </span><span class="kn">proxy_set_header</span><span class="w"> </span><span class="s">X-Forwarded-For</span><span class="w"> </span><span class="nv">$proxy_add_x_forwarded_for</span><span class="p">;</span>
+<span class="w">  </span><span class="kn">proxy_set_header</span><span class="w"> </span><span class="s">X-Forwarded-Proto</span><span class="w"> </span><span class="nv">$scheme</span><span class="p">;</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<ol start="3">
+<li>Rebuild and start the containers if they are running.</li>
+<li>Log in with an administrator account.</li>
+<li>Visit <code>http://localhost:5002/install</code> (or your domain's <code>/install</code>) and verify the page lists the prerequisite checks.</li>
+<li>Complete the <strong>Configuration</strong> step by supplying:
+   - A PostgreSQL connection string, database user, and database password.
+   - SMTP host, port, username, and password so SkillBridge can deliver transactional email.
+   - The default “from” email address used for outbound messages.
+   - (Optional) Your Codecanyon purchase or subscription key so future updates can validate the license.
+   - The public application display name.
+   - Either a logo image upload (PNG/JPG/SVG up to 2&nbsp;MB) or an HTTPS URL to an existing logo.
+   - The admin email and password for the first administrator.</li>
+<li>Run the installer to apply the configuration. The script updates <code>backend/.env</code>, writes the selected logo to <code>backend/uploads/app/</code>, seeds the branding/email settings in the database, and finally provisions the administrator account.</li>
+</ol>
+<p>The prerequisite card now verifies that PostgreSQL is reachable using the
+   credentials in <code>.env</code>, confirms SMTP settings (or acknowledges that
+   <code>DISABLE_EMAILS=true</code> is set), checks that <code>APP_NAME</code> is defined, and ensures
+   <code>backend/uploads/app</code> is writable for logo uploads. Address any failures the
+   installer reports before continuing.</p>
+<p>Whether you run SkillBridge directly from the monorepo or from the packaged
+container image, the backend automatically serves the installer assets. During
+development it reads from the top-level <code>install/</code> directory, and in production
+it falls back to <code>backend/install/</code> inside the container image when the
+repository layout is different.</p>
+<p>Common problems:</p>
+<ul>
+<li><strong>404 Not Found</strong> – the Nginx block is missing or <code>ENABLE_INSTALL</code> is false.</li>
+<li><strong>Installation via API is disabled</strong> – <code>INSTALL_API_ENABLED</code> is not set to <code>true</code>.</li>
+<li><strong>Unauthorized</strong> – you must be logged in as an admin before visiting <code>/install</code>.</li>
+</ul>
+<h2 id="6-running-tests">6. Running tests</h2>
+<p>The project includes Jest suites for both the API and the frontend.</p>
+<h3 id="backend_1">Backend</h3>
+<div class="codehilite"><pre><span></span><code><span class="nb">cd</span><span class="w"> </span>backend
+npm<span class="w"> </span><span class="nb">test</span>
+</code></pre></div>
+
+<h3 id="frontend">Frontend</h3>
+<div class="codehilite"><pre><span></span><code><span class="nb">cd</span><span class="w"> </span>frontend
+npm<span class="w"> </span><span class="nb">test</span>
+</code></pre></div>
+
+<h2 id="7-hosting-on-a-server">7. Hosting on a server</h2>
+<p>To deploy SkillBridge for real users on a remote host:</p>
+<ol>
+<li><strong>Provision a server</strong> running Linux and install <a href="https://docs.docker.com/engine/install/">Docker</a> and <a href="https://docs.docker.com/compose/install/">Docker Compose</a>.</li>
+<li><strong>Clone the repository</strong> on the server and configure environment variables as described above.
+   - In <code>backend/.env</code>, set production values such as <code>NODE_ENV=production</code>, <code>FRONTEND_URL=https://&lt;your-domain&gt;</code>, <code>COOKIE_SECURE=true</code>, and <code>COOKIE_SAMESITE=None</code>.
+   - Create <code>frontend/.env.local</code> with <code>NEXT_PUBLIC_API_BASE_URL=https://&lt;your-domain&gt;/api</code>.</li>
+<li><strong>Adjust Nginx for your domain.</strong>
+   - Set the <code>APP_DOMAIN</code> environment variable so Nginx and the backend use your domain.
+   - Obtain TLS certificates (e.g. via Let's Encrypt's certbot) and ensure the paths in <code>ssl.conf</code> match the certificate locations.</li>
+<li><strong>Run database migrations and seeds</strong> before starting the containers:</li>
+</ol>
+<p><code>bash
+   docker compose run --rm backend npm run migrate
+   docker compose run --rm backend npm run seed</code></p>
+<ol start="5">
+<li><strong>Build and start the containers</strong> in detached mode:</li>
+</ol>
+<p><code>bash
+   docker compose up -d --build</code></p>
+<ol start="6">
+<li><strong>Verify the deployment</strong> by visiting <code>https://&lt;your-domain&gt;</code> in a browser. The API will be available at <code>https://&lt;your-domain&gt;/api</code>.</li>
+</ol>
+<p>For updates, pull the latest changes and rebuild:</p>
+<div class="codehilite"><pre><span></span><code>git<span class="w"> </span>pull
+docker<span class="w"> </span>compose<span class="w"> </span>up<span class="w"> </span>-d<span class="w"> </span>--build
+</code></pre></div>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/license-verification.html
+++ b/docs/license-verification.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>License Verification with CodeCanyon/Envato | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html" class="active">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="license-verification-with-codecanyonenvato">License Verification with CodeCanyon/Envato</h1>
+<p>This guide explains how to validate purchases of your CodeCanyon product to ensure only legitimate customers can activate and continue using your application.</p>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul>
+<li><strong>Envato personal token</strong> with permission to view sales (stored in <code>ENVATO_TOKEN</code>).</li>
+<li><strong>Backend endpoint</strong> capable of making HTTPS requests.</li>
+<li><strong>Database table</strong> for tracking <code>purchase_code</code>, <code>domain</code>, <code>email</code>, <code>ip</code>, <code>status</code>, <code>activated_at</code>, <code>last_check</code>, and <code>logs</code>.</li>
+</ul>
+<h2 id="activation-workflow">Activation Workflow</h2>
+<ol>
+<li><strong>Customer buys the item</strong> on CodeCanyon and receives a unique purchase code.</li>
+<li><strong>Client submits activation request</strong> with purchase code, installation domain, email and IP to your server (e.g. <code>POST /api/license/activate</code>).</li>
+<li><strong>Server verifies with Envato</strong> by calling:
+   <code>http
+   GET https://api.envato.com/v3/market/author/sale?code=&lt;purchase_code&gt;
+   Authorization: Bearer &lt;ENVATO_TOKEN&gt;</code></li>
+<li><strong>Persist license record</strong> if Envato confirms the sale; otherwise return an error to the client.</li>
+<li><strong>Respond to client</strong> with activation status.</li>
+</ol>
+<h2 id="subsequent-validation">Subsequent Validation</h2>
+<ul>
+<li>Compare the stored domain against the current domain on each run or scheduled job.</li>
+<li>Update <code>last_check</code> timestamps and count any unauthorized instances.</li>
+<li>Allow administrators to deactivate licenses or inspect activation logs.</li>
+</ul>
+<h2 id="security-logging-tips">Security &amp; Logging Tips</h2>
+<ul>
+<li>Keep <code>ENVATO_TOKEN</code> on the server; never expose it client-side.</li>
+<li>Sanitize and validate all user input before contacting Envato.</li>
+<li>Rate-limit activation attempts and hash sensitive data where possible.</li>
+<li>Log activations, validations and domain mismatches for audit trails.</li>
+</ul>
+<h2 id="testing-recommendations">Testing Recommendations</h2>
+<ul>
+<li>Unit test the activation and validation services with mocked Envato responses.</li>
+<li>Integration tests should cover valid activations, invalid codes, domain mismatches and API failures.</li>
+</ul>
+<p>Implementing this flow helps protect your product from unauthorized use while giving you tools to audit legitimate installations.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/messages-config.html
+++ b/docs/messages-config.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Messaging Providers Configuration | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html" class="active">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="messaging-providers-configuration">Messaging Providers Configuration</h1>
+<p>SkillBridge lets administrators manage SMS gateway settings from the dashboard.
+Only one gateway provider can be <strong>Active</strong> and <strong>Default</strong> at a time so
+outgoing messages don't conflict.</p>
+<h2 id="backend">Backend</h2>
+<ul>
+<li>Settings are stored with the key <code>messages_settings</code> in the <code>settings</code> table.</li>
+<li>API routes under <code>/api/messages/config</code> read and update the configuration.</li>
+<li>When sending phone OTPs the service in <code>backend/src/services/smsService.js</code>
+  checks the active provider and sends SMS via Infobip if configured.</li>
+</ul>
+<h2 id="frontend">Frontend</h2>
+<ul>
+<li>Admin page: <code>frontend/src/pages/dashboard/admin/settings/messages-config</code>.</li>
+<li>Providers are listed in the UI. Toggle <strong>Active</strong> to enable one gateway and
+  select <strong>Default</strong> for the provider used for most messages.</li>
+<li>The Infobip form asks for <strong>API Key</strong>, <strong>Sender ID</strong> and <strong>Base URL / Region</strong>.
+  Enter your API key <em>without</em> the <code>App</code> prefix; the app will add it
+  automatically.</li>
+<li>The verification dialogs display a "Default OTP: <code>123456</code>" hint so users can
+  proceed even if SMS delivery fails during testing.</li>
+</ul>
+<p>Once saved, SMS OTPs will be delivered through the active provider.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/payment-icon-sources.html
+++ b/docs/payment-icon-sources.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Payment Icon Sources | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html" class="active">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="payment-icon-sources">Payment Icon Sources</h1>
+<p>SkillBridge displays icons for payment methods during checkout. To avoid loading images from untrusted locations, icons are only loaded from approved hosts or from assets bundled with the application.</p>
+<h2 id="supported-schemes">Supported schemes</h2>
+<p>Only <code>http</code> and <code>https</code> schemes are supported for payment method icons. Icons using other schemes (e.g. <code>javascript:</code> or <code>data:</code>) are rejected.</p>
+<h2 id="trusted-domains">Trusted domains</h2>
+<p>Payment method icons may be served from the following domains:</p>
+<ul>
+<li><code>yourdomain.com</code></li>
+<li><code>cdn.yourdomain.com</code></li>
+</ul>
+<p>These domains are defined in <code>TRUSTED_ICON_HOSTS</code> within <code>frontend/src/pages/payments/checkout.js</code> and can be overridden with the <code>NEXT_PUBLIC_TRUSTED_ICON_HOSTS</code> variable.</p>
+<p>Relative paths (e.g. <code>/images/payments/stripe.png</code>) are also permitted and should be placed under <code>frontend/public/images</code>.</p>
+<h2 id="fallback-behaviour">Fallback behaviour</h2>
+<p>If an icon is missing, uses an unapproved domain, or fails to load, the checkout page falls back to a generic money icon so the interface remains functional.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/release-checklist.html
+++ b/docs/release-checklist.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Release Checklist | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html" class="active">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="release-checklist">Release Checklist</h1>
+<p>Use this checklist to verify the repository is clean before creating a release package.</p>
+<ul>
+<li>[ ] Run <code>git status</code> to ensure no uncommitted changes remain.</li>
+<li>[ ] Remove any chat transcripts or temporary notes.</li>
+<li>[ ] Delete empty <code>project-structure*.txt</code> files.</li>
+<li>[ ] Ensure every <code>package-lock.json</code> has a corresponding <code>package.json</code> in the same directory.</li>
+<li>[ ] Confirm <code>node_modules</code> directories and build artifacts are not committed.</li>
+<li>[ ] Run backend tests with <code>npm test</code> from the <code>backend</code> directory.</li>
+<li>[ ] Run frontend tests with <code>npm test</code> from the <code>frontend</code> directory.</li>
+<li>[ ] Review documentation for accuracy and completeness.</li>
+<li>[ ] Verify the application builds successfully.</li>
+<li>[ ] Verify the light/dark mode toggle in the dashboard header switches themes without visual regressions.</li>
+</ul>
+<p>Following this checklist helps keep release packages lean and reliable.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -10,6 +10,7 @@ Use this checklist to verify the repository is clean before creating a release p
 - [ ] Run backend tests with `npm test` from the `backend` directory.
 - [ ] Run frontend tests with `npm test` from the `frontend` directory.
 - [ ] Review documentation for accuracy and completeness.
+- [ ] Regenerate the static HTML docs with `python scripts/generate_docs_html.py` so the ZIP bundle contains up-to-date guides.
 - [ ] Verify the application builds successfully.
 - [ ] Verify the light/dark mode toggle in the dashboard header switches themes without visual regressions.
 

--- a/docs/social-login-setup.html
+++ b/docs/social-login-setup.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Social Login Setup | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html" class="active">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="social-login-setup">Social Login Setup</h1>
+<p>This guide explains how to configure OAuth providers like Google so users can sign in to SkillBridge using their existing accounts.</p>
+<h2 id="seed-default-settings">Seed default settings</h2>
+<p>Run this seed from the <code>backend</code> directory to create a default <code>social_login_settings</code> row with all providers disabled:</p>
+<div class="codehilite"><pre><span></span><code>knex<span class="w"> </span>seed:run<span class="w"> </span>--specific<span class="o">=</span>08_social_login_settings_seed.js
+</code></pre></div>
+
+<h2 id="google">Google</h2>
+<ol>
+<li>Open the <strong>Google Cloud Console</strong> and create OAuth 2.0 credentials.</li>
+<li>Add the following URI to the <strong>Authorized redirect URIs</strong> list:</li>
+</ol>
+<p><code>http://localhost:5002/api/auth/google/callback</code></p>
+<p>Replace <code>http://localhost:5002</code> with your production backend URL when deploying. For example:</p>
+<p><code>https://yourdomain.com/api/auth/google/callback</code></p>
+<ol start="3">
+<li>Copy the generated <strong>Client ID</strong> and <strong>Client secret</strong> and enter them in the admin dashboard under <strong>Social Login Settings</strong>. Saving will automatically write the values to <code>backend/.env</code>.</li>
+<li>If the auto-generated redirect URL shown in the admin panel does not match the one configured in Google, enter the desired URL in the <strong>Redirect URL</strong> field for Google and save.</li>
+<li>Restart the backend so the new credentials take effect.</li>
+</ol>
+<p>If the redirect URI does not exactly match what is configured on Google, the login page will display <strong>Error 400: redirect_uri_mismatch</strong>.</p>
+<p>If clicking <strong>Sign in with Google</strong> takes you to <code>/auth/google</code> and shows a 404 error, verify the frontend's <code>NEXT_PUBLIC_API_BASE_URL</code> points to your backend URL including the <code>/api</code> prefix. When using Docker Compose, configure this in <code>frontend/.env.production</code> and remove or ignore the root <code>.env</code> which defaults to <code>http://localhost:5002/api</code>. Set it to your externally reachable domain such as <code>https://yourdomain.com/api</code>. Without this variable the login and register buttons default to <code>/api/auth/*</code> which only works when the frontend and backend share the same host. Both buttons now append <code>?origin=</code> with the current site origin so the API can redirect back correctly even when <code>FRONTEND_URL</code> is not configured.</p>
+<p>If requests to <code>/api/*</code> still return a Next.js 404 page, confirm your reverse proxy forwards the <code>/api</code> path to the backend container. The provided <code>nginx/conf.d</code> configs use <code>location ^~ /api/</code> to proxy to <code>backend:5002</code> without rewriting the prefix. Restart nginx after updating the configuration.</p>
+<p>After editing the files you can verify that nginx picked up the change by running:</p>
+<div class="codehilite"><pre><span></span><code>sudo<span class="w"> </span>nginx<span class="w"> </span>-T<span class="w"> </span><span class="p">|</span><span class="w"> </span>grep<span class="w"> </span><span class="s1">&#39;/api&#39;</span>
+</code></pre></div>
+
+<p>The output should list the <code>/api</code> location pointing at the backend. If the block is missing, reload nginx (for example <code>sudo systemctl reload nginx</code>) and try the login flow again.</p>
+<p>If the authentication completes but you land on a 404 page, check that the backend's
+<code>FRONTEND_URL</code> matches your frontend domain. An incorrect value can cause the API
+to redirect to the wrong host. You may also omit <code>FRONTEND_URL</code> to use the
+request's <code>Origin</code> header automatically.</p>
+<h2 id="github">GitHub</h2>
+<ol>
+<li>On GitHub open <strong>Settings → Developer settings → OAuth Apps</strong> and create a new OAuth App.</li>
+<li>Set the <strong>Authorization callback URL</strong> to:
+   <code>http://localhost:5002/api/auth/github/callback</code>
+   Replace <code>http://localhost:5002</code> with your backend URL when deployed. For example:
+   <code>https://${APP_DOMAIN}/api/auth/github/callback</code></li>
+<li>Enter the generated <strong>Client ID</strong> and <strong>Client Secret</strong> in the admin panel under <strong>Social Login Settings</strong>. These values will be stored in <code>backend/.env</code> automatically.</li>
+<li>Save the settings and restart the backend so the GitHub strategy is initialized.</li>
+</ol>
+<p>After completing these steps the <strong>Sign in with GitHub</strong> button should redirect back to <code>/auth/social-success</code> and automatically log the user in.</p>
+<h2 id="facebook">Facebook</h2>
+<ol>
+<li>Go to the <strong>Meta for Developers</strong> portal and create a new app with the <strong>Facebook Login</strong> product.</li>
+<li>Under <strong>Valid OAuth Redirect URIs</strong>, add:
+   <code>https://&lt;backend&gt;/api/auth/facebook/callback</code>
+   Replace <code>&lt;backend&gt;</code> with your backend's base URL.</li>
+<li>Request the <code>email</code> and <code>public_profile</code> permissions for the app.</li>
+<li>Enter the generated <strong>App ID</strong> and <strong>App Secret</strong> in the admin panel under <strong>Social Login Settings</strong>. Saving will update <code>backend/.env</code>.</li>
+<li>Restart the backend so the Facebook strategy is initialized.</li>
+</ol>
+<h2 id="recaptcha">reCAPTCHA</h2>
+<p>SkillBridge can optionally validate a Google reCAPTCHA token during login and registration. This behaviour is controlled by the <code>social_login_settings</code> record stored in the database. When the <code>recaptcha.active</code> flag is <code>true</code> the backend will verify the provided token using Google's API before authenticating the user. reCAPTCHA settings are only available under <strong>Social Login Settings</strong> in the admin dashboard.</p>
+<p>To temporarily disable reCAPTCHA you can call the configuration endpoint with admin credentials:</p>
+<div class="codehilite"><pre><span></span><code>curl<span class="w"> </span>-X<span class="w"> </span>PUT<span class="w"> </span>http://localhost:5002/api/social-login/config<span class="w"> </span><span class="se">\</span>
+<span class="w">  </span>-H<span class="w"> </span><span class="s1">&#39;Content-Type: application/json&#39;</span><span class="w"> </span><span class="se">\</span>
+<span class="w">  </span>-d<span class="w"> </span><span class="s1">&#39;{ &quot;recaptcha&quot;: { &quot;active&quot;: false } }&#39;</span>
+</code></pre></div>
+
+<p>Setting <code>active</code> back to <code>true</code> re-enables the verification check. When disabled, the server only validates the email and password.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/student-enrollment-workflow.html
+++ b/docs/student-enrollment-workflow.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Student Class Purchase &amp; Enrollment Workflow | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html" class="active">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="student-class-purchase-enrollment-workflow">Student Class Purchase &amp; Enrollment Workflow</h1>
+<p>This document outlines the typical flow a student follows when purchasing or enrolling in a class through SkillBridge.</p>
+<h2 id="1-discover-classes">1. Discover Classes</h2>
+<ul>
+<li>Browse <code>/classes</code> on the main website or homepage.</li>
+<li>Filter by category, level, instructor and price.</li>
+<li>Logged-in users can add classes to their wishlist.</li>
+<li>Open a class to view details via <code>/classes/[id]</code>.</li>
+</ul>
+<h2 id="2-view-class-details">2. View Class Details</h2>
+<p>A class detail page displays:
+- Full description and instructor bio.
+- Curriculum and lessons list.
+- Student reviews and requirements.
+- Schedule information (online or offline).</p>
+<p>Actions available:
+- <strong>Add to Cart</strong> if the class is paid.
+- <strong>Enroll Directly</strong> if the class is free.</p>
+<h2 id="3-cart-system">3. Cart System</h2>
+<p>On <code>/cart</code> students can review selected classes:
+- See title, price and instructor information.
+- Remove classes if needed.
+- View the total price and proceed to checkout.</p>
+<h2 id="4-checkout">4. Checkout</h2>
+<p>The <code>/checkout</code> page requires the student to be logged in. A completed profile may also be required. Students select a payment method, confirm billing details and review their order summary before proceeding.</p>
+<h2 id="5-payment-gateway">5. Payment Gateway</h2>
+<p>Students are redirected to the configured payment processor (Stripe, Tap, PayPal or an NFT wallet). On successful payment they return to <code>/checkout/success</code> where the order is saved and the student is officially enrolled. Failures redirect to <code>/checkout/failure</code> with options to retry or contact support.</p>
+<p>For card payments, the checkout uses Stripe Elements to tokenize sensitive details in the browser. Only the tokenized payment identifier is sent to our server, keeping raw card numbers out of the application.</p>
+<p>If paying via bank transfer or another offline method, students may need to upload a payment receipt. Accepted formats are JPG, PNG or PDF files up to 5 MB.</p>
+<h2 id="6-order-invoicing">6. Order &amp; Invoicing</h2>
+<ul>
+<li>Administrators can view orders under <code>/dashboard/admin/orders</code>.</li>
+<li>Students can download invoices from <code>/dashboard/student/invoices</code>.</li>
+<li>Email confirmations and receipts are automatically sent.</li>
+<li>Instructors may be notified of new students.</li>
+</ul>
+<h2 id="7-student-class-access">7. Student Class Access</h2>
+<p>Once payment is confirmed, students appear in the class's roster and gain access to:
+- The classroom page <code>/dashboard/student/classes/[id]</code>.
+- Lessons, resources and assignments.
+- Certificate eligibility when applicable.</p>
+<p>Optional enhancements include guest checkout, coupon codes, a wallet/credits system and automated reminders for upcoming classes.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/student-registration-guide.html
+++ b/docs/student-registration-guide.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Student Registration &amp; Class Enrollment Guide | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html" class="active">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="student-registration-class-enrollment-guide">Student Registration &amp; Class Enrollment Guide</h1>
+<p>This guide explains how a new user can create an account on SkillBridge and sign up for an online class.</p>
+<h2 id="1-create-an-account">1. Create an Account</h2>
+<ol>
+<li>Visit <code>/register</code> on the website.</li>
+<li>Fill in your name, email and password.</li>
+<li>Submit the form to receive a confirmation email.</li>
+<li>Click the verification link in the email to activate your account.</li>
+<li>If you try to log in before verifying, you'll see an "Account pending activation" message. Check your inbox (and spam folder) for the verification email or contact support for help.</li>
+</ol>
+<h2 id="2-browse-available-classes">2. Browse Available Classes</h2>
+<ol>
+<li>Go to <code>/online-classes</code> after logging in.</li>
+<li>Use the filters to narrow down classes by category, level or instructor.</li>
+<li>Click a class card to view details like schedule and price.</li>
+</ol>
+<h2 id="3-enroll-in-a-class">3. Enroll in a Class</h2>
+<h3 id="free-classes">Free classes</h3>
+<ol>
+<li>On the class detail page click <strong>Enroll Now</strong>.</li>
+<li>You will be added to the class immediately and can access the lessons.</li>
+</ol>
+<h3 id="paid-classes">Paid classes</h3>
+<ol>
+<li>Click <strong>Add to Cart</strong> on the class page.</li>
+<li>Open <code>/cart</code> and proceed to <strong>Checkout</strong>.</li>
+<li>Complete the payment using your preferred method.</li>
+<li>After payment you are redirected to <code>/checkout/success</code> and the class will appear in your dashboard under <code>My Classes</code>.</li>
+</ol>
+<h2 id="4-access-your-classes">4. Access Your Classes</h2>
+<ul>
+<li>Navigate to <code>/dashboard/student/classes</code> to view all the courses you have enrolled in.</li>
+<li>Click a class to start learning and track your progress.</li>
+</ul>
+<p>For a more detailed walkthrough of the enrollment flow see <a href="student-enrollment-workflow.html">docs/student-enrollment-workflow.md</a>.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/subscription-plan-style.html
+++ b/docs/subscription-plan-style.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Subscription Plan Style Configuration | Skillbridge Documentation</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }
+    header {
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+    main {
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }
+    nav {
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    nav h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      margin: 0.35rem 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    nav a:hover {
+      background: #d9e2ec;
+    }
+    nav a.active {
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }
+    article {
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }
+    article h1, article h2, article h3, article h4 {
+      color: #102a43;
+    }
+    article pre {
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }
+    article code {
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }
+    article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }
+    article table, article th, article td {
+      border: 1px solid #cbd2d9;
+    }
+    article th, article td {
+      padding: 0.75rem;
+      text-align: left;
+    }
+    article blockquote {
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }
+    @media (max-width: 960px) {
+      main {
+        flex-direction: column;
+      }
+      nav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="README.html">SkillBridge Documentation</a></li>
+<li><a href="admin-ads-management.html">Admin Ads Management</a></li>
+<li><a href="admin-alerts.html">Admin Alerts</a></li>
+<li><a href="admin-category-management.html">Admin Category Management</a></li>
+<li><a href="admin-third-party-integrations.html">Admin Third Party Integrations</a></li>
+<li><a href="api-docs.html">API Overview</a></li>
+<li><a href="architecture.html">Backend Architecture Overview</a></li>
+<li><a href="book-workflow.html">Book Marketplace Module Workflow</a></li>
+<li><a href="changelog.html">Changelog</a></li>
+<li><a href="class-lifecycle-workflow.html">Class Lifecycle &amp; Certificate Workflow</a></li>
+<li><a href="class-plan-coverage.html">Class Plan Coverage</a></li>
+<li><a href="coupon-management.html">Coupon Management</a></li>
+<li><a href="deployment.html">Deployment Guide</a></li>
+<li><a href="index.html">Getting Started</a></li>
+<li><a href="installation.html">Installation Guide</a></li>
+<li><a href="license-verification.html">License Verification with CodeCanyon/Envato</a></li>
+<li><a href="messages-config.html">Messaging Providers Configuration</a></li>
+<li><a href="payment-icon-sources.html">Payment Icon Sources</a></li>
+<li><a href="release-checklist.html">Release Checklist</a></li>
+<li><a href="social-login-setup.html">Social Login Setup</a></li>
+<li><a href="student-enrollment-workflow.html">Student Class Purchase &amp; Enrollment Workflow</a></li>
+<li><a href="student-registration-guide.html">Student Registration &amp; Class Enrollment Guide</a></li>
+<li><a href="subscription-plan-style.html" class="active">Subscription Plan Style Configuration</a></li>
+      </ul>
+    </nav>
+    <article>
+      <h1 id="subscription-plan-style-configuration">Subscription Plan Style Configuration</h1>
+<p>Subscription plans have optional fields that control how they appear on the website pricing page:</p>
+<ul>
+<li><strong>color</strong> – background color of the plan card.</li>
+<li><strong>style</strong> – JSON string with additional visual settings:</li>
+<li><code>textColor</code> – text color for the card contents.</li>
+<li><code>gradientStart</code>/<code>gradientEnd</code> – optional gradient background.</li>
+<li><code>buttonColor</code> – subscription button background color.</li>
+<li><code>buttonTextColor</code> – subscription button text color.</li>
+</ul>
+<p>Administrators can set these values when creating or editing a plan from
+<code>/dashboard/admin/plans</code>. The <code>SubscriptionPlans</code> component automatically
+uses these fields, so adjusting them in the dashboard updates the site
+without code changes.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/scripts/generate_docs_html.py
+++ b/scripts/generate_docs_html.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Generate static HTML files from Markdown documentation."""
+from __future__ import annotations
+
+import argparse
+import html
+import re
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import markdown
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = ROOT / "docs"
+
+
+def find_markdown_files(paths: Iterable[Path] | None = None) -> List[Path]:
+    if not paths:
+        paths = [DOCS_DIR]
+    md_files: List[Path] = []
+    for base in paths:
+        for path in sorted(base.glob("*.md")):
+            md_files.append(path)
+    return md_files
+
+
+def extract_title(markdown_path: Path) -> str:
+    for line in markdown_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("# ").strip()
+    return markdown_path.stem.replace("-", " ").title()
+
+
+def build_navigation(md_files: Iterable[Path]) -> List[Tuple[str, str]]:
+    entries: List[Tuple[str, str]] = []
+    for path in md_files:
+        title = extract_title(path)
+        if path.name == "index.md" and title.lower() == "installation guide":
+            title = "Getting Started"
+        entries.append((title, path.with_suffix(".html").name))
+    return entries
+
+
+def convert_markdown(md_path: Path) -> str:
+    text = md_path.read_text(encoding="utf-8")
+    html_body = markdown.markdown(
+        text,
+        extensions=[
+            "extra",
+            "toc",
+            "tables",
+            "sane_lists",
+            "codehilite",
+        ],
+        output_format="html5",
+    )
+    return html_body
+
+
+HREF_MD_DOUBLE = re.compile(r'(href="[^"#]+?)\.md([#"])')
+HREF_MD_SINGLE = re.compile(r"(href='[^'#]+?)\.md([#'])")
+
+
+def replace_md_links(html_content: str) -> str:
+    """Ensure references to Markdown files point at generated HTML."""
+
+    def _sub(match: re.Match[str]) -> str:
+        return f"{match.group(1)}.html{match.group(2)}"
+
+    content = HREF_MD_DOUBLE.sub(_sub, html_content)
+    content = HREF_MD_SINGLE.sub(_sub, content)
+    return content
+
+
+def build_page(title: str, body: str, navigation: Iterable[Tuple[str, str]], *, active: str) -> str:
+    nav_items = []
+    for nav_title, href in navigation:
+        is_active = " class=\"active\"" if href == active else ""
+        nav_items.append(f"<li><a href=\"{html.escape(href)}\"{is_active}>{html.escape(nav_title)}</a></li>")
+    nav_html = "\n".join(nav_items)
+    template = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>{html.escape(title)} | Skillbridge Documentation</title>
+  <style>
+    body {{
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #1a1d23;
+    }}
+    header {{
+      background: #1f2933;
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }}
+    header h1 {{
+      margin: 0;
+      font-size: 1.75rem;
+    }}
+    main {{
+      display: flex;
+      min-height: calc(100vh - 64px);
+    }}
+    nav {{
+      width: 260px;
+      background: #f0f4f8;
+      border-right: 1px solid #d9e2ec;
+      padding: 1.5rem 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }}
+    nav h2 {{
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #52606d;
+      margin-top: 0;
+    }}
+    nav ul {{
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }}
+    nav li {{
+      margin: 0.35rem 0;
+    }}
+    nav a {{
+      display: block;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      color: #1f2933;
+      text-decoration: none;
+      transition: background 0.2s ease, color 0.2s ease;
+    }}
+    nav a:hover {{
+      background: #d9e2ec;
+    }}
+    nav a.active {{
+      background: #3e4c59;
+      color: #fff;
+      font-weight: 600;
+    }}
+    article {{
+      flex: 1;
+      padding: 2rem 3rem;
+      box-sizing: border-box;
+      max-width: 960px;
+    }}
+    article h1, article h2, article h3, article h4 {{
+      color: #102a43;
+    }}
+    article pre {{
+      background: #243b53;
+      color: #f0f4f8;
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 6px;
+    }}
+    article code {{
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      font-size: 0.95em;
+    }}
+    article table {{
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+    }}
+    article table, article th, article td {{
+      border: 1px solid #cbd2d9;
+    }}
+    article th, article td {{
+      padding: 0.75rem;
+      text-align: left;
+    }}
+    article blockquote {{
+      border-left: 4px solid #9fb3c8;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1rem;
+      background: #e4ebf5;
+      color: #334e68;
+    }}
+    @media (max-width: 960px) {{
+      main {{
+        flex-direction: column;
+      }}
+      nav {{
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #d9e2ec;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skillbridge Documentation</h1>
+  </header>
+  <main>
+    <nav>
+      <h2>Guides</h2>
+      <ul>
+        {nav_html}
+      </ul>
+    </nav>
+    <article>
+      {body}
+    </article>
+  </main>
+</body>
+</html>
+"""
+    return template
+
+
+def generate_html(md_files: Iterable[Path], *, dry_run: bool = False) -> None:
+    md_files = list(md_files)
+    navigation = build_navigation(md_files)
+    for md_path in md_files:
+        body_html = convert_markdown(md_path)
+        body_html = replace_md_links(body_html)
+        title = extract_title(md_path)
+        html_page = build_page(title, body_html, navigation, active=md_path.with_suffix(".html").name)
+        output_path = md_path.with_suffix(".html")
+        if dry_run:
+            print(f"Would write {output_path.relative_to(ROOT)}")
+        else:
+            output_path.write_text(html_page, encoding="utf-8")
+            print(f"Wrote {output_path.relative_to(ROOT)}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path, help="Specific Markdown files or directories to convert")
+    parser.add_argument("--dry-run", action="store_true", help="Only print the files that would be generated")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    md_files = []
+    if args.paths:
+        for path in args.paths:
+            if path.is_dir():
+                md_files.extend(find_markdown_files([path]))
+            elif path.suffix.lower() == ".md":
+                md_files.append(path)
+            else:
+                raise SystemExit(f"Unsupported path: {path}")
+    else:
+        md_files = find_markdown_files()
+
+    if not md_files:
+        raise SystemExit("No markdown files found to convert")
+
+    generate_html(md_files, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script that converts Markdown docs into styled static HTML with navigation
- check in the generated HTML pages so offline ZIP packages can use `.html` links
- document regenerating the HTML output as part of the release checklist

## Testing
- python scripts/generate_docs_html.py

------
https://chatgpt.com/codex/tasks/task_e_68d843484ce08328b3d904bf16b80e45