### PR TITLE
Fix instructor class creation service and add tests

### DIFF
--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -81,13 +81,19 @@ export const fetchInstructorClassById = async (id) => {
 
 export const createInstructorClass = async (payload, onUploadProgress) => {
   await ensureCsrfToken();
-  const config = {
-    headers: {
-      "Content-Type": "multipart/form-data",
-    },
-    ...(onUploadProgress ? { onUploadProgress } : {}),
+  const headers = await buildCsrfHeaders({
+    "Content-Type": "multipart/form-data",
   });
-  return formatClass(response.data?.data);
+  const config = {
+    headers,
+    ...(onUploadProgress ? { onUploadProgress } : {}),
+  };
+  const { data } = await api.post(
+    "users/classes/instructor",
+    payload,
+    config,
+  );
+  return data?.data ? formatClass(data.data) : null;
 };
 
 export const updateInstructorClass = async (id, payload) => {

--- a/frontend/tests/services/instructor/classService.test.js
+++ b/frontend/tests/services/instructor/classService.test.js
@@ -1,0 +1,81 @@
+import api from '@/services/api/api';
+import { ensureCsrfToken } from '@/services/api/csrf';
+import { createInstructorClass } from '@/services/instructor/classService';
+
+jest.mock('@/services/api/api', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+    get: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    patch: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/api/csrf', () => ({
+  ensureCsrfToken: jest.fn(),
+}));
+
+describe('createInstructorClass', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('posts the class payload and returns formatted class data', async () => {
+    ensureCsrfToken.mockResolvedValue('csrf-token');
+    const apiResponse = {
+      data: {
+        data: {
+          id: 42,
+          title: 'New Class',
+          status: 'draft',
+          trending: 0,
+          cover_image: null,
+          demo_video_url: null,
+          instructor_image: null,
+          start_date: null,
+          end_date: null,
+          views: 5,
+        },
+      },
+    };
+    api.post.mockResolvedValue(apiResponse);
+
+    const payload = new FormData();
+    const onUploadProgress = jest.fn();
+
+    const result = await createInstructorClass(payload, onUploadProgress);
+
+    expect(ensureCsrfToken).toHaveBeenCalled();
+    expect(api.post).toHaveBeenCalledWith(
+      'users/classes/instructor',
+      payload,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'multipart/form-data',
+          'x-csrf-token': 'csrf-token',
+        }),
+        onUploadProgress,
+      }),
+    );
+    expect(result).toMatchObject({
+      id: 42,
+      title: 'New Class',
+      publishStatus: 'draft',
+      trending: false,
+      start_date: null,
+      end_date: null,
+      views: 5,
+    });
+  });
+
+  it('returns null when API responds without data', async () => {
+    ensureCsrfToken.mockResolvedValue('csrf-token');
+    api.post.mockResolvedValue({ data: {} });
+
+    const result = await createInstructorClass(new FormData());
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `createInstructorClass` posts multipart data with CSRF headers and returns formatted results
- add unit coverage for the instructor class creation helper to validate request config and response handling

## Testing
- npm test -- classService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e293017c28832894d823c7cf5712ff