### PR TITLE
Handle browsers without ResizeObserver for analytics charts

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -32,6 +32,15 @@ function AnalyticsDashboard() {
   const { id } = router.query;
   const { t, i18n } = useTranslation('dashboard');
   const [stats, setStats] = useState(null);
+  const [supportsResizeObserver, setSupportsResizeObserver] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    setSupportsResizeObserver(Boolean(window.ResizeObserver));
+  }, []);
 
   useEffect(() => {
     if (!id) return;
@@ -85,6 +94,11 @@ function AnalyticsDashboard() {
       ? ((totalCompleted / totalStudents) * 100).toFixed(1)
       : "0";
 
+  const chartsUnavailableMessage = t(
+    "classAnalyticsPage.chartsUnavailableResizeObserver",
+    "Charts are unavailable because ResizeObserver is not supported in this browser."
+  );
+
   return (
     <div className="p-6 space-y-6" dir={i18n.dir()}>
       <h1 className="text-2xl font-bold text-gray-800">
@@ -129,11 +143,18 @@ function AnalyticsDashboard() {
         </div>
       </div>
 
+      {!supportsResizeObserver && (
+        <p className="text-sm text-muted-foreground">
+          {chartsUnavailableMessage}
+        </p>
+      )}
+
       <AnalyticsCharts
         t={t}
         locations={locations}
         devices={devices}
         registrationTrend={registrationTrend}
+        disableResizeObserver={!supportsResizeObserver}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- detect ResizeObserver support when the analytics dashboard mounts
- disable chart rendering and surface fallback messaging when ResizeObserver is unavailable

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e17eb849ac8328b05acc6574149eb9