### PR TITLE
Fix bank transfer checkout settings support

### DIFF
--- a/frontend/src/components/payments/forms/BankTransferForm.js
+++ b/frontend/src/components/payments/forms/BankTransferForm.js
@@ -5,6 +5,9 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
   const { t } = useTranslation('common');
   const { register, handleSubmit } = useForm();
 
+  const resolvedDetails =
+    (bankDetails && (bankDetails.settings || bankDetails.config)) || bankDetails || {};
+
   const submit = (data) => {
     onSubmit({
       reference: data.reference || '',
@@ -19,7 +22,7 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.bank_name || ''}
+          value={resolvedDetails.bank_name || ''}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
@@ -28,7 +31,7 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.account_holder_name || ''}
+          value={resolvedDetails.account_holder_name || ''}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
@@ -37,7 +40,7 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.account_number || ''}
+          value={resolvedDetails.account_number || ''}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
@@ -46,17 +49,17 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.swift_code || ''}
+          value={resolvedDetails.swift_code || ''}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
-      {bankDetails.branch_address && (
+      {resolvedDetails.branch_address && (
         <label className="block">
           <span className="text-sm">{t('branch_address')}</span>
           <input
             type="text"
             readOnly
-            value={bankDetails.branch_address}
+            value={resolvedDetails.branch_address}
             className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
           />
         </label>

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -873,7 +873,11 @@ export default function CheckoutPage() {
           ) : selectedMethodIdentifier === 'bank' ? (
             <BankTransferForm
               onSubmit={handlePayment}
-              bankDetails={selectedMethodObj?.config || selectedMethodObj}
+              bankDetails={
+                selectedMethodObj?.settings ||
+                selectedMethodObj?.config ||
+                selectedMethodObj
+              }
               processing={paymentStatus === 'processing'}
               finalPrice={finalPrice}
             />

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -156,7 +156,12 @@ test('adjusts inputs based on payment selection and submits bank reference', asy
       id: 3,
       name: 'Bank',
       type: 'bank',
-      config: { bank_name: 'Test Bank', account_holder_name: 'John', account_number: '123', swift_code: 'ABCDEF' },
+      settings: {
+        bank_name: 'Test Bank',
+        account_holder_name: 'John',
+        account_number: '123',
+        swift_code: 'ABCDEF',
+      },
     },
   ]);
   initiateBankPayment.mockResolvedValue({ id: 42 });


### PR DESCRIPTION
## Summary
- update the checkout bank transfer flow to consume the payment method settings payload
- make the BankTransferForm resolve nested settings/config objects for backward compatibility
- refresh the checkout payment flow test to cover the settings-based bank mock

## Testing
- npm test -- checkoutPaymentFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a385de2483288021f0c9730246f2