### PR TITLE
Fix cover image upload validation handling

### DIFF
--- a/frontend/src/hooks/useCoverImageUpload.js
+++ b/frontend/src/hooks/useCoverImageUpload.js
@@ -10,6 +10,13 @@ export default function useCoverImageUpload(t) {
   const [fileError, setFileError] = useState(null);
   const fileInputRef = useRef(null);
 
+  const resetFileSelection = useCallback(() => {
+    setCoverPreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }, []);
+
   const handleFileChange = useCallback(
     (e) => {
       const file = e.target.files[0];
@@ -18,11 +25,13 @@ export default function useCoverImageUpload(t) {
       const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
       if (!allowedTypes.includes(file.type)) {
         setFileError(t('validation.invalidFileType'));
+        resetFileSelection();
         return;
       }
 
       if (file.size > MAX_IMAGE_SIZE) {
         setFileError(t('validation.fileTooLarge', { size: `${MAX_IMAGE_SIZE_MB}MB` }));
+        resetFileSelection();
         return;
       }
 
@@ -33,14 +42,13 @@ export default function useCoverImageUpload(t) {
       };
       reader.readAsDataURL(file);
     },
-    [t]
+    [resetFileSelection, t]
   );
 
   const handleRemoveImage = useCallback(() => {
-    setCoverPreview(null);
     setFileError(null);
-    if (fileInputRef.current) fileInputRef.current.value = '';
-  }, []);
+    resetFileSelection();
+  }, [resetFileSelection]);
 
   return {
     coverPreview,

--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -53,7 +53,7 @@ function AdminCreateBookPage() {
   }, [t]);
 
   const handleSubmit = async (formData, setProgress) => {
-    if (fileInputRef.current?.files?.[0]) {
+    if (!fileError && fileInputRef.current?.files?.[0]) {
       formData.append("cover_image", fileInputRef.current.files[0]);
     }
     try {

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -69,7 +69,7 @@ function AdminEditBookPage() {
   }, [id, t]);
 
   const handleSubmit = async (formData, setProgress) => {
-    if (fileInputRef.current?.files?.[0]) {
+    if (!fileError && fileInputRef.current?.files?.[0]) {
       formData.append("cover_image", fileInputRef.current.files[0]);
     }
     try {


### PR DESCRIPTION
## Summary
- reset the cover image input and preview when an invalid file is selected
- ensure the create and edit book forms only append cover images when validation passes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e22ba304348328b287ce3b46592acb