### PR TITLE
Add helper to select subscription payment methods for plan coverage

### DIFF
--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -12,6 +12,7 @@ const libraryService = require("../library/library.service");
 const { v4: uuidv4 } = require("uuid");
 const { getActiveStudentPlanId } = require("../plans/subscription.helper");
 const planRevenue = require("../payments/helpers/planRevenue");
+const { getPlanCoveredMethod } = require("../payments/helpers/methods");
 
 const { STATUS: PAYMENT_STATUS } = paymentsService;
 
@@ -310,11 +311,16 @@ exports.checkout = async (studentId) => {
     }
 
     const payments = [];
+    let planMethodRecord = null;
     for (const b of books) {
       const includedPlans = Array.isArray(b.included_plans) ? b.included_plans : [];
       const coveredBySubscription = activePlanId && includedPlans.includes(activePlanId);
 
       if (coveredBySubscription) {
+        if (!planMethodRecord) {
+          planMethodRecord = await getPlanCoveredMethod(trx);
+        }
+
         const usage = await trx('plan_usage_metrics')
           .where({ plan_id: activePlanId, item_type: 'book', item_id: b.id })
           .first();
@@ -337,6 +343,7 @@ exports.checkout = async (studentId) => {
           .insert({
             id: uuidv4(),
             user_id: studentId,
+            method_id: planMethodRecord.id,
             item_type: 'book',
             item_id: b.id,
             amount: 0,

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -47,6 +47,10 @@ jest.mock('../../../payments/helpers/wallet', () => ({
   creditInstructorSubscription: jest.fn(),
 }));
 
+jest.mock('../../../payments/helpers/methods.js', () => ({
+  getPlanCoveredMethod: jest.fn(),
+}));
+
 jest.mock('../../../../utils/logger.js', () => ({
   log: jest.fn(),
   debug: jest.fn(),
@@ -56,6 +60,7 @@ jest.mock('../../../../utils/logger.js', () => ({
 
 const { getActiveStudentPlanId } = require('../../../plans/subscription.helper');
 const { creditInstructorSubscription } = require('../../../payments/helpers/wallet');
+const { getPlanCoveredMethod } = require('../../../payments/helpers/methods.js');
 const logger = require('../../../../utils/logger.js');
 const db = require('../../../../config/database');
 
@@ -68,6 +73,7 @@ app.use('/classes', routes);
 describe('Class enrollment routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getPlanCoveredMethod.mockResolvedValue({ id: 'plan-method' });
   });
 
   test('enroll in class', async () => {
@@ -152,12 +158,14 @@ describe('Class enrollment routes', () => {
     expect(db.insert).toHaveBeenCalledWith(
       expect.objectContaining({
         user_id: 'test-user',
+        method_id: 'plan-method',
         item_id: 'abc',
         item_type: 'class',
         source: 'subscription',
         amount: 0,
       }),
     );
+    expect(getPlanCoveredMethod).toHaveBeenCalledTimes(1);
   });
 
   test('reject enrollment when subscription active but class not covered', async () => {

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -9,6 +9,7 @@ const paymentsService = require("../../payments/payments.service");
 const { getActiveStudentPlanId } = require("../../plans/subscription.helper");
 const { creditInstructorSubscription } = require("../../payments/helpers/wallet");
 const planRevenue = require("../../payments/helpers/planRevenue");
+const { getPlanCoveredMethod } = require("../../payments/helpers/methods");
 
 exports.enroll = catchAsync(async (req, res) => {
   const { classId } = req.params;
@@ -43,6 +44,8 @@ exports.enroll = catchAsync(async (req, res) => {
       activePlanId && includedPlans.includes(activePlanId);
 
     if (coveredBySubscription) {
+      const planMethod = await getPlanCoveredMethod(trx);
+
       const usage = await trx("plan_usage_metrics")
         .where({ plan_id: activePlanId, item_type: "class", item_id: classId })
         .first();
@@ -69,6 +72,7 @@ exports.enroll = catchAsync(async (req, res) => {
 
       await trx("payments").insert({
         user_id,
+        method_id: planMethod.id,
         item_id: classId,
         item_type: "class",
         source: "subscription",

--- a/backend/src/modules/payments/helpers/__tests__/methods.test.js
+++ b/backend/src/modules/payments/helpers/__tests__/methods.test.js
@@ -1,0 +1,62 @@
+jest.mock('../../../../config/database', () => {
+  const db = jest.fn(() => db);
+  db.where = jest.fn(() => db);
+  db.first = jest.fn();
+  return db;
+});
+
+const db = require('../../../../config/database');
+const AppError = require('../../../../utils/AppError.js');
+const { getPlanCoveredMethod } = require('../methods.js');
+
+describe('getPlanCoveredMethod', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns subscription method when available', async () => {
+    const method = { id: 'sub', type: 'subscription' };
+    db.first.mockResolvedValueOnce(method);
+
+    const result = await getPlanCoveredMethod();
+
+    expect(result).toEqual(method);
+    expect(db).toHaveBeenCalledWith('payment_methods_config');
+    expect(db.where).toHaveBeenCalledWith({ type: 'subscription' });
+    expect(db.first).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to free method when subscription not found', async () => {
+    db.first
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'free', type: 'free' });
+
+    const result = await getPlanCoveredMethod();
+
+    expect(result).toEqual({ id: 'free', type: 'free' });
+    expect(db.where).toHaveBeenNthCalledWith(1, { type: 'subscription' });
+    expect(db.where).toHaveBeenNthCalledWith(2, { type: 'free' });
+    expect(db.first).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when no subscription or free method configured', async () => {
+    db.first.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+    await expect(getPlanCoveredMethod()).rejects.toMatchObject({
+      message: 'Subscription payment method not configured',
+      statusCode: 500,
+    });
+  });
+
+  it('uses transaction client when provided', async () => {
+    const trx = jest.fn(() => trx);
+    trx.where = jest.fn(() => trx);
+    trx.first = jest.fn().mockResolvedValue({ id: 'trx-sub', type: 'subscription' });
+
+    const result = await getPlanCoveredMethod(trx);
+
+    expect(result).toEqual({ id: 'trx-sub', type: 'subscription' });
+    expect(trx).toHaveBeenCalledWith('payment_methods_config');
+    expect(db).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/payments/helpers/methods.js
+++ b/backend/src/modules/payments/helpers/methods.js
@@ -1,0 +1,35 @@
+const knex = require("../../../config/database");
+const AppError = require("../../../utils/AppError");
+
+const resolveClient = (trx) => {
+  if (trx && typeof trx === "function") {
+    return trx;
+  }
+  return knex;
+};
+
+const TABLE_NAME = "payment_methods_config";
+
+async function getPlanCoveredMethod(trx) {
+  const client = resolveClient(trx);
+
+  const subscriptionMethod = await client(TABLE_NAME)
+    .where({ type: "subscription" })
+    .first();
+
+  if (subscriptionMethod) {
+    return subscriptionMethod;
+  }
+
+  const freeMethod = await client(TABLE_NAME)
+    .where({ type: "free" })
+    .first();
+
+  if (freeMethod) {
+    return freeMethod;
+  }
+
+  throw new AppError("Subscription payment method not configured", 500);
+}
+
+module.exports = { getPlanCoveredMethod };

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -6,6 +6,7 @@ const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
 const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
 const planRevenue = require("../../../payments/helpers/planRevenue");
+const { getPlanCoveredMethod } = require("../../../payments/helpers/methods");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -30,6 +31,8 @@ exports.enroll = catchAsync(async (req, res) => {
 
   const enroll = async (trx) => {
     if (coveredBySubscription) {
+      const planMethod = await getPlanCoveredMethod(trx);
+
       const usage = await trx("plan_usage_metrics")
         .where({
           plan_id: activePlanId,
@@ -64,6 +67,7 @@ exports.enroll = catchAsync(async (req, res) => {
 
       await trx("payments").insert({
         user_id,
+        method_id: planMethod.id,
         item_id: tutorialId,
         item_type: "tutorial",
         source: "subscription",

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -13,7 +13,11 @@ const { getActiveStudentPlanId } = require('../src/modules/plans/subscription.he
 jest.mock('../src/modules/payments/helpers/planRevenue', () => ({
   calculateInstructorAmount: jest.fn(),
 }));
+jest.mock('../src/modules/payments/helpers/methods.js', () => ({
+  getPlanCoveredMethod: jest.fn(),
+}));
 const planRevenue = require('../src/modules/payments/helpers/planRevenue');
+const { getPlanCoveredMethod } = require('../src/modules/payments/helpers/methods.js');
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
@@ -34,6 +38,7 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getActiveStudentPlanId.mockResolvedValue(null);
+    getPlanCoveredMethod.mockResolvedValue({ id: 'plan-method' });
   });
 
   it('enrolls in a free tutorial', async () => {
@@ -172,11 +177,13 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
     expect(planInsert).toHaveBeenCalled();
     expect(paymentInsert).toHaveBeenCalledWith({
       user_id: 'user1',
+      method_id: 'plan-method',
       item_id: tutorialId,
       item_type: 'tutorial',
       source: 'subscription',
       amount: 0,
     });
+    expect(getPlanCoveredMethod).toHaveBeenCalledTimes(1);
     expect(planRevenue.calculateInstructorAmount).toHaveBeenCalledWith(
       'plan1',
       tutorialId,


### PR DESCRIPTION
## Summary
- add a payments helper that retrieves the configured method for plan-covered transactions with subscription/free fallbacks
- update class and tutorial enrollment flows plus book checkout to persist the helper's method_id when recording subscription payments
- expand tests to cover the helper and assert subscription enrollments use the expected payment method configuration

## Testing
- npm test -- --runTestsByPath tests/tutorialEnrollmentRoutes.test.js src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js src/modules/payments/helpers/__tests__/methods.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d876b86ea88328810b2060b0fcb104