### PR TITLE
Use auth protection for admin class rules page

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/rules.js
@@ -12,7 +12,7 @@ import {
   updateClassRule,
   deleteClassRule,
 } from "@/services/admin/classRuleService";
-import withAdminGuard from "@/hooks/withAdminGuard";
+import withAuthProtection from "@/hooks/withAuthProtection";
 
 function ClassRulesPage() {
   const router = useRouter();
@@ -93,6 +93,8 @@ export async function getServerSideProps({ locale }) {
   };
 }
 
-const ProtectedClassRulesPage = withAdminGuard(ClassRulesPage);
+const ProtectedClassRulesPage = withAuthProtection(ClassRulesPage, {
+  permissions: ['ADD_ONLINE_CLASS_RULE'],
+});
 ProtectedClassRulesPage.getLayout = ClassRulesPage.getLayout;
 export default ProtectedClassRulesPage;


### PR DESCRIPTION
## Summary
- replace the admin guard on the class rules page with the shared auth protection HOC
- require the ADD_ONLINE_CLASS_RULE permission when accessing the page to ensure unauthorized admins are redirected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e07b43f4832891c6957a4deed4cf