### PR TITLE
Add subscription payment metadata handling

### DIFF
--- a/backend/src/migrations/20251101000000_add_source_to_payments.js
+++ b/backend/src/migrations/20251101000000_add_source_to_payments.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('payments', function (table) {
+    table.string('source');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('payments', function (table) {
+    table.dropColumn('source');
+  });
+};

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -333,17 +333,28 @@ exports.checkout = async (studentId) => {
 
         await planRevenue.calculateInstructorAmount(activePlanId, b.id, trx, 'book');
 
-        const [payment] = await trx('payments')
-          .insert({
+        const subscriptionMethod = await paymentMethodsService.getByType(
+          'subscription'
+        );
+        if (!subscriptionMethod) {
+          throw new AppError('Subscription payment method not configured', 500);
+        }
+
+        const payment = await paymentsService.create(
+          {
             id: uuidv4(),
             user_id: studentId,
             item_type: 'book',
             item_id: b.id,
             amount: 0,
             status: PAYMENT_STATUS.PAID,
+            method_id: subscriptionMethod.id,
             source: 'subscription',
-          })
-          .returning('*');
+            paid_at: new Date(),
+          },
+          [],
+          trx
+        );
 
         await trx('book_purchases').insert({
           student_id: studentId,

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -47,6 +47,15 @@ jest.mock('../../../payments/helpers/wallet', () => ({
   creditInstructorSubscription: jest.fn(),
 }));
 
+jest.mock('../../../payments/payments.service', () => ({
+  create: jest.fn(),
+  STATUS: { PAID: 'paid' },
+}));
+
+jest.mock('../../../paymentMethods/paymentMethods.service', () => ({
+  getByType: jest.fn(),
+}));
+
 jest.mock('../../../../utils/logger.js', () => ({
   log: jest.fn(),
   debug: jest.fn(),
@@ -58,6 +67,8 @@ const { getActiveStudentPlanId } = require('../../../plans/subscription.helper')
 const { creditInstructorSubscription } = require('../../../payments/helpers/wallet');
 const logger = require('../../../../utils/logger.js');
 const db = require('../../../../config/database');
+const paymentsService = require('../../../payments/payments.service');
+const paymentMethodsService = require('../../../paymentMethods/paymentMethods.service');
 
 const routes = require('../../class.routes');
 
@@ -137,6 +148,7 @@ describe('Class enrollment routes', () => {
     service.countEnrollments.mockResolvedValue(0);
     service.findEnrollment.mockResolvedValue(null);
     getActiveStudentPlanId.mockResolvedValue('plan1');
+    paymentMethodsService.getByType.mockResolvedValueOnce({ id: 'subscription-method' });
     service.createEnrollment.mockResolvedValue({ id: '1' });
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(200);
@@ -149,14 +161,19 @@ describe('Class enrollment routes', () => {
       expect.anything(),
     );
     expect(creditInstructorSubscription).toHaveBeenCalledTimes(1);
-    expect(db.insert).toHaveBeenCalledWith(
+    expect(paymentsService.create).toHaveBeenCalledWith(
       expect.objectContaining({
         user_id: 'test-user',
         item_id: 'abc',
         item_type: 'class',
         source: 'subscription',
         amount: 0,
+        status: 'paid',
+        method_id: 'subscription-method',
+        paid_at: expect.any(Date),
       }),
+      [],
+      db,
     );
   });
 

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -6,6 +6,7 @@ const AppError = require("../../../utils/AppError");
 const service = require("./classEnrollment.service");
 const db = require("../../../config/database");
 const paymentsService = require("../../payments/payments.service");
+const paymentMethodsService = require("../../paymentMethods/paymentMethods.service");
 const { getActiveStudentPlanId } = require("../../plans/subscription.helper");
 const { creditInstructorSubscription } = require("../../payments/helpers/wallet");
 const planRevenue = require("../../payments/helpers/planRevenue");
@@ -67,13 +68,27 @@ exports.enroll = catchAsync(async (req, res) => {
         "class"
       );
 
-      await trx("payments").insert({
-        user_id,
-        item_id: classId,
-        item_type: "class",
-        source: "subscription",
-        amount: 0,
-      });
+      const subscriptionMethod = await paymentMethodsService.getByType(
+        "subscription"
+      );
+      if (!subscriptionMethod) {
+        throw new AppError("Subscription payment method not configured", 500);
+      }
+
+      await paymentsService.create(
+        {
+          user_id,
+          item_id: classId,
+          item_type: "class",
+          amount: 0,
+          status: paymentsService.STATUS.PAID,
+          paid_at: new Date(),
+          method_id: subscriptionMethod.id,
+          source: "subscription",
+        },
+        [],
+        trx
+      );
       // Credit the instructor for subscription-based enrollments so that
       // instructors are compensated when a class is taken via a plan.
       await creditInstructorSubscription("class", classId, activePlanId, trx);

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -6,6 +6,8 @@ const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
 const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
 const planRevenue = require("../../../payments/helpers/planRevenue");
+const paymentsService = require("../../../payments/payments.service");
+const paymentMethodsService = require("../../../paymentMethods/paymentMethods.service");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -30,6 +32,13 @@ exports.enroll = catchAsync(async (req, res) => {
 
   const enroll = async (trx) => {
     if (coveredBySubscription) {
+      const subscriptionMethod = await paymentMethodsService.getByType(
+        "subscription"
+      );
+      if (!subscriptionMethod) {
+        throw new AppError("Subscription payment method not configured", 500);
+      }
+
       const usage = await trx("plan_usage_metrics")
         .where({
           plan_id: activePlanId,
@@ -62,13 +71,20 @@ exports.enroll = catchAsync(async (req, res) => {
         "tutorial"
       );
 
-      await trx("payments").insert({
-        user_id,
-        item_id: tutorialId,
-        item_type: "tutorial",
-        source: "subscription",
-        amount: 0,
-      });
+      await paymentsService.create(
+        {
+          user_id,
+          item_id: tutorialId,
+          item_type: "tutorial",
+          amount: 0,
+          status: paymentsService.STATUS.PAID,
+          paid_at: new Date(),
+          method_id: subscriptionMethod.id,
+          source: "subscription",
+        },
+        [],
+        trx
+      );
     } else if (Number(tutorial.price) > 0) {
       const payment = await trx("payments")
         .where({ user_id, item_type: "tutorial", item_id: tutorialId })

--- a/backend/src/seeds/08_payment_methods_seed.js
+++ b/backend/src/seeds/08_payment_methods_seed.js
@@ -20,6 +20,17 @@ exports.seed = async function(knex) {
     },
     {
       id: knex.raw('uuid_generate_v4()'),
+      name: 'Subscription',
+      type: 'subscription',
+      icon: 'subscription',
+      active: true,
+      settings: {},
+      is_default: false,
+      created_at: now,
+      updated_at: now
+    },
+    {
+      id: knex.raw('uuid_generate_v4()'),
       name: 'paypal',
       type: 'paypal',
       icon: 'paypal',


### PR DESCRIPTION
## Summary
- add a migration for the payments.source column and seed a subscription payment method
- resolve the subscription payment method when creating zero-amount payments and funnel those writes through the payments service
- update book subscription purchases and class enrollment tests to expect subscription payment metadata

## Testing
- npx jest classEnrollment.routes.test.js *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d87464b55c8328957745df596b559c