### PR TITLE
Refine SEO config store retry API

### DIFF
--- a/frontend/src/store/seoConfigStore.js
+++ b/frontend/src/store/seoConfigStore.js
@@ -17,26 +17,32 @@ const useSEOConfigStore = create(
       loaded: false,
       failed: false,
       error: null,
-      retry: false,
+      retryPending: false,
       fetch: async () => {
         if (get().loading) return;
-        set({ loading: true, error: null, failed: false });
+        set({ loading: true, error: null, failed: false, retryPending: false });
         try {
           const data = await fetchSEOConfig();
-          set({ settings: data || {}, loaded: true, loading: false, failed: false });
+          set({
+            settings: data || {},
+            loaded: true,
+            loading: false,
+            failed: false,
+            retryPending: false,
+          });
         } catch (err) {
           toast.error("Failed to load SEO settings");
-          set({ loaded: false, loading: false, error: err.message });
+          set({ loaded: false, loading: false, error: err.message, retryPending: true });
         }
       },
-      retry: async () => {
-        if (get().error) {
-          return get().fetch();
-        }
+      retryOnError: async () => {
+        if (!get().error) return;
+        set({ retryPending: false });
+        return get().fetch();
       },
-      retry: () => {
+      forceRetry: () => {
         if (get().loading) return;
-        set({ loaded: false, failed: false });
+        set({ loaded: false, failed: false, retryPending: false });
         return get().fetch();
       },
       update: (newSettings) =>
@@ -72,7 +78,7 @@ const useSEOConfigStore = create(
           set({ pages: [], error: err.message });
         }
       },
-      clear: () => set({ settings: {}, loaded: false, failed: false })
+      clear: () => set({ settings: {}, loaded: false, failed: false, retryPending: false })
     }),
     { name: "seo-config" }
   )

--- a/frontend/src/tests/__tests__/SEOConfigStore.test.js
+++ b/frontend/src/tests/__tests__/SEOConfigStore.test.js
@@ -64,20 +64,22 @@ test('fetchPages loads page list', async () => {
 
 test('fetch error leaves loaded false and allows retry', async () => {
   fetchSEOConfig.mockRejectedValueOnce(new Error('fail'));
-  const { fetch, retry } = useSEOConfigStore.getState();
+  const { fetch, retryOnError } = useSEOConfigStore.getState();
   await act(async () => {
     await fetch();
   });
   let state = useSEOConfigStore.getState();
   expect(state.loaded).toBe(false);
   expect(state.error).toBe('fail');
+  expect(state.retryPending).toBe(true);
 
   fetchSEOConfig.mockResolvedValueOnce({ metaTags: { '/': { title: 'Retry' } } });
   await act(async () => {
-    await retry();
+    await retryOnError();
   });
   state = useSEOConfigStore.getState();
   expect(state.loaded).toBe(true);
   expect(state.error).toBeNull();
+  expect(state.retryPending).toBe(false);
   expect(state.settings.metaTags['/'].title).toBe('Retry');
 });


### PR DESCRIPTION
## Summary
- separate the retry flag from retry actions in the SEO config store
- add retryOnError and forceRetry handlers while tracking retryPending state
- update the SEO config store test to cover the new retry flow

## Testing
- npm test -- SEOConfigStore

------
https://chatgpt.com/codex/tasks/task_e_68e00db3e0f083289c6820906fa7a245