### PR TITLE
Fix duplicate isMounted declaration in class analytics page

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -42,8 +42,6 @@ function AnalyticsDashboard() {
       };
     }
 
-    let isMounted = true;
-
     setStats(null);
     fetchAdminClassAnalytics(classId)
       .then((data) => {


### PR DESCRIPTION
## Summary
- remove the duplicate `isMounted` declaration in the admin class analytics page so the effect lifecycle uses a single flag

## Testing
- npm --prefix frontend run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2581d20408328b4ae7ddbbb0e0227