### PR TITLE
Fix failed request retry guard in admin classes table

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -256,26 +256,26 @@ export default function AdminClassesTable() {
 
     const failedSignature = lastFailedSignatureRef.current;
 
-    if (
-      failedSignature &&
-      failedSignature.signature !== requestDetails.signature
-    ) {
-      clearFailedSignature(failedSignature);
-    } else if (failedSignature) {
-      const elapsed = Date.now() - failedSignature.failedAt;
-      if (elapsed >= FAILED_SIGNATURE_RETRY_DELAY_MS) {
+    if (failedSignature) {
+      if (failedSignature.signature !== requestDetails.signature) {
         clearFailedSignature(failedSignature);
       } else {
-        return;
+        const failureTimestamp =
+          typeof failedSignature.failedAt === "number" &&
+          Number.isFinite(failedSignature.failedAt)
+            ? failedSignature.failedAt
+            : failedSignature.timestamp;
+        if (
+          typeof failureTimestamp === "number" &&
+          Number.isFinite(failureTimestamp)
+        ) {
+          const elapsed = Date.now() - failureTimestamp;
+          if (elapsed < FAILED_SIGNATURE_RETRY_DELAY_MS) {
+            return;
+          }
+        }
+        clearFailedSignature(failedSignature);
       }
-    }
-
-    if (lastFailedSignatureRef.current?.signature === requestDetails.signature) {
-      const failureAge = Date.now() - (lastFailedSignatureRef.current.timestamp ?? 0);
-      if (!Number.isFinite(failureAge) || failureAge < FAILED_REQUEST_RETRY_DELAY_MS) {
-        return;
-      }
-      clearFailedSignature();
     }
 
     if (inFlightRequestRef.current === requestDetails.signature) {
@@ -434,9 +434,11 @@ export default function AdminClassesTable() {
           toast.error("Failed to load classes");
         }
         clearFailedSignature();
+        const failureTimestamp = Date.now();
         const failureRecord = {
           signature,
-          timestamp: Date.now(),
+          timestamp: failureTimestamp,
+          failedAt: failureTimestamp,
           retryTimer: null,
         };
         failureRecord.retryTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- ensure the failed request guard checks the recorded timestamp consistently
- stop returning early once the retry delay has elapsed
- record a failedAt timestamp for retry bookkeeping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15baf51f083289be9bff18331fa28