### PR TITLE
Allow admin All page size to fetch entire dataset

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -40,6 +40,15 @@ Tune these values in `backend/.env` (and the production variant) to align with
 your deployment's traffic patterns. The health check endpoint remains exempt so
 load balancers and uptime monitors are unaffected.
 
+### Pagination defaults
+
+List endpoints share a pagination helper that now caps `limit` values at
+10,000. This higher ceiling allows the admin "All" option to truly fetch every
+matching record—useful for exports—while still providing a hard stop against
+unbounded queries. If your datasets grow beyond this size, raise the value in
+`src/utils/pagination.js` in tandem with any frontend controls that surface an
+"All" selection.
+
 The `/api/system-errors` route reads the latest lines from `logs/error.log` and is used by the admin alerts page. Only authenticated admins can access it.
 
 ### Rate limiting

--- a/backend/src/utils/pagination.js
+++ b/backend/src/utils/pagination.js
@@ -1,6 +1,9 @@
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 10;
-const MAX_LIMIT = 100;
+// Raised to support "All" selections in admin tables without truncating results.
+// Aligns with the largest datasets exposed through our APIs while still
+// preventing unbounded queries.
+const MAX_LIMIT = 10000;
 
 exports.parsePagination = ({ page = DEFAULT_PAGE, limit = DEFAULT_LIMIT } = {}) => {
   let pageNum = parseInt(page, 10);

--- a/frontend/tests/components/AdminClassesTablePagination.test.js
+++ b/frontend/tests/components/AdminClassesTablePagination.test.js
@@ -149,6 +149,97 @@ describe("AdminClassesTable schedule filtering", () => {
   });
 });
 
+describe("AdminClassesTable page size control", () => {
+  const mockedFetchAdminClasses = fetchAdminClasses;
+
+  beforeEach(() => {
+    mockedFetchAdminClasses.mockReset();
+    toast.error.mockClear();
+  });
+
+  it("fetches and renders every available class when 'All' is selected", async () => {
+    const initialData = [
+      {
+        id: "1",
+        title: "Algebra 101",
+        instructor: "Teacher A",
+        start_date: "2024-01-01",
+        end_date: "2024-01-05",
+        category: "Math",
+        publishStatus: "draft",
+        approvalStatus: "Approved",
+        scheduleStatus: "Upcoming",
+        price: 0,
+      },
+      {
+        id: "2",
+        title: "Geometry Basics",
+        instructor: "Teacher B",
+        start_date: "2024-02-01",
+        end_date: "2024-02-05",
+        category: "Math",
+        publishStatus: "draft",
+        approvalStatus: "Approved",
+        scheduleStatus: "Upcoming",
+        price: 0,
+      },
+    ];
+
+    const fullData = [
+      ...initialData,
+      {
+        id: "3",
+        title: "Trigonometry Essentials",
+        instructor: "Teacher C",
+        start_date: "2024-03-01",
+        end_date: "2024-03-05",
+        category: "Math",
+        publishStatus: "draft",
+        approvalStatus: "Approved",
+        scheduleStatus: "Upcoming",
+        price: 0,
+      },
+    ];
+
+    mockedFetchAdminClasses.mockResolvedValue({
+      data: fullData,
+      meta: { totalPages: 1, total: fullData.length },
+    });
+    mockedFetchAdminClasses
+      .mockResolvedValueOnce({
+        data: initialData,
+        meta: { totalPages: 1, total: fullData.length },
+      })
+      .mockResolvedValueOnce({
+        data: fullData,
+        meta: { totalPages: 1, total: fullData.length },
+      });
+
+    render(<AdminClassesTable />);
+
+    await screen.findByText("Algebra 101");
+
+    const pageSizeSelect = screen.getByDisplayValue("5");
+    fireEvent.change(pageSizeSelect, { target: { value: "all" } });
+
+    await waitFor(() => {
+      expect(mockedFetchAdminClasses).toHaveBeenCalledTimes(2);
+    });
+
+    const [, secondCallArgs] = mockedFetchAdminClasses.mock.calls;
+    expect(secondCallArgs[0]).toMatchObject({ limit: fullData.length });
+
+    await waitFor(() => {
+      const rows = screen.getAllByRole("row");
+      expect(rows).toHaveLength(fullData.length + 1);
+    });
+
+    for (const cls of fullData) {
+      expect(await screen.findByText(cls.title)).toBeInTheDocument();
+    }
+  });
+});
+
 describe("AdminClassesTable error handling", () => {
   const mockedFetchAdminClasses = fetchAdminClasses;
 


### PR DESCRIPTION
## Summary
- raise the backend pagination ceiling so "All" requests are no longer truncated
- document the new 10,000 item limit for operators
- add a regression test confirming the All page-size option renders every row

## Testing
- npm test -- AdminClassesTablePagination.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e0e077e9008328aa005f03ac8d64db