### PR TITLE
Fix docs asset tracing and resolution

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -225,8 +225,8 @@ const nextConfig = {
     largePageDataBytes: 256 * 1024,
     externalDir: true,
     outputFileTracingIncludes: {
-      '/docs': ['./docs/**/*'],
-      '/docs/[slug]': ['./docs/**/*'],
+      '/docs': ['../docs/**/*'],
+      '/docs/[slug]': ['../docs/**/*'],
     },
     turbo: {
       resolveAlias: {

--- a/frontend/src/pages/docs/[slug].js
+++ b/frontend/src/pages/docs/[slug].js
@@ -5,6 +5,8 @@ import Head from 'next/head';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+
 const sanitizeSlug = (value) => value.replace(/\.md$/, '').replace(/[^a-zA-Z0-9-_]/g, '');
 
 const resolveDocLink = (href) => {
@@ -33,6 +35,8 @@ const DOCS_DIR_CANDIDATES = [
   path.join(process.cwd(), 'docs'),
   path.join(process.cwd(), '..', 'docs'),
   path.join(process.cwd(), '..', '..', 'docs'),
+  path.resolve(moduleDir, '../../docs'),
+  path.resolve(moduleDir, '../../../docs'),
 ];
 
 async function resolveDocsDirectory() {

--- a/frontend/src/pages/docs/index.js
+++ b/frontend/src/pages/docs/index.js
@@ -11,10 +11,14 @@ import Navbar from '@/components/website/sections/Navbar';
 import PageHead from '@/components/common/PageHead';
 import nextI18NextConfig from '../../../next-i18next.config.js';
 
+const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+
 const DOCS_DIR_CANDIDATES = [
   path.join(process.cwd(), 'docs'),
   path.join(process.cwd(), '..', 'docs'),
   path.join(process.cwd(), '..', '..', 'docs'),
+  path.resolve(moduleDir, '../../docs'),
+  path.resolve(moduleDir, '../../../docs'),
 ];
 
 async function resolveDocsDirectory() {


### PR DESCRIPTION
## Summary
- point Next.js output file tracing at the repository-level docs directory so Markdown files are bundled
- add module-relative fallbacks when resolving the docs directory at runtime for the docs landing page and individual guide route

## Testing
- npm run build
- npm run start
- curl -sS http://localhost:3000/docs | sed 's/></>\n</g' | grep -m 1 "SkillBridge Documentation"
- curl -sS http://localhost:3000/docs/installation | sed 's/></>\n</g' | grep -m 1 "Installation"


------
https://chatgpt.com/codex/tasks/task_e_68d846e86d008328b0363c687793619a