### PR TITLE
Fix admin class analytics effect for normalized classId

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -36,14 +36,14 @@ function AnalyticsDashboard() {
   useEffect(() => {
     let isMounted = true;
 
-    if (!classId) {
+    if (!classId || !classId.trim()) {
       return () => {
         isMounted = false;
       };
     }
 
     setStats(null);
-    fetchAdminClassAnalytics(id)
+    fetchAdminClassAnalytics(classId)
       .then((data) => {
         if (!isMounted) return;
         setStats({


### PR DESCRIPTION
## Summary
- prevent the analytics effect from running when the normalized classId is empty
- call fetchAdminClassAnalytics with the normalized classId and rely on it for the effect dependency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e20dbd5f8c83288041beaec0ecf307