### PR TITLE
Add backend base URL helper for payment callbacks

### DIFF
--- a/backend/src/config/__tests__/backendUrl.test.js
+++ b/backend/src/config/__tests__/backendUrl.test.js
@@ -1,0 +1,51 @@
+const ORIGINAL_ENV = { ...process.env };
+
+const loadHelper = ({ config = {}, env = {} } = {}) => {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV, ...env };
+
+  jest.doMock('../env', () => ({
+    NODE_ENV: 'test',
+    BACKEND_PORT: 5002,
+    APP_DOMAIN: undefined,
+    ...config,
+  }));
+
+  // eslint-disable-next-line global-require
+  const helper = require('../backendUrl');
+  jest.dontMock('../env');
+  return helper;
+};
+
+describe('backend base URL helper', () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('prefers BACKEND_URL when provided and normalizes trailing slashes', () => {
+    const helper = loadHelper({ env: { BACKEND_URL: 'https://api.example.com/base/' } });
+    expect(helper.requireBackendBaseUrl()).toBe('https://api.example.com/base');
+  });
+
+  it('derives URL from APP_DOMAIN with protocol and port', () => {
+    const helper = loadHelper({
+      config: { NODE_ENV: 'production', BACKEND_PORT: 8443, APP_DOMAIN: 'api.example.com' },
+    });
+    expect(helper.requireBackendBaseUrl()).toBe('https://api.example.com:8443');
+  });
+
+  it('falls back to localhost when not in production', () => {
+    const helper = loadHelper({ env: { BACKEND_URL: '', APP_DOMAIN: '' } });
+    expect(helper.requireBackendBaseUrl()).toBe('http://localhost:5002');
+  });
+
+  it('surfaces an error when production URL cannot be resolved', () => {
+    const helper = loadHelper({
+      config: { NODE_ENV: 'production', APP_DOMAIN: undefined, BACKEND_PORT: 5002 },
+      env: { BACKEND_URL: '' },
+    });
+
+    expect(helper.getBackendBaseUrl()).toBeUndefined();
+    expect(helper.getBackendBaseUrlError()).toMatch(/Unable to determine backend base URL/);
+  });
+});

--- a/backend/src/config/backendUrl.js
+++ b/backend/src/config/backendUrl.js
@@ -1,0 +1,116 @@
+const logger = require('../utils/logger');
+const config = require('./env');
+
+let cachedUrl;
+let cachedError;
+let resolved = false;
+
+const hasScheme = (value) => /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
+
+const normalizeBaseUrl = (value) => {
+  try {
+    const url = new URL(value);
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      return null;
+    }
+    const sanitizedPath = url.pathname === '/' ? '' : url.pathname.replace(/\/+$/, '');
+    return `${url.origin}${sanitizedPath}`;
+  } catch {
+    return null;
+  }
+};
+
+const shouldIncludePort = (port, protocol) => {
+  const numeric = Number(port);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return false;
+  }
+  const defaultPort = protocol === 'https' ? 443 : 80;
+  return numeric !== defaultPort;
+};
+
+const buildFromAppDomain = () => {
+  const domain = (config.APP_DOMAIN || '').trim();
+  if (!domain) {
+    return null;
+  }
+
+  if (hasScheme(domain)) {
+    return domain;
+  }
+
+  const protocol = config.NODE_ENV === 'production' ? 'https' : 'http';
+  const portSegment = shouldIncludePort(config.BACKEND_PORT, protocol)
+    ? `:${config.BACKEND_PORT}`
+    : '';
+
+  return `${protocol}://${domain}${portSegment}`;
+};
+
+const buildLocalFallback = () => {
+  const port = Number(config.BACKEND_PORT);
+  const portSegment = Number.isFinite(port) && port > 0 ? `:${port}` : '';
+  return `http://localhost${portSegment}`;
+};
+
+const resolve = () => {
+  if (resolved) {
+    return { url: cachedUrl, error: cachedError };
+  }
+
+  resolved = true;
+  const candidates = [];
+  const explicit = (process.env.BACKEND_URL || '').trim();
+  if (explicit) {
+    candidates.push(explicit);
+  }
+
+  const domainCandidate = buildFromAppDomain();
+  if (domainCandidate) {
+    candidates.push(domainCandidate);
+  }
+
+  if (config.NODE_ENV !== 'production') {
+    candidates.push(buildLocalFallback());
+  }
+
+  for (const candidate of candidates) {
+    const normalized = normalizeBaseUrl(candidate);
+    if (normalized) {
+      cachedUrl = normalized;
+      cachedError = undefined;
+      return { url: cachedUrl, error: cachedError };
+    }
+  }
+
+  cachedUrl = undefined;
+  cachedError =
+    'Unable to determine backend base URL. Set BACKEND_URL or provide APP_DOMAIN and BACKEND_PORT.';
+  logger.error('[config] %s', cachedError);
+  return { url: cachedUrl, error: cachedError };
+};
+
+const getBackendBaseUrl = () => resolve().url;
+
+const requireBackendBaseUrl = () => {
+  const { url, error } = resolve();
+  if (!url) {
+    throw new Error(error);
+  }
+  return url;
+};
+
+const getBackendBaseUrlError = () => resolve().error;
+
+const resetBackendBaseUrlCache = () => {
+  cachedUrl = undefined;
+  cachedError = undefined;
+  resolved = false;
+};
+
+module.exports = {
+  getBackendBaseUrl,
+  requireBackendBaseUrl,
+  getBackendBaseUrlError,
+  resetBackendBaseUrlCache,
+};

--- a/backend/src/modules/payments/__tests__/paymentUrls.test.js
+++ b/backend/src/modules/payments/__tests__/paymentUrls.test.js
@@ -1,0 +1,176 @@
+jest.mock('../../../utils/catchAsync', () => (fn) => fn);
+jest.mock('../../paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn(),
+}));
+jest.mock('../../paymentMethods/paymentMethods.service', () => ({
+  getByType: jest.fn(),
+  getById: jest.fn(),
+}));
+jest.mock('../../../services/nowPaymentsService', () => ({
+  createInvoice: jest.fn(),
+  verifyIpnSignature: jest.fn(),
+}));
+jest.mock('../../../services/paypalService', () => ({
+  createOrder: jest.fn(),
+  captureOrder: jest.fn(),
+}));
+jest.mock('../payments.service', () => ({
+  STATUS: {
+    PENDING_PAYMENT: 'pending_payment',
+    PAID: 'paid',
+    REJECTED: 'rejected',
+  },
+  create: jest.fn(),
+  update: jest.fn(),
+  getById: jest.fn(),
+}));
+jest.mock('../paymentAccess', () => ({
+  grantAccess: jest.fn(),
+}));
+jest.mock('../../plans/plans.service', () => ({
+  getPlanById: jest.fn(),
+}));
+jest.mock('../../../utils/response', () => ({
+  sendSuccess: jest.fn(),
+}));
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'payment-123'),
+}));
+jest.mock('../../../config/backendUrl', () => ({
+  requireBackendBaseUrl: jest.fn(),
+  getBackendBaseUrlError: jest.fn(),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+const setBaseEnv = (overrides = {}) => {
+  process.env = {
+    ...ORIGINAL_ENV,
+    NODE_ENV: 'test',
+    JWT_SECRET: 'test-jwt',
+    REFRESH_TOKEN_SECRET: 'test-refresh',
+    SESSION_SECRET: 'test-session',
+    TEST_DATABASE_URL: 'postgres://user:pass@localhost:5432/testdb',
+    BACKEND_PORT: '5002',
+    FRONTEND_URL: 'https://frontend.example.com',
+    ...overrides,
+  };
+};
+
+describe('payment controller URLs', () => {
+  let cryptoController;
+  let paypalController;
+  let nowPaymentsService;
+  let paypalService;
+  let paymentMethodsService;
+  let paymentsService;
+  let backendUrl;
+
+  beforeEach(() => {
+    jest.resetModules();
+    setBaseEnv({ BACKEND_URL: 'https://api.example.com/base/' });
+
+    nowPaymentsService = require('../../../services/nowPaymentsService');
+    paypalService = require('../../../services/paypalService');
+    paymentMethodsService = require('../../paymentMethods/paymentMethods.service');
+    paymentsService = require('../payments.service');
+    backendUrl = require('../../../config/backendUrl');
+    backendUrl.requireBackendBaseUrl.mockReturnValue('https://api.example.com/base');
+    backendUrl.getBackendBaseUrlError.mockReturnValue(undefined);
+    paymentsService.create.mockResolvedValue({ id: 'payment-123', status: 'pending_payment' });
+    nowPaymentsService.createInvoice.mockResolvedValue({
+      id: 'invoice-1',
+      invoice_url: 'https://payments.example.com/invoice',
+    });
+    paypalService.createOrder.mockResolvedValue({
+      id: 'order-1',
+      links: [{ rel: 'approve', href: 'https://paypal.example.com/approve' }],
+    });
+
+    paymentMethodsService.getByType.mockResolvedValue({
+      id: 'method-1',
+      settings: {
+        api_key: 'secret',
+        ipn_secret: 'ipn-secret',
+        currency: 'USDT',
+      },
+    });
+
+    cryptoController = require('../crypto.controller');
+    paypalController = require('../paypal.controller');
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.clearAllMocks();
+  });
+
+  const createResponseMock = () => ({
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  });
+
+  it('builds the crypto IPN callback URL from the backend base URL', async () => {
+    const req = {
+      body: {
+        item_type: 'class',
+        item_id: 'item-1',
+        amount: 25,
+        currency: 'USD',
+        method_type: 'crypto',
+      },
+      user: { id: 'user-1' },
+    };
+
+    await cryptoController.initiateCryptoPayment(req, createResponseMock());
+
+    expect(nowPaymentsService.createInvoice).toHaveBeenCalledWith(
+      'secret',
+      expect.objectContaining({
+        ipn_callback_url: 'https://api.example.com/base/api/payments/crypto/ipn',
+      }),
+    );
+  });
+
+  it('builds the PayPal return URL from the backend base URL', async () => {
+    const req = {
+      body: {
+        item_type: 'class',
+        item_id: 'item-1',
+        amount: 15,
+        currency: 'USD',
+      },
+      user: { id: 'user-1' },
+    };
+
+    await paypalController.createPayPalPayment(req, createResponseMock());
+
+    expect(paypalService.createOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        returnUrl: 'https://api.example.com/base/api/payments/paypal/callback?payment_id=payment-123',
+      }),
+    );
+  });
+
+  it('throws an error when backend base URL cannot be resolved', async () => {
+    backendUrl.requireBackendBaseUrl.mockImplementation(() => {
+      throw new Error('missing base');
+    });
+    backendUrl.getBackendBaseUrlError.mockReturnValue('missing base');
+
+    const req = {
+      body: {
+        item_type: 'class',
+        item_id: 'item-1',
+        amount: 25,
+        currency: 'USD',
+        method_type: 'crypto',
+      },
+      user: { id: 'user-1' },
+    };
+
+    await expect(cryptoController.initiateCryptoPayment(req, createResponseMock())).rejects.toThrow(
+      'Backend base URL is not configured',
+    );
+  });
+});

--- a/backend/src/modules/payments/crypto.controller.js
+++ b/backend/src/modules/payments/crypto.controller.js
@@ -10,6 +10,10 @@ const nowPayments = require('../../services/nowPaymentsService');
 const { v4: uuidv4 } = require('uuid');
 const { grantAccess } = require('./paymentAccess');
 const plansService = require('../plans/plans.service');
+const {
+  requireBackendBaseUrl,
+  getBackendBaseUrlError,
+} = require('../../config/backendUrl');
 
 const DEFAULT_PLATFORM_CUT = {
   class: 15,
@@ -83,7 +87,15 @@ exports.initiateCryptoPayment = catchAsync(async (req, res) => {
     order_id: paymentId,
   };
   if (settings.ipn_secret) {
-    params.ipn_callback_url = `${process.env.BACKEND_URL || ''}/api/payments/crypto/ipn`;
+    let backendBaseUrl;
+    try {
+      backendBaseUrl = requireBackendBaseUrl();
+    } catch (error) {
+      const reason = getBackendBaseUrlError() || error.message;
+      logger.error('Failed to resolve backend base URL for crypto IPN: %s', reason);
+      throw new AppError('Backend base URL is not configured', 500);
+    }
+    params.ipn_callback_url = `${backendBaseUrl}/api/payments/crypto/ipn`;
   }
   if (process.env.FRONTEND_URL) {
     params.success_url = `${process.env.FRONTEND_URL}/payments/success`;

--- a/backend/src/modules/payments/paypal.controller.js
+++ b/backend/src/modules/payments/paypal.controller.js
@@ -10,6 +10,10 @@ const paypalService = require('../../services/paypalService');
 const { grantAccess } = require('./paymentAccess');
 const { v4: uuidv4 } = require('uuid');
 const plansService = require('../plans/plans.service');
+const {
+  requireBackendBaseUrl,
+  getBackendBaseUrlError,
+} = require('../../config/backendUrl');
 
 const DEFAULT_PLATFORM_CUT = {
   class: 15,
@@ -71,10 +75,19 @@ exports.createPayPalPayment = catchAsync(async (req, res) => {
 
   const paymentId = uuidv4();
 
+  let backendBaseUrl;
+  try {
+    backendBaseUrl = requireBackendBaseUrl();
+  } catch (error) {
+    const reason = getBackendBaseUrlError() || error.message;
+    logger.error('Failed to resolve backend base URL for PayPal return URL: %s', reason);
+    throw new AppError('Backend base URL is not configured', 500);
+  }
+
   const order = await paypalService.createOrder({
     amount: numericAmount,
     currency: currencyCode,
-    returnUrl: `${process.env.BACKEND_URL || ''}/api/payments/paypal/callback?payment_id=${paymentId}`,
+    returnUrl: `${backendBaseUrl}/api/payments/paypal/callback?payment_id=${paymentId}`,
     cancelUrl: process.env.FRONTEND_URL
       ? `${process.env.FRONTEND_URL}/payments/error`
       : undefined,


### PR DESCRIPTION
## Summary
- add a backend base URL resolver that validates configuration and logs failures
- update crypto and PayPal payment controllers to use the resolved backend URL when building callback endpoints
- add targeted tests covering the helper and payment URL generation scenarios

## Testing
- npx jest src/config/__tests__/backendUrl.test.js
- npx jest src/modules/payments/__tests__/paymentUrls.test.js

------
https://chatgpt.com/codex/tasks/task_e_68da45d78578832890dba2fad5f35ae4