### PR TITLE
Fix docs output tracing path

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -225,8 +225,8 @@ const nextConfig = {
     largePageDataBytes: 256 * 1024,
     externalDir: true,
     outputFileTracingIncludes: {
-      '/docs': ['./docs/**/*'],
-      '/docs/[slug]': ['./docs/**/*'],
+      '/docs': ['../docs/**/*'],
+      '/docs/[slug]': ['../docs/**/*'],
     },
     turbo: {
       resolveAlias: {


### PR DESCRIPTION
## Summary
- point the docs output file tracing includes to the shared ../docs directory so markdown files are bundled

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d84810b6488328ad9afee634b434c6