### PR TITLE
Handle role selection errors gracefully

### DIFF
--- a/frontend/src/components/admin/roles/RoleManagement.js
+++ b/frontend/src/components/admin/roles/RoleManagement.js
@@ -40,8 +40,13 @@ export default function RoleManagement() {
   }, []);
 
   const handleSelect = async (role) => {
-    const detailed = await fetchRoleById(role.id);
-    setSelectedRole(detailed);
+    try {
+      const detailed = await fetchRoleById(role.id);
+      setSelectedRole(detailed);
+    } catch (error) {
+      console.error(error);
+      toast.error("Failed to load role");
+    }
   };
 
   const handleAddRole = async (payload) => {

--- a/frontend/src/components/admin/roles/__tests__/RoleManagement.test.jsx
+++ b/frontend/src/components/admin/roles/__tests__/RoleManagement.test.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import RoleManagement from "../RoleManagement";
+import useAuthStore from "@/store/auth/authStore";
+import {
+  fetchAllRoles,
+  fetchRoleById,
+} from "@/services/admin/roleService";
+import { toast } from "react-toastify";
+
+jest.mock("@/utils/logger", () => ({
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock("@/services/admin/roleService", () => ({
+  fetchAllRoles: jest.fn(),
+  fetchRoleById: jest.fn(),
+  createRole: jest.fn(),
+  updateRole: jest.fn(),
+  deleteRole: jest.fn(),
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("../PermissionAssignment", () => ({ role }) => (
+  <div data-testid="permission-assignment">{role ? role.name : "no-role"}</div>
+));
+
+jest.mock("../AddRoleModal", () => () => null);
+jest.mock("../EditRoleModal", () => () => null);
+
+describe("RoleManagement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    act(() => {
+      useAuthStore.setState({ user: { permissions: ["manage_roles"] } });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useAuthStore.setState({ user: null });
+    });
+  });
+
+  it("shows a toast and keeps the previous selection when fetching a role fails", async () => {
+    const roles = [
+      { id: "1", name: "Admin" },
+      { id: "2", name: "Editor" },
+    ];
+
+    fetchAllRoles.mockResolvedValue(roles);
+    fetchRoleById
+      .mockResolvedValueOnce({ id: "1", name: "Admin" })
+      .mockRejectedValueOnce(new Error("network error"));
+
+    render(<RoleManagement />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("permission-assignment")).toHaveTextContent("Admin")
+    );
+
+    const editorRole = await screen.findByText("Editor");
+    fireEvent.click(editorRole);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to load role");
+    });
+
+    expect(screen.getByTestId("permission-assignment")).toHaveTextContent("Admin");
+    expect(fetchRoleById).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap role selection fetch in a try/catch to keep the previous selection when role details fail to load
- surface a toast error when role loading fails so admins receive feedback
- add a RoleManagement test that covers a rejected fetchRoleById call

## Testing
- npm test -- RoleManagement

------
https://chatgpt.com/codex/tasks/task_e_68e209480b648328a2f74df91034023a