### PR TITLE
Fix permission assignment requested code tracking

### DIFF
--- a/frontend/src/components/admin/roles/PermissionAssignment.js
+++ b/frontend/src/components/admin/roles/PermissionAssignment.js
@@ -127,6 +127,7 @@ export default function PermissionAssignment({
 
   const handleSave = async () => {
     if (!canManage || !canViewPermissions) return;
+    const requestedCodes = [...assignedPermissions];
     const ids = assignedPermissions
       .map((code) => permissions.find((p) => p.code === code)?.id)
       .filter(Boolean);


### PR DESCRIPTION
## Summary
- store the requested permission codes before saving so backend-added permission messaging can reference them safely

## Testing
- npm run build *(fails: existing module parse errors in unrelated admin components)*

------
https://chatgpt.com/codex/tasks/task_e_68e22b7d67d88328ba40247b3517577b