### PR TITLE
Capture license IDs in license validation responses

### DIFF
--- a/backend/src/services/licenseService.js
+++ b/backend/src/services/licenseService.js
@@ -49,6 +49,7 @@ async function validatePurchaseCode(code, domain, options = {}) {
   const normalisedDomain = normaliseDomain(domain);
   const token = process.env.ENVATO_TOKEN;
   const shouldPersist = options.persist ?? (typeof normalisedDomain === 'string' && normalisedDomain.length > 0);
+  let licenseId = null;
 
   if (token) {
     try {
@@ -57,12 +58,12 @@ async function validatePurchaseCode(code, domain, options = {}) {
       });
 
       if (!data || data.error || !data.item) {
-        return { valid: false, message: 'Invalid purchase code' };
+        return { valid: false, message: 'Invalid purchase code', licenseId: null };
       }
 
       const envatoEmail = typeof data?.buyer_email === 'string' ? data.buyer_email : null;
       if (shouldPersist) {
-        await upsertLicense(code, {
+        licenseId = await upsertLicense(code, {
           domain: normalisedDomain,
           email: envatoEmail,
           verifiedAt,
@@ -72,19 +73,20 @@ async function validatePurchaseCode(code, domain, options = {}) {
       return { valid: true, message: 'License verified with Envato', licenseId };
     } catch (error) {
       if (error?.response?.status === 404) {
-        return { valid: false, message: 'Invalid purchase code' };
+        return { valid: false, message: 'Invalid purchase code', licenseId: null };
       }
 
       return {
         valid: false,
         message: 'Unable to verify purchase code with Envato. Please try again later.',
+        licenseId: null,
       };
     }
   }
 
   if (code === 'DEMO-CODE-1234') {
     if (shouldPersist) {
-      await upsertLicense(code, {
+      licenseId = await upsertLicense(code, {
         domain: normalisedDomain,
         email: PLACEHOLDER_EMAIL,
         verifiedAt,
@@ -94,7 +96,7 @@ async function validatePurchaseCode(code, domain, options = {}) {
     return { valid: true, message: 'Demo license accepted', licenseId };
   }
 
-  return { valid: false, message: 'Invalid purchase code' };
+  return { valid: false, message: 'Invalid purchase code', licenseId: null };
 }
 
 module.exports = { validatePurchaseCode };

--- a/backend/tests/services/licenseService.test.js
+++ b/backend/tests/services/licenseService.test.js
@@ -1,0 +1,92 @@
+const axios = require('axios');
+
+jest.mock('axios');
+
+jest.mock('../../src/config/database', () => {
+  const mockInsert = jest.fn(() => Promise.resolve());
+  const mockDb = jest.fn(() => ({
+    where: jest.fn(() => ({
+      first: jest.fn(() => Promise.resolve(mockDb.__firstQueue.shift() ?? null)),
+      update: jest.fn(() => Promise.resolve()),
+    })),
+    insert: mockInsert,
+  }));
+
+  Object.assign(mockDb, {
+    __firstQueue: [],
+    __setFirstQueue(values) {
+      mockDb.__firstQueue = [...values];
+    },
+    __getInsertMock() {
+      return mockInsert;
+    },
+    __reset() {
+      mockDb.mockClear();
+      mockInsert.mockClear();
+      mockDb.__firstQueue = [];
+    },
+  });
+
+  return mockDb;
+});
+
+const db = require('../../src/config/database');
+const { validatePurchaseCode } = require('../../src/services/licenseService');
+
+describe('licenseService.validatePurchaseCode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    db.__reset();
+    delete process.env.ENVATO_TOKEN;
+  });
+
+  it('returns Envato verification payload including persisted licenseId', async () => {
+    process.env.ENVATO_TOKEN = 'test-token';
+    db.__setFirstQueue([null, { id: 123 }]);
+    axios.get.mockResolvedValue({
+      data: {
+        item: { id: 1 },
+        buyer_email: 'buyer@example.com',
+      },
+    });
+
+    const result = await validatePurchaseCode('CODE-123', 'example.com', { persist: true });
+
+    expect(result).toEqual({
+      valid: true,
+      message: 'License verified with Envato',
+      licenseId: 123,
+    });
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining('CODE-123'),
+      expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } })
+    );
+    expect(db.__getInsertMock()).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purchase_code: 'CODE-123',
+        domain: 'example.com',
+        email: 'buyer@example.com',
+      })
+    );
+  });
+
+  it('returns demo license payload including persisted licenseId', async () => {
+    db.__setFirstQueue([null, { id: 456 }]);
+
+    const result = await validatePurchaseCode('DEMO-CODE-1234', 'demo.example', { persist: true });
+
+    expect(result).toEqual({
+      valid: true,
+      message: 'Demo license accepted',
+      licenseId: 456,
+    });
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(db.__getInsertMock()).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purchase_code: 'DEMO-CODE-1234',
+        domain: 'demo.example',
+        email: 'license@placeholder.invalid',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- capture the persisted license id for Envato and demo validation flows and return it with the response
- ensure all license validation responses include a licenseId field for consistent payloads
- add unit coverage around Envato and demo success cases to assert the returned licenseId

## Testing
- npm test -- --runTestsByPath tests/services/licenseService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68da466a8c088328a6cb5673c70b535e