### PR TITLE
Resolve invoice attachment paths and tighten invoice email tests

### DIFF
--- a/backend/src/modules/invoices/helpers/invoicePath.js
+++ b/backend/src/modules/invoices/helpers/invoicePath.js
@@ -1,0 +1,22 @@
+const path = require("path");
+
+function normalizePdfUrl(pdfUrl) {
+  if (!pdfUrl) return null;
+  return pdfUrl.replace(/^\/+/, "");
+}
+
+function resolveInvoicePdfPath(invoiceOrUrl) {
+  if (!invoiceOrUrl) return null;
+  const pdfUrl =
+    typeof invoiceOrUrl === "string"
+      ? invoiceOrUrl
+      : invoiceOrUrl.pdf_url;
+  const normalized = normalizePdfUrl(pdfUrl);
+  if (!normalized) return null;
+
+  return path.join(__dirname, "../../../../", normalized);
+}
+
+module.exports = {
+  resolveInvoicePdfPath,
+};

--- a/backend/src/modules/invoices/invoices.controller.js
+++ b/backend/src/modules/invoices/invoices.controller.js
@@ -1,8 +1,8 @@
-const path = require("path");
 const catchAsync = require("../../utils/catchAsync");
 const AppError = require("../../utils/AppError");
 const { sendSuccess } = require("../../utils/response");
 const service = require("./invoices.service");
+const { resolveInvoicePdfPath } = require("./helpers/invoicePath");
 
 exports.getInvoices = catchAsync(async (_req, res) => {
   const data = await service.getInvoices();
@@ -46,10 +46,6 @@ exports.downloadInvoice = catchAsync(async (req, res) => {
   ) {
     throw new AppError("Forbidden", 403);
   }
-  const filePath = path.join(
-    __dirname,
-    "../../../",
-    invoice.pdf_url.replace(/^\//, "")
-  );
+  const filePath = resolveInvoicePdfPath(invoice);
   res.download(filePath);
 });

--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -19,6 +19,7 @@ const tutorialService = require("../users/tutorials/tutorial.service");
 const plansService = require("../plans/plans.service");
 
 const invoiceService = require("../invoices/invoices.service");
+const { resolveInvoicePdfPath } = require("../invoices/helpers/invoicePath");
 
 const DEFAULT_PLATFORM_CUT = {
   class: 15,
@@ -336,12 +337,15 @@ exports.approveBankPayment = catchAsync(async (req, res) => {
     if (user) {
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user.email && !user.invoice_email_opt_out && invoice?.pdf_url) {
-        await mailService.sendMail({
-          to: user.email,
-          subject: "Payment Invoice",
-          html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: invoice.pdf_url }],
-        });
+        const attachmentPath = resolveInvoicePdfPath(invoice);
+        if (attachmentPath) {
+          await mailService.sendMail({
+            to: user.email,
+            subject: "Payment Invoice",
+            html: `<p>Please find your invoice attached.</p>`,
+            attachments: [{ path: attachmentPath }],
+          });
+        }
       }
     }
   } catch (err) {

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -18,6 +18,7 @@ const paymentMethodsService = require("../paymentMethods/paymentMethods.service"
 const { validatePaymentData } = require("./helpers/validation");
 const { calculatePlatformFee } = require("./helpers/platformFee");
 const { handleEnrollment } = require("./helpers/enrollment");
+const { resolveInvoicePdfPath } = require("../invoices/helpers/invoicePath");
 
 exports.createPayment = catchAsync(async (req, res) => {
   const { method_id, item_type, item_id, receipt_url, coupon_id } = req.body;
@@ -187,12 +188,15 @@ exports.createPayment = catchAsync(async (req, res) => {
       }
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
-        await mailService.sendMail({
-          to: user.email,
-          subject: "Payment Invoice",
-          html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: invoice.pdf_url }],
-        });
+        const attachmentPath = resolveInvoicePdfPath(invoice);
+        if (attachmentPath) {
+          await mailService.sendMail({
+            to: user.email,
+            subject: "Payment Invoice",
+            html: `<p>Please find your invoice attached.</p>`,
+            attachments: [{ path: attachmentPath }],
+          });
+        }
       }
     } catch (err) {
       logger.error("Failed to generate invoice:", err);
@@ -280,12 +284,15 @@ exports.updatePayment = catchAsync(async (req, res) => {
         try {
           const invoice = await invoiceService.generateFromPayment(payment, user);
           if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
-            await mailService.sendMail({
-              to: user.email,
-              subject: "Payment Invoice",
-              html: `<p>Please find your invoice attached.</p>`,
-              attachments: [{ path: invoice.pdf_url }],
-            });
+            const attachmentPath = resolveInvoicePdfPath(invoice);
+            if (attachmentPath) {
+              await mailService.sendMail({
+                to: user.email,
+                subject: "Payment Invoice",
+                html: `<p>Please find your invoice attached.</p>`,
+                attachments: [{ path: attachmentPath }],
+              });
+            }
           }
         } catch (err) {
           logger.error("Failed to generate invoice:", err);

--- a/backend/tests/paymentInvoiceEmail.test.js
+++ b/backend/tests/paymentInvoiceEmail.test.js
@@ -19,11 +19,16 @@ jest.mock('../src/modules/coupons/coupons.service', () => ({ getCouponById: jest
 jest.mock('../src/modules/plans/plans.service', () => ({ getPlanById: jest.fn() }));
 jest.mock('../src/modules/subscriptions/subscription.service', () => ({ createOrRenewSubscription: jest.fn() }));
 jest.mock('../src/modules/payouts/wallet.service', () => ({ increment: jest.fn() }));
+jest.mock('../src/modules/payments/helpers/wallet', () => ({ creditInstructorWallet: jest.fn() }));
 jest.mock('../src/modules/classes/class.service', () => ({ getClassById: jest.fn() }));
 jest.mock('../src/modules/books/book.service', () => ({ getBookById: jest.fn() }));
 jest.mock('../src/modules/users/tutorials/tutorial.service', () => ({ getTutorialById: jest.fn() }));
+jest.mock('../src/modules/plans/subscription.helper', () => ({ getActiveStudentPlanId: jest.fn().mockResolvedValue(null) }));
 jest.mock('../src/modules/invoices/invoices.service', () => ({ generateFromPayment: jest.fn() }));
 jest.mock('../src/modules/payments/paymentAccess', () => ({ grantAccess: jest.fn() }));
+
+const fs = require('fs');
+const path = require('path');
 
 const paymentsController = require('../src/modules/payments/payments.controller');
 const bankController = require('../src/modules/payments/bank.controller');
@@ -35,19 +40,33 @@ const userModel = require('../src/modules/users/user.model');
 const bookService = require('../src/modules/books/book.service');
 const invoiceService = require('../src/modules/invoices/invoices.service');
 const mailService = require('../src/services/mailService');
-const walletService = require('../src/modules/payouts/wallet.service');
 const plansService = require('../src/modules/plans/plans.service');
 const subscriptionService = require('../src/modules/subscriptions/subscription.service');
 const notificationService = require('../src/modules/notifications/notifications.service');
+const { resolveInvoicePdfPath } = require('../src/modules/invoices/helpers/invoicePath');
+const { creditInstructorWallet } = require('../src/modules/payments/helpers/wallet');
+
+const TEST_INVOICE_URL = '/uploads/invoices/test-invoice.pdf';
 
 beforeEach(() => {
   jest.clearAllMocks();
-  invoiceService.generateFromPayment.mockResolvedValue({ pdf_url: '/inv.pdf' });
+  invoiceService.generateFromPayment.mockResolvedValue({ pdf_url: TEST_INVOICE_URL });
   mailService.sendMail.mockResolvedValue();
   paymentConfigService.getSettings.mockResolvedValue({ platformCut: {} });
   userModel.findById.mockResolvedValue({ id: 'u1', email: 'u@test.com', full_name: 'User' });
   bookService.getBookById.mockResolvedValue({ price: 100, instructor_id: 'i1' });
   paymentsService.approveBankPayment.mockResolvedValue({ id: 'p3', user_id: 'u1', item_type: 'book', item_id: 'b1', instructor_amount: 90 });
+
+  const absoluteInvoicePath = resolveInvoicePdfPath(TEST_INVOICE_URL);
+  fs.mkdirSync(path.dirname(absoluteInvoicePath), { recursive: true });
+  fs.writeFileSync(absoluteInvoicePath, 'test');
+});
+
+afterEach(() => {
+  const absoluteInvoicePath = resolveInvoicePdfPath(TEST_INVOICE_URL);
+  if (absoluteInvoicePath && fs.existsSync(absoluteInvoicePath)) {
+    fs.unlinkSync(absoluteInvoicePath);
+  }
 });
 
 function mockRes() {
@@ -57,6 +76,15 @@ function mockRes() {
   };
 }
 
+async function waitForMailCall() {
+  for (let i = 0; i < 10; i += 1) {
+    if (mailService.sendMail.mock.calls.length > 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 describe('invoice email dispatch', () => {
   it('sends invoice email for card payments', async () => {
     paymentMethodsService.getById.mockResolvedValue({ id: 'm1', type: 'card', active: true });
@@ -64,10 +92,16 @@ describe('invoice email dispatch', () => {
 
     const req = { body: { method_id: 'm1', item_type: 'book', item_id: 'b1', amount: 100, status: 'paid' }, user: { id: 'u1' } };
     const res = mockRes();
-    await paymentsController.createPayment(req, res, () => {});
+    const next = jest.fn();
+    await paymentsController.createPayment(req, res, next);
     await new Promise(process.nextTick);
+    await waitForMailCall();
 
-    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+    expect(next).not.toHaveBeenCalled();
+    expect(invoiceService.generateFromPayment).toHaveBeenCalled();
+    const expectedPath = resolveInvoicePdfPath(TEST_INVOICE_URL);
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: expectedPath }] }));
+    expect(fs.existsSync(expectedPath)).toBe(true);
   });
 
   it('sends invoice email for zero-amount payments', async () => {
@@ -79,9 +113,12 @@ describe('invoice email dispatch', () => {
     const res = mockRes();
     await paymentsController.createPayment(req, res, () => {});
     await new Promise(process.nextTick);
+    await waitForMailCall();
 
     expect(paymentsService.create).toHaveBeenCalledWith(expect.objectContaining({ amount: 0, status: 'paid' }));
-    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+    const expectedPath = resolveInvoicePdfPath(TEST_INVOICE_URL);
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: expectedPath }] }));
+    expect(fs.existsSync(expectedPath)).toBe(true);
   });
 
   it('sends invoice email for bank payments upon approval', async () => {
@@ -89,8 +126,11 @@ describe('invoice email dispatch', () => {
     const res = mockRes();
     await bankController.approveBankPayment(req, res, () => {});
     await new Promise(process.nextTick);
+    await waitForMailCall();
 
-    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+    const expectedPath = resolveInvoicePdfPath(TEST_INVOICE_URL);
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: expectedPath }] }));
+    expect(fs.existsSync(expectedPath)).toBe(true);
   });
 
   it('handles zero-amount payments without a method', async () => {
@@ -102,12 +142,15 @@ describe('invoice email dispatch', () => {
     const res = mockRes();
     await paymentsController.createPayment(req, res, () => {});
     await new Promise(process.nextTick);
+    await waitForMailCall();
 
     expect(paymentMethodsService.getByType).toHaveBeenCalledWith('free');
     expect(paymentsService.create).toHaveBeenCalled();
     expect(paymentsService.create.mock.calls[0][0].status).toBe('paid');
-    expect(walletService.increment).toHaveBeenCalledWith('i1', 0);
-    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: '/inv.pdf' }] }));
+    expect(creditInstructorWallet).toHaveBeenCalledWith('book', 'b1', 0);
+    const expectedPath = resolveInvoicePdfPath(TEST_INVOICE_URL);
+    expect(mailService.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'u@test.com', attachments: [{ path: expectedPath }] }));
+    expect(fs.existsSync(expectedPath)).toBe(true);
   });
 
   it('triggers notification for paid plan payments', async () => {


### PR DESCRIPTION
## Summary
- add a shared helper to resolve stored invoice pdf_url values to filesystem paths
- use the helper in invoice download and payment email flows so attachments use absolute paths
- expand the invoice email dispatch test to create a real invoice file and assert the attachment path exists on disk

## Testing
- npm test -- paymentInvoiceEmail.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8769652f0832893e444d62990faa2