### PR TITLE
Handle installer form success state caching

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -343,6 +343,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const fieldErrors = new Map();
+  const fieldSuccesses = new Map();
   const codecanyonVerification = { key: '', status: 'idle', message: '' };
 
   if (codecanyonInput) {
@@ -351,6 +352,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!sanitized) {
         clearCodecanyonStatus({ resetKey: true });
         clearFieldError('codecanyonKey');
+        clearFieldSuccess('codecanyonKey');
         return;
       }
       if (codecanyonVerification.status === 'success' && codecanyonVerification.key !== sanitized) {
@@ -363,6 +365,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!sanitized) {
         clearCodecanyonStatus({ resetKey: true });
         clearFieldError('codecanyonKey');
+        clearFieldSuccess('codecanyonKey');
         return;
       }
       const result = await verifyCodecanyonLicense(sanitized);
@@ -390,6 +393,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const el = configForm ? configForm.querySelector(`[data-field-success="${name}"]`) : null;
     fieldSuccesses.set(name, el || null);
     return el || null;
+  }
+
+  function clearFieldSuccess(name) {
+    const successEl = getFieldSuccessElement(name);
+    if (successEl) {
+      successEl.textContent = '';
+      successEl.classList.add('hidden');
+    }
   }
 
   function setProgress(percent) {
@@ -610,8 +621,14 @@ document.addEventListener('DOMContentLoaded', () => {
       el.classList.add('hidden');
     });
     configForm.querySelectorAll('[data-field-success]').forEach((el) => {
-      el.textContent = '';
-      el.classList.add('hidden');
+      const fieldName = el.getAttribute('data-field-success');
+      if (fieldName) {
+        fieldSuccesses.set(fieldName, el);
+        clearFieldSuccess(fieldName);
+      } else {
+        el.textContent = '';
+        el.classList.add('hidden');
+      }
     });
   }
 
@@ -626,6 +643,19 @@ document.addEventListener('DOMContentLoaded', () => {
     if (errorEl) {
       errorEl.textContent = '';
       errorEl.classList.add('hidden');
+    }
+  }
+
+  function setFieldSuccess(name, message) {
+    if (!configForm) return;
+    if (!message) {
+      clearFieldSuccess(name);
+      return;
+    }
+    const successEl = getFieldSuccessElement(name);
+    if (successEl) {
+      successEl.textContent = message;
+      successEl.classList.remove('hidden');
     }
   }
 
@@ -884,6 +914,7 @@ document.addEventListener('DOMContentLoaded', () => {
       codecanyonVerification.key = sanitized;
       updateCodecanyonStatus('success', message);
       clearFieldError('codecanyonKey');
+      setFieldSuccess('codecanyonKey', message);
       return { ok: true, message };
     } catch (error) {
       const message = `Unable to verify license: ${error.message}`;


### PR DESCRIPTION
## Summary
- cache field success placeholder elements alongside error placeholders in the installer
- add helpers to clear and show per-field success messages and reuse them across code paths
- surface Envato/Codecanyon license verification success inline while keeping caches in sync

## Testing
- not run (UI changes require manual validation in a browser)


------
https://chatgpt.com/codex/tasks/task_e_68de23271fec8328bbd1d732b3725bef