### PR TITLE
Fix instructor class details price display

### DIFF
--- a/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
+++ b/frontend/src/pages/dashboard/instructor/online-classes/[id]/details.js
@@ -93,7 +93,12 @@ function InstructorClassDetailPage() {
                   {publishStatusLabel}
                 </span>
               </p>
-              {details?.price && <p><strong>💵 Price:</strong> ${details.price}</p>}
+              {details?.price !== undefined && details?.price !== null && (
+                <p>
+                  <strong>💵 Price:</strong>{" "}
+                  {details.price === 0 ? "Free" : `$${details.price}`}
+                </p>
+              )}
               <p><strong>👁️ Views:</strong> {details?.views ?? 0}</p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- ensure the instructor class details page renders a price when it is zero
- show a "Free" label when the class has no cost to clarify the UX

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18b17f57483288bdafd63f63ebc0f