### PR TITLE
Fix admin class schedule filtering across pages

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -96,6 +96,9 @@ export default function AdminClassesTable() {
     setMounted(true);
   }, []);
 
+  const sortClasses = (items) =>
+    [...items].sort((a, b) => compareValues(a, b, sortKey));
+
   const hydratedUser = isMounted && hasHydrated ? user : null;
   const canManageRules =
     isMounted && hasHydrated && user?.permissions?.includes('ADD_ONLINE_CLASS_RULE');
@@ -104,33 +107,70 @@ export default function AdminClassesTable() {
     const load = async () => {
       setLoading(true);
       try {
+        const scheduleFiltering = shouldApplyScheduleFilter(filterStatus);
         const statusQuery = mapStatusFilterToQuery(filterStatus);
-        const { data, meta } = await fetchAdminClasses({
-          page: currentPage,
-          limit: itemsPerPage,
+        const safeLimit = Math.max(itemsPerPage, 1);
+        const baseParams = {
+          limit: safeLimit,
           filter: searchTerm,
-          approval: filterApproval !== "All" ? filterApproval : undefined,
-          status: statusQuery,
-        });
-        const filteredData = shouldApplyScheduleFilter(filterStatus)
-          ? data.filter(
-              (cls) =>
-                cls.scheduleStatus?.toLowerCase() ===
-                filterStatus.toLowerCase()
-            )
-          : data;
-        const sortedData = [...filteredData].sort((a, b) =>
-          a[sortKey] > b[sortKey] ? 1 : -1
-        );
-        setClassList(sortedData);
+          ...(filterApproval !== "All" ? { approval: filterApproval } : {}),
+          ...(statusQuery ? { status: statusQuery } : {}),
+        };
 
-        if (shouldApplyScheduleFilter(filterStatus)) {
-          setTotalItems(filteredData.length);
-          setTotalPages(
-            Math.max(1, Math.ceil(filteredData.length / itemsPerPage))
+        const initialPage = scheduleFiltering ? 1 : currentPage;
+        const { data, meta } = await fetchAdminClasses({
+          ...baseParams,
+          page: initialPage,
+        });
+
+        if (scheduleFiltering) {
+          const totalPagesFromMeta = meta?.totalPages ?? 1;
+          let aggregatedData = data;
+
+          if (totalPagesFromMeta > 1) {
+            const subsequentPages = await Promise.all(
+              Array.from({ length: totalPagesFromMeta - 1 }, (_, index) =>
+                fetchAdminClasses({
+                  ...baseParams,
+                  page: index + 2,
+                }).then((res) => res.data)
+              )
+            );
+            aggregatedData = aggregatedData.concat(...subsequentPages);
+          }
+
+          const filteredData = aggregatedData.filter(
+            (cls) =>
+              cls.scheduleStatus?.toLowerCase() ===
+              filterStatus.toLowerCase()
           );
+          const sortedData = sortClasses(filteredData);
+          const totalFilteredItems = sortedData.length;
+          const totalFilteredPages = Math.max(
+            1,
+            Math.ceil(totalFilteredItems / safeLimit)
+          );
+          const normalizedPage = Math.min(
+            Math.max(currentPage, 1),
+            totalFilteredPages
+          );
+
+          setTotalItems(totalFilteredItems);
+          setTotalPages(totalFilteredPages);
+          if (normalizedPage !== currentPage) {
+            setCurrentPage(normalizedPage);
+          }
+
+          const startIndex = (normalizedPage - 1) * safeLimit;
+          const paginatedData = sortedData.slice(
+            startIndex,
+            startIndex + safeLimit
+          );
+          setClassList(paginatedData);
         } else {
-          setTotalPages(meta?.totalPages || 1);
+          const sortedData = sortClasses(data);
+          setClassList(sortedData);
+          setTotalPages(meta?.totalPages ? Math.max(meta.totalPages, 1) : 1);
           setTotalItems(meta?.total ?? data.length);
         }
       } catch (err) {

--- a/frontend/tests/components/AdminClassesTablePagination.test.js
+++ b/frontend/tests/components/AdminClassesTablePagination.test.js
@@ -1,0 +1,148 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AdminClassesTable from "@/components/admin/online-classes/AdminClassesTable";
+import { fetchAdminClasses } from "@/services/admin/classService";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }) => (
+    <a {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+const mockAuthState = {
+  user: { id: 1, permissions: [] },
+  hasHydrated: true,
+};
+
+jest.mock("@/store/auth/authStore", () => ({
+  __esModule: true,
+  default: (selector) => selector(mockAuthState),
+}));
+
+const mockNotificationStore = { fetch: jest.fn() };
+jest.mock("@/store/notifications/notificationStore", () => ({
+  __esModule: true,
+  default: (selector) => selector(mockNotificationStore),
+}));
+
+const mockMessageStore = { fetch: jest.fn() };
+jest.mock("@/store/messages/messageStore", () => ({
+  __esModule: true,
+  default: (selector) => selector(mockMessageStore),
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock("@/services/notificationService", () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock("@/services/messageService", () => ({
+  sendChatMessage: jest.fn(),
+}));
+
+jest.mock("@/services/admin/classService", () => ({
+  fetchAdminClasses: jest.fn(),
+  updateAdminClass: jest.fn(),
+  deleteAdminClass: jest.fn(),
+  approveAdminClass: jest.fn(),
+  rejectAdminClass: jest.fn(),
+  toggleClassStatus: jest.fn(),
+}));
+
+describe("AdminClassesTable schedule filtering", () => {
+  const mockedFetchAdminClasses = fetchAdminClasses;
+
+  beforeEach(() => {
+    mockedFetchAdminClasses.mockReset();
+  });
+
+  it("retains access to upcoming classes spread across multiple pages", async () => {
+    mockedFetchAdminClasses.mockResolvedValue({
+      data: [],
+      meta: { totalPages: 1, total: 0 },
+    });
+    mockedFetchAdminClasses
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "1",
+            title: "Ongoing Class",
+            instructor: "Teacher A",
+            start_date: "2024-01-01",
+            end_date: "2024-01-05",
+            category: "Math",
+            publishStatus: "draft",
+            approvalStatus: "Approved",
+            scheduleStatus: "Ongoing",
+            price: 0,
+          },
+        ],
+        meta: { totalPages: 2, total: 3 },
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "1",
+            title: "Ongoing Class",
+            instructor: "Teacher A",
+            start_date: "2024-01-01",
+            end_date: "2024-01-05",
+            category: "Math",
+            publishStatus: "draft",
+            approvalStatus: "Approved",
+            scheduleStatus: "Ongoing",
+            price: 0,
+          },
+        ],
+        meta: { totalPages: 2, total: 3 },
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "3",
+            title: "Future Class",
+            instructor: "Teacher C",
+            start_date: "2025-01-01",
+            end_date: "2025-01-02",
+            category: "Science",
+            publishStatus: "draft",
+            approvalStatus: "Approved",
+            scheduleStatus: "Upcoming",
+            price: 0,
+          },
+        ],
+        meta: { totalPages: 2, total: 3 },
+      });
+
+    render(<AdminClassesTable />);
+
+    await screen.findByText("Ongoing Class");
+
+    const [scheduleSelect] = screen.getAllByRole("combobox");
+    fireEvent.change(scheduleSelect, { target: { value: "Upcoming" } });
+
+    await waitFor(() => {
+      expect(mockedFetchAdminClasses).toHaveBeenCalledTimes(3);
+    });
+
+    expect(
+      mockedFetchAdminClasses.mock.calls.some(([params]) => params.page === 2)
+    ).toBe(true);
+
+    expect(await screen.findByText("Future Class")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- aggregate admin class pages before applying schedule filters so pagination counts and slices use the filtered dataset
- ensure total counts stay in sync with schedule-filtered results spanning all pages
- add a Jest component test covering multi-page "Upcoming" schedule filtering

## Testing
- npm test -- AdminClassesTablePagination

------
https://chatgpt.com/codex/tasks/task_e_68d85519224c8328bd7a908226469444