### PR TITLE
Restrict instructor class query overrides

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -1,6 +1,8 @@
 const request = require('supertest');
 const express = require('express');
 
+let mockUser = { id: 'test-user', role: 'instructor' };
+
 // Mock database to avoid connection attempts
 jest.mock('../../../config/database', () => {
   const db = jest.fn(() => db);
@@ -50,7 +52,7 @@ jest.mock('../../../middleware/validate', () => () => (req, _res, next) => next(
 // Mock auth middleware to bypass authentication
 jest.mock('../../../middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
-    req.user = { id: 'test-user', role: 'instructor' };
+    req.user = { ...mockUser };
     next();
   },
   isStudent: (_req, _res, next) => next(),
@@ -77,6 +79,7 @@ app.use((err, _req, res, _next) => {
 describe('Class routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUser = { id: 'test-user', role: 'instructor' };
     getActiveInstructorPlan.mockResolvedValue({ id: 'plan1', max_courses: 10 });
     planService.getPlanById.mockResolvedValue({
       id: 'plan1',
@@ -154,6 +157,50 @@ describe('Class routes', () => {
     expect(res.body.data).toEqual(list);
     expect(res.body.meta).toEqual(result.meta);
     expect(service.getClassesByInstructor).toHaveBeenCalledWith('test-user', { page: 1, limit: 5 });
+  });
+
+  test('instructor cannot override instructorId when fetching own classes', async () => {
+    mockUser = { id: 'instructor-123', role: 'instructor' };
+    const list = [{ id: '1', instructor_id: 'instructor-123', title: 'Mine' }];
+    const result = {
+      data: list,
+      meta: { page: 1, limit: 3, total: 1, totalPages: 1 },
+    };
+    service.getClassesByInstructor.mockResolvedValue(result);
+
+    const res = await request(app).get(
+      '/classes/instructor/my?instructorId=other-instructor&limit=3'
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual(list);
+    expect(res.body.meta).toEqual(result.meta);
+    expect(service.getClassesByInstructor).toHaveBeenCalledWith('instructor-123', {
+      page: 1,
+      limit: 3,
+    });
+  });
+
+  test('admin can override instructorId when fetching instructor classes', async () => {
+    mockUser = { id: 'admin-user', role: 'admin' };
+    const list = [{ id: '1', instructor_id: 'target-instructor', title: 'Other' }];
+    const result = {
+      data: list,
+      meta: { page: 2, limit: 2, total: 1, totalPages: 1 },
+    };
+    service.getClassesByInstructor.mockResolvedValue(result);
+
+    const res = await request(app).get(
+      '/classes/admin/my?instructorId=target-instructor&page=2&limit=2'
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual(list);
+    expect(res.body.meta).toEqual(result.meta);
+    expect(service.getClassesByInstructor).toHaveBeenCalledWith('target-instructor', {
+      page: 2,
+      limit: 2,
+    });
   });
 
   test('get published classes', async () => {

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -11,6 +11,7 @@ const { getActiveInstructorPlan } = require("../plans/instructor.helper");
 const planService = require("../plans/plans.service");
 const AppError = require("../../utils/AppError");
 const { parsePlanFeatures } = require("../../utils/planFeatures");
+const { isAdminRole } = require("../../utils/role");
 
 const slugify = require("slugify");
 const db = require("../../config/database");
@@ -246,7 +247,8 @@ exports.getClassById = catchAsync(async (req, res) => {
 
 exports.getMyClasses = catchAsync(async (req, res) => {
   const { page = 1, limit = 10, instructorId } = req.query;
-  const targetId = instructorId || req.user.id;
+  const isAdmin = isAdminRole(req.user?.roles || req.user?.role);
+  const targetId = isAdmin && instructorId ? instructorId : req.user.id;
   const result = await service.getClassesByInstructor(targetId, {
     page: Number(page),
     limit: Number(limit),


### PR DESCRIPTION
## Summary
- ensure getMyClasses only honors the instructorId query parameter for admin users
- import the shared isAdminRole helper into the class controller
- cover instructor and admin class listing routes with tests for query override behavior

## Testing
- npm test -- class.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e293036d5083289b02a6a70e7b3dac