### PR TITLE
Ensure AssignmentManager uses normalized due dates

### DIFF
--- a/frontend/src/components/instructors/AssignmentManager.js
+++ b/frontend/src/components/instructors/AssignmentManager.js
@@ -51,28 +51,31 @@ export default function AssignmentManager({ classId, initialAssignments = [] }) 
         </div>
       )}
       <ul className="space-y-3">
-        {assignments.map((a, i) => (
-          <li
-            key={a.id}
-            className="bg-gray-700 p-3 rounded flex justify-between items-center"
-          >
-            <div>
-              <p className="font-medium">{a.title}</p>
-              {a.due_date && (
-                <p className="text-gray-400 text-xs">
-                  Due: {toDateInput(a.due_date)}
-                </p>
-              )}
-              <p className="text-gray-400 text-xs">Status: {computeStatus(a.due_date)}</p>
-            </div>
-            <button
-              onClick={() => removeAssignment(i)}
-              className="text-red-400 hover:underline text-xs"
+        {assignments.map((a, i) => {
+          const dueDate = a?.dueDate ?? a?.due_date;
+          return (
+            <li
+              key={a.id}
+              className="bg-gray-700 p-3 rounded flex justify-between items-center"
             >
-              Remove
-            </button>
-          </li>
-        ))}
+              <div>
+                <p className="font-medium">{a.title}</p>
+                {dueDate && (
+                  <p className="text-gray-400 text-xs">
+                    Due: {toDateInput(dueDate)}
+                  </p>
+                )}
+                <p className="text-gray-400 text-xs">Status: {computeStatus(dueDate)}</p>
+              </div>
+              <button
+                onClick={() => removeAssignment(i)}
+                className="text-red-400 hover:underline text-xs"
+              >
+                Remove
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- read the normalized `dueDate` field when rendering assignments
- ensure due date text and status share the same resolved value

## Testing
- node - <<'NODE'
const computeStatus = (due) => {
  if (!due) return "Ongoing";
  const now = new Date();
  const d = new Date(due);
  return now > d ? "Past Due" : "Ongoing";
};

const toDateInput = (value) => {
  if (!value) return "";
  const d = new Date(value);
  if (Number.isNaN(d.getTime())) return value;
  return d.toISOString().split("T")[0];
};

const assignmentsFromManagement = [
  { id: 1, title: "Legacy assignment", due_date: new Date(Date.now() - 86400000).toISOString() },
  { id: 2, title: "Future management", due_date: new Date(Date.now() + 86400000).toISOString() },
];

const assignmentsFromFetch = [
  { id: 3, title: "Normalized assignment", dueDate: new Date(Date.now() - 3600000).toISOString() },
  { id: 4, title: "Upcoming normalized", dueDate: new Date(Date.now() + 3600000).toISOString() },
];

const render = (assignments) => assignments.map((a) => {
  const dueDate = a?.dueDate ?? a?.due_date;
  return {
    id: a.id,
    title: a.title,
    dueText: dueDate ? `Due: ${toDateInput(dueDate)}` : null,
    status: computeStatus(dueDate),
  };
});

console.log("Management assignments:");
console.log(render(assignmentsFromManagement));
console.log("Assignments API assignments:");
console.log(render(assignmentsFromFetch));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d85a2edb5883288f08bb0ca0cbf7a5