### PR TITLE
Add server-side schedule filtering for admin classes

### DIFF
--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -195,6 +195,7 @@ exports.getAllClasses = catchAsync(async (req, res) => {
     filter,
     approval,
     status,
+    schedule,
   } = req.query;
   const result = await service.getAllClasses({
     page: Number(page),
@@ -202,6 +203,7 @@ exports.getAllClasses = catchAsync(async (req, res) => {
     filter,
     approval,
     status,
+    schedule,
   });
   sendSuccess(res, result.data, undefined, result.meta);
 });

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -25,9 +25,21 @@ exports.countPublishedClasses = async (instructorId) => {
 };
 
 exports.getAllClasses = async (
-  { page = 1, limit = 10, filter, approval, status } = {}
+  { page = 1, limit = 10, filter, approval, status, schedule } = {}
 ) => {
   const { page: pg, limit: lim, offset } = parsePagination({ page, limit });
+  const scheduleCaseSql = `
+    CASE
+      WHEN c.start_date IS NOT NULL AND c.start_date > NOW() THEN 'Upcoming'
+      WHEN c.start_date IS NOT NULL AND c.end_date IS NOT NULL AND NOW() BETWEEN c.start_date AND c.end_date THEN 'Ongoing'
+      WHEN c.end_date IS NOT NULL AND NOW() > c.end_date THEN 'Completed'
+      ELSE 'Upcoming'
+    END
+  `;
+  const scheduleNormalized =
+    typeof schedule === "string" && schedule.trim()
+      ? schedule.trim().toLowerCase()
+      : null;
 
   const countQuery = db("online_classes as c")
     .leftJoin("users as u", "c.instructor_id", "u.id");
@@ -41,6 +53,8 @@ exports.getAllClasses = async (
   }
   if (approval) countQuery.where("c.moderation_status", approval);
   if (status) countQuery.where("c.status", status);
+  if (scheduleNormalized)
+    countQuery.whereRaw(`LOWER(${scheduleCaseSql}) = ?`, [scheduleNormalized]);
   const totalRow = await countQuery.countDistinct("c.id as count").first();
   const total = parseInt(totalRow.count, 10) || 0;
 
@@ -64,6 +78,7 @@ exports.getAllClasses = async (
       "c.instructor_id",
       "u.full_name as instructor",
       "cat.name as category",
+      db.raw(`${scheduleCaseSql} as schedule_status`),
       db.raw(
         "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
       )
@@ -79,6 +94,8 @@ exports.getAllClasses = async (
   }
   if (approval) query.where("c.moderation_status", approval);
   if (status) query.where("c.status", status);
+  if (scheduleNormalized)
+    query.whereRaw(`LOWER(${scheduleCaseSql}) = ?`, [scheduleNormalized]);
 
   const classes = await query
     .groupBy(

--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -105,34 +105,23 @@ export default function AdminClassesTable() {
       setLoading(true);
       try {
         const statusQuery = mapStatusFilterToQuery(filterStatus);
+        const scheduleFilter = shouldApplyScheduleFilter(filterStatus)
+          ? filterStatus
+          : undefined;
         const { data, meta } = await fetchAdminClasses({
           page: currentPage,
           limit: itemsPerPage,
           filter: searchTerm,
           approval: filterApproval !== "All" ? filterApproval : undefined,
           status: statusQuery,
+          schedule: scheduleFilter,
         });
-        const filteredData = shouldApplyScheduleFilter(filterStatus)
-          ? data.filter(
-              (cls) =>
-                cls.scheduleStatus?.toLowerCase() ===
-                filterStatus.toLowerCase()
-            )
-          : data;
-        const sortedData = [...filteredData].sort((a, b) =>
+        const sortedData = [...data].sort((a, b) =>
           a[sortKey] > b[sortKey] ? 1 : -1
         );
         setClassList(sortedData);
-
-        if (shouldApplyScheduleFilter(filterStatus)) {
-          setTotalItems(filteredData.length);
-          setTotalPages(
-            Math.max(1, Math.ceil(filteredData.length / itemsPerPage))
-          );
-        } else {
-          setTotalPages(meta?.totalPages || 1);
-          setTotalItems(meta?.total ?? data.length);
-        }
+        setTotalPages(Math.max(1, meta?.totalPages || 0));
+        setTotalItems(meta?.total ?? data.length);
       } catch (err) {
         console.error(err);
         toast.error("Failed to load classes");

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -5,7 +5,7 @@ import { safeEncodeURI } from "@/utils/url";
 import { computeScheduleStatus } from "@/utils/classSchedule";
 
 const formatClass = (cls) => {
-  const { status, ...rest } = cls;
+  const { status, schedule_status, ...rest } = cls;
   return {
     ...rest,
     publishStatus: status,
@@ -33,7 +33,8 @@ const formatClass = (cls) => {
     endDateInput: cls.end_date ? toDateInput(cls.end_date) : "",
 
     approvalStatus: cls.moderation_status || "Pending",
-    scheduleStatus: computeScheduleStatus(cls.start_date, cls.end_date),
+    scheduleStatus:
+      schedule_status || computeScheduleStatus(cls.start_date, cls.end_date),
     views: cls.views || 0,
   };
 };
@@ -44,11 +45,13 @@ export const fetchAdminClasses = async ({
   filter = "",
   approval = "All",
   status = "All",
+  schedule,
 } = {}) => {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (filter) params.set("filter", filter);
   if (approval && approval !== "All") params.set("approval", approval);
   if (status && status !== "All") params.set("status", status);
+  if (schedule) params.set("schedule", schedule);
   const { data } = await api.get(`/users/classes/admin?${params.toString()}`);
   const list = data?.data ?? [];
   return { data: list.map(formatClass), meta: data?.meta || {} };


### PR DESCRIPTION
## Summary
- allow the admin class listing to send an optional schedule filter to the API
- compute class schedule status server-side and apply the schedule filter before pagination
- rely on the API's pagination metadata instead of client-side overrides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8550cdb248328a72812170f053748