### PR TITLE
refactor: reuse shared docs directory resolver

### DIFF
--- a/frontend/src/pages/docs/[slug].js
+++ b/frontend/src/pages/docs/[slug].js
@@ -47,47 +47,7 @@ const resolveDocLink = (href) => {
   return slug ? `/docs/${slug}` : href;
 };
 
-// Mirror the landing page fallbacks so standalone builds that execute from
-// .next/standalone/server still reach the root docs directory.
-const DOCS_DIR_CANDIDATES = [
-  path.join(process.cwd(), 'docs'),
-  path.join(process.cwd(), '..', 'docs'),
-  path.join(process.cwd(), '..', '..', 'docs'),
-  path.join(process.cwd(), '..', '..', '..', 'docs'),
-  path.resolve(moduleDir, '../../docs'),
-  path.resolve(moduleDir, '../../../docs'),
-  path.resolve(moduleDir, '../../../..', 'docs'),
-];
-
-async function resolveDocsDirectory() {
-  const envDocsDir = process.env.DOCS_DIR
-    ? path.resolve(process.cwd(), process.env.DOCS_DIR)
-    : null;
-
-  if (envDocsDir) {
-    try {
-      const stats = await fs.stat(envDocsDir);
-      if (stats.isDirectory()) {
-        return envDocsDir;
-      }
-    } catch (error) {
-      // Ignore invalid overrides and fall back to default locations.
-    }
-  }
-
-  for (const candidate of DOCS_DIR_CANDIDATES) {
-    try {
-      const stats = await fs.stat(candidate);
-      if (stats.isDirectory()) {
-        return candidate;
-      }
-    } catch (error) {
-      // Ignore missing paths and keep checking candidates.
-    }
-  }
-
-  return null;
-}
+// Additional resolution handled by shared utility.
 
 export async function getStaticPaths() {
   const docsDir = await resolveDocsDirectory({ moduleDirectory: moduleDir });

--- a/frontend/src/pages/docs/index.js
+++ b/frontend/src/pages/docs/index.js
@@ -17,48 +17,6 @@ import { resolveDocsDirectory } from '@/utils/docsDirectory';
 
 const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
 
-// Include deep fallbacks so standalone builds (where process.cwd() resolves to
-// .next/standalone/server) can still locate the project-level docs directory.
-const DOCS_DIR_CANDIDATES = [
-  path.join(process.cwd(), 'docs'),
-  path.join(process.cwd(), '..', 'docs'),
-  path.join(process.cwd(), '..', '..', 'docs'),
-  path.join(process.cwd(), '..', '..', '..', 'docs'),
-  path.resolve(moduleDir, '../../docs'),
-  path.resolve(moduleDir, '../../../docs'),
-  path.resolve(moduleDir, '../../../..', 'docs'),
-];
-
-async function resolveDocsDirectory() {
-  const envDocsDir = process.env.DOCS_DIR
-    ? path.resolve(process.cwd(), process.env.DOCS_DIR)
-    : null;
-
-  if (envDocsDir) {
-    try {
-      const stats = await fs.stat(envDocsDir);
-      if (stats.isDirectory()) {
-        return envDocsDir;
-      }
-    } catch (error) {
-      // Ignore invalid overrides and fall back to default locations.
-    }
-  }
-
-  for (const candidate of DOCS_DIR_CANDIDATES) {
-    try {
-      const stats = await fs.stat(candidate);
-      if (stats.isDirectory()) {
-        return candidate;
-      }
-    } catch (error) {
-      // Ignore missing paths and continue.
-    }
-  }
-
-  return null;
-}
-
 function sanitizeSlug(value) {
   return value
     .replace(/\.(md|html)$/i, '')


### PR DESCRIPTION
## Summary
- refactor docs landing and slug pages to reuse the shared docsDirectory resolver
- remove duplicated filesystem fallback logic now handled by the utility

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d85407f4208328a140230479282a61