### PR TITLE
Reset pagination when tag filters change

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -405,12 +405,13 @@ function AdminBooksPage() {
                     {tag}
                     <button
                       type="button"
-                      onClick={() =>
+                      onClick={() => {
                         setFilters({
                           ...filters,
                           tags: filters.tags.filter((t) => t !== tag),
-                        })
-                      }
+                        });
+                        setPage(1);
+                      }}
                       className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
                     >
                       &times;
@@ -428,6 +429,7 @@ function AdminBooksPage() {
                       e.preventDefault();
                       if (tagInput && !filters.tags.includes(tagInput)) {
                         setFilters({ ...filters, tags: [...filters.tags, tagInput] });
+                        setPage(1);
                       }
                       setTagInput("");
                     }
@@ -443,6 +445,7 @@ function AdminBooksPage() {
                         onClick={() => {
                           if (!filters.tags.includes(tg.name)) {
                             setFilters({ ...filters, tags: [...filters.tags, tg.name] });
+                            setPage(1);
                           }
                           setTagInput("");
                         }}

--- a/frontend/src/pages/dashboard/instructor/books/index.js
+++ b/frontend/src/pages/dashboard/instructor/books/index.js
@@ -410,12 +410,13 @@ function InstructorBooksPage() {
                     {tag}
                     <button
                       type="button"
-                      onClick={() =>
+                      onClick={() => {
                         setFilters({
                           ...filters,
                           tags: filters.tags.filter((t) => t !== tag),
-                        })
-                      }
+                        });
+                        setPage(1);
+                      }}
                       className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
                     >
                       &times;
@@ -433,6 +434,7 @@ function InstructorBooksPage() {
                       e.preventDefault();
                       if (tagInput && !filters.tags.includes(tagInput)) {
                         setFilters({ ...filters, tags: [...filters.tags, tagInput] });
+                        setPage(1);
                       }
                       setTagInput("");
                     }
@@ -448,6 +450,7 @@ function InstructorBooksPage() {
                         onClick={() => {
                           if (!filters.tags.includes(tg.name)) {
                             setFilters({ ...filters, tags: [...filters.tags, tg.name] });
+                            setPage(1);
                           }
                           setTagInput("");
                         }}


### PR DESCRIPTION
## Summary
- reset pagination to page 1 whenever admin dashboard tag filters change, including manual entry, suggestion selection, and removal
- mirror the pagination reset for instructor dashboard tag filter changes so both views stay in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e22bad2a1c832899bab11bd55d1ea0