### PR TITLE
Fix invoice email attachments to use filesystem paths

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const logger = require('../../utils/logger.js');
 const catchAsync = require("../../utils/catchAsync");
 const AppError = require("../../utils/AppError");
@@ -336,11 +337,15 @@ exports.approveBankPayment = catchAsync(async (req, res) => {
     if (user) {
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user.email && !user.invoice_email_opt_out && invoice?.pdf_url) {
+        const attachmentPath = path.join(
+          process.cwd(),
+          invoice.pdf_url.replace(/^\/+/, "")
+        );
         await mailService.sendMail({
           to: user.email,
           subject: "Payment Invoice",
           html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: invoice.pdf_url }],
+          attachments: [{ path: attachmentPath }],
         });
       }
     }

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const logger = require('../../utils/logger.js');
 const catchAsync = require("../../utils/catchAsync");
 const AppError = require("../../utils/AppError");
@@ -187,11 +188,15 @@ exports.createPayment = catchAsync(async (req, res) => {
       }
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
+        const attachmentPath = path.join(
+          process.cwd(),
+          invoice.pdf_url.replace(/^\/+/, "")
+        );
         await mailService.sendMail({
           to: user.email,
           subject: "Payment Invoice",
           html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: invoice.pdf_url }],
+          attachments: [{ path: attachmentPath }],
         });
       }
     } catch (err) {
@@ -280,11 +285,15 @@ exports.updatePayment = catchAsync(async (req, res) => {
         try {
           const invoice = await invoiceService.generateFromPayment(payment, user);
           if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
+            const attachmentPath = path.join(
+              process.cwd(),
+              invoice.pdf_url.replace(/^\/+/, "")
+            );
             await mailService.sendMail({
               to: user.email,
               subject: "Payment Invoice",
               html: `<p>Please find your invoice attached.</p>`,
-              attachments: [{ path: invoice.pdf_url }],
+              attachments: [{ path: attachmentPath }],
             });
           }
         } catch (err) {


### PR DESCRIPTION
## Summary
- resolve invoice PDF URLs to filesystem paths before sending emails
- attach invoices using resolved paths for payment and bank payment flows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d876d0e6b48328ad186eee6fdc663f