### PR TITLE
Fix admin tutorials page missing filters hook import

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
+import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
 import { Button } from "@/components/ui/button";
 import { FaPlus } from "react-icons/fa";


### PR DESCRIPTION
## Summary
- add the missing `useTutorialFilters` hook import on the admin tutorials page to prevent runtime reference errors

## Testing
- npm run lint *(fails: existing lint errors and warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e020a60a1c8328ac8fae2c66fb50dc