### PR TITLE
Trim whitespace when creating admin permissions

### DIFF
--- a/frontend/src/components/admin/roles/PermissionAssignment.js
+++ b/frontend/src/components/admin/roles/PermissionAssignment.js
@@ -62,15 +62,29 @@ export default function PermissionAssignment({ role, canManage }) {
   };
 
   const handleAddNewPermission = async () => {
-    if (!canAddPermission || !newPermission) return;
-    if (permissions.some((p) => p.code === newPermission)) {
+    if (!canAddPermission) return;
+    const code = newPermission.trim();
+    if (!code) {
+      toast.error("Permission code cannot be empty");
+      return;
+    }
+
+    const normalisedCode = code.toLowerCase();
+    if (
+      permissions.some(
+        (p) => typeof p.code === "string" && p.code.toLowerCase() === normalisedCode
+      )
+    ) {
       toast.error("Permission already exists");
       return;
     }
     try {
-      const created = await createPermission({ code: newPermission });
-      setPermissions([...permissions, created]);
-      setAssignedPermissions([...assignedPermissions, created.code]);
+      const created = await createPermission({ code });
+      const createdCode =
+        typeof created?.code === "string" ? created.code.trim() : code;
+      const createdPermission = { ...created, code: createdCode };
+      setPermissions([...permissions, createdPermission]);
+      setAssignedPermissions([...assignedPermissions, createdCode]);
       setNewPermission("");
       setShowAddModal(false);
       toast.success("Permission created");

--- a/frontend/src/tests/components/admin/roles/PermissionAssignment.test.jsx
+++ b/frontend/src/tests/components/admin/roles/PermissionAssignment.test.jsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import PermissionAssignment from "@/components/admin/roles/PermissionAssignment";
+import { toast } from "react-toastify";
+import {
+  fetchAllPermissions,
+  fetchRoleById,
+  createPermission,
+} from "@/services/admin/roleService";
+import useAuthStore from "@/store/auth/authStore";
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock("@/store/auth/authStore", () => jest.fn());
+
+jest.mock("@/services/admin/roleService", () => ({
+  fetchAllPermissions: jest.fn(),
+  updateRolePermissions: jest.fn(),
+  fetchRoleById: jest.fn(),
+  createPermission: jest.fn(),
+}));
+
+describe("PermissionAssignment - Add Permission", () => {
+  const role = { id: 1, name: "Admin" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStore.mockReturnValue({
+      user: { permissions: ["manage_permissions"] },
+    });
+    fetchAllPermissions.mockResolvedValue([]);
+    fetchRoleById.mockResolvedValue({ permissions: [] });
+    createPermission.mockResolvedValue({ id: 10, code: "manage_users" });
+  });
+
+  const openAddModal = async () => {
+    render(<PermissionAssignment role={role} canManage />);
+
+    await waitFor(() => expect(fetchAllPermissions).toHaveBeenCalled());
+    await waitFor(() => expect(fetchRoleById).toHaveBeenCalledWith(role.id));
+
+    fireEvent.click(screen.getByText("Add Permission"));
+  };
+
+  it("trims whitespace before creating a permission", async () => {
+    await openAddModal();
+
+    const input = screen.getByPlaceholderText("e.g. manage_users");
+    fireEvent.change(input, { target: { value: "  Manage_Users  " } });
+
+    fireEvent.click(screen.getByText("Add"));
+
+    await waitFor(() =>
+      expect(createPermission).toHaveBeenCalledWith({ code: "Manage_Users" })
+    );
+    expect(toast.success).toHaveBeenCalledWith("Permission created");
+  });
+
+  it("prevents creating permissions that are empty after trimming", async () => {
+    await openAddModal();
+
+    const input = screen.getByPlaceholderText("e.g. manage_users");
+    fireEvent.change(input, { target: { value: "   " } });
+
+    fireEvent.click(screen.getByText("Add"));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Permission code cannot be empty")
+    );
+    expect(createPermission).not.toHaveBeenCalled();
+  });
+
+  it("prevents duplicates when codes only differ by spacing or case", async () => {
+    fetchAllPermissions.mockResolvedValue([{ id: 2, code: "manage_users" }]);
+
+    await openAddModal();
+
+    const input = screen.getByPlaceholderText("e.g. manage_users");
+    fireEvent.change(input, { target: { value: "  MANAGE_USERS  " } });
+
+    fireEvent.click(screen.getByText("Add"));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Permission already exists")
+    );
+    expect(createPermission).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- trim new permission codes before creation and block empty submissions
- normalize permission code comparisons to prevent duplicates caused by spacing or casing
- add tests covering whitespace-only and duplicate permission scenarios in the admin modal

## Testing
- npm test -- PermissionAssignment

------
https://chatgpt.com/codex/tasks/task_e_68e2088a678c8328914c72dc28eea71f