### PR TITLE
Fix admin classes table pagination refs

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -107,6 +107,10 @@ export default function AdminClassesTable() {
   const inFlightRequestRef = useRef(null);
   const pendingRequestRef = useRef(null);
   const isComponentMountedRef = useRef(true);
+  const currentPageRef = useRef(currentPage);
+  const totalItemsRef = useRef(totalItems);
+  const totalPagesRef = useRef(totalPages);
+  const loadingRef = useRef(false);
   const lastNormalizedPageRef = useRef(currentPage);
   const { user, hasHydrated } = useAuthStore((state) => ({
     user: state.user,


### PR DESCRIPTION
## Summary
- initialize pagination and loading refs when the admin classes table mounts
- prevent reference errors by aligning ref declarations with existing state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dff8745adc832893d353e440e933fd