### PR TITLE
Ensure CSRF token refreshed before access token refresh

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -25,6 +25,7 @@ import {
 } from "@/services/messageService";
 import useSEOConfigStore from "@/store/seoConfigStore";
 import * as authService from "@/services/auth/authService";
+import { ensureCsrfToken } from "@/services/api/csrf";
 import { getFullProfile } from "@/services/profile/profileService";
 import Head from "next/head";
 import Script from "next/script";
@@ -88,6 +89,7 @@ function MyApp({ Component, pageProps, router }) {
 
     const init = async () => {
       try {
+        await ensureCsrfToken({ forceRefresh: true });
         const { accessToken } = await authService.refreshAccessToken();
         useAuthStore.setState({ accessToken });
         const res = await getFullProfile();

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -1,7 +1,7 @@
 // 📁 src/services/auth/authService.js
 import api from "@/services/api/api";
 import logger from "@/utils/logger";
-import { ensureCsrfToken } from "@/services/api/csrf";
+import { ensureCsrfToken, clearCachedCsrfToken } from "@/services/api/csrf";
 import { getCookie } from "@/utils/cookies";
 import { normalizeError } from "@/utils/error";
 
@@ -120,6 +120,7 @@ export const resetPassword = async ({ email, code, new_password }) => {
  */
 export const refreshAccessToken = async () => {
   try {
+    await ensureCsrfToken({ forceRefresh: true });
     const csrfToken = getCookie("csrfToken");
     const res = await api.post(
       "auth/refresh",
@@ -128,9 +129,9 @@ export const refreshAccessToken = async () => {
         headers: csrfToken ? { "x-csrf-token": csrfToken } : {},
       }
     );
-    await ensureCsrfToken();
     return res.data;
   } catch (err) {
+    clearCachedCsrfToken();
     throw normalizeError(err);
   }
 };


### PR DESCRIPTION
## Summary
- force a CSRF token refresh during hydration before requesting a new access token
- refresh CSRF tokens and clear cached values when calling refreshAccessToken to avoid stale cookies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e231393a9083289b8004ee5dea4b2f