### PR TITLE
Handle malformed class tag payloads

### DIFF
--- a/backend/src/modules/classes/__tests__/class.controller.test.js
+++ b/backend/src/modules/classes/__tests__/class.controller.test.js
@@ -59,6 +59,7 @@ const controller = require('../class.controller');
 const service = require('../class.service');
 const { getActiveInstructorPlan } = require('../../plans/instructor.helper');
 const notificationService = require('../../notifications/notifications.service');
+const AppError = require('../../../utils/AppError');
 
 describe('class.controller createClass', () => {
   beforeEach(() => {
@@ -138,6 +139,32 @@ describe('class.controller createClass', () => {
         data: expect.objectContaining({ included_plans: ['plan-student'] })
       })
     );
+  });
+
+  test('rejects malformed tags payload', async () => {
+    const req = {
+      body: { title: 'Test', tags: '{not-json}' },
+      user: { id: 'admin1', role: 'admin' },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      next.mockImplementation((err) => {
+        resolve();
+        return err;
+      });
+      controller.createClass(req, res, next);
+    });
+
+    expect(service.createClass).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(AppError));
+    expect(next.mock.calls[0][0].statusCode).toBe(400);
+    expect(next.mock.calls[0][0].message).toBe('Invalid tags format. Expected an array of strings.');
   });
 
   test('allows creating free access classes when specified', async () => {
@@ -286,6 +313,39 @@ describe('class.controller updateClass', () => {
         data: expect.objectContaining({ instructor_id: 'newInst' }),
       })
     );
+  });
+
+  test('update rejects malformed tags payload', async () => {
+    service.getClassById.mockResolvedValue({
+      id: 'class1',
+      instructor_id: 'admin1',
+      title: 'Title',
+    });
+
+    const req = {
+      params: { id: 'class1' },
+      body: { tags: '{not-json}' },
+      user: { id: 'admin1', role: 'admin', full_name: 'Admin' },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      next.mockImplementation((err) => {
+        resolve();
+        return err;
+      });
+      controller.updateClass(req, res, next);
+    });
+
+    expect(service.updateClass).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(AppError));
+    expect(next.mock.calls[0][0].statusCode).toBe(400);
+    expect(next.mock.calls[0][0].message).toBe('Invalid tags format. Expected an array of strings.');
   });
 });
 

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -18,6 +18,34 @@ const db = require("../../config/database");
 const fs = require("fs");
 const path = require("path");
 
+const TAGS_FORMAT_ERROR = "Invalid tags format. Expected an array of strings.";
+
+const normalizeTagsInput = (input, { defaultValue = [] } = {}) => {
+  if (input === undefined || input === null || input === "") {
+    return defaultValue;
+  }
+
+  if (Array.isArray(input)) {
+    return input;
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input);
+
+      if (!Array.isArray(parsed)) {
+        throw new AppError(TAGS_FORMAT_ERROR, 400);
+      }
+
+      return parsed;
+    } catch (error) {
+      throw new AppError(TAGS_FORMAT_ERROR, 400);
+    }
+  }
+
+  throw new AppError(TAGS_FORMAT_ERROR, 400);
+};
+
 const generateUniqueSlug = async (title) => {
   const base = slugify(title, { lower: true, strict: true });
   let slug = base;
@@ -91,7 +119,7 @@ exports.createClass = catchAsync(async (req, res) => {
   if (req.files?.demo_video?.[0]) {
     data.demo_video_url = `/uploads/classes/${req.files.demo_video[0].filename}`;
   }
-  const tags = rawTags ? JSON.parse(rawTags) : [];
+  const tags = normalizeTagsInput(rawTags);
   const cls = await service.createClass(data);
   if (tags.length) {
     const tagIds = [];
@@ -282,24 +310,28 @@ exports.updateClass = catchAsync(async (req, res) => {
   if (req.user.role === 'instructor') {
     data.instructor_id = existing.instructor_id;
   }
-  const tags = rawTags ? JSON.parse(rawTags) : null;
+  const tags = normalizeTagsInput(rawTags, { defaultValue: null });
   const cls = await service.updateClass(req.params.id, data);
-  if (tags) {
+  if (tags !== null) {
     // remove existing then add
     await db('class_tag_map').where({ class_id: cls.id }).del();
-    const tagIds = [];
-    for (const name of tags) {
-      const existingTag = await tagService.findByName(name);
-      const tag =
-        existingTag ||
-        (await tagService.createTag({
-          name,
-          slug: slugify(name, { lower: true, strict: true }),
-        }));
-      tagIds.push(tag.id);
+    if (tags.length) {
+      const tagIds = [];
+      for (const name of tags) {
+        const existingTag = await tagService.findByName(name);
+        const tag =
+          existingTag ||
+          (await tagService.createTag({
+            name,
+            slug: slugify(name, { lower: true, strict: true }),
+          }));
+        tagIds.push(tag.id);
+      }
+      await service.addClassTags(cls.id, tagIds);
+      cls.tags = await service.getClassTags(cls.id);
+    } else {
+      cls.tags = [];
     }
-    await service.addClassTags(cls.id, tagIds);
-    cls.tags = await service.getClassTags(cls.id);
   }
   if (
     req.user.role !== "instructor" &&


### PR DESCRIPTION
## Summary
- add a shared tag normalization helper in the class controller to validate raw tag payloads
- reuse the helper for create and update flows to avoid double parsing and ensure consistent tag state
- expand controller tests to cover malformed tag submissions returning 400 errors

## Testing
- npm test -- class.controller.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8741b7944832895f0b1ec53d4c7a7