### PR TITLE
Sync permission assignment state with backend updates

### DIFF
--- a/frontend/src/components/admin/roles/PermissionAssignment.js
+++ b/frontend/src/components/admin/roles/PermissionAssignment.js
@@ -9,7 +9,11 @@ import {
   createPermission,
 } from "@/services/admin/roleService";
 
-export default function PermissionAssignment({ role, canManage }) {
+export default function PermissionAssignment({
+  role,
+  canManage,
+  onRolePermissionsUpdated,
+}) {
   const [assignedPermissions, setAssignedPermissions] = useState([]);
   const [permissions, setPermissions] = useState([]);
   const [showAddModal, setShowAddModal] = useState(false);
@@ -81,12 +85,31 @@ export default function PermissionAssignment({ role, canManage }) {
 
   const handleSave = async () => {
     if (!canManage) return;
-    const ids = assignedPermissions
+    const requestedCodes = [...assignedPermissions];
+    const ids = requestedCodes
       .map((code) => permissions.find((p) => p.code === code)?.id)
       .filter(Boolean);
     try {
-      await updateRolePermissions(role.id, ids);
-      toast.success("Permissions saved");
+      const updatedRole = await updateRolePermissions(role.id, ids);
+      const updatedPermissions = updatedRole?.permissions ?? [];
+      setAssignedPermissions(updatedPermissions);
+      if (onRolePermissionsUpdated) {
+        onRolePermissionsUpdated(updatedRole);
+      }
+
+      const backendAdded = updatedPermissions.filter(
+        (code) => !requestedCodes.includes(code)
+      );
+
+      if (backendAdded.length) {
+        toast.success(
+          `Permissions saved. Additional permissions applied by the system: ${backendAdded.join(
+            ", "
+          )}`
+        );
+      } else {
+        toast.success("Permissions saved");
+      }
     } catch (err) {
       toast.error("Failed to save permissions");
     }

--- a/frontend/src/components/admin/roles/RoleManagement.js
+++ b/frontend/src/components/admin/roles/RoleManagement.js
@@ -84,6 +84,16 @@ export default function RoleManagement() {
     }
   };
 
+  const handleRolePermissionsUpdated = (updatedRole) => {
+    if (!updatedRole) return;
+    setRoles((prev) =>
+      prev.map((role) => (role.id === updatedRole.id ? { ...role, ...updatedRole } : role))
+    );
+    if (selectedRole?.id === updatedRole.id) {
+      setSelectedRole(updatedRole);
+    }
+  };
+
   return (
     <div className="flex space-x-8">
       <div className="w-1/4 bg-white rounded-2xl shadow-md border border-gray-100 p-5">
@@ -136,7 +146,13 @@ export default function RoleManagement() {
       </div>
 
       <div className="w-3/4 bg-white rounded-2xl shadow-md border border-gray-100 p-5">
-        {selectedRole && <PermissionAssignment role={selectedRole} canManage={canManage} />}
+        {selectedRole && (
+          <PermissionAssignment
+            role={selectedRole}
+            canManage={canManage}
+            onRolePermissionsUpdated={handleRolePermissionsUpdated}
+          />
+        )}
       </div>
       {showAdd && canManage && (
         <AddRoleModal


### PR DESCRIPTION
## Summary
- capture the role returned from `updateRolePermissions` so the assignment list reflects backend changes
- surface any backend-added permissions in the success toast to clarify forced adjustments
- notify `RoleManagement` when permissions change so the selected role stays in sync

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2089e9ea88328aa8c15bb6f7aae02