### PR TITLE
Fix missing tutorial filters import

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
+import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
 import { Button } from "@/components/ui/button";
 import { FaPlus } from "react-icons/fa";


### PR DESCRIPTION
## Summary
- import the tutorial filters hook in the admin tutorials page so it can be used during rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e040f6e3f88328b82ee5fc3c3b81ee