### PR TITLE
Fix duplicate isMounted declaration in analytics page

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -37,7 +37,6 @@ function AnalyticsDashboard() {
     let isMounted = true;
     if (!id) return;
     setStats(null);
-    let isMounted = true;
     fetchAdminClassAnalytics(id)
       .then((data) => {
         if (!isMounted) return;


### PR DESCRIPTION
## Summary
- remove the redundant `isMounted` declaration in the admin online class analytics page so the cleanup guard is only defined once

## Testing
- npm run build *(fails: frontend/src/components/admin/charts/CategoryPieChart.js already defines `hasData`; also syntax error reported in frontend/src/services/instructor/classService.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e204459fa483289bbc12c20a7128a3