### PR TITLE
Fix duplicate instructor wallet credits on class subscriptions

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -133,6 +133,7 @@ describe('Class enrollment routes', () => {
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(200);
     expect(service.createEnrollment).toHaveBeenCalled();
+    expect(creditInstructorSubscription).toHaveBeenCalledTimes(1);
     expect(creditInstructorSubscription).toHaveBeenCalledWith(
       'class',
       'abc',

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -67,8 +67,6 @@ exports.enroll = catchAsync(async (req, res) => {
         "class"
       );
 
-      await creditInstructorSubscription("class", classId, activePlanId, trx);
-
       await trx("payments").insert({
         user_id,
         item_id: classId,


### PR DESCRIPTION
## Summary
- ensure subscription enrollments only credit instructor wallets once and record payment first
- keep wallet credit logic after revenue calculation and payment record
- extend enrollment route test to assert only one credit entry is produced for subscription enrollments

## Testing
- npm test -- --runTestsByPath src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d86aee2aa88328aff0578d6f1cc6fb