### PR TITLE
Fix duplicate tutorial filters import

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -4,7 +4,6 @@ import withAuthProtection from "@/hooks/withAuthProtection";
 import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
 import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
-import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import { Button } from "@/components/ui/button";
 import { FaPlus } from "react-icons/fa";
 import Filters from "@/components/dashboard/admin/tutorials/Filters";


### PR DESCRIPTION
## Summary
- remove the duplicate tutorial filters hook import on the admin tutorials page to resolve the Next.js compile error

## Testing
- npm run dev
- curl -I http://localhost:3000/dashboard/admin/tutorials
- curl -I http://localhost:3000/dashboard/admin/online-classes

------
https://chatgpt.com/codex/tasks/task_e_68e0309d008083288e12552e82cc2d0d