### PR TITLE
Fix subscription enrollment wallet credit handling

### DIFF
--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -11,7 +11,6 @@ const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const libraryService = require("../library/library.service");
 const { v4: uuidv4 } = require("uuid");
 const { getActiveStudentPlanId } = require("../plans/subscription.helper");
-const planRevenue = require("../payments/helpers/planRevenue");
 const { getPlanCoveredMethod } = require("../payments/helpers/methods");
 
 const { STATUS: PAYMENT_STATUS } = paymentsService;
@@ -333,24 +332,6 @@ exports.checkout = async (studentId) => {
         if (!planMethodRecord) {
           planMethodRecord = await getPlanCoveredMethod(trx);
         }
-
-        const usage = await trx('plan_usage_metrics')
-          .where({ plan_id: activePlanId, item_type: 'book', item_id: b.id })
-          .first();
-        if (usage) {
-          await trx('plan_usage_metrics')
-            .where({ plan_id: activePlanId, item_type: 'book', item_id: b.id })
-            .update({ usage_count: usage.usage_count + 1 });
-        } else {
-          await trx('plan_usage_metrics').insert({
-            plan_id: activePlanId,
-            item_type: 'book',
-            item_id: b.id,
-            usage_count: 1,
-          });
-        }
-
-        await planRevenue.calculateInstructorAmount(activePlanId, b.id, trx, 'book');
         const [payment] = await trx('payments')
           .insert({
             id: uuidv4(),

--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -11,6 +11,9 @@ jest.mock('../../../../config/database', () => {
   db.select = jest.fn(() => db);
   db.insert = jest.fn(() => db);
   db.update = jest.fn(() => db);
+  db.onConflict = jest.fn(() => db);
+  db.merge = jest.fn(() => db);
+  db.returning = jest.fn(() => Promise.resolve([{}]));
   db.forUpdate = jest.fn(() => db);
   db.transaction = jest.fn(async (fn) => fn(db));
   return db;
@@ -43,18 +46,16 @@ jest.mock('../../../plans/subscription.helper', () => ({
   getActiveStudentPlanId: jest.fn(),
 }));
 
-jest.mock('../../../payments/helpers/wallet', () => {
-  const creditInstructorSubscription = jest.fn(async (_type, _id, _planId, trx) => {
-    await trx('plan_usage_metrics').update({
-      usage_count: 1,
-      instructor_amount: 5,
-    });
-  });
-  return { creditInstructorSubscription };
-});
+jest.mock('../../../payments/helpers/planRevenue', () => ({
+  calculateInstructorAmount: jest.fn(),
+}));
 
-jest.mock('../../../payments/helpers/planPayments', () => ({
-  recordPlanCoveredPayment: jest.fn(),
+jest.mock('../../../payouts/wallet.service', () => ({
+  increment: jest.fn(),
+}));
+
+jest.mock('../../class.service', () => ({
+  getClassById: jest.fn(),
 }));
 
 jest.mock('../../../payments/helpers/planPayments', () => ({
@@ -69,9 +70,10 @@ jest.mock('../../../../utils/logger.js', () => ({
 }));
 
 const { getActiveStudentPlanId } = require('../../../plans/subscription.helper');
-const { creditInstructorSubscription } = require('../../../payments/helpers/wallet');
+const { calculateInstructorAmount } = require('../../../payments/helpers/planRevenue');
+const walletService = require('../../../payouts/wallet.service');
+const classService = require('../../class.service');
 const { recordPlanCoveredPayment } = require('../../../payments/helpers/planPayments');
-const logger = require('../../../../utils/logger.js');
 const db = require('../../../../config/database');
 const routes = require('../../class.routes');
 
@@ -82,6 +84,11 @@ app.use('/classes', routes);
 describe('Class enrollment routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    calculateInstructorAmount.mockReset();
+    walletService.increment.mockReset();
+    classService.getClassById.mockReset();
+    db.first.mockReset();
+    db.first.mockImplementation(() => Promise.resolve(null));
   });
 
   test('enroll in class', async () => {
@@ -142,6 +149,20 @@ describe('Class enrollment routes', () => {
   });
 
   test('allow enrollment when class covered by subscription', async () => {
+    const usageTracker = { count: 0 };
+    calculateInstructorAmount.mockImplementation(
+      async (_planId, _itemId, trx, _itemType) => {
+        usageTracker.count += 1;
+        await trx('plan_usage_metrics').update({
+          usage_count: usageTracker.count,
+          instructor_amount: 5,
+        });
+        return 5;
+      }
+    );
+    classService.getClassById.mockResolvedValue({ instructor_id: 'instructor-42' });
+    walletService.increment.mockResolvedValue({});
+
     db.first
       .mockResolvedValueOnce({
         status: 'published',
@@ -159,12 +180,21 @@ describe('Class enrollment routes', () => {
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(200);
     expect(service.createEnrollment).toHaveBeenCalled();
-    expect(creditInstructorSubscription).toHaveBeenCalledTimes(1);
-    expect(creditInstructorSubscription).toHaveBeenCalledWith(
-      'class',
-      'abc',
+    expect(calculateInstructorAmount).toHaveBeenCalledTimes(1);
+    expect(calculateInstructorAmount).toHaveBeenCalledWith(
       'plan1',
+      'abc',
       expect.anything(),
+      'class'
+    );
+    expect(usageTracker.count).toBe(1);
+    expect(db.update).toHaveBeenCalledWith(
+      expect.objectContaining({ usage_count: 1, instructor_amount: 5 })
+    );
+    expect(walletService.increment).toHaveBeenCalledWith(
+      'instructor-42',
+      5,
+      expect.anything()
     );
     expect(recordPlanCoveredPayment).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -9,7 +9,6 @@ const paymentsService = require("../../payments/payments.service");
 const { recordPlanCoveredPayment } = require("../../payments/helpers/planPayments");
 const { getActiveStudentPlanId } = require("../../plans/subscription.helper");
 const { creditInstructorSubscription } = require("../../payments/helpers/wallet");
-const planRevenue = require("../../payments/helpers/planRevenue");
 
 exports.enroll = catchAsync(async (req, res) => {
   const { classId } = req.params;
@@ -44,29 +43,6 @@ exports.enroll = catchAsync(async (req, res) => {
       activePlanId && includedPlans.includes(activePlanId);
 
     if (coveredBySubscription) {
-      const usage = await trx("plan_usage_metrics")
-        .where({ plan_id: activePlanId, item_type: "class", item_id: classId })
-        .first();
-
-      if (usage) {
-        await trx("plan_usage_metrics")
-          .where({ plan_id: activePlanId, item_type: "class", item_id: classId })
-          .update({ usage_count: usage.usage_count + 1 });
-      } else {
-        await trx("plan_usage_metrics").insert({
-          plan_id: activePlanId,
-          item_type: "class",
-          item_id: classId,
-          usage_count: 1,
-        });
-      }
-
-      await planRevenue.calculateInstructorAmount(
-        activePlanId,
-        classId,
-        trx,
-        "class"
-      );
       await recordPlanCoveredPayment({
         trx,
         userId: user_id,

--- a/backend/src/modules/payments/helpers/wallet.js
+++ b/backend/src/modules/payments/helpers/wallet.js
@@ -58,7 +58,7 @@ async function creditInstructorSubscription(item_type, item_id, planId, trx) {
       trx,
       item_type
     );
-    if (amount <= 0) return;
+    if (amount <= 0) return amount;
 
     let instructorId;
     if (item_type === "class") {
@@ -75,6 +75,7 @@ async function creditInstructorSubscription(item_type, item_id, planId, trx) {
     if (instructorId) {
       await walletService.increment(instructorId, amount, trx);
     }
+    return amount;
   } catch (err) {
     logger.error("Failed to credit instructor wallet from subscription:", err);
   }

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -5,7 +5,6 @@ const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
 const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
-const planRevenue = require("../../../payments/helpers/planRevenue");
 const { creditTutorialSubscription } = require("../../../payments/helpers/wallet");
 
 // Enroll in tutorial
@@ -32,38 +31,6 @@ exports.enroll = catchAsync(async (req, res) => {
   const enroll = async (trx) => {
     if (coveredBySubscription) {
       const planMethod = await getPlanCoveredMethod(trx);
-
-      const usage = await trx("plan_usage_metrics")
-        .where({
-          plan_id: activePlanId,
-          item_type: "tutorial",
-          item_id: tutorialId,
-        })
-        .first();
-
-      if (usage) {
-        await trx("plan_usage_metrics")
-          .where({
-            plan_id: activePlanId,
-            item_type: "tutorial",
-            item_id: tutorialId,
-          })
-          .update({ usage_count: usage.usage_count + 1 });
-      } else {
-        await trx("plan_usage_metrics").insert({
-          plan_id: activePlanId,
-          item_type: "tutorial",
-          item_id: tutorialId,
-          usage_count: 1,
-        });
-      }
-
-      await planRevenue.calculateInstructorAmount(
-        activePlanId,
-        tutorialId,
-        trx,
-        "tutorial"
-      );
 
       await trx("payments").insert({
         user_id,


### PR DESCRIPTION
## Summary
- rely on the wallet helper to calculate plan-covered payouts for classes, tutorials, and books so plan usage is only incremented once per enrollment
- return the calculated subscription payout from the wallet helper and apply it to the instructor wallet
- extend the class enrollment subscription test to assert plan usage and wallet credits occur exactly once

## Testing
- npm test -- classEnrollment.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e298c4974483288f2e56e547555fa0