### PR TITLE
Fix student online class join condition

### DIFF
--- a/frontend/src/pages/dashboard/student/online-classes/index.js
+++ b/frontend/src/pages/dashboard/student/online-classes/index.js
@@ -234,7 +234,8 @@ function MyEnrolledClassesPage() {
                 >
                   <FaClipboardList className="inline mr-1" /> {t('studentOnlineClassesPage.view_assignments')}
                 </Link>
-                {cls.scheduleStatus === 'Ongoing' && cls.joined ? (
+                {cls.scheduleStatus === 'Ongoing' &&
+                  cls.enrollmentStatus?.toLowerCase() === 'enrolled' ? (
                   <Link
                     href={`/dashboard/student/online-classes/${cls.linkId || cls.id}`}
                     className="block bg-yellow-500 text-black text-center py-2 px-4 rounded hover:bg-yellow-600 font-semibold"


### PR DESCRIPTION
## Summary
- ensure the live class card checks the enrollment status instead of a missing flag so ongoing enrollments show the join link

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e298ca77dc83288fe9ac15404b08ce