### PR TITLE
Add chart status translations to admin dashboard locales

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -1808,6 +1808,9 @@
     "tutorials": "الدروس التعليمية",
     "classes": "الفصول",
     "monthlyRevenue": "الإيرادات الشهرية",
+    "chartsUnavailableResizeObserver": "لا تتوفر المخططات لأن ميزة مراقب تغيير الحجم (ResizeObserver) غير مدعومة في هذا المتصفح.",
+    "chartsFailedToLoad": "فشل تحميل المخططات. يرجى تحديث الصفحة والمحاولة مرة أخرى.",
+    "loadingCharts": "جارٍ تحميل المخططات...",
     "monthlySignups": "التسجيلات الشهرية",
     "tutorialsByCategory": "الدروس حسب الفئة",
     "instructorTutorialCount": "عدد الدروس لكل مدرب"

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -1833,6 +1833,9 @@
     "noUnauthorizedInstances": "✅ No unauthorized instances",
     "noLicenseData": "No license data",
     "monthlyRevenue": "Monthly Revenue",
+    "chartsUnavailableResizeObserver": "Diagramme sind nicht verfügbar, da ResizeObserver in diesem Browser nicht unterstützt wird.",
+    "chartsFailedToLoad": "Diagramme konnten nicht geladen werden. Bitte aktualisieren Sie, um es erneut zu versuchen.",
+    "loadingCharts": "Diagramme werden geladen…",
     "monthlySignups": "Monthly Signups",
     "tutorialsByCategory": "Tutorials by Category",
     "instructorTutorialCount": "Instructor Tutorial Count"

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -1825,6 +1825,9 @@
     "tutorials": "Tutorials",
     "classes": "Classes",
     "monthlyRevenue": "Monthly Revenue",
+    "chartsUnavailableResizeObserver": "Charts are unavailable because ResizeObserver is not supported in this browser.",
+    "chartsFailedToLoad": "Charts failed to load. Please refresh to try again.",
+    "loadingCharts": "Loading charts…",
     "monthlySignups": "Monthly Signups",
     "tutorialsByCategory": "Tutorials by Category",
     "instructorTutorialCount": "Instructor Tutorial Count"

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -1819,6 +1819,9 @@
     "noUnauthorizedInstances": "✅ No hay instancias no autorizadas",
     "noLicenseData": "No hay datos de licencia",
     "monthlyRevenue": "Ingresos mensuales",
+    "chartsUnavailableResizeObserver": "Los gráficos no están disponibles porque ResizeObserver no es compatible con este navegador.",
+    "chartsFailedToLoad": "No se pudieron cargar los gráficos. Actualiza para intentarlo de nuevo.",
+    "loadingCharts": "Cargando gráficos…",
     "monthlySignups": "Registros mensuales",
     "tutorialsByCategory": "Tutoriales por categoría",
     "instructorTutorialCount": "Cantidad de tutoriales por instructor"

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -1808,6 +1808,9 @@
     "tutorials": "Tutoriels",
     "classes": "Cours",
     "monthlyRevenue": "Revenus mensuels",
+    "chartsUnavailableResizeObserver": "Les graphiques ne sont pas disponibles, car ResizeObserver n’est pas pris en charge par ce navigateur.",
+    "chartsFailedToLoad": "Échec du chargement des graphiques. Veuillez actualiser pour réessayer.",
+    "loadingCharts": "Chargement des graphiques…",
     "monthlySignups": "Inscriptions mensuelles",
     "tutorialsByCategory": "Tutoriels par catégorie",
     "instructorTutorialCount": "Nombre de tutoriels par instructeur"

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -1819,6 +1819,9 @@
     "noUnauthorizedInstances": "✅ कोई अनधिकृत इंस्टेंस नहीं",
     "noLicenseData": "लाइसेंस डेटा उपलब्ध नहीं",
     "monthlyRevenue": "मासिक राजस्व",
+    "chartsUnavailableResizeObserver": "चार्ट उपलब्ध नहीं हैं क्योंकि इस ब्राउज़र में ResizeObserver समर्थित नहीं है।",
+    "chartsFailedToLoad": "चार्ट लोड नहीं हो पाए। दोबारा प्रयास करने के लिए कृपया रिफ्रेश करें।",
+    "loadingCharts": "चार्ट लोड हो रहे हैं…",
     "monthlySignups": "मासिक साइनअप",
     "tutorialsByCategory": "श्रेणी के अनुसार ट्यूटोरियल",
     "instructorTutorialCount": "प्रत्येक प्रशिक्षक के ट्यूटोरियल संख्या"

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -1833,6 +1833,9 @@
     "noUnauthorizedInstances": "✅ Nessuna istanza non autorizzata",
     "noLicenseData": "Nessun dato di licenza",
     "monthlyRevenue": "Entrate mensili",
+    "chartsUnavailableResizeObserver": "I grafici non sono disponibili perché ResizeObserver non è supportato da questo browser.",
+    "chartsFailedToLoad": "Impossibile caricare i grafici. Aggiorna la pagina per riprovare.",
+    "loadingCharts": "Caricamento dei grafici…",
     "monthlySignups": "Iscrizioni mensili",
     "tutorialsByCategory": "Tutorial per categoria",
     "instructorTutorialCount": "Numero di tutorial per istruttore"

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -1818,6 +1818,9 @@
     "noUnauthorizedInstances": "✅ 没有未经授权的实例",
     "noLicenseData": "没有许可证数据",
     "monthlyRevenue": "每月收入",
+    "chartsUnavailableResizeObserver": "由于此浏览器不支持 ResizeObserver，无法显示图表。",
+    "chartsFailedToLoad": "图表加载失败。请刷新后重试。",
+    "loadingCharts": "正在加载图表……",
     "monthlySignups": "每月注册",
     "tutorialsByCategory": "按类别划分的教程",
     "instructorTutorialCount": "讲师教程数量"


### PR DESCRIPTION
## Summary
- add fallback chart status strings for admin dashboard charts in the English locale
- translate the new chart status strings across Arabic, German, Spanish, French, Hindi, Italian, and Chinese locales to keep parity

## Testing
- python - <<'PY'
import json
from pathlib import Path
base = Path('frontend/public/locales')
missing = {}
for lang_dir in base.iterdir():
    dashboard = lang_dir / 'dashboard.json'
    if not dashboard.exists():
        continue
    data = json.loads(dashboard.read_text(encoding='utf-8'))
    home = data.get('adminDashboardHome', {})
    for key in (
        'chartsUnavailableResizeObserver',
        'chartsFailedToLoad',
        'loadingCharts',
    ):
        if key not in home:
            missing.setdefault(lang_dir.name, []).append(key)
if missing:
    print('Missing keys:', missing)
else:
    print('All locales contain the new chart keys.')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e18af72fdc8328b0eb11ec8ed3e474