### PR TITLE
Remove duplicate path import in bank payments controller

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -8,7 +8,6 @@ const { STATUS } = paymentsService;
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const notificationService = require("../notifications/notifications.service");
-const path = require("path");
 const mailService = require("../../services/mailService");
 const userModel = require("../users/user.model");
 const walletService = require("../payouts/wallet.service");


### PR DESCRIPTION
## Summary
- remove the duplicate `path` import in the bank payments controller to prevent redeclaration errors

## Testing
- NODE_ENV=test JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test TEST_DATABASE_URL=postgres://user:pass@localhost:5432/test BACKEND_PORT=5002 node -e "require('./src/modules/payments/bank.controller.js'); console.log('Module loaded successfully');"

------
https://chatgpt.com/codex/tasks/task_e_68da6d155c348328aaa0e2e8b012029c