### PR TITLE
Remove duplicate ref declarations in AdminClassesTable

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -112,10 +112,6 @@ export default function AdminClassesTable() {
   const totalPagesRef = useRef(totalPages);
   const loadingRef = useRef(false);
   const lastNormalizedPageRef = useRef(currentPage);
-  const currentPageRef = useRef(currentPage);
-  const totalItemsRef = useRef(totalItems);
-  const totalPagesRef = useRef(totalPages);
-  const loadingRef = useRef(false);
   const { user, hasHydrated } = useAuthStore((state) => ({
     user: state.user,
     hasHydrated: state.hasHydrated,


### PR DESCRIPTION
## Summary
- remove the duplicate ref declarations in the admin classes table component to avoid redeclaration errors

## Testing
- npm run lint *(fails: existing lint warnings and errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dfff4031e48328ab3ed7508e48424e