### PR TITLE
Handle canceled Axios requests without showing network toast

### DIFF
--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -3,6 +3,7 @@
 // This file sets up an Axios interceptor to handle token-based authentication
 // 📁 src/services/api/tokenInterceptor.js
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+import axios from "axios";
 import api from "./api";
 import { toast } from "react-toastify";
 import Router from "next/router";
@@ -55,6 +56,14 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
     const authStore = useAuthStore.getState();
+
+    if (
+      axios.isCancel?.(error) ||
+      error?.code === "ERR_CANCELED" ||
+      error?.name === "CanceledError"
+    ) {
+      return Promise.reject(error);
+    }
 
     if (
       (error.code === "ERR_NETWORK" || !error.response) &&


### PR DESCRIPTION
## Summary
- add a cancellation guard in the token interceptor so intentional cancels skip the network error toast
- import axios to reuse its isCancel helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e040fe83b48328b4be909e0e7373c5