### PR TITLE
Add configurable cookie security overrides

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -44,6 +44,26 @@ const parseBooleanFromEnv = (value, defaultValue = false) => {
 
 const booleanLike = z.union([z.boolean(), z.string(), z.number()]).optional();
 
+const normalizeSameSite = (value) => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const stringValue = String(value).trim();
+  if (!stringValue) {
+    return undefined;
+  }
+
+  const normalized = stringValue.toLowerCase();
+  if (!['lax', 'strict', 'none'].includes(normalized)) {
+    throw new Error(
+      `Invalid COOKIE_SAMESITE value: ${value}. Expected one of: lax, strict, none.`
+    );
+  }
+
+  return normalized;
+};
+
 const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   BACKEND_PORT: z.coerce.number().default(5002),
@@ -82,6 +102,8 @@ const EnvSchema = z.object({
   FRONTEND_URL: z.string().default('http://localhost:3000'),
   APP_DOMAIN: z.string().optional(),
   COOKIE_DOMAIN: z.string().optional(),
+  COOKIE_SECURE: booleanLike,
+  COOKIE_SAMESITE: z.string().optional(),
   ENABLE_INSTALL: booleanLike,
   INSTALL_API_ENABLED: booleanLike,
   RATE_LIMIT_MAX_REQUESTS: z
@@ -136,6 +158,23 @@ const createValidatedEnv = () => {
       : sanitizedEnv[key];
     sanitizedEnv[key] = parseBooleanFromEnv(rawValue, defaultValue);
   });
+
+  if (Object.prototype.hasOwnProperty.call(modifiedEnv, 'COOKIE_SECURE')) {
+    sanitizedEnv.COOKIE_SECURE = parseBooleanFromEnv(
+      modifiedEnv.COOKIE_SECURE,
+      undefined
+    );
+  } else {
+    sanitizedEnv.COOKIE_SECURE = undefined;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(modifiedEnv, 'COOKIE_SAMESITE')) {
+    sanitizedEnv.COOKIE_SAMESITE = normalizeSameSite(
+      modifiedEnv.COOKIE_SAMESITE
+    );
+  } else {
+    sanitizedEnv.COOKIE_SAMESITE = undefined;
+  }
 
   return sanitizedEnv;
 };
@@ -376,6 +415,8 @@ module.exports = {
   FRONTEND_ORIGINS,
   APP_DOMAIN: env.APP_DOMAIN,
   COOKIE_DOMAIN: env.COOKIE_DOMAIN,
+  COOKIE_SECURE: env.COOKIE_SECURE,
+  COOKIE_SAMESITE: env.COOKIE_SAMESITE,
   ENABLE_INSTALL: env.ENABLE_INSTALL,
   INSTALL_API_ENABLED: env.INSTALL_API_ENABLED,
   RATE_LIMIT_MAX_REQUESTS: env.RATE_LIMIT_MAX_REQUESTS,

--- a/backend/src/utils/cookie.js
+++ b/backend/src/utils/cookie.js
@@ -9,17 +9,43 @@
 // ---------------------------------------------------------------------------
 
 const { REFRESH_TOKEN_MAX_AGE } = require("../config/tokens");
-const { COOKIE_DOMAIN, NODE_ENV } = require("../config/env");
+const {
+  COOKIE_DOMAIN,
+  COOKIE_SECURE,
+  COOKIE_SAMESITE,
+  NODE_ENV,
+} = require("../config/env");
 
 // Use the provided cookie domain when available. Leaving it undefined allows
 // browsers to scope the cookie to the current host which works for local
 // development and custom deployments without additional configuration.
 const domain = COOKIE_DOMAIN ? COOKIE_DOMAIN.trim() || undefined : undefined;
 
+const secure =
+  COOKIE_SECURE !== undefined ? COOKIE_SECURE : NODE_ENV === "production";
+
+const resolveSameSite = () => {
+  if (COOKIE_SAMESITE) {
+    if (COOKIE_SAMESITE === "none") {
+      return "None";
+    }
+    if (COOKIE_SAMESITE === "lax") {
+      return "Lax";
+    }
+    if (COOKIE_SAMESITE === "strict") {
+      return "Strict";
+    }
+  }
+
+  return NODE_ENV === "production" ? "None" : "Lax";
+};
+
+const sameSite = resolveSameSite();
+
 const refreshCookieOptions = {
   httpOnly: true,
-  secure: NODE_ENV === 'production',
-  sameSite: NODE_ENV === 'production' ? 'None' : 'Lax',
+  secure,
+  sameSite,
   maxAge: REFRESH_TOKEN_MAX_AGE,
 };
 
@@ -28,8 +54,8 @@ const refreshCookieOptions = {
 // token to ensure it is available across subdomains in production.
 const csrfCookieOptions = {
   httpOnly: false,
-  secure: NODE_ENV === 'production',
-  sameSite: NODE_ENV === 'production' ? 'None' : 'Lax',
+  secure,
+  sameSite,
 };
 
 if (domain) {

--- a/backend/tests/authRefreshRoutes.test.js
+++ b/backend/tests/authRefreshRoutes.test.js
@@ -74,6 +74,53 @@ describe('POST /api/auth/refresh', () => {
     return { sessionCookie, csrfCookie, csrfToken };
   };
 
+  const createAppWithEnvOverrides = (overrides = {}) => {
+    const originalEnv = { ...process.env };
+    Object.entries(overrides).forEach(([key, value]) => {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    });
+
+    let result;
+
+    jest.isolateModules(() => {
+      const isolatedExpress = require('express');
+      const isolatedCookieParser = require('cookie-parser');
+      const isolatedSession = require('express-session');
+      const isolatedCsrf = require('../src/middleware/csrf');
+      const isolatedRoutes = require('../src/routes/auth');
+      const isolatedErrorHandler = require('../src/middleware/errorHandler');
+      const isolatedAuthService = require('../src/modules/auth/services/auth.service');
+
+      const isolatedApp = isolatedExpress();
+      isolatedApp.use(isolatedCookieParser());
+      isolatedApp.use(
+        isolatedSession({ secret: 'test', resave: false, saveUninitialized: true })
+      );
+      isolatedApp.use(isolatedExpress.json());
+      isolatedApp.use(isolatedCsrf);
+      isolatedApp.use(isolatedRoutes);
+      isolatedApp.use(isolatedErrorHandler);
+
+      result = { app: isolatedApp, authService: isolatedAuthService };
+    });
+
+    Object.keys(process.env).forEach((key) => {
+      if (!Object.prototype.hasOwnProperty.call(originalEnv, key)) {
+        delete process.env[key];
+      }
+    });
+
+    Object.entries(originalEnv).forEach(([key, value]) => {
+      process.env[key] = value;
+    });
+
+    return result;
+  };
+
   it('refreshes token with refresh cookie', async () => {
     authService.rotateRefreshToken.mockResolvedValue({
       decoded: { id: 1, role: 'User' },
@@ -154,5 +201,33 @@ describe('POST /api/auth/refresh', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringMatching(/CSRF token helper missing on refresh request.*skipping csrfToken cookie/i)
     );
+  });
+
+  it('allows refresh over HTTP when COOKIE_SECURE=false', async () => {
+    const { app: insecureApp, authService: insecureAuthService } =
+      createAppWithEnvOverrides({ COOKIE_SECURE: 'false' });
+
+    insecureAuthService.rotateRefreshToken.mockResolvedValue({
+      decoded: { id: 1, role: 'User' },
+      refreshToken: 'newR',
+    });
+    insecureAuthService.generateAccessToken.mockReturnValue('newA');
+
+    const csrfRes = await request(insecureApp).get('/api/auth/refresh');
+    const cookies = csrfRes.headers['set-cookie'] || [];
+    const sessionCookie = cookies.find((c) => c.startsWith('connect.sid'));
+    const csrfCookie = cookies.find((c) => c.startsWith('csrfToken='));
+    const csrfToken = csrfCookie?.split(';')[0].split('=')[1];
+
+    expect(csrfCookie).toBeDefined();
+    expect(csrfCookie).not.toContain('Secure');
+
+    const refreshRes = await request(insecureApp)
+      .post('/api/auth/refresh')
+      .set('Cookie', [`refreshToken=r`, sessionCookie, csrfCookie])
+      .set('x-csrf-token', csrfToken);
+
+    expect(refreshRes.status).toBe(200);
+    expect(insecureAuthService.rotateRefreshToken).toHaveBeenCalledWith('r');
   });
 });


### PR DESCRIPTION
## Summary
- parse the optional COOKIE_SECURE and COOKIE_SAMESITE environment variables and expose them through the config layer
- honor the new cookie security overrides when building refresh and CSRF cookie options
- cover a COOKIE_SECURE=false scenario to ensure the refresh route works over HTTP

## Testing
- npm test -- authRefreshRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e231321d248328a9b0f0449fe165b3