### PR TITLE
Resolve invoice attachments to filesystem paths

### DIFF
--- a/backend/src/modules/invoices/invoices.service.js
+++ b/backend/src/modules/invoices/invoices.service.js
@@ -6,9 +6,36 @@ const model = require("./invoice.model");
 
 const uploadDir = path.join(__dirname, "../../../uploads/invoices");
 
+const buildAbsolutePath = (pdfUrl) => {
+  if (!pdfUrl) return null;
+  return path.join(__dirname, "../../../", pdfUrl.replace(/^\//, ""));
+};
+
+const resolveInvoicePath = (invoiceOrUrl) => {
+  if (!invoiceOrUrl) return null;
+  if (typeof invoiceOrUrl === "string") {
+    return buildAbsolutePath(invoiceOrUrl);
+  }
+  if (invoiceOrUrl.pdf_path) {
+    return invoiceOrUrl.pdf_path;
+  }
+  return buildAbsolutePath(invoiceOrUrl.pdf_url);
+};
+
+const withResolvedPath = (invoice) => {
+  if (!invoice) return invoice;
+  const pdf_path = resolveInvoicePath(invoice);
+  if (pdf_path && invoice.pdf_path !== pdf_path) {
+    return { ...invoice, pdf_path };
+  }
+  return invoice;
+};
+
+exports.resolveInvoicePath = resolveInvoicePath;
+
 exports.generateFromPayment = async (payment, user) => {
   const existing = await model.findByPayment(payment.id);
-  if (existing) return existing;
+  if (existing) return withResolvedPath(existing);
 
   await fs.promises.mkdir(uploadDir, { recursive: true });
 
@@ -56,7 +83,8 @@ exports.generateFromPayment = async (payment, user) => {
     },
   };
 
-  return model.create(data);
+  const created = await model.create(data);
+  return withResolvedPath(created);
 };
 
 exports.getInvoices = () => model.getAll();

--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const logger = require('../../utils/logger.js');
 const catchAsync = require("../../utils/catchAsync");
 const AppError = require("../../utils/AppError");
@@ -336,12 +337,30 @@ exports.approveBankPayment = catchAsync(async (req, res) => {
     if (user) {
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user.email && !user.invoice_email_opt_out && invoice?.pdf_url) {
-        await mailService.sendMail({
-          to: user.email,
-          subject: "Payment Invoice",
-          html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: invoice.pdf_url }],
-        });
+        const attachmentPath =
+          (typeof invoiceService.resolveInvoicePath === "function"
+            ? invoiceService.resolveInvoicePath(invoice)
+            : null) ||
+          invoice.pdf_path ||
+          path.join(
+            __dirname,
+            "../../../",
+            invoice.pdf_url.replace(/^\//, "")
+          );
+
+        if (attachmentPath) {
+          await mailService.sendMail({
+            to: user.email,
+            subject: "Payment Invoice",
+            html: `<p>Please find your invoice attached.</p>`,
+            attachments: [{ path: attachmentPath }],
+          });
+        } else {
+          logger.warn(
+            "Invoice generated without a resolvable attachment path",
+            { invoiceId: invoice?.id, pdf_url: invoice?.pdf_url }
+          );
+        }
       }
     }
   } catch (err) {

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const logger = require('../../utils/logger.js');
 const catchAsync = require("../../utils/catchAsync");
 const AppError = require("../../utils/AppError");
@@ -187,12 +188,30 @@ exports.createPayment = catchAsync(async (req, res) => {
       }
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
-        await mailService.sendMail({
-          to: user.email,
-          subject: "Payment Invoice",
-          html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: invoice.pdf_url }],
-        });
+        const attachmentPath =
+          (typeof invoiceService.resolveInvoicePath === "function"
+            ? invoiceService.resolveInvoicePath(invoice)
+            : null) ||
+          invoice.pdf_path ||
+          path.join(
+            __dirname,
+            "../../../",
+            invoice.pdf_url.replace(/^\//, "")
+          );
+
+        if (attachmentPath) {
+          await mailService.sendMail({
+            to: user.email,
+            subject: "Payment Invoice",
+            html: `<p>Please find your invoice attached.</p>`,
+            attachments: [{ path: attachmentPath }],
+          });
+        } else {
+          logger.warn(
+            "Invoice generated without a resolvable attachment path",
+            { invoiceId: invoice?.id, pdf_url: invoice?.pdf_url }
+          );
+        }
       }
     } catch (err) {
       logger.error("Failed to generate invoice:", err);
@@ -280,12 +299,30 @@ exports.updatePayment = catchAsync(async (req, res) => {
         try {
           const invoice = await invoiceService.generateFromPayment(payment, user);
           if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
-            await mailService.sendMail({
-              to: user.email,
-              subject: "Payment Invoice",
-              html: `<p>Please find your invoice attached.</p>`,
-              attachments: [{ path: invoice.pdf_url }],
-            });
+            const attachmentPath =
+              (typeof invoiceService.resolveInvoicePath === "function"
+                ? invoiceService.resolveInvoicePath(invoice)
+                : null) ||
+              invoice.pdf_path ||
+              path.join(
+                __dirname,
+                "../../../",
+                invoice.pdf_url.replace(/^\//, "")
+              );
+
+            if (attachmentPath) {
+              await mailService.sendMail({
+                to: user.email,
+                subject: "Payment Invoice",
+                html: `<p>Please find your invoice attached.</p>`,
+                attachments: [{ path: attachmentPath }],
+              });
+            } else {
+              logger.warn(
+                "Invoice generated without a resolvable attachment path",
+                { invoiceId: invoice?.id, pdf_url: invoice?.pdf_url }
+              );
+            }
           }
         } catch (err) {
           logger.error("Failed to generate invoice:", err);

--- a/backend/tests/paymentInvoiceEmail.test.js
+++ b/backend/tests/paymentInvoiceEmail.test.js
@@ -19,10 +19,34 @@ jest.mock('../src/modules/coupons/coupons.service', () => ({ getCouponById: jest
 jest.mock('../src/modules/plans/plans.service', () => ({ getPlanById: jest.fn() }));
 jest.mock('../src/modules/subscriptions/subscription.service', () => ({ createOrRenewSubscription: jest.fn() }));
 jest.mock('../src/modules/payouts/wallet.service', () => ({ increment: jest.fn() }));
+jest.mock('../src/modules/payments/helpers/planRevenue', () => ({ calculateInstructorAmount: jest.fn().mockResolvedValue(0) }));
 jest.mock('../src/modules/classes/class.service', () => ({ getClassById: jest.fn() }));
 jest.mock('../src/modules/books/book.service', () => ({ getBookById: jest.fn() }));
 jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({ getTutorialById: jest.fn() }));
-jest.mock('../src/modules/invoices/invoices.service', () => ({ generateFromPayment: jest.fn() }));
+const path = require("path");
+
+jest.mock('../src/modules/invoices/invoices.service', () => {
+  const mockPath = require('path');
+  const invoicesDir = mockPath.join(__dirname, '../src/modules/invoices');
+  const buildAbsolutePath = (pdfUrl) => {
+    if (!pdfUrl) return null;
+    return mockPath.join(invoicesDir, '../../../', pdfUrl.replace(/^\//, ''));
+  };
+  const resolveInvoicePath = jest.fn((invoiceOrUrl) => {
+    if (!invoiceOrUrl) return null;
+    if (typeof invoiceOrUrl === 'string') {
+      return buildAbsolutePath(invoiceOrUrl);
+    }
+    if (invoiceOrUrl.pdf_path) {
+      return invoiceOrUrl.pdf_path;
+    }
+    return buildAbsolutePath(invoiceOrUrl.pdf_url);
+  });
+  return {
+    generateFromPayment: jest.fn(),
+    resolveInvoicePath,
+  };
+});
 jest.mock('../src/modules/payments/paymentAccess', () => ({ grantAccess: jest.fn() }));
 
 const paymentsController = require('../src/modules/payments/payments.controller');
@@ -43,7 +67,15 @@ const notificationService = require('../src/modules/notifications/notifications.
 beforeEach(() => {
   jest.clearAllMocks();
   invoiceService.generateFromPayment.mockResolvedValue({ pdf_url: '/inv.pdf' });
-  mailService.sendMail.mockResolvedValue();
+  const expectedAttachmentPath = invoiceService.resolveInvoicePath({ pdf_url: '/inv.pdf' });
+  mailService.sendMail.mockImplementation((options = {}) => {
+    const attachmentPath = options.attachments?.[0]?.path;
+    if (attachmentPath) {
+      expect(attachmentPath).toBe(expectedAttachmentPath);
+      expect(path.isAbsolute(attachmentPath)).toBe(true);
+    }
+    return Promise.resolve();
+  });
   paymentConfigService.getSettings.mockResolvedValue({ platformCut: {} });
   userModel.findById.mockResolvedValue({ id: 'u1', email: 'u@test.com', full_name: 'User' });
   bookService.getBookById.mockResolvedValue({ price: 100, instructor_id: 'i1' });
@@ -67,7 +99,23 @@ describe('invoice email dispatch', () => {
     await paymentsController.createPayment(req, res, () => {});
     await new Promise(process.nextTick);
 
-    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+    const expectedAttachmentPath = invoiceService.resolveInvoicePath({ pdf_url: '/inv.pdf' });
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: expectedAttachmentPath }] }));
+  });
+
+  it('resolves invoice attachment paths to an absolute filesystem location', async () => {
+    paymentMethodsService.getById.mockResolvedValue({ id: 'mA', type: 'card', active: true });
+    paymentsService.create.mockResolvedValue({ id: 'pA', user_id: 'u1', method_id: 'mA', item_type: 'book', item_id: 'b1', amount: 100, currency: 'USD', status: 'paid' });
+
+    const req = { body: { method_id: 'mA', item_type: 'book', item_id: 'b1', amount: 100, status: 'paid' }, user: { id: 'u1' } };
+    const res = mockRes();
+    await paymentsController.createPayment(req, res, () => {});
+    await new Promise(process.nextTick);
+
+    const mailArgs = mailService.sendMail.mock.calls[0][0];
+    const attachmentPath = mailArgs.attachments?.[0]?.path;
+    expect(path.isAbsolute(attachmentPath)).toBe(true);
+    await expect(mailService.sendMail.mock.results[0].value).resolves.toBeUndefined();
   });
 
   it('sends invoice email for zero-amount payments', async () => {
@@ -81,7 +129,8 @@ describe('invoice email dispatch', () => {
     await new Promise(process.nextTick);
 
     expect(paymentsService.create).toHaveBeenCalledWith(expect.objectContaining({ amount: 0, status: 'paid' }));
-    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+    const expectedAttachmentPath = invoiceService.resolveInvoicePath({ pdf_url: '/inv.pdf' });
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: expectedAttachmentPath }] }));
   });
 
   it('sends invoice email for bank payments upon approval', async () => {
@@ -90,7 +139,8 @@ describe('invoice email dispatch', () => {
     await bankController.approveBankPayment(req, res, () => {});
     await new Promise(process.nextTick);
 
-    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+    const expectedAttachmentPath = invoiceService.resolveInvoicePath({ pdf_url: '/inv.pdf' });
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: expectedAttachmentPath }] }));
   });
 
   it('handles zero-amount payments without a method', async () => {
@@ -107,7 +157,8 @@ describe('invoice email dispatch', () => {
     expect(paymentsService.create).toHaveBeenCalled();
     expect(paymentsService.create.mock.calls[0][0].status).toBe('paid');
     expect(walletService.increment).toHaveBeenCalledWith('i1', 0);
-    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+    const expectedAttachmentPath = invoiceService.resolveInvoicePath({ pdf_url: '/inv.pdf' });
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: expectedAttachmentPath }] }));
   });
 
   it('triggers notification for paid plan payments', async () => {


### PR DESCRIPTION
## Summary
- resolve invoice attachments to filesystem paths in the payments and bank controllers before emailing and log when resolution fails
- expose a helper in the invoice service that maps stored pdf URLs to absolute paths and attach the resolved path to invoice objects
- extend the payment invoice email tests to verify absolute attachment paths and ensure mail delivery succeeds

## Testing
- npm test -- paymentInvoiceEmail --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d8741ce8a08328b391e7abdac7be35