### PR TITLE
Fix duplicate source column in payments migration

### DIFF
--- a/backend/src/migrations/20251101090000_alter_payments_add_source_and_nullable_method.js
+++ b/backend/src/migrations/20251101090000_alter_payments_add_source_and_nullable_method.js
@@ -1,18 +1,10 @@
 exports.up = async function (knex) {
   await knex.schema.alterTable("payments", (table) => {
-    table.string("source");
-  });
-
-  await knex.schema.alterTable("payments", (table) => {
     table.uuid("method_id").nullable().alter();
   });
 };
 
 exports.down = async function (knex) {
-  await knex.schema.alterTable("payments", (table) => {
-    table.dropColumn("source");
-  });
-
   await knex.schema.alterTable("payments", (table) => {
     table.uuid("method_id").notNullable().alter();
   });


### PR DESCRIPTION
## Summary
- remove the redundant `source` column alteration from the 20251101090000 payments migration so only the method change remains

## Testing
- not run (docker-compose not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68da5bfbc3608328a470002a2096b715