### PR TITLE
Remove duplicate refs in AdminClassesTable

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -112,10 +112,6 @@ export default function AdminClassesTable() {
   const totalPagesRef = useRef(totalPages);
   const loadingRef = useRef(false);
   const lastNormalizedPageRef = useRef(currentPage);
-  const currentPageRef = useRef(currentPage);
-  const totalItemsRef = useRef(totalItems);
-  const totalPagesRef = useRef(totalPages);
-  const loadingRef = useRef(false);
   const { user, hasHydrated } = useAuthStore((state) => ({
     user: state.user,
     hasHydrated: state.hasHydrated,


### PR DESCRIPTION
## Summary
- remove the duplicate `useRef` declarations in the admin classes table component to prevent redeclaration errors

## Testing
- npm run lint *(fails: existing lint errors and warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dfff520e988328a5dcb5392bc5cacf