### PR TITLE
Use relative API paths for messaging services

### DIFF
--- a/frontend/src/services/messageService.js
+++ b/frontend/src/services/messageService.js
@@ -10,7 +10,7 @@ const socket = getSocket();
 
 
 export const getUsers = async () => {
-  const res = await api.get("/chat/users");
+  const res = await api.get("chat/users");
   const data = res.data.data || res.data;
   return (data || []).map((u) => ({
     ...u,
@@ -20,7 +20,7 @@ export const getUsers = async () => {
 };
 
 export const getGroups = async () => {
-  const res = await api.get("/groups/my");
+  const res = await api.get("groups/my");
   const data = res.data.data || res.data;
   return (data || []).map((g) => ({
     ...g,
@@ -33,7 +33,7 @@ export const getMessages = async ({ limit, offset } = {}) => {
   const params = {};
   if (limit !== undefined) params.limit = limit;
   if (offset !== undefined) params.offset = offset;
-  const res = await api.get("/messages", { params });
+  const res = await api.get("messages", { params });
   return res.data.data || res.data;
 };
 
@@ -41,7 +41,7 @@ export const markMessageAsRead = async (id) => {
   const headers = {};
   const token = getCsrfToken();
   if (token) headers["x-csrf-token"] = token;
-  const res = await api.patch(`/messages/${id}/read`, {}, { headers });
+  const res = await api.patch(`messages/${id}/read`, {}, { headers });
   return res.data.data || res.data;
 };
 
@@ -49,23 +49,23 @@ export const deleteMessage = async (id) => {
   const headers = {};
   const token = getCsrfToken();
   if (token) headers["x-csrf-token"] = token;
-  const res = await api.delete(`/messages/${id}`, { headers });
+  const res = await api.delete(`messages/${id}`, { headers });
   return res.data.data || res.data;
 };
 
 export const sendDirectEmail = async (userId, { subject, message }) => {
-  const res = await api.post(`/messages/${userId}/email`, { subject, message });
+  const res = await api.post(`messages/${userId}/email`, { subject, message });
   return res.data.data || res.data;
 };
 
 export const sendWhatsAppMessage = async (userId, { message }) => {
-  const res = await api.post(`/messages/${userId}/whatsapp`, { message });
+  const res = await api.post(`messages/${userId}/whatsapp`, { message });
   return res.data.data || res.data;
 };
 
 export const startVideoCall = async (userId) => {
   try {
-    const res = await api.post(`/messages/${userId}/video-call`);
+    const res = await api.post(`messages/${userId}/video-call`);
     const { roomId, callId } = res.data.data || res.data;
     useCallStore.getState().initiateCall({ chatId: userId, roomId, callId });
     const caller = useAuthStore.getState().user;
@@ -80,17 +80,17 @@ export const startVideoCall = async (userId) => {
 };
 
 export const respondToCall = async (callId, action) => {
-  const res = await api.post(`/messages/call/${callId}/respond`, { action });
+  const res = await api.post(`messages/call/${callId}/respond`, { action });
   return res.data.data || res.data;
 };
 
 export const endCall = async (callId) => {
-  const res = await api.post(`/messages/call/${callId}/end`);
+  const res = await api.post(`messages/call/${callId}/end`);
   return res.data.data || res.data;
 };
 
 export const getConversation = async (userId) => {
-  const res = await api.get(`/chat/${userId}`);
+  const res = await api.get(`chat/${userId}`);
   return res.data.data || res.data;
 };
 
@@ -100,19 +100,19 @@ export const sendChatMessage = async (userId, { text, file, audio, replyId }) =>
   if (file) form.append("file", file);
   if (audio) form.append("audio", audio);
   if (replyId) form.append("replyTo", replyId);
-  const res = await api.post(`/chat/${userId}`, form, {
+  const res = await api.post(`chat/${userId}`, form, {
     headers: { "Content-Type": "multipart/form-data" },
   });
   return res.data.data || res.data;
 };
 
 export const deleteChatMessage = async (id) => {
-  const res = await api.delete(`/chat/messages/${id}`);
+  const res = await api.delete(`chat/messages/${id}`);
   return res.data.data || res.data;
 };
 
 export const togglePinMessage = async (id) => {
-  const res = await api.patch(`/chat/messages/${id}/pin`);
+  const res = await api.patch(`chat/messages/${id}/pin`);
   return res.data.data || res.data;
 };
 

--- a/frontend/src/services/notificationService.js
+++ b/frontend/src/services/notificationService.js
@@ -3,7 +3,7 @@ import { getCsrfToken } from "@/services/api/csrf";
 import logger from "@/utils/logger";
 
 export const getNotifications = async () => {
-  const res = await api.get("/notifications");
+  const res = await api.get("notifications");
   return res.data.data || res.data;
 };
 
@@ -11,7 +11,7 @@ export const markNotificationAsRead = async (id) => {
   const headers = {};
   const token = getCsrfToken();
   if (token) headers["x-csrf-token"] = token;
-  const res = await api.patch(`/notifications/${id}/read`, {}, { headers });
+  const res = await api.patch(`notifications/${id}/read`, {}, { headers });
   return res.data.data || res.data;
 };
 
@@ -19,12 +19,12 @@ export const deleteNotification = async (id) => {
   const headers = {};
   const token = getCsrfToken();
   if (token) headers["x-csrf-token"] = token;
-  const res = await api.delete(`/notifications/${id}`, { headers });
+  const res = await api.delete(`notifications/${id}`, { headers });
   return res.data.data || res.data;
 };
 
 export const createNotification = async (payload) => {
-  const res = await api.post('/notifications', payload);
+  const res = await api.post("notifications", payload);
   return res.data.data || res.data;
 };
 

--- a/frontend/src/tests/pages/dashboard/admin/online-classes/index.test.jsx
+++ b/frontend/src/tests/pages/dashboard/admin/online-classes/index.test.jsx
@@ -97,6 +97,55 @@ describe("AdminClassesTable status toggling", () => {
     });
   });
 
+  it("approves a class without showing an error toast", async () => {
+    approveAdminClassMock.mockResolvedValue({ publishStatus: "published" });
+
+    render(<AdminClassesTable />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Approve" })[0]).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Approve" })[0]);
+
+    await waitFor(() => {
+      expect(approveAdminClassMock).toHaveBeenCalledWith("class-1");
+    });
+
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith("Class approved");
+    });
+
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a class without showing an error toast", async () => {
+    rejectAdminClassMock.mockResolvedValue(undefined);
+
+    render(<AdminClassesTable />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Reject" })[0]).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Reject" })[0]);
+
+    const reasonField = await screen.findByPlaceholderText("Enter rejection reason");
+    fireEvent.change(reasonField, { target: { value: "Not a good fit" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Yes, Reject" }));
+
+    await waitFor(() => {
+      expect(rejectAdminClassMock).toHaveBeenCalledWith("class-1", "Not a good fit");
+    });
+
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith("Class rejected");
+    });
+
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
   it("replaces the entire row with the refreshed class after toggling publish status", async () => {
     const refreshedClass = {
       ...baseClass,


### PR DESCRIPTION
## Summary
- update notification service endpoints to call the API client with relative paths
- adjust message service routes to avoid leading slashes while preserving functionality
- extend AdminClassesTable tests to cover approve, reject, and toggle flows without error toasts

## Testing
- npm test -- --runTestsByPath src/tests/pages/dashboard/admin/online-classes/index.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e289460e748328a2bcaa0bfed31005