### PR TITLE
Fix subscription wallet credit arguments

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -47,8 +47,16 @@ jest.mock('../../../payments/helpers/wallet', () => ({
   creditInstructorSubscription: jest.fn(),
 }));
 
+jest.mock('../../../../utils/logger.js', () => ({
+  log: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
 const { getActiveStudentPlanId } = require('../../../plans/subscription.helper');
 const { creditInstructorSubscription } = require('../../../payments/helpers/wallet');
+const logger = require('../../../../utils/logger.js');
 const db = require('../../../../config/database');
 
 const routes = require('../../class.routes');
@@ -139,6 +147,7 @@ describe('Class enrollment routes', () => {
       'plan1',
       expect.anything(),
     );
+    expect(logger.error).not.toHaveBeenCalled();
     expect(db.insert).toHaveBeenCalledWith(
       expect.objectContaining({
         user_id: 'test-user',

--- a/backend/src/modules/payments/helpers/wallet.js
+++ b/backend/src/modules/payments/helpers/wallet.js
@@ -32,9 +32,9 @@ async function creditInstructorSubscription(item_type, item_id, planId, trx) {
   try {
     const amount = await calculateInstructorAmount(
       planId,
-      classId,
+      item_id,
       trx,
-      "class"
+      item_type
     );
     if (amount <= 0) return;
 


### PR DESCRIPTION
## Summary
- pass the subscription item id and type through to calculateInstructorAmount when crediting instructor wallets
- extend class enrollment subscription test coverage to assert wallet credits succeed without logging errors

## Testing
- npm test -- classEnrollment.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d86ab4c0d483288ce93a9a9691dcba