### PR TITLE
Ensure admin role bypasses role management permission checks

### DIFF
--- a/frontend/src/components/admin/roles/PermissionAssignment.js
+++ b/frontend/src/components/admin/roles/PermissionAssignment.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { CheckCircle, CheckSquare, PlusCircle } from "lucide-react";
 import { toast } from "react-toastify";
 import useAuthStore from "@/store/auth/authStore";
+import { getNormalizedRoles } from "@/utils/auth/roleUtils";
 import {
   fetchAllPermissions,
   updateRolePermissions,
@@ -20,8 +21,14 @@ export default function PermissionAssignment({
   const [showAddModal, setShowAddModal] = useState(false);
   const [newPermission, setNewPermission] = useState("");
   const { user } = useAuthStore();
-  const canAddPermission = user?.permissions?.includes("manage_permissions");
-  const canViewPermissions = user?.permissions?.includes("view_permissions");
+  const normalizedRoles = getNormalizedRoles(user);
+  const hasAdminRole = normalizedRoles.some((role) =>
+    ["admin", "superadmin"].includes(role)
+  );
+  const canAddPermission =
+    hasAdminRole || user?.permissions?.includes("manage_permissions");
+  const canViewPermissions =
+    hasAdminRole || user?.permissions?.includes("view_permissions");
 
   useEffect(() => {
     const loadPermissions = async () => {

--- a/frontend/src/components/admin/roles/RoleManagement.js
+++ b/frontend/src/components/admin/roles/RoleManagement.js
@@ -5,6 +5,7 @@ import PermissionAssignment from "./PermissionAssignment";
 import AddRoleModal from "./AddRoleModal";
 import EditRoleModal from "./EditRoleModal";
 import { toast } from "react-toastify";
+import { getNormalizedRoles } from "@/utils/auth/roleUtils";
 import {
   fetchAllRoles,
   fetchRoleById,
@@ -20,7 +21,12 @@ export default function RoleManagement() {
   const [showAdd, setShowAdd] = useState(false);
   const [editRole, setEditRole] = useState(null);
   const { user } = useAuthStore();
-  const canManage = user?.permissions?.includes("manage_roles");
+  const normalizedRoles = getNormalizedRoles(user);
+  const hasAdminRole = normalizedRoles.some((role) =>
+    ["admin", "superadmin"].includes(role)
+  );
+  const canManage =
+    hasAdminRole || user?.permissions?.includes("manage_roles");
   const latestRequestedRoleId = useRef(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- allow admin and superadmin dashboard users to bypass the manage_roles permission gate when managing roles
- allow admin and superadmin dashboard users to automatically view and add permissions in the assignment panel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e221353e688328a2e4c75c0176cfad