### PR TITLE
Fix online class access type migration column handling

### DIFF
--- a/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
+++ b/backend/src/migrations/20251022120000_add_access_type_to_online_classes.js
@@ -1,6 +1,4 @@
 exports.up = async function (knex) {
-  const hasColumn = await knex.schema.hasColumn('online_classes', 'access_type');
-
   const {
     rows: [typeExists],
   } = await knex.raw(
@@ -13,13 +11,6 @@ exports.up = async function (knex) {
     );
   }
 
-  if (!hasColumn) {
-    await knex.raw(
-      "ALTER TABLE online_classes ADD COLUMN IF NOT EXISTS access_type online_class_access_type NOT NULL DEFAULT 'paid'"
-    );
-    return;
-  }
-
   const columnInfo = await knex('information_schema.columns')
     .select('udt_name', 'data_type')
     .where({
@@ -30,6 +21,18 @@ exports.up = async function (knex) {
     .first();
 
   if (!columnInfo) {
+    await knex.raw(
+      "ALTER TABLE online_classes ADD COLUMN access_type online_class_access_type"
+    );
+    await knex.raw(
+      "UPDATE online_classes SET access_type = 'paid' WHERE access_type IS NULL"
+    );
+    await knex.raw(
+      "ALTER TABLE online_classes ALTER COLUMN access_type SET DEFAULT 'paid'"
+    );
+    await knex.raw(
+      "ALTER TABLE online_classes ALTER COLUMN access_type SET NOT NULL"
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary
- ensure the online class access type migration checks for the column directly via information_schema
- add and backfill the access_type column only when it is absent to avoid duplicate column errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d927a3259c832893707232531b8b25