### PR TITLE
Fix duplicate instructor class creation request

### DIFF
--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -81,7 +81,7 @@ export const fetchInstructorClassById = async (id) => {
 
 export const createInstructorClass = async (payload, onUploadProgress) => {
   await ensureCsrfToken();
-  const { data } = await api.post("users/classes/instructor", payload, {
+  const config = {
     headers: {
       "Content-Type": "multipart/form-data",
     },


### PR DESCRIPTION
## Summary
- avoid issuing duplicate POST requests when creating an instructor class
- reuse the response from the API call and return the formatted class data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18b0d73848328af05c282964ef4c0