### PR TITLE
Delay admin classes fetch until auth hydration

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -187,6 +187,7 @@ export default function AdminClassesTable() {
     [...items].sort((a, b) => compareValues(a, b, key));
 
   const hydratedUser = isMounted && hasHydrated ? user : null;
+  const authIdentifier = user?.id ?? null;
   const canManageRules =
     isMounted && hasHydrated && user?.permissions?.includes('ADD_ONLINE_CLASS_RULE');
 
@@ -206,6 +207,13 @@ export default function AdminClassesTable() {
   }, [currentPage, totalPages, totalItems, normalizedItemsPerPage]);
 
   useEffect(() => {
+    if (!hasHydrated || !authIdentifier) {
+      if (lastFailedSignatureRef.current) {
+        lastFailedSignatureRef.current = null;
+      }
+      return;
+    }
+
     if (normalizedPage !== currentPage) {
       if (lastNormalizedPageRef.current !== normalizedPage) {
         lastNormalizedPageRef.current = normalizedPage;
@@ -435,6 +443,8 @@ export default function AdminClassesTable() {
     filterApproval,
     filterStatus,
     sortKey,
+    hasHydrated,
+    authIdentifier,
   ]);
 
   const formatCSVRow = (row) =>


### PR DESCRIPTION
## Summary
- prevent admin classes requests from running until auth hydration completes
- clear stale failure signature state when waiting on hydration so the next fetch succeeds automatically
- re-run the fetch effect when hydration or user identity changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e013959ef8832882a1a061f2b7c8a6