### PR TITLE
Fix instructor class creation request

### DIFF
--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -81,14 +81,13 @@ export const fetchInstructorClassById = async (id) => {
 
 export const createInstructorClass = async (payload, onUploadProgress) => {
   await ensureCsrfToken();
-  const { data } = await api.post("users/classes/instructor", payload, {
+  const response = await api.post("users/classes/instructor", payload, {
     headers: {
       "Content-Type": "multipart/form-data",
     },
     ...(onUploadProgress ? { onUploadProgress } : {}),
-  };
-  const { data } = await api.post("users/classes/instructor", payload, config);
-  return data?.data ? formatClass(data.data) : null;
+  });
+  return formatClass(response.data?.data);
 };
 
 export const updateInstructorClass = async (id, payload) => {


### PR DESCRIPTION
## Summary
- rewrite `createInstructorClass` to perform a single multipart POST request with optional upload progress tracking
- return the normalized class data from the API response

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e18b1752708328ad0fc60b2c78c315