### PR TITLE
Fix AdminClassesTable pagination loops when dataset shrinks

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -107,6 +107,10 @@ export default function AdminClassesTable() {
   const inFlightRequestRef = useRef(null);
   const pendingRequestRef = useRef(null);
   const isComponentMountedRef = useRef(true);
+  const currentPageRef = useRef(currentPage);
+  const totalPagesRef = useRef(totalPages);
+  const totalItemsRef = useRef(totalItems);
+  const loadingRef = useRef(loading);
   const { user, hasHydrated } = useAuthStore((state) => ({
     user: state.user,
     hasHydrated: state.hasHydrated,
@@ -131,6 +135,22 @@ export default function AdminClassesTable() {
       isComponentMountedRef.current = false;
     };
   }, []);
+
+  useEffect(() => {
+    currentPageRef.current = currentPage;
+  }, [currentPage]);
+
+  useEffect(() => {
+    totalPagesRef.current = totalPages;
+  }, [totalPages]);
+
+  useEffect(() => {
+    totalItemsRef.current = totalItems;
+  }, [totalItems]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
 
   const sortClasses = (items, key = sortKey) =>
     [...items].sort((a, b) => compareValues(a, b, key));
@@ -194,8 +214,20 @@ export default function AdminClassesTable() {
 
       inFlightRequestRef.current = signature;
 
-      if (isComponentMountedRef.current) {
+      if (isComponentMountedRef.current && !loadingRef.current) {
+        loadingRef.current = true;
         setLoading(true);
+      }
+
+      if (process.env.NODE_ENV !== "production") {
+        console.debug("[AdminClassesTable] executeRequest", signature, {
+          page,
+          itemsPerPage: limitValue,
+          searchTerm: searchValue,
+          filterApproval: approvalValue,
+          filterStatus: statusValue,
+          sortKey: sortValue,
+        });
       }
 
       try {
@@ -255,9 +287,19 @@ export default function AdminClassesTable() {
             return;
           }
 
-          setTotalItems(totalFilteredItems);
-          setTotalPages(totalFilteredPages);
-          if (Number.isFinite(normalizedPage) && normalizedPage !== page) {
+          if (totalItemsRef.current !== totalFilteredItems) {
+            totalItemsRef.current = totalFilteredItems;
+            setTotalItems(totalFilteredItems);
+          }
+          if (totalPagesRef.current !== totalFilteredPages) {
+            totalPagesRef.current = totalFilteredPages;
+            setTotalPages(totalFilteredPages);
+          }
+          if (
+            Number.isFinite(normalizedPage) &&
+            currentPageRef.current !== normalizedPage
+          ) {
+            currentPageRef.current = normalizedPage;
             setCurrentPage(normalizedPage);
           }
 
@@ -280,8 +322,27 @@ export default function AdminClassesTable() {
           }
 
           setClassList(sortedData);
-          setTotalPages(meta?.totalPages ? Math.max(meta.totalPages, 1) : 1);
-          setTotalItems(meta?.total ?? data.length);
+          const nextTotalPages = meta?.totalPages ? Math.max(meta.totalPages, 1) : 1;
+          const nextTotalItems = meta?.total ?? data.length;
+
+          if (totalPagesRef.current !== nextTotalPages) {
+            totalPagesRef.current = nextTotalPages;
+            setTotalPages(nextTotalPages);
+          }
+
+          if (totalItemsRef.current !== nextTotalItems) {
+            totalItemsRef.current = nextTotalItems;
+            setTotalItems(nextTotalItems);
+          }
+
+          if (
+            nextTotalPages > 0 &&
+            page > nextTotalPages &&
+            currentPageRef.current !== nextTotalPages
+          ) {
+            currentPageRef.current = nextTotalPages;
+            setCurrentPage(nextTotalPages);
+          }
         }
 
         lastSuccessfulSignatureRef.current = signature;
@@ -293,7 +354,8 @@ export default function AdminClassesTable() {
         }
         lastFailedSignatureRef.current = signature;
       } finally {
-        if (isComponentMountedRef.current) {
+        if (isComponentMountedRef.current && loadingRef.current) {
+          loadingRef.current = false;
           setLoading(false);
         }
         inFlightRequestRef.current = null;

--- a/frontend/tests/components/AdminClassesTableOutOfRange.test.js
+++ b/frontend/tests/components/AdminClassesTableOutOfRange.test.js
@@ -1,0 +1,183 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AdminClassesTable from "@/components/admin/online-classes/AdminClassesTable";
+import { fetchAdminClasses } from "@/services/admin/classService";
+import { toast } from "react-toastify";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }) => (
+    <a {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+const mockAuthState = {
+  user: { id: 1, permissions: [] },
+  hasHydrated: true,
+};
+
+jest.mock("@/store/auth/authStore", () => ({
+  __esModule: true,
+  default: (selector) => selector(mockAuthState),
+}));
+
+const mockNotificationStore = { fetch: jest.fn() };
+jest.mock("@/store/notifications/notificationStore", () => ({
+  __esModule: true,
+  default: (selector) => selector(mockNotificationStore),
+}));
+
+const mockMessageStore = { fetch: jest.fn() };
+jest.mock("@/store/messages/messageStore", () => ({
+  __esModule: true,
+  default: (selector) => selector(mockMessageStore),
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock("@/services/notificationService", () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock("@/services/messageService", () => ({
+  sendChatMessage: jest.fn(),
+}));
+
+jest.mock("@/services/admin/classService", () => ({
+  fetchAdminClasses: jest.fn(),
+  updateAdminClass: jest.fn(),
+  deleteAdminClass: jest.fn(),
+  approveAdminClass: jest.fn(),
+  rejectAdminClass: jest.fn(),
+  toggleClassStatus: jest.fn(),
+}));
+
+describe("AdminClassesTable out-of-range handling", () => {
+  const mockedFetchAdminClasses = fetchAdminClasses;
+
+  beforeEach(() => {
+    mockedFetchAdminClasses.mockReset();
+    toast.error.mockClear();
+    toast.success.mockClear();
+  });
+
+  it("avoids repeated fetches when the resolved total pages drop below the current page", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const responses = [
+      {
+        data: [
+          {
+            id: "p1",
+            title: "Class Page 1",
+            instructor: "Instructor 1",
+            start_date: "2024-01-01",
+            end_date: "2024-01-05",
+            category: "Category",
+            publishStatus: "draft",
+            approvalStatus: "Approved",
+            scheduleStatus: "Upcoming",
+            price: 0,
+          },
+        ],
+        meta: { totalPages: 3, total: 3 },
+      },
+      {
+        data: [
+          {
+            id: "p2",
+            title: "Class Page 2",
+            instructor: "Instructor 2",
+            start_date: "2024-02-01",
+            end_date: "2024-02-05",
+            category: "Category",
+            publishStatus: "draft",
+            approvalStatus: "Approved",
+            scheduleStatus: "Upcoming",
+            price: 0,
+          },
+        ],
+        meta: { totalPages: 3, total: 3 },
+      },
+      {
+        data: [],
+        meta: { totalPages: 1, total: 1 },
+      },
+      {
+        data: [
+          {
+            id: "s1",
+            title: "Shrunk Class",
+            instructor: "Instructor 3",
+            start_date: "2024-03-01",
+            end_date: "2024-03-05",
+            category: "Category",
+            publishStatus: "draft",
+            approvalStatus: "Approved",
+            scheduleStatus: "Upcoming",
+            price: 0,
+          },
+        ],
+        meta: { totalPages: 1, total: 1 },
+      },
+    ];
+
+    const signatures = [];
+
+    mockedFetchAdminClasses.mockImplementation(async (params) => {
+      signatures.push(JSON.stringify(params));
+      const response = responses[signatures.length - 1];
+      if (!response) {
+        throw new Error(`Unexpected fetch call ${signatures.length}`);
+      }
+      return response;
+    });
+
+    render(<AdminClassesTable />);
+
+    await screen.findByText("Class Page 1");
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    await screen.findByText("Class Page 2");
+
+    fireEvent.click(screen.getByRole("button", { name: "3" }));
+
+    await waitFor(() => {
+      expect(mockedFetchAdminClasses).toHaveBeenCalledTimes(4);
+    });
+
+    await screen.findByText("Shrunk Class");
+
+    signatures.forEach((signature, index) => {
+      if (index === 0) return;
+      expect(signature).not.toBe(signatures[index - 1]);
+    });
+
+    const error185 = consoleErrorSpy.mock.calls.some((call) =>
+      call.some(
+        (arg) =>
+          typeof arg === "string" &&
+          arg.includes("Too many re-renders")
+      )
+    );
+
+    expect(error185).toBe(false);
+
+    consoleErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- guard AdminClassesTable pagination updates with refs to prevent redundant state churn
- add non-production logging of executeRequest signatures to aid diagnosing repeated fetches
- add an out-of-range pagination regression test for AdminClassesTable

## Testing
- npm test -- AdminClassesTableOutOfRange

------
https://chatgpt.com/codex/tasks/task_e_68dff4c800048328914db56fa7cbfed1