### PR TITLE
Ensure selected book IDs stay in sync with data

### DIFF
--- a/frontend/src/hooks/useBookTable.js
+++ b/frontend/src/hooks/useBookTable.js
@@ -37,6 +37,17 @@ export default function useBookTable({
   }, [filters, storageKey]);
 
   useEffect(() => {
+    setSelectedItems((prevSelected) => {
+      if (!prevSelected.length) return prevSelected;
+
+      const itemIds = new Set(items.map((item) => item.id));
+      const filtered = prevSelected.filter((id) => itemIds.has(id));
+
+      return filtered.length === prevSelected.length ? prevSelected : filtered;
+    });
+  }, [items]);
+
+  useEffect(() => {
     setAllSelected(items.length > 0 && selectedItems.length === items.length);
   }, [items, selectedItems]);
 


### PR DESCRIPTION
## Summary
- prune stale selections when the available book list changes so allSelected remains accurate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e22bae13148328a04ff0f4e96146b0