### PR TITLE
Remove duplicate tutorial filter import

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -4,7 +4,6 @@ import withAuthProtection from "@/hooks/withAuthProtection";
 import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
 import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
-import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import { Button } from "@/components/ui/button";
 import { FaPlus } from "react-icons/fa";
 import Filters from "@/components/dashboard/admin/tutorials/Filters";


### PR DESCRIPTION
## Summary
- remove the duplicate import of the tutorial filters hook on the admin tutorials page

## Testing
- `npm run lint` *(fails: existing lint errors and warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e0269228b48328980b8c113a1ce9fd