### PR TITLE
Clarify invoice path handling in payments controller

### DIFF
--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -19,6 +19,8 @@ const paymentMethodsService = require("../paymentMethods/paymentMethods.service"
 const { validatePaymentData } = require("./helpers/validation");
 const { calculatePlatformFee } = require("./helpers/platformFee");
 const { handleEnrollment } = require("./helpers/enrollment");
+// Attachment paths are resolved within the invoicePath helper, so no local
+// path module import is required here.
 const { resolveInvoicePdfPath } = require("../invoices/helpers/invoicePath");
 
 exports.createPayment = catchAsync(async (req, res) => {


### PR DESCRIPTION
## Summary
- document that invoice attachment paths are provided by the helper used in the payments controller

## Testing
- docker compose build backend *(fails: docker not installed in environment)*
- docker compose up -d backend *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da81990f008328985c70525156692a