### PR TITLE
Fix home page section refs for smooth scrolling

### DIFF
--- a/frontend/src/pages/website/index.js
+++ b/frontend/src/pages/website/index.js
@@ -180,7 +180,12 @@ export default function Home() {
       <IncompleteAlertModal />
 
       {sections.map(({ component: Component, props }, index) => (
-        <section key={index} ref={sectionRefs.current[index]}>
+        <section
+          key={index}
+          ref={(element) => {
+            sectionRefs.current[index] = element ?? null;
+          }}
+        >
           <Component {...props} />
         </section>
       ))}


### PR DESCRIPTION
## Summary
- ensure the website home page stores DOM section elements in refs so navigation buttons trigger scrollIntoView correctly

## Testing
- npm test -- WebsiteHomeScroll

------
https://chatgpt.com/codex/tasks/task_e_68e160aa65d08328ad51808e22abae9d