### PR TITLE
Add role management permissions to seeds and migrations

### DIFF
--- a/backend/src/migrations/20251201000000_add_role_management_permissions.js
+++ b/backend/src/migrations/20251201000000_add_role_management_permissions.js
@@ -1,0 +1,84 @@
+const PERMISSION_CODES = [
+  {
+    code: 'view_roles',
+    description: 'Permission to view roles',
+  },
+  {
+    code: 'manage_roles',
+    description: 'Permission to create and update roles',
+  },
+  {
+    code: 'view_permissions',
+    description: 'Permission to view permissions',
+  },
+  {
+    code: 'manage_permissions',
+    description: 'Permission to create and update permissions',
+  },
+];
+
+const ROLE_NAMES = ['Admin', 'SuperAdmin'];
+
+exports.up = async function up(knex) {
+  await knex('permissions')
+    .insert(PERMISSION_CODES)
+    .onConflict('code')
+    .ignore();
+
+  const permissions = await knex('permissions')
+    .select('id', 'code')
+    .whereIn(
+      'code',
+      PERMISSION_CODES.map((permission) => permission.code),
+    );
+
+  if (permissions.length === 0) {
+    return;
+  }
+
+  const roles = await knex('roles')
+    .select('id', 'name')
+    .whereIn('name', ROLE_NAMES);
+
+  const roleIdLookup = roles.reduce((accumulator, role) => {
+    accumulator[role.name] = role.id;
+    return accumulator;
+  }, {});
+
+  const rows = [];
+
+  permissions.forEach((permission) => {
+    ROLE_NAMES.forEach((roleName) => {
+      const roleId = roleIdLookup[roleName];
+      if (!roleId) {
+        return;
+      }
+
+      rows.push({
+        role_id: roleId,
+        permission_id: permission.id,
+      });
+    });
+  });
+
+  if (rows.length === 0) {
+    return;
+  }
+
+  await knex('role_permissions').insert(rows).onConflict(['role_id', 'permission_id']).ignore();
+};
+
+exports.down = async function down(knex) {
+  const permissionCodes = PERMISSION_CODES.map((permission) => permission.code);
+
+  const permissions = await knex('permissions')
+    .select('id')
+    .whereIn('code', permissionCodes);
+
+  if (permissions.length > 0) {
+    const permissionIds = permissions.map((permission) => permission.id);
+    await knex('role_permissions').whereIn('permission_id', permissionIds).del();
+  }
+
+  await knex('permissions').whereIn('code', permissionCodes).del();
+};

--- a/backend/src/seeds/10_permissions_seed.js
+++ b/backend/src/seeds/10_permissions_seed.js
@@ -39,6 +39,10 @@ exports.seed = async function (knex) {
       code: 'ADD_ONLINE_CLASS_RULE',
       description: 'Permission to add or manage online class rules',
     },
+    { code: 'view_roles', description: 'Permission to view roles' },
+    { code: 'manage_roles', description: 'Permission to create and update roles' },
+    { code: 'view_permissions', description: 'Permission to view permissions' },
+    { code: 'manage_permissions', description: 'Permission to create and update permissions' },
   ];
 
   await knex('permissions')


### PR DESCRIPTION
## Summary
- add role and permission management codes to the permissions seed
- create a migration that inserts the new permissions and assigns them to Admin and SuperAdmin

## Testing
- not run (database service not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e22b8a96f88328a73e08b2a8ceafc6