### PR TITLE
Handle ResizeObserver for admin analytics charts

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,6 +10,12 @@ From the `frontend` directory install dependencies:
 npm install
 ```
 
+### Browser Support
+
+- The admin analytics dashboard relies on `ResizeObserver` for responsive charts. We bootstrap a shared
+  [`resize-observer-polyfill`](https://github.com/que-etc/resize-observer-polyfill) in `_app.js` so older
+  browsers without a native implementation can still render the charts.
+
 ## Environment Variables
 
 The production build reads configuration from `.env.production`. Define the following keys before building:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -79,6 +79,7 @@
         "react-toastify": "^11.0.5",
         "recharts": "^2.15.2",
         "remark-gfm": "^4.0.1",
+        "resize-observer-polyfill": "^1.5.1",
         "simple-peer": "^9.11.1",
         "socket.io-client": "^4.8.1",
         "stripe": "^17.6.0",
@@ -14294,6 +14295,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,6 +81,7 @@
     "react-swipeable": "^7.0.2",
     "react-syntax-highlighter": "^15.6.6",
     "react-toastify": "^11.0.5",
+    "resize-observer-polyfill": "^1.5.1",
     "recharts": "^2.15.2",
     "remark-gfm": "^4.0.1",
     "simple-peer": "^9.11.1",

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -7,6 +7,7 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import "react-quill/dist/quill.snow.css";       // ✅ Rich text editor
 import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
+import "resize-observer-polyfill";
 import "@/styles/globals.css";
 import "@/services/api/tokenInterceptor";
 import useAuthStore from "@/store/auth/authStore";

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -7,19 +7,6 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import nextI18NextConfig from "../../../../../../next-i18next.config.js";
 import { fetchAdminClassAnalytics } from "@/services/admin/classService";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  CartesianGrid,
-  PieChart,
-  Pie,
-  Cell,
-  Legend,
-} from "recharts";
 
 const COLORS = ["#60a5fa", "#34d399", "#fbbf24", "#f87171"];
 
@@ -46,6 +33,37 @@ function AnalyticsDashboard() {
   const { id } = router.query;
   const { t, i18n } = useTranslation('dashboard');
   const [stats, setStats] = useState(null);
+  const [chartsLib, setChartsLib] = useState(null);
+  const [resizeObserverSupported, setResizeObserverSupported] = useState(true);
+  const [chartsLoadError, setChartsLoadError] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (!window.ResizeObserver) {
+      setResizeObserverSupported(false);
+      return;
+    }
+
+    let isMounted = true;
+    import("recharts")
+      .then((module) => {
+        if (!isMounted) return;
+        setChartsLib(module);
+      })
+      .catch((error) => {
+        console.error("Failed to load Recharts", error);
+        if (!isMounted) return;
+        setChartsLoadError(true);
+        setChartsLib(null);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!id) return;
@@ -85,6 +103,17 @@ function AnalyticsDashboard() {
   const locations = stats.locations ?? EMPTY_STATS.locations;
   const devices = stats.devices ?? EMPTY_STATS.devices;
   const registrationTrend = stats.registrationTrend ?? EMPTY_STATS.registrationTrend;
+  const ResponsiveContainer = chartsLib?.ResponsiveContainer;
+  const PieChart = chartsLib?.PieChart;
+  const Pie = chartsLib?.Pie;
+  const Cell = chartsLib?.Cell;
+  const Legend = chartsLib?.Legend;
+  const Tooltip = chartsLib?.Tooltip;
+  const BarChart = chartsLib?.BarChart;
+  const Bar = chartsLib?.Bar;
+  const XAxis = chartsLib?.XAxis;
+  const YAxis = chartsLib?.YAxis;
+  const CartesianGrid = chartsLib?.CartesianGrid;
 
   const avgRevenue =
     totalStudents > 0
@@ -146,46 +175,94 @@ function AnalyticsDashboard() {
       <div className="grid md:grid-cols-2 gap-6">
         <div className="bg-white p-6 rounded-xl shadow border">
           <h2 className="text-lg font-semibold text-gray-700 mb-4">🌍 {t('classAnalyticsPage.top_countries')}</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie data={locations} dataKey="value" nameKey="name" outerRadius={100}>
-                {(locations ?? []).map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Pie>
-              <Legend />
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          {resizeObserverSupported && ResponsiveContainer && PieChart ? (
+            <ResponsiveContainer width="100%" height={300}>
+              <PieChart>
+                <Pie data={locations} dataKey="value" nameKey="name" outerRadius={100}>
+                  {(locations ?? []).map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Legend />
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+              {resizeObserverSupported
+                ? chartsLoadError
+                  ? t(
+                      'classAnalyticsPage.chartsFailedToLoad',
+                      'Charts failed to load. Please refresh to try again.'
+                    )
+                  : t('classAnalyticsPage.loadingCharts', 'Loading charts…')
+                : t(
+                    'classAnalyticsPage.chartsUnavailableResizeObserver',
+                    'Charts are unavailable because ResizeObserver is not supported in this browser.'
+                  )}
+            </div>
+          )}
         </div>
 
         <div className="bg-white p-6 rounded-xl shadow border">
           <h2 className="text-lg font-semibold text-gray-700 mb-4">📱 {t('classAnalyticsPage.devices_used')}</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie data={devices} dataKey="value" nameKey="name" outerRadius={100}>
-                {(devices ?? []).map((entry, index) => (
-                  <Cell key={`cell-dev-${index}`} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Pie>
-              <Legend />
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          {resizeObserverSupported && ResponsiveContainer && PieChart ? (
+            <ResponsiveContainer width="100%" height={300}>
+              <PieChart>
+                <Pie data={devices} dataKey="value" nameKey="name" outerRadius={100}>
+                  {(devices ?? []).map((entry, index) => (
+                    <Cell key={`cell-dev-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Legend />
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+              {resizeObserverSupported
+                ? chartsLoadError
+                  ? t(
+                      'classAnalyticsPage.chartsFailedToLoad',
+                      'Charts failed to load. Please refresh to try again.'
+                    )
+                  : t('classAnalyticsPage.loadingCharts', 'Loading charts…')
+                : t(
+                    'classAnalyticsPage.chartsUnavailableResizeObserver',
+                    'Charts are unavailable because ResizeObserver is not supported in this browser.'
+                  )}
+            </div>
+          )}
         </div>
       </div>
 
       <div className="bg-white p-6 rounded-xl shadow border">
         <h2 className="text-lg font-semibold text-gray-700 mb-4">📈 {t('classAnalyticsPage.registration_trend')}</h2>
-        <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={registrationTrend}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="date" />
-            <YAxis />
-            <Tooltip />
-            <Bar dataKey="students" fill="#facc15" />
-          </BarChart>
-        </ResponsiveContainer>
+        {resizeObserverSupported && ResponsiveContainer && BarChart ? (
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={registrationTrend}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="students" fill="#facc15" />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            {resizeObserverSupported
+              ? chartsLoadError
+                ? t(
+                    'classAnalyticsPage.chartsFailedToLoad',
+                    'Charts failed to load. Please refresh to try again.'
+                  )
+                : t('classAnalyticsPage.loadingCharts', 'Loading charts…')
+              : t(
+                  'classAnalyticsPage.chartsUnavailableResizeObserver',
+                  'Charts are unavailable because ResizeObserver is not supported in this browser.'
+                )}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- lazy-load Recharts in the admin class analytics page only when ResizeObserver is available and provide graceful fallbacks
- add a shared resize-observer polyfill during app bootstrap and document the dependency for browser support

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*
- node - <<'NODE' ... *(verifies ResizeObserver fallback logic)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e068bf3483288d7dc4d46657d7fd