### PR TITLE
Ensure backend log directory has node ownership

### DIFF
--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -62,6 +62,9 @@ ensure_upload_permissions() {
 
   mkdir -p /app/data
   chown -R node:node /app/data
+
+  mkdir -p /app/logs
+  chown -R node:node /app/logs
 }
 
 ensure_critical_migrations() {


### PR DESCRIPTION
## Summary
- ensure the backend entrypoint also prepares /app/logs with node ownership when running as root

## Testing
- docker compose build backend *(fails: docker command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da818d144083289a41071824aed42b