### PR TITLE
Fix ongoing schedule status when no end date

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/student/online-classes/[id].js
@@ -16,6 +16,7 @@ const computeScheduleStatus = (start, end) => {
   const e = end ? new Date(end) : null;
   if (s && now < s) return "Upcoming";
   if (s && e && now >= s && now <= e) return "Ongoing";
+  if (s && !e && now >= s) return "Ongoing";
   if (e && now > e) return "Completed";
   return "Upcoming";
 };

--- a/frontend/src/pages/online-classes/[id].js
+++ b/frontend/src/pages/online-classes/[id].js
@@ -28,6 +28,7 @@ const computeScheduleStatus = (start, end) => {
   const e = end ? new Date(end) : null;
   if (s && now < s) return 'Upcoming';
   if (s && e && now >= s && now <= e) return 'Ongoing';
+  if (s && !e && now >= s) return 'Ongoing';
   if (e && now > e) return 'Completed';
   return 'Upcoming';
 };

--- a/frontend/src/utils/classSchedule.js
+++ b/frontend/src/utils/classSchedule.js
@@ -4,6 +4,7 @@ export const computeScheduleStatus = (startDate, endDate) => {
   const end = endDate ? new Date(endDate) : null;
   if (start && now < start) return "Upcoming";
   if (start && end && now >= start && now <= end) return "Ongoing";
+  if (start && !end && now >= start) return "Ongoing";
   if (end && now > end) return "Completed";
   return "Upcoming";
 };

--- a/frontend/tests/utils/classSchedule.test.js
+++ b/frontend/tests/utils/classSchedule.test.js
@@ -1,0 +1,31 @@
+import { computeScheduleStatus } from "@/utils/classSchedule";
+
+describe("computeScheduleStatus", () => {
+  const now = new Date();
+
+  it("returns Upcoming when the start date is in the future", () => {
+    const futureStart = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    expect(computeScheduleStatus(futureStart.toISOString())).toBe("Upcoming");
+  });
+
+  it("returns Ongoing when the class has started and no end date is provided", () => {
+    const pastStart = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    expect(computeScheduleStatus(pastStart.toISOString(), null)).toBe("Ongoing");
+  });
+
+  it("returns Ongoing when the class is between the start and end dates", () => {
+    const pastStart = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const futureEnd = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    expect(
+      computeScheduleStatus(pastStart.toISOString(), futureEnd.toISOString())
+    ).toBe("Ongoing");
+  });
+
+  it("returns Completed when the end date has passed", () => {
+    const pastStart = new Date(now.getTime() - 48 * 60 * 60 * 1000);
+    const pastEnd = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    expect(
+      computeScheduleStatus(pastStart.toISOString(), pastEnd.toISOString())
+    ).toBe("Completed");
+  });
+});


### PR DESCRIPTION
## Summary
- ensure computeScheduleStatus marks classes without an end date as Ongoing once started
- mirror the updated logic in schedule helpers used by student and public class detail pages
- add unit tests covering the revised schedule status behaviour

## Testing
- npm test -- classSchedule

------
https://chatgpt.com/codex/tasks/task_e_68d8551dbe9c8328b8fb8c67be4a8b35