### PR TITLE
Normalize frontend healthcheck host resolution

### DIFF
--- a/frontend/scripts/healthcheck.js
+++ b/frontend/scripts/healthcheck.js
@@ -12,7 +12,35 @@ function parsePositiveInt(value, fallback) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-const host = process.env.HEALTHCHECK_HOST || DEFAULT_HOST;
+function normalizeHost(rawHost) {
+  const trimmed = rawHost?.trim();
+  if (!trimmed) {
+    return { hostname: DEFAULT_HOST, displayHost: DEFAULT_HOST };
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  if (lower === '0.0.0.0') {
+    return { hostname: DEFAULT_HOST, displayHost: DEFAULT_HOST };
+  }
+
+  if (['::', '::0', '0:0:0:0:0:0:0:0', '[::]', '[::0]'].includes(lower)) {
+    return { hostname: '::1', displayHost: '[::1]' };
+  }
+
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const inner = trimmed.slice(1, -1);
+    return { hostname: inner, displayHost: trimmed };
+  }
+
+  if (trimmed.includes(':')) {
+    return { hostname: trimmed, displayHost: `[${trimmed}]` };
+  }
+
+  return { hostname: trimmed, displayHost: trimmed };
+}
+
+const { hostname: host, displayHost } = normalizeHost(process.env.HEALTHCHECK_HOST);
 const port = parsePositiveInt(process.env.PORT, 3000);
 const protocol = (process.env.HEALTHCHECK_PROTOCOL || DEFAULT_PROTOCOL).toLowerCase();
 const path = process.env.HEALTHCHECK_PATH || DEFAULT_PATH;
@@ -25,7 +53,7 @@ const defaultPorts = new Map([
 ]);
 
 const defaultPortForProtocol = defaultPorts.get(protocol);
-const hostHeader = defaultPortForProtocol && port === defaultPortForProtocol ? host : `${host}:${port}`;
+const hostHeader = defaultPortForProtocol && port === defaultPortForProtocol ? displayHost : `${displayHost}:${port}`;
 
 const allowedProtocols = new Set(['http', 'https']);
 if (!allowedProtocols.has(protocol)) {
@@ -45,7 +73,7 @@ const requestOptions = {
   headers: {
     'User-Agent': 'skillbridge-frontend-healthcheck',
     Accept: 'application/json',
-    host: hostHeader,
+    Host: hostHeader,
   },
 };
 

--- a/frontend/scripts/normalize-package-json.js
+++ b/frontend/scripts/normalize-package-json.js
@@ -51,7 +51,10 @@ function attemptStructuralRepairs(input) {
   let output = input;
   let scriptOverrides = null;
 
-  const duplicateScriptsPattern = /("scripts"\s*:\s*{[\s\S]*?}\s*,\s*\n)(\s*"dev"\s*:\s*"[^"]*",?\s*\n\s*"build"\s*:\s*"[^"]*",?\s*\n\s*"start"\s*:\s*"[^"]*",?\s*\n\s*"lint"\s*:\s*"[^"]*",?\s*\n\s*"test"\s*:\s*"[^"]*"\s*,?\s*\n)(\s*},)/m;
+  // Some merge tools accidentally inline a second scripts block directly after the
+  // real one, leaving behind duplicated entries without the surrounding "scripts" key.
+  // Capture the valid block and the stray entries so we can merge them safely.
+  const duplicateScriptsPattern = /("scripts"\s*:\s*{[\s\S]*?}\s*,\s*\n)(\s*"dev"\s*:\s*"[^"]*",?[\s\S]*?\n\s*"test"\s*:\s*"[^"]*"\s*,?\s*\n)(\s*},)/m;
   const redundantClosingPattern = /},\s*\n\s*},/m;
 
   const match = output.match(duplicateScriptsPattern);

--- a/frontend/src/pages/docs/[slug].js
+++ b/frontend/src/pages/docs/[slug].js
@@ -7,20 +7,12 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import DOMPurify from 'isomorphic-dompurify';
 import cheerio from 'cheerio';
-import { resolveDocsDirectory } from '@/utils/docsDirectory';
+import { buildDefaultDocsExplicitPaths, resolveDocsDirectory } from '@/utils/docsDirectory';
 
 const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
 
 // Ensure standalone builds can still locate the project-level docs directory.
-const docsDirectoryExplicitPaths = [
-  path.join(process.cwd(), 'docs'),
-  path.join(process.cwd(), '..', 'docs'),
-  path.join(process.cwd(), '..', '..', 'docs'),
-  path.join(process.cwd(), '..', '..', '..', 'docs'),
-  path.resolve(moduleDir, '../../docs'),
-  path.resolve(moduleDir, '../../../docs'),
-  path.resolve(moduleDir, '../../../..', 'docs'),
-];
+const docsDirectoryExplicitPaths = buildDefaultDocsExplicitPaths(moduleDir);
 
 const sanitizeSlug = (value = '') =>
   value

--- a/frontend/src/pages/docs/index.js
+++ b/frontend/src/pages/docs/index.js
@@ -13,9 +13,10 @@ import Footer from '@/components/website/sections/Footer';
 import Navbar from '@/components/website/sections/Navbar';
 import PageHead from '@/components/common/PageHead';
 import nextI18NextConfig from '../../../next-i18next.config.js';
-import { resolveDocsDirectory } from '@/utils/docsDirectory';
+import { buildDefaultDocsExplicitPaths, resolveDocsDirectory } from '@/utils/docsDirectory';
 
 const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+const docsDirectoryExplicitPaths = buildDefaultDocsExplicitPaths(moduleDir);
 
 function sanitizeSlug(value) {
   return value

--- a/frontend/src/utils/docsDirectory.js
+++ b/frontend/src/utils/docsDirectory.js
@@ -4,6 +4,32 @@ import path from 'path';
 const DEFAULT_DOCS_DIR_NAME = 'docs';
 const DEFAULT_MAX_DEPTH = 8;
 
+function resolveModuleDirectory(moduleDirectory) {
+  if (moduleDirectory) {
+    return moduleDirectory;
+  }
+
+  if (typeof __dirname !== 'undefined') {
+    return __dirname;
+  }
+
+  return process.cwd();
+}
+
+export function buildDefaultDocsExplicitPaths(moduleDirectory) {
+  const moduleDir = resolveModuleDirectory(moduleDirectory);
+
+  return [
+    path.join(process.cwd(), 'docs'),
+    path.join(process.cwd(), '..', 'docs'),
+    path.join(process.cwd(), '..', '..', 'docs'),
+    path.join(process.cwd(), '..', '..', '..', 'docs'),
+    path.resolve(moduleDir, '../../docs'),
+    path.resolve(moduleDir, '../../../docs'),
+    path.resolve(moduleDir, '../../../..', 'docs'),
+  ];
+}
+
 function addCandidate(candidates, value) {
   if (!value) {
     return;
@@ -47,11 +73,11 @@ export function computeDocsDirCandidates({
 
   [...explicitPaths, ...envPaths].forEach((candidate) => addCandidate(candidates, candidate));
 
-  const fallbackModuleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+  const fallbackModuleDir = resolveModuleDirectory(moduleDirectory);
   const allStartDirs = [
     ...startDirs,
     process.cwd(),
-    moduleDirectory || fallbackModuleDir,
+    fallbackModuleDir,
   ];
 
   allStartDirs.forEach((startDir) => {


### PR DESCRIPTION
## Summary
- normalize the frontend healthcheck script to coerce wildcard hosts like 0.0.0.0 into loopback-safe addresses and ensure headers format IPv6 correctly

## Testing
- node scripts/healthcheck.js
- HEALTHCHECK_HOST=0.0.0.0 node scripts/healthcheck.js

------
https://chatgpt.com/codex/tasks/task_e_68d85bf3e51c83288c6198949a4bbc71