### PR TITLE
Fix duplicate isMounted declaration in analytics page

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/analytics.js
@@ -42,8 +42,6 @@ function AnalyticsDashboard() {
       };
     }
 
-    let isMounted = true;
-
     setStats(null);
     fetchAdminClassAnalytics(classId)
       .then((data) => {


### PR DESCRIPTION
## Summary
- remove the duplicate isMounted declaration inside the admin online class analytics effect
- keep the cleanup function focused on flipping the single isMounted flag to false

## Testing
- npm run build *(fails: existing syntax errors in CategoryPieChart.js and classService.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e25828ae588328a64237b311573466