### PR TITLE
Clarify class approval plan messaging

### DIFF
--- a/backend/src/modules/classes/__tests__/class.routes.test.js
+++ b/backend/src/modules/classes/__tests__/class.routes.test.js
@@ -185,6 +185,29 @@ describe('Class routes', () => {
     expect(res.body.data).toEqual(approved);
   });
 
+  test('approve class fails without active plan', async () => {
+    getActiveInstructorPlan.mockResolvedValueOnce(null);
+
+    const res = await request(app).patch('/classes/admin/1/approve');
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toBe(
+      'Active instructor plan required to approve classes'
+    );
+    expect(service.updateModeration).not.toHaveBeenCalled();
+  });
+
+  test('approve class fails when max courses reached', async () => {
+    getActiveInstructorPlan.mockResolvedValueOnce({ id: 'plan1', max_courses: 1 });
+    service.countPublishedClasses.mockResolvedValueOnce(1);
+
+    const res = await request(app).patch('/classes/admin/1/approve');
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toBe('Course limit reached for your plan');
+    expect(service.updateModeration).not.toHaveBeenCalled();
+  });
+
   test('instructor can create class within plan limit', async () => {
     const data = {
       id: '1',

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -506,7 +506,10 @@ exports.approveClass = catchAsync(async (req, res) => {
   if (!existing) throw new AppError("Class not found", 404);
   const plan = await getActiveInstructorPlan(existing.instructor_id);
   if (!plan) {
-    throw new AppError("Course limit reached for your plan", 403);
+    throw new AppError(
+      "Active instructor plan required to approve classes",
+      403
+    );
   }
   if (plan.max_courses) {
     const count = await service.countPublishedClasses(existing.instructor_id);

--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -730,7 +730,11 @@ export default function AdminClassesTable() {
 
     } catch (err) {
       console.error(err);
-      toast.error("Failed to update class");
+      const errorMessage =
+        err?.response?.data?.message ||
+        err?.message ||
+        "Failed to update class";
+      toast.error(errorMessage);
     } finally {
       setModalClass(null);
     }


### PR DESCRIPTION
## Summary
- update class approval logic to report a missing active instructor plan with a clear error
- show admins the API error message when class approval fails in the dashboard
- add coverage ensuring the missing plan and max course limit errors return the expected copy

## Testing
- npm test -- class.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e293314e9083288aa1ee3f4230416a