### PR TITLE
Fix failed signature retry guard in AdminClassesTable

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -262,7 +262,7 @@ export default function AdminClassesTable() {
     ) {
       clearFailedSignature(failedSignature);
     } else if (failedSignature) {
-      const elapsed = Date.now() - failedSignature.failedAt;
+      const elapsed = Date.now() - failedSignature.timestamp;
       if (elapsed >= FAILED_SIGNATURE_RETRY_DELAY_MS) {
         clearFailedSignature(failedSignature);
       } else {


### PR DESCRIPTION
## Summary
- use the stored failure timestamp when evaluating the retry delay guard in AdminClassesTable
- ensure manual filter and pagination changes can trigger new fetches without waiting on an expired timeout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15ae905f88328a84248bffe3f77ab