### PR TITLE
Adjust installment payment amount handling

### DIFF
--- a/frontend/src/components/payments/forms/CardPaymentForm.js
+++ b/frontend/src/components/payments/forms/CardPaymentForm.js
@@ -7,9 +7,10 @@ export default function CardPaymentForm({ onSubmit, processing, allowInstallment
   const { register, handleSubmit, formState: { errors } } = useForm();
   const stripe = useStripe();
   const elements = useElements();
+  const usingInstallments = allowInstallments && installments > 1;
   const buttonText = processing
     ? 'Processing...'
-    : allowInstallments
+    : usingInstallments
       ? `Pay $${perInstallment.toFixed(2)} (1/${installments}) with ${selectedMethodLabel}`
       : `Pay $${finalPrice} with ${selectedMethodLabel}`;
 

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -288,11 +288,16 @@ export async function handleDefaultPayment({
 }) {
   try {
     setPaymentStatus('processing');
+    const installmentCount = Math.max(Number(installments) || 1, 1);
+    const usingInstallments = allowInstallments && installmentCount > 1;
+    const amount = usingInstallments
+      ? finalPrice / installmentCount
+      : finalPrice;
     const payload = {
       method_id: method?.id,
       item_type: itemType,
       item_id: itemInfo.id,
-      amount: finalPrice,
+      amount,
       allow_installments: allowInstallments,
       installments,
     };
@@ -714,23 +719,26 @@ export default function CheckoutPage() {
     setInstallments(count);
   }, [existingPayment, itemInfo]);
 
-  const perInstallment = useMemo(
-    () => finalPrice / installments,
-    [finalPrice, installments]
-  );
+  const perInstallment = useMemo(() => {
+    const count = Math.max(Number(installments) || 1, 1);
+    if (allowInstallments && count > 1) {
+      return finalPrice / count;
+    }
+    return finalPrice;
+  }, [allowInstallments, finalPrice, installments]);
   const schedule = useMemo(() => {
     if (!allowInstallments) return [];
-    const amount = finalPrice / installments;
-    return Array.from({ length: installments }, (_, i) => {
+    const count = Math.max(Number(installments) || 1, 1);
+    return Array.from({ length: count }, (_, i) => {
       const d = new Date();
       d.setMonth(d.getMonth() + i);
       return {
         number: i + 1,
         date: d.toLocaleDateString(),
-        amount: amount.toFixed(2),
+        amount: perInstallment.toFixed(2),
       };
     });
-  }, [finalPrice, allowInstallments, installments]);
+  }, [allowInstallments, installments, perInstallment]);
 
   if (checkoutError) return <div className="text-white text-center mt-32">{checkoutError}</div>;
   if (!itemInfo) return <div className="text-white text-center mt-32">{t('loading')}</div>;

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -67,7 +67,18 @@ jest.mock('../../services/subscriptionService', () => ({
   fetchMySubscription: jest.fn(),
 }));
 jest.mock('../../components/payments/forms/CardPaymentForm', () => {
-  return function MockCardForm({ onSubmit, finalPrice, selectedMethodLabel }) {
+  return function MockCardForm({
+    onSubmit,
+    finalPrice,
+    selectedMethodLabel,
+    allowInstallments,
+    installments,
+    perInstallment,
+  }) {
+    const usingInstallments = allowInstallments && installments > 1;
+    const buttonLabel = usingInstallments
+      ? `Pay $${perInstallment.toFixed(2)} (1/${installments}) with ${selectedMethodLabel}`
+      : `Pay $${finalPrice} with ${selectedMethodLabel}`;
     return (
       <form
         onSubmit={(e) => {
@@ -82,7 +93,7 @@ jest.mock('../../components/payments/forms/CardPaymentForm', () => {
         <input placeholder="Expiration Date (MM/YY)" />
         <input placeholder="CVC" />
         <div data-testid="card-element" />
-        <button type="submit">{`Pay $${finalPrice} with ${selectedMethodLabel}`}</button>
+        <button type="submit">{buttonLabel}</button>
       </form>
     );
   };
@@ -189,6 +200,44 @@ test('renders card form without Elements for non-stripe processors', async () =>
   await waitFor(() =>
     expect(createPayment).toHaveBeenCalledWith(
       expect.objectContaining({ token: 'tok_123' })
+    )
+  );
+});
+
+test('submits per-installment amount for multi-installment card payments', async () => {
+  fetchClassDetails.mockResolvedValue({
+    data: {
+      id: 1,
+      title: 'Test Class',
+      instructor: 'Inst',
+      price: 100,
+      cover_image: '',
+      installments: 4,
+    },
+  });
+  fetchPaymentMethods.mockResolvedValue([
+    { id: 1, name: 'Paystack', type: 'paystack' },
+  ]);
+  createPayment.mockResolvedValue({ status: 'paid' });
+
+  render(<CheckoutPage />);
+  await screen.findByText('Checkout');
+
+  const installmentToggle = screen.getByLabelText('Pay in 4 monthly installments');
+  fireEvent.click(installmentToggle);
+
+  const button = await screen.findByRole('button', {
+    name: /Pay \$25\.00 \(1\/4\) with Paystack/i,
+  });
+  fireEvent.click(button);
+
+  await waitFor(() =>
+    expect(createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 25,
+        allow_installments: true,
+        installments: 4,
+      })
     )
   );
 });


### PR DESCRIPTION
## Summary
- ensure default payment requests send per-installment amounts when installments are enabled
- keep checkout schedule and card form text aligned with computed installment pricing
- extend checkout payment flow tests to cover multi-installment submissions

## Testing
- npm test -- checkoutPaymentFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d874683b74832898d81ec175082913