### PR TITLE
Ensure ads detail API uses default base URL fallback

### DIFF
--- a/frontend/src/pages/api/ads/[id].js
+++ b/frontend/src/pages/api/ads/[id].js
@@ -6,9 +6,9 @@ export default async function handler(req, res) {
   const { id } = req.query;
 
   try {
-    const { data } = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/ads/public/${id}`
-    );
+    const base =
+      process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5002/api";
+    const { data } = await axios.get(`${base}/ads/public/${id}`);
     if (!data?.data) {
       return res.status(404).json({ error: "Ad not found" });
     }


### PR DESCRIPTION
## Summary
- align the ads detail API handler with the list handler by using a shared base URL fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da481d3ddc83288cb4e540e0f0b4e6