### PR TITLE
Ensure ResizeObserver polyfill available in browser

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -7,7 +7,7 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import "react-quill/dist/quill.snow.css";       // ✅ Rich text editor
 import "react-phone-input-2/lib/style.css";     // ✅ Phone input styles
-import "resize-observer-polyfill";
+import ResizeObserver from "resize-observer-polyfill";
 import "@/styles/globals.css";
 import "@/services/api/tokenInterceptor";
 import useAuthStore from "@/store/auth/authStore";
@@ -34,6 +34,9 @@ import SeoTags from "@/components/common/SeoTags";
 import PageLoader from "@/components/PageLoader";
 import PopupAnnouncement from "@/components/common/PopupAnnouncement";
 
+if (typeof window !== "undefined" && !window.ResizeObserver) {
+  window.ResizeObserver = ResizeObserver;
+}
 
 const langFetcher = () => getLanguages();
 


### PR DESCRIPTION
## Summary
- replace the side-effect import of resize-observer-polyfill with a named import
- register the ponyfill on window when ResizeObserver is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ea928ae48328891fa39071b45525