### PR TITLE
Use instructor full name in booking request modal

### DIFF
--- a/frontend/src/components/student/instructors/BookingRequestModal.js
+++ b/frontend/src/components/student/instructors/BookingRequestModal.js
@@ -22,6 +22,8 @@ export default function BookingRequestModal({ instructor, onClose }) {
   const [availability, setAvailability] = useState([]);
   const [error, setError] = useState("");
   const [hasPending, setHasPending] = useState(false);
+  const instructorDisplayName =
+    instructor?.full_name || instructor?.name || "the instructor";
 
   // Ensure only logged in students can book
   useEffect(() => {
@@ -120,7 +122,7 @@ export default function BookingRequestModal({ instructor, onClose }) {
         instructor_id: instructor.id,
         start_time: startIso,
         end_time: endIso,
-        notes: `${type} with ${instructor.name}`,
+        notes: `${type} with ${instructorDisplayName}`,
       });
       setSubmitted(true);
     } catch (err) {
@@ -146,7 +148,7 @@ export default function BookingRequestModal({ instructor, onClose }) {
           <div className="text-center">
             <h3 className="text-2xl font-semibold text-green-600 mb-2">Request Sent!</h3>
             <p className="text-gray-700 mb-4">
-              Your lesson request has been sent to <strong>{instructor?.name}</strong>.
+              Your lesson request has been sent to <strong>{instructorDisplayName}</strong>.
             </p>
             <button
               onClick={onClose}


### PR DESCRIPTION
## Summary
- update the booking request modal to derive a display name from the instructor's full name with a fallback
- apply the display name to both the booking notes payload and the confirmation message

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d86af07e208328a5303f4e96c12e5c