### PR TITLE
Return CSRF token payload to unblock instructor class submissions

### DIFF
--- a/backend/src/middleware/__tests__/csrf.integration.test.js
+++ b/backend/src/middleware/__tests__/csrf.integration.test.js
@@ -83,9 +83,10 @@ describe('CSRF middleware integration', () => {
     const agent = request.agent(app);
 
     const csrfResponse = await agent.get('/api/csrf-token');
-    expect(csrfResponse.status).toBe(204);
+    expect(csrfResponse.status).toBe(200);
     const initialToken = extractCookie(csrfResponse, 'csrfToken');
     expect(initialToken).toBeDefined();
+    expect(csrfResponse.body?.token).toBe(initialToken);
 
     const loginResponse = await agent
       .post('/api/auth/login')

--- a/backend/src/routes/csrf.routes.js
+++ b/backend/src/routes/csrf.routes.js
@@ -4,10 +4,12 @@ const { csrfCookieOptions } = require('../utils/cookie');
 const logger = require('../utils/logger');
 
 router.get('/', (req, res) => {
+  let issuedToken = null;
+
   if (typeof req.csrfToken === 'function') {
     try {
-      const token = req.csrfToken();
-      res.cookie('csrfToken', token, csrfCookieOptions);
+      issuedToken = req.csrfToken();
+      res.cookie('csrfToken', issuedToken, csrfCookieOptions);
     } catch (err) {
       logger.warn(
         `⚠️ Failed to issue CSRF cookie on CSRF route: ${err.message}`
@@ -18,7 +20,9 @@ router.get('/', (req, res) => {
       '⚠️ CSRF token helper missing on CSRF route; skipping csrfToken cookie. Verify session/Redis configuration.'
     );
   }
-  return res.status(204).json();
+
+  const status = issuedToken ? 200 : 204;
+  return res.status(status).json({ token: issuedToken });
 });
 
 module.exports = router;

--- a/backend/tests/csrfTokenRoute.test.js
+++ b/backend/tests/csrfTokenRoute.test.js
@@ -22,12 +22,16 @@ function createApp() {
 }
 
 describe('GET /api/csrf-token', () => {
-  it('sets csrfToken cookie and returns 204', async () => {
+  it('sets csrfToken cookie and returns the token payload', async () => {
     const app = createApp();
     const res = await request(app).get('/api/csrf-token');
-    expect(res.status).toBe(204);
+    expect(res.status).toBe(200);
     expect(res.headers['set-cookie']).toEqual(
       expect.arrayContaining([expect.stringContaining('csrfToken=')])
+    );
+    expect(res.body).toHaveProperty('token');
+    expect(typeof res.body.token === 'string' && res.body.token.length > 0).toBe(
+      true
     );
   });
 });

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -110,7 +110,29 @@ const ensureApiSuffix = (candidate) => {
   return `${trimmedCandidate.replace(/\/+$/, "")}/api`;
 };
 
-const baseURL = ensureAbsoluteUrl(ensureApiSuffix(pickBaseCandidate()));
+const ensureTrailingSlash = (candidate) => {
+  if (!candidate) {
+    return candidate;
+  }
+
+  if (/^https?:\/\//i.test(candidate)) {
+    try {
+      const url = new URL(candidate);
+      url.pathname = `${url.pathname.replace(/\/+$/, "")}/`;
+      return url.toString();
+    } catch (error) {
+      logger.warn(
+        `Failed to normalise API base URL trailing slash for "${candidate}": ${error.message}`,
+      );
+    }
+  }
+
+  return `${candidate.replace(/\/+$/, "")}/`;
+};
+
+const baseURL = ensureTrailingSlash(
+  ensureAbsoluteUrl(ensureApiSuffix(pickBaseCandidate())),
+);
 
 // Warn developers if the default domain URL is used in production
 if (

--- a/frontend/src/services/api/csrf.js
+++ b/frontend/src/services/api/csrf.js
@@ -19,11 +19,15 @@ export const ensureCsrfToken = async () => {
       // next POST request fails with a 403. Using a relative path ensures we
       // always call `/api/csrf-token`, allowing the server to issue the
       // expected cookie before we retry the protected request.
-      await api.get("csrf-token");
+      const response = await api.get("csrf-token", {
+        params: { _: Date.now() },
+        headers: { "Cache-Control": "no-cache" },
+      });
+
+      token = response?.data?.token || getCsrfToken();
     } catch (e) {
       // The route may not exist; we only care about the cookie.
     }
-    token = getCsrfToken();
   }
   return token;
 };

--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -9,6 +9,7 @@ import { toast } from "react-toastify";
 import Router from "next/router";
 import useAuthStore from "@/store/auth/authStore";
 import { getCookie } from "@/utils/cookies";
+import { ensureCsrfToken } from "@/services/api/csrf";
 import logger from "@/utils/logger";
 
 let isRefreshing = false;
@@ -28,7 +29,9 @@ const processQueue = (error, token = null) => {
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 api.interceptors.request.use(
-  (config) => {
+  async (config) => {
+    config.headers = config.headers ?? {};
+
     const { accessToken } = useAuthStore.getState();
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
@@ -36,7 +39,18 @@ api.interceptors.request.use(
 
     const method = config.method?.toLowerCase();
     if (["post", "put", "patch", "delete"].includes(method)) {
-      const csrfToken = getCookie("csrfToken");
+      let csrfToken = getCookie("csrfToken");
+
+      if (!csrfToken) {
+        try {
+          csrfToken = await ensureCsrfToken();
+        } catch (error) {
+          logger.warn(
+            `Failed to refresh CSRF token before ${method?.toUpperCase()} ${config?.url}: ${error?.message || error}`
+          );
+        }
+      }
+
       if (csrfToken) {
         config.headers["x-csrf-token"] = csrfToken;
       }

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -54,11 +54,20 @@ const formatClass = (cls) => {
   };
 };
 
+const buildCsrfHeaders = async (headers = {}) => {
+  const csrfToken = await ensureCsrfToken();
+  if (!csrfToken) return headers;
+  return {
+    ...headers,
+    "x-csrf-token": csrfToken,
+  };
+};
+
 export const fetchInstructorClasses = async (instructorId) => {
   // Fetch only classes belonging to the specified instructor
   const requestConfig = instructorId ? { params: { instructorId } } : {};
   const { data } = await api.get(
-    "/users/classes/instructor/my",
+    "users/classes/instructor/my",
     requestConfig,
   );
   const list = data?.data ?? [];
@@ -66,50 +75,53 @@ export const fetchInstructorClasses = async (instructorId) => {
 };
 
 export const fetchInstructorClassById = async (id) => {
-  const { data } = await api.get(`/users/classes/instructor/${id}`);
+  const { data } = await api.get(`users/classes/instructor/${id}`);
   return data?.data ? formatClass(data.data) : null;
 };
 
 export const createInstructorClass = async (payload, onUploadProgress) => {
-  await ensureCsrfToken();
-  const { data } = await api.post("/users/classes/instructor", payload, {
-    headers: {
-      "Content-Type": "multipart/form-data",
-    },
+  const headers = await buildCsrfHeaders();
+  const config = {
+    headers,
     ...(onUploadProgress ? { onUploadProgress } : {}),
-  });
+  };
+  const { data } = await api.post("users/classes/instructor", payload, config);
   return data?.data ? formatClass(data.data) : null;
 };
 
 export const updateInstructorClass = async (id, payload) => {
-  await ensureCsrfToken();
-  const { data } = await api.put(`/users/classes/instructor/${id}`, payload, {
-    headers: {
-      "Content-Type": "multipart/form-data",
-    },
-  });
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.put(
+    `users/classes/instructor/${id}`,
+    payload,
+    { headers },
+  );
   return data?.data ? formatClass(data.data) : null;
 };
 
 export const deleteInstructorClass = async (id) => {
-  await ensureCsrfToken();
-  await api.delete(`/users/classes/instructor/${id}`);
+  const headers = await buildCsrfHeaders();
+  await api.delete(`users/classes/instructor/${id}`, { headers });
   return true;
 };
 
 export const fetchInstructorClassAnalytics = async (id) => {
-  const { data } = await api.get(`/users/classes/instructor/${id}/analytics`);
+  const { data } = await api.get(`users/classes/instructor/${id}/analytics`);
   return data?.data ?? {};
 };
 
 export const toggleClassStatus = async (id) => {
-  await ensureCsrfToken();
-  const { data } = await api.patch(`/users/classes/instructor/${id}/status`);
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.patch(
+    `users/classes/instructor/${id}/status`,
+    undefined,
+    { headers },
+  );
   return data?.data;
 };
 
 export const fetchClassManagementData = async (id) => {
-  const { data } = await api.get(`/users/classes/instructor/${id}/manage`);
+  const { data } = await api.get(`users/classes/instructor/${id}/manage`);
   if (!data?.data) return null;
   return {
     class: data.data.class ? formatClass(data.data.class) : null,
@@ -119,31 +131,43 @@ export const fetchClassManagementData = async (id) => {
 };
 
 export const createClassLesson = async (classId, payload) => {
-  await ensureCsrfToken();
-  const { data } = await api.post(`/users/classes/lessons/class/${classId}`, payload);
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.post(
+    `users/classes/lessons/class/${classId}`,
+    payload,
+    { headers },
+  );
   return data?.data;
 };
 
 export const updateClassLesson = async (lessonId, payload) => {
-  await ensureCsrfToken();
-  const { data } = await api.put(`/users/classes/lessons/${lessonId}`, payload);
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.put(
+    `users/classes/lessons/${lessonId}`,
+    payload,
+    { headers },
+  );
   return data?.data;
 };
 
 export const deleteClassLesson = async (lessonId) => {
-  await ensureCsrfToken();
-  await api.delete(`/users/classes/lessons/${lessonId}`);
+  const headers = await buildCsrfHeaders();
+  await api.delete(`users/classes/lessons/${lessonId}`, { headers });
 };
 
 export const createClassAssignment = async (classId, payload) => {
-  await ensureCsrfToken();
-  const { data } = await api.post(`/users/classes/assignments/class/${classId}`, payload);
+  const headers = await buildCsrfHeaders();
+  const { data } = await api.post(
+    `users/classes/assignments/class/${classId}`,
+    payload,
+    { headers },
+  );
   return data?.data;
 };
 
 export const deleteClassAssignment = async (assignmentId) => {
-  await ensureCsrfToken();
-  await api.delete(`/users/classes/assignments/${assignmentId}`);
+  const headers = await buildCsrfHeaders();
+  await api.delete(`users/classes/assignments/${assignmentId}`, { headers });
 };
 
 // Fetch upcoming schedule events for the current instructor


### PR DESCRIPTION
## Summary
- expose the CSRF token value from the `/api/csrf-token` route so clients can read it even when the cookie is not yet visible
- update the frontend CSRF helper to consume the token payload and avoid re-submission failures caused by missing headers
- refresh targeted backend tests to cover the new token response contract

## Testing
- npm test -- --runTestsByPath tests/csrfTokenRoute.test.js src/middleware/__tests__/csrf.integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e166cc33a88328b597aa91cab479e9