### PR TITLE
Add admin class bulk deletion endpoint

### DIFF
--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -393,6 +393,56 @@ exports.deleteClass = catchAsync(async (req, res) => {
   sendSuccess(res, null, "Class deleted");
 });
 
+exports.bulkDeleteClasses = catchAsync(async (req, res) => {
+  const ids = req.body?.ids;
+
+  if (!Array.isArray(ids) || ids.length === 0) {
+    throw new AppError("ids must be a non-empty array", 400);
+  }
+
+  const invalidIds = ids.filter(
+    (id) => typeof id !== "string" || !id.trim()
+  );
+
+  if (invalidIds.length) {
+    throw new AppError("Each id must be a non-empty string", 400);
+  }
+
+  const normalizedIds = Array.from(new Set(ids.map((id) => id.trim())));
+
+  const classes = await service.bulkDeleteClasses(normalizedIds);
+
+  const notificationPromises = classes
+    .filter((cls) => cls?.instructor_id)
+    .map((cls) =>
+      notificationService
+        .createNotification({
+          user_id: cls.instructor_id,
+          type: "class_deleted",
+          message: `Class "${cls.title}" deleted`,
+        })
+        .catch((err) =>
+          logger.error(
+            "Failed to notify instructor of class deletion:",
+            err.message
+          )
+        )
+    );
+
+  if (notificationPromises.length) {
+    await Promise.allSettled(notificationPromises);
+  }
+
+  sendSuccess(
+    res,
+    {
+      ids: classes.map((cls) => cls.id),
+      count: classes.length,
+    },
+    "Classes deleted"
+  );
+});
+
 exports.getPublishedClasses = catchAsync(async (req, res) => {
   const { page = 1, limit = 10 } = req.query;
   const result = await service.getPublishedClasses({

--- a/backend/src/modules/classes/class.routes.js
+++ b/backend/src/modules/classes/class.routes.js
@@ -93,6 +93,12 @@ router.delete(
   isAdmin,
   controller.deleteClass
 );
+router.post(
+  "/admin/bulk-delete",
+  verifyToken,
+  isAdmin,
+  controller.bulkDeleteClasses
+);
 router.patch(
   "/admin/:id/status",
   verifyToken,

--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -1,6 +1,7 @@
 const db = require("../../config/database");
 const ClassModel = require("./class.model");
 const { parsePagination } = require("../../utils/pagination");
+const AppError = require("../../utils/AppError");
 
 exports.createClass = async (data) => {
   const normalizedAccessType =
@@ -220,6 +221,28 @@ exports.updateClass = async (id, data) => {
 
 exports.deleteClass = async (id) => {
   return ClassModel.remove(id);
+};
+
+exports.bulkDeleteClasses = async (ids) => {
+  return db.transaction(async (trx) => {
+    const classes = await trx("online_classes")
+      .select("id", "title", "instructor_id")
+      .whereIn("id", ids);
+
+    const foundIds = new Set(classes.map((cls) => cls.id));
+    const missingIds = ids.filter((id) => !foundIds.has(id));
+
+    if (missingIds.length) {
+      throw new AppError(
+        `Classes not found: ${missingIds.join(", ")}`,
+        404
+      );
+    }
+
+    await trx("online_classes").whereIn("id", ids).del();
+
+    return classes;
+  });
 };
 
 exports.togglePublishStatus = async (id) => {

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -35,6 +35,7 @@ with status `204` and no body.
   - `GET /api/users/classes/:id` – view details for a published class
   - `POST /api/users/classes/admin` – create a class (instructor or admin)
   - `PUT /api/users/classes/admin/:id` – update a class
+  - `POST /api/users/classes/admin/bulk-delete` – delete multiple classes in a single request (admin only)
   - `DELETE /api/users/classes/admin/:id` – remove a class
   - `GET /api/users/classes/admin/my` – list classes for the logged in instructor
 - `/admin` – administrator dashboard features


### PR DESCRIPTION
## Summary
- add an admin bulk-delete controller and service method for classes
- validate requested class ids, delete them in a single transaction, and notify instructors
- document the new bulk deletion endpoint for the admin classes API

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e01398cc548328bc7b3b76e968f25d