### PR TITLE
Prevent duplicate lesson creation on admin retries

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -32,6 +32,7 @@ import useNotificationStore from '@/store/notifications/notificationStore';
 import useMessageStore from '@/store/messages/messageStore';
 import FloatingInput from '@/components/shared/FloatingInput';
 import { toDateTimeISO } from '@/utils/date';
+import { getPendingLessonEntries } from '@/utils/lessonSubmission';
 import useMediaUploader from '@/hooks/useMediaUploader';
 import nextI18NextConfig from '@/../next-i18next.config.js';
 
@@ -62,7 +63,8 @@ function CreateOnlineClass() {
     title: '',
     duration: '',
     resource: null,
-    start_time: ''
+    start_time: '',
+    status: 'pending'
   });
 
   const [formData, setFormData] = useState({
@@ -93,6 +95,7 @@ function CreateOnlineClass() {
   const [selectedTags, setSelectedTags] = useState([]);
   const [tagInput, setTagInput] = useState('');
   const [failedLessonIndices, setFailedLessonIndices] = useState([]);
+  const [createdClass, setCreatedClass] = useState(null);
   const [instructors, setInstructors] = useState([]);
   const [instructorId, setInstructorId] = useState('');
   const [instructorSearch, setInstructorSearch] = useState('');
@@ -294,9 +297,10 @@ function CreateOnlineClass() {
   };
 
   const handleAddLesson = () => {
+    const newLesson = createEmptyLesson();
     setFormData((prev) => ({
       ...prev,
-      lessons: [...prev.lessons, createEmptyLesson()],
+      lessons: [...prev.lessons, newLesson],
     }));
   };
 
@@ -305,6 +309,11 @@ function CreateOnlineClass() {
       ...prev,
       lessons: prev.lessons.filter((_, idx) => idx !== index),
     }));
+    setFailedLessonIndices((prev) =>
+      prev
+        .filter((idx) => idx !== index)
+        .map((idx) => (idx > index ? idx - 1 : idx))
+    );
   };
 
   const addTag = (tag) => {
@@ -438,76 +447,129 @@ function CreateOnlineClass() {
         setIsServerUploading(true);
         setUploadProgress(0);
         setFailedLessonIndices([]);
+        const finalizeCreation = (classRecord) => {
+          const events = [
+            {
+              id: `class-${classRecord.id}`,
+              title: `Class: ${classRecord.title}`,
+              start: toDateTimeISO(formData.startDate || classRecord.start_date),
+            },
+            ...formData.lessons.map((l) => ({
+              id: `lesson-${classRecord.id}-${l.id}`,
+              title: `Lesson: ${l.title}`,
+              start: toDateTimeISO(l.start_time),
+            })),
+          ];
+          addEvents(events);
 
-        const payload = new FormData();
-        payload.append('instructor_id', instructorId);
-        payload.append('title', formData.title);
-        if (formData.description) payload.append('description', formData.description);
-        if (formData.level) payload.append('level', formData.level);
-        if (formData.language) payload.append('language', formData.language);
-        if (formData.startDate)
-          payload.append('start_date', toDateTimeISO(formData.startDate));
-        if (formData.endDate)
-          payload.append('end_date', toDateTimeISO(formData.endDate));
+          toast.success(t('class_created'));
+          fetchNotifications();
+          fetchMessages();
+          router.push('/dashboard/admin/online-classes');
+        };
 
-        payload.append('access_type', formData.accessType);
-        if (formData.accessType === 'free') {
-          payload.append('price', '0');
-          if (formData.includedPlans.length)
-            payload.append('included_plans', JSON.stringify(formData.includedPlans));
-        } else if (Number.isFinite(priceValue)) {
-          payload.append('price', priceValue.toFixed(2));
+        let classRecord = createdClass;
+
+        if (!classRecord?.id) {
+          const payload = new FormData();
+          payload.append('instructor_id', instructorId);
+          payload.append('title', formData.title);
+          if (formData.description) payload.append('description', formData.description);
+          if (formData.level) payload.append('level', formData.level);
+          if (formData.language) payload.append('language', formData.language);
+          if (formData.startDate)
+            payload.append('start_date', toDateTimeISO(formData.startDate));
+          if (formData.endDate)
+            payload.append('end_date', toDateTimeISO(formData.endDate));
+
+          payload.append('access_type', formData.accessType);
+          if (formData.accessType === 'free') {
+            payload.append('price', '0');
+            if (formData.includedPlans.length)
+              payload.append('included_plans', JSON.stringify(formData.includedPlans));
+          } else if (Number.isFinite(priceValue)) {
+            payload.append('price', priceValue.toFixed(2));
+          }
+          if (formData.maxStudents) payload.append('max_students', formData.maxStudents);
+          payload.append('allow_installments', formData.allowInstallments ? 'true' : 'false');
+          payload.append('status', formData.isApproved ? 'published' : 'draft');
+          if (formData.category) payload.append('category_id', formData.category);
+          if (formData.image) payload.append('cover_image', formData.image);
+          if (formData.demoVideo) payload.append('demo_video', formData.demoVideo);
+
+          if (selectedTags.length) payload.append('tags', JSON.stringify(selectedTags));
+          const newClass = await createAdminClass(payload, (e) => {
+            if (!e?.total) return;
+            const percent = Math.round((e.loaded * 100) / e.total);
+            setUploadProgress(percent);
+          });
+
+          if (!newClass?.id) {
+            console.error('createAdminClass returned an unexpected payload', newClass);
+            toast.error(
+              t('class_creation_failed', {
+                defaultValue:
+                  'We could not confirm the new class details. Please try again in a moment.',
+              })
+            );
+            return;
+          }
+
+          setCreatedClass(newClass);
+          classRecord = newClass;
         }
-        if (formData.maxStudents) payload.append('max_students', formData.maxStudents);
-        payload.append('allow_installments', formData.allowInstallments ? 'true' : 'false');
-        payload.append('status', formData.isApproved ? 'published' : 'draft');
-        if (formData.category) payload.append('category_id', formData.category);
-        if (formData.image) payload.append('cover_image', formData.image);
-        if (formData.demoVideo) payload.append('demo_video', formData.demoVideo);
 
-        if (selectedTags.length) payload.append('tags', JSON.stringify(selectedTags));
-        const newClass = await createAdminClass(payload, (e) => {
-          if (!e?.total) return;
-          const percent = Math.round((e.loaded * 100) / e.total);
-          setUploadProgress(percent);
-        });
+        const lessonsToSubmit = getPendingLessonEntries(formData.lessons);
 
-        if (!newClass?.id) {
-          console.error('createAdminClass returned an unexpected payload', newClass);
-          toast.error(
-            t('class_creation_failed', {
-              defaultValue:
-                'We could not confirm the new class details. Please try again in a moment.',
-            })
-          );
+        if (!lessonsToSubmit.length) {
+          finalizeCreation(classRecord);
           return;
         }
 
         const lessonResults = await Promise.allSettled(
-          formData.lessons.map(async (lesson) => {
+          lessonsToSubmit.map(async ({ lesson }) => {
             const lessonData = new FormData();
             lessonData.append('title', lesson.title);
             if (lesson.duration) lessonData.append('duration', lesson.duration);
             if (lesson.resource) lessonData.append('resource', lesson.resource);
             lessonData.append('start_time', toDateTimeISO(lesson.start_time));
-            return createClassLesson(newClass.id, lessonData);
+            return createClassLesson(classRecord.id, lessonData);
           })
         );
 
-        const failedIndices = lessonResults.reduce((acc, result, index) => {
-          if (result.status === 'rejected') {
-            acc.push(index);
+        const indexToStatus = new Map();
+        const failedIndices = [];
+
+        lessonResults.forEach((result, idx) => {
+          const { index } = lessonsToSubmit[idx];
+          if (result.status === 'fulfilled') {
+            indexToStatus.set(index, 'succeeded');
+          } else {
+            indexToStatus.set(index, 'failed');
+            failedIndices.push(index);
           }
-          return acc;
-        }, []);
+        });
+
+        if (indexToStatus.size) {
+          setFormData((prev) => ({
+            ...prev,
+            lessons: prev.lessons.map((lesson, idx) => {
+              if (!indexToStatus.has(idx)) {
+                return lesson;
+              }
+              return { ...lesson, status: indexToStatus.get(idx) };
+            }),
+          }));
+        }
 
         if (failedIndices.length) {
-          setFailedLessonIndices(failedIndices);
+          const sortedFailed = [...failedIndices].sort((a, b) => a - b);
+          setFailedLessonIndices(sortedFailed);
           toast.error(
             t('lesson_creation_failed', {
-              count: failedIndices.length,
-              indices: failedIndices.map((idx) => idx + 1).join(', '),
-              defaultValue: `Failed to create ${failedIndices.length} lesson(s). Please review highlighted lessons (${failedIndices
+              count: sortedFailed.length,
+              indices: sortedFailed.map((idx) => idx + 1).join(', '),
+              defaultValue: `Failed to create ${sortedFailed.length} lesson(s). Please review highlighted lessons (${sortedFailed
                 .map((idx) => idx + 1)
                 .join(', ')}).`,
             })
@@ -516,24 +578,7 @@ function CreateOnlineClass() {
           return;
         }
 
-        const events = [
-          {
-            id: `class-${newClass.id}`,
-            title: `Class: ${newClass.title}`,
-            start: toDateTimeISO(formData.startDate || newClass.start_date),
-          },
-          ...formData.lessons.map((l) => ({
-            id: `lesson-${newClass.id}-${l.id}`,
-            title: `Lesson: ${l.title}`,
-            start: toDateTimeISO(l.start_time),
-          })),
-        ];
-        addEvents(events);
-
-        toast.success(t('class_created'));
-        fetchNotifications();
-        fetchMessages();
-        router.push('/dashboard/admin/online-classes');
+        finalizeCreation(classRecord);
       } catch (error) {
         console.error(error);
         toast.error(error.response?.data?.message || t('upload_failed', { defaultValue: 'Upload failed. Please try again.' }));

--- a/frontend/src/utils/__tests__/lessonSubmission.test.js
+++ b/frontend/src/utils/__tests__/lessonSubmission.test.js
@@ -1,0 +1,25 @@
+import { getPendingLessonEntries } from '@/utils/lessonSubmission';
+
+describe('getPendingLessonEntries', () => {
+  it('returns only lessons that are not marked as succeeded', () => {
+    const lessons = [
+      { id: 'a', status: 'succeeded' },
+      { id: 'b', status: 'failed' },
+      { id: 'c', status: 'pending' },
+      { id: 'd' },
+    ];
+
+    const result = getPendingLessonEntries(lessons);
+
+    expect(result).toEqual([
+      { lesson: lessons[1], index: 1 },
+      { lesson: lessons[2], index: 2 },
+      { lesson: lessons[3], index: 3 },
+    ]);
+  });
+
+  it('returns an empty array when input is not an array', () => {
+    expect(getPendingLessonEntries(null)).toEqual([]);
+    expect(getPendingLessonEntries(undefined)).toEqual([]);
+  });
+});

--- a/frontend/src/utils/lessonSubmission.js
+++ b/frontend/src/utils/lessonSubmission.js
@@ -1,0 +1,9 @@
+export const getPendingLessonEntries = (lessons = []) => {
+  if (!Array.isArray(lessons)) {
+    return [];
+  }
+
+  return lessons
+    .map((lesson, index) => ({ lesson, index }))
+    .filter(({ lesson }) => lesson?.status !== 'succeeded');
+};


### PR DESCRIPTION
## Summary
- preserve the created class and per-lesson status so retries only submit lessons that have not succeeded while keeping failure highlighting
- add a reusable helper for filtering pending lessons and apply it in the admin create flow
- cover the helper with a focused Jest test to ensure succeeded lessons are skipped on resubmission

## Testing
- npm run test -- lessonSubmission

------
https://chatgpt.com/codex/tasks/task_e_68d8551f09bc832880ed7f929c694678