### PR TITLE
Consolidate online class access type migration

### DIFF
--- a/backend/src/migrations/20251021120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251021120000_add_access_type_to_online_classes.js
@@ -1,14 +1,7 @@
-exports.up = function (knex) {
-  return knex.schema.table('online_classes', function (table) {
-    table
-      .enu('access_type', ['paid', 'free'])
-      .notNullable()
-      .defaultTo('paid');
-  });
+exports.up = async function () {
+  // No-op: superseded by 20251022120000_add_access_type_to_online_classes.js
 };
 
-exports.down = function (knex) {
-  return knex.schema.table('online_classes', function (table) {
-    table.dropColumn('access_type');
-  });
+exports.down = async function () {
+  // No-op: superseded by 20251022120000_add_access_type_to_online_classes.js
 };

--- a/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
@@ -1,14 +1,21 @@
 exports.up = async function (knex) {
-  const columnInfo = await knex('information_schema.columns')
-    .select('udt_name', 'data_type')
-    .where({
-      table_schema: 'public',
-      table_name: 'online_classes',
-      column_name: 'access_type',
-    })
-    .first();
+  const columnExists = await knex.schema.hasColumn(
+    'online_classes',
+    'access_type'
+  );
 
-  const columnExists = Boolean(columnInfo);
+  let columnInfo = null;
+
+  if (columnExists) {
+    columnInfo = await knex('information_schema.columns')
+      .select('udt_name', 'data_type')
+      .where({
+        table_schema: 'public',
+        table_name: 'online_classes',
+        column_name: 'access_type',
+      })
+      .first();
+  }
 
   const {
     rows: [typeExists],
@@ -26,7 +33,7 @@ exports.up = async function (knex) {
     await knex.raw(
       "ALTER TABLE online_classes ADD COLUMN access_type online_class_access_type NOT NULL DEFAULT 'paid'"
     );
-  } else if (columnInfo.udt_name !== 'online_class_access_type') {
+  } else if (columnInfo?.udt_name !== 'online_class_access_type') {
     await knex.raw(
       "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL OR access_type NOT IN ('paid', 'free')"
     );

--- a/backend/src/migrations/20251030120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251030120000_add_access_type_to_online_classes.js
@@ -1,22 +1,7 @@
-exports.up = async function (knex) {
-  await knex.schema.alterTable('online_classes', (table) => {
-    table
-      .enu('access_type', ['paid', 'free'], {
-        useNative: true,
-        enumName: 'online_classes_access_type_enum',
-      })
-      .notNullable()
-      .defaultTo('paid');
-  });
-
-  await knex('online_classes')
-    .whereNull('access_type')
-    .update({ access_type: 'paid' });
+exports.up = async function () {
+  // No-op: superseded by 20251022120000_add_access_type_to_online_classes.js
 };
 
-exports.down = async function (knex) {
-  await knex.schema.alterTable('online_classes', (table) => {
-    table.dropColumn('access_type');
-  });
-  await knex.raw('DROP TYPE IF EXISTS online_classes_access_type_enum');
+exports.down = async function () {
+  // No-op: superseded by 20251022120000_add_access_type_to_online_classes.js
 };

--- a/backend/src/migrations/20251031120000_add_access_type_column_to_online_classes.js
+++ b/backend/src/migrations/20251031120000_add_access_type_column_to_online_classes.js
@@ -1,19 +1,7 @@
-exports.up = async function (knex) {
-  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
-  if (!hasColumn) {
-    await knex.schema.alterTable('online_classes', (table) => {
-      table.string('access_type').notNullable().defaultTo('paid');
-    });
-  }
-
-  await knex('online_classes').whereNull('access_type').update({ access_type: 'paid' });
+exports.up = async function () {
+  // No-op: superseded by 20251022120000_add_access_type_to_online_classes.js
 };
 
-exports.down = async function (knex) {
-  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
-  if (hasColumn) {
-    await knex.schema.alterTable('online_classes', (table) => {
-      table.dropColumn('access_type');
-    });
-  }
+exports.down = async function () {
+  // No-op: superseded by 20251022120000_add_access_type_to_online_classes.js
 };


### PR DESCRIPTION
## Summary
- ensure only the 20251022120000 migration owns the online_classes.access_type column and enum definition
- guard the migration with a hasColumn check before touching the access_type column
- convert other duplicate access_type migrations into documented no-ops for idempotent replays

## Testing
- NODE_ENV=development DATABASE_URL=postgresql://skillbridge:password@127.0.0.1:5432/skillbridge JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test npm run migrate

------
https://chatgpt.com/codex/tasks/task_e_68d9157794748328a16a1c46739e85b3