### PR TITLE
Fix instructor class creation request options

### DIFF
--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -81,14 +81,18 @@ export const fetchInstructorClassById = async (id) => {
 
 export const createInstructorClass = async (payload, onUploadProgress) => {
   await ensureCsrfToken();
-  const { data } = await api.post("users/classes/instructor", payload, {
+  const options = {
     headers: {
       "Content-Type": "multipart/form-data",
     },
-    ...(onUploadProgress ? { onUploadProgress } : {}),
   };
-  const { data } = await api.post("users/classes/instructor", payload, config);
-  return data?.data ? formatClass(data.data) : null;
+
+  if (onUploadProgress) {
+    options.onUploadProgress = onUploadProgress;
+  }
+
+  const response = await api.post("users/classes/instructor", payload, options);
+  return response.data?.data ? formatClass(response.data.data) : null;
 };
 
 export const updateInstructorClass = async (id, payload) => {


### PR DESCRIPTION
## Summary
- ensure the instructor class creation request is sent once with a properly closed api call
- build the request options object locally, including the optional upload progress handler
- return the formatted class data from the single response payload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18df8e8588328b8ae82a7de32f922