### PR TITLE
Restrict permission assignment to authorized viewers

### DIFF
--- a/frontend/src/components/admin/roles/PermissionAssignment.js
+++ b/frontend/src/components/admin/roles/PermissionAssignment.js
@@ -16,9 +16,14 @@ export default function PermissionAssignment({ role, canManage }) {
   const [newPermission, setNewPermission] = useState("");
   const { user } = useAuthStore();
   const canAddPermission = user?.permissions?.includes("manage_permissions");
+  const canViewPermissions = user?.permissions?.includes("view_permissions");
 
   useEffect(() => {
     const loadPermissions = async () => {
+      if (!canViewPermissions) {
+        setPermissions([]);
+        return;
+      }
       try {
         const all = await fetchAllPermissions();
         setPermissions(all);
@@ -27,7 +32,13 @@ export default function PermissionAssignment({ role, canManage }) {
       }
     };
     loadPermissions();
-  }, []);
+  }, [canViewPermissions]);
+
+  useEffect(() => {
+    if (!canViewPermissions) {
+      setShowAddModal(false);
+    }
+  }, [canViewPermissions]);
 
   useEffect(() => {
     if (role) {
@@ -44,7 +55,7 @@ export default function PermissionAssignment({ role, canManage }) {
   }, [role]);
 
   const handleTogglePermission = (code) => {
-    if (!canManage) return;
+    if (!canManage || !canViewPermissions) return;
     setAssignedPermissions((current) =>
       current.includes(code)
         ? current.filter((p) => p !== code)
@@ -53,7 +64,7 @@ export default function PermissionAssignment({ role, canManage }) {
   };
 
   const handleCheckAll = () => {
-    if (!canManage) return;
+    if (!canManage || !canViewPermissions) return;
     setAssignedPermissions((prev) =>
       prev.length === permissions.length
         ? []
@@ -62,7 +73,7 @@ export default function PermissionAssignment({ role, canManage }) {
   };
 
   const handleAddNewPermission = async () => {
-    if (!canAddPermission || !newPermission) return;
+    if (!canAddPermission || !canViewPermissions || !newPermission) return;
     if (permissions.some((p) => p.code === newPermission)) {
       toast.error("Permission already exists");
       return;
@@ -80,7 +91,7 @@ export default function PermissionAssignment({ role, canManage }) {
   };
 
   const handleSave = async () => {
-    if (!canManage) return;
+    if (!canManage || !canViewPermissions) return;
     const ids = assignedPermissions
       .map((code) => permissions.find((p) => p.code === code)?.id)
       .filter(Boolean);
@@ -100,7 +111,7 @@ export default function PermissionAssignment({ role, canManage }) {
           Permissions for <span className="ml-2 text-blue-500">{role.name}</span>
         </h3>
         <div className="flex gap-2">
-          {canManage && (
+          {canManage && canViewPermissions && (
             <button
               className="flex items-center text-sm bg-gray-100 hover:bg-gray-200 rounded-xl py-2 px-4"
               onClick={handleCheckAll}
@@ -109,7 +120,7 @@ export default function PermissionAssignment({ role, canManage }) {
               {assignedPermissions.length === permissions.length ? "Uncheck All" : "Check All"}
             </button>
           )}
-          {canAddPermission && (
+          {canAddPermission && canViewPermissions && (
             <button
               className="flex items-center text-sm bg-yellow-100 hover:bg-yellow-200 rounded-xl py-2 px-4"
               onClick={() => setShowAddModal(true)}
@@ -121,38 +132,45 @@ export default function PermissionAssignment({ role, canManage }) {
         </div>
       </div>
 
-      <div className="grid grid-cols-3 gap-4">
-        {permissions.map((perm) => (
-          <label
-            key={perm.id || perm.code}
-            className={`flex items-center p-3 border rounded-xl cursor-pointer transition ${
-              assignedPermissions.includes(perm.code)
-                ? "bg-yellow-50 border-yellow-400 text-yellow-700"
-                : "hover:bg-gray-50 border-gray-200"
-            }`}
-          >
-            <input
-              type="checkbox"
-              checked={assignedPermissions.includes(perm.code)}
-              onChange={() => handleTogglePermission(perm.code)}
-              className="mr-3 accent-yellow-500"
-              disabled={!canManage}
-            />
-            <span className="capitalize">{perm.code.replace(/_/g, " ")}</span>
-          </label>
-        ))}
-      </div>
+      {!canViewPermissions ? (
+        <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-xl text-yellow-700">
+          Additional permission required to view available permissions.
+        </div>
+      ) : (
+        <div className="grid grid-cols-3 gap-4">
+          {permissions.map((perm) => (
+            <label
+              key={perm.id || perm.code}
+              className={`flex items-center p-3 border rounded-xl cursor-pointer transition ${
+                assignedPermissions.includes(perm.code)
+                  ? "bg-yellow-50 border-yellow-400 text-yellow-700"
+                  : "hover:bg-gray-50 border-gray-200"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={assignedPermissions.includes(perm.code)}
+                onChange={() => handleTogglePermission(perm.code)}
+                className="mr-3 accent-yellow-500"
+                disabled={!canManage}
+              />
+              <span className="capitalize">{perm.code.replace(/_/g, " ")}</span>
+            </label>
+          ))}
+        </div>
+      )}
 
       {canManage && (
         <button
-          className="mt-6 bg-gradient-to-r from-yellow-500 to-yellow-600 hover:to-yellow-700 text-white px-6 py-2 rounded-xl shadow transition duration-200"
+          className="mt-6 bg-gradient-to-r from-yellow-500 to-yellow-600 hover:to-yellow-700 text-white px-6 py-2 rounded-xl shadow transition duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
           onClick={handleSave}
+          disabled={!canViewPermissions}
         >
           Save Changes
         </button>
       )}
 
-      {showAddModal && canAddPermission && (
+      {showAddModal && canAddPermission && canViewPermissions && (
         <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-40 z-50">
           <div className="bg-white p-6 rounded-xl w-full max-w-md">
             <h3 className="text-lg font-bold mb-4">Add New Permission</h3>

--- a/frontend/src/pages/dashboard/admin/roles/index.js
+++ b/frontend/src/pages/dashboard/admin/roles/index.js
@@ -15,4 +15,6 @@ function RolesPage() {
   );
 }
 
-export default withAuthProtection(RolesPage, { permissions: ["view_roles"] });
+export default withAuthProtection(RolesPage, {
+  permissions: ["view_roles", "view_permissions"],
+});


### PR DESCRIPTION
## Summary
- add a dedicated view permission flag to control loading and UI for the permission assignment panel
- show an informational message and disable bulk/add actions when the user cannot view permissions
- tighten the roles page guard to require both role and permission view access

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2088e3fb4832893a917a7d0eae586