### PR TITLE
Fix admin classes pagination refs

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -108,6 +108,10 @@ export default function AdminClassesTable() {
   const pendingRequestRef = useRef(null);
   const isComponentMountedRef = useRef(true);
   const lastNormalizedPageRef = useRef(currentPage);
+  const currentPageRef = useRef(currentPage);
+  const totalItemsRef = useRef(totalItems);
+  const totalPagesRef = useRef(totalPages);
+  const loadingRef = useRef(false);
   const { user, hasHydrated } = useAuthStore((state) => ({
     user: state.user,
     hasHydrated: state.hasHydrated,
@@ -144,6 +148,10 @@ export default function AdminClassesTable() {
   useEffect(() => {
     totalPagesRef.current = totalPages;
   }, [totalPages]);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
 
   const setCurrentPageIfNeeded = (value) => {
     if (!Number.isFinite(value)) {


### PR DESCRIPTION
## Summary
- ensure the admin classes table tracks pagination state via refs used by helper setters
- synchronize the loading ref with the React state so request logic stays accurate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff885fb6c832882c38857ce7e5066