### PR TITLE
Add missing tutorial filters hook import

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
+import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
 import { Button } from "@/components/ui/button";
 import { FaPlus } from "react-icons/fa";


### PR DESCRIPTION
## Summary
- add the missing useTutorialFilters hook import to the admin tutorials page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e020a27f388328b4896b6f0ab080aa