### PR TITLE
Fix online classes access type migration idempotency

### DIFF
--- a/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
@@ -1,26 +1,69 @@
 exports.up = async function (knex) {
-  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
+  const columnInfo = await knex('information_schema.columns')
+    .select('udt_name', 'data_type')
+    .where({
+      table_schema: 'public',
+      table_name: 'online_classes',
+      column_name: 'access_type',
+    })
+    .first();
 
-  if (!hasColumn) {
-    await knex.schema.alterTable('online_classes', (table) => {
-      table
-        .enu('access_type', ['paid', 'free'], {
-          useNative: true,
-          enumName: 'online_class_access_type',
-        })
-        .notNullable()
-        .defaultTo('paid');
-    });
+  const columnExists = Boolean(columnInfo);
+
+  const {
+    rows: [typeExists],
+  } = await knex.raw(
+    "SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'online_class_access_type') AS exists"
+  );
+
+  if (!typeExists?.exists) {
+    await knex.raw(
+      "CREATE TYPE online_class_access_type AS ENUM ('paid', 'free')"
+    );
+  }
+
+  if (!columnExists) {
+    await knex.raw(
+      "ALTER TABLE online_classes ADD COLUMN access_type online_class_access_type NOT NULL DEFAULT 'paid'"
+    );
+  } else if (columnInfo.udt_name !== 'online_class_access_type') {
+    await knex.raw(
+      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL OR access_type NOT IN ('paid', 'free')"
+    );
+    await knex.raw(
+      "ALTER TABLE online_classes ALTER COLUMN access_type TYPE online_class_access_type USING access_type::online_class_access_type"
+    );
+    await knex.raw(
+      "ALTER TABLE online_classes ALTER COLUMN access_type SET DEFAULT 'paid'"
+    );
+    await knex.raw(
+      "ALTER TABLE online_classes ALTER COLUMN access_type SET NOT NULL"
+    );
+  } else {
+    await knex.raw(
+      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL"
+    );
+    await knex.raw(
+      "ALTER TABLE online_classes ALTER COLUMN access_type SET DEFAULT 'paid'"
+    );
+    await knex.raw(
+      "ALTER TABLE online_classes ALTER COLUMN access_type SET NOT NULL"
+    );
   }
 };
 
 exports.down = async function (knex) {
-  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
+  const columnInfo = await knex('information_schema.columns')
+    .select('udt_name')
+    .where({
+      table_schema: 'public',
+      table_name: 'online_classes',
+      column_name: 'access_type',
+    })
+    .first();
 
-  if (hasColumn) {
-    await knex.schema.alterTable('online_classes', (table) => {
-      table.dropColumn('access_type');
-    });
+  if (columnInfo) {
+    await knex.raw('ALTER TABLE online_classes DROP COLUMN access_type');
   }
 
   const {
@@ -30,6 +73,14 @@ exports.down = async function (knex) {
   );
 
   if (typeExists?.exists) {
-    await knex.raw('DROP TYPE online_class_access_type');
+    const {
+      rows: [usage],
+    } = await knex.raw(
+      "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE atttypid = 'online_class_access_type'::regtype) AS in_use"
+    );
+
+    if (!usage?.in_use) {
+      await knex.raw('DROP TYPE online_class_access_type');
+    }
   }
 };


### PR DESCRIPTION
## Summary
- ensure the online_classes access_type migration creates the enum type only when missing
- guard the column creation and convert existing columns to the enum type when necessary
- make the down migration drop the enum type only when no longer referenced

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8c9bd1d2c8328896444d55445f1c2