### PR TITLE
Return licenseId in license validation responses

### DIFF
--- a/backend/src/services/licenseService.js
+++ b/backend/src/services/licenseService.js
@@ -57,44 +57,45 @@ async function validatePurchaseCode(code, domain, options = {}) {
       });
 
       if (!data || data.error || !data.item) {
-        return { valid: false, message: 'Invalid purchase code' };
+        return { valid: false, message: 'Invalid purchase code', licenseId: null };
       }
 
       const envatoEmail = typeof data?.buyer_email === 'string' ? data.buyer_email : null;
-      if (shouldPersist) {
-        await upsertLicense(code, {
-          domain: normalisedDomain,
-          email: envatoEmail,
-          verifiedAt,
-        });
-      }
+      const licenseId = shouldPersist
+        ? await upsertLicense(code, {
+            domain: normalisedDomain,
+            email: envatoEmail,
+            verifiedAt,
+          })
+        : null;
 
       return { valid: true, message: 'License verified with Envato', licenseId };
     } catch (error) {
       if (error?.response?.status === 404) {
-        return { valid: false, message: 'Invalid purchase code' };
+        return { valid: false, message: 'Invalid purchase code', licenseId: null };
       }
 
       return {
         valid: false,
         message: 'Unable to verify purchase code with Envato. Please try again later.',
+        licenseId: null,
       };
     }
   }
 
   if (code === 'DEMO-CODE-1234') {
-    if (shouldPersist) {
-      await upsertLicense(code, {
-        domain: normalisedDomain,
-        email: PLACEHOLDER_EMAIL,
-        verifiedAt,
-      });
-    }
+    const licenseId = shouldPersist
+      ? await upsertLicense(code, {
+          domain: normalisedDomain,
+          email: PLACEHOLDER_EMAIL,
+          verifiedAt,
+        })
+      : null;
 
     return { valid: true, message: 'Demo license accepted', licenseId };
   }
 
-  return { valid: false, message: 'Invalid purchase code' };
+  return { valid: false, message: 'Invalid purchase code', licenseId: null };
 }
 
 module.exports = { validatePurchaseCode };

--- a/backend/tests/services/licenseService.test.js
+++ b/backend/tests/services/licenseService.test.js
@@ -1,0 +1,89 @@
+jest.mock('axios');
+jest.mock('../../src/config/database', () => jest.fn());
+
+const axios = require('axios');
+const db = require('../../src/config/database');
+
+const { validatePurchaseCode } = require('../../src/services/licenseService');
+
+describe('licenseService.validatePurchaseCode', () => {
+  const demoCode = 'DEMO-CODE-1234';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    db.mockReset();
+    delete process.env.ENVATO_TOKEN;
+  });
+
+  it('returns Envato verification success with persisted license id', async () => {
+    process.env.ENVATO_TOKEN = 'token-123';
+
+    axios.get.mockResolvedValue({
+      data: {
+        item: { id: 1 },
+        buyer_email: 'buyer@example.com',
+      },
+    });
+
+    const firstLookup = jest.fn().mockResolvedValue(null);
+    const firstWhere = jest.fn().mockReturnValue({ first: firstLookup });
+    db.mockImplementationOnce(() => ({ where: firstWhere }));
+
+    const insert = jest.fn().mockResolvedValue([1]);
+    db.mockImplementationOnce(() => ({ insert }));
+
+    const finalLookup = jest.fn().mockResolvedValue({ id: 987 });
+    const finalWhere = jest.fn().mockReturnValue({ first: finalLookup });
+    db.mockImplementationOnce(() => ({ where: finalWhere }));
+
+    const result = await validatePurchaseCode('CODE-123', 'example.com');
+
+    expect(result).toEqual({
+      valid: true,
+      message: 'License verified with Envato',
+      licenseId: 987,
+    });
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.envato.com/v3/market/author/sale?code=CODE-123',
+      { headers: { Authorization: 'Bearer token-123' } },
+    );
+    expect(firstWhere).toHaveBeenCalledWith({ purchase_code: 'CODE-123' });
+    expect(insert).toHaveBeenCalledWith({
+      purchase_code: 'CODE-123',
+      domain: 'example.com',
+      email: 'buyer@example.com',
+      status: 'active',
+      verified_at: expect.any(Date),
+    });
+    expect(finalWhere).toHaveBeenCalledWith({ purchase_code: 'CODE-123' });
+  });
+
+  it('returns demo license success with persisted license id when envato token missing', async () => {
+    const firstLookup = jest.fn().mockResolvedValue(null);
+    const firstWhere = jest.fn().mockReturnValue({ first: firstLookup });
+    db.mockImplementationOnce(() => ({ where: firstWhere }));
+
+    const insert = jest.fn().mockResolvedValue([1]);
+    db.mockImplementationOnce(() => ({ insert }));
+
+    const finalLookup = jest.fn().mockResolvedValue({ id: 456 });
+    const finalWhere = jest.fn().mockReturnValue({ first: finalLookup });
+    db.mockImplementationOnce(() => ({ where: finalWhere }));
+
+    const result = await validatePurchaseCode(demoCode, 'demo.example.com');
+
+    expect(result).toEqual({
+      valid: true,
+      message: 'Demo license accepted',
+      licenseId: 456,
+    });
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(insert).toHaveBeenCalledWith({
+      purchase_code: demoCode,
+      domain: 'demo.example.com',
+      email: 'license@placeholder.invalid',
+      status: 'active',
+      verified_at: expect.any(Date),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- return a consistent payload from validatePurchaseCode that includes the persisted license id
- add unit coverage for Envato and demo success paths to guard the new response shape

## Testing
- npm test -- licenseService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68da45d7861083288eddc0cdda64ebe5