### PR TITLE
Remove duplicate admin class refs to fix React runtime error

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -112,10 +112,6 @@ export default function AdminClassesTable() {
   const totalPagesRef = useRef(totalPages);
   const loadingRef = useRef(false);
   const lastNormalizedPageRef = useRef(currentPage);
-  const currentPageRef = useRef(currentPage);
-  const totalItemsRef = useRef(totalItems);
-  const totalPagesRef = useRef(totalPages);
-  const loadingRef = useRef(false);
   const { user, hasHydrated } = useAuthStore((state) => ({
     user: state.user,
     hasHydrated: state.hasHydrated,


### PR DESCRIPTION
## Summary
- remove the duplicate useRef declarations in AdminClassesTable so each ref is defined once
- rely on the original refs to prevent React runtime reference errors during rendering

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfff459e308328a91b1d1fa6cdf4a3