### PR TITLE
Fix admin classes pagination refs initialization

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -108,6 +108,10 @@ export default function AdminClassesTable() {
   const pendingRequestRef = useRef(null);
   const isComponentMountedRef = useRef(true);
   const lastNormalizedPageRef = useRef(currentPage);
+  const currentPageRef = useRef(currentPage);
+  const totalItemsRef = useRef(totalItems);
+  const totalPagesRef = useRef(totalPages);
+  const loadingRef = useRef(false);
   const { user, hasHydrated } = useAuthStore((state) => ({
     user: state.user,
     hasHydrated: state.hasHydrated,
@@ -144,6 +148,10 @@ export default function AdminClassesTable() {
   useEffect(() => {
     totalPagesRef.current = totalPages;
   }, [totalPages]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
 
   const setCurrentPageIfNeeded = (value) => {
     if (!Number.isFinite(value)) {


### PR DESCRIPTION
## Summary
- add missing refs for pagination and loading state in the admin classes table
- keep the refs synchronized with state updates to avoid stale or undefined reads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff87af7988328b43be851958e377e