### PR TITLE
Stabilize admin online classes pagination limit handling

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -34,6 +34,20 @@ import {
 const BACKEND_STATUSES = new Set(["draft", "published", "archived"]);
 const MIN_REJECTION_REASON_LENGTH = 3;
 
+const resolvePositiveInteger = (value, fallback = 1) => {
+  const numericValue = Number(value);
+  if (Number.isFinite(numericValue) && numericValue > 0) {
+    return Math.floor(numericValue);
+  }
+
+  const fallbackValue = Number(fallback);
+  if (Number.isFinite(fallbackValue) && fallbackValue > 0) {
+    return Math.floor(fallbackValue);
+  }
+
+  return 1;
+};
+
 export const mapStatusFilterToQuery = (filterStatus) => {
   if (!filterStatus || filterStatus === "All") {
     return undefined;
@@ -82,6 +96,7 @@ export default function AdminClassesTable() {
   const [rejectionReason, setRejectionReason] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(5);
+  const [showAllItems, setShowAllItems] = useState(false);
   const [loading, setLoading] = useState(false);
   const [totalPages, setTotalPages] = useState(1);
   const [totalItems, setTotalItems] = useState(0);
@@ -99,6 +114,9 @@ export default function AdminClassesTable() {
   const { t } = useTranslation('dashboard');
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
+  const normalizedItemsPerPage = resolvePositiveInteger(itemsPerPage);
+  const classCount = classList.length;
+
   useEffect(() => {
     setMounted(true);
     isComponentMountedRef.current = true;
@@ -118,14 +136,14 @@ export default function AdminClassesTable() {
     const requestDetails = {
       signature: JSON.stringify({
         page: currentPage,
-        limit: itemsPerPage,
+        limit: normalizedItemsPerPage,
         searchTerm,
         approval: filterApproval,
         status: filterStatus,
         sortKey,
       }),
       page: currentPage,
-      itemsPerPage,
+      itemsPerPage: normalizedItemsPerPage,
       searchTerm,
       filterApproval,
       filterStatus,
@@ -176,7 +194,7 @@ export default function AdminClassesTable() {
       try {
         const scheduleFiltering = shouldApplyScheduleFilter(statusValue);
         const statusQuery = mapStatusFilterToQuery(statusValue);
-        const safeLimit = Math.max(limitValue, 1);
+        const safeLimit = resolvePositiveInteger(limitValue);
         const baseParams = {
           limit: safeLimit,
           filter: searchValue,
@@ -217,13 +235,14 @@ export default function AdminClassesTable() {
             1,
             Math.ceil(totalFilteredItems / safeLimit)
           );
-          const normalizedPage = Math.min(
+          const normalizedPageRaw = Math.min(
             Math.max(page, 1),
             totalFilteredPages
           );
-          const effectivePage = Number.isFinite(normalizedPage)
-            ? normalizedPage
+          const normalizedPage = Number.isFinite(normalizedPageRaw)
+            ? normalizedPageRaw
             : 1;
+          const effectivePage = normalizedPage;
 
           if (!isComponentMountedRef.current) {
             return;
@@ -231,7 +250,7 @@ export default function AdminClassesTable() {
 
           setTotalItems(totalFilteredItems);
           setTotalPages(totalFilteredPages);
-          if (normalizedPage !== page) {
+          if (Number.isFinite(normalizedPage) && normalizedPage !== page) {
             setCurrentPage(normalizedPage);
           }
 
@@ -497,8 +516,30 @@ export default function AdminClassesTable() {
     handleDeleteClass(modalClass.id);
   };
 
-  const handlePrev = () => setCurrentPage(prev => Math.max(prev - 1, 1));
-  const handleNext = () => setCurrentPage(prev => Math.min(prev + 1, totalPages));
+  useEffect(() => {
+    if (showAllItems) {
+      const inferredTotal = resolvePositiveInteger(totalItems || classCount, 1);
+
+      if (itemsPerPage !== inferredTotal) {
+        setItemsPerPage(inferredTotal);
+      }
+      return;
+    }
+
+    if (itemsPerPage !== normalizedItemsPerPage) {
+      setItemsPerPage(normalizedItemsPerPage);
+    }
+  }, [
+    showAllItems,
+    totalItems,
+    classCount,
+    itemsPerPage,
+    normalizedItemsPerPage,
+  ]);
+
+  const handlePrev = () => setCurrentPage((prev) => Math.max(prev - 1, 1));
+  const handleNext = () =>
+    setCurrentPage((prev) => Math.min(prev + 1, totalPages));
 
   if (loading) {
     return (
@@ -559,21 +600,34 @@ export default function AdminClassesTable() {
             <option value="instructor">Sort by Instructor</option>
           </select>
           <select
-            value={itemsPerPage}
+            value={showAllItems ? "all" : String(normalizedItemsPerPage)}
             onChange={(e) => {
-              const numericValue = Number(e.target.value);
-              const nextItemsPerPage = Number.isFinite(numericValue)
-                ? numericValue
-                : totalItems || 1;
-              setItemsPerPage(nextItemsPerPage);
+              const { value } = e.target;
+
+              if (value === "all") {
+                setShowAllItems(true);
+                const inferredTotal = resolvePositiveInteger(
+                  totalItems || classCount,
+                  1
+                );
+                setItemsPerPage(inferredTotal);
+              } else {
+                setShowAllItems(false);
+                const sanitizedValue = resolvePositiveInteger(
+                  value,
+                  totalItems || classCount || 1
+                );
+                setItemsPerPage(sanitizedValue);
+              }
+
               setCurrentPage(1);
             }}
             className="border border-gray-300 rounded-xl px-2 py-2 text-sm"
           >
-            <option value={5}>5</option>
-            <option value={10}>10</option>
-            <option value={25}>25</option>
-            <option value={totalItems}>All</option>
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="all">All</option>
           </select>
           <button
             onClick={exportCSV}
@@ -739,7 +793,8 @@ export default function AdminClassesTable() {
       {totalPages > 1 && (
         <div className="mt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
           <div className="text-sm text-gray-500">
-            Showing {(currentPage - 1) * itemsPerPage + 1}–{Math.min(currentPage * itemsPerPage, totalItems)} of {totalItems} classes
+            Showing {(currentPage - 1) * normalizedItemsPerPage + 1}–
+            {Math.min(currentPage * normalizedItemsPerPage, totalItems)} of {totalItems} classes
           </div>
           <div className="flex items-center gap-2">
             <button onClick={handlePrev} disabled={currentPage === 1} className="text-sm px-3 py-1 bg-gray-200 hover:bg-yellow-100 rounded disabled:opacity-50">


### PR DESCRIPTION
## Summary
- sanitize the admin classes pagination limit before fetching data or paginating results
- track the "All" page-size selection and re-synchronize it with the current totals so the selector never yields invalid page sizes

## Testing
- npm --prefix frontend run lint *(fails: existing lint violations outside the touched component)*

------
https://chatgpt.com/codex/tasks/task_e_68de27c207c083289623196bc93d86a4