### PR TITLE
Add manage online classes permission seed

### DIFF
--- a/backend/src/seeds/10_permissions_seed.js
+++ b/backend/src/seeds/10_permissions_seed.js
@@ -34,6 +34,7 @@ exports.seed = async function (knex) {
     { code: 'view_third_party_config', description: 'Permission to view third-party configuration' },
     { code: 'manage_third_party_config', description: 'Permission to manage third-party configuration' },
     { code: 'view_online_classes', description: 'Permission to view online classes' },
+    { code: 'manage_online_classes', description: 'Permission to manage online classes' },
   ];
 
   await knex('permissions')


### PR DESCRIPTION
## Summary
- add the manage online classes permission to the permissions seed data so it can be assigned to admin roles

## Testing
- npm run seed *(fails: database connection is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e012e98574832898db22def4dd06be