### PR TITLE
Fix admin classes table failed signature guard

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -261,6 +261,7 @@ export default function AdminClassesTable() {
       clearFailedSignature();
     }
 
+    const failedSignature = lastFailedSignatureRef.current;
     if (failedSignature) {
       if (failedSignature.signature !== requestDetails.signature) {
         clearFailedSignature();


### PR DESCRIPTION
## Summary
- ensure the admin classes request effect caches the failed signature before checking it

## Testing
- not run (environment limitations)

------
https://chatgpt.com/codex/tasks/task_e_68e150f2748483289eb79fd17d9123e2