### PR TITLE
Ensure subscription payments include method id

### DIFF
--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -15,6 +15,18 @@ const planRevenue = require("../payments/helpers/planRevenue");
 
 const { STATUS: PAYMENT_STATUS } = paymentsService;
 
+const getSubscriptionPaymentMethod = async () => {
+  const method =
+    (await paymentMethodsService.getByType("subscription")) ||
+    (await paymentMethodsService.getByType("free"));
+
+  if (!method) {
+    throw new AppError("Subscription payment method not configured", 400);
+  }
+
+  return method;
+};
+
 const DEFAULT_PLATFORM_CUT = { book: 10 };
 
 exports.createBook = async (data) => {
@@ -273,6 +285,7 @@ exports.checkout = async (studentId) => {
   if (!bankMethod) throw new AppError('Bank payment method not configured', 400);
 
   const activePlanId = await getActiveStudentPlanId(studentId);
+  let subscriptionMethod = null;
 
   return db.transaction(async (trx) => {
     const items = await trx('book_cart')
@@ -315,6 +328,9 @@ exports.checkout = async (studentId) => {
       const coveredBySubscription = activePlanId && includedPlans.includes(activePlanId);
 
       if (coveredBySubscription) {
+        if (!subscriptionMethod) {
+          subscriptionMethod = await getSubscriptionPaymentMethod();
+        }
         const usage = await trx('plan_usage_metrics')
           .where({ plan_id: activePlanId, item_type: 'book', item_id: b.id })
           .first();
@@ -342,6 +358,7 @@ exports.checkout = async (studentId) => {
             amount: 0,
             status: PAYMENT_STATUS.PAID,
             source: 'subscription',
+            method_id: subscriptionMethod.id,
           })
           .returning('*');
 

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -47,6 +47,10 @@ jest.mock('../../../payments/helpers/wallet', () => ({
   creditInstructorSubscription: jest.fn(),
 }));
 
+jest.mock('../../../paymentMethods/paymentMethods.service', () => ({
+  getByType: jest.fn(),
+}));
+
 jest.mock('../../../../utils/logger.js', () => ({
   log: jest.fn(),
   debug: jest.fn(),
@@ -56,6 +60,7 @@ jest.mock('../../../../utils/logger.js', () => ({
 
 const { getActiveStudentPlanId } = require('../../../plans/subscription.helper');
 const { creditInstructorSubscription } = require('../../../payments/helpers/wallet');
+const paymentMethodsService = require('../../../paymentMethods/paymentMethods.service');
 const logger = require('../../../../utils/logger.js');
 const db = require('../../../../config/database');
 
@@ -68,6 +73,11 @@ app.use('/classes', routes);
 describe('Class enrollment routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    paymentMethodsService.getByType.mockImplementation((type) => {
+      if (type === 'subscription') return Promise.resolve(null);
+      if (type === 'free') return Promise.resolve({ id: 'free-method' });
+      return Promise.resolve(null);
+    });
   });
 
   test('enroll in class', async () => {
@@ -156,6 +166,7 @@ describe('Class enrollment routes', () => {
         item_type: 'class',
         source: 'subscription',
         amount: 0,
+        method_id: 'free-method',
       }),
     );
   });

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -9,6 +9,19 @@ const paymentsService = require("../../payments/payments.service");
 const { getActiveStudentPlanId } = require("../../plans/subscription.helper");
 const { creditInstructorSubscription } = require("../../payments/helpers/wallet");
 const planRevenue = require("../../payments/helpers/planRevenue");
+const paymentMethodsService = require("../../paymentMethods/paymentMethods.service");
+
+const getSubscriptionPaymentMethod = async () => {
+  const method =
+    (await paymentMethodsService.getByType("subscription")) ||
+    (await paymentMethodsService.getByType("free"));
+
+  if (!method) {
+    throw new AppError("Subscription payment method not configured", 400);
+  }
+
+  return method;
+};
 
 exports.enroll = catchAsync(async (req, res) => {
   const { classId } = req.params;
@@ -43,6 +56,7 @@ exports.enroll = catchAsync(async (req, res) => {
       activePlanId && includedPlans.includes(activePlanId);
 
     if (coveredBySubscription) {
+      const subscriptionMethod = await getSubscriptionPaymentMethod();
       const usage = await trx("plan_usage_metrics")
         .where({ plan_id: activePlanId, item_type: "class", item_id: classId })
         .first();
@@ -73,6 +87,7 @@ exports.enroll = catchAsync(async (req, res) => {
         item_type: "class",
         source: "subscription",
         amount: 0,
+        method_id: subscriptionMethod.id,
       });
       // Credit the instructor for subscription-based enrollments so that
       // instructors are compensated when a class is taken via a plan.

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -6,6 +6,19 @@ const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
 const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
 const planRevenue = require("../../../payments/helpers/planRevenue");
+const paymentMethodsService = require("../../../paymentMethods/paymentMethods.service");
+
+const getSubscriptionPaymentMethod = async () => {
+  const method =
+    (await paymentMethodsService.getByType("subscription")) ||
+    (await paymentMethodsService.getByType("free"));
+
+  if (!method) {
+    throw new AppError("Subscription payment method not configured", 400);
+  }
+
+  return method;
+};
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -30,6 +43,7 @@ exports.enroll = catchAsync(async (req, res) => {
 
   const enroll = async (trx) => {
     if (coveredBySubscription) {
+      const subscriptionMethod = await getSubscriptionPaymentMethod();
       const usage = await trx("plan_usage_metrics")
         .where({
           plan_id: activePlanId,
@@ -68,6 +82,7 @@ exports.enroll = catchAsync(async (req, res) => {
         item_type: "tutorial",
         source: "subscription",
         amount: 0,
+        method_id: subscriptionMethod.id,
       });
     } else if (Number(tutorial.price) > 0) {
       const payment = await trx("payments")

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -15,6 +15,11 @@ jest.mock('../src/modules/payments/helpers/planRevenue', () => ({
 }));
 const planRevenue = require('../src/modules/payments/helpers/planRevenue');
 
+jest.mock('../src/modules/paymentMethods/paymentMethods.service', () => ({
+  getByType: jest.fn(),
+}));
+const paymentMethodsService = require('../src/modules/paymentMethods/paymentMethods.service');
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
     req.user = { id: 'user1' };
@@ -34,6 +39,11 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getActiveStudentPlanId.mockResolvedValue(null);
+    paymentMethodsService.getByType.mockImplementation((type) => {
+      if (type === 'subscription') return Promise.resolve(null);
+      if (type === 'free') return Promise.resolve({ id: 'free-method' });
+      return Promise.resolve(null);
+    });
   });
 
   it('enrolls in a free tutorial', async () => {
@@ -176,6 +186,7 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
       item_type: 'tutorial',
       source: 'subscription',
       amount: 0,
+      method_id: 'free-method',
     });
     expect(planRevenue.calculateInstructorAmount).toHaveBeenCalledWith(
       'plan1',


### PR DESCRIPTION
## Summary
- load the configured subscription payment method when recording plan-funded enrollments for classes, tutorials, and books
- persist the method identifier on zero-amount subscription payments and raise a controlled error if no method is configured
- update enrollment route tests to mock the payment method lookup and assert the method_id is included in subscription payment payloads

## Testing
- npm test -- tutorialEnrollmentRoutes.test.js classEnrollment.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d87414bdb88328b60fbe7adbdb9856