### PR TITLE
Fix cookie domain handling and add login cookie tests

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -138,11 +138,16 @@ app.use(
 app.get("/api/health", (_req, res) => {
   res.status(200).json({ status: "ok" });
 });
+const sessionCookieOptions = { ...refreshCookieOptions };
+
 const sessionOptions = {
   secret: config.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
-  cookie: { ...refreshCookieOptions },
+  // Reuse the same cookie defaults as refresh tokens so domain, secure and
+  // sameSite stay consistent. When COOKIE_DOMAIN is not set the domain remains
+  // undefined which lets browsers scope the cookie to the current host.
+  cookie: sessionCookieOptions,
 };
 
 if (redisClient) {

--- a/backend/src/utils/cookie.js
+++ b/backend/src/utils/cookie.js
@@ -11,11 +11,10 @@
 const { REFRESH_TOKEN_MAX_AGE } = require("../config/tokens");
 const { COOKIE_DOMAIN, NODE_ENV } = require("../config/env");
 
-// Use the provided cookie domain or fall back to the production domain so
-// browsers store the csrfToken cookie when deployed.
-const domain =
-  COOKIE_DOMAIN ||
-  (NODE_ENV === "production" ? ".eduskillbridge.net" : undefined);
+// Use the provided cookie domain when available. Leaving it undefined allows
+// browsers to scope the cookie to the current host which works for local
+// development and custom deployments without additional configuration.
+const domain = COOKIE_DOMAIN ? COOKIE_DOMAIN.trim() || undefined : undefined;
 
 const refreshCookieOptions = {
   httpOnly: true,

--- a/backend/tests/authLoginCookieDomain.test.js
+++ b/backend/tests/authLoginCookieDomain.test.js
@@ -1,0 +1,146 @@
+const request = require('supertest');
+
+const payload = { email: 'test@example.com', password: 'StrongPass1!' };
+
+const envKeys = [
+  'NODE_ENV',
+  'JWT_SECRET',
+  'REFRESH_TOKEN_SECRET',
+  'SESSION_SECRET',
+  'DATABASE_URL',
+  'COOKIE_DOMAIN',
+];
+
+const originalEnv = envKeys.reduce((acc, key) => {
+  acc[key] = process.env[key];
+  return acc;
+}, {});
+
+const baseEnv = {
+  NODE_ENV: 'production',
+  JWT_SECRET: 'testsecret',
+  REFRESH_TOKEN_SECRET: 'refreshsecret',
+  SESSION_SECRET: 'sessionsecret',
+  DATABASE_URL: 'postgres://user:pass@localhost:5432/db',
+};
+
+const routerMocks = [
+  '../src/modules/users/user.routes',
+  '../src/modules/verify/verify.routes',
+  '../src/modules/license/license.routes',
+  '../src/modules/users/tutorials/certificate/certificatePublic.routes',
+  '../src/modules/users/tutorials/certificate/certificateAdmin.routes',
+  '../src/modules/certificateTemplates/certificateTemplates.routes',
+  '../src/modules/roles/roles.routes',
+  '../src/modules/plans/plans.routes',
+  '../src/modules/subscriptions/subscriptions.routes',
+];
+
+const setEnv = (cookieDomain) => {
+  Object.entries(baseEnv).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+
+  if (cookieDomain === undefined || cookieDomain === null || cookieDomain === '') {
+    delete process.env.COOKIE_DOMAIN;
+  } else {
+    process.env.COOKIE_DOMAIN = cookieDomain;
+  }
+};
+
+const mockDependencies = () => {
+  jest.doMock('../src/config/database', () => ({
+    raw: jest.fn(() => Promise.resolve()),
+  }));
+
+  jest.doMock('../src/utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }));
+
+  jest.doMock('../src/modules/auth/services/auth.service', () => ({
+    loginUser: jest.fn(),
+  }));
+
+  jest.doMock('../src/modules/socialLoginConfig/socialLoginConfig.service', () => ({
+    getSettings: jest.fn().mockResolvedValue({ recaptcha: { active: false } }),
+  }));
+
+  jest.doMock('../src/modules/recaptcha/recaptcha.service', () => ({
+    verify: jest.fn(),
+    shouldBypass: jest.fn().mockReturnValue(false),
+  }));
+
+  routerMocks.forEach((modulePath) => {
+    jest.doMock(modulePath, () => require('express').Router());
+  });
+};
+
+const createApp = async ({ cookieDomain } = {}) => {
+  jest.resetModules();
+  setEnv(cookieDomain);
+  mockDependencies();
+
+  const express = require('express');
+  const routes = require('../src/routes/auth');
+  const errorHandler = require('../src/middleware/errorHandler');
+  const authService = require('../src/modules/auth/services/auth.service');
+
+  authService.loginUser.mockResolvedValue({
+    accessToken: 'a',
+    refreshToken: 'r',
+    user: { id: 1 },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.csrfToken = jest.fn(() => 'csrf-token');
+    next();
+  });
+  app.use(routes);
+  app.use(errorHandler);
+
+  return app;
+};
+
+describe('POST /api/auth/login cookie domain handling', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    envKeys.forEach((key) => {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    });
+  });
+
+  it('omits cookie domain when COOKIE_DOMAIN is not set', async () => {
+    const app = await createApp();
+    const res = await request(app).post('/api/auth/login').send(payload);
+
+    expect(res.status).toBe(200);
+    const cookies = res.headers['set-cookie'] || [];
+    expect(cookies.some((cookie) => /Domain=/i.test(cookie))).toBe(false);
+  });
+
+  it('applies explicit COOKIE_DOMAIN to refresh and csrf cookies', async () => {
+    const app = await createApp({ cookieDomain: '.example.com' });
+    const res = await request(app).post('/api/auth/login').send(payload);
+
+    expect(res.status).toBe(200);
+    const cookies = res.headers['set-cookie'] || [];
+    const refreshCookies = cookies.filter((cookie) => cookie.startsWith('refreshToken='));
+    const csrfCookies = cookies.filter((cookie) => cookie.startsWith('csrfToken='));
+
+    expect(refreshCookies.length).toBeGreaterThan(0);
+    expect(csrfCookies.length).toBeGreaterThan(0);
+    expect(refreshCookies.every((cookie) => cookie.includes('Domain=.example.com'))).toBe(true);
+    expect(csrfCookies.every((cookie) => cookie.includes('Domain=.example.com'))).toBe(true);
+  });
+});

--- a/backend/tests/authLoginRoutes.test.js
+++ b/backend/tests/authLoginRoutes.test.js
@@ -129,7 +129,7 @@ describe('POST /api/auth/login', () => {
       expect.not.arrayContaining([expect.stringMatching(/^csrfToken=/)]),
     );
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to generate CSRF token during login: csrf failure'),
+      expect.stringContaining('Failed to issue CSRF cookie on login: csrf failure'),
     );
   });
 });


### PR DESCRIPTION
## Summary
- stop defaulting authentication cookies to the eduskillbridge domain when COOKIE_DOMAIN is unset
- reuse the refresh cookie configuration for express-session cookies so explicit domains propagate consistently
- add login integration tests that assert Set-Cookie headers reflect different COOKIE_DOMAIN values

## Testing
- npm test -- authLoginRoutes.test.js authLoginCookieDomain.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e10fc33c8c8328b1ea50426681f03f