### PR TITLE
Wrap instructor classroom page with layout

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id].js
@@ -11,6 +11,7 @@ import StudentProgressPanel from "@/components/instructors/StudentProgressPanel"
 import { fetchClassManagementData } from "@/services/instructor/classService";
 import useAuthStore from "@/store/auth/authStore";
 import withAuthProtection from "@/hooks/withAuthProtection";
+import InstructorLayout from "@/components/layouts/InstructorLayout";
 
 
 const isClassLive = (classData) => {
@@ -158,6 +159,8 @@ function InstructorClassRoom() {
     </div>
   );
 }
+
+InstructorClassRoom.getLayout = (page) => <InstructorLayout>{page}</InstructorLayout>;
 
 const ProtectedInstructorClassRoom = withAuthProtection(
   InstructorClassRoom,


### PR DESCRIPTION
## Summary
- import the shared InstructorLayout component for the instructor classroom page
- attach the layout via getLayout so the instructor classroom and its protected wrapper render with the layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d86ab9fd188328a238a5e7f9a576b8