### PR TITLE
Fix docs output tracing paths

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -225,8 +225,8 @@ const nextConfig = {
     largePageDataBytes: 256 * 1024,
     externalDir: true,
     outputFileTracingIncludes: {
-      '/docs': ['./docs/**/*'],
-      '/docs/[slug]': ['./docs/**/*'],
+      '/docs': ['../docs/**/*'],
+      '/docs/[slug]': ['../docs/**/*'],
     },
     turbo: {
       resolveAlias: {


### PR DESCRIPTION
## Summary
- update the frontend outputFileTracingIncludes paths so the serverless bundle captures the shared docs directory

## Testing
- npm run build
- npm run start


------
https://chatgpt.com/codex/tasks/task_e_68d847ee98bc832886d53251847d338c