### PR TITLE
Add missing tutorial filters hook import

### DIFF
--- a/frontend/src/pages/dashboard/admin/tutorials/index.js
+++ b/frontend/src/pages/dashboard/admin/tutorials/index.js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import useTutorialsData from "@/hooks/admin/tutorials/useTutorialsData";
 import useBulkSelection from "@/hooks/admin/tutorials/useBulkSelection";
+import useTutorialFilters from "@/hooks/admin/tutorials/useTutorialFilters";
 import { Button } from "@/components/ui/button";
 import { FaPlus } from "react-icons/fa";
 import Filters from "@/components/dashboard/admin/tutorials/Filters";


### PR DESCRIPTION
## Summary
- add the missing useTutorialFilters hook import on the admin tutorials dashboard page to prevent a ReferenceError when rendering

## Testing
- npm run lint *(fails: existing lint errors throughout the project unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e040e84bc4832887e0cef9241d471c