### PR TITLE
Fix admin classes retry guard to read failed signature ref safely

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -254,23 +254,19 @@ export default function AdminClassesTable() {
       sortKey,
     };
 
-    if (
-      lastFailedSignatureRef.current &&
-      lastFailedSignatureRef.current.signature !== requestDetails.signature
-    ) {
-      clearFailedSignature();
-    }
+    const failedSignature = lastFailedSignatureRef.current;
 
-    if (failedSignature) {
-      if (failedSignature.signature !== requestDetails.signature) {
-        clearFailedSignature();
+    if (
+      failedSignature &&
+      failedSignature.signature !== requestDetails.signature
+    ) {
+      clearFailedSignature(failedSignature);
+    } else if (failedSignature) {
+      const elapsed = Date.now() - failedSignature.failedAt;
+      if (elapsed >= FAILED_SIGNATURE_RETRY_DELAY_MS) {
+        clearFailedSignature(failedSignature);
       } else {
-        const elapsed = Date.now() - failedSignature.failedAt;
-        if (elapsed >= FAILED_SIGNATURE_RETRY_DELAY_MS) {
-          clearFailedSignature();
-        } else {
-          return;
-        }
+        return;
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure the AdminClassesTable retry guard reads the failed signature ref through a declared variable
- keep the retry clearing logic when the signature changes or the delay expires to prevent stale state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e150ea537083288d55b0828c8196a0