### PR TITLE
Add manage_online_classes permission and ensure guard coverage

### DIFF
--- a/backend/src/seeds/10_permissions_seed.js
+++ b/backend/src/seeds/10_permissions_seed.js
@@ -34,6 +34,7 @@ exports.seed = async function (knex) {
     { code: 'view_third_party_config', description: 'Permission to view third-party configuration' },
     { code: 'manage_third_party_config', description: 'Permission to manage third-party configuration' },
     { code: 'view_online_classes', description: 'Permission to view online classes' },
+    { code: 'manage_online_classes', description: 'Permission to manage online classes' },
   ];
 
   await knex('permissions')

--- a/frontend/tests/hooks/withAuthProtection.test.js
+++ b/frontend/tests/hooks/withAuthProtection.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import withAuthProtection from '@/hooks/withAuthProtection';
+
+const replaceMock = jest.fn();
+const logoutMock = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+}));
+
+jest.mock('@/utils/auth/tokenUtils', () => ({
+  isTokenExpired: jest.fn(() => false),
+}));
+
+let storeState;
+
+const mockUseAuthStore = jest.fn();
+
+jest.mock('@/store/auth/authStore', () => ({
+  __esModule: true,
+  default: (selector) => {
+    const state = mockUseAuthStore();
+    if (typeof selector === 'function') {
+      return selector(state);
+    }
+    return state;
+  },
+}));
+
+const TestComponent = () => <div>protected content</div>;
+
+describe('withAuthProtection permissions', () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+    logoutMock.mockReset();
+    storeState = {
+      user: {
+        id: 'admin-1',
+        role: 'Admin',
+        roles: ['Admin'],
+        permissions: ['view_online_classes'],
+      },
+      accessToken: 'valid.token.value',
+      hasHydrated: true,
+      logout: logoutMock,
+    };
+
+    mockUseAuthStore.mockImplementation(() => storeState);
+  });
+
+  afterEach(() => {
+    mockUseAuthStore.mockReset();
+  });
+
+  it('allows admins with manage_online_classes permission to continue', async () => {
+    storeState.user.permissions.push('manage_online_classes');
+
+    const ProtectedComponent = withAuthProtection(TestComponent, {
+      permissions: ['manage_online_classes'],
+    });
+
+    render(<ProtectedComponent />);
+
+    await waitFor(() =>
+      expect(screen.getByText('protected content')).toBeInTheDocument()
+    );
+
+    expect(replaceMock).not.toHaveBeenCalledWith('/error/403');
+  });
+
+  it('redirects to 403 when manage_online_classes is missing', async () => {
+    const ProtectedComponent = withAuthProtection(TestComponent, {
+      permissions: ['manage_online_classes'],
+    });
+
+    render(<ProtectedComponent />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith('/error/403');
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add the manage_online_classes permission to the seed list so it is provisioned with other class permissions
- add a withAuthProtection test suite to confirm admins keep access when they have the new permission and are redirected otherwise

## Testing
- npm test -- withAuthProtection.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e012e572908328804f76e3a6af8c96