### PR TITLE
Ensure admin classes table refetches after page normalization

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -228,14 +228,12 @@ export default function AdminClassesTable() {
     }
 
     if (normalizedPage !== currentPage) {
-      if (lastNormalizedPageRef.current !== normalizedPage) {
-        lastNormalizedPageRef.current = normalizedPage;
-        setCurrentPage(normalizedPage);
-      }
-      return;
+      setCurrentPageIfNeeded(normalizedPage);
     }
 
-    lastNormalizedPageRef.current = normalizedPage;
+    if (lastNormalizedPageRef.current !== normalizedPage) {
+      lastNormalizedPageRef.current = normalizedPage;
+    }
 
     const requestDetails = {
       signature: JSON.stringify({


### PR DESCRIPTION
## Summary
- allow the admin classes table to refetch data immediately when the normalized page differs from the current page
- keep the normalized page reference in sync while continuing to rely on the existing request de-duplication logic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e15d81ed7083289953cdf357804818