### PR TITLE
Prevent duplicate admin class fetches

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -299,6 +299,16 @@ export default function AdminClassesTable() {
       }
     }
 
+    if (lastSuccessfulSignatureRef.current === requestDetails.signature) {
+      if (
+        pendingRequestRef.current &&
+        pendingRequestRef.current.signature === requestDetails.signature
+      ) {
+        pendingRequestRef.current = null;
+      }
+      return;
+    }
+
     if (inFlightRequestRef.current === requestDetails.signature) {
       return;
     }
@@ -461,8 +471,10 @@ export default function AdminClassesTable() {
           previousFailure?.toastShown;
         const shouldShowToast =
           isComponentMountedRef.current && !toastAlreadyShownForSignature;
-        const statusCode = err?.response?.status;
-        const isAuthFailure = statusCode === 401 || statusCode === 403;
+        const responseStatusCode = err?.response?.status;
+        const hadAuthFailure = authFailureRef.current;
+        const isAuthFailure =
+          responseStatusCode === 401 || responseStatusCode === 403;
         if (isAuthFailure) {
           authFailureRef.current = true;
           if (isComponentMountedRef.current) {
@@ -472,7 +484,7 @@ export default function AdminClassesTable() {
             setTotalPagesIfNeeded(1);
           }
         }
-        if (shouldShowToast && !isAuthFailure) {
+        if (shouldShowToast && (!isAuthFailure || !hadAuthFailure)) {
           toast.error("Failed to load classes");
         }
         clearFailedSignature();

--- a/frontend/tests/components/AdminClassesTablePagination.test.js
+++ b/frontend/tests/components/AdminClassesTablePagination.test.js
@@ -150,6 +150,52 @@ describe("AdminClassesTable schedule filtering", () => {
   });
 });
 
+describe("AdminClassesTable request deduplication", () => {
+  const mockedFetchAdminClasses = fetchAdminClasses;
+
+  beforeEach(() => {
+    mockedFetchAdminClasses.mockReset();
+    toast.error.mockClear();
+    toast.success.mockClear();
+  });
+
+  it("does not queue duplicate fetches after a successful load", async () => {
+    mockedFetchAdminClasses.mockResolvedValue({
+      data: [
+        {
+          id: "solo",
+          title: "Solo Class",
+          instructor: "Only Instructor",
+          start_date: "2024-01-01",
+          end_date: "2024-01-02",
+          category: "Category",
+          publishStatus: "draft",
+          approvalStatus: "Approved",
+          scheduleStatus: "Upcoming",
+          price: 0,
+        },
+      ],
+      meta: { totalPages: 1, total: 1 },
+    });
+
+    const { rerender } = render(<AdminClassesTable />);
+
+    expect(await screen.findByText("Solo Class")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockedFetchAdminClasses).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<AdminClassesTable />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockedFetchAdminClasses).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("AdminClassesTable page size control", () => {
   const mockedFetchAdminClasses = fetchAdminClasses;
 


### PR DESCRIPTION
## Summary
- skip executing admin class fetches when the computed request signature already matches the last success
- ensure authentication failures still surface a single toast while clearing redundant pending requests
- add a regression test that confirms no duplicate fetches are queued after a successful load

## Testing
- npm test -- AdminClassesTablePagination

------
https://chatgpt.com/codex/tasks/task_e_68e2326622908328abe9124dd9731cd7