### PR TITLE
Fix bulk selection after deleting book

### DIFF
--- a/frontend/src/pages/dashboard/admin/books/index.js
+++ b/frontend/src/pages/dashboard/admin/books/index.js
@@ -800,6 +800,7 @@ function AdminBooksPage() {
                                     const newTotalPages = Math.max(1, Math.ceil(newTotal / perPage));
 
                                     setBooks(remaining);
+                                    setSelectedBooks((prev) => prev.filter((id) => id !== book.id));
                                     setMeta((m) => ({ ...m, total: newTotal, totalPages: newTotalPages }));
                                     toast.success(t("Book deleted"));
 


### PR DESCRIPTION
## Summary
- clear the deleted book id from the selected books state when confirming deletion
- ensure the bulk selection banner no longer includes removed book ids after deletion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e22bc556e08328964af85b4eb68dcf