### PR TITLE
Handle plan-covered payments without method requirement

### DIFF
--- a/backend/src/migrations/20251101090000_alter_payments_add_source_and_nullable_method.js
+++ b/backend/src/migrations/20251101090000_alter_payments_add_source_and_nullable_method.js
@@ -1,0 +1,19 @@
+exports.up = async function (knex) {
+  await knex.schema.alterTable("payments", (table) => {
+    table.string("source");
+  });
+
+  await knex.schema.alterTable("payments", (table) => {
+    table.uuid("method_id").nullable().alter();
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable("payments", (table) => {
+    table.dropColumn("source");
+  });
+
+  await knex.schema.alterTable("payments", (table) => {
+    table.uuid("method_id").notNullable().alter();
+  });
+};

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -47,6 +47,10 @@ jest.mock('../../../payments/helpers/wallet', () => ({
   creditInstructorSubscription: jest.fn(),
 }));
 
+jest.mock('../../../payments/helpers/planPayments', () => ({
+  recordPlanCoveredPayment: jest.fn(),
+}));
+
 jest.mock('../../../../utils/logger.js', () => ({
   log: jest.fn(),
   debug: jest.fn(),
@@ -56,6 +60,7 @@ jest.mock('../../../../utils/logger.js', () => ({
 
 const { getActiveStudentPlanId } = require('../../../plans/subscription.helper');
 const { creditInstructorSubscription } = require('../../../payments/helpers/wallet');
+const { recordPlanCoveredPayment } = require('../../../payments/helpers/planPayments');
 const logger = require('../../../../utils/logger.js');
 const db = require('../../../../config/database');
 
@@ -138,6 +143,7 @@ describe('Class enrollment routes', () => {
     service.findEnrollment.mockResolvedValue(null);
     getActiveStudentPlanId.mockResolvedValue('plan1');
     service.createEnrollment.mockResolvedValue({ id: '1' });
+    recordPlanCoveredPayment.mockResolvedValue({ id: 'payment-id' });
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(200);
     expect(service.createEnrollment).toHaveBeenCalled();
@@ -149,13 +155,13 @@ describe('Class enrollment routes', () => {
       expect.anything(),
     );
     expect(creditInstructorSubscription).toHaveBeenCalledTimes(1);
-    expect(db.insert).toHaveBeenCalledWith(
+    expect(recordPlanCoveredPayment).toHaveBeenCalledWith(
       expect.objectContaining({
-        user_id: 'test-user',
-        item_id: 'abc',
-        item_type: 'class',
+        trx: expect.any(Function),
+        userId: 'test-user',
+        itemId: 'abc',
+        itemType: 'class',
         source: 'subscription',
-        amount: 0,
       }),
     );
   });

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -6,6 +6,7 @@ const AppError = require("../../../utils/AppError");
 const service = require("./classEnrollment.service");
 const db = require("../../../config/database");
 const paymentsService = require("../../payments/payments.service");
+const { recordPlanCoveredPayment } = require("../../payments/helpers/planPayments");
 const { getActiveStudentPlanId } = require("../../plans/subscription.helper");
 const { creditInstructorSubscription } = require("../../payments/helpers/wallet");
 const planRevenue = require("../../payments/helpers/planRevenue");
@@ -67,12 +68,12 @@ exports.enroll = catchAsync(async (req, res) => {
         "class"
       );
 
-      await trx("payments").insert({
-        user_id,
-        item_id: classId,
-        item_type: "class",
+      await recordPlanCoveredPayment({
+        trx,
+        userId: user_id,
+        itemId: classId,
+        itemType: "class",
         source: "subscription",
-        amount: 0,
       });
       // Credit the instructor for subscription-based enrollments so that
       // instructors are compensated when a class is taken via a plan.

--- a/backend/src/modules/payments/helpers/__tests__/planPayments.test.js
+++ b/backend/src/modules/payments/helpers/__tests__/planPayments.test.js
@@ -1,0 +1,94 @@
+const knex = require('knex');
+
+const STATUS = { PAID: 'paid' };
+
+jest.mock('../../payments.service', () => ({
+  STATUS,
+  create: jest.fn(() => Promise.resolve({ id: 'payment-id' })),
+}));
+
+jest.mock('../../../../config/database', () => jest.fn());
+
+const paymentsService = require('../../payments.service');
+const { recordPlanCoveredPayment } = require('../planPayments');
+
+describe('planPayments helper', () => {
+  let db;
+
+  beforeEach(async () => {
+    paymentsService.create.mockClear();
+
+    db = knex({
+      client: 'sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+
+    await db.schema.createTable('payment_methods_config', (table) => {
+      table.string('id');
+      table.string('type');
+      table.string('name');
+      table.boolean('is_default');
+      table.timestamp('created_at');
+    });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test('records plan payment with nullable method when none configured', async () => {
+    await recordPlanCoveredPayment({
+      trx: db,
+      userId: 'user-1',
+      itemId: 'class-1',
+      itemType: 'class',
+      source: 'subscription',
+    });
+
+    expect(paymentsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        item_id: 'class-1',
+        item_type: 'class',
+        amount: 0,
+        currency: 'USD',
+        status: STATUS.PAID,
+        source: 'subscription',
+        method_id: null,
+        paid_at: expect.any(Date),
+      }),
+      [],
+      db,
+    );
+  });
+
+  test('uses configured subscription method when available', async () => {
+    await db('payment_methods_config').insert({
+      id: 'method-1',
+      type: 'subscription',
+      name: 'Plan Subscription',
+      is_default: 0,
+      created_at: new Date(),
+    });
+
+    await recordPlanCoveredPayment({
+      trx: db,
+      userId: 'user-2',
+      itemId: 'tutorial-1',
+      itemType: 'tutorial',
+      source: 'subscription',
+    });
+
+    expect(paymentsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-2',
+        item_id: 'tutorial-1',
+        item_type: 'tutorial',
+        method_id: 'method-1',
+      }),
+      [],
+      db,
+    );
+  });
+});

--- a/backend/src/modules/payments/helpers/planPayments.js
+++ b/backend/src/modules/payments/helpers/planPayments.js
@@ -1,0 +1,75 @@
+const db = require("../../../config/database");
+const paymentsService = require("../payments.service");
+
+const METHOD_TYPE_PRIORITY = [
+  "plan_subscription",
+  "subscription",
+  "plan",
+  "free",
+];
+
+const NAME_HINTS = ["subscription", "plan", "free"];
+
+const normalize = (value) => (value ? value.toLowerCase() : "");
+
+async function resolvePlanPaymentMethod(trx) {
+  const connection = trx || db;
+
+  try {
+    const rows = await connection("payment_methods_config")
+      .select("id", "type", "name", "is_default", "created_at")
+      .orderBy("is_default", "desc")
+      .orderBy("created_at", "asc");
+
+    const normalizedRows = rows.map((row) => ({
+      ...row,
+      type: normalize(row.type),
+      name: normalize(row.name),
+    }));
+
+    const byType = normalizedRows.find((row) =>
+      METHOD_TYPE_PRIORITY.includes(row.type)
+    );
+    if (byType) {
+      return byType.id;
+    }
+
+    const byName = normalizedRows.find((row) =>
+      NAME_HINTS.some((hint) => row.name.includes(hint))
+    );
+    return byName ? byName.id : null;
+  } catch (err) {
+    return null;
+  }
+}
+
+async function recordPlanCoveredPayment({
+  trx,
+  userId,
+  itemId,
+  itemType,
+  source = "subscription",
+  amount = 0,
+  currency = "USD",
+}) {
+  const methodId = await resolvePlanPaymentMethod(trx);
+
+  const data = {
+    user_id: userId,
+    item_id: itemId,
+    item_type: itemType,
+    amount,
+    currency,
+    status: paymentsService.STATUS.PAID,
+    source,
+    paid_at: new Date(),
+    method_id: methodId ?? null,
+  };
+
+  return paymentsService.create(data, [], trx);
+}
+
+module.exports = {
+  resolvePlanPaymentMethod,
+  recordPlanCoveredPayment,
+};

--- a/backend/src/modules/users/tutorials/enrollments/__tests__/tutorialEnrollment.routes.test.js
+++ b/backend/src/modules/users/tutorials/enrollments/__tests__/tutorialEnrollment.routes.test.js
@@ -1,0 +1,89 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn(() => Promise.resolve(null));
+  db.insert = jest.fn(() => db);
+  db.update = jest.fn(() => db);
+  db.transaction = jest.fn(async (fn) => fn(db));
+  db.count = jest.fn(() => Promise.resolve([{ count: 0 }]));
+  db.andWhere = jest.fn(() => db);
+  db.join = jest.fn(() => db);
+  return db;
+});
+
+jest.mock('../../../../../middleware/auth/authMiddleware', () => ({
+  verifyToken: (req, _res, next) => {
+    req.user = { id: 'student-1' };
+    next();
+  },
+  isStudent: (_req, _res, next) => next(),
+  isInstructorOrAdmin: (_req, _res, next) => next(),
+  isAdmin: (_req, _res, next) => next(),
+}));
+
+jest.mock('../../../../plans/subscription.helper', () => ({
+  getActiveStudentPlanId: jest.fn(),
+}));
+
+jest.mock('../../../../payments/helpers/planRevenue', () => ({
+  calculateInstructorAmount: jest.fn(() => Promise.resolve(0)),
+}));
+
+jest.mock('../../../../payments/helpers/planPayments', () => ({
+  recordPlanCoveredPayment: jest.fn(),
+}));
+
+const db = require('../../../../../config/database');
+const { getActiveStudentPlanId } = require('../../../../plans/subscription.helper');
+const { recordPlanCoveredPayment } = require('../../../../payments/helpers/planPayments');
+
+const routes = require('../../tutorial.routes');
+
+const app = express();
+app.use(express.json());
+app.use('/tutorials', routes);
+
+describe('Tutorial enrollment routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('enrolls tutorial via subscription without payment method requirement', async () => {
+    const tutorial = {
+      status: 'published',
+      moderation_status: 'Approved',
+      price: 25,
+      included_plans: ['plan-1'],
+    };
+
+    db.first
+      .mockResolvedValueOnce(tutorial)
+      .mockResolvedValueOnce(null);
+    getActiveStudentPlanId.mockResolvedValue('plan-1');
+    recordPlanCoveredPayment.mockResolvedValue({ id: 'payment-id' });
+
+    const res = await request(app).post('/tutorials/enroll/abc-tutorial');
+
+    expect(res.statusCode).toBe(200);
+    expect(recordPlanCoveredPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trx: expect.any(Function),
+        userId: 'student-1',
+        itemId: 'abc-tutorial',
+        itemType: 'tutorial',
+        source: 'subscription',
+      }),
+    );
+    expect(db.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: expect.any(String),
+        user_id: 'student-1',
+        tutorial_id: 'abc-tutorial',
+        status: 'enrolled',
+      }),
+    );
+  });
+});

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -6,6 +6,7 @@ const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
 const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
 const planRevenue = require("../../../payments/helpers/planRevenue");
+const { recordPlanCoveredPayment } = require("../../../payments/helpers/planPayments");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -62,12 +63,12 @@ exports.enroll = catchAsync(async (req, res) => {
         "tutorial"
       );
 
-      await trx("payments").insert({
-        user_id,
-        item_id: tutorialId,
-        item_type: "tutorial",
+      await recordPlanCoveredPayment({
+        trx,
+        userId: user_id,
+        itemId: tutorialId,
+        itemType: "tutorial",
         source: "subscription",
-        amount: 0,
       });
     } else if (Number(tutorial.price) > 0) {
       const payment = await trx("payments")


### PR DESCRIPTION
## Summary
- add a migration that adds a source column to payments and allows null method ids
- add a helper for plan-covered payment inserts and wire it into class and tutorial enrollments
- extend enrollment tests and add helper unit tests to cover subscription-covered scenarios

## Testing
- npm test -- --runInBand --runTestsByPath src/modules/payments/helpers/__tests__/planPayments.test.js src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js src/modules/users/tutorials/enrollments/__tests__/tutorialEnrollment.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8769280d083288001381295efcf3d