### PR TITLE
Require permission catalog access for roles page

### DIFF
--- a/frontend/src/pages/dashboard/admin/roles/index.js
+++ b/frontend/src/pages/dashboard/admin/roles/index.js
@@ -15,4 +15,6 @@ function RolesPage() {
   );
 }
 
-export default withAuthProtection(RolesPage, { permissions: ["view_roles"] });
+export default withAuthProtection(RolesPage, {
+  permissions: ["view_roles", "view_permissions"],
+});


### PR DESCRIPTION
## Summary
- require both the roles and permissions viewing privileges before loading the admin roles page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e20886ba688328bb8ced4ef907d933