### PR TITLE
Sanitize admin online classes pagination limit

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -111,7 +111,8 @@ export default function AdminClassesTable() {
       try {
         const scheduleFiltering = shouldApplyScheduleFilter(filterStatus);
         const statusQuery = mapStatusFilterToQuery(filterStatus);
-        const safeLimit = Math.max(itemsPerPage, 1);
+        const safeLimit =
+          Number.isFinite(itemsPerPage) && itemsPerPage > 0 ? itemsPerPage : 1;
         const baseParams = {
           limit: safeLimit,
           filter: searchTerm,
@@ -447,7 +448,14 @@ export default function AdminClassesTable() {
           </select>
           <select
             value={itemsPerPage}
-            onChange={(e) => { setItemsPerPage(Number(e.target.value)); setCurrentPage(1); }}
+            onChange={(e) => {
+              const numericValue = Number(e.target.value);
+              const nextItemsPerPage = Number.isFinite(numericValue)
+                ? numericValue
+                : totalItems || 1;
+              setItemsPerPage(nextItemsPerPage);
+              setCurrentPage(1);
+            }}
             className="border border-gray-300 rounded-xl px-2 py-2 text-sm"
           >
             <option value={5}>5</option>


### PR DESCRIPTION
## Summary
- sanitize the pagination limit in the admin classes table so non-positive or non-finite values default to 1
- guard the page size selector to avoid setting NaN when "All" or invalid values are chosen

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68de2b0a6bf083289c8c18321276c8c5