### PR TITLE
Protect student online class pages with auth guard

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/[id].js
+++ b/frontend/src/pages/dashboard/student/online-classes/[id].js
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { FaVideo, FaCheckCircle } from 'react-icons/fa';
 import VideoCallScreen from "@/components/video-call/VideoCallScreen";
 import StudentScoreSummary from "@/components/students/StudentScoreSummary";
+import withAuthProtection from "@/hooks/withAuthProtection";
 import {
   fetchClassDetails,
   fetchClassLessons,
@@ -21,7 +22,7 @@ const computeScheduleStatus = (start, end) => {
   return "Upcoming";
 };
 
-export default function StudentClassRoom() {
+function StudentClassRoom() {
   const router = useRouter();
   const { id } = router.query;
   const [classData, setClassData] = useState(null);
@@ -244,3 +245,5 @@ export default function StudentClassRoom() {
     </div>
   );
 }
+
+export default withAuthProtection(StudentClassRoom, ['student']);

--- a/frontend/src/pages/dashboard/student/online-classes/index.js
+++ b/frontend/src/pages/dashboard/student/online-classes/index.js
@@ -16,10 +16,11 @@ import {
   FaSortAmountDown
 } from 'react-icons/fa';
 import StudentLayout from '@/components/layouts/StudentLayout';
+import withAuthProtection from '@/hooks/withAuthProtection';
 import { fetchMyEnrolledClasses, subscribeToClassReminder } from '@/services/classService';
 import { toast } from 'react-toastify';
 
-export default function MyEnrolledClassesPage() {
+function MyEnrolledClassesPage() {
   const [classes, setClasses] = useState([]);
   const [filter, setFilter] = useState('all');
   const [visibleCount, setVisibleCount] = useState(6);
@@ -272,3 +273,5 @@ export default function MyEnrolledClassesPage() {
     </StudentLayout>
   );
 }
+
+export default withAuthProtection(MyEnrolledClassesPage, ['student']);


### PR DESCRIPTION
## Summary
- wrap the student online classes listing and detail pages with the shared auth protection HOC
- ensure both exports require the student role before rendering

## Testing
- not run (auth flows require integration testing)


------
https://chatgpt.com/codex/tasks/task_e_68d86abb21f88328a48a2cc7f2c84791