### PR TITLE
Standardize online class access_type migrations

### DIFF
--- a/backend/src/migrations/20251021120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251021120000_add_access_type_to_online_classes.js
@@ -1,14 +1,47 @@
-exports.up = function (knex) {
-  return knex.schema.table('online_classes', function (table) {
-    table
-      .enu('access_type', ['paid', 'free'])
-      .notNullable()
-      .defaultTo('paid');
-  });
+exports.up = async function (knex) {
+  const {
+    rows: [typeExists],
+  } = await knex.raw(
+    "SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'online_class_access_type') AS exists"
+  );
+
+  if (!typeExists?.exists) {
+    await knex.raw(
+      "CREATE TYPE online_class_access_type AS ENUM ('paid', 'free')"
+    );
+  }
+
+  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
+
+  if (!hasColumn) {
+    await knex.raw(
+      "ALTER TABLE online_classes ADD COLUMN access_type online_class_access_type NOT NULL DEFAULT 'paid'"
+    );
+  }
 };
 
-exports.down = function (knex) {
-  return knex.schema.table('online_classes', function (table) {
-    table.dropColumn('access_type');
-  });
+exports.down = async function (knex) {
+  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
+
+  if (hasColumn) {
+    await knex.raw('ALTER TABLE online_classes DROP COLUMN access_type');
+  }
+
+  const {
+    rows: [typeExists],
+  } = await knex.raw(
+    "SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'online_class_access_type') AS exists"
+  );
+
+  if (typeExists?.exists) {
+    const {
+      rows: [usage],
+    } = await knex.raw(
+      "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE atttypid = 'online_class_access_type'::regtype) AS in_use"
+    );
+
+    if (!usage?.in_use) {
+      await knex.raw('DROP TYPE online_class_access_type');
+    }
+  }
 };

--- a/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
@@ -1,14 +1,5 @@
 exports.up = async function (knex) {
-  const columnInfo = await knex('information_schema.columns')
-    .select('udt_name', 'data_type')
-    .where({
-      table_schema: 'public',
-      table_name: 'online_classes',
-      column_name: 'access_type',
-    })
-    .first();
-
-  const columnExists = Boolean(columnInfo);
+  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
 
   const {
     rows: [typeExists],
@@ -22,39 +13,15 @@ exports.up = async function (knex) {
     );
   }
 
-  if (!columnExists) {
+  if (!hasColumn) {
     await knex.raw(
       "ALTER TABLE online_classes ADD COLUMN access_type online_class_access_type NOT NULL DEFAULT 'paid'"
     );
-  } else if (columnInfo.udt_name !== 'online_class_access_type') {
-    await knex.raw(
-      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL OR access_type NOT IN ('paid', 'free')"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type TYPE online_class_access_type USING access_type::online_class_access_type"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type SET DEFAULT 'paid'"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type SET NOT NULL"
-    );
-  } else {
-    await knex.raw(
-      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type SET DEFAULT 'paid'"
-    );
-    await knex.raw(
-      "ALTER TABLE online_classes ALTER COLUMN access_type SET NOT NULL"
-    );
+    return;
   }
-};
 
-exports.down = async function (knex) {
   const columnInfo = await knex('information_schema.columns')
-    .select('udt_name')
+    .select('udt_name', 'data_type')
     .where({
       table_schema: 'public',
       table_name: 'online_classes',
@@ -62,7 +29,35 @@ exports.down = async function (knex) {
     })
     .first();
 
-  if (columnInfo) {
+  if (!columnInfo) {
+    return;
+  }
+
+  if (columnInfo.udt_name !== 'online_class_access_type') {
+    await knex.raw(
+      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL OR access_type NOT IN ('paid', 'free')"
+    );
+    await knex.raw(
+      "ALTER TABLE online_classes ALTER COLUMN access_type TYPE online_class_access_type USING access_type::online_class_access_type"
+    );
+  } else {
+    await knex.raw(
+      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL"
+    );
+  }
+
+  await knex.raw(
+    "ALTER TABLE online_classes ALTER COLUMN access_type SET DEFAULT 'paid'"
+  );
+  await knex.raw(
+    "ALTER TABLE online_classes ALTER COLUMN access_type SET NOT NULL"
+  );
+};
+
+exports.down = async function (knex) {
+  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
+
+  if (hasColumn) {
     await knex.raw('ALTER TABLE online_classes DROP COLUMN access_type');
   }
 

--- a/backend/src/migrations/20251030120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251030120000_add_access_type_to_online_classes.js
@@ -1,22 +1,8 @@
-exports.up = async function (knex) {
-  await knex.schema.alterTable('online_classes', (table) => {
-    table
-      .enu('access_type', ['paid', 'free'], {
-        useNative: true,
-        enumName: 'online_classes_access_type_enum',
-      })
-      .notNullable()
-      .defaultTo('paid');
-  });
-
-  await knex('online_classes')
-    .whereNull('access_type')
-    .update({ access_type: 'paid' });
+exports.up = async function () {
+  // Access type column is fully managed by earlier migrations.
+  // This migration is now a no-op to avoid duplicating column definitions.
 };
 
-exports.down = async function (knex) {
-  await knex.schema.alterTable('online_classes', (table) => {
-    table.dropColumn('access_type');
-  });
-  await knex.raw('DROP TYPE IF EXISTS online_classes_access_type_enum');
+exports.down = async function () {
+  // No-op.
 };

--- a/backend/src/migrations/20251031120000_add_access_type_column_to_online_classes.js
+++ b/backend/src/migrations/20251031120000_add_access_type_column_to_online_classes.js
@@ -1,19 +1,8 @@
-exports.up = async function (knex) {
-  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
-  if (!hasColumn) {
-    await knex.schema.alterTable('online_classes', (table) => {
-      table.string('access_type').notNullable().defaultTo('paid');
-    });
-  }
-
-  await knex('online_classes').whereNull('access_type').update({ access_type: 'paid' });
+exports.up = async function () {
+  // Access type column already exists and is standardized by prior migrations.
+  // Intentionally left blank to prevent redundant alterations.
 };
 
-exports.down = async function (knex) {
-  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
-  if (hasColumn) {
-    await knex.schema.alterTable('online_classes', (table) => {
-      table.dropColumn('access_type');
-    });
-  }
+exports.down = async function () {
+  // No-op.
 };


### PR DESCRIPTION
## Summary
- ensure the initial access_type migration creates the shared PostgreSQL enum and column definition once
- make the follow-up migration use knex.schema.hasColumn and reuse the enum when normalizing existing columns
- neutralize later duplicate migrations so they no longer attempt to add the access_type column again

## Testing
- NODE_ENV=development DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/skillbridge_fresh JWT_SECRET=secret REFRESH_TOKEN_SECRET=secret SESSION_SECRET=secret npm run knex:migrate
- NODE_ENV=development DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/skillbridge_existing JWT_SECRET=secret REFRESH_TOKEN_SECRET=secret SESSION_SECRET=secret npm run knex:migrate

------
https://chatgpt.com/codex/tasks/task_e_68d9235c67f4832898b75549f040c573