### PR TITLE
Adjust schedule filter pagination effective page handling

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -339,10 +339,15 @@ export default function AdminClassesTable() {
           const effectivePage = Number.isFinite(normalizedPageRaw)
             ? normalizedPageRaw
             : 1;
-          const effectivePage = normalizedPage;
-          if (Number.isFinite(normalizedPage) && normalizedPage !== page) {
+          const pageForSignature = Number.isFinite(normalizedPage)
+            ? normalizedPage
+            : effectivePage;
+          if (
+            Number.isFinite(pageForSignature) &&
+            pageForSignature !== page
+          ) {
             finalSignature = JSON.stringify({
-              page: normalizedPage,
+              page: pageForSignature,
               limit: limitValue,
               searchTerm: searchValue,
               approval: approvalValue,


### PR DESCRIPTION
## Summary
- remove the duplicate effective page assignment in the schedule-filter pagination logic
- fall back to the computed effective page when the normalized page value is not finite before updating the request signature

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dff875a3fc8328946e66e4829ced3f