### PR TITLE
Guard login hydration logout

### DIFF
--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -66,7 +66,9 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading })
     if (!hasHydrated) return;
 
     if (!user || !accessToken || isTokenExpired(accessToken)) {
-      logout(true);
+      if (user || accessToken) {
+        logout(true);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- guard the login hydration logout call so it only runs when session data exists
- preserve the early return path for unauthenticated sessions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00db9e42c8328a00d9bb4f5ebcc9a