### PR TITLE
Prevent analytics state updates after unmount

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -44,8 +44,10 @@ function AnalyticsDashboard() {
 
   useEffect(() => {
     if (!id) return;
+    let isMounted = true;
     fetchAdminClassAnalytics(id)
-      .then((data) =>
+      .then((data) => {
+        if (!isMounted) return;
         setStats({
           ...EMPTY_STATS,
           ...(data ?? {}),
@@ -56,12 +58,17 @@ function AnalyticsDashboard() {
           locations: data?.locations ?? EMPTY_STATS.locations,
           devices: data?.devices ?? EMPTY_STATS.devices,
           registrationTrend: data?.registrationTrend ?? EMPTY_STATS.registrationTrend,
-        })
-      )
+        });
+      })
       .catch((err) => {
+        if (!isMounted) return;
         console.error("Failed to load analytics", err);
         setStats(EMPTY_STATS);
       });
+
+    return () => {
+      isMounted = false;
+    };
   }, [id]);
 
   if (!stats) {


### PR DESCRIPTION
## Summary
- add an isMounted guard around the admin class analytics request to avoid state updates on unmounted components
- bail out from success and error handlers when the effect is cleaned up
- provide a cleanup function that flips the mounted flag during unmount

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e182da8a288328acd2053c3c240dd8