### PR TITLE
Use shared invoice path helper in bank controller

### DIFF
--- a/backend/src/modules/payments/bank.controller.js
+++ b/backend/src/modules/payments/bank.controller.js
@@ -1,4 +1,3 @@
-const path = require("path");
 const logger = require('../../utils/logger.js');
 const catchAsync = require("../../utils/catchAsync");
 const AppError = require("../../utils/AppError");
@@ -8,7 +7,6 @@ const { STATUS } = paymentsService;
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const paymentMethodsService = require("../paymentMethods/paymentMethods.service");
 const notificationService = require("../notifications/notifications.service");
-const path = require("path");
 const mailService = require("../../services/mailService");
 const userModel = require("../users/user.model");
 const walletService = require("../payouts/wallet.service");
@@ -29,15 +27,7 @@ const resolveInvoiceAttachmentPath = (invoice) => {
     if (resolved) return resolved;
   }
 
-  if (!invoice?.pdf_url) {
-    return null;
-  }
-
-  return path.join(
-    __dirname,
-    "../../../",
-    invoice.pdf_url.replace(/^\/+/, "")
-  );
+  return resolveInvoicePdfPath(invoice);
 };
 
 const DEFAULT_PLATFORM_CUT = {
@@ -356,16 +346,19 @@ exports.approveBankPayment = catchAsync(async (req, res) => {
     if (user) {
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user.email && !user.invoice_email_opt_out && invoice?.pdf_url) {
-        const attachmentPath = path.join(
-          process.cwd(),
-          invoice.pdf_url.replace(/^\/+/, "")
-        );
-        await mailService.sendMail({
-          to: user.email,
-          subject: "Payment Invoice",
-          html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: attachmentPath }],
-        });
+        const attachmentPath = resolveInvoiceAttachmentPath(invoice);
+        if (attachmentPath) {
+          await mailService.sendMail({
+            to: user.email,
+            subject: "Payment Invoice",
+            html: `<p>Please find your invoice attached.</p>`,
+            attachments: [{ path: attachmentPath }],
+          });
+        } else {
+          logger.warn(
+            "Invoice PDF URL was present but could not be resolved for attachment"
+          );
+        }
       }
     }
   } catch (err) {

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -1,4 +1,3 @@
-const path = require("path");
 const logger = require('../../utils/logger.js');
 const catchAsync = require("../../utils/catchAsync");
 const AppError = require("../../utils/AppError");
@@ -175,16 +174,19 @@ exports.createPayment = catchAsync(async (req, res) => {
       }
       const invoice = await invoiceService.generateFromPayment(payment, user);
       if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
-        const attachmentPath = path.join(
-          process.cwd(),
-          invoice.pdf_url.replace(/^\/+/, "")
-        );
-        await mailService.sendMail({
-          to: user.email,
-          subject: "Payment Invoice",
-          html: `<p>Please find your invoice attached.</p>`,
-          attachments: [{ path: attachmentPath }],
-        });
+        const attachmentPath = resolveInvoicePdfPath(invoice);
+        if (attachmentPath) {
+          await mailService.sendMail({
+            to: user.email,
+            subject: "Payment Invoice",
+            html: `<p>Please find your invoice attached.</p>`,
+            attachments: [{ path: attachmentPath }],
+          });
+        } else {
+          logger.warn(
+            "Invoice PDF URL was present but could not be resolved for attachment"
+          );
+        }
       }
     } catch (err) {
       logger.error("Failed to generate invoice:", err);
@@ -272,16 +274,19 @@ exports.updatePayment = catchAsync(async (req, res) => {
         try {
           const invoice = await invoiceService.generateFromPayment(payment, user);
           if (user?.email && !user?.invoice_email_opt_out && invoice?.pdf_url) {
-            const attachmentPath = path.join(
-              process.cwd(),
-              invoice.pdf_url.replace(/^\/+/, "")
-            );
-            await mailService.sendMail({
-              to: user.email,
-              subject: "Payment Invoice",
-              html: `<p>Please find your invoice attached.</p>`,
-              attachments: [{ path: attachmentPath }],
-            });
+            const attachmentPath = resolveInvoicePdfPath(invoice);
+            if (attachmentPath) {
+              await mailService.sendMail({
+                to: user.email,
+                subject: "Payment Invoice",
+                html: `<p>Please find your invoice attached.</p>`,
+                attachments: [{ path: attachmentPath }],
+              });
+            } else {
+              logger.warn(
+                "Invoice PDF URL was present but could not be resolved for attachment"
+              );
+            }
           }
         } catch (err) {
           logger.error("Failed to generate invoice:", err);


### PR DESCRIPTION
## Summary
- update the bank payments controller to use the shared invoice PDF path helper instead of duplicating path resolution logic
- add defensive logging when an invoice attachment path cannot be resolved before sending the email

## Testing
- NODE_ENV=test JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test TEST_DATABASE_URL=postgres://user:pass@localhost:5432/test BACKEND_PORT=5002 node -e "require('./src/modules/payments/payments.controller.js'); console.log('payments controller loaded');"
- NODE_ENV=test JWT_SECRET=test REFRESH_TOKEN_SECRET=test SESSION_SECRET=test TEST_DATABASE_URL=postgres://user:pass@localhost:5432/test BACKEND_PORT=5002 node -e "require('./src/modules/payments/bank.controller.js'); console.log('bank controller loaded');"

------
https://chatgpt.com/codex/tasks/task_e_68da6d155c348328aaa0e2e8b012029c