### PR TITLE
Block student payments for unavailable classes

### DIFF
--- a/backend/src/modules/payments/helpers/validation.js
+++ b/backend/src/modules/payments/helpers/validation.js
@@ -5,6 +5,7 @@ const paypalService = require("../../../services/paypalService");
 const stripeService = require("../../../services/stripeService");
 const couponService = require("../../coupons/coupons.service");
 const classService = require("../../classes/class.service");
+const classEnrollmentService = require("../../classes/enrollments/classEnrollment.service");
 const bookService = require("../../books/book.service");
 const tutorialService = require("../../users/tutorials/tutorial.service");
 const plansService = require("../../plans/plans.service");
@@ -134,6 +135,17 @@ async function validatePaymentData(body, userId) {
   if (item_type === "class") {
     const cls = await classService.getClassById(item_id);
     if (!cls) throw new AppError("Class not found", 404);
+    if (cls.status !== "published" || cls.moderation_status !== "Approved") {
+      throw new AppError("Class is not available for enrollment", 400);
+    }
+    if (cls.max_students) {
+      const currentEnrollments = await classEnrollmentService.countEnrollments(
+        item_id
+      );
+      if (currentEnrollments >= cls.max_students) {
+        throw new AppError("Class is fully booked", 400);
+      }
+    }
     basePrice = Number(cls.price);
   } else if (item_type === "book") {
     const book = await bookService.getBookById(item_id);

--- a/backend/tests/studentPaymentRoutes.test.js
+++ b/backend/tests/studentPaymentRoutes.test.js
@@ -1,7 +1,14 @@
 const request = require('supertest');
 const express = require('express');
 
+process.env.TEST_DATABASE_URL =
+  process.env.TEST_DATABASE_URL || 'postgres://user:pass@localhost:5432/test';
+
 jest.mock('../src/modules/payments/payments.service', () => ({
+  STATUS: {
+    PENDING_PAYMENT: 'pending_payment',
+    PAID: 'paid',
+  },
   getByUser: jest.fn(),
   getById: jest.fn(),
   create: jest.fn(),
@@ -9,6 +16,14 @@ jest.mock('../src/modules/payments/payments.service', () => ({
 
 jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
   getById: jest.fn(),
+}));
+
+jest.mock('../src/modules/classes/class.service', () => ({
+  getClassById: jest.fn(),
+}));
+
+jest.mock('../src/modules/classes/enrollments/classEnrollment.service', () => ({
+  countEnrollments: jest.fn(),
 }));
 
 jest.mock('../src/modules/paymentConfig/paymentConfig.service', () => ({
@@ -35,6 +50,8 @@ jest.mock('../src/middleware/auth/authMiddleware', () => ({
 
 const service = require('../src/modules/payments/payments.service');
 const methodService = require('../src/modules/paymentMethods/paymentMethods.service');
+const classService = require('../src/modules/classes/class.service');
+const enrollmentService = require('../src/modules/classes/enrollments/classEnrollment.service');
 const configService = require('../src/modules/paymentConfig/paymentConfig.service');
 const couponService = require('../src/modules/coupons/coupons.service');
 const routes = require('../src/modules/payments/student.routes');
@@ -81,6 +98,14 @@ describe('GET /api/payments/student/:id', () => {
 describe('POST /api/payments/student', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    classService.getClassById.mockResolvedValue({
+      id: 'i1',
+      price: 100,
+      status: 'published',
+      moderation_status: 'Approved',
+      max_students: null,
+    });
+    enrollmentService.countEnrollments.mockResolvedValue(0);
   });
 
   it('creates a payment using authenticated user id', async () => {
@@ -127,6 +152,51 @@ describe('POST /api/payments/student', () => {
       item_id: 'i1',
       amount: 100,
       coupon_id: 'bad',
+    });
+
+    expect(res.status).toBe(400);
+    expect(service.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects unpublished classes', async () => {
+    methodService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
+    configService.getSettings.mockResolvedValue({ platformCut: {} });
+    classService.getClassById.mockResolvedValue({
+      id: 'i1',
+      price: 100,
+      status: 'draft',
+      moderation_status: 'Pending',
+      max_students: null,
+    });
+
+    const res = await request(app).post('/api/payments/student').send({
+      method_id: 'm1',
+      item_type: 'class',
+      item_id: 'i1',
+      amount: 100,
+    });
+
+    expect(res.status).toBe(400);
+    expect(service.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects fully booked classes', async () => {
+    methodService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
+    configService.getSettings.mockResolvedValue({ platformCut: {} });
+    classService.getClassById.mockResolvedValue({
+      id: 'i1',
+      price: 100,
+      status: 'published',
+      moderation_status: 'Approved',
+      max_students: 1,
+    });
+    enrollmentService.countEnrollments.mockResolvedValue(1);
+
+    const res = await request(app).post('/api/payments/student').send({
+      method_id: 'm1',
+      item_type: 'class',
+      item_id: 'i1',
+      amount: 100,
     });
 
     expect(res.status).toBe(400);


### PR DESCRIPTION
## Summary
- ensure class payments are only accepted for published and approved classes
- prevent payments for classes that have reached their maximum enrollment
- cover unpublished and fully booked class scenarios in student payment route tests

## Testing
- npm test -- studentPaymentRoutes

------
https://chatgpt.com/codex/tasks/task_e_68d87413e71883288ba0abafb01c28cd