### PR TITLE
Fix license ID handling in license validation service

### DIFF
--- a/backend/src/services/licenseService.js
+++ b/backend/src/services/licenseService.js
@@ -52,6 +52,7 @@ async function validatePurchaseCode(code, domain, options = {}) {
 
   if (token) {
     try {
+      let licenseId = null;
       const { data } = await axios.get(`${ENVATO_SALE_URL}?code=${encodeURIComponent(code)}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -62,7 +63,7 @@ async function validatePurchaseCode(code, domain, options = {}) {
 
       const envatoEmail = typeof data?.buyer_email === 'string' ? data.buyer_email : null;
       if (shouldPersist) {
-        await upsertLicense(code, {
+        licenseId = await upsertLicense(code, {
           domain: normalisedDomain,
           email: envatoEmail,
           verifiedAt,
@@ -83,8 +84,9 @@ async function validatePurchaseCode(code, domain, options = {}) {
   }
 
   if (code === 'DEMO-CODE-1234') {
+    let licenseId = null;
     if (shouldPersist) {
-      await upsertLicense(code, {
+      licenseId = await upsertLicense(code, {
         domain: normalisedDomain,
         email: PLACEHOLDER_EMAIL,
         verifiedAt,


### PR DESCRIPTION
## Summary
- capture the license ID returned from `upsertLicense` in both Envato and demo validation paths
- include the captured ID in success responses, defaulting to null when persistence is skipped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da481c1b3c83289606ce35a8b50092