### PR TITLE
Align tutorial filter defaults with UI sentinel values

### DIFF
--- a/frontend/src/hooks/admin/tutorials/useTutorialFilters.js
+++ b/frontend/src/hooks/admin/tutorials/useTutorialFilters.js
@@ -2,9 +2,9 @@ import { useState, useMemo } from "react";
 
 export default function useTutorialFilters(tutorials) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [filterCategory, setFilterCategory] = useState("All");
-  const [filterStatus, setFilterStatus] = useState("All");
-  const [filterApproval, setFilterApproval] = useState("All");
+  const [filterCategory, setFilterCategory] = useState("");
+  const [filterStatus, setFilterStatus] = useState("");
+  const [filterApproval, setFilterApproval] = useState("");
 
   const filteredTutorials = useMemo(() => {
     const normalizedQuery = searchQuery.toLowerCase();
@@ -17,10 +17,10 @@ export default function useTutorialFilters(tutorials) {
         normalizedTitle.includes(normalizedSearch) ||
         normalizedInstructor.includes(normalizedSearch);
       const matchesCategory =
-        filterCategory === "All" || tut.category === filterCategory;
-      const matchesStatus = filterStatus === "All" || tut.status === filterStatus;
+        !filterCategory || tut.category === filterCategory;
+      const matchesStatus = !filterStatus || tut.status === filterStatus;
       const matchesApproval =
-        filterApproval === "All" || tut.approvalStatus === filterApproval;
+        !filterApproval || tut.approvalStatus === filterApproval;
       return matchesSearch && matchesCategory && matchesStatus && matchesApproval;
     });
   }, [tutorials, searchQuery, filterCategory, filterStatus, filterApproval]);

--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -71,15 +71,15 @@ function AdminTutorialsPage() {
         next.search = trimmedSearch;
       }
 
-      if (filterCategory && filterCategory !== "All") {
+      if (filterCategory) {
         next.category = filterCategory;
       }
 
-      if (filterStatus && filterStatus !== "All") {
+      if (filterStatus) {
         next.status = filterStatus;
       }
 
-      if (filterApproval && filterApproval !== "All") {
+      if (filterApproval) {
         next.approval = filterApproval;
       }
 


### PR DESCRIPTION
## Summary
- initialize tutorial filter hooks with empty-string sentinel to match the select "All" options
- ensure server-side filter payload skips empty-string selections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e020a7f2448328aaaa02a1e2c47532