### PR TITLE
Fix non-Stripe card checkout flow

### DIFF
--- a/frontend/src/components/payments/forms/CardPaymentForm.js
+++ b/frontend/src/components/payments/forms/CardPaymentForm.js
@@ -7,6 +7,7 @@ export default function CardPaymentForm({ onSubmit, processing, allowInstallment
   const { register, handleSubmit, formState: { errors } } = useForm();
   const stripe = useStripe();
   const elements = useElements();
+  const hasStripeContext = Boolean(stripe && elements);
   const usingInstallments = allowInstallments && installments > 1;
   const buttonText = processing
     ? 'Processing...'
@@ -15,14 +16,25 @@ export default function CardPaymentForm({ onSubmit, processing, allowInstallment
       : `Pay $${finalPrice} with ${selectedMethodLabel}`;
 
   const submit = async (data) => {
-    if (!stripe || !elements) return;
     setError(null);
+
+    if (!hasStripeContext) {
+      onSubmit(data);
+      return;
+    }
+
     const cardElement = elements.getElement(CardElement);
+    if (!cardElement) {
+      setError('Payment information is incomplete.');
+      return;
+    }
+
     const { error: stripeError, token } = await stripe.createToken(cardElement);
     if (stripeError) {
       setError(stripeError.message);
       return;
     }
+
     onSubmit({ ...data, token: token.id });
   };
 
@@ -43,13 +55,15 @@ export default function CardPaymentForm({ onSubmit, processing, allowInstallment
         className="w-full mb-1 p-3 text-sm rounded bg-gray-700 text-white"
         {...register('email', { required: 'Email is required' })}
       />
-      <div className="w-full mb-6 p-3 text-sm rounded bg-gray-700 text-white">
-        <CardElement options={{ style: { base: { color: '#fff' } } }} />
-      </div>
+      {hasStripeContext && (
+        <div className="w-full mb-6 p-3 text-sm rounded bg-gray-700 text-white">
+          <CardElement options={{ style: { base: { color: '#fff' } } }} />
+        </div>
+      )}
       {error && <p className="text-red-500 text-sm mb-3">{error}</p>}
       <button
         type="submit"
-        disabled={processing || !stripe}
+        disabled={processing}
         className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all"
       >
         {buttonText}

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -105,6 +105,42 @@ export function resolveIconElement(method) {
   );
 }
 
+function DirectGatewayPayment({
+  onSubmit,
+  processing,
+  allowInstallments,
+  installments,
+  perInstallment,
+  finalPrice,
+  selectedMethodLabel,
+}) {
+  const usingInstallments = allowInstallments && installments > 1;
+  const buttonText = processing
+    ? 'Processing...'
+    : usingInstallments
+    ? `Pay $${perInstallment.toFixed(2)} (1/${installments}) with ${selectedMethodLabel}`
+    : `Pay $${finalPrice} with ${selectedMethodLabel}`;
+
+  return (
+    <div className="space-y-4 text-center">
+      <p className="text-sm text-gray-300">
+        Complete your payment using {selectedMethodLabel}.
+      </p>
+      <button
+        type="button"
+        onClick={() => onSubmit({})}
+        disabled={processing}
+        className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {buttonText}
+      </button>
+      <p className="text-sm text-gray-500">
+        You&apos;ll be redirected after successful payment.
+      </p>
+    </div>
+  );
+}
+
 function getMethodIdentifier(method) {
   const type = method?.type;
   if (type !== undefined && type !== null) {
@@ -896,7 +932,7 @@ export default function CheckoutPage() {
               />
             </Elements>
           ) : (
-            <CardPaymentForm
+            <DirectGatewayPayment
               onSubmit={handlePayment}
               processing={paymentStatus === 'processing'}
               allowInstallments={allowInstallments}

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -180,28 +180,21 @@ test.skip('completes payment for unhandled methods on success', async () => {
   /* Skipped: requires card processing setup */
 });
 
-test('renders card form without Elements for non-stripe processors', async () => {
+test('submits payment for non-stripe card processors without Stripe tokenization', async () => {
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Paystack', type: 'paystack' },
   ]);
   createPayment.mockResolvedValue({ status: 'paid' });
+  global.mockStripeCreateToken.mockClear();
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
   expect(screen.queryByTestId('elements-wrapper')).toBeNull();
-  fireEvent.change(screen.getByPlaceholderText('Full Name'), {
-    target: { value: 'John Doe' },
-  });
-  fireEvent.change(screen.getByPlaceholderText('Email Address'), {
-    target: { value: 'john@example.com' },
-  });
-  fireEvent.click(
-    screen.getByRole('button', { name: /Pay \$100 with Paystack/i })
-  );
-  await waitFor(() =>
-    expect(createPayment).toHaveBeenCalledWith(
-      expect.objectContaining({ token: 'tok_123' })
-    )
-  );
+  const button = screen.getByRole('button', { name: /Pay \$100 with Paystack/i });
+  fireEvent.click(button);
+  await waitFor(() => expect(createPayment).toHaveBeenCalled());
+  const payload = createPayment.mock.calls[0][0];
+  expect(payload.token).toBeUndefined();
+  expect(global.mockStripeCreateToken).not.toHaveBeenCalled();
 });
 
 test('submits per-installment amount for multi-installment card payments', async () => {


### PR DESCRIPTION
## Summary
- add a dedicated gateway submission flow for non-Stripe card processors in checkout
- guard the Stripe token creation logic in CardPaymentForm so submissions still work without Elements
- extend the checkout payment flow test to assert createPayment is called for non-Stripe card gateways

## Testing
- npm test -- checkoutPaymentFlow.test.js
- npm test -- CardPaymentForm.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a3921e908328ab475cffafedf29f