### PR TITLE
Deduplicate payment invoice email test imports

### DIFF
--- a/backend/tests/paymentInvoiceEmail.test.js
+++ b/backend/tests/paymentInvoiceEmail.test.js
@@ -32,18 +32,13 @@ const path = require('path');
 
 const paymentsController = require('../src/modules/payments/payments.controller');
 const bankController = require('../src/modules/payments/bank.controller');
-
-const path = require('path');
 const invoiceService = require('../src/modules/invoices/invoices.service');
 const mailService = require('../src/services/mailService');
-const bankController = require('../src/modules/payments/bank.controller');
 const paymentsService = require('../src/modules/payments/payments.service');
 const paymentMethodsService = require('../src/modules/paymentMethods/paymentMethods.service');
 const paymentConfigService = require('../src/modules/paymentConfig/paymentConfig.service');
 const userModel = require('../src/modules/users/user.model');
 const bookService = require('../src/modules/books/book.service');
-const invoiceService = require('../src/modules/invoices/invoices.service');
-const mailService = require('../src/services/mailService');
 const plansService = require('../src/modules/plans/plans.service');
 const subscriptionService = require('../src/modules/subscriptions/subscription.service');
 const notificationService = require('../src/modules/notifications/notifications.service');


### PR DESCRIPTION
## Summary
- remove the duplicate require declarations in the payment invoice email test
- keep a single set of dependency imports so the mocks and helpers referenced in the suite remain available

## Testing
- npm test *(fails: extensive suite requires TEST_DATABASE_URL and other mocks outside the touched test)*

------
https://chatgpt.com/codex/tasks/task_e_68da8191b95c8328ba9981429050c6fb