### PR TITLE
Add public alias for featured tutorials and update client fallback

### DIFF
--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -4,6 +4,7 @@ const {
   requireInstallApiEnabled,
   router: installRouter,
 } = require('../modules/install/install.routes');
+const tutorialController = require('../modules/users/tutorials/tutorial.controller');
 
 router.use('/api/csrf-token', require('./csrf.routes'));
 router.use('/api/license', require('./licenseVerify.routes'));
@@ -64,6 +65,9 @@ router.use('/api/search', require('../modules/search/search.routes'));
 router.use('/api/install', requireInstallApiEnabled, installRouter);
 router.use('/api/users/classes/lessons', require('./lesson.routes'));
 router.use('/api/video-calls', require('./videoCalls.routes'));
+
+// Public tutorials shortcuts (used by the marketing site)
+router.get('/api/tutorials/featured', tutorialController.getFeaturedTutorials);
 
 router.get('/', (_req, res) => res.send('🚀 SkillBridge API is live.'));
 

--- a/frontend/src/services/tutorialService.js
+++ b/frontend/src/services/tutorialService.js
@@ -114,11 +114,27 @@ export const formatTutorial = (tut) => {
   };
 };
 
-export const fetchFeaturedTutorials = async (config = {}) => {
-  const cfg = Object.keys(config).length ? config : undefined;
-  const res = await api.get("/users/tutorials/featured", cfg);
+const mapTutorialList = (res) => {
   const list = extractData(res);
   return Array.isArray(list) ? list.map(formatTutorial) : list;
+};
+
+export const fetchFeaturedTutorials = async (config = {}) => {
+  const cfg = Object.keys(config).length ? config : undefined;
+
+  try {
+    const res = await api.get("/users/tutorials/featured", cfg);
+    return mapTutorialList(res);
+  } catch (error) {
+    const status = error?.response?.status;
+
+    if (status === 404 || status === 410 || status === 301) {
+      const res = await api.get("/tutorials/featured", cfg);
+      return mapTutorialList(res);
+    }
+
+    throw error;
+  }
 };
 
 export const fetchPublishedTutorials = async ({ page, limit, ...config } = {}) => {


### PR DESCRIPTION
## Summary
- add a public `/api/tutorials/featured` route that reuses the existing featured tutorials controller
- update the frontend tutorial service to map featured tutorial responses and fall back between legacy and new endpoints

## Testing
- npm test -- TutorialsSection

------
https://chatgpt.com/codex/tasks/task_e_68dff4ac370c8328b8316928c1de2315