### PR TITLE
Fix duplicate pagination refs in admin classes table

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -107,10 +107,6 @@ export default function AdminClassesTable() {
   const inFlightRequestRef = useRef(null);
   const pendingRequestRef = useRef(null);
   const isComponentMountedRef = useRef(true);
-  const currentPageRef = useRef(currentPage);
-  const totalItemsRef = useRef(totalItems);
-  const totalPagesRef = useRef(totalPages);
-  const loadingRef = useRef(false);
   const lastNormalizedPageRef = useRef(currentPage);
   const currentPageRef = useRef(currentPage);
   const totalItemsRef = useRef(totalItems);


### PR DESCRIPTION
## Summary
- remove the duplicate useRef declarations for pagination state in the admin classes table component to prevent React runtime errors

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfff5654a88328a4d594c99a8e3d9a