### PR TITLE
Use plan payment helper for class enrollment

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -47,8 +47,8 @@ jest.mock('../../../payments/helpers/wallet', () => ({
   creditInstructorSubscription: jest.fn(),
 }));
 
-jest.mock('../../../payments/helpers/methods.js', () => ({
-  getPlanCoveredMethod: jest.fn(),
+jest.mock('../../../payments/helpers/planPayments', () => ({
+  recordPlanCoveredPayment: jest.fn(),
 }));
 
 jest.mock('../../../../utils/logger.js', () => ({
@@ -60,12 +60,9 @@ jest.mock('../../../../utils/logger.js', () => ({
 
 const { getActiveStudentPlanId } = require('../../../plans/subscription.helper');
 const { creditInstructorSubscription } = require('../../../payments/helpers/wallet');
-const { getPlanCoveredMethod } = require('../../../payments/helpers/methods.js');
+const { recordPlanCoveredPayment } = require('../../../payments/helpers/planPayments');
 const logger = require('../../../../utils/logger.js');
 const db = require('../../../../config/database');
-const paymentsService = require('../../../payments/payments.service');
-const paymentMethodsService = require('../../../paymentMethods/paymentMethods.service');
-
 const routes = require('../../class.routes');
 
 const app = express();
@@ -75,7 +72,6 @@ app.use('/classes', routes);
 describe('Class enrollment routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getPlanCoveredMethod.mockResolvedValue({ id: 'plan-method' });
   });
 
   test('enroll in class', async () => {
@@ -145,7 +141,6 @@ describe('Class enrollment routes', () => {
     service.countEnrollments.mockResolvedValue(0);
     service.findEnrollment.mockResolvedValue(null);
     getActiveStudentPlanId.mockResolvedValue('plan1');
-    paymentMethodsService.getByType.mockResolvedValueOnce({ id: 'subscription-method' });
     service.createEnrollment.mockResolvedValue({ id: '1' });
     recordPlanCoveredPayment.mockResolvedValue({ id: 'payment-id' });
     const res = await request(app).post('/classes/enroll/abc');
@@ -161,16 +156,14 @@ describe('Class enrollment routes', () => {
     expect(creditInstructorSubscription).toHaveBeenCalledTimes(1);
     expect(recordPlanCoveredPayment).toHaveBeenCalledWith(
       expect.objectContaining({
-        user_id: 'test-user',
-        method_id: 'plan-method',
-        item_id: 'abc',
-        item_type: 'class',
-        source: 'subscription',
+        trx: db,
+        userId: 'test-user',
+        itemId: 'abc',
+        itemType: 'class',
+        amount: 0,
+        currency: 'USD',
       }),
-      [],
-      db,
     );
-    expect(getPlanCoveredMethod).toHaveBeenCalledTimes(1);
   });
 
   test('reject enrollment when subscription active but class not covered', async () => {

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -10,7 +10,6 @@ const { recordPlanCoveredPayment } = require("../../payments/helpers/planPayment
 const { getActiveStudentPlanId } = require("../../plans/subscription.helper");
 const { creditInstructorSubscription } = require("../../payments/helpers/wallet");
 const planRevenue = require("../../payments/helpers/planRevenue");
-const { getPlanCoveredMethod } = require("../../payments/helpers/methods");
 
 exports.enroll = catchAsync(async (req, res) => {
   const { classId } = req.params;
@@ -45,8 +44,6 @@ exports.enroll = catchAsync(async (req, res) => {
       activePlanId && includedPlans.includes(activePlanId);
 
     if (coveredBySubscription) {
-      const planMethod = await getPlanCoveredMethod(trx);
-
       const usage = await trx("plan_usage_metrics")
         .where({ plan_id: activePlanId, item_type: "class", item_id: classId })
         .first();
@@ -70,12 +67,13 @@ exports.enroll = catchAsync(async (req, res) => {
         trx,
         "class"
       );
-      await trx("payments").insert({
-        user_id,
-        method_id: planMethod.id,
-        item_id: classId,
-        item_type: "class",
-        source: "subscription",
+      await recordPlanCoveredPayment({
+        trx,
+        userId: user_id,
+        itemId: classId,
+        itemType: "class",
+        amount: 0,
+        currency: cls.currency || "USD",
       });
       await creditInstructorSubscription("class", classId, activePlanId, trx);
     } else if (Number(cls.price) > 0) {


### PR DESCRIPTION
## Summary
- replace the manual plan-covered payment insert in class enrollment with the shared helper that records amount and currency
- tidy related test mocks and expectations to validate the helper call for subscription-covered enrollments

## Testing
- npm test -- classEnrollment.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2933103548328adfe6ecbf47d67e4