### PR TITLE
Refactor admin charts to lazily load Recharts

### DIFF
--- a/frontend/src/components/admin/charts/CategoryPieChart.js
+++ b/frontend/src/components/admin/charts/CategoryPieChart.js
@@ -1,26 +1,75 @@
 // components/admin/charts/CategoryPieChart.js
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
 import { useTranslation } from "next-i18next";
+import useLazyRecharts from "./useLazyRecharts";
 
 const COLORS = ['#facc15', '#60a5fa', '#f87171', '#34d399'];
 
 export default function CategoryPieChart({ data = [], title }) {
   const { t } = useTranslation("dashboard");
   const heading = title ?? t("adminDashboardHome.tutorialsByCategory");
+  const { chartsLib, chartsLoadError, resizeObserverSupported, loading } =
+    useLazyRecharts();
+
+  const PieChart = chartsLib?.PieChart;
+  const Pie = chartsLib?.Pie;
+  const Cell = chartsLib?.Cell;
+  const Tooltip = chartsLib?.Tooltip;
+  const ResponsiveContainer = chartsLib?.ResponsiveContainer;
+
+  const renderFallbackMessage = () => {
+    if (!resizeObserverSupported) {
+      return t(
+        "adminDashboardHome.chartsUnavailableResizeObserver",
+        "Charts are unavailable because ResizeObserver is not supported in this browser."
+      );
+    }
+
+    if (chartsLoadError) {
+      return t(
+        "adminDashboardHome.chartsFailedToLoad",
+        "Charts failed to load. Please refresh to try again."
+      );
+    }
+
+    return t("adminDashboardHome.loadingCharts", "Loading charts…");
+  };
+
+  const shouldRenderChart =
+    !loading &&
+    resizeObserverSupported &&
+    !chartsLoadError &&
+    PieChart &&
+    Pie &&
+    Cell &&
+    Tooltip &&
+    ResponsiveContainer;
 
   return (
     <div className="bg-white p-6 rounded-xl shadow">
       <h2 className="text-xl font-semibold mb-4">📚 {heading}</h2>
-      <ResponsiveContainer width="100%" height={300}>
-        <PieChart>
-          <Pie data={data} dataKey="value" nameKey="name" outerRadius={100} fill="#8884d8" label>
-            {data.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-            ))}
-          </Pie>
-          <Tooltip />
-        </PieChart>
-      </ResponsiveContainer>
+      {shouldRenderChart ? (
+        <ResponsiveContainer width="100%" height={300}>
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="name"
+              outerRadius={100}
+              fill="#8884d8"
+              label
+            >
+              {data.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+          {renderFallbackMessage()}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/admin/charts/InstructorActivityChart.js
+++ b/frontend/src/components/admin/charts/InstructorActivityChart.js
@@ -1,23 +1,69 @@
 // components/admin/charts/InstructorActivityChart.js
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
 import { useTranslation } from "next-i18next";
+import useLazyRecharts from "./useLazyRecharts";
 
 export default function InstructorActivityChart({ data = [], title }) {
   const { t } = useTranslation("dashboard");
   const heading = title ?? t("adminDashboardHome.instructorTutorialCount");
+  const { chartsLib, chartsLoadError, resizeObserverSupported, loading } =
+    useLazyRecharts();
+
+  const BarChart = chartsLib?.BarChart;
+  const Bar = chartsLib?.Bar;
+  const XAxis = chartsLib?.XAxis;
+  const YAxis = chartsLib?.YAxis;
+  const Tooltip = chartsLib?.Tooltip;
+  const ResponsiveContainer = chartsLib?.ResponsiveContainer;
+  const CartesianGrid = chartsLib?.CartesianGrid;
+
+  const renderFallbackMessage = () => {
+    if (!resizeObserverSupported) {
+      return t(
+        "adminDashboardHome.chartsUnavailableResizeObserver",
+        "Charts are unavailable because ResizeObserver is not supported in this browser."
+      );
+    }
+
+    if (chartsLoadError) {
+      return t(
+        "adminDashboardHome.chartsFailedToLoad",
+        "Charts failed to load. Please refresh to try again."
+      );
+    }
+
+    return t("adminDashboardHome.loadingCharts", "Loading charts…");
+  };
+
+  const shouldRenderChart =
+    !loading &&
+    resizeObserverSupported &&
+    !chartsLoadError &&
+    BarChart &&
+    Bar &&
+    XAxis &&
+    YAxis &&
+    Tooltip &&
+    ResponsiveContainer &&
+    CartesianGrid;
 
   return (
     <div className="bg-white p-6 rounded-xl shadow">
       <h2 className="text-xl font-semibold mb-4">👨‍🏫 {heading}</h2>
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="instructor" />
-          <YAxis />
-          <Tooltip />
-          <Bar dataKey="tutorials" fill="#a78bfa" />
-        </BarChart>
-      </ResponsiveContainer>
+      {shouldRenderChart ? (
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="instructor" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="tutorials" fill="#a78bfa" />
+          </BarChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+          {renderFallbackMessage()}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/admin/charts/RevenueChart.js
+++ b/frontend/src/components/admin/charts/RevenueChart.js
@@ -1,23 +1,74 @@
 // components/admin/charts/RevenueChart.js
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
 import { useTranslation } from "next-i18next";
+import useLazyRecharts from "./useLazyRecharts";
 
 export default function RevenueChart({ data = [], title }) {
   const { t } = useTranslation("dashboard");
   const heading = title ?? t("adminDashboardHome.monthlyRevenue");
+  const { chartsLib, chartsLoadError, resizeObserverSupported, loading } =
+    useLazyRecharts();
+
+  const LineChart = chartsLib?.LineChart;
+  const Line = chartsLib?.Line;
+  const XAxis = chartsLib?.XAxis;
+  const YAxis = chartsLib?.YAxis;
+  const Tooltip = chartsLib?.Tooltip;
+  const ResponsiveContainer = chartsLib?.ResponsiveContainer;
+  const CartesianGrid = chartsLib?.CartesianGrid;
+
+  const renderFallbackMessage = () => {
+    if (!resizeObserverSupported) {
+      return t(
+        "adminDashboardHome.chartsUnavailableResizeObserver",
+        "Charts are unavailable because ResizeObserver is not supported in this browser."
+      );
+    }
+
+    if (chartsLoadError) {
+      return t(
+        "adminDashboardHome.chartsFailedToLoad",
+        "Charts failed to load. Please refresh to try again."
+      );
+    }
+
+    return t("adminDashboardHome.loadingCharts", "Loading charts…");
+  };
+
+  const shouldRenderChart =
+    !loading &&
+    resizeObserverSupported &&
+    !chartsLoadError &&
+    LineChart &&
+    Line &&
+    XAxis &&
+    YAxis &&
+    Tooltip &&
+    ResponsiveContainer &&
+    CartesianGrid;
 
   return (
     <div className="bg-white p-6 rounded-xl shadow">
       <h2 className="text-xl font-semibold mb-4">📈 {heading}</h2>
-      <ResponsiveContainer width="100%" height={300}>
-        <LineChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="month" />
-          <YAxis tickFormatter={(value) => `$${value}`} />
-          <Tooltip formatter={(value) => `$${value}`} />
-          <Line type="monotone" dataKey="revenue" stroke="#facc15" strokeWidth={3} />
-        </LineChart>
-      </ResponsiveContainer>
+      {shouldRenderChart ? (
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" />
+            <YAxis tickFormatter={(value) => `$${value}`} />
+            <Tooltip formatter={(value) => `$${value}`} />
+            <Line
+              type="monotone"
+              dataKey="revenue"
+              stroke="#facc15"
+              strokeWidth={3}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+          {renderFallbackMessage()}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/admin/charts/SignupsChart.js
+++ b/frontend/src/components/admin/charts/SignupsChart.js
@@ -1,23 +1,69 @@
 // components/admin/charts/SignupsChart.js
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
 import { useTranslation } from "next-i18next";
+import useLazyRecharts from "./useLazyRecharts";
 
 export default function SignupsChart({ data = [], title }) {
   const { t } = useTranslation("dashboard");
   const heading = title ?? t("adminDashboardHome.monthlySignups");
+  const { chartsLib, chartsLoadError, resizeObserverSupported, loading } =
+    useLazyRecharts();
+
+  const BarChart = chartsLib?.BarChart;
+  const Bar = chartsLib?.Bar;
+  const XAxis = chartsLib?.XAxis;
+  const YAxis = chartsLib?.YAxis;
+  const Tooltip = chartsLib?.Tooltip;
+  const ResponsiveContainer = chartsLib?.ResponsiveContainer;
+  const CartesianGrid = chartsLib?.CartesianGrid;
+
+  const renderFallbackMessage = () => {
+    if (!resizeObserverSupported) {
+      return t(
+        "adminDashboardHome.chartsUnavailableResizeObserver",
+        "Charts are unavailable because ResizeObserver is not supported in this browser."
+      );
+    }
+
+    if (chartsLoadError) {
+      return t(
+        "adminDashboardHome.chartsFailedToLoad",
+        "Charts failed to load. Please refresh to try again."
+      );
+    }
+
+    return t("adminDashboardHome.loadingCharts", "Loading charts…");
+  };
+
+  const shouldRenderChart =
+    !loading &&
+    resizeObserverSupported &&
+    !chartsLoadError &&
+    BarChart &&
+    Bar &&
+    XAxis &&
+    YAxis &&
+    Tooltip &&
+    ResponsiveContainer &&
+    CartesianGrid;
 
   return (
     <div className="bg-white p-6 rounded-xl shadow">
       <h2 className="text-xl font-semibold mb-4">👥 {heading}</h2>
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="month" />
-          <YAxis />
-          <Tooltip />
-          <Bar dataKey="users" fill="#60a5fa" />
-        </BarChart>
-      </ResponsiveContainer>
+      {shouldRenderChart ? (
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="users" fill="#60a5fa" />
+          </BarChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex h-[300px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+          {renderFallbackMessage()}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/admin/charts/useLazyRecharts.js
+++ b/frontend/src/components/admin/charts/useLazyRecharts.js
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+
+export function useLazyRecharts({ disableResizeObserver = false } = {}) {
+  const [chartsLib, setChartsLib] = useState(null);
+  const [chartsLoadError, setChartsLoadError] = useState(false);
+  const [resizeObserverSupported, setResizeObserverSupported] = useState(true);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const ensureResizeObserver = async () => {
+      if (typeof window === "undefined") {
+        return false;
+      }
+
+      if (window.ResizeObserver) {
+        return true;
+      }
+
+      try {
+        const polyfillModule = await import("resize-observer-polyfill");
+        if (!isMounted) {
+          return false;
+        }
+
+        const ResizeObserverPolyfill = polyfillModule?.default ?? polyfillModule;
+        if (ResizeObserverPolyfill && !window.ResizeObserver) {
+          window.ResizeObserver = ResizeObserverPolyfill;
+          return true;
+        }
+      } catch (error) {
+        console.warn("Failed to load ResizeObserver polyfill", error);
+      }
+
+      return Boolean(window.ResizeObserver);
+    };
+
+    const loadChartsLibrary = async () => {
+      if (disableResizeObserver) {
+        if (!isMounted) {
+          return;
+        }
+        setChartsLib(null);
+        setChartsLoadError(false);
+        setResizeObserverSupported(false);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setChartsLoadError(false);
+
+      const supported = await ensureResizeObserver();
+      if (!isMounted) {
+        return;
+      }
+
+      if (!supported) {
+        setResizeObserverSupported(false);
+        setChartsLib(null);
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const module = await import("recharts");
+        if (!isMounted) {
+          return;
+        }
+        setChartsLib(module);
+        setChartsLoadError(false);
+        setResizeObserverSupported(true);
+      } catch (error) {
+        console.error("Failed to load Recharts", error);
+        if (!isMounted) {
+          return;
+        }
+        setChartsLoadError(true);
+        setChartsLib(null);
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadChartsLibrary();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [disableResizeObserver]);
+
+  return { chartsLib, chartsLoadError, resizeObserverSupported, loading };
+}
+
+export default useLazyRecharts;


### PR DESCRIPTION
## Summary
- add a shared `useLazyRecharts` hook that verifies `ResizeObserver` support before loading Recharts
- refactor admin dashboard chart components to use the lazy loader and render consistent fallbacks when charts are unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e17eb1090883289d3aef43ca5a95d5