### PR TITLE
Add view_online_classes permission to seed data

### DIFF
--- a/backend/src/seeds/10_permissions_seed.js
+++ b/backend/src/seeds/10_permissions_seed.js
@@ -33,6 +33,7 @@ exports.seed = async function (knex) {
     { code: 'manage_certificate_templates', description: 'Permission to manage certificate templates' },
     { code: 'view_third_party_config', description: 'Permission to view third-party configuration' },
     { code: 'manage_third_party_config', description: 'Permission to manage third-party configuration' },
+    { code: 'view_online_classes', description: 'Permission to view online classes' },
   ];
 
   await knex('permissions')


### PR DESCRIPTION
## Summary
- add the missing `view_online_classes` permission to the seed data so it can be assigned to roles automatically

## Testing
- npx knex migrate:latest --knexfile knexfile.js
- npx knex seed:run --knexfile knexfile.js
- psql postgres://skillbridge_user:skillbridge_pass@127.0.0.1:5432/skillbridge_db -c "SELECT r.name FROM roles r JOIN role_permissions rp ON r.id = rp.role_id JOIN permissions p ON p.id = rp.permission_id WHERE p.code = 'view_online_classes' ORDER BY r.name;"


------
https://chatgpt.com/codex/tasks/task_e_68de2bcc35408328a2c5ad8022d1a75a