### PR TITLE
Handle canceled Axios requests in token interceptor

### DIFF
--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -56,6 +56,15 @@ api.interceptors.response.use(
     const originalRequest = error.config;
     const authStore = useAuthStore.getState();
 
+    const isCanceledRequest =
+      error?.code === "ERR_CANCELED" ||
+      error?.name === "CanceledError" ||
+      error?.message?.toLowerCase() === "canceled";
+
+    if (isCanceledRequest) {
+      return Promise.reject(error);
+    }
+
     if (
       (error.code === "ERR_NETWORK" || !error.response) &&
       Date.now() - lastNetworkToast > 5000


### PR DESCRIPTION
## Summary
- treat Axios cancellation errors separately so they don't trigger network error toasts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0410a625483288228553b6665657e