### PR TITLE
Normalize Axios base URL to retain /api prefix

### DIFF
--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -110,7 +110,29 @@ const ensureApiSuffix = (candidate) => {
   return `${trimmedCandidate.replace(/\/+$/, "")}/api`;
 };
 
-const baseURL = ensureAbsoluteUrl(ensureApiSuffix(pickBaseCandidate()));
+const ensureTrailingSlash = (candidate) => {
+  if (!candidate) {
+    return candidate;
+  }
+
+  if (/^https?:\/\//i.test(candidate)) {
+    try {
+      const url = new URL(candidate);
+      url.pathname = `${url.pathname.replace(/\/+$/, "")}/`;
+      return url.toString();
+    } catch (error) {
+      logger.warn(
+        `Failed to normalise API base URL trailing slash for "${candidate}": ${error.message}`,
+      );
+    }
+  }
+
+  return `${candidate.replace(/\/+$/, "")}/`;
+};
+
+const baseURL = ensureTrailingSlash(
+  ensureAbsoluteUrl(ensureApiSuffix(pickBaseCandidate())),
+);
 
 // Warn developers if the default domain URL is used in production
 if (

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -54,11 +54,20 @@ const formatClass = (cls) => {
   };
 };
 
+const buildCsrfHeaders = async (headers = {}) => {
+  const csrfToken = await ensureCsrfToken();
+  if (!csrfToken) return headers;
+  return {
+    ...headers,
+    "x-csrf-token": csrfToken,
+  };
+};
+
 export const fetchInstructorClasses = async (instructorId) => {
   // Fetch only classes belonging to the specified instructor
   const requestConfig = instructorId ? { params: { instructorId } } : {};
   const { data } = await api.get(
-    "/users/classes/instructor/my",
+    "users/classes/instructor/my",
     requestConfig,
   );
   const list = data?.data ?? [];
@@ -66,50 +75,53 @@ export const fetchInstructorClasses = async (instructorId) => {
 };
 
 export const fetchInstructorClassById = async (id) => {
-  const { data } = await api.get(`/users/classes/instructor/${id}`);
+  const { data } = await api.get(`users/classes/instructor/${id}`);
   return data?.data ? formatClass(data.data) : null;
 };
 
 export const createInstructorClass = async (payload, onUploadProgress) => {
-  await ensureCsrfToken();
-  const { data } = await api.post("/users/classes/instructor", payload, {
-    headers: {
-      "Content-Type": "multipart/form-data",
-    },
+  const headers = await buildCsrfHeaders();
+  const config = {
+    headers,
     ...(onUploadProgress ? { onUploadProgress } : {}),
-  });
+  };
+  const { data } = await api.post("users/classes/instructor", payload, config);
   return data?.data ? formatClass(data.data) : null;
 };
 
 export const updateInstructorClass = async (id, payload) => {
-  await ensureCsrfToken();
-  const { data } = await api.put(`/users/classes/instructor/${id}`, payload, {
-    headers: {
-      "Content-Type": "multipart/form-data",
-    },
-  });
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.put(
+    `users/classes/instructor/${id}`,
+    payload,
+    { headers },
+  );
   return data?.data ? formatClass(data.data) : null;
 };
 
 export const deleteInstructorClass = async (id) => {
-  await ensureCsrfToken();
-  await api.delete(`/users/classes/instructor/${id}`);
+  const headers = await buildCsrfHeaders();
+  await api.delete(`users/classes/instructor/${id}`, { headers });
   return true;
 };
 
 export const fetchInstructorClassAnalytics = async (id) => {
-  const { data } = await api.get(`/users/classes/instructor/${id}/analytics`);
+  const { data } = await api.get(`users/classes/instructor/${id}/analytics`);
   return data?.data ?? {};
 };
 
 export const toggleClassStatus = async (id) => {
-  await ensureCsrfToken();
-  const { data } = await api.patch(`/users/classes/instructor/${id}/status`);
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.patch(
+    `users/classes/instructor/${id}/status`,
+    undefined,
+    { headers },
+  );
   return data?.data;
 };
 
 export const fetchClassManagementData = async (id) => {
-  const { data } = await api.get(`/users/classes/instructor/${id}/manage`);
+  const { data } = await api.get(`users/classes/instructor/${id}/manage`);
   if (!data?.data) return null;
   return {
     class: data.data.class ? formatClass(data.data.class) : null,
@@ -119,31 +131,43 @@ export const fetchClassManagementData = async (id) => {
 };
 
 export const createClassLesson = async (classId, payload) => {
-  await ensureCsrfToken();
-  const { data } = await api.post(`/users/classes/lessons/class/${classId}`, payload);
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.post(
+    `users/classes/lessons/class/${classId}`,
+    payload,
+    { headers },
+  );
   return data?.data;
 };
 
 export const updateClassLesson = async (lessonId, payload) => {
-  await ensureCsrfToken();
-  const { data } = await api.put(`/users/classes/lessons/${lessonId}`, payload);
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.put(
+    `users/classes/lessons/${lessonId}`,
+    payload,
+    { headers },
+  );
   return data?.data;
 };
 
 export const deleteClassLesson = async (lessonId) => {
-  await ensureCsrfToken();
-  await api.delete(`/users/classes/lessons/${lessonId}`);
+  const headers = await buildCsrfHeaders();
+  await api.delete(`users/classes/lessons/${lessonId}`, { headers });
 };
 
 export const createClassAssignment = async (classId, payload) => {
-  await ensureCsrfToken();
-  const { data } = await api.post(`/users/classes/assignments/class/${classId}`, payload);
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.post(
+    `users/classes/assignments/class/${classId}`,
+    payload,
+    { headers },
+  );
   return data?.data;
 };
 
 export const deleteClassAssignment = async (assignmentId) => {
-  await ensureCsrfToken();
-  await api.delete(`/users/classes/assignments/${assignmentId}`);
+  const headers = await buildCsrfHeaders();
+  await api.delete(`users/classes/assignments/${assignmentId}`, { headers });
 };
 
 // Fetch upcoming schedule events for the current instructor


### PR DESCRIPTION
## Summary
- add a helper that normalizes the Axios base URL so it always ends with a trailing slash
- ensure instructor class service requests concatenate onto `/api/…` instead of `…/apiusers` when using relative paths, preserving CSRF cookies

## Testing
- npm run lint -- --max-warnings=0 *(fails: existing lint errors/warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e166cc33a88328b597aa91cab479e9