### PR TITLE
Fix pagination normalization in admin classes schedule filter

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -336,11 +336,11 @@ export default function AdminClassesTable() {
             Math.max(page, 1),
             totalFilteredPages
           );
-          const effectivePage = Number.isFinite(normalizedPageRaw)
+          let effectivePage = Number.isFinite(normalizedPageRaw)
             ? normalizedPageRaw
             : 1;
-          const effectivePage = normalizedPage;
           if (Number.isFinite(normalizedPage) && normalizedPage !== page) {
+            effectivePage = normalizedPage;
             finalSignature = JSON.stringify({
               page: normalizedPage,
               limit: limitValue,


### PR DESCRIPTION
## Summary
- ensure the schedule-filter pagination logic reuses the normalized page fallback
- update the pending request signature when the normalized page differs from the requested page

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dff87d69448328b8ce1cb2f79360fe