### PR TITLE
Support HTML fallback for docs pages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "axios": "^1.7.9",
         "bad-words": "^4.0.0",
         "chart.js": "^4.4.9",
+        "cheerio": "^1.0.0",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "dompurify": "^3.2.6",
@@ -4931,6 +4932,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bowser": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
@@ -5265,6 +5272,57 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -5644,6 +5702,34 @@
       "license": "MIT",
       "dependencies": {
         "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/css.escape": {
@@ -6187,6 +6273,44 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -6211,6 +6335,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
@@ -6218,6 +6357,20 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -6332,6 +6485,31 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/engine.io-client": {
       "version": "6.6.3",
@@ -8216,6 +8394,25 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -12214,6 +12411,18 @@
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
       "license": "MIT"
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.20",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
@@ -12580,6 +12789,31 @@
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -15744,6 +15978,15 @@
       },
       "peerDependencies": {
         "react": ">=15.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.7.9",
     "bad-words": "^4.0.0",
     "chart.js": "^4.4.9",
+    "cheerio": "^1.0.0",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "dompurify": "^3.2.6",

--- a/frontend/src/pages/docs/[slug].js
+++ b/frontend/src/pages/docs/[slug].js
@@ -2,13 +2,20 @@ import fs from 'fs/promises';
 import path from 'path';
 import Link from 'next/link';
 import Head from 'next/head';
+import { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import DOMPurify from 'isomorphic-dompurify';
+import cheerio from 'cheerio';
 
 const sanitizeSlug = (value) => value.replace(/\.md$/, '').replace(/[^a-zA-Z0-9-_]/g, '');
 
 const resolveDocLink = (href) => {
   if (!href) {
+    return href;
+  }
+
+  if (href.startsWith('#') || href.startsWith('?')) {
     return href;
   }
 
@@ -18,8 +25,8 @@ const resolveDocLink = (href) => {
 
   const cleaned = href.replace(/^\.\//, '').replace(/^docs\//, '');
 
-  if (cleaned.endsWith('.md')) {
-    return `/docs/${cleaned.replace(/\.md$/, '')}`;
+  if (cleaned.endsWith('.md') || cleaned.endsWith('.html')) {
+    return `/docs/${cleaned.replace(/\.(md|html)$/, '')}`;
   }
 
   if (cleaned.startsWith('/')) {
@@ -63,11 +70,16 @@ export async function getStaticPaths() {
     }
   }
 
-  const paths = entries
-    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
-    .map((entry) => ({
-      params: { slug: entry.name.replace(/\.md$/, '') },
-    }));
+  const slugs = new Set();
+  entries
+    .filter((entry) => entry.isFile() && (/\.md$/i.test(entry.name) || /\.html$/i.test(entry.name)))
+    .forEach((entry) => {
+      slugs.add(entry.name.replace(/\.(md|html)$/i, ''));
+    });
+
+  const paths = Array.from(slugs).map((slug) => ({
+    params: { slug },
+  }));
 
   return {
     paths,
@@ -85,11 +97,12 @@ export async function getStaticProps({ params }) {
   }
 
   const slug = sanitizeSlug(params.slug);
-  const targetPath = path.join(docsDir, `${slug}.md`);
+  const markdownPath = path.join(docsDir, `${slug}.md`);
+  const htmlPath = path.join(docsDir, `${slug}.html`);
 
   try {
-    const content = await fs.readFile(targetPath, 'utf8');
-    const stats = await fs.stat(targetPath);
+    const content = await fs.readFile(markdownPath, 'utf8');
+    const stats = await fs.stat(markdownPath);
     const match = content.match(/^#\s+(.+)/m);
     const title = match ? match[1].trim() : slug.replace(/[-_]/g, ' ');
 
@@ -99,6 +112,53 @@ export async function getStaticProps({ params }) {
         title,
         content,
         lastUpdated: stats.mtime.toISOString(),
+        format: 'md',
+      },
+      revalidate: 300,
+    };
+  } catch (error) {
+    console.warn(`Markdown version for slug "${slug}" not found:`, error);
+  }
+
+  try {
+    const content = await fs.readFile(htmlPath, 'utf8');
+    const stats = await fs.stat(htmlPath);
+    const $ = cheerio.load(content);
+    const title = $('h1').first().text().trim() || slug.replace(/[-_]/g, ' ');
+
+    $('a[href]').each((_, element) => {
+      const href = $(element).attr('href');
+      const resolved = resolveDocLink(href);
+      if (!resolved) {
+        return;
+      }
+
+      $(element).attr('href', resolved);
+
+      if (resolved.startsWith('/docs/') || resolved.startsWith('/')) {
+        $(element).removeAttr('target');
+        $(element).removeAttr('rel');
+      } else {
+        $(element).attr('target', '_blank');
+        $(element).attr('rel', 'noopener noreferrer');
+      }
+    });
+
+    const normalizedHtml = $('body').length
+      ? $('body').html() || ''
+      : $.root()
+          .children()
+          .toArray()
+          .map((element) => $.html(element))
+          .join('');
+
+    return {
+      props: {
+        slug,
+        title,
+        content: normalizedHtml || '',
+        lastUpdated: stats.mtime.toISOString(),
+        format: 'html',
       },
       revalidate: 300,
     };
@@ -109,7 +169,7 @@ export async function getStaticProps({ params }) {
     };
   }
 }
-export default function DocPage({ title, content, lastUpdated }) {
+export default function DocPage({ title, content, lastUpdated, format }) {
   const formattedUpdated = lastUpdated
     ? new Intl.DateTimeFormat('en', {
         year: 'numeric',
@@ -117,6 +177,14 @@ export default function DocPage({ title, content, lastUpdated }) {
         day: 'numeric',
       }).format(new Date(lastUpdated))
     : null;
+
+  const sanitizedHtml = useMemo(() => {
+    if (format !== 'html' || !content) {
+      return null;
+    }
+
+    return DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
+  }, [content, format]);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-16 px-4 sm:px-6 lg:px-8">
@@ -148,68 +216,72 @@ export default function DocPage({ title, content, lastUpdated }) {
           </div>
 
           <div className="docs-content mt-10 text-base leading-7 text-gray-700 dark:text-gray-200">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                a({ href, children, ...props }) {
-                  const resolved = resolveDocLink(href);
+            {format === 'html' ? (
+              <div dangerouslySetInnerHTML={{ __html: sanitizedHtml || '' }} />
+            ) : (
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  a({ href, children, ...props }) {
+                    const resolved = resolveDocLink(href);
 
-                  if (!resolved) {
-                    return <span {...props}>{children}</span>;
-                  }
+                    if (!resolved) {
+                      return <span {...props}>{children}</span>;
+                    }
 
-                  if (resolved.startsWith('/docs/')) {
+                    if (resolved.startsWith('/docs/')) {
+                      return (
+                        <Link href={resolved} {...props} className="docs-link">
+                          {children}
+                        </Link>
+                      );
+                    }
+
+                    if (resolved.startsWith('/')) {
+                      return (
+                        <Link href={resolved} {...props} className="docs-link">
+                          {children}
+                        </Link>
+                      );
+                    }
+
                     return (
-                      <Link href={resolved} {...props} className="docs-link">
+                      <a
+                        href={resolved}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        {...props}
+                        className="docs-link"
+                      >
                         {children}
-                      </Link>
+                      </a>
                     );
-                  }
-
-                  if (resolved.startsWith('/')) {
+                  },
+                  table({ children }) {
                     return (
-                      <Link href={resolved} {...props} className="docs-link">
-                        {children}
-                      </Link>
+                      <div className="docs-table-wrapper">
+                        <table>{children}</table>
+                      </div>
                     );
-                  }
-
-                  return (
-                    <a
-                      href={resolved}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      {...props}
-                      className="docs-link"
-                    >
-                      {children}
-                    </a>
-                  );
-                },
-                table({ children }) {
-                  return (
-                    <div className="docs-table-wrapper">
-                      <table>{children}</table>
-                    </div>
-                  );
-                },
-                img({ alt, src, ...props }) {
-                  if (!src) {
-                    return null;
-                  }
-                  return (
-                    <img
-                      src={src}
-                      alt={alt}
-                      {...props}
-                      className="docs-image"
-                    />
-                  );
-                },
-              }}
-            >
-              {content}
-            </ReactMarkdown>
+                  },
+                  img({ alt, src, ...props }) {
+                    if (!src) {
+                      return null;
+                    }
+                    return (
+                      <img
+                        src={src}
+                        alt={alt}
+                        {...props}
+                        className="docs-image"
+                      />
+                    );
+                  },
+                }}
+              >
+                {content}
+              </ReactMarkdown>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/docs/index.js
+++ b/frontend/src/pages/docs/index.js
@@ -1,8 +1,11 @@
 import fs from 'fs/promises';
 import path from 'path';
 import Link from 'next/link';
+import { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import DOMPurify from 'isomorphic-dompurify';
+import cheerio from 'cheerio';
 
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
@@ -61,7 +64,43 @@ function extractSummaryFromContent(content) {
   return '';
 }
 
-export default function DocumentationLandingPage({ docs, installationContent }) {
+function extractMetadataFromHtml(html, slug) {
+  const $ = cheerio.load(html);
+  const title = $('h1').first().text().trim() || slug.replace(/[-_]/g, ' ');
+
+  let summary = '';
+  $('p').each((_, element) => {
+    if (summary) {
+      return false;
+    }
+
+    const text = $(element).text().replace(/\s+/g, ' ').trim();
+    if (text) {
+      summary = text;
+    }
+
+    return undefined;
+  });
+
+  return {
+    title,
+    summary,
+  };
+}
+
+function sanitizeHtmlContent(content) {
+  return DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
+}
+
+export default function DocumentationLandingPage({ docs, installationContent, installationFormat }) {
+  const sanitizedInstallation = useMemo(() => {
+    if (installationFormat !== 'html' || !installationContent) {
+      return null;
+    }
+
+    return sanitizeHtmlContent(installationContent);
+  }, [installationContent, installationFormat]);
+
   return (
     <>
       <PageHead
@@ -92,12 +131,16 @@ export default function DocumentationLandingPage({ docs, installationContent }) 
 
           {installationContent ? (
             <div className="docs-content mx-auto max-w-none space-y-6 text-left text-gray-100">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{installationContent}</ReactMarkdown>
+              {installationFormat === 'html' ? (
+                <div dangerouslySetInnerHTML={{ __html: sanitizedInstallation }} />
+              ) : (
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{installationContent}</ReactMarkdown>
+              )}
             </div>
           ) : (
             <div className="rounded-2xl border border-gray-800 bg-gray-900/70 p-8 text-center text-gray-300">
-              The installation guide could not be loaded. Please ensure <code>installation.md</code> exists in the
-              <code>docs/</code> directory.
+              The installation guide could not be loaded. Please ensure <code>installation.md</code> or
+              <code>installation.html</code> exists in the <code>docs/</code> directory.
             </div>
           )}
         </div>
@@ -178,7 +221,7 @@ export default function DocumentationLandingPage({ docs, installationContent }) 
                 >
                   <div className="space-y-4">
                     <div className="inline-flex items-center rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-200">
-                      Markdown guide
+                      {doc.format === 'html' ? 'HTML guide' : 'Markdown guide'}
                     </div>
                     <h3 className="text-2xl font-semibold text-white transition group-hover:text-indigo-200">{doc.title}</h3>
                     {doc.summary && <p className="text-sm text-gray-300">{doc.summary}</p>}
@@ -208,20 +251,46 @@ export async function getStaticProps({ locale }) {
   const docsDir = await resolveDocsDirectory();
   let docs = [];
   let installationContent = null;
+  let installationFormat = null;
 
   if (docsDir) {
     try {
       const entries = await fs.readdir(docsDir, { withFileTypes: true });
-      const markdownFiles = entries.filter((entry) => entry.isFile() && entry.name.endsWith('.md'));
+      const docEntries = entries.filter(
+        (entry) => entry.isFile() && (/\.md$/i.test(entry.name) || /\.html$/i.test(entry.name)),
+      );
+
+      const docsBySlug = new Map();
+      for (const entry of docEntries) {
+        const slug = entry.name.replace(/\.(md|html)$/i, '');
+        const ext = entry.name.toLowerCase().endsWith('.md') ? 'md' : 'html';
+        if (!docsBySlug.has(slug)) {
+          docsBySlug.set(slug, {});
+        }
+        docsBySlug.get(slug)[ext] = entry.name;
+      }
 
       docs = await Promise.all(
-        markdownFiles.map(async (entry) => {
-          const slug = entry.name.replace(/\.md$/, '');
-          const filePath = path.join(docsDir, entry.name);
+        Array.from(docsBySlug.entries()).map(async ([slug, files]) => {
+          const targetName = files.md || files.html;
+          const format = files.md ? 'md' : 'html';
+          const filePath = path.join(docsDir, targetName);
           const content = await fs.readFile(filePath, 'utf8');
           const stats = await fs.stat(filePath);
-          const title = extractTitleFromContent(content, slug.replace(/[-_]/g, ' '));
-          const summary = extractSummaryFromContent(content);
+          const fallbackTitle = slug.replace(/[-_]/g, ' ');
+
+          let title = fallbackTitle;
+          let summary = '';
+
+          if (format === 'md') {
+            title = extractTitleFromContent(content, fallbackTitle);
+            summary = extractSummaryFromContent(content);
+          } else {
+            const metadata = extractMetadataFromHtml(content, slug);
+            title = metadata.title;
+            summary = metadata.summary;
+          }
+
           const lastUpdated = new Intl.DateTimeFormat('en', {
             year: 'numeric',
             month: 'short',
@@ -233,6 +302,7 @@ export async function getStaticProps({ locale }) {
             title,
             summary,
             lastUpdated,
+            format,
           };
         }),
       );
@@ -243,10 +313,17 @@ export async function getStaticProps({ locale }) {
     }
 
     try {
-      const installationPath = path.join(docsDir, 'installation.md');
-      installationContent = await fs.readFile(installationPath, 'utf8');
+      const installationMdPath = path.join(docsDir, 'installation.md');
+      installationContent = await fs.readFile(installationMdPath, 'utf8');
+      installationFormat = 'md';
     } catch (error) {
-      console.warn('Installation guide not found or failed to load:', error);
+      try {
+        const installationHtmlPath = path.join(docsDir, 'installation.html');
+        installationContent = await fs.readFile(installationHtmlPath, 'utf8');
+        installationFormat = 'html';
+      } catch (htmlError) {
+        console.warn('Installation guide not found or failed to load:', error, htmlError);
+      }
     }
   }
 
@@ -254,6 +331,7 @@ export async function getStaticProps({ locale }) {
     props: {
       docs,
       installationContent,
+      installationFormat,
       ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
     },
     revalidate: 300,


### PR DESCRIPTION
## Summary
- update the docs landing page to index both Markdown and HTML guides, extract HTML metadata, and sanitize installation content when only HTML is available
- allow individual doc pages to fall back to HTML files, sanitize the markup before rendering, and normalize intra-doc links that point at .html files
- add the cheerio dependency so HTML parsing is available while keeping the existing docs directory included in the build output

## Testing
- `npm run lint` *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d847f483388328b3d405f6ce6c2df3