### PR TITLE
Improve online classes access type migration safety

### DIFF
--- a/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
@@ -1,14 +1,21 @@
 exports.up = async function (knex) {
-  const columnInfo = await knex('information_schema.columns')
-    .select('udt_name', 'data_type')
-    .where({
-      table_schema: 'public',
-      table_name: 'online_classes',
-      column_name: 'access_type',
-    })
-    .first();
+  const columnExists = await knex.schema.hasColumn(
+    'online_classes',
+    'access_type'
+  );
 
-  const columnExists = Boolean(columnInfo);
+  let columnInfo;
+  if (columnExists) {
+    columnInfo = await knex('information_schema.columns')
+      .select('udt_name', 'data_type')
+      .where({
+        table_schema: 'public',
+        table_name: 'online_classes',
+        column_name: 'access_type',
+      })
+      .whereRaw('table_catalog = current_database()')
+      .first();
+  }
 
   const {
     rows: [typeExists],
@@ -24,9 +31,9 @@ exports.up = async function (knex) {
 
   if (!columnExists) {
     await knex.raw(
-      "ALTER TABLE online_classes ADD COLUMN access_type online_class_access_type NOT NULL DEFAULT 'paid'"
+      "ALTER TABLE online_classes ADD COLUMN IF NOT EXISTS access_type online_class_access_type NOT NULL DEFAULT 'paid'"
     );
-  } else if (columnInfo.udt_name !== 'online_class_access_type') {
+  } else if (!columnInfo || columnInfo.udt_name !== 'online_class_access_type') {
     await knex.raw(
       "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL OR access_type NOT IN ('paid', 'free')"
     );
@@ -60,6 +67,7 @@ exports.down = async function (knex) {
       table_name: 'online_classes',
       column_name: 'access_type',
     })
+    .whereRaw('table_catalog = current_database()')
     .first();
 
   if (columnInfo) {


### PR DESCRIPTION
## Summary
- guard the migration with `hasColumn` before adding the `access_type` column
- scope `information_schema` lookups to the current database and handle missing metadata safely
- add `IF NOT EXISTS` to the column addition for safer concurrent execution

## Testing
- Not Run (requires a configured database)


------
https://chatgpt.com/codex/tasks/task_e_68d91583169483289ab4594308759bee