### PR TITLE
Fix certificate preview modal rendering

### DIFF
--- a/frontend/src/components/admin/certificates/CertificatePreviewModal.js
+++ b/frontend/src/components/admin/certificates/CertificatePreviewModal.js
@@ -1,105 +1,272 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { FaTimes } from "react-icons/fa";
 import QRCode from "react-qr-code";
-import { getTemplatePreview } from "@/services/admin/certificateTemplateService";
 
-const isTemplateAsset = (url) =>
-  typeof url === "string" &&
-  url.startsWith("/api/uploads/certificateTemplates/");
+const DEFAULT_PLATFORM_NAME = process.env.NEXT_PUBLIC_APP_NAME || "SkillBridge";
+const FALLBACK_VERIFICATION_BASE = (() => {
+  const domain =
+    process.env.NEXT_PUBLIC_APP_DOMAIN ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    "";
 
-const buildFallbackPreview = (template) => {
+  if (!domain) {
+    return "https://example.com";
+  }
+
+  return domain.startsWith("http") ? domain : `https://${domain}`;
+})();
+
+const FIELD_MAPPINGS = [
+  { target: "id", keys: ["id", "sample_id", "certificate_id"] },
+  { target: "studentName", keys: ["studentName", "student_name", "student"] },
+  { target: "courseName", keys: ["courseName", "course_name", "course_title"] },
+  { target: "issueDate", keys: ["issueDate", "issue_date", "issued_at"] },
+  { target: "instructor", keys: ["instructor", "instructor_name", "teacher"] },
+  { target: "platformName", keys: ["platformName", "platform_name", "issuer"] },
+  { target: "grade", keys: ["grade", "final_grade", "score"] },
+  {
+    target: "certificateCode",
+    keys: ["certificateCode", "certificate_code", "serial", "serial_number", "code"],
+  },
+  {
+    target: "certificateUrl",
+    keys: ["certificateUrl", "certificate_url", "verificationUrl", "verification_url"],
+  },
+];
+
+const parseJsonMaybe = (value) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    console.warn("Failed to parse certificate preview JSON", error);
+    return null;
+  }
+};
+
+const normalizeCertificatePayload = (payload) => {
+  const source = parseJsonMaybe(payload);
+
+  if (!source || typeof source !== "object") {
+    return {};
+  }
+
+  const normalized = {};
+
+  for (const { target, keys } of FIELD_MAPPINGS) {
+    for (const key of keys) {
+      if (source[key] !== undefined && source[key] !== null && source[key] !== "") {
+        normalized[target] = source[key];
+        break;
+      }
+    }
+  }
+
+  if (source.sample_data) {
+    Object.assign(normalized, normalizeCertificatePayload(source.sample_data));
+  }
+
+  if (source.sampleData) {
+    Object.assign(normalized, normalizeCertificatePayload(source.sampleData));
+  }
+
+  if (normalized.issueDate instanceof Date) {
+    normalized.issueDate = normalized.issueDate.toISOString();
+  }
+
+  return normalized;
+};
+
+const buildDefaultPreviewData = (template) => {
   const now = new Date();
-  const safeId = template?.id || `preview-${now.getTime()}`;
+  const fallbackId = template?.id || `preview-${now.getTime()}`;
   const courseName = template?.name ? `${template.name} Course` : "Sample Course";
-  const platformName = process.env.NEXT_PUBLIC_APP_NAME || "SkillBridge";
 
   return {
-    id: safeId,
+    id: fallbackId,
     studentName: "Sample Student",
     courseName,
     issueDate: now.toISOString(),
     instructor: "Sample Instructor",
-    platformName,
+    platformName: DEFAULT_PLATFORM_NAME,
     grade: "A+",
-    certificateCode: `PREVIEW-${String(safeId).slice(0, 8).toUpperCase()}`,
+    certificateCode: `PREVIEW-${String(fallbackId).slice(0, 8).toUpperCase()}`,
   };
+};
 
-  const sampleData = template.sample_data || {};
-  const normalizedSampleData = {
-    id:
-      sampleData.id ??
-      sampleData.sample_id ??
-      sampleData.serial_number ??
-      sampleData.serial ??
-      undefined,
-    studentName:
-      sampleData.student_name ?? sampleData.studentName ?? undefined,
-    courseName:
-      sampleData.course_name ?? sampleData.courseName ?? undefined,
-    issueDate:
-      sampleData.issue_date ?? sampleData.issueDate ?? undefined,
-    instructor:
-      sampleData.instructor ??
-      sampleData.instructor_name ??
-      sampleData.teacher ??
-      undefined,
-    platformName:
-      sampleData.platform_name ?? sampleData.platformName ?? undefined,
-    grade: sampleData.grade ?? sampleData.final_grade ?? undefined,
+const sanitizeTemplateImage = (value, fallback) => {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://") || trimmed.startsWith("data:")) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith("/")) {
+    return trimmed;
+  }
+
+  return fallback;
+};
+
+const resolveTemplateStyles = (template) => {
+  const borderColor = template?.border_color ?? template?.borderColor ?? "#FACC15";
+  const fontFamily = template?.font_family ?? template?.fontFamily ?? "Georgia, serif";
+  const titleFont = template?.title_font ?? template?.titleFont ?? "'Great Vibes', cursive";
+  const showQRSetting = template?.show_qr ?? template?.showQR;
+  const backgroundValue =
+    template?.background ?? template?.background_image ?? template?.backgroundUrl;
+  const logoValue = template?.logo ?? template?.logo_url ?? template?.logoUrl;
+
+  return {
+    borderColor,
+    fontFamily,
+    titleFont,
+    showQR: typeof showQRSetting === "boolean" ? showQRSetting : true,
+    backgroundImage: sanitizeTemplateImage(backgroundValue, "/images/paper-texture.png"),
+    logoImage: sanitizeTemplateImage(logoValue, "/images/certificate/logo.png"),
   };
+};
 
-  const sanitizedSampleData = Object.fromEntries(
-    Object.entries(normalizedSampleData).filter(([, value]) => value !== undefined && value !== null)
+const buildVerificationUrl = (serialValue, data) => {
+  const explicitUrl = data.certificateUrl;
+  if (explicitUrl && typeof explicitUrl === "string" && explicitUrl.trim()) {
+    return explicitUrl.trim();
+  }
+
+  const base = FALLBACK_VERIFICATION_BASE.replace(/\/$/, "");
+  return `${base}/certificate/verify/${encodeURIComponent(serialValue)}`;
+};
+
+export default function CertificatePreviewModal({
+  template,
+  previewData,
+  loadingPreview = false,
+  onClose,
+}) {
+  const templateData = template || {};
+
+  useEffect(() => {
+    const originalOverflow = typeof document !== "undefined" ? document.body.style.overflow : "";
+
+    if (typeof document !== "undefined") {
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      if (typeof document !== "undefined") {
+        document.body.style.overflow = originalOverflow;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape" && onClose) {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  const { borderColor, fontFamily, titleFont, showQR, backgroundImage, logoImage } = useMemo(
+    () => resolveTemplateStyles(templateData),
+    [templateData],
   );
 
-  const data = {
-    ...defaultData,
-    ...sanitizedSampleData,
-    ...(mockData || {}),
+  const resolvedData = useMemo(() => {
+    const defaults = buildDefaultPreviewData(templateData);
+    const sampleData = normalizeCertificatePayload(
+      templateData.sample_data ?? templateData.sampleData,
+    );
+    const previewOverrides = normalizeCertificatePayload(previewData);
+
+    const merged = {
+      ...defaults,
+      ...sampleData,
+      ...previewOverrides,
+    };
+
+    if (!merged.certificateCode && merged.id) {
+      merged.certificateCode = `PREVIEW-${String(merged.id).slice(0, 8).toUpperCase()}`;
+    }
+
+    return merged;
+  }, [templateData, previewData]);
+
+  const serialValue = useMemo(() => {
+    const raw =
+      resolvedData.certificateCode || resolvedData.certificateId || resolvedData.id || "";
+    const trimmed = String(raw).trim();
+    return trimmed ? trimmed.toUpperCase() : "PREVIEW-000000";
+  }, [resolvedData]);
+
+  const issueDateLabel = useMemo(() => {
+    if (!resolvedData.issueDate) {
+      return null;
+    }
+
+    const date = new Date(resolvedData.issueDate);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return date.toLocaleDateString();
+  }, [resolvedData.issueDate]);
+
+  const verificationUrl = useMemo(
+    () => buildVerificationUrl(serialValue, resolvedData),
+    [resolvedData, serialValue],
+  );
+
+  const effectiveLoading = Boolean(loadingPreview && !previewData);
+  const certificateType = templateData.type || "Completion";
+
+  const handleBackdropClick = (event) => {
+    if (event.target === event.currentTarget && onClose) {
+      onClose();
+    }
   };
 
-  const {
-    border_color,
-    font_family,
-    title_font,
-    background = "/images/paper-texture.png",
-    logo = "/images/certificate/logo.png",
-    show_qr,
-    borderColor: legacyBorderColor,
-    fontFamily: legacyFontFamily,
-    titleFont: legacyTitleFont,
-    showQR: legacyShowQR,
-  } = template;
-
-  const borderColor = border_color ?? legacyBorderColor ?? "#FACC15";
-  const fontFamily = font_family ?? legacyFontFamily ?? "Georgia, serif";
-  const titleFont = title_font ?? legacyTitleFont ?? "'Great Vibes', cursive";
-  const showQR = show_qr ?? legacyShowQR ?? true;
-  const safeBackground = isTemplateAsset(background)
-    ? background
-    : "/images/paper-texture.png";
-  const safeLogo = isTemplateAsset(logo)
-    ? logo
-    : "/images/certificate/logo.png";
-
-  const serialValue = (resolvedData.certificateCode || `CERT-${String(resolvedData.id).slice(0, 6)}`).toUpperCase();
-
   return (
-    <div className="fixed inset-0 bg-gradient-to-br from-black/80 to-black/60 flex items-center justify-center z-50">
-      <div className="relative w-full max-w-5xl max-h-[90vh] bg-white rounded-2xl shadow-2xl p-6 overflow-auto border border-gray-200">
-        {/* Close Button */}
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      onClick={handleBackdropClick}
+    >
+      <div className="relative w-full max-w-5xl max-h-[90vh] overflow-auto rounded-2xl border border-gray-200 bg-white p-6 shadow-2xl">
         <button
+          type="button"
           onClick={onClose}
-          className="absolute top-4 right-4 text-gray-500 hover:text-red-500 z-10"
+          className="absolute right-4 top-4 text-gray-500 transition hover:text-red-500"
+          aria-label="Close certificate preview"
         >
           <FaTimes size={20} />
         </button>
 
-        {/* Certificate Design */}
         <div
-          className="w-full border-[12px] rounded-xl p-10 text-center relative shadow-inner"
+          className="relative w-full border-[12px] rounded-xl p-10 text-center shadow-inner"
           style={{
-            backgroundImage: `url('${safeBackground}')`,
+            backgroundImage: `url('${backgroundImage}')`,
             backgroundSize: "cover",
             backgroundRepeat: "no-repeat",
             borderColor,
@@ -107,75 +274,62 @@ const buildFallbackPreview = (template) => {
           }}
         >
           {effectiveLoading && (
-            <div className="absolute inset-0 bg-white/70 backdrop-blur-sm flex items-center justify-center z-20 rounded-xl">
-              <span className="text-gray-600 font-semibold">Loading preview...</span>
+            <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-white/75 backdrop-blur-sm">
+              <span className="text-gray-600">Loading preview...</span>
             </div>
           )}
-          {/* Logo */}
-          <div className="flex justify-center mb-6">
-            <img src={safeLogo} alt="Logo" className="w-32" />
+
+          <div className="mb-6 flex justify-center">
+            <img src={logoImage} alt="Certificate logo" className="h-24 w-24 object-contain" />
           </div>
 
-          {/* Title */}
-          <h1
-            className="text-5xl font-bold text-yellow-600 mb-6"
-            style={{ fontFamily: titleFont }}
-          >
-            Certificate of {template.type || "Completion"}
+          <h1 className="mb-6 text-5xl font-bold text-yellow-600" style={{ fontFamily: titleFont }}>
+            Certificate of {certificateType}
           </h1>
 
-          <p className="text-lg text-gray-700 mb-1">This certifies that</p>
+          <p className="mb-1 text-lg text-gray-700">This certifies that</p>
 
-          <h2 className="text-4xl font-extrabold text-gray-800 mb-4">
+          <h2 className="mb-4 text-4xl font-extrabold text-gray-800">
             {resolvedData.studentName}
           </h2>
 
-          <p className="text-lg text-gray-700 mb-1">has successfully completed</p>
+          <p className="mb-1 text-lg text-gray-700">has successfully completed</p>
 
-          <h3 className="text-2xl italic text-gray-700 mb-6">
-            "{resolvedData.courseName}"
-          </h3>
+          <h3 className="mb-6 text-2xl italic text-gray-700">“{resolvedData.courseName}”</h3>
 
           {resolvedData.grade && (
-            <p className="text-lg text-gray-600 mb-4">
-              Final Grade: <span className="text-green-600 font-bold text-2xl">{resolvedData.grade}</span>
+            <p className="mb-4 text-lg text-gray-600">
+              Final Grade: <span className="text-2xl font-bold text-green-600">{resolvedData.grade}</span>
             </p>
           )}
 
-          <p className="text-sm text-gray-500 mb-1">
-            Issued on: <strong>{new Date(resolvedData.issueDate).toLocaleDateString()}</strong>
+          <p className="mb-1 text-sm text-gray-500">
+            Issued on: <strong>{issueDateLabel || "Pending"}</strong>
           </p>
-          <p className="text-sm text-gray-500 mb-6">
+          <p className="mb-6 text-sm text-gray-500">
             Serial Number: <strong>{serialValue}</strong>
           </p>
 
-          {/* Footer Row */}
-          <div className="flex flex-col sm:flex-row justify-between items-center gap-6 px-4 mt-8">
-            {/* Instructor Signature */}
+          <div className="mt-8 flex flex-col items-center gap-6 px-4 sm:flex-row sm:justify-between">
             <div className="text-center">
               <p className="text-sm text-gray-500">Instructor</p>
               <h4 className="font-bold text-gray-700">{resolvedData.instructor}</h4>
               <img
                 src="/images/certificate/instructor-signature.png"
-                alt="Instructor Signature"
-                className="w-28 mx-auto mt-2"
+                alt="Instructor signature"
+                className="mx-auto mt-2 w-28"
               />
             </div>
 
-            {/* QR Code */}
             {showQR && (
               <div className="text-center">
-                <div className="bg-white border border-gray-200 p-2 rounded-md inline-block shadow-sm">
-                  <QRCode
-                    value={`https://yourplatform.com/certificate/verify/${resolvedData.id}`}
-                    size={80}
-                  />
+                <div className="inline-block rounded-md border border-gray-200 bg-white p-2 shadow-sm">
+                  <QRCode value={verificationUrl} size={96} />
                 </div>
-                <p className="text-[10px] text-gray-500 mt-1">Scan to Verify</p>
+                <p className="mt-1 text-[10px] uppercase tracking-wide text-gray-500">Scan to verify</p>
               </div>
             )}
 
-            {/* Platform Signature */}
             <div className="text-center">
               <p className="text-sm text-gray-500">Issued by</p>
               <h4 className="font-bold text-gray-700">{resolvedData.platformName}</h4>


### PR DESCRIPTION
## Summary
- rewrite the certificate preview modal so it exports a valid component and no longer crashes the frontend build
- normalize sample and preview data, add resilient fallbacks, and polish the modal UX for instructor and admin previews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d86ca8b5ec8328a638ea1cde6f15fa