### PR TITLE
Enhance instructor assignment creation payload

### DIFF
--- a/frontend/src/pages/dashboard/instructor/assignments/create.js
+++ b/frontend/src/pages/dashboard/instructor/assignments/create.js
@@ -6,6 +6,7 @@ import { toast } from 'react-toastify';
 import InstructorLayout from '@/components/layouts/InstructorLayout';
 import { v4 as uuidv4 } from 'uuid';
 import { fetchInstructorClasses, createClassAssignment } from '@/services/instructor/classService';
+import { prepareAssignmentPayload } from '@/utils/assignments/payload';
 
 export default function CreateAssignmentPage() {
   const router = useRouter();
@@ -62,12 +63,19 @@ export default function CreateAssignmentPage() {
       return;
     }
 
-    const payload = {
+    const { payload } = prepareAssignmentPayload({
       title,
       description,
-      due_date: dueDate,
-      time_to_finish: timeToFinish || null,
-    };
+      dueDate,
+      timeToFinish,
+      type,
+      questions,
+      language,
+      starterCode,
+      allowLate,
+      gradingRubric,
+      resourceFile,
+    });
 
     try {
       await createClassAssignment(classId, payload);
@@ -192,15 +200,22 @@ export default function CreateAssignmentPage() {
             </div>
           )}
 
-          {/* File Upload or Text Answer */}
-          {type === 'text' && (
-            <textarea
-              placeholder="Grading Rubric (optional)"
-              value={gradingRubric}
-              onChange={(e) => setGradingRubric(e.target.value)}
-              className="w-full p-3 h-24 bg-gray-100 rounded-md"
-            />
+          {type === 'file' && (
+            <div className="space-y-4">
+              <input
+                type="file"
+                onChange={(e) => setResourceFile(e.target.files?.[0] || null)}
+                className="w-full p-3 bg-gray-100 rounded-md"
+              />
+            </div>
           )}
+
+          <textarea
+            placeholder="Grading Rubric (optional)"
+            value={gradingRubric}
+            onChange={(e) => setGradingRubric(e.target.value)}
+            className="w-full p-3 h-24 bg-gray-100 rounded-md"
+          />
 
           {/* Late Submission Option */}
           <div className="flex items-center gap-2">

--- a/frontend/src/services/instructor/classService.js
+++ b/frontend/src/services/instructor/classService.js
@@ -150,9 +150,27 @@ export const deleteClassLesson = async (lessonId) => {
   await api.delete(`users/classes/lessons/${lessonId}`);
 };
 
-export const createClassAssignment = async (classId, payload) => {
+export const createClassAssignment = async (classId, payload, options = {}) => {
   await ensureCsrfToken();
-  const { data } = await api.post(`users/classes/assignments/class/${classId}`, payload);
+  const detectedFormData =
+    typeof FormData !== "undefined" && payload instanceof FormData;
+
+  const { headers: optionHeaders, ...restOptions } = options;
+  const headers = await buildCsrfHeaders({
+    ...(detectedFormData ? {} : { "Content-Type": "application/json" }),
+    ...(optionHeaders || {}),
+  });
+
+  const config = {
+    ...restOptions,
+    headers,
+  };
+
+  const { data } = await api.post(
+    `users/classes/assignments/class/${classId}`,
+    payload,
+    config
+  );
   return data?.data;
 };
 

--- a/frontend/src/utils/assignments/payload.js
+++ b/frontend/src/utils/assignments/payload.js
@@ -1,0 +1,71 @@
+export const sanitizeQuestions = (questions = []) =>
+  questions
+    .filter((q) => (q?.question || '').trim().length > 0)
+    .map((q) => ({
+      id: q.id,
+      question: q.question,
+      options: Array.isArray(q.options) ? q.options : [],
+      correct: typeof q.correct === 'number' ? q.correct : 0,
+      points: typeof q.points === 'number' ? q.points : 0,
+    }));
+
+const appendFormDataValue = (formData, key, value) => {
+  if (value === undefined || value === null) return;
+  if (value instanceof Blob) {
+    formData.append(key, value, value.name || 'upload');
+    return;
+  }
+  if (typeof value === 'object') {
+    formData.append(key, JSON.stringify(value));
+    return;
+  }
+  formData.append(key, String(value));
+};
+
+export const prepareAssignmentPayload = ({
+  title,
+  description,
+  dueDate,
+  timeToFinish,
+  type,
+  questions,
+  language,
+  starterCode,
+  allowLate,
+  gradingRubric,
+  resourceFile,
+}) => {
+  const basePayload = {
+    title,
+    description,
+    due_date: dueDate,
+    time_to_finish: timeToFinish || null,
+    type,
+    allow_late: Boolean(allowLate),
+    grading_rubric: gradingRubric || null,
+  };
+
+  if (type === 'mcq') {
+    basePayload.questions = sanitizeQuestions(questions);
+  }
+
+  if (type === 'code') {
+    basePayload.coding = {
+      language,
+      starterCode,
+    };
+  }
+
+  if (resourceFile) {
+    const formData = new FormData();
+    Object.entries(basePayload).forEach(([key, value]) =>
+      appendFormDataValue(formData, key, value)
+    );
+    appendFormDataValue(formData, 'resource_file', resourceFile);
+    return { payload: formData, isFormData: true };
+  }
+
+  return { payload: basePayload, isFormData: false };
+};
+
+export default prepareAssignmentPayload;

--- a/frontend/src/utils/assignments/payload.test.js
+++ b/frontend/src/utils/assignments/payload.test.js
@@ -1,0 +1,80 @@
+import { prepareAssignmentPayload, sanitizeQuestions } from './payload';
+
+describe('sanitizeQuestions', () => {
+  it('removes empty questions and normalizes properties', () => {
+    const result = sanitizeQuestions([
+      { id: '1', question: '  ', options: [], correct: 0, points: 1 },
+      { id: '2', question: 'Question?', options: ['A', 'B', 'C', 'D'], correct: 2, points: 3 },
+      { id: '3', question: 'Another', options: 'invalid', correct: '1', points: '5' },
+    ]);
+
+    expect(result).toEqual([
+      { id: '2', question: 'Question?', options: ['A', 'B', 'C', 'D'], correct: 2, points: 3 },
+      { id: '3', question: 'Another', options: [], correct: 0, points: 0 },
+    ]);
+  });
+});
+
+describe('prepareAssignmentPayload', () => {
+  const baseProps = {
+    title: 'Quiz 1',
+    description: 'Basics',
+    dueDate: '2024-10-31',
+    timeToFinish: '2h',
+    allowLate: true,
+    gradingRubric: 'Accuracy matters',
+  };
+
+  it('builds JSON payload for MCQ assignments', () => {
+    const questions = [
+      { id: 'q1', question: 'What?', options: ['A', 'B'], correct: 1, points: 5 },
+    ];
+
+    const { payload, isFormData } = prepareAssignmentPayload({
+      ...baseProps,
+      type: 'mcq',
+      questions,
+      language: 'javascript',
+      starterCode: '',
+      resourceFile: null,
+    });
+
+    expect(isFormData).toBe(false);
+    expect(payload).toMatchObject({
+      title: 'Quiz 1',
+      description: 'Basics',
+      type: 'mcq',
+      allow_late: true,
+      grading_rubric: 'Accuracy matters',
+      due_date: '2024-10-31',
+      time_to_finish: '2h',
+    });
+    expect(payload.questions).toEqual([
+      { id: 'q1', question: 'What?', options: ['A', 'B'], correct: 1, points: 5 },
+    ]);
+  });
+
+  it('builds FormData payload for coding assignments with uploads', () => {
+    const file = new File(['print("Hello")'], 'starter.py', { type: 'text/x-python' });
+    const { payload, isFormData } = prepareAssignmentPayload({
+      ...baseProps,
+      type: 'code',
+      questions: [],
+      language: 'python',
+      starterCode: 'print("Hi")',
+      resourceFile: file,
+    });
+
+    expect(isFormData).toBe(true);
+    expect(payload instanceof FormData).toBe(true);
+    expect(payload.get('title')).toBe('Quiz 1');
+    expect(payload.get('type')).toBe('code');
+    expect(JSON.parse(payload.get('coding'))).toEqual({
+      language: 'python',
+      starterCode: 'print("Hi")',
+    });
+    const uploadedFile = payload.get('resource_file');
+    expect(uploadedFile).toBeInstanceOf(File);
+    expect(uploadedFile.name).toBe('starter.py');
+  });
+});


### PR DESCRIPTION
## Summary
- enrich the instructor assignment creation flow to include type-specific metadata, grading rubric, late-submission flag, and optional uploads
- add a reusable payload builder to normalize MCQ questions and wrap uploads with FormData when needed
- adjust the instructor class service to detect multipart submissions and add unit coverage for the payload builder

## Testing
- npm test -- payload.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e298c607448328aef4898faaaea30c