### PR TITLE
Remove duplicate path import in bank controller

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -8,7 +8,6 @@ const { STATUS } = paymentsService;
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const notificationService = require("../notifications/notifications.service");
-const path = require("path");
 const mailService = require("../../services/mailService");
 const userModel = require("../users/user.model");
 const walletService = require("../payouts/wallet.service");


### PR DESCRIPTION
## Summary
- remove the duplicate `path` import from the bank payments controller to resolve the redeclaration error

## Testing
- ⚠️ `docker-compose up backend` *(fails in container: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da6d0f53188328a9f34e01f03012b6