### PR TITLE
Ensure online_classes access_type migration chain is idempotent

### DIFF
--- a/backend/src/migrations/20251021120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251021120000_add_access_type_to_online_classes.js
@@ -1,14 +1,8 @@
-exports.up = function (knex) {
-  return knex.schema.table('online_classes', function (table) {
-    table
-      .enu('access_type', ['paid', 'free'])
-      .notNullable()
-      .defaultTo('paid');
-  });
+exports.up = async function () {
+  // This migration is intentionally left empty. The access_type column is now
+  // fully managed by later migrations that ensure a consistent enum type.
 };
 
-exports.down = function (knex) {
-  return knex.schema.table('online_classes', function (table) {
-    table.dropColumn('access_type');
-  });
+exports.down = async function () {
+  // No-op: nothing was changed in the up migration.
 };

--- a/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
@@ -1,14 +1,5 @@
 exports.up = async function (knex) {
-  const columnInfo = await knex('information_schema.columns')
-    .select('udt_name', 'data_type')
-    .where({
-      table_schema: 'public',
-      table_name: 'online_classes',
-      column_name: 'access_type',
-    })
-    .first();
-
-  const columnExists = Boolean(columnInfo);
+  const columnExists = await knex.schema.hasColumn('online_classes', 'access_type');
 
   const {
     rows: [typeExists],
@@ -26,35 +17,11 @@ exports.up = async function (knex) {
     await knex.raw(
       "ALTER TABLE online_classes ADD COLUMN access_type online_class_access_type NOT NULL DEFAULT 'paid'"
     );
-  } else if (columnInfo.udt_name !== 'online_class_access_type') {
-    await knex.raw(
-      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL OR access_type NOT IN ('paid', 'free')"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type TYPE online_class_access_type USING access_type::online_class_access_type"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type SET DEFAULT 'paid'"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type SET NOT NULL"
-    );
-  } else {
-    await knex.raw(
-      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type SET DEFAULT 'paid'"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type SET NOT NULL"
-    );
+    return;
   }
-};
 
-exports.down = async function (knex) {
   const columnInfo = await knex('information_schema.columns')
-    .select('udt_name')
+    .select('udt_name', 'data_type')
     .where({
       table_schema: 'public',
       table_name: 'online_classes',
@@ -62,7 +29,38 @@ exports.down = async function (knex) {
     })
     .first();
 
-  if (columnInfo) {
+  if (!columnInfo) {
+    return;
+  }
+
+  if (columnInfo.udt_name !== 'online_class_access_type') {
+    await knex.raw(
+      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL OR access_type NOT IN ('paid', 'free')"
+    );
+    await knex.raw(
+      'ALTER TABLE online_classes ALTER COLUMN access_type DROP DEFAULT'
+    );
+    await knex.raw(
+      "ALTER TABLE online_classes ALTER COLUMN access_type TYPE online_class_access_type USING access_type::online_class_access_type"
+    );
+  } else {
+    await knex.raw(
+      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL"
+    );
+  }
+
+  await knex.raw(
+    "ALTER TABLE online_classes ALTER COLUMN access_type SET DEFAULT 'paid'"
+  );
+  await knex.raw(
+    "ALTER TABLE online_classes ALTER COLUMN access_type SET NOT NULL"
+  );
+};
+
+exports.down = async function (knex) {
+  const columnExists = await knex.schema.hasColumn('online_classes', 'access_type');
+
+  if (columnExists) {
     await knex.raw('ALTER TABLE online_classes DROP COLUMN access_type');
   }
 

--- a/backend/src/migrations/20251030120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251030120000_add_access_type_to_online_classes.js
@@ -1,22 +1,7 @@
-exports.up = async function (knex) {
-  await knex.schema.alterTable('online_classes', (table) => {
-    table
-      .enu('access_type', ['paid', 'free'], {
-        useNative: true,
-        enumName: 'online_classes_access_type_enum',
-      })
-      .notNullable()
-      .defaultTo('paid');
-  });
-
-  await knex('online_classes')
-    .whereNull('access_type')
-    .update({ access_type: 'paid' });
+exports.up = async function () {
+  // No-op: superseded by 20251022120000_add_access_type_to_online_classes.
 };
 
-exports.down = async function (knex) {
-  await knex.schema.alterTable('online_classes', (table) => {
-    table.dropColumn('access_type');
-  });
-  await knex.raw('DROP TYPE IF EXISTS online_classes_access_type_enum');
+exports.down = async function () {
+  // No-op: nothing to revert.
 };

--- a/backend/src/migrations/20251031120000_add_access_type_column_to_online_classes.js
+++ b/backend/src/migrations/20251031120000_add_access_type_column_to_online_classes.js
@@ -1,19 +1,7 @@
-exports.up = async function (knex) {
-  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
-  if (!hasColumn) {
-    await knex.schema.alterTable('online_classes', (table) => {
-      table.string('access_type').notNullable().defaultTo('paid');
-    });
-  }
-
-  await knex('online_classes').whereNull('access_type').update({ access_type: 'paid' });
+exports.up = async function () {
+  // No-op: superseded by 20251022120000_add_access_type_to_online_classes.
 };
 
-exports.down = async function (knex) {
-  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
-  if (hasColumn) {
-    await knex.schema.alterTable('online_classes', (table) => {
-      table.dropColumn('access_type');
-    });
-  }
+exports.down = async function () {
+  // No-op: nothing to revert.
 };


### PR DESCRIPTION
## Summary
- neutralized redundant access_type migrations so the column definition now lives in a single canonical script
- hardened the 20251022120000 migration to create the enum, add the column when missing, or coerce existing columns (dropping stale defaults before conversion)
- standardized the access_type enum to be NOT NULL with a `paid` default regardless of prior schema state

## Testing
- npx knex migrate:up --knexfile backend/knexfile.js 20250712143530_create_online_classes_table.js
- npx knex migrate:up --knexfile backend/knexfile.js 20251022120000_add_access_type_to_online_classes.js
- npx knex migrate:up --knexfile backend/knexfile.js 20251022120000_add_access_type_to_online_classes.js (against a database where the column already existed as text)


------
https://chatgpt.com/codex/tasks/task_e_68d9234dab2c8328941b0abdd9d5dab9