### PR TITLE
Remove duplicate path import in payments controller

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -11,7 +11,6 @@ const userModel = require("../users/user.model");
 const libraryService = require("../library/library.service");
 const notificationService = require("../notifications/notifications.service");
 const mailService = require("../../services/mailService");
-const path = require("path");
 const couponService = require("../coupons/coupons.service");
 const plansService = require("../plans/plans.service");
 const subscriptionService = require("../subscriptions/subscription.service");


### PR DESCRIPTION
## Summary
- remove the duplicate `path` import in the payments controller to avoid redeclaration

## Testing
- docker-compose restart backend *(fails: command not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da649b82248328a628c7dc2d51acd3