### PR TITLE
Normalize class ID handling in admin analytics

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -30,6 +30,7 @@ const EMPTY_STATS = {
 function AnalyticsDashboard() {
   const router = useRouter();
   const { id } = router.query;
+  const classId = Array.isArray(id) ? id[0] : id || "";
   const { t, i18n } = useTranslation('dashboard');
   const [stats, setStats] = useState(null);
   const [supportsResizeObserver, setSupportsResizeObserver] = useState(true);
@@ -43,8 +44,8 @@ function AnalyticsDashboard() {
   }, []);
 
   useEffect(() => {
-    if (!id) return;
-    fetchAdminClassAnalytics(id)
+    if (!classId) return;
+    fetchAdminClassAnalytics(classId)
       .then((data) =>
         setStats({
           ...EMPTY_STATS,
@@ -62,7 +63,7 @@ function AnalyticsDashboard() {
         console.error("Failed to load analytics", err);
         setStats(EMPTY_STATS);
       });
-  }, [id]);
+  }, [classId]);
 
   if (!stats) {
     return (
@@ -102,7 +103,7 @@ function AnalyticsDashboard() {
   return (
     <div className="p-6 space-y-6" dir={i18n.dir()}>
       <h1 className="text-2xl font-bold text-gray-800">
-        📊 {t('classAnalyticsPage.title')} - {t('classAnalyticsPage.class_id')} {id}
+        📊 {t('classAnalyticsPage.title')} - {t('classAnalyticsPage.class_id')} {classId}
       </h1>
 
       <div className="grid md:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- derive a normalized `classId` from the route query before using it in the admin analytics page
- update the analytics data fetching effect to depend on and call the API with the normalized identifier
- display the normalized `classId` in the page header for consistency

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e182e6cfd88328875bfe0d3280bab1