### PR TITLE
Fix admin class analytics effect dependencies

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -29,21 +29,18 @@ const EMPTY_STATS = {
 
 function AnalyticsDashboard() {
   const router = useRouter();
-  const { id } = router.query;
-  const classId = Array.isArray(id) ? id[0] : id || "";
+  const rawId = router.query?.id;
+  const classId = Array.isArray(rawId) ? rawId[0] : rawId ?? "";
   const { t, i18n } = useTranslation('dashboard');
   const [stats, setStats] = useState(null);
   useEffect(() => {
-    let isMounted = true;
-
     if (!classId) {
-      return () => {
-        isMounted = false;
-      };
+      return;
     }
 
+    let isMounted = true;
     setStats(null);
-    fetchAdminClassAnalytics(id)
+    fetchAdminClassAnalytics(classId)
       .then((data) => {
         if (!isMounted) return;
         setStats({


### PR DESCRIPTION
## Summary
- normalize the dynamic admin class analytics route id into a single classId string
- guard the analytics fetching effect when no classId is available and reuse the normalized value in the fetch call
- ensure the mounted flag is declared only once per effect run to prevent redundant declarations

## Testing
- npm run lint *(fails: repository does not contain a package.json so lint script cannot be executed)*

------
https://chatgpt.com/codex/tasks/task_e_68e20dc4a6e88328aa88d04bd6c3c0a7