### PR TITLE
Adjust instructor class list loading state handling

### DIFF
--- a/frontend/src/components/instructors/OnlineClassList.js
+++ b/frontend/src/components/instructors/OnlineClassList.js
@@ -22,9 +22,13 @@ export default function OnlineClassList() {
   };
 
   useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+
     const load = async () => {
+      setLoading(true);
       try {
-        if (!user?.id) return;
         const data = await fetchInstructorClasses(user.id);
         setClasses(data || []);
       } catch (err) {


### PR DESCRIPTION
## Summary
- prevent the instructor class list effect from running when no user ID is present
- set the loading flag before fetching instructor classes while keeping the existing cleanup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18df842f08328b3a31233207b563e