### PR TITLE
Credit tutorial subscription wallet payouts

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -6,6 +6,7 @@ const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
 const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
 const planRevenue = require("../../../payments/helpers/planRevenue");
+const { creditTutorialSubscription } = require("../../../payments/helpers/wallet");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -69,6 +70,8 @@ exports.enroll = catchAsync(async (req, res) => {
         source: "subscription",
         amount: 0,
       });
+
+      await creditTutorialSubscription(tutorialId, activePlanId, trx);
     } else if (Number(tutorial.price) > 0) {
       const payment = await trx("payments")
         .where({ user_id, item_type: "tutorial", item_id: tutorialId })

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -15,6 +15,11 @@ jest.mock('../src/modules/payments/helpers/planRevenue', () => ({
 }));
 const planRevenue = require('../src/modules/payments/helpers/planRevenue');
 
+jest.mock('../src/modules/payments/helpers/wallet', () => ({
+  creditTutorialSubscription: jest.fn(),
+}));
+const { creditTutorialSubscription } = require('../src/modules/payments/helpers/wallet');
+
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
     req.user = { id: 'user1' };
@@ -34,6 +39,8 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getActiveStudentPlanId.mockResolvedValue(null);
+    planRevenue.calculateInstructorAmount.mockResolvedValue(0);
+    creditTutorialSubscription.mockResolvedValue();
   });
 
   it('enrolls in a free tutorial', async () => {
@@ -132,6 +139,7 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
   it('enrolls in paid tutorial covered by subscription', async () => {
     const planInsert = jest.fn(() => Promise.resolve());
     const paymentInsert = jest.fn(() => Promise.resolve());
+    const calculatedAmount = 42;
 
     db.mockImplementation((table) => {
       if (table === 'tutorials')
@@ -162,6 +170,11 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
     });
 
     getActiveStudentPlanId.mockResolvedValue('plan1');
+    planRevenue.calculateInstructorAmount.mockResolvedValue(calculatedAmount);
+    let instructorWalletBalance = 0;
+    creditTutorialSubscription.mockImplementation(async () => {
+      instructorWalletBalance += calculatedAmount;
+    });
 
     const tutorialId = '123e4567-e89b-12d3-a456-426614174003';
     const res = await request(app).post(
@@ -183,6 +196,12 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
       expect.anything(),
       'tutorial'
     );
+    expect(creditTutorialSubscription).toHaveBeenCalledWith(
+      tutorialId,
+      'plan1',
+      expect.anything(),
+    );
+    expect(instructorWalletBalance).toBe(calculatedAmount);
   });
 });
 


### PR DESCRIPTION
## Summary
- import and invoke the tutorial subscription wallet credit helper during subscription enrollments
- ensure subscription enrollments trigger instructor wallet credits after recording the payment
- extend tutorial enrollment route tests to validate wallet credits and payment tracking

## Testing
- npm test -- tutorialEnrollmentRoutes

------
https://chatgpt.com/codex/tasks/task_e_68d876b94be08328ad67020c89688ff3