### PR TITLE
Remove duplicate tutorial filters import

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -4,7 +4,6 @@ import withAuthProtection from "@/hooks/withAuthProtection";
 import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
 import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
-import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import { Button } from "@/components/ui/button";
 import { FaPlus } from "react-icons/fa";
 import Filters from "@/components/dashboard/admin/tutorials/Filters";


### PR DESCRIPTION
## Summary
- remove the duplicate `useTutorialFilters` import from the admin tutorials page entrypoint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e03097397c8328be4f689f33bc9539