### PR TITLE
Fix invoice attachment path resolution in payments controller

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -8,7 +8,6 @@ const { STATUS } = paymentsService;
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const notificationService = require("../notifications/notifications.service");
-const path = require("path");
 const mailService = require("../../services/mailService");
 const userModel = require("../users/user.model");
 const walletService = require("../payouts/wallet.service");

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -1,4 +1,3 @@
-const path = require("path");
 const logger = require('../../utils/logger.js');
 const catchAsync = require("../../utils/catchAsync");
 const AppError = require("../../utils/AppError");
@@ -175,16 +174,19 @@ exports.createPayment = catchAsync(async (req, res) => {
       }
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
-        const attachmentPath = path.join(
-          process.cwd(),
-          invoice.pdf_url.replace(/^\/+/, "")
-        );
-        await mailService.sendMail({
-          to: user.email,
-          subject: "Payment Invoice",
-          html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: attachmentPath }],
-        });
+        const attachmentPath = resolveInvoicePdfPath(invoice);
+        if (attachmentPath) {
+          await mailService.sendMail({
+            to: user.email,
+            subject: "Payment Invoice",
+            html: `<p>Please find your invoice attached.</p>`,
+            attachments: [{ path: attachmentPath }],
+          });
+        } else {
+          logger.warn(
+            "Invoice PDF URL was present but could not be resolved for attachment"
+          );
+        }
       }
     } catch (err) {
       logger.error("Failed to generate invoice:", err);
@@ -272,16 +274,19 @@ exports.updatePayment = catchAsync(async (req, res) => {
         try {
           const invoice = await invoiceService.generateFromPayment(payment, user);
           if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
-            const attachmentPath = path.join(
-              process.cwd(),
-              invoice.pdf_url.replace(/^\/+/, "")
-            );
-            await mailService.sendMail({
-              to: user.email,
-              subject: "Payment Invoice",
-              html: `<p>Please find your invoice attached.</p>`,
-              attachments: [{ path: attachmentPath }],
-            });
+            const attachmentPath = resolveInvoicePdfPath(invoice);
+            if (attachmentPath) {
+              await mailService.sendMail({
+                to: user.email,
+                subject: "Payment Invoice",
+                html: `<p>Please find your invoice attached.</p>`,
+                attachments: [{ path: attachmentPath }],
+              });
+            } else {
+              logger.warn(
+                "Invoice PDF URL was present but could not be resolved for attachment"
+              );
+            }
           }
         } catch (err) {
           logger.error("Failed to generate invoice:", err);


### PR DESCRIPTION
## Summary
- remove the duplicate Node path import in the payments controller by using the shared invoice path helper
- add defensive logging when the invoice attachment path cannot be resolved before sending the email

## Testing
- NODE_ENV=test JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test TEST_DATABASE_URL=postgres://user:pass@localhost:5432/test BACKEND_PORT=5002 node -e "require('./src/modules/payments/payments.controller.js'); console.log('Module loaded successfully');"

------
https://chatgpt.com/codex/tasks/task_e_68da6d155c348328aaa0e2e8b012029c