### PR TITLE
Auto-approve admin published classes

### DIFF
--- a/backend/src/modules/classes/__tests__/class.controller.test.js
+++ b/backend/src/modules/classes/__tests__/class.controller.test.js
@@ -204,6 +204,53 @@ describe('class.controller createClass', () => {
     );
   });
 
+  test('auto-approves published classes created by admins', async () => {
+    service.createClass.mockImplementation(async (data) => data);
+
+    const req = {
+      body: {
+        title: 'Admin Published Class',
+        status: 'published',
+        instructor_id: 'instructor1',
+      },
+      user: { id: 'admin1', role: 'admin', roles: ['admin'] },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      res.json.mockImplementation((data) => {
+        resolve();
+        return data;
+      });
+      next.mockImplementation((err) => {
+        resolve();
+        return err;
+      });
+      controller.createClass(req, res, next);
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(service.createClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'published',
+        moderation_status: 'Approved',
+      })
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'published',
+          moderation_status: 'Approved',
+        }),
+      })
+    );
+  });
+
   test('rejects non-student plan', async () => {
     service.createClass.mockImplementation(async (data) => data);
 

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -60,12 +60,16 @@ const generateUniqueSlug = async (title) => {
 exports.createClass = catchAsync(async (req, res) => {
   const slug = await generateUniqueSlug(req.body.title);
   const { tags: rawTags, status, included_plans, access_type, ...body } = req.body;
+  const roles = req.user?.roles || req.user?.role;
+  const adminCaller = isAdminRole(roles);
+  const normalizedStatus = status === "published" ? "published" : "draft";
+  const shouldAutoApprove = adminCaller && normalizedStatus === "published";
   const data = {
     ...body,
     id: uuidv4(),
     slug,
-    status: status === "published" ? "published" : "draft",
-    moderation_status: "Pending",
+    status: normalizedStatus,
+    moderation_status: shouldAutoApprove ? "Approved" : "Pending",
     access_type: "paid",
   };
   if (included_plans) {


### PR DESCRIPTION
## Summary
- mark admin or superadmin published class submissions as Approved during creation
- add a controller test covering the admin auto-approval scenario

## Testing
- npm test -- class.controller

------
https://chatgpt.com/codex/tasks/task_e_68e298c27db48328980f69494eac48c9