### PR TITLE
Enable instructor reassignment when editing admin classes

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/online-classes/edit/[id].js
@@ -10,7 +10,7 @@
 // is alerted about the update.
 // -------------------------------------------------
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
@@ -19,6 +19,7 @@ import AdminLayout from '@/components/layouts/AdminLayout';
 import withAuthProtection from '@/hooks/withAuthProtection';
 import { FaArrowLeft } from 'react-icons/fa';
 import { fetchAdminClassById, updateAdminClass } from '@/services/admin/classService';
+import { fetchAllInstructors } from '@/services/admin/instructorService';
 import { fetchPlanIdentifiers } from '@/services/admin/planService';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
@@ -45,6 +46,10 @@ function EditClassPage() {
     included_plans: [],
   });
   const [plans, setPlans] = useState([]);
+  const [instructors, setInstructors] = useState([]);
+  const [instructorSearch, setInstructorSearch] = useState('');
+  const [loadingInstructors, setLoadingInstructors] = useState(false);
+  const [instructorId, setInstructorId] = useState('');
 
   useEffect(() => {
     if (!id) return;
@@ -69,6 +74,7 @@ function EditClassPage() {
             access_type: data.access_type || 'paid',
             included_plans: data.included_plans || [],
           });
+          setInstructorId(data.instructor_id || '');
         }
       } catch (err) {
         console.error('Failed to load class', err);
@@ -82,6 +88,45 @@ function EditClassPage() {
       .then(setPlans)
       .catch(() => setPlans([]));
   }, []);
+
+  useEffect(() => {
+    setLoadingInstructors(true);
+    fetchAllInstructors(1, 100)
+      .then(({ instructors: data }) => {
+        setInstructors(Array.isArray(data) ? data : []);
+      })
+      .catch((err) => {
+        console.error('Failed to load instructors', err);
+        setInstructors([]);
+      })
+      .finally(() => setLoadingInstructors(false));
+  }, []);
+
+  useEffect(() => {
+    if (!instructorId || !formData.instructor) return;
+    setInstructors((prev) => {
+      if (prev.some((inst) => inst?.id === instructorId)) {
+        return prev;
+      }
+      return [
+        ...prev,
+        {
+          id: instructorId,
+          full_name: formData.instructor,
+        },
+      ];
+    });
+  }, [instructorId, formData.instructor]);
+
+  const filteredInstructors = useMemo(() => {
+    if (!instructorSearch.trim()) return instructors;
+    const term = instructorSearch.toLowerCase();
+    return instructors.filter((inst) => {
+      const name = inst?.full_name?.toLowerCase?.() || '';
+      const email = inst?.email?.toLowerCase?.() || '';
+      return name.includes(term) || email.includes(term);
+    });
+  }, [instructors, instructorSearch]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -109,6 +154,7 @@ function EditClassPage() {
       if (formData.max_students) payload.append('max_students', formData.max_students);
       payload.append('status', formData.status || '');
       payload.append('access_type', formData.access_type);
+      if (instructorId) payload.append('instructor_id', instructorId);
       if (formData.access_type === 'free') {
         payload.append('price', '0');
         if (formData.included_plans.length)
@@ -144,13 +190,40 @@ function EditClassPage() {
           placeholder={t('class_title_label')}
           className="w-full border rounded px-4 py-2"
         />
-        <input
-          name="instructor"
-          value={formData.instructor}
-          onChange={handleChange}
-          placeholder={t('instructor_name_label')}
-          className="w-full border rounded px-4 py-2"
-        />
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">
+            {t('instructor_select_label')}
+          </label>
+          <input
+            type="text"
+            value={instructorSearch}
+            onChange={(event) => setInstructorSearch(event.target.value)}
+            placeholder={t('instructor_search_placeholder')}
+            className="w-full border rounded px-4 py-2"
+          />
+          <select
+            value={instructorId}
+            onChange={(event) => setInstructorId(event.target.value)}
+            className="w-full border rounded px-4 py-2"
+          >
+            <option value="">{t('select_instructor_placeholder')}</option>
+            {filteredInstructors.map((inst) => {
+              const name = inst?.full_name || inst?.email || '';
+              const email = inst?.email && inst?.full_name ? ` (${inst.email})` : '';
+              return (
+                <option key={inst.id} value={inst.id}>
+                  {`${name}${email}`}
+                </option>
+              );
+            })}
+          </select>
+          {loadingInstructors && (
+            <p className="text-sm text-gray-500">{t('loading', { defaultValue: 'Loading...' })}</p>
+          )}
+          {!loadingInstructors && filteredInstructors.length === 0 && (
+            <p className="text-sm text-gray-500">{t('no_instructors_found')}</p>
+          )}
+        </div>
         <div className="flex gap-4">
           <input
             name="start_date"


### PR DESCRIPTION
## Summary
- load the instructor directory when editing an admin online class and allow filtering/selecting instructors
- include the chosen instructor_id in update submissions so reassigned instructors persist server-side

## Testing
- npm --prefix frontend run lint -- --max-warnings=0 *(fails: existing lint violations throughout the repo)*

## Manual QA
- [x] Update an admin class locally, select a different instructor, submit, and confirm the API response echoes the new instructor_id

------
https://chatgpt.com/codex/tasks/task_e_68d8551aa9988328b5da8ab94b259f02