### PR TITLE
Fix admin analytics charts hydration handling

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -32,14 +32,14 @@ function AnalyticsDashboard() {
   const { id } = router.query;
   const { t, i18n } = useTranslation('dashboard');
   const [stats, setStats] = useState(null);
-  const [supportsResizeObserver, setSupportsResizeObserver] = useState(true);
+  const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
 
-    setSupportsResizeObserver(Boolean(window.ResizeObserver));
+    setIsClient(true);
   }, []);
 
   useEffect(() => {
@@ -94,11 +94,6 @@ function AnalyticsDashboard() {
       ? ((totalCompleted / totalStudents) * 100).toFixed(1)
       : "0";
 
-  const chartsUnavailableMessage = t(
-    "classAnalyticsPage.chartsUnavailableResizeObserver",
-    "Charts are unavailable because ResizeObserver is not supported in this browser."
-  );
-
   return (
     <div className="p-6 space-y-6" dir={i18n.dir()}>
       <h1 className="text-2xl font-bold text-gray-800">
@@ -143,18 +138,12 @@ function AnalyticsDashboard() {
         </div>
       </div>
 
-      {!supportsResizeObserver && (
-        <p className="text-sm text-muted-foreground">
-          {chartsUnavailableMessage}
-        </p>
-      )}
-
       <AnalyticsCharts
         t={t}
         locations={locations}
         devices={devices}
         registrationTrend={registrationTrend}
-        disableResizeObserver={!supportsResizeObserver}
+        disableResizeObserver={!isClient}
       />
     </div>
   );

--- a/frontend/src/tests/pages/dashboard/admin/online-classes/analytics.test.jsx
+++ b/frontend/src/tests/pages/dashboard/admin/online-classes/analytics.test.jsx
@@ -28,6 +28,15 @@ jest.mock("@/components/layouts/AdminLayout", () => ({
   default: ({ children }) => <div data-testid="admin-layout">{children}</div>,
 }));
 
+jest.mock("resize-observer-polyfill", () => ({
+  __esModule: true,
+  default: class ResizeObserverPolyfill {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+}));
+
 jest.mock("recharts", () => ({
   ResponsiveContainer: ({ children }) => <div data-testid="responsive">{children}</div>,
   PieChart: ({ children }) => <div data-testid="pie-chart">{children}</div>,
@@ -77,5 +86,22 @@ describe("Admin class analytics page", () => {
       .closest("li");
     expect(fullPaymentsRow).not.toBeNull();
     expect(within(fullPaymentsRow).getByText("0")).toBeInTheDocument();
+  });
+
+  it("loads charts using the ResizeObserver polyfill when not supported natively", async () => {
+    const originalResizeObserver = global.ResizeObserver;
+    // Simulate browsers without native ResizeObserver support.
+    delete global.ResizeObserver;
+
+    render(<AnalyticsPage />);
+
+    await waitFor(() => expect(mockFetchAdminClassAnalytics).toHaveBeenCalledWith("123"));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("responsive").length).toBeGreaterThan(0);
+      expect(global.ResizeObserver).toBeTruthy();
+    });
+
+    global.ResizeObserver = originalResizeObserver;
   });
 });


### PR DESCRIPTION
## Summary
- ensure the admin analytics page only disables charts during SSR by switching to a client-ready flag
- rely on AnalyticsCharts to manage ResizeObserver polyfills instead of showing a redundant fallback message
- extend analytics page tests to cover the ResizeObserver polyfill path

## Testing
- npm test -- --runTestsByPath src/tests/pages/dashboard/admin/online-classes/analytics.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e182e40b2083289cd2a209b853fcd4