### PR TITLE
Fix admin analytics isMounted initialization

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -37,7 +37,6 @@ function AnalyticsDashboard() {
     let isMounted = true;
     if (!id) return;
     setStats(null);
-    let isMounted = true;
     fetchAdminClassAnalytics(id)
       .then((data) => {
         if (!isMounted) return;


### PR DESCRIPTION
## Summary
- ensure the admin online class analytics hook defines `isMounted` only once before fetching data
- keep the existing cleanup guard for `isMounted`

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e206fc672c83288f56511bb1143500