### PR TITLE
Fix permission save backend comparison

### DIFF
--- a/frontend/src/components/admin/roles/PermissionAssignment.js
+++ b/frontend/src/components/admin/roles/PermissionAssignment.js
@@ -127,6 +127,7 @@ export default function PermissionAssignment({
 
   const handleSave = async () => {
     if (!canManage || !canViewPermissions) return;
+    const requestedCodes = [...assignedPermissions];
     const ids = assignedPermissions
       .map((code) => permissions.find((p) => p.code === code)?.id)
       .filter(Boolean);


### PR DESCRIPTION
## Summary
- capture the requested permission codes before resolving IDs to keep backend comparison logic intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e22b89fbcc8328bb81488076878eaf