### PR TITLE
Fix browser API base fallback for relative URLs

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,6 +23,8 @@ Environment files support variable expansion using [`dotenv-expand`](https://git
 
 Only commit placeholder values. Supply real values in production via environment variables or a mounted `.env.production` so `npm run build` can generate a bundle that connects to the correct services. If `APP_DOMAIN` is defined you may set `NEXT_PUBLIC_API_BASE_URL=/api`; the build expands the relative path to `https://${APP_DOMAIN}/api` while still rejecting non-HTTPS public hosts.
 
+For local development create a `.env.local` file and set `NEXT_PUBLIC_API_BASE_URL` to your backend, for example `http://localhost:5002/api`. Without this the browser falls back to `/api`, causing admin pages to send requests to the Next.js dev server instead of the actual API.
+
 Docker builds export `STRICT_PUBLIC_API=true`, so container images **must** provide `NEXT_PUBLIC_API_BASE_URL` either by passing `--build-arg NEXT_PUBLIC_API_BASE_URL=https://your-domain/api` (or `/api` alongside `--build-arg APP_DOMAIN=your-domain`) or by including it in `.env.production`. Builds fail if the value is missing or if a non-local host still uses `http://`.
 
 ## Development Server

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -42,18 +42,17 @@ const ensureAbsoluteUrl = (candidate) => {
   };
 
   if (isBrowser) {
-    const origin = window?.location?.origin;
-    if (origin) {
-      const resolved = tryResolveWithBase(origin);
-      if (resolved) {
-        return resolved;
-      }
-    }
+    const fallbackBrowserBase = [DEFAULT_SERVER_BASE_URL, internalBaseCandidate]
+      .filter((base) => base && /^https?:\/\//i.test(base))
+      .shift();
+
+    const fallback = fallbackBrowserBase || DEFAULT_SERVER_BASE_URL;
 
     logger.warn(
-      `API base "${candidate}" is not absolute. Falling back to the current browser origin.`
+      `API base "${candidate}" is not absolute. Falling back to "${fallback}".`
     );
-    return origin ? tryResolveWithBase(origin) || origin : candidate;
+
+    return fallback;
   }
 
   const appDomain = process.env.APP_DOMAIN;


### PR DESCRIPTION
## Summary
- make the browser-side API client fall back to the backend base URL when NEXT_PUBLIC_API_BASE_URL is left relative
- document that local development must set NEXT_PUBLIC_API_BASE_URL to point at the backend

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2b5fa3b483289e425fe95848d046