### PR TITLE
Update admin online classes access permission

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/index.js
@@ -38,7 +38,7 @@ const ProtectedAdminOnlineClassesPage = withAuthProtection(
   AdminOnlineClassesPage,
   {
     roles: ["admin", "superadmin"],
-    permissions: ["view_online_classes"],
+    permissions: ["manage_online_classes"],
   }
 );
 

--- a/frontend/tests/hooks/withAuthProtection.test.js
+++ b/frontend/tests/hooks/withAuthProtection.test.js
@@ -42,7 +42,7 @@ describe('withAuthProtection permissions', () => {
         id: 'admin-1',
         role: 'Admin',
         roles: ['Admin'],
-        permissions: ['view_online_classes'],
+        permissions: [],
       },
       accessToken: 'valid.token.value',
       hasHydrated: true,
@@ -57,7 +57,7 @@ describe('withAuthProtection permissions', () => {
   });
 
   it('allows admins with manage_online_classes permission to continue', async () => {
-    storeState.user.permissions.push('manage_online_classes');
+    storeState.user.permissions = ['manage_online_classes'];
 
     const ProtectedComponent = withAuthProtection(TestComponent, {
       permissions: ['manage_online_classes'],


### PR DESCRIPTION
## Summary
- require the manage_online_classes permission to access the admin online classes page
- adjust auth protection tests to reflect the new permission requirement

## Testing
- npm test -- hooks/withAuthProtection.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e28842f5f8832881f6f31efb7be3eb