### PR TITLE
Add ResizeObserver ponyfill for legacy browsers

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -7,7 +7,7 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import "react-quill/dist/quill.snow.css";       // ✅ Rich text editor
 import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
-import "resize-observer-polyfill";
+import ResizeObserver from "resize-observer-polyfill";
 import "@/styles/globals.css";
 import "@/services/api/tokenInterceptor";
 import useAuthStore from "@/store/auth/authStore";
@@ -34,6 +34,9 @@ import SeoTags from "@/components/common/SeoTags";
 import PageLoader from "@/components/PageLoader";
 import PopupAnnouncement from "@/components/common/PopupAnnouncement";
 
+if (typeof window !== "undefined" && !window.ResizeObserver) {
+  window.ResizeObserver = ResizeObserver;
+}
 
 const langFetcher = () => getLanguages();
 


### PR DESCRIPTION
## Summary
- import the ResizeObserver ponyfill rather than the side-effect module
- attach the ResizeObserver ponyfill to window when native support is absent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0ea80d9f08328ba72c39858c6a309