### PR TITLE
Limit class reminders to subscribed active students

### DIFF
--- a/backend/src/jobs/classReminderJob.js
+++ b/backend/src/jobs/classReminderJob.js
@@ -1,6 +1,6 @@
 const logger = require('../utils/logger.js');
 const classService = require("../modules/classes/class.service");
-const enrollmentService = require("../modules/classes/enrollments/classEnrollment.service");
+const notificationService = require("../modules/classes/notifications/classNotification.service");
 const smsService = require("../services/smsService");
 const { sendClassReminderEmail } = require("../utils/email");
 
@@ -12,7 +12,7 @@ function startClassReminderJob() {
     try {
       const classes = await classService.getClassesStartingBetween(startWindow, endWindow);
       for (const cls of classes) {
-        const students = await enrollmentService.getByClass(cls.id);
+        const students = await notificationService.getSubscribedStudentsByClass(cls.id);
         for (const student of students) {
           const startTime = new Date(cls.start_date).toLocaleString();
           const text = `Reminder: ${cls.title} starts at ${startTime}`;

--- a/backend/src/modules/classes/notifications/__tests__/classNotification.service.test.js
+++ b/backend/src/modules/classes/notifications/__tests__/classNotification.service.test.js
@@ -1,0 +1,129 @@
+const { newDb } = require('pg-mem');
+const { v4: uuidv4 } = require('uuid');
+
+const db = newDb();
+db.public.registerFunction({ name: 'uuid_generate_v4', returns: 'uuid', implementation: uuidv4 });
+const mockDb = db.adapters.createKnex();
+
+jest.mock('../../../../config/database', () => mockDb);
+
+const service = require('../classNotification.service');
+
+describe('classNotification.service', () => {
+  const classId = uuidv4();
+  const activeUserId = uuidv4();
+  const cancelledUserId = uuidv4();
+  const unsubscribedUserId = uuidv4();
+
+  beforeAll(async () => {
+    await mockDb.schema.createTable('users', (table) => {
+      table.uuid('id').primary();
+      table.string('full_name');
+      table.string('email');
+      table.string('phone');
+      table.string('locale');
+    });
+
+    await mockDb.schema.createTable('class_enrollments', (table) => {
+      table.uuid('id').primary();
+      table.uuid('user_id');
+      table.uuid('class_id');
+      table.string('status');
+      table.timestamp('enrolled_at');
+    });
+
+    await mockDb.schema.createTable('class_reminder_subscriptions', (table) => {
+      table.uuid('id').primary();
+      table.uuid('user_id');
+      table.uuid('class_id');
+      table.timestamp('created_at');
+    });
+  });
+
+  afterAll(async () => {
+    await mockDb.destroy();
+  });
+
+  beforeEach(async () => {
+    await mockDb('class_reminder_subscriptions').del();
+    await mockDb('class_enrollments').del();
+    await mockDb('users').del();
+
+    await mockDb('users').insert([
+      {
+        id: activeUserId,
+        full_name: 'Active Student',
+        email: 'active@example.com',
+        phone: '555-1000',
+        locale: 'en-US',
+      },
+      {
+        id: cancelledUserId,
+        full_name: 'Cancelled Student',
+        email: 'cancelled@example.com',
+        phone: '555-2000',
+        locale: 'en-US',
+      },
+      {
+        id: unsubscribedUserId,
+        full_name: 'Unsubscribed Student',
+        email: 'unsubscribed@example.com',
+        phone: '555-3000',
+        locale: 'en-US',
+      },
+    ]);
+
+    await mockDb('class_enrollments').insert([
+      {
+        id: uuidv4(),
+        user_id: activeUserId,
+        class_id: classId,
+        status: 'enrolled',
+        enrolled_at: new Date('2024-01-01T10:00:00Z'),
+      },
+      {
+        id: uuidv4(),
+        user_id: cancelledUserId,
+        class_id: classId,
+        status: 'cancelled',
+        enrolled_at: new Date('2024-01-02T10:00:00Z'),
+      },
+      {
+        id: uuidv4(),
+        user_id: unsubscribedUserId,
+        class_id: classId,
+        status: 'enrolled',
+        enrolled_at: new Date('2024-01-03T10:00:00Z'),
+      },
+    ]);
+
+    await mockDb('class_reminder_subscriptions').insert([
+      {
+        id: uuidv4(),
+        user_id: activeUserId,
+        class_id: classId,
+        created_at: new Date('2024-01-01T11:00:00Z'),
+      },
+      {
+        id: uuidv4(),
+        user_id: cancelledUserId,
+        class_id: classId,
+        created_at: new Date('2024-01-02T11:00:00Z'),
+      },
+    ]);
+  });
+
+  test('returns only active, subscribed students', async () => {
+    const students = await service.getSubscribedStudentsByClass(classId);
+
+    expect(students).toHaveLength(1);
+    expect(students[0]).toEqual(
+      expect.objectContaining({
+        email: 'active@example.com',
+        phone: '555-1000',
+        status: 'enrolled',
+        locale: 'en-US',
+      }),
+    );
+  });
+});

--- a/backend/src/modules/classes/notifications/classNotification.service.js
+++ b/backend/src/modules/classes/notifications/classNotification.service.js
@@ -1,6 +1,8 @@
 const db = require('../../../config/database');
 const { v4: uuidv4 } = require('uuid');
 
+const ACTIVE_ENROLLMENT_STATUSES = ['enrolled'];
+
 exports.subscribe = async (userId, classId) => {
   const [item] = await db('class_reminder_subscriptions')
     .insert({ id: uuidv4(), user_id: userId, class_id: classId })
@@ -9,3 +11,36 @@ exports.subscribe = async (userId, classId) => {
     .returning('*');
   return item;
 };
+
+exports.getSubscribedStudentsByClass = async (
+  classId,
+  statuses = ACTIVE_ENROLLMENT_STATUSES,
+) => {
+  if (!Array.isArray(statuses) || statuses.length === 0) {
+    statuses = ACTIVE_ENROLLMENT_STATUSES;
+  }
+
+  return db('class_reminder_subscriptions as crs')
+    .join('class_enrollments as ce', function joinEnrollments() {
+      this.on('crs.user_id', '=', 'ce.user_id').andOn(
+        'crs.class_id',
+        '=',
+        'ce.class_id',
+      );
+    })
+    .join('users as u', 'ce.user_id', 'u.id')
+    .where('crs.class_id', classId)
+    .whereIn('ce.status', statuses)
+    .select(
+      'u.id',
+      'u.full_name',
+      'u.email',
+      'u.phone',
+      'u.locale',
+      'ce.status',
+      'ce.enrolled_at',
+    )
+    .orderBy('ce.enrolled_at');
+};
+
+exports.ACTIVE_ENROLLMENT_STATUSES = ACTIVE_ENROLLMENT_STATUSES;

--- a/backend/tests/classReminderJob.test.js
+++ b/backend/tests/classReminderJob.test.js
@@ -2,8 +2,8 @@ jest.mock('../src/modules/classes/class.service', () => ({
   getClassesStartingBetween: jest.fn(),
 }));
 
-jest.mock('../src/modules/classes/enrollments/classEnrollment.service', () => ({
-  getByClass: jest.fn(),
+jest.mock('../src/modules/classes/notifications/classNotification.service', () => ({
+  getSubscribedStudentsByClass: jest.fn(),
 }));
 
 jest.mock('../src/services/smsService', () => ({
@@ -15,7 +15,7 @@ jest.mock('../src/utils/email', () => ({
 }));
 
 const classService = require('../src/modules/classes/class.service');
-const enrollmentService = require('../src/modules/classes/enrollments/classEnrollment.service');
+const notificationService = require('../src/modules/classes/notifications/classNotification.service');
 const smsService = require('../src/services/smsService');
 const { sendClassReminderEmail } = require('../src/utils/email');
 const startClassReminderJob = require('../src/jobs/classReminderJob');
@@ -33,17 +33,17 @@ describe('classReminderJob', () => {
     global.setInterval.mockRestore();
   });
 
-  test('dispatches email and sms to enrolled students', async () => {
+  test('dispatches email and sms only to subscribed students', async () => {
     const cls = { id: 1, title: 'Math', start_date: '2023-01-01T00:00:00Z' };
-    const student = { email: 's@example.com', phone: '123', locale: 'en-US' };
+    const subscribedStudent = { email: 's@example.com', phone: '123', locale: 'en-US' };
     classService.getClassesStartingBetween.mockResolvedValue([cls]);
-    enrollmentService.getByClass.mockResolvedValue([student]);
+    notificationService.getSubscribedStudentsByClass.mockResolvedValue([subscribedStudent]);
 
     startClassReminderJob();
     await new Promise(setImmediate);
 
     expect(classService.getClassesStartingBetween).toHaveBeenCalled();
-    expect(enrollmentService.getByClass).toHaveBeenCalledWith(cls.id);
+    expect(notificationService.getSubscribedStudentsByClass).toHaveBeenCalledWith(cls.id);
     expect(smsService.sendSMS).toHaveBeenCalledWith({
       to: '123',
       text: expect.stringContaining('Reminder'),
@@ -54,6 +54,18 @@ describe('classReminderJob', () => {
       cls.start_date,
       'en-US'
     );
+  });
+
+  test('skips sending reminders when no students are subscribed', async () => {
+    const cls = { id: 1, title: 'Math', start_date: '2023-01-01T00:00:00Z' };
+    classService.getClassesStartingBetween.mockResolvedValue([cls]);
+    notificationService.getSubscribedStudentsByClass.mockResolvedValue([]);
+
+    startClassReminderJob();
+    await new Promise(setImmediate);
+
+    expect(smsService.sendSMS).not.toHaveBeenCalled();
+    expect(sendClassReminderEmail).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- add a subscription-aware enrollment query that only returns active class reminder subscribers
- update the reminder job to use the subscription-aware query so only opted-in, active students are contacted
- add unit tests covering the reminder job and subscription query filtering behavior

## Testing
- npm test -- classReminderJob
- npm test -- classNotification

------
https://chatgpt.com/codex/tasks/task_e_68e298bb7d088328bfc0fc99ec95b768