### PR TITLE
Handle automatic retry after failed admin class fetch

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -35,6 +35,7 @@ const BACKEND_STATUSES = new Set(["draft", "published", "archived"]);
 const MIN_REJECTION_REASON_LENGTH = 3;
 
 const DEFAULT_PAGE_SIZE = 5;
+const FAILED_REQUEST_RETRY_DELAY_MS = 5000;
 const resolvePositiveInteger = (value, fallback = 1) => {
   const numericValue = Number(value);
   if (Number.isFinite(numericValue) && numericValue > 0) {
@@ -129,11 +130,21 @@ export default function AdminClassesTable() {
     return resolvePositiveInteger(pageSizeSetting, DEFAULT_PAGE_SIZE);
   }, [pageSizeSetting, totalItems, classCount]);
 
+  const clearFailedSignature = (failureRecord = lastFailedSignatureRef.current) => {
+    if (failureRecord?.retryTimer) {
+      clearTimeout(failureRecord.retryTimer);
+    }
+    if (lastFailedSignatureRef.current === failureRecord) {
+      lastFailedSignatureRef.current = null;
+    }
+  };
+
   useEffect(() => {
     setMounted(true);
     isComponentMountedRef.current = true;
     return () => {
       isComponentMountedRef.current = false;
+      clearFailedSignature();
     };
   }, []);
 
@@ -209,7 +220,7 @@ export default function AdminClassesTable() {
   useEffect(() => {
     if (!hasHydrated || !authIdentifier) {
       if (lastFailedSignatureRef.current) {
-        lastFailedSignatureRef.current = null;
+        clearFailedSignature();
       }
       return;
     }
@@ -243,17 +254,21 @@ export default function AdminClassesTable() {
 
     if (
       lastFailedSignatureRef.current &&
-      lastFailedSignatureRef.current !== requestDetails.signature
+      lastFailedSignatureRef.current.signature !== requestDetails.signature
     ) {
-      lastFailedSignatureRef.current = null;
+      clearFailedSignature();
     }
 
     if (lastSuccessfulSignatureRef.current === requestDetails.signature) {
       return;
     }
 
-    if (lastFailedSignatureRef.current === requestDetails.signature) {
-      return;
+    if (lastFailedSignatureRef.current?.signature === requestDetails.signature) {
+      const failureAge = Date.now() - (lastFailedSignatureRef.current.timestamp ?? 0);
+      if (!Number.isFinite(failureAge) || failureAge < FAILED_REQUEST_RETRY_DELAY_MS) {
+        return;
+      }
+      clearFailedSignature();
     }
 
     if (inFlightRequestRef.current === requestDetails.signature) {
@@ -405,13 +420,38 @@ export default function AdminClassesTable() {
         }
 
         lastSuccessfulSignatureRef.current = finalSignature;
-        lastFailedSignatureRef.current = null;
+        clearFailedSignature();
       } catch (err) {
         console.error(err);
         if (isComponentMountedRef.current) {
           toast.error("Failed to load classes");
         }
-        lastFailedSignatureRef.current = signature;
+        clearFailedSignature();
+        const failureRecord = {
+          signature,
+          timestamp: Date.now(),
+          retryTimer: null,
+        };
+        failureRecord.retryTimer = setTimeout(() => {
+          if (!isComponentMountedRef.current) {
+            return;
+          }
+          const activeFailure = lastFailedSignatureRef.current;
+          if (!activeFailure || activeFailure.signature !== signature) {
+            return;
+          }
+          clearFailedSignature(activeFailure);
+          if (
+            lastSuccessfulSignatureRef.current === signature ||
+            inFlightRequestRef.current ||
+            (pendingRequestRef.current &&
+              pendingRequestRef.current.signature === signature)
+          ) {
+            return;
+          }
+          executeRequest(details);
+        }, FAILED_REQUEST_RETRY_DELAY_MS);
+        lastFailedSignatureRef.current = failureRecord;
       } finally {
         if (isComponentMountedRef.current && loadingRef.current) {
           loadingRef.current = false;
@@ -425,7 +465,7 @@ export default function AdminClassesTable() {
           if (
             isComponentMountedRef.current &&
             lastSuccessfulSignatureRef.current !== nextRequest.signature &&
-            lastFailedSignatureRef.current !== nextRequest.signature
+            lastFailedSignatureRef.current?.signature !== nextRequest.signature
           ) {
             executeRequest(nextRequest);
           }

--- a/frontend/src/tests/pages/dashboard/admin/online-classes/index.test.jsx
+++ b/frontend/src/tests/pages/dashboard/admin/online-classes/index.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import AdminClassesTable from "@/components/admin/online-classes/AdminClassesTable";
 
@@ -126,5 +126,31 @@ describe("AdminClassesTable status toggling", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Approve")).not.toBeInTheDocument();
     expect(toastSuccessMock).toHaveBeenCalledWith("Status updated");
+  });
+
+  it("retries fetching classes automatically after a failure", async () => {
+    jest.useFakeTimers();
+    try {
+      const networkError = new Error("Network error");
+      fetchAdminClassesMock.mockRejectedValueOnce(networkError);
+
+      render(<AdminClassesTable />);
+
+      await waitFor(() => {
+        expect(fetchAdminClassesMock).toHaveBeenCalledTimes(1);
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to load classes");
+
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+
+      await waitFor(() => {
+        expect(fetchAdminClassesMock).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add a retry delay guard and automatic retry scheduling for admin class fetch failures
- clean up failed request state when navigating away or when a retry is eligible
- cover the retry flow with a unit test that simulates a failed request and verifies the automatic retry

## Testing
- npm test -- --runTestsByPath src/tests/pages/dashboard/admin/online-classes/index.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e1040e4fdc8328b3dd6b7e411593ec