### PR TITLE
Validate rejection reason in admin class modal

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -118,6 +118,7 @@
   "rejected": "مرفوض",
   "free_class": "صف مجاني",
   "free_label": "مجاني",
+  "rejection_reason_min_length": "يرجى إدخال ما لا يقل عن 3 أحرف لسبب الرفض.",
   "allow_installments": "السماح بالتقسيط",
   "publish_immediately": "النشر فوراً",
   "description_label": "الوصف",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -118,6 +118,7 @@
   "rejected": "Rejected",
   "free_class": "Free Class",
   "free_label": "Free",
+  "rejection_reason_min_length": "Bitte geben Sie mindestens 3 Zeichen für den Ablehnungsgrund ein.",
   "allow_installments": "Allow Installments",
   "publish_immediately": "Publish Immediately",
   "description_label": "Description",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -118,6 +118,7 @@
   "rejected": "Rejected",
   "free_class": "Free Class",
   "free_label": "Free",
+  "rejection_reason_min_length": "Please provide at least 3 characters for the rejection reason.",
   "allow_installments": "Allow Installments",
   "publish_immediately": "Publish Immediately",
   "description_label": "Description",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -118,6 +118,7 @@
   "rejected": "Rechazado",
   "free_class": "Clase gratuita",
   "free_label": "Gratis",
+  "rejection_reason_min_length": "Proporcione al menos 3 caracteres para el motivo del rechazo.",
   "allow_installments": "Permitir cuotas",
   "publish_immediately": "Publicar inmediatamente",
   "description_label": "Descripción",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -118,6 +118,7 @@
   "rejected": "Rejeté",
   "free_class": "Cours gratuit",
   "free_label": "Gratuit",
+  "rejection_reason_min_length": "Veuillez fournir au moins 3 caractères pour la raison du rejet.",
   "allow_installments": "Autoriser les paiements échelonnés",
   "publish_immediately": "Publier immédiatement",
   "description_label": "Description",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -118,6 +118,7 @@
   "rejected": "अस्वीकार कर दिया",
   "free_class": "नि: शुल्क वर्ग",
   "free_label": "मुक्त",
+  "rejection_reason_min_length": "कृपया अस्वीकृति के कारण के लिए कम से कम 3 अक्षर दर्ज करें।",
   "allow_installments": "किस्तों की अनुमति दें",
   "publish_immediately": "तुरंत प्रकाशित करें",
   "description_label": "विवरण",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -118,6 +118,7 @@
   "rejected": "Respinto",
   "free_class": "Classe gratuita",
   "free_label": "Gratuito",
+  "rejection_reason_min_length": "Fornisci almeno 3 caratteri per il motivo del rifiuto.",
   "allow_installments": "Consentire rate",
   "publish_immediately": "Pubblica immediatamente",
   "description_label": "Descrizione",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -118,6 +118,7 @@
   "rejected": "已拒绝",
   "free_class": "免费课程",
   "free_label": "免费",
+  "rejection_reason_min_length": "请为拒绝原因提供至少3个字符。",
   "allow_installments": "允许分期付款",
   "publish_immediately": "立即发布",
   "description_label": "描述",

--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -32,6 +32,7 @@ import {
 } from "react-icons/fa";
 
 const BACKEND_STATUSES = new Set(["draft", "published", "archived"]);
+const MIN_REJECTION_REASON_LENGTH = 3;
 
 export const mapStatusFilterToQuery = (filterStatus) => {
   if (!filterStatus || filterStatus === "All") {
@@ -279,6 +280,27 @@ export default function AdminClassesTable() {
     } finally {
       setModalClass(null);
     }
+  };
+
+  const trimmedRejectionReason = rejectionReason.trim();
+  const isRejectionReasonValid =
+    trimmedRejectionReason.length >= MIN_REJECTION_REASON_LENGTH;
+
+  const handleModalConfirm = () => {
+    if (!modalClass) {
+      return;
+    }
+
+    if (modalType === 'reject') {
+      if (!isRejectionReasonValid) {
+        toast.error(t('rejection_reason_min_length'));
+        return;
+      }
+      handleStatusChange(modalClass.id, 'reject', trimmedRejectionReason);
+      return;
+    }
+
+    handleDeleteClass(modalClass.id);
   };
 
   const handlePrev = () => setCurrentPage(prev => Math.max(prev - 1, 1));
@@ -548,10 +570,11 @@ export default function AdminClassesTable() {
             <div className="flex justify-center gap-4">
               <button onClick={() => setModalClass(null)} className="bg-gray-200 px-4 py-2 rounded">Cancel</button>
               <button
-                onClick={() => modalType === 'reject'
-                  ? handleStatusChange(modalClass.id, 'reject', rejectionReason)
-                  : handleDeleteClass(modalClass.id)}
-                className={`px-4 py-2 rounded text-white ${modalType === 'reject' ? 'bg-red-600' : 'bg-gray-800'}`}
+                onClick={handleModalConfirm}
+                disabled={modalType === 'reject' && !isRejectionReasonValid}
+                className={`px-4 py-2 rounded text-white ${
+                  modalType === 'reject' ? 'bg-red-600' : 'bg-gray-800'
+                } disabled:opacity-50 disabled:cursor-not-allowed`}
               >
                 Yes, {modalType === 'reject' ? 'Reject' : 'Delete'}
               </button>


### PR DESCRIPTION
## Summary
- require a minimum rejection reason length before allowing class rejection from the admin modal and disable the confirm action until valid
- add localized error messaging for the rejection reason validation across dashboard locales

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8550e9dd48328bc5cdba7eefe5a27