### PR TITLE
Handle missing class targets during status updates

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -528,6 +528,13 @@ export default function AdminClassesTable() {
       return;
     }
     const target = classList.find((c) => c.id === id);
+    if (!target) {
+      toast.warn("Unable to locate the selected class. Please refresh and try again.");
+      setModalClass(null);
+      return;
+    }
+    const targetTitle = target.title ? `"${target.title}"` : "the class";
+    const targetInstructorId = target?.instructor_id;
     try {
 
       if (action === "approve") {
@@ -540,17 +547,17 @@ export default function AdminClassesTable() {
           )
         );
         toast.success("Class approved");
-        const message = `Class "${target.title}" approved.`;
+        const message = `Class ${targetTitle} approved.`;
         await createNotification({ user_id: hydratedUser.id, type: "class_approved", message });
         await sendChatMessage(hydratedUser.id, { text: message });
-        if (target.instructor_id && target.instructor_id !== hydratedUser.id) {
+        if (targetInstructorId && targetInstructorId !== hydratedUser.id) {
           await createNotification({
-            user_id: target.instructor_id,
+            user_id: targetInstructorId,
             type: "class_approved",
-            message: `Your class "${target.title}" was approved!`,
+            message: `Your class ${targetTitle} was approved!`,
           });
-          await sendChatMessage(target.instructor_id, {
-            text: `Your class "${target.title}" was approved!`,
+          await sendChatMessage(targetInstructorId, {
+            text: `Your class ${targetTitle} was approved!`,
           });
         }
         refreshNotifications?.();
@@ -563,17 +570,17 @@ export default function AdminClassesTable() {
           )
         );
         toast.success("Class rejected");
-        const message = `Class "${target.title}" was rejected.`;
+        const message = `Class ${targetTitle} was rejected.`;
         await createNotification({ user_id: hydratedUser.id, type: "class_rejected", message });
         await sendChatMessage(hydratedUser.id, { text: `${message} Reason: ${reason}` });
-        if (target.instructor_id && target.instructor_id !== hydratedUser.id) {
+        if (targetInstructorId && targetInstructorId !== hydratedUser.id) {
           await createNotification({
-            user_id: target.instructor_id,
+            user_id: targetInstructorId,
             type: "class_rejected",
-            message: `Your class "${target.title}" was rejected.`,
+            message: `Your class ${targetTitle} was rejected.`,
           });
-          await sendChatMessage(target.instructor_id, {
-            text: `Your class "${target.title}" was rejected. Reason: ${reason}`,
+          await sendChatMessage(targetInstructorId, {
+            text: `Your class ${targetTitle} was rejected. Reason: ${reason}`,
           });
         }
         refreshNotifications?.();
@@ -587,17 +594,17 @@ export default function AdminClassesTable() {
           prev.map((c) => (c.id === id ? { ...c, ...updated } : c))
         );
         toast.success("Status updated");
-        const message = `Class "${target.title}" publish status changed to ${updated.publishStatus}.`;
+        const message = `Class ${targetTitle} publish status changed to ${updated.publishStatus}.`;
         await createNotification({ user_id: hydratedUser.id, type: "class_status_changed", message });
         await sendChatMessage(hydratedUser.id, { text: message });
-        if (target.instructor_id && target.instructor_id !== hydratedUser.id) {
+        if (targetInstructorId && targetInstructorId !== hydratedUser.id) {
           await createNotification({
-            user_id: target.instructor_id,
+            user_id: targetInstructorId,
             type: "class_status_changed",
-            message: `Your class "${target.title}" publish status was changed to ${updated.publishStatus}.`,
+            message: `Your class ${targetTitle} publish status was changed to ${updated.publishStatus}.`,
           });
-          await sendChatMessage(target.instructor_id, {
-            text: `Your class "${target.title}" publish status was changed to ${updated.publishStatus}.`,
+          await sendChatMessage(targetInstructorId, {
+            text: `Your class ${targetTitle} publish status was changed to ${updated.publishStatus}.`,
           });
         }
         refreshNotifications?.();


### PR DESCRIPTION
## Summary
- add a guard for missing classes before running status change side effects
- reuse safe cached values for instructor and title messaging throughout updates
- reset open modals when the targeted class disappears mid-action

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0177f23648328b6b23148c05e8b1e