### PR TITLE
Fix duplicate guard in analytics effect

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -37,7 +37,6 @@ function AnalyticsDashboard() {
     let isMounted = true;
     if (!id) return;
     setStats(null);
-    let isMounted = true;
     fetchAdminClassAnalytics(id)
       .then((data) => {
         if (!isMounted) return;


### PR DESCRIPTION
## Summary
- remove the duplicate `isMounted` guard inside the admin class analytics effect so the cleanup toggles a single flag

## Testing
- npm run build *(fails: existing compilation errors in CategoryPieChart.js and classService.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e2044be2b083289c1adb2a02114c88