### PR TITLE
Fix class installment validation

### DIFF
--- a/backend/src/modules/payments/helpers/validation.js
+++ b/backend/src/modules/payments/helpers/validation.js
@@ -29,19 +29,7 @@ async function validatePaymentData(body, userId) {
 
   let schedules = [];
   let next_due_date = null;
-  let totalInstallments = allow_installments ? installments || 1 : 1;
-  if (allow_installments && totalInstallments > 1) {
-    for (let i = 2; i <= totalInstallments; i++) {
-      const due = new Date();
-      due.setMonth(due.getMonth() + (i - 1));
-      schedules.push({
-        installment_number: i,
-        amount,
-        due_date: due,
-      });
-    }
-    next_due_date = schedules[0]?.due_date || null;
-  }
+  let totalInstallments = allow_installments ? Number(installments) || 1 : 1;
 
   let method;
   if (method_id) {
@@ -134,6 +122,15 @@ async function validatePaymentData(body, userId) {
   if (item_type === "class") {
     const cls = await classService.getClassById(item_id);
     if (!cls) throw new AppError("Class not found", 404);
+    if (
+      !cls.allow_installments &&
+      (allow_installments || (Number(installments) || 0) > 1)
+    ) {
+      throw new AppError("Installments not allowed for this class", 400);
+    }
+    if (!cls.allow_installments) {
+      totalInstallments = 1;
+    }
     basePrice = Number(cls.price);
   } else if (item_type === "book") {
     const book = await bookService.getBookById(item_id);
@@ -201,6 +198,19 @@ async function validatePaymentData(body, userId) {
     if (Math.abs(verifiedAmount - expected) >= EPS) {
       throw new AppError("Payment amount does not match item price", 400);
     }
+  }
+
+  if (totalInstallments > 1) {
+    for (let i = 2; i <= totalInstallments; i++) {
+      const due = new Date();
+      due.setMonth(due.getMonth() + (i - 1));
+      schedules.push({
+        installment_number: i,
+        amount,
+        due_date: due,
+      });
+    }
+    next_due_date = schedules[0]?.due_date || null;
   }
 
   return {

--- a/backend/tests/studentPaymentRoutes.test.js
+++ b/backend/tests/studentPaymentRoutes.test.js
@@ -5,10 +5,18 @@ jest.mock('../src/modules/payments/payments.service', () => ({
   getByUser: jest.fn(),
   getById: jest.fn(),
   create: jest.fn(),
+  STATUS: {
+    PAID: 'paid',
+    PENDING_PAYMENT: 'pending_payment',
+  },
 }));
 
 jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
   getById: jest.fn(),
+}));
+
+jest.mock('../src/modules/classes/class.service', () => ({
+  getClassById: jest.fn(),
 }));
 
 jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
@@ -37,11 +45,19 @@ const service = require('../src/modules/payments/payments.service');
 const methodService = require('../src/modules/paymentMethods/paymentMethods.service');
 const configService = require('../src/modules/paymentConfig/paymentConfig.service');
 const couponService = require('../src/modules/coupons/coupons.service');
+const classService = require('../src/modules/classes/class.service');
+
+process.env.TEST_DATABASE_URL =
+  process.env.TEST_DATABASE_URL || 'postgres://user:pass@localhost:5432/testdb';
 const routes = require('../src/modules/payments/student.routes');
 
 const app = express();
 app.use(express.json());
 app.use('/api/payments/student', routes);
+app.use((err, _req, res, _next) => {
+  const status = err.statusCode || err.status || 500;
+  res.status(status).json({ message: err.message });
+});
 
 describe('GET /api/payments/student', () => {
   it('returns student payments', async () => {
@@ -86,6 +102,11 @@ describe('POST /api/payments/student', () => {
   it('creates a payment using authenticated user id', async () => {
     methodService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
     configService.getSettings.mockResolvedValue({ platformCut: {} });
+    classService.getClassById.mockResolvedValue({
+      id: 'i1',
+      price: 100,
+      allow_installments: true,
+    });
     service.create.mockResolvedValue({ id: 'p1', reference_id: 'ref', status: 'pending_payment' });
 
     const res = await request(app).post('/api/payments/student').send({
@@ -127,6 +148,28 @@ describe('POST /api/payments/student', () => {
       item_id: 'i1',
       amount: 100,
       coupon_id: 'bad',
+    });
+
+    expect(res.status).toBe(400);
+    expect(service.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects installments when class does not allow them', async () => {
+    methodService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
+    configService.getSettings.mockResolvedValue({ platformCut: {} });
+    classService.getClassById.mockResolvedValue({
+      id: 'i1',
+      price: 100,
+      allow_installments: false,
+    });
+
+    const res = await request(app).post('/api/payments/student').send({
+      method_id: 'm1',
+      item_type: 'class',
+      item_id: 'i1',
+      amount: 100,
+      allow_installments: true,
+      installments: 3,
     });
 
     expect(res.status).toBe(400);


### PR DESCRIPTION
## Summary
- block installment checkout requests for classes that disallow installments and normalize the installment count before schedule creation
- add regression coverage for student payment creation when class installments are disabled

## Testing
- npm test -- studentPaymentRoutes

------
https://chatgpt.com/codex/tasks/task_e_68d874122f308328a91b61a9e6e4edac