### PR TITLE
Fix admin class deletion pagination regression

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -622,7 +622,41 @@ export default function AdminClassesTable() {
   const handleDeleteClass = async (id) => {
     try {
       await deleteAdminClass(id);
-      setClassList(prev => prev.filter(cls => cls.id !== id));
+
+      const updatedList = classList.filter((cls) => cls.id !== id);
+      const nextTotalItems = Math.max(
+        totalItemsRef.current - 1,
+        updatedList.length,
+        0
+      );
+      const derivedItemsPerPage =
+        pageSizeSetting === "all"
+          ? resolvePositiveInteger(
+              Math.max(nextTotalItems, updatedList.length, 1),
+              DEFAULT_PAGE_SIZE
+            )
+          : resolvePositiveInteger(pageSizeSetting, DEFAULT_PAGE_SIZE);
+      const nextTotalPages = Math.max(
+        1,
+        Math.ceil(
+          nextTotalItems > 0
+            ? nextTotalItems / derivedItemsPerPage
+            : 0
+        )
+      );
+
+      setClassList(updatedList);
+      setTotalItemsIfNeeded(nextTotalItems);
+      setTotalPagesIfNeeded(nextTotalPages);
+
+      if (updatedList.length === 0 && currentPageRef.current > 1) {
+        const candidatePage = Math.min(
+          currentPageRef.current - 1,
+          nextTotalPages
+        );
+        setCurrentPageIfNeeded(candidatePage);
+      }
+
       toast.success("Class deleted");
     } catch (err) {
       console.error(err);

--- a/frontend/tests/components/AdminClassesTablePagination.test.js
+++ b/frontend/tests/components/AdminClassesTablePagination.test.js
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import AdminClassesTable from "@/components/admin/online-classes/AdminClassesTable";
-import { fetchAdminClasses } from "@/services/admin/classService";
+import { fetchAdminClasses, deleteAdminClass } from "@/services/admin/classService";
 import { toast } from "react-toastify";
 
 jest.mock("next/link", () => ({
@@ -70,6 +70,7 @@ describe("AdminClassesTable schedule filtering", () => {
   beforeEach(() => {
     mockedFetchAdminClasses.mockReset();
     toast.error.mockClear();
+    toast.success.mockClear();
   });
 
   it("retains access to upcoming classes spread across multiple pages", async () => {
@@ -155,6 +156,7 @@ describe("AdminClassesTable error handling", () => {
   beforeEach(() => {
     mockedFetchAdminClasses.mockReset();
     toast.error.mockClear();
+    toast.success.mockClear();
   });
 
   it("shows a single toast and avoids duplicate retries when the fetch fails", async () => {
@@ -171,5 +173,87 @@ describe("AdminClassesTable error handling", () => {
     expect(toast.error).toHaveBeenCalledWith("Failed to load classes");
 
     consoleSpy.mockRestore();
+  });
+});
+
+describe("AdminClassesTable deletion navigation", () => {
+  const mockedFetchAdminClasses = fetchAdminClasses;
+  const mockedDeleteAdminClass = deleteAdminClass;
+
+  beforeEach(() => {
+    mockedFetchAdminClasses.mockReset();
+    mockedDeleteAdminClass.mockReset();
+    toast.error.mockClear();
+    toast.success.mockClear();
+  });
+
+  it("returns to a valid page and updates totals after deleting the last class on a page", async () => {
+    const pageSize = 5;
+    const createClass = (index) => ({
+      id: `class-${index}`,
+      title: `Class ${index}`,
+      instructor: `Instructor ${index}`,
+      start_date: `2024-0${index}-01`,
+      end_date: `2024-0${index}-02`,
+      category: "Category",
+      publishStatus: "draft",
+      approvalStatus: "Approved",
+      scheduleStatus: "Upcoming",
+      price: 0,
+    });
+
+    const firstPageData = Array.from({ length: pageSize }, (_, idx) =>
+      createClass(idx + 1)
+    );
+    const lastPageItem = createClass(pageSize + 1);
+
+    mockedFetchAdminClasses
+      .mockResolvedValueOnce({
+        data: firstPageData,
+        meta: { totalPages: 2, total: pageSize + 1 },
+      })
+      .mockResolvedValueOnce({
+        data: [lastPageItem],
+        meta: { totalPages: 2, total: pageSize + 1 },
+      })
+      .mockResolvedValueOnce({
+        data: firstPageData,
+        meta: { totalPages: 1, total: pageSize },
+      });
+
+    mockedDeleteAdminClass.mockResolvedValue();
+
+    render(<AdminClassesTable />);
+
+    await screen.findByText("Class 1");
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    await screen.findByText(lastPageItem.title);
+
+    fireEvent.click(screen.getByTitle("Delete Class"));
+
+    const confirmButton = await screen.findByRole("button", {
+      name: "Yes, Delete",
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockedDeleteAdminClass).toHaveBeenCalledWith(lastPageItem.id);
+    });
+
+    await waitFor(() => {
+      expect(mockedFetchAdminClasses).toHaveBeenCalledTimes(3);
+    });
+
+    expect(mockedFetchAdminClasses.mock.calls[2][0]).toMatchObject({ page: 1 });
+
+    await screen.findByText("Class 1");
+    await waitFor(() => {
+      expect(screen.getAllByRole("row")).toHaveLength(pageSize + 1);
+    });
+    expect(screen.queryByText(lastPageItem.title)).not.toBeInTheDocument();
+
+    expect(toast.success).toHaveBeenCalledWith("Class deleted");
   });
 });


### PR DESCRIPTION
## Summary
- update the admin classes table deletion handler to keep totals and pagination in sync after removing a class
- add a regression test that deletes the final class on a later page and verifies the component lands on a valid page

## Testing
- npm test -- AdminClassesTablePagination.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e0e0658f948328a5a5961924059e22