### PR TITLE
Fix error namespace usage for admin book pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/create.js
+++ b/frontend/src/pages/dashboard/admin/books/create.js
@@ -42,8 +42,8 @@ function AdminCreateBookPage() {
         setCategories(result?.data || result || []);
       } catch (err) {
         console.error("Failed to load categories", err);
-        setError(t("errors.categoryLoad"));
-        toast.error(t("errors.categoryLoad"));
+        setError(t("errors:categoryLoad"));
+        toast.error(t("errors:categoryLoad"));
       } finally {
         setIsLoading(false);
       }

--- a/frontend/src/pages/dashboard/admin/books/edit/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/edit/[id].js
@@ -59,8 +59,8 @@ function AdminEditBookPage() {
         setCoverPreview(bookData?.cover_image_url || null);
       } catch (err) {
         console.error("Failed to load book", err);
-        setError(t("errors.bookLoad"));
-        toast.error(t("errors.bookLoad"));
+        setError(t("errors:bookLoad"));
+        toast.error(t("errors:bookLoad"));
       } finally {
         setIsLoading(false);
       }

--- a/frontend/src/pages/dashboard/admin/books/view/[id].js
+++ b/frontend/src/pages/dashboard/admin/books/view/[id].js
@@ -59,12 +59,12 @@ function AdminViewBookPage() {
         setLoading(false);
       } catch (err) {
         console.error("Failed to load book", err);
-        setError(t("errors.bookLoad"));
+        setError(t("errors:bookLoad"));
         setLoading(false);
       }
     };
     load();
-  }, [id]);
+  }, [id, t]);
 
   const handleDelete = () => {
     openConfirmModal({


### PR DESCRIPTION
## Summary
- ensure the admin book create/edit pages use the errors namespace for load failure toasts and UI messages
- update the admin book view page to read the book load error string from the errors namespace and react to translation changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e22bb1163083289ba410e3dcc05981