### PR TITLE
Sync repository docs into Next.js public assets

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -16,6 +16,7 @@ node_modules/
 # next.js
 /.next/
 /out/
+/public/docs/
 
 # production
 /build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "sync-docs": "node scripts/sync-docs.mjs",
+    "prebuild": "npm run sync-docs",
     "build": "next build",
     "start": "next start -H 0.0.0.0",
     "lint": "eslint .",

--- a/frontend/scripts/sync-docs.mjs
+++ b/frontend/scripts/sync-docs.mjs
@@ -1,0 +1,54 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+
+const docsCandidates = [
+  path.resolve(projectRoot, 'docs'),
+  path.resolve(projectRoot, '..', 'docs'),
+  path.resolve(projectRoot, '..', '..', 'docs'),
+];
+
+const destinationDir = path.join(projectRoot, 'public', 'docs');
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureDestinationParent() {
+  const parentDir = path.dirname(destinationDir);
+  await fs.mkdir(parentDir, { recursive: true });
+}
+
+async function copyDocs(sourceDir) {
+  await ensureDestinationParent();
+  await fs.rm(destinationDir, { recursive: true, force: true });
+  await fs.cp(sourceDir, destinationDir, { recursive: true });
+}
+
+async function main() {
+  for (const candidate of docsCandidates) {
+    if (await pathExists(candidate)) {
+      await copyDocs(candidate);
+      console.log(`Copied documentation from "${candidate}" to "${destinationDir}".`);
+      return;
+    }
+  }
+
+  console.warn(
+    'No documentation directory found. Skipping docs sync. Ensure the repository docs/ directory is available.'
+  );
+}
+
+main().catch((error) => {
+  console.error('Failed to copy documentation into the Next.js public directory:', error);
+  process.exitCode = 1;
+});

--- a/frontend/src/pages/docs/[slug].js
+++ b/frontend/src/pages/docs/[slug].js
@@ -39,6 +39,8 @@ const resolveDocLink = (href) => {
 };
 
 const DOCS_DIR_CANDIDATES = [
+  path.join(process.cwd(), 'public', 'docs'),
+  path.resolve(moduleDir, '../../../public/docs'),
   path.join(process.cwd(), 'docs'),
   path.join(process.cwd(), '..', 'docs'),
   path.join(process.cwd(), '..', '..', 'docs'),

--- a/frontend/src/pages/docs/index.js
+++ b/frontend/src/pages/docs/index.js
@@ -17,6 +17,8 @@ import nextI18NextConfig from '../../../next-i18next.config.js';
 const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
 
 const DOCS_DIR_CANDIDATES = [
+  path.join(process.cwd(), 'public', 'docs'),
+  path.resolve(moduleDir, '../../../public/docs'),
   path.join(process.cwd(), 'docs'),
   path.join(process.cwd(), '..', 'docs'),
   path.join(process.cwd(), '..', '..', 'docs'),


### PR DESCRIPTION
## Summary
- add a sync-docs script that copies the repository docs tree into the Next.js public/docs directory
- hook the script into the build lifecycle and ignore the generated docs copy in git
- update the docs pages to resolve the new in-project docs location before falling back to external paths

## Testing
- NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm run build
- NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm run start (verified /docs and /docs/installation)


------
https://chatgpt.com/codex/tasks/task_e_68d84e2e3a148328b5430bb0ac33b65a