### PR TITLE
Ensure refresh token requests obtain CSRF token when cookie missing

### DIFF
--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -120,7 +120,11 @@ export const resetPassword = async ({ email, code, new_password }) => {
  */
 export const refreshAccessToken = async () => {
   try {
-    const csrfToken = getCookie("csrfToken");
+    const existingToken = getCookie("csrfToken");
+    const csrfToken = await ensureCsrfToken({
+      forceRefresh: !existingToken,
+    });
+
     const res = await api.post(
       "auth/refresh",
       null,
@@ -128,6 +132,7 @@ export const refreshAccessToken = async () => {
         headers: csrfToken ? { "x-csrf-token": csrfToken } : {},
       }
     );
+
     await ensureCsrfToken();
     return res.data;
   } catch (err) {

--- a/frontend/src/tests/__tests__/tokenInterceptorRefresh.test.js
+++ b/frontend/src/tests/__tests__/tokenInterceptorRefresh.test.js
@@ -81,6 +81,12 @@ jest.mock("@/services/api/csrf", () => ({
   clearCachedCsrfToken: clearCachedCsrfTokenMock,
 }));
 
+const getCookieMock = jest.fn();
+jest.mock("@/utils/cookies", () => ({
+  __esModule: true,
+  getCookie: getCookieMock,
+}));
+
 describe("tokenInterceptor refresh logic", () => {
   let responseInterceptor;
   let authState;
@@ -94,6 +100,7 @@ describe("tokenInterceptor refresh logic", () => {
     loggerErrorMock.mockReset();
     ensureCsrfTokenMock.mockReset();
     clearCachedCsrfTokenMock.mockReset();
+    getCookieMock.mockReset();
     mockGetState.mockReset();
 
     apiMockInstance.mockClear();
@@ -183,5 +190,54 @@ describe("tokenInterceptor refresh logic", () => {
     expect(toastInfoMock).not.toHaveBeenCalled();
     expect(toastErrorMock).not.toHaveBeenCalled();
     expect(error.config.headers.Authorization).toBe("Bearer fresh-access");
+  });
+});
+
+describe("refreshAccessToken auth service", () => {
+  beforeEach(() => {
+    ensureCsrfTokenMock.mockReset();
+    clearCachedCsrfTokenMock.mockReset();
+    getCookieMock.mockReset();
+    apiPostMock.mockReset();
+    apiMockInstance.mockClear();
+  });
+
+  it("fetches a CSRF token before refreshing when no cookie is present", async () => {
+    getCookieMock.mockReturnValueOnce(null);
+    ensureCsrfTokenMock
+      .mockResolvedValueOnce("fetched-csrf")
+      .mockResolvedValueOnce("rotated-csrf");
+
+    apiPostMock.mockResolvedValueOnce({
+      data: { accessToken: "new-access" },
+    });
+
+    let refreshAccessToken;
+    jest.isolateModules(() => {
+      ({ refreshAccessToken } = require("@/services/auth/authService"));
+    });
+
+    const result = await refreshAccessToken();
+
+    expect(result).toEqual({ accessToken: "new-access" });
+
+    expect(getCookieMock).toHaveBeenCalledWith("csrfToken");
+    expect(ensureCsrfTokenMock).toHaveBeenCalledTimes(2);
+    expect(ensureCsrfTokenMock).toHaveBeenNthCalledWith(1, {
+      forceRefresh: true,
+    });
+    expect(ensureCsrfTokenMock.mock.calls[1]).toEqual([]);
+
+    expect(
+      ensureCsrfTokenMock.mock.invocationCallOrder[0]
+    ).toBeLessThan(apiPostMock.mock.invocationCallOrder[0]);
+
+    expect(apiPostMock).toHaveBeenCalledWith(
+      "auth/refresh",
+      null,
+      expect.objectContaining({
+        headers: { "x-csrf-token": "fetched-csrf" },
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- call ensureCsrfToken before refresh requests to fetch a token when the cookie is absent
- continue caching refreshed CSRF tokens after refresh calls
- add unit coverage for the no-cookie refresh scenario to assert the token is fetched prior to posting

## Testing
- npm test -- --runTestsByPath src/tests/__tests__/tokenInterceptorRefresh.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e23265fd048328baa7c8d5603732f1