### PR TITLE
Fix admin class status toggling refresh

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -237,10 +237,11 @@ export default function AdminClassesTable() {
         refreshMessages?.();
       } else if (action === "toggle") {
         const updated = await toggleClassStatus(id);
+        if (!updated) {
+          throw new Error("Failed to toggle class status");
+        }
         setClassList((prev) =>
-          prev.map((c) =>
-            c.id === id ? { ...c, publishStatus: updated.publishStatus } : c
-          )
+          prev.map((c) => (c.id === id ? updated : c))
         );
         toast.success("Status updated");
         const message = `Class "${target.title}" publish status changed to ${updated.publishStatus}.`;

--- a/frontend/src/tests/pages/dashboard/admin/online-classes/index.test.jsx
+++ b/frontend/src/tests/pages/dashboard/admin/online-classes/index.test.jsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import AdminClassesTable from "@/components/admin/online-classes/AdminClassesTable";
+
+const fetchAdminClassesMock = jest.fn();
+const toggleClassStatusMock = jest.fn();
+const approveAdminClassMock = jest.fn();
+const rejectAdminClassMock = jest.fn();
+const deleteAdminClassMock = jest.fn();
+const updateAdminClassMock = jest.fn();
+
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: { dir: () => "ltr" },
+  }),
+}));
+
+jest.mock("@/services/admin/classService", () => ({
+  __esModule: true,
+  fetchAdminClasses: (...args) => fetchAdminClassesMock(...args),
+  toggleClassStatus: (...args) => toggleClassStatusMock(...args),
+  approveAdminClass: (...args) => approveAdminClassMock(...args),
+  rejectAdminClass: (...args) => rejectAdminClassMock(...args),
+  deleteAdminClass: (...args) => deleteAdminClassMock(...args),
+  updateAdminClass: (...args) => updateAdminClassMock(...args),
+}));
+
+jest.mock("@/services/notificationService", () => ({
+  createNotification: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/services/messageService", () => ({
+  sendChatMessage: jest.fn().mockResolvedValue(undefined),
+}));
+
+const notificationFetchMock = jest.fn();
+jest.mock("@/store/notifications/notificationStore", () => ({
+  __esModule: true,
+  default: (selector) =>
+    selector
+      ? selector({ fetch: notificationFetchMock })
+      : { fetch: notificationFetchMock },
+}));
+
+const messageFetchMock = jest.fn();
+jest.mock("@/store/messages/messageStore", () => ({
+  __esModule: true,
+  default: (selector) =>
+    selector ? selector({ fetch: messageFetchMock }) : { fetch: messageFetchMock },
+}));
+
+const authState = {
+  user: { id: "admin-1", permissions: ["ADD_ONLINE_CLASS_RULE"] },
+  hasHydrated: true,
+};
+jest.mock("@/store/auth/authStore", () => ({
+  __esModule: true,
+  default: (selector) =>
+    selector
+      ? selector(authState)
+      : authState,
+}));
+
+const toastSuccessMock = jest.fn();
+const toastErrorMock = jest.fn();
+jest.mock("react-toastify", () => ({
+  toast: {
+    success: (...args) => toastSuccessMock(...args),
+    error: (...args) => toastErrorMock(...args),
+  },
+}));
+
+describe("AdminClassesTable status toggling", () => {
+  const baseClass = {
+    id: "class-1",
+    title: "Sample Class",
+    instructor: "John Doe",
+    instructor_id: "admin-1",
+    start_date: "2024-01-10",
+    end_date: "2024-01-12",
+    category: "Tech",
+    price: 0,
+    scheduleStatus: "Upcoming",
+    publishStatus: "draft",
+    approvalStatus: "Pending",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchAdminClassesMock.mockResolvedValue({
+      data: [baseClass],
+      meta: { totalPages: 1, total: 1 },
+    });
+  });
+
+  it("replaces the entire row with the refreshed class after toggling publish status", async () => {
+    const refreshedClass = {
+      ...baseClass,
+      publishStatus: "published",
+      approvalStatus: "Approved",
+    };
+    toggleClassStatusMock.mockResolvedValue(refreshedClass);
+
+    render(<AdminClassesTable />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Draft" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Approve")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+
+    await waitFor(() => {
+      expect(toggleClassStatusMock).toHaveBeenCalledWith("class-1");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Published" })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Approved", { selector: "span" })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Approve")).not.toBeInTheDocument();
+    expect(toastSuccessMock).toHaveBeenCalledWith("Status updated");
+  });
+});


### PR DESCRIPTION
## Summary
- replace the toggled admin class row with the refreshed payload from the status API so approval badges stay in sync
- add a regression test for the admin online classes table status toggle behaviour

## Testing
- npm test -- src/tests/pages/dashboard/admin/online-classes/index.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d8553db08083288b0e5f8a17cf2799