### PR TITLE
Fix field success handling in installer

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -343,6 +343,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const fieldErrors = new Map();
+  const fieldSuccesses = new Map();
   const codecanyonVerification = { key: '', status: 'idle', message: '' };
 
   if (codecanyonInput) {
@@ -626,6 +627,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (errorEl) {
       errorEl.textContent = '';
       errorEl.classList.add('hidden');
+    }
+  }
+
+  function clearFieldSuccess(name) {
+    if (!configForm) return;
+    const successEl = getFieldSuccessElement(name);
+    if (successEl) {
+      successEl.textContent = '';
+      successEl.classList.add('hidden');
     }
   }
 


### PR DESCRIPTION
## Summary
- add a cache for field success elements alongside existing error cache
- add a helper to clear success indicators before showing field errors

## Testing
- ⚠️ Manual installer smoke test (not run: environment lacks browser access)

------
https://chatgpt.com/codex/tasks/task_e_68de2335c6b48328ad238aca76584326