### PR TITLE
Align class catalog cards with API response fields

### DIFF
--- a/frontend/src/components/online-classes/ClassCard.js
+++ b/frontend/src/components/online-classes/ClassCard.js
@@ -2,18 +2,59 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { FaHeart, FaThumbsUp } from 'react-icons/fa';
 import { toast } from 'react-toastify';
+import { computeScheduleStatus } from '@/utils/classSchedule';
 
 function ClassCard({ classData, index }) {
   const {
     id,
     title,
     instructor,
-    date,
+    start_date,
+    end_date,
     price,
-    spotsLeft,
-    duration,
-    image,
+    spots_left,
+    cover_image,
   } = classData;
+
+  const coverImage = cover_image || '/default-class.jpg';
+
+  const formatDate = (value) => {
+    if (!value) return null;
+    const date = new Date(value);
+    return Number.isNaN(date.getTime())
+      ? null
+      : date.toLocaleDateString(undefined, {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        });
+  };
+
+  const formattedStartDate = formatDate(start_date) || 'TBD';
+  const formattedEndDate = formatDate(end_date);
+  const scheduleStatus = computeScheduleStatus(start_date, end_date);
+
+  let durationText = 'Schedule TBD';
+  if (formattedStartDate !== 'TBD' && formattedEndDate) {
+    durationText = `${formattedStartDate} - ${formattedEndDate}`;
+  } else if (formattedStartDate !== 'TBD') {
+    durationText = `Starts ${formattedStartDate}`;
+  } else if (formattedEndDate) {
+    durationText = `Until ${formattedEndDate}`;
+  }
+
+  if (scheduleStatus) {
+    durationText =
+      durationText === 'Schedule TBD'
+        ? scheduleStatus
+        : `${durationText} • ${scheduleStatus}`;
+  }
+
+  const normalizedSpotsLeft =
+    typeof spots_left === 'number' && !Number.isNaN(spots_left)
+      ? Math.max(spots_left, 0)
+      : null;
+  const isFull = normalizedSpotsLeft !== null ? normalizedSpotsLeft === 0 : false;
 
   const [liked, setLiked] = useState(false);
 
@@ -29,7 +70,7 @@ function ClassCard({ classData, index }) {
       toast.info('Already in wishlist');
       return;
     }
-    stored.push({ id, title, image, instructor, price });
+    stored.push({ id, title, image: coverImage, instructor, price });
     localStorage.setItem('wishlist', JSON.stringify(stored));
     toast.success('Added to wishlist');
   };
@@ -41,7 +82,7 @@ function ClassCard({ classData, index }) {
       toast.info('Already liked');
       return;
     }
-    stored.push({ id, title, image, instructor, price });
+    stored.push({ id, title, image: coverImage, instructor, price });
     localStorage.setItem('likedClasses', JSON.stringify(stored));
     setLiked(true);
     toast.success('Class liked');
@@ -53,7 +94,7 @@ function ClassCard({ classData, index }) {
         {/* Image */}
         <div className="h-40 mb-4 overflow-hidden rounded-md relative">
           <img
-            src={image || '/default-class.jpg'}
+            src={coverImage}
             alt={title}
             className="w-full h-full object-cover"
           />
@@ -77,19 +118,19 @@ function ClassCard({ classData, index }) {
 
         {/* Details */}
         <div className="text-sm text-gray-400 space-y-1 mb-4">
-          <p>📅 Start: {date}</p>
-          <p>🕒 Duration: {duration}</p>
+          <p>📅 Start: {formattedStartDate}</p>
+          <p>🕒 Duration: {durationText}</p>
           <p>💰 Price: {price === 0 ? 'Free' : `$${price}`}</p>
-          <p>👥 Spots Left: {spotsLeft}</p>
+          <p>👥 Spots Left: {normalizedSpotsLeft !== null ? normalizedSpotsLeft : 'N/A'}</p>
         </div>
 
         {/* Button */}
         <div className={`mt-auto px-4 py-2 text-center rounded-md font-semibold ${
-          spotsLeft === 0
+          isFull
             ? 'bg-gray-600 text-gray-400 cursor-not-allowed'
             : 'bg-yellow-500 text-black hover:bg-yellow-400'
         }`}>
-          {spotsLeft === 0 ? 'Full' : 'View Details'}
+          {isFull ? 'Full' : 'View Details'}
         </div>
       </div>
     </Link>

--- a/frontend/src/components/online-classes/ClassesGrid.js
+++ b/frontend/src/components/online-classes/ClassesGrid.js
@@ -13,7 +13,7 @@ function ClassesGrid({ classes }) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       {classes.map((item, index) => (
-        <ClassCard key={index} classData={item} index={index} />
+        <ClassCard key={item.id} classData={item} index={index} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- update the class catalog card to consume API-provided cover images, schedule dates, and seat availability
- format the displayed start date and duration/status details derived from the start/end dates
- use the class id as the grid key when rendering cards to keep React reconciliation stable

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d86aef2dec8328a99e485d8a8cc5b4