### PR TITLE
Reset analytics stats before refetch

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -44,6 +44,7 @@ function AnalyticsDashboard() {
 
   useEffect(() => {
     if (!id) return;
+    setStats(null);
     fetchAdminClassAnalytics(id)
       .then((data) =>
         setStats({


### PR DESCRIPTION
## Summary
- reset analytics stats to null when triggering a new fetch so the loading state displays during refreshes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e182da7674832886bdb73e8dbb48a4