### PR TITLE
Fix duplicate subscription credits for class enrollments

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -139,6 +139,7 @@ describe('Class enrollment routes', () => {
       'plan1',
       expect.anything(),
     );
+    expect(creditInstructorSubscription).toHaveBeenCalledTimes(1);
     expect(db.insert).toHaveBeenCalledWith(
       expect.objectContaining({
         user_id: 'test-user',

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -67,8 +67,6 @@ exports.enroll = catchAsync(async (req, res) => {
         "class"
       );
 
-      await creditInstructorSubscription("class", classId, activePlanId, trx);
-
       await trx("payments").insert({
         user_id,
         item_id: classId,


### PR DESCRIPTION
## Summary
- ensure class enrollment controller only credits instructor wallets once per subscription enrollment
- extend enrollment route test to assert a single wallet credit call when a class is covered by a subscription

## Testing
- npm test -- classEnrollment.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d86ab58fac8328903ccd6bd3d5f814