### PR TITLE
Add ADD_ONLINE_CLASS_RULE permission to seed data

### DIFF
--- a/backend/src/seeds/10_permissions_seed.js
+++ b/backend/src/seeds/10_permissions_seed.js
@@ -35,6 +35,10 @@ exports.seed = async function (knex) {
     { code: 'manage_third_party_config', description: 'Permission to manage third-party configuration' },
     { code: 'view_online_classes', description: 'Permission to view online classes' },
     { code: 'manage_online_classes', description: 'Permission to manage online classes' },
+    {
+      code: 'ADD_ONLINE_CLASS_RULE',
+      description: 'Permission to add or manage online class rules',
+    },
   ];
 
   await knex('permissions')


### PR DESCRIPTION
## Summary
- add the ADD_ONLINE_CLASS_RULE permission to the base permissions seed so it is available after seeding
- reseed the relevant role and admin user data in-memory to confirm admin inherits the new permission

## Testing
- node - <<'NODE' ... (pg-mem seed verification)


------
https://chatgpt.com/codex/tasks/task_e_68e0e08039388328b00924d8d9235272