### PR TITLE
Improve token refresh CSRF handling

### DIFF
--- a/frontend/src/services/api/csrf.js
+++ b/frontend/src/services/api/csrf.js
@@ -3,31 +3,53 @@ import { getCookie } from "@/utils/cookies";
 
 export const getCsrfToken = () => getCookie("csrfToken");
 
+let cachedToken = null;
+
+export const clearCachedCsrfToken = () => {
+  cachedToken = null;
+};
+
+const fetchCsrfToken = async () => {
+  try {
+    // Use a relative URL so Axios appends it to the configured base URL.
+    // A leading slash causes Axios to treat the path as absolute, which
+    // skips the `/api` prefix in production and prevents the backend CSRF
+    // route from being hit. That leaves the csrfToken cookie unset and the
+    // next POST request fails with a 403. Using a relative path ensures we
+    // always call `/api/csrf-token`, allowing the server to issue the
+    // expected cookie before we retry the protected request.
+    const response = await api.get("csrf-token", {
+      params: { _: Date.now() },
+      headers: { "Cache-Control": "no-cache" },
+    });
+
+    return response?.data?.token || getCsrfToken();
+  } catch (e) {
+    // The route may not exist; we only care about the cookie.
+    return getCsrfToken();
+  }
+};
+
 /**
  * Ensure a CSRF token cookie exists.
- * If absent, performs a lightweight GET request to trigger the server
- * to set one, then returns the newly acquired token.
+ * If absent (or a forced refresh is requested), performs a lightweight GET
+ * request to trigger the server to set one, then returns the token.
  */
-export const ensureCsrfToken = async () => {
-  let token = getCsrfToken();
-  if (!token) {
-    try {
-      // Use a relative URL so Axios appends it to the configured base URL.
-      // A leading slash causes Axios to treat the path as absolute, which
-      // skips the `/api` prefix in production and prevents the backend CSRF
-      // route from being hit. That leaves the csrfToken cookie unset and the
-      // next POST request fails with a 403. Using a relative path ensures we
-      // always call `/api/csrf-token`, allowing the server to issue the
-      // expected cookie before we retry the protected request.
-      const response = await api.get("csrf-token", {
-        params: { _: Date.now() },
-        headers: { "Cache-Control": "no-cache" },
-      });
-
-      token = response?.data?.token || getCsrfToken();
-    } catch (e) {
-      // The route may not exist; we only care about the cookie.
-    }
+export const ensureCsrfToken = async ({ forceRefresh = false } = {}) => {
+  if (!forceRefresh && cachedToken) {
+    return cachedToken;
   }
-  return token;
+
+  if (!forceRefresh) {
+    const existingToken = getCsrfToken();
+    if (existingToken) {
+      cachedToken = existingToken;
+      return cachedToken;
+    }
+  } else {
+    clearCachedCsrfToken();
+  }
+
+  cachedToken = await fetchCsrfToken();
+  return cachedToken;
 };

--- a/frontend/src/services/api/tokenInterceptor.js
+++ b/frontend/src/services/api/tokenInterceptor.js
@@ -8,8 +8,7 @@ import api from "./api";
 import { toast } from "react-toastify";
 import Router from "next/router";
 import useAuthStore from "@/store/auth/authStore";
-import { getCookie } from "@/utils/cookies";
-import { ensureCsrfToken } from "@/services/api/csrf";
+import { ensureCsrfToken, clearCachedCsrfToken } from "@/services/api/csrf";
 import logger from "@/utils/logger";
 
 let isRefreshing = false;
@@ -39,20 +38,15 @@ api.interceptors.request.use(
 
     const method = config.method?.toLowerCase();
     if (["post", "put", "patch", "delete"].includes(method)) {
-      let csrfToken = getCookie("csrfToken");
-
-      if (!csrfToken) {
-        try {
-          csrfToken = await ensureCsrfToken();
-        } catch (error) {
-          logger.warn(
-            `Failed to refresh CSRF token before ${method?.toUpperCase()} ${config?.url}: ${error?.message || error}`
-          );
+      try {
+        const csrfToken = await ensureCsrfToken();
+        if (csrfToken) {
+          config.headers["x-csrf-token"] = csrfToken;
         }
-      }
-
-      if (csrfToken) {
-        config.headers["x-csrf-token"] = csrfToken;
+      } catch (error) {
+        logger.warn(
+          `Failed to refresh CSRF token before ${method?.toUpperCase()} ${config?.url}: ${error?.message || error}`
+        );
       }
     }
 
@@ -133,10 +127,19 @@ api.interceptors.response.use(
       originalRequest._retry = true;
       isRefreshing = true;
 
-      try {
-        logger.log("\uD83D\uDD04 Attempting token refresh...");
-        const csrfToken = getCookie("csrfToken");
-        const { data } = await api.post(
+      const performRefreshRequest = async (forceCsrfRefresh = false) => {
+        let csrfToken;
+        try {
+          csrfToken = await ensureCsrfToken(
+            forceCsrfRefresh ? { forceRefresh: true } : undefined
+          );
+        } catch (csrfError) {
+          logger.warn(
+            `Failed to ensure CSRF token before refresh: ${csrfError?.message || csrfError}`
+          );
+        }
+
+        return api.post(
           "/auth/refresh",
           null,
           {
@@ -144,22 +147,49 @@ api.interceptors.response.use(
             headers: csrfToken ? { "x-csrf-token": csrfToken } : {},
           }
         );
+      };
+
+      const handleRefreshSuccess = async (data) => {
         logger.log("\u2705 Token refresh successful");
         authStore.setToken(data.accessToken);
         processQueue(null, data.accessToken);
 
         originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
         return api(originalRequest);
-      } catch (refreshErr) {
-        logger.error("\u274C Refresh token request failed:", refreshErr);
-        processQueue(refreshErr, null);
+      };
+
+      const handleRefreshFailure = async (failureError) => {
+        logger.error("\u274C Refresh token request failed:", failureError);
+        processQueue(failureError, null);
         authStore.logout(true);
         toast.info("You have been logged out.");
         toast.error("Session expired. Please log in again.");
         if (typeof window !== "undefined") {
           Router.push("/auth/login");
         }
-        return Promise.reject(refreshErr);
+        return Promise.reject(failureError);
+      };
+
+      try {
+        logger.log("\uD83D\uDD04 Attempting token refresh...");
+        const { data } = await performRefreshRequest();
+        return handleRefreshSuccess(data);
+      } catch (refreshErr) {
+        const refreshStatus = refreshErr?.response?.status;
+        if (refreshStatus === 401 || refreshStatus === 403) {
+          logger.warn(
+            `\u26A0\uFE0F Refresh token request returned ${refreshStatus}. Forcing CSRF refresh and retrying once.`
+          );
+          try {
+            clearCachedCsrfToken();
+            const { data } = await performRefreshRequest(true);
+            return handleRefreshSuccess(data);
+          } catch (retryError) {
+            return handleRefreshFailure(retryError);
+          }
+        }
+
+        return handleRefreshFailure(refreshErr);
       } finally {
         isRefreshing = false;
       }

--- a/frontend/src/tests/__tests__/tokenInterceptorRefresh.test.js
+++ b/frontend/src/tests/__tests__/tokenInterceptorRefresh.test.js
@@ -1,0 +1,187 @@
+const createInterceptorStore = () => {
+  const handlers = [];
+  const use = jest.fn((fulfilled, rejected) => {
+    const handler = { fulfilled, rejected };
+    handlers.push(handler);
+    return handlers.length - 1;
+  });
+  const eject = jest.fn((id) => {
+    if (typeof id === "number" && id >= 0 && id < handlers.length) {
+      handlers[id] = null;
+    }
+  });
+
+  return { handlers, use, eject };
+};
+
+const requestInterceptors = createInterceptorStore();
+const responseInterceptors = createInterceptorStore();
+const apiPostMock = jest.fn();
+const apiRequestMock = jest.fn();
+const apiMockInstance = jest.fn((config) => apiRequestMock(config));
+
+apiMockInstance.post = apiPostMock;
+apiMockInstance.request = apiRequestMock;
+apiMockInstance.interceptors = {
+  request: requestInterceptors,
+  response: responseInterceptors,
+};
+
+jest.mock("@/services/api/api", () => ({
+  __esModule: true,
+  default: apiMockInstance,
+  __mock: {
+    requestInterceptors,
+    responseInterceptors,
+    postMock: apiPostMock,
+    requestMock: apiRequestMock,
+  },
+}));
+
+const toastInfoMock = jest.fn();
+const toastErrorMock = jest.fn();
+jest.mock("react-toastify", () => ({
+  toast: {
+    info: toastInfoMock,
+    error: toastErrorMock,
+  },
+}));
+
+const pushMock = jest.fn();
+jest.mock("next/router", () => ({
+  __esModule: true,
+  default: { push: pushMock },
+}));
+
+const loggerLogMock = jest.fn();
+const loggerWarnMock = jest.fn();
+const loggerErrorMock = jest.fn();
+jest.mock("@/utils/logger", () => ({
+  __esModule: true,
+  default: {
+    log: loggerLogMock,
+    warn: loggerWarnMock,
+    error: loggerErrorMock,
+  },
+}));
+
+const mockGetState = jest.fn();
+jest.mock("@/store/auth/authStore", () => ({
+  __esModule: true,
+  default: {
+    getState: mockGetState,
+  },
+}));
+
+const ensureCsrfTokenMock = jest.fn();
+const clearCachedCsrfTokenMock = jest.fn();
+jest.mock("@/services/api/csrf", () => ({
+  __esModule: true,
+  ensureCsrfToken: ensureCsrfTokenMock,
+  clearCachedCsrfToken: clearCachedCsrfTokenMock,
+}));
+
+describe("tokenInterceptor refresh logic", () => {
+  let responseInterceptor;
+  let authState;
+
+  beforeEach(() => {
+    toastInfoMock.mockReset();
+    toastErrorMock.mockReset();
+    pushMock.mockReset();
+    loggerLogMock.mockReset();
+    loggerWarnMock.mockReset();
+    loggerErrorMock.mockReset();
+    ensureCsrfTokenMock.mockReset();
+    clearCachedCsrfTokenMock.mockReset();
+    mockGetState.mockReset();
+
+    apiMockInstance.mockClear();
+    apiPostMock.mockReset();
+    apiRequestMock.mockReset();
+    requestInterceptors.use.mockClear();
+    requestInterceptors.eject.mockClear();
+    responseInterceptors.use.mockClear();
+    responseInterceptors.eject.mockClear();
+    requestInterceptors.handlers.length = 0;
+    responseInterceptors.handlers.length = 0;
+
+    authState = {
+      accessToken: "old-access",
+      user: { id: 1 },
+      setToken: jest.fn(),
+      setUser: jest.fn(),
+      logout: jest.fn(),
+    };
+
+    mockGetState.mockReturnValue(authState);
+
+    jest.isolateModules(() => {
+      require("@/services/api/tokenInterceptor");
+    });
+
+    const handlers = responseInterceptors.handlers;
+    responseInterceptor = handlers[handlers.length - 1].rejected;
+  });
+
+  it("retries refresh after a 403 by forcing a new CSRF token", async () => {
+    ensureCsrfTokenMock
+      .mockResolvedValueOnce("csrf-one")
+      .mockResolvedValueOnce("csrf-two");
+
+    apiPostMock
+      .mockRejectedValueOnce({ response: { status: 403 } })
+      .mockResolvedValueOnce({ data: { accessToken: "fresh-access" } });
+
+    apiRequestMock.mockResolvedValue({ data: "ok" });
+
+    const error = {
+      config: {
+        url: "/secure/resource",
+        method: "get",
+        headers: {},
+      },
+      response: { status: 401 },
+    };
+
+    const result = await responseInterceptor(error);
+
+    expect(result).toEqual({ data: "ok" });
+
+    expect(ensureCsrfTokenMock).toHaveBeenCalledTimes(2);
+    expect(ensureCsrfTokenMock).toHaveBeenNthCalledWith(1, undefined);
+    expect(ensureCsrfTokenMock).toHaveBeenNthCalledWith(2, { forceRefresh: true });
+
+    expect(clearCachedCsrfTokenMock).toHaveBeenCalledTimes(1);
+    expect(clearCachedCsrfTokenMock.mock.invocationCallOrder[0]).toBeLessThan(
+      ensureCsrfTokenMock.mock.invocationCallOrder[1]
+    );
+
+    expect(apiPostMock).toHaveBeenCalledTimes(2);
+    expect(apiPostMock).toHaveBeenNthCalledWith(
+      1,
+      "/auth/refresh",
+      null,
+      expect.objectContaining({
+        headers: { "x-csrf-token": "csrf-one" },
+        withCredentials: true,
+      })
+    );
+    expect(apiPostMock).toHaveBeenNthCalledWith(
+      2,
+      "/auth/refresh",
+      null,
+      expect.objectContaining({
+        headers: { "x-csrf-token": "csrf-two" },
+        withCredentials: true,
+      })
+    );
+
+    expect(apiRequestMock).toHaveBeenCalledWith(error.config);
+    expect(authState.setToken).toHaveBeenCalledWith("fresh-access");
+    expect(authState.logout).not.toHaveBeenCalled();
+    expect(toastInfoMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(error.config.headers.Authorization).toBe("Bearer fresh-access");
+  });
+});


### PR DESCRIPTION
## Summary
- cache CSRF tokens with an explicit reset helper to support forced refreshes
- always ensure a CSRF token before calling the refresh endpoint and retry once after a 401/403 response
- add a unit test covering the CSRF refresh retry path for the token interceptor

## Testing
- npm test -- tokenInterceptorRefresh

------
https://chatgpt.com/codex/tasks/task_e_68e22493d5cc8328a7df59009537e0cf