### PR TITLE
Ensure invoice PDFs use absolute attachment paths

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -7,6 +7,7 @@ const { STATUS } = paymentsService;
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const notificationService = require("../notifications/notifications.service");
+const path = require("path");
 const mailService = require("../../services/mailService");
 const userModel = require("../users/user.model");
 const walletService = require("../payouts/wallet.service");
@@ -336,11 +337,15 @@ exports.approveBankPayment = catchAsync(async (req, res) => {
     if (user) {
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user.email && !user.invoice_email_opt_out && invoice?.pdf_url) {
+        const attachmentPath = path.join(
+          process.cwd(),
+          invoice.pdf_url.replace(/^\/+/, "")
+        );
         await mailService.sendMail({
           to: user.email,
           subject: "Payment Invoice",
           html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: invoice.pdf_url }],
+          attachments: [{ path: attachmentPath }],
         });
       }
     }

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -10,6 +10,7 @@ const userModel = require("../users/user.model");
 const libraryService = require("../library/library.service");
 const notificationService = require("../notifications/notifications.service");
 const mailService = require("../../services/mailService");
+const path = require("path");
 const couponService = require("../coupons/coupons.service");
 const plansService = require("../plans/plans.service");
 const subscriptionService = require("../subscriptions/subscription.service");
@@ -187,11 +188,15 @@ exports.createPayment = catchAsync(async (req, res) => {
       }
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
+        const attachmentPath = path.join(
+          process.cwd(),
+          invoice.pdf_url.replace(/^\/+/, "")
+        );
         await mailService.sendMail({
           to: user.email,
           subject: "Payment Invoice",
           html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: invoice.pdf_url }],
+          attachments: [{ path: attachmentPath }],
         });
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- resolve invoice pdf paths to absolute filesystem locations before emailing invoices
- apply the same logic for standard and bank payment invoice notifications

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d876b5cf4c8328846e8995905bcd71