### PR TITLE
Fix missing field success helper in installer

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -343,6 +343,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const fieldErrors = new Map();
+  const fieldSuccesses = new Map();
   const codecanyonVerification = { key: '', status: 'idle', message: '' };
 
   if (codecanyonInput) {
@@ -603,7 +604,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!configForm) return;
     configForm.querySelectorAll('[name]').forEach((input) => {
       input.removeAttribute('aria-invalid');
-      input.classList.remove('border-red-400', 'focus:border-red-500', 'focus:ring-red-200');
+      input.classList.remove(
+        'border-red-400',
+        'focus:border-red-500',
+        'focus:ring-red-200',
+        'border-green-400',
+        'focus:border-green-500',
+        'focus:ring-green-200'
+      );
     });
     configForm.querySelectorAll('[data-field-error]').forEach((el) => {
       el.textContent = '';
@@ -626,6 +634,19 @@ document.addEventListener('DOMContentLoaded', () => {
     if (errorEl) {
       errorEl.textContent = '';
       errorEl.classList.add('hidden');
+    }
+  }
+
+  function clearFieldSuccess(name) {
+    if (!configForm) return;
+    const field = configForm.querySelector(`[name="${name}"]`);
+    if (field) {
+      field.classList.remove('border-green-400', 'focus:border-green-500', 'focus:ring-green-200');
+    }
+    const successEl = getFieldSuccessElement(name);
+    if (successEl) {
+      successEl.textContent = '';
+      successEl.classList.add('hidden');
     }
   }
 


### PR DESCRIPTION
## Summary
- add a field success cache alongside the existing error cache in the installer
- implement a clearFieldSuccess helper that hides success messages and removes success styling
- ensure bulk field clearing also removes success styles for future success states

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de23565a8083288301381f8d71d2b6