### PR TITLE
Handle existing access_type column in migration

### DIFF
--- a/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
@@ -1,19 +1,35 @@
 exports.up = async function (knex) {
-  return knex.schema.alterTable('online_classes', (table) => {
-    table
-      .enu('access_type', ['paid', 'free'], {
-        useNative: true,
-        enumName: 'online_class_access_type',
-      })
-      .notNullable()
-      .defaultTo('paid');
-  });
+  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
 
+  if (!hasColumn) {
+    await knex.schema.alterTable('online_classes', (table) => {
+      table
+        .enu('access_type', ['paid', 'free'], {
+          useNative: true,
+          enumName: 'online_class_access_type',
+        })
+        .notNullable()
+        .defaultTo('paid');
+    });
+  }
 };
 
 exports.down = async function (knex) {
-  await knex.schema.alterTable('online_classes', (table) => {
-    table.dropColumn('access_type');
-  });
-  await knex.raw('DROP TYPE IF EXISTS online_class_access_type');
+  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
+
+  if (hasColumn) {
+    await knex.schema.alterTable('online_classes', (table) => {
+      table.dropColumn('access_type');
+    });
+  }
+
+  const {
+    rows: [typeExists],
+  } = await knex.raw(
+    "SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'online_class_access_type') AS exists"
+  );
+
+  if (typeExists?.exists) {
+    await knex.raw('DROP TYPE online_class_access_type');
+  }
 };


### PR DESCRIPTION
## Summary
- guard the online_classes access_type migration to skip when the column already exists
- ensure the down migration only drops the column and enum type when present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d86ffadb9883288c234881c3a870ea