### PR TITLE
Handle empty admin category chart data gracefully

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1810,7 +1810,8 @@
     "monthlyRevenue": "الإيرادات الشهرية",
     "monthlySignups": "التسجيلات الشهرية",
     "tutorialsByCategory": "الدروس حسب الفئة",
-    "instructorTutorialCount": "عدد الدروس لكل مدرب"
+    "instructorTutorialCount": "عدد الدروس لكل مدرب",
+    "noChartData": "لا توجد بيانات متاحة"
   },
   "tutorialViewPage": {
     "loading": "تحميل البرنامج التعليمي ...",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1835,7 +1835,8 @@
     "monthlyRevenue": "Monthly Revenue",
     "monthlySignups": "Monthly Signups",
     "tutorialsByCategory": "Tutorials by Category",
-    "instructorTutorialCount": "Instructor Tutorial Count"
+    "instructorTutorialCount": "Instructor Tutorial Count",
+    "noChartData": "Keine Daten verfügbar"
   },
   "tutorialViewPage": {
     "loading": "Loading tutorial...",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1827,7 +1827,8 @@
     "monthlyRevenue": "Monthly Revenue",
     "monthlySignups": "Monthly Signups",
     "tutorialsByCategory": "Tutorials by Category",
-    "instructorTutorialCount": "Instructor Tutorial Count"
+    "instructorTutorialCount": "Instructor Tutorial Count",
+    "noChartData": "No data available"
   },
   "tutorialViewPage": {
     "loading": "Loading tutorial...",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1821,7 +1821,8 @@
     "monthlyRevenue": "Ingresos mensuales",
     "monthlySignups": "Registros mensuales",
     "tutorialsByCategory": "Tutoriales por categoría",
-    "instructorTutorialCount": "Cantidad de tutoriales por instructor"
+    "instructorTutorialCount": "Cantidad de tutoriales por instructor",
+    "noChartData": "No hay datos disponibles"
   },
   "tutorialViewPage": {
     "loading": "Tutorial de carga ...",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1810,7 +1810,8 @@
     "monthlyRevenue": "Revenus mensuels",
     "monthlySignups": "Inscriptions mensuelles",
     "tutorialsByCategory": "Tutoriels par catégorie",
-    "instructorTutorialCount": "Nombre de tutoriels par instructeur"
+    "instructorTutorialCount": "Nombre de tutoriels par instructeur",
+    "noChartData": "Aucune donnée disponible"
   },
   "tutorialViewPage": {
     "loading": "Chargement du tutoriel...",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1821,7 +1821,8 @@
     "monthlyRevenue": "मासिक राजस्व",
     "monthlySignups": "मासिक साइनअप",
     "tutorialsByCategory": "श्रेणी के अनुसार ट्यूटोरियल",
-    "instructorTutorialCount": "प्रत्येक प्रशिक्षक के ट्यूटोरियल संख्या"
+    "instructorTutorialCount": "प्रत्येक प्रशिक्षक के ट्यूटोरियल संख्या",
+    "noChartData": "कोई डेटा उपलब्ध नहीं है"
   },
   "tutorialViewPage": {
     "loading": "लोडिंग ट्यूटोरियल ...",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1835,7 +1835,8 @@
     "monthlyRevenue": "Entrate mensili",
     "monthlySignups": "Iscrizioni mensili",
     "tutorialsByCategory": "Tutorial per categoria",
-    "instructorTutorialCount": "Numero di tutorial per istruttore"
+    "instructorTutorialCount": "Numero di tutorial per istruttore",
+    "noChartData": "Nessun dato disponibile"
   },
   "tutorialViewPage": {
     "loading": "Tutorial di caricamento ...",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1820,7 +1820,8 @@
     "monthlyRevenue": "每月收入",
     "monthlySignups": "每月注册",
     "tutorialsByCategory": "按类别划分的教程",
-    "instructorTutorialCount": "讲师教程数量"
+    "instructorTutorialCount": "讲师教程数量",
+    "noChartData": "没有可用数据"
   },
   "tutorialViewPage": {
     "loading": "加载教程...",

--- a/frontend/src/components/admin/charts/CategoryPieChart.js
+++ b/frontend/src/components/admin/charts/CategoryPieChart.js
@@ -16,7 +16,13 @@ export default function CategoryPieChart({ data = [], title }) {
   const Tooltip = chartsLib?.Tooltip;
   const ResponsiveContainer = chartsLib?.ResponsiveContainer;
 
+  const hasData = Array.isArray(data) && data.some(({ value }) => value > 0);
+
   const renderFallbackMessage = () => {
+    if (loading) {
+      return t("adminDashboardHome.loadingCharts", "Loading charts…");
+    }
+
     if (!resizeObserverSupported) {
       return t(
         "adminDashboardHome.chartsUnavailableResizeObserver",
@@ -31,6 +37,13 @@ export default function CategoryPieChart({ data = [], title }) {
       );
     }
 
+    if (!hasData) {
+      return t(
+        "adminDashboardHome.noChartData",
+        "No data available"
+      );
+    }
+
     return t("adminDashboardHome.loadingCharts", "Loading charts…");
   };
 
@@ -38,6 +51,7 @@ export default function CategoryPieChart({ data = [], title }) {
     !loading &&
     resizeObserverSupported &&
     !chartsLoadError &&
+    hasData &&
     PieChart &&
     Pie &&
     Cell &&


### PR DESCRIPTION
## Summary
- prevent the admin category pie chart from rendering without data and show a translated empty-state message
- add the adminDashboardHome.noChartData copy to every locale file used by the dashboard

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18aeefc24832886c3be2589f606db