### PR TITLE
Fix admin class toggle to preserve existing fields

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -574,7 +574,7 @@ export default function AdminClassesTable() {
           throw new Error("Failed to toggle class status");
         }
         setClassList((prev) =>
-          prev.map((c) => (c.id === id ? updated : c))
+          prev.map((c) => (c.id === id ? { ...c, ...updated } : c))
         );
         toast.success("Status updated");
         const message = `Class "${target.title}" publish status changed to ${updated.publishStatus}.`;


### PR DESCRIPTION
## Summary
- update the toggle status handler so it merges returned fields into the existing class entry

## Testing
- not run (frontend change requires manual verification in full environment)

------
https://chatgpt.com/codex/tasks/task_e_68e01397f9e083289d4c5d51a2a83495