### PR TITLE
Refactor docs pages to reuse shared directory resolver

### DIFF
--- a/frontend/src/pages/docs/[slug].js
+++ b/frontend/src/pages/docs/[slug].js
@@ -11,6 +11,17 @@ import { resolveDocsDirectory } from '@/utils/docsDirectory';
 
 const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
 
+// Ensure standalone builds can still locate the project-level docs directory.
+const docsDirectoryExplicitPaths = [
+  path.join(process.cwd(), 'docs'),
+  path.join(process.cwd(), '..', 'docs'),
+  path.join(process.cwd(), '..', '..', 'docs'),
+  path.join(process.cwd(), '..', '..', '..', 'docs'),
+  path.resolve(moduleDir, '../../docs'),
+  path.resolve(moduleDir, '../../../docs'),
+  path.resolve(moduleDir, '../../../..', 'docs'),
+];
+
 const sanitizeSlug = (value = '') =>
   value
     .replace(/\.(md|html)$/i, '')
@@ -47,50 +58,11 @@ const resolveDocLink = (href) => {
   return slug ? `/docs/${slug}` : href;
 };
 
-// Mirror the landing page fallbacks so standalone builds that execute from
-// .next/standalone/server still reach the root docs directory.
-const DOCS_DIR_CANDIDATES = [
-  path.join(process.cwd(), 'docs'),
-  path.join(process.cwd(), '..', 'docs'),
-  path.join(process.cwd(), '..', '..', 'docs'),
-  path.join(process.cwd(), '..', '..', '..', 'docs'),
-  path.resolve(moduleDir, '../../docs'),
-  path.resolve(moduleDir, '../../../docs'),
-  path.resolve(moduleDir, '../../../..', 'docs'),
-];
-
-async function resolveDocsDirectory() {
-  const envDocsDir = process.env.DOCS_DIR
-    ? path.resolve(process.cwd(), process.env.DOCS_DIR)
-    : null;
-
-  if (envDocsDir) {
-    try {
-      const stats = await fs.stat(envDocsDir);
-      if (stats.isDirectory()) {
-        return envDocsDir;
-      }
-    } catch (error) {
-      // Ignore invalid overrides and fall back to default locations.
-    }
-  }
-
-  for (const candidate of DOCS_DIR_CANDIDATES) {
-    try {
-      const stats = await fs.stat(candidate);
-      if (stats.isDirectory()) {
-        return candidate;
-      }
-    } catch (error) {
-      // Ignore missing paths and keep checking candidates.
-    }
-  }
-
-  return null;
-}
-
 export async function getStaticPaths() {
-  const docsDir = await resolveDocsDirectory({ moduleDirectory: moduleDir });
+  const docsDir = await resolveDocsDirectory({
+    moduleDirectory: moduleDir,
+    explicitPaths: docsDirectoryExplicitPaths,
+  });
   let entries = [];
   if (!docsDir) {
     console.warn('Documentation directory not found while generating static paths.');
@@ -123,7 +95,10 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  const docsDir = await resolveDocsDirectory({ moduleDirectory: moduleDir });
+  const docsDir = await resolveDocsDirectory({
+    moduleDirectory: moduleDir,
+    explicitPaths: docsDirectoryExplicitPaths,
+  });
   if (!docsDir) {
     console.error('Documentation directory not available while generating static props.');
     return {

--- a/frontend/src/pages/docs/index.js
+++ b/frontend/src/pages/docs/index.js
@@ -17,9 +17,8 @@ import { resolveDocsDirectory } from '@/utils/docsDirectory';
 
 const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
 
-// Include deep fallbacks so standalone builds (where process.cwd() resolves to
-// .next/standalone/server) can still locate the project-level docs directory.
-const DOCS_DIR_CANDIDATES = [
+// Ensure standalone builds can still locate the project-level docs directory.
+const docsDirectoryExplicitPaths = [
   path.join(process.cwd(), 'docs'),
   path.join(process.cwd(), '..', 'docs'),
   path.join(process.cwd(), '..', '..', 'docs'),
@@ -28,36 +27,6 @@ const DOCS_DIR_CANDIDATES = [
   path.resolve(moduleDir, '../../../docs'),
   path.resolve(moduleDir, '../../../..', 'docs'),
 ];
-
-async function resolveDocsDirectory() {
-  const envDocsDir = process.env.DOCS_DIR
-    ? path.resolve(process.cwd(), process.env.DOCS_DIR)
-    : null;
-
-  if (envDocsDir) {
-    try {
-      const stats = await fs.stat(envDocsDir);
-      if (stats.isDirectory()) {
-        return envDocsDir;
-      }
-    } catch (error) {
-      // Ignore invalid overrides and fall back to default locations.
-    }
-  }
-
-  for (const candidate of DOCS_DIR_CANDIDATES) {
-    try {
-      const stats = await fs.stat(candidate);
-      if (stats.isDirectory()) {
-        return candidate;
-      }
-    } catch (error) {
-      // Ignore missing paths and continue.
-    }
-  }
-
-  return null;
-}
 
 function sanitizeSlug(value) {
   return value
@@ -280,7 +249,10 @@ export default function DocumentationLandingPage({ docs, installationContent, in
 }
 
 export async function getStaticProps({ locale }) {
-  const docsDir = await resolveDocsDirectory({ moduleDirectory: moduleDir });
+  const docsDir = await resolveDocsDirectory({
+    moduleDirectory: moduleDir,
+    explicitPaths: docsDirectoryExplicitPaths,
+  });
   let docs = [];
   let installationContent = null;
   let installationFormat = null;


### PR DESCRIPTION
## Summary
- reuse the shared docs directory resolver on the docs index and detail pages
- provide explicit fallback directories so standalone builds continue to find bundled docs

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*
- npm run build *(fails: pre-existing import error for CertificatePreviewModal)*

------
https://chatgpt.com/codex/tasks/task_e_68d853e080a48328857c2b82694e8445