### PR TITLE
Fix subscription tutorial enrollment payment creation

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -6,6 +6,43 @@ const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
 const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
 const planRevenue = require("../../../payments/helpers/planRevenue");
+const paymentsService = require("../../../payments/payments.service");
+
+const { STATUS: PAYMENT_STATUS } = paymentsService;
+
+const SUBSCRIPTION_METHOD_TYPE = "subscription";
+const SUBSCRIPTION_METHOD_NAME = "Subscription Credit";
+const SUBSCRIPTION_SOURCE = "subscription";
+
+const ensureSubscriptionPaymentMethod = async (trx) => {
+  const existing = await trx("payment_methods_config")
+    .where({ type: SUBSCRIPTION_METHOD_TYPE })
+    .first();
+
+  if (existing) return existing.id;
+
+  const inserted = await trx("payment_methods_config")
+    .insert({
+      id: uuidv4(),
+      name: SUBSCRIPTION_METHOD_NAME,
+      type: SUBSCRIPTION_METHOD_TYPE,
+      icon: null,
+      active: true,
+      settings: {},
+      is_default: false,
+    })
+    .returning("*");
+
+  const row = Array.isArray(inserted) ? inserted[0] : inserted;
+  if (row?.id) return row.id;
+
+  const created = await trx("payment_methods_config")
+    .where({ type: SUBSCRIPTION_METHOD_TYPE })
+    .first();
+  if (created?.id) return created.id;
+
+  throw new AppError("Subscription payment method unavailable", 500);
+};
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -26,7 +63,7 @@ exports.enroll = catchAsync(async (req, res) => {
   const coveredBySubscription =
     activePlanId && includedPlans.includes(activePlanId);
 
-  const id = uuidv4();
+  const enrollmentId = uuidv4();
 
   const enroll = async (trx) => {
     if (coveredBySubscription) {
@@ -62,13 +99,24 @@ exports.enroll = catchAsync(async (req, res) => {
         "tutorial"
       );
 
-      await trx("payments").insert({
-        user_id,
-        item_id: tutorialId,
-        item_type: "tutorial",
-        source: "subscription",
-        amount: 0,
-      });
+      const methodId = await ensureSubscriptionPaymentMethod(trx);
+      await paymentsService.create(
+        {
+          id: uuidv4(),
+          user_id,
+          method_id: methodId,
+          item_id: tutorialId,
+          item_type: "tutorial",
+          amount: 0,
+          currency: tutorial.currency || "USD",
+          status: PAYMENT_STATUS.PAID,
+          source: SUBSCRIPTION_SOURCE,
+          platform_fee: 0,
+          instructor_amount: 0,
+        },
+        [],
+        trx,
+      );
     } else if (Number(tutorial.price) > 0) {
       const payment = await trx("payments")
         .where({ user_id, item_type: "tutorial", item_id: tutorialId })
@@ -80,7 +128,7 @@ exports.enroll = catchAsync(async (req, res) => {
     }
 
     await trx("tutorial_enrollments").insert({
-      id,
+      id: enrollmentId,
       user_id,
       tutorial_id: tutorialId,
       status: "enrolled",
@@ -100,7 +148,7 @@ exports.enroll = catchAsync(async (req, res) => {
     throw err;
   }
 
-  sendSuccess(res, { id }, "Enrolled successfully");
+  sendSuccess(res, { id: enrollmentId }, "Enrolled successfully");
 });
 
 // Mark as completed

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -15,6 +15,17 @@ jest.mock('../src/modules/payments/helpers/planRevenue', () => ({
 }));
 const planRevenue = require('../src/modules/payments/helpers/planRevenue');
 
+jest.mock('../src/modules/payments/payments.service', () => ({
+  create: jest.fn(() => Promise.resolve({})),
+  STATUS: {
+    PENDING_PAYMENT: 'pending_payment',
+    AWAITING_APPROVAL: 'awaiting_approval',
+    PAID: 'paid',
+    REJECTED: 'rejected',
+  },
+}));
+const paymentsService = require('../src/modules/payments/payments.service');
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
     req.user = { id: 'user1' };
@@ -34,6 +45,7 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getActiveStudentPlanId.mockResolvedValue(null);
+    paymentsService.create.mockResolvedValue({});
   });
 
   it('enrolls in a free tutorial', async () => {
@@ -131,7 +143,10 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
 
   it('enrolls in paid tutorial covered by subscription', async () => {
     const planInsert = jest.fn(() => Promise.resolve());
-    const paymentInsert = jest.fn(() => Promise.resolve());
+    const paymentMethodWhere = jest.fn(() => ({
+      first: jest.fn(() => Promise.resolve({ id: 'subscription-method-id' })),
+    }));
+    const paymentMethodInsert = jest.fn(() => Promise.resolve([{ id: 'subscription-method-id' }]));
 
     db.mockImplementation((table) => {
       if (table === 'tutorials')
@@ -157,8 +172,8 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
           where: () => ({ first: () => Promise.resolve(null), update: jest.fn() }),
           insert: planInsert,
         };
-      if (table === 'payments')
-        return { insert: paymentInsert };
+      if (table === 'payment_methods_config')
+        return { where: paymentMethodWhere, insert: paymentMethodInsert };
     });
 
     getActiveStudentPlanId.mockResolvedValue('plan1');
@@ -170,13 +185,20 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Enrolled successfully');
     expect(planInsert).toHaveBeenCalled();
-    expect(paymentInsert).toHaveBeenCalledWith({
-      user_id: 'user1',
-      item_id: tutorialId,
-      item_type: 'tutorial',
-      source: 'subscription',
-      amount: 0,
-    });
+    expect(paymentMethodWhere).toHaveBeenCalledWith({ type: 'subscription' });
+    expect(paymentsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user1',
+        item_id: tutorialId,
+        item_type: 'tutorial',
+        method_id: 'subscription-method-id',
+        amount: 0,
+        status: 'paid',
+        source: 'subscription',
+      }),
+      [],
+      expect.anything(),
+    );
     expect(planRevenue.calculateInstructorAmount).toHaveBeenCalledWith(
       'plan1',
       tutorialId,


### PR DESCRIPTION
## Summary
- ensure tutorial subscription enrollments create payments through the shared payments service with all required metadata
- provision a dedicated subscription payment method when missing and return consistent enrollment identifiers
- update the tutorial enrollment route tests to mock the payments service and validate the new behavior

## Testing
- npm test -- tutorialEnrollmentRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d876ad00d48328bdf9a6687c0c96e7