### PR TITLE
Sanitize admin class pagination parameters

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -111,7 +111,10 @@ export default function AdminClassesTable() {
       try {
         const scheduleFiltering = shouldApplyScheduleFilter(filterStatus);
         const statusQuery = mapStatusFilterToQuery(filterStatus);
-        const safeLimit = Math.max(itemsPerPage, 1);
+        const safeLimit =
+          Number.isFinite(itemsPerPage) && itemsPerPage > 0 ? itemsPerPage : 1;
+        const safePage =
+          Number.isFinite(currentPage) && currentPage > 0 ? currentPage : 1;
         const baseParams = {
           limit: safeLimit,
           filter: searchTerm,
@@ -119,7 +122,7 @@ export default function AdminClassesTable() {
           ...(statusQuery ? { status: statusQuery } : {}),
         };
 
-        const initialPage = scheduleFiltering ? 1 : currentPage;
+        const initialPage = scheduleFiltering ? 1 : safePage;
         const { data, meta } = await fetchAdminClasses({
           ...baseParams,
           page: initialPage,
@@ -153,17 +156,23 @@ export default function AdminClassesTable() {
             Math.ceil(totalFilteredItems / safeLimit)
           );
           const normalizedPage = Math.min(
-            Math.max(currentPage, 1),
+            Math.max(safePage, 1),
             totalFilteredPages
           );
+          const effectivePage = Number.isFinite(normalizedPage)
+            ? normalizedPage
+            : 1;
 
           setTotalItems(totalFilteredItems);
           setTotalPages(totalFilteredPages);
-          if (normalizedPage !== currentPage) {
+          if (
+            Number.isFinite(normalizedPage) &&
+            normalizedPage !== currentPage
+          ) {
             setCurrentPage(normalizedPage);
           }
 
-          const startIndex = (normalizedPage - 1) * safeLimit;
+          const startIndex = (effectivePage - 1) * safeLimit;
           const paginatedData = sortedData.slice(
             startIndex,
             startIndex + safeLimit


### PR DESCRIPTION
## Summary
- sanitize the pagination limit and page before issuing admin class fetches
- prevent NaN values from updating pagination state and slicing filtered data

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68de2ab88c008328a4839a71c6e0aeb4