### PR TITLE
Fix instructor class service endpoints to respect API base path

### DIFF
--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -58,7 +58,7 @@ export const fetchInstructorClasses = async (instructorId) => {
   // Fetch only classes belonging to the specified instructor
   const requestConfig = instructorId ? { params: { instructorId } } : {};
   const { data } = await api.get(
-    "/users/classes/instructor/my",
+    "users/classes/instructor/my",
     requestConfig,
   );
   const list = data?.data ?? [];
@@ -66,13 +66,13 @@ export const fetchInstructorClasses = async (instructorId) => {
 };
 
 export const fetchInstructorClassById = async (id) => {
-  const { data } = await api.get(`/users/classes/instructor/${id}`);
+  const { data } = await api.get(`users/classes/instructor/${id}`);
   return data?.data ? formatClass(data.data) : null;
 };
 
 export const createInstructorClass = async (payload, onUploadProgress) => {
   await ensureCsrfToken();
-  const { data } = await api.post("/users/classes/instructor", payload, {
+  const { data } = await api.post("users/classes/instructor", payload, {
     headers: {
       "Content-Type": "multipart/form-data",
     },
@@ -83,7 +83,7 @@ export const createInstructorClass = async (payload, onUploadProgress) => {
 
 export const updateInstructorClass = async (id, payload) => {
   await ensureCsrfToken();
-  const { data } = await api.put(`/users/classes/instructor/${id}`, payload, {
+  const { data } = await api.put(`users/classes/instructor/${id}`, payload, {
     headers: {
       "Content-Type": "multipart/form-data",
     },
@@ -93,23 +93,23 @@ export const updateInstructorClass = async (id, payload) => {
 
 export const deleteInstructorClass = async (id) => {
   await ensureCsrfToken();
-  await api.delete(`/users/classes/instructor/${id}`);
+  await api.delete(`users/classes/instructor/${id}`);
   return true;
 };
 
 export const fetchInstructorClassAnalytics = async (id) => {
-  const { data } = await api.get(`/users/classes/instructor/${id}/analytics`);
+  const { data } = await api.get(`users/classes/instructor/${id}/analytics`);
   return data?.data ?? {};
 };
 
 export const toggleClassStatus = async (id) => {
   await ensureCsrfToken();
-  const { data } = await api.patch(`/users/classes/instructor/${id}/status`);
+  const { data } = await api.patch(`users/classes/instructor/${id}/status`);
   return data?.data;
 };
 
 export const fetchClassManagementData = async (id) => {
-  const { data } = await api.get(`/users/classes/instructor/${id}/manage`);
+  const { data } = await api.get(`users/classes/instructor/${id}/manage`);
   if (!data?.data) return null;
   return {
     class: data.data.class ? formatClass(data.data.class) : null,
@@ -120,30 +120,30 @@ export const fetchClassManagementData = async (id) => {
 
 export const createClassLesson = async (classId, payload) => {
   await ensureCsrfToken();
-  const { data } = await api.post(`/users/classes/lessons/class/${classId}`, payload);
+  const { data } = await api.post(`users/classes/lessons/class/${classId}`, payload);
   return data?.data;
 };
 
 export const updateClassLesson = async (lessonId, payload) => {
   await ensureCsrfToken();
-  const { data } = await api.put(`/users/classes/lessons/${lessonId}`, payload);
+  const { data } = await api.put(`users/classes/lessons/${lessonId}`, payload);
   return data?.data;
 };
 
 export const deleteClassLesson = async (lessonId) => {
   await ensureCsrfToken();
-  await api.delete(`/users/classes/lessons/${lessonId}`);
+  await api.delete(`users/classes/lessons/${lessonId}`);
 };
 
 export const createClassAssignment = async (classId, payload) => {
   await ensureCsrfToken();
-  const { data } = await api.post(`/users/classes/assignments/class/${classId}`, payload);
+  const { data } = await api.post(`users/classes/assignments/class/${classId}`, payload);
   return data?.data;
 };
 
 export const deleteClassAssignment = async (assignmentId) => {
   await ensureCsrfToken();
-  await api.delete(`/users/classes/assignments/${assignmentId}`);
+  await api.delete(`users/classes/assignments/${assignmentId}`);
 };
 
 // Fetch upcoming schedule events for the current instructor


### PR DESCRIPTION
## Summary
- remove leading slashes from instructor online class service endpoints so axios keeps the /api prefix and CSRF cookies are sent correctly

## Testing
- npm run lint -- --max-warnings=0 *(fails: existing warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e166cc33a88328b597aa91cab479e9