### PR TITLE
Prevent duplicate admin class fetches

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -1,5 +1,5 @@
 // ✅ AdminClassesTable.js with Full Routing, Labeled Buttons, and Tooltips
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
 import { toast } from "react-toastify";
@@ -87,6 +87,11 @@ export default function AdminClassesTable() {
   const [totalItems, setTotalItems] = useState(0);
   const [exporting, setExporting] = useState(false);
   const [isMounted, setMounted] = useState(false);
+  const lastSuccessfulSignatureRef = useRef(null);
+  const lastFailedSignatureRef = useRef(null);
+  const inFlightRequestRef = useRef(null);
+  const pendingRequestRef = useRef(null);
+  const isComponentMountedRef = useRef(true);
   const { user, hasHydrated } = useAuthStore((state) => ({
     user: state.user,
     hasHydrated: state.hasHydrated,
@@ -96,30 +101,90 @@ export default function AdminClassesTable() {
   const refreshMessages = useMessageStore((state) => state.fetch);
   useEffect(() => {
     setMounted(true);
+    isComponentMountedRef.current = true;
+    return () => {
+      isComponentMountedRef.current = false;
+    };
   }, []);
 
-  const sortClasses = (items) =>
-    [...items].sort((a, b) => compareValues(a, b, sortKey));
+  const sortClasses = (items, key = sortKey) =>
+    [...items].sort((a, b) => compareValues(a, b, key));
 
   const hydratedUser = isMounted && hasHydrated ? user : null;
   const canManageRules =
     isMounted && hasHydrated && user?.permissions?.includes('ADD_ONLINE_CLASS_RULE');
 
   useEffect(() => {
-    const load = async () => {
-      setLoading(true);
+    const requestDetails = {
+      signature: JSON.stringify({
+        page: currentPage,
+        limit: itemsPerPage,
+        searchTerm,
+        approval: filterApproval,
+        status: filterStatus,
+        sortKey,
+      }),
+      page: currentPage,
+      itemsPerPage,
+      searchTerm,
+      filterApproval,
+      filterStatus,
+      sortKey,
+    };
+
+    if (
+      lastFailedSignatureRef.current &&
+      lastFailedSignatureRef.current !== requestDetails.signature
+    ) {
+      lastFailedSignatureRef.current = null;
+    }
+
+    if (lastSuccessfulSignatureRef.current === requestDetails.signature) {
+      return;
+    }
+
+    if (lastFailedSignatureRef.current === requestDetails.signature) {
+      return;
+    }
+
+    if (inFlightRequestRef.current) {
+      pendingRequestRef.current = requestDetails;
+      return;
+    }
+
+    const executeRequest = async (details) => {
+      const {
+        signature,
+        page,
+        itemsPerPage: limitValue,
+        searchTerm: searchValue,
+        filterApproval: approvalValue,
+        filterStatus: statusValue,
+        sortKey: sortValue,
+      } = details;
+
+      if (!isComponentMountedRef.current) {
+        return;
+      }
+
+      inFlightRequestRef.current = signature;
+
+      if (isComponentMountedRef.current) {
+        setLoading(true);
+      }
+
       try {
-        const scheduleFiltering = shouldApplyScheduleFilter(filterStatus);
-        const statusQuery = mapStatusFilterToQuery(filterStatus);
-        const safeLimit = Math.max(itemsPerPage, 1);
+        const scheduleFiltering = shouldApplyScheduleFilter(statusValue);
+        const statusQuery = mapStatusFilterToQuery(statusValue);
+        const safeLimit = Math.max(limitValue, 1);
         const baseParams = {
           limit: safeLimit,
-          filter: searchTerm,
-          ...(filterApproval !== "All" ? { approval: filterApproval } : {}),
+          filter: searchValue,
+          ...(approvalValue !== "All" ? { approval: approvalValue } : {}),
           ...(statusQuery ? { status: statusQuery } : {}),
         };
 
-        const initialPage = scheduleFiltering ? 1 : currentPage;
+        const initialPage = scheduleFiltering ? 1 : page;
         const { data, meta } = await fetchAdminClasses({
           ...baseParams,
           page: initialPage,
@@ -144,22 +209,26 @@ export default function AdminClassesTable() {
           const filteredData = aggregatedData.filter(
             (cls) =>
               cls.scheduleStatus?.toLowerCase() ===
-              filterStatus.toLowerCase()
+              statusValue.toLowerCase()
           );
-          const sortedData = sortClasses(filteredData);
+          const sortedData = sortClasses(filteredData, sortValue);
           const totalFilteredItems = sortedData.length;
           const totalFilteredPages = Math.max(
             1,
             Math.ceil(totalFilteredItems / safeLimit)
           );
           const normalizedPage = Math.min(
-            Math.max(currentPage, 1),
+            Math.max(page, 1),
             totalFilteredPages
           );
 
+          if (!isComponentMountedRef.current) {
+            return;
+          }
+
           setTotalItems(totalFilteredItems);
           setTotalPages(totalFilteredPages);
-          if (normalizedPage !== currentPage) {
+          if (normalizedPage !== page) {
             setCurrentPage(normalizedPage);
           }
 
@@ -168,22 +237,63 @@ export default function AdminClassesTable() {
             startIndex,
             startIndex + safeLimit
           );
+
+          if (!isComponentMountedRef.current) {
+            return;
+          }
+
           setClassList(paginatedData);
         } else {
-          const sortedData = sortClasses(data);
+          const sortedData = sortClasses(data, sortValue);
+
+          if (!isComponentMountedRef.current) {
+            return;
+          }
+
           setClassList(sortedData);
           setTotalPages(meta?.totalPages ? Math.max(meta.totalPages, 1) : 1);
           setTotalItems(meta?.total ?? data.length);
         }
+
+        lastSuccessfulSignatureRef.current = signature;
+        lastFailedSignatureRef.current = null;
       } catch (err) {
         console.error(err);
-        toast.error("Failed to load classes");
+        if (isComponentMountedRef.current) {
+          toast.error("Failed to load classes");
+        }
+        lastFailedSignatureRef.current = signature;
       } finally {
-        setLoading(false);
+        if (isComponentMountedRef.current) {
+          setLoading(false);
+        }
+        inFlightRequestRef.current = null;
+
+        const nextRequest = pendingRequestRef.current;
+        if (nextRequest && nextRequest.signature !== signature) {
+          pendingRequestRef.current = null;
+          if (
+            isComponentMountedRef.current &&
+            lastSuccessfulSignatureRef.current !== nextRequest.signature &&
+            lastFailedSignatureRef.current !== nextRequest.signature
+          ) {
+            executeRequest(nextRequest);
+          }
+        } else if (nextRequest && nextRequest.signature === signature) {
+          pendingRequestRef.current = null;
+        }
       }
     };
-    load();
-  }, [currentPage, itemsPerPage, searchTerm, filterApproval, filterStatus, sortKey]);
+
+    executeRequest(requestDetails);
+  }, [
+    currentPage,
+    itemsPerPage,
+    searchTerm,
+    filterApproval,
+    filterStatus,
+    sortKey,
+  ]);
 
   const formatCSVRow = (row) =>
     row

--- a/frontend/tests/components/AdminClassesTablePagination.test.js
+++ b/frontend/tests/components/AdminClassesTablePagination.test.js
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import AdminClassesTable from "@/components/admin/online-classes/AdminClassesTable";
 import { fetchAdminClasses } from "@/services/admin/classService";
+import { toast } from "react-toastify";
 
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -68,6 +69,7 @@ describe("AdminClassesTable schedule filtering", () => {
 
   beforeEach(() => {
     mockedFetchAdminClasses.mockReset();
+    toast.error.mockClear();
   });
 
   it("retains access to upcoming classes spread across multiple pages", async () => {
@@ -144,5 +146,30 @@ describe("AdminClassesTable schedule filtering", () => {
     ).toBe(true);
 
     expect(await screen.findByText("Future Class")).toBeInTheDocument();
+  });
+});
+
+describe("AdminClassesTable error handling", () => {
+  const mockedFetchAdminClasses = fetchAdminClasses;
+
+  beforeEach(() => {
+    mockedFetchAdminClasses.mockReset();
+    toast.error.mockClear();
+  });
+
+  it("shows a single toast and avoids duplicate retries when the fetch fails", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockedFetchAdminClasses.mockRejectedValue(new Error("Network error"));
+
+    render(<AdminClassesTable />);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockedFetchAdminClasses).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith("Failed to load classes");
+
+    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- coordinate admin class table fetches with refs to avoid concurrent loads and repeated retries
- reset loading state only when allowed and guard error toasts against repetition
- add a Jest test covering the single-toast failure scenario

## Testing
- npm test -- AdminClassesTablePagination

------
https://chatgpt.com/codex/tasks/task_e_68de2b6a2e648328913401ae9812c25d