### PR TITLE
Fix failed signature retry timestamp handling

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -271,7 +271,7 @@ export default function AdminClassesTable() {
     }
 
     if (lastFailedSignatureRef.current?.signature === requestDetails.signature) {
-      const failureAge = Date.now() - (lastFailedSignatureRef.current.timestamp ?? 0);
+      const failureAge = Date.now() - (lastFailedSignatureRef.current.failedAt ?? 0);
       if (!Number.isFinite(failureAge) || failureAge < FAILED_REQUEST_RETRY_DELAY_MS) {
         return;
       }
@@ -436,7 +436,7 @@ export default function AdminClassesTable() {
         clearFailedSignature();
         const failureRecord = {
           signature,
-          timestamp: Date.now(),
+          failedAt: Date.now(),
           retryTimer: null,
         };
         failureRecord.retryTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- align the failed signature retry guard with the stored timestamp field
- ensure retry attempts compute failure age from the same property written in the catch block

## Testing
- `npm test -- --watch=false` *(fails: existing Jest failures in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e15d80d7e08328a5f7f6e122e917d4