### PR TITLE
Add offline documentation hub index

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ npm --prefix frontend install
 
 4. Visit `http://localhost:3000` to access the frontend when running locally. The API will be available at `http://localhost:5002/api`.
 
+For an offline-friendly overview open [`docs/index.html`](docs/index.html) in a browser. It links to the HTML and Markdown guides bundled in the repository ZIP.
+
 For detailed instructions see [docs/installation.md](docs/installation.md).
 See [docs/deployment.md](docs/deployment.md) for tips on configuring environment variables when hosting the app.
 When deploying, ensure the backend's exported `clearServerCache` utility remains available so the admin **Clear Cache** button can purge server-side caches; otherwise `/api/cache/clear` will return a 503 status.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # SkillBridge Documentation
 
+Open `index.html` in this folder for the bundled documentation hub when viewing the packaged ZIP offline. It links directly to every HTML guide and their Markdown sources.
+
 ## Installation
 
 Choose the path that matches your environment:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SkillBridge Documentation</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f7fa;
+      color: #102a43;
+      line-height: 1.6;
+    }
+    header {
+      background: linear-gradient(135deg, #4338ca, #0ea5e9);
+      color: #ffffff;
+      padding: 3rem 1.5rem 2.5rem;
+      text-align: center;
+    }
+    header h1 {
+      margin: 0;
+      font-size: clamp(2.25rem, 5vw, 3rem);
+      letter-spacing: -0.03em;
+    }
+    header p {
+      margin: 0.75rem auto 0;
+      max-width: 720px;
+      font-size: 1.05rem;
+      color: rgba(255, 255, 255, 0.9);
+    }
+    main {
+      max-width: 1100px;
+      margin: -2rem auto 4rem;
+      padding: 0 1.5rem;
+    }
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+      margin-bottom: 3rem;
+    }
+    .card {
+      background: #ffffff;
+      border-radius: 18px;
+      box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+      padding: 1.75rem 1.5rem;
+      border: 1px solid rgba(15, 23, 42, 0.06);
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 24px 50px rgba(15, 23, 42, 0.16);
+    }
+    .card h2 {
+      margin-top: 0;
+      font-size: 1.35rem;
+      color: #0f172a;
+    }
+    .card p {
+      margin: 0.75rem 0 1.25rem;
+      color: #475569;
+      font-size: 0.95rem;
+    }
+    .link-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    .link-group a {
+      background: #1d4ed8;
+      color: #ffffff;
+      text-decoration: none;
+      padding: 0.45rem 0.9rem;
+      border-radius: 999px;
+      font-size: 0.9rem;
+      transition: background 0.2s ease;
+    }
+    .link-group a.secondary {
+      background: rgba(37, 99, 235, 0.12);
+      color: #1d4ed8;
+    }
+    .link-group a:hover {
+      background: #1e40af;
+      color: #ffffff;
+    }
+    .link-group a.secondary:hover {
+      background: rgba(29, 78, 216, 0.22);
+      color: #1d4ed8;
+    }
+    section + section {
+      margin-top: 3.5rem;
+    }
+    section h3 {
+      font-size: 1.1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #64748b;
+      margin-bottom: 1.5rem;
+    }
+    footer {
+      margin: 4rem auto 3rem;
+      max-width: 900px;
+      text-align: center;
+      color: #475569;
+      font-size: 0.95rem;
+    }
+    footer a {
+      color: #1d4ed8;
+      text-decoration: none;
+    }
+    footer a:hover {
+      text-decoration: underline;
+    }
+    @media (max-width: 600px) {
+      header {
+        padding: 2.5rem 1.25rem 2rem;
+      }
+      main {
+        margin-top: -2.5rem;
+      }
+      .card {
+        padding: 1.5rem 1.35rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>SkillBridge Documentation Hub</h1>
+    <p>
+      Start here when unpacking the customer ZIP or cloning the repository. These guides cover installation,
+      day-to-day operations, integration details, and release management. All links work offline &mdash; just
+      open this page directly from the <code>docs/</code> folder.
+    </p>
+  </header>
+  <main>
+    <section>
+      <h3>Start here</h3>
+      <div class="card-grid">
+        <article class="card">
+          <div>
+            <h2>Getting Started</h2>
+            <p>Unpack the CodeCanyon package, review prerequisites, and bootstrap your environment quickly.</p>
+          </div>
+          <div class="link-group">
+            <a href="./getting-started.html">Read HTML</a>
+            <a class="secondary" href="./getting-started.md">View Markdown</a>
+          </div>
+        </article>
+        <article class="card">
+          <div>
+            <h2>Installation Guide</h2>
+            <p>Detailed setup for Docker, environment variables, and local or production deployments.</p>
+          </div>
+          <div class="link-group">
+            <a href="./installation.html">Read HTML</a>
+            <a class="secondary" href="./installation.md">View Markdown</a>
+          </div>
+        </article>
+        <article class="card">
+          <div>
+            <h2>Deployment Checklist</h2>
+            <p>Best practices for shipping updates, securing services, and handling ZIP deployments.</p>
+          </div>
+          <div class="link-group">
+            <a href="./deployment.html">Read HTML</a>
+            <a class="secondary" href="./deployment.md">View Markdown</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h3>Platform Architecture &amp; API</h3>
+      <div class="card-grid">
+        <article class="card">
+          <div>
+            <h2>Architecture Overview</h2>
+            <p>Understand the backend, frontend, and infrastructure layers that power SkillBridge.</p>
+          </div>
+          <div class="link-group">
+            <a href="./architecture.html">Read HTML</a>
+            <a class="secondary" href="./architecture.md">View Markdown</a>
+          </div>
+        </article>
+        <article class="card">
+          <div>
+            <h2>API Reference</h2>
+            <p>Endpoints, authentication, and integration guidance for building against the SkillBridge API.</p>
+          </div>
+          <div class="link-group">
+            <a href="./api-docs.html">Read HTML</a>
+            <a class="secondary" href="./api-docs.md">View Markdown</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h3>Operations &amp; Administration</h3>
+      <div class="card-grid">
+        <article class="card">
+          <div>
+            <h2>Admin Workflows</h2>
+            <p>Guides for alerts, ads, enrollment, third-party integrations, and other staff tasks.</p>
+          </div>
+          <div class="link-group">
+            <a href="./admin-alerts.html">Alerts</a>
+            <a class="secondary" href="./admin-alerts.md">Markdown</a>
+            <a href="./admin-ads-management.html">Ads</a>
+            <a class="secondary" href="./admin-third-party-integrations.html">Integrations</a>
+          </div>
+        </article>
+        <article class="card">
+          <div>
+            <h2>Student Journeys</h2>
+            <p>Walkthroughs covering registration, enrollment, class lifecycle, and subscription styling.</p>
+          </div>
+          <div class="link-group">
+            <a href="./student-registration-guide.html">Registration</a>
+            <a class="secondary" href="./student-registration-guide.md">Markdown</a>
+            <a href="./student-enrollment-workflow.html">Enrollment</a>
+            <a class="secondary" href="./class-lifecycle-workflow.html">Class lifecycle</a>
+          </div>
+        </article>
+        <article class="card">
+          <div>
+            <h2>Billing &amp; Compliance</h2>
+            <p>Configure subscription plans, coupons, payment icons, and license verification.</p>
+          </div>
+          <div class="link-group">
+            <a href="./subscription-plan-style.html">Subscriptions</a>
+            <a class="secondary" href="./subscription-plan-style.md">Markdown</a>
+            <a href="./coupon-management.html">Coupons</a>
+            <a class="secondary" href="./license-verification.html">License checks</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h3>Release management</h3>
+      <div class="card-grid">
+        <article class="card">
+          <div>
+            <h2>Release Checklist</h2>
+            <p>Follow this list before publishing updates to customers or pushing new Docker images.</p>
+          </div>
+          <div class="link-group">
+            <a href="./release-checklist.html">Read HTML</a>
+            <a class="secondary" href="./release-checklist.md">View Markdown</a>
+          </div>
+        </article>
+        <article class="card">
+          <div>
+            <h2>Changelog</h2>
+            <p>Track notable fixes and features to communicate what changed between releases.</p>
+          </div>
+          <div class="link-group">
+            <a href="./changelog.html">Read HTML</a>
+            <a class="secondary" href="./changelog.md">View Markdown</a>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+  <footer>
+    Need something else? Browse the full list of Markdown sources in this folder or open the
+    <a href="../frontend/src/pages/docs/index.js">in-app documentation index</a> for the live UI.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an offline-friendly documentation landing page at docs/index.html linking to the bundled guides
- update root and docs README files to direct customers to the new entry point when unpacking the ZIP

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d85408d298832883b3fa36b1521167