### PR TITLE
Fix duplicated isMounted guard in admin analytics page

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -42,8 +42,6 @@ function AnalyticsDashboard() {
       };
     }
 
-    let isMounted = true;
-
     setStats(null);
     fetchAdminClassAnalytics(classId)
       .then((data) => {


### PR DESCRIPTION
## Summary
- remove the duplicate `isMounted` declaration in the admin class analytics effect
- keep the early-return cleanup to reuse the same flag and avoid crashes when loading analytics

## Testing
- npx eslint src/pages/dashboard/admin/online-classes/[id]/analytics.js

------
https://chatgpt.com/codex/tasks/task_e_68e25822e9f88328af1b0eb2728ac2d8