### PR TITLE
Guard analytics charts against missing ResizeObserver

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/AnalyticsCharts.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/AnalyticsCharts.js
@@ -1,21 +1,122 @@
-import React from "react";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  CartesianGrid,
-  PieChart,
-  Pie,
-  Cell,
-  Legend,
-} from "recharts";
+import React, { useEffect, useState } from "react";
 
 const COLORS = ["#60a5fa", "#34d399", "#fbbf24", "#f87171"];
 
 export default function AnalyticsCharts({ t, locations, devices, registrationTrend }) {
+  const [chartsLib, setChartsLib] = useState(null);
+  const [chartsLoadError, setChartsLoadError] = useState(false);
+  const [resizeObserverSupported, setResizeObserverSupported] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const ensureResizeObserver = async () => {
+      if (typeof window === "undefined") {
+        return false;
+      }
+
+      if (window.ResizeObserver) {
+        return true;
+      }
+
+      try {
+        const polyfillModule = await import("resize-observer-polyfill");
+        if (!isMounted) {
+          return false;
+        }
+        const ResizeObserverPolyfill = polyfillModule?.default ?? polyfillModule;
+        if (ResizeObserverPolyfill && !window.ResizeObserver) {
+          window.ResizeObserver = ResizeObserverPolyfill;
+          return true;
+        }
+      } catch (error) {
+        console.warn("Failed to load ResizeObserver polyfill", error);
+      }
+
+      return Boolean(window.ResizeObserver);
+    };
+
+    const loadCharts = async () => {
+      const supported = await ensureResizeObserver();
+      if (!isMounted) {
+        return;
+      }
+
+      if (!supported) {
+        setResizeObserverSupported(false);
+        return;
+      }
+
+      try {
+        const module = await import("recharts");
+        if (!isMounted) {
+          return;
+        }
+        setChartsLib(module);
+        setChartsLoadError(false);
+        setResizeObserverSupported(true);
+      } catch (error) {
+        console.error("Failed to load Recharts", error);
+        if (!isMounted) {
+          return;
+        }
+        setChartsLoadError(true);
+        setChartsLib(null);
+      }
+    };
+
+    loadCharts();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const ResponsiveContainer = chartsLib?.ResponsiveContainer;
+  const PieChart = chartsLib?.PieChart;
+  const Pie = chartsLib?.Pie;
+  const Cell = chartsLib?.Cell;
+  const Legend = chartsLib?.Legend;
+  const Tooltip = chartsLib?.Tooltip;
+  const BarChart = chartsLib?.BarChart;
+  const Bar = chartsLib?.Bar;
+  const XAxis = chartsLib?.XAxis;
+  const YAxis = chartsLib?.YAxis;
+  const CartesianGrid = chartsLib?.CartesianGrid;
+
+  const renderFallbackMessage = () => {
+    if (!resizeObserverSupported) {
+      return t(
+        "classAnalyticsPage.chartsUnavailableResizeObserver",
+        "Charts are unavailable because ResizeObserver is not supported in this browser."
+      );
+    }
+
+    if (chartsLoadError) {
+      return t(
+        "classAnalyticsPage.chartsFailedToLoad",
+        "Charts failed to load. Please refresh to try again."
+      );
+    }
+
+    return t("classAnalyticsPage.loadingCharts", "Loading charts…");
+  };
+
+  const shouldRenderCharts =
+    resizeObserverSupported &&
+    !chartsLoadError &&
+    ResponsiveContainer &&
+    PieChart &&
+    Pie &&
+    Cell &&
+    Legend &&
+    Tooltip &&
+    BarChart &&
+    Bar &&
+    XAxis &&
+    YAxis &&
+    CartesianGrid;
+
   return (
     <>
       <div className="grid md:grid-cols-2 gap-6">
@@ -23,34 +124,46 @@ export default function AnalyticsCharts({ t, locations, devices, registrationTre
           <h2 className="text-lg font-semibold text-gray-700 mb-4">
             🌍 {t("classAnalyticsPage.top_countries")}
           </h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie data={locations} dataKey="value" nameKey="name" outerRadius={100}>
-                {(locations ?? []).map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Pie>
-              <Legend />
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          {shouldRenderCharts ? (
+            <ResponsiveContainer width="100%" height={300}>
+              <PieChart>
+                <Pie data={locations} dataKey="value" nameKey="name" outerRadius={100}>
+                  {(locations ?? []).map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Legend />
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+              {renderFallbackMessage()}
+            </div>
+          )}
         </div>
 
         <div className="bg-white p-6 rounded-xl shadow border">
           <h2 className="text-lg font-semibold text-gray-700 mb-4">
             📱 {t("classAnalyticsPage.devices_used")}
           </h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie data={devices} dataKey="value" nameKey="name" outerRadius={100}>
-                {(devices ?? []).map((entry, index) => (
-                  <Cell key={`cell-dev-${index}`} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Pie>
-              <Legend />
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          {shouldRenderCharts ? (
+            <ResponsiveContainer width="100%" height={300}>
+              <PieChart>
+                <Pie data={devices} dataKey="value" nameKey="name" outerRadius={100}>
+                  {(devices ?? []).map((entry, index) => (
+                    <Cell key={`cell-dev-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Legend />
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+              {renderFallbackMessage()}
+            </div>
+          )}
         </div>
       </div>
 
@@ -58,15 +171,21 @@ export default function AnalyticsCharts({ t, locations, devices, registrationTre
         <h2 className="text-lg font-semibold text-gray-700 mb-4">
           📈 {t("classAnalyticsPage.registration_trend")}
         </h2>
-        <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={registrationTrend}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="date" />
-            <YAxis />
-            <Tooltip />
-            <Bar dataKey="students" fill="#facc15" />
-          </BarChart>
-        </ResponsiveContainer>
+        {shouldRenderCharts ? (
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={registrationTrend}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="students" fill="#facc15" />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            {renderFallbackMessage()}
+          </div>
+        )}
       </div>
     </>
   );

--- a/frontend/src/tests/__tests__/AnalyticsCharts.test.js
+++ b/frontend/src/tests/__tests__/AnalyticsCharts.test.js
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AnalyticsCharts from "../../pages/dashboard/admin/online-classes/[id]/AnalyticsCharts";
+
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  PieChart: ({ children }) => <div data-testid="pie-chart">{children}</div>,
+  Pie: ({ children }) => <div data-testid="pie">{children}</div>,
+  Cell: ({ fill }) => <div data-testid="cell" data-fill={fill} />,
+  Legend: () => <div data-testid="legend" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  BarChart: ({ children }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => <div data-testid="bar" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+}));
+
+const defaultProps = {
+  t: (_key, fallback) => fallback ?? _key,
+  locations: [{ name: "USA", value: 10 }],
+  devices: [{ name: "Desktop", value: 5 }],
+  registrationTrend: [{ date: "2024-01-01", students: 3 }],
+};
+
+describe("AnalyticsCharts", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete global.ResizeObserver;
+    if (typeof window !== "undefined") {
+      delete window.ResizeObserver;
+    }
+  });
+
+  it("renders charts when ResizeObserver is available", async () => {
+    const ResizeObserverMock = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    global.ResizeObserver = ResizeObserverMock;
+    if (typeof window !== "undefined") {
+      window.ResizeObserver = ResizeObserverMock;
+    }
+
+    render(<AnalyticsCharts {...defaultProps} />);
+
+    const pieCharts = await screen.findAllByTestId("pie-chart");
+    expect(pieCharts).toHaveLength(2);
+    expect(await screen.findByTestId("bar-chart")).toBeInTheDocument();
+  });
+
+  it("renders fallback messaging when ResizeObserver is unsupported", async () => {
+    if (typeof window !== "undefined") {
+      Object.defineProperty(window, "ResizeObserver", {
+        configurable: true,
+        get: () => undefined,
+        set: () => {},
+      });
+    }
+    delete global.ResizeObserver;
+
+    render(<AnalyticsCharts {...defaultProps} />);
+
+    const fallbacks = await screen.findAllByText(
+      "Charts are unavailable because ResizeObserver is not supported in this browser."
+    );
+    expect(fallbacks).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- lazy-load Recharts in the admin analytics charts component behind a ResizeObserver/ polyfill guard
- show localized fallback messaging whenever the browser cannot observe size changes or the chart library fails to load
- add unit coverage to assert both the supported and unsupported ResizeObserver flows

## Testing
- npm test -- AnalyticsCharts

------
https://chatgpt.com/codex/tasks/task_e_68e0ea7b8c808328af3f008b780ad4f5