### PR TITLE
Fix bank transfer settings mapping

### DIFF
--- a/frontend/src/components/payments/forms/BankTransferForm.js
+++ b/frontend/src/components/payments/forms/BankTransferForm.js
@@ -5,6 +5,12 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
   const { t } = useTranslation('common');
   const { register, handleSubmit } = useForm();
 
+  const settings =
+    bankDetails?.settings && typeof bankDetails.settings === 'object' && !Array.isArray(bankDetails.settings)
+      ? bankDetails.settings
+      : {};
+  const resolvedBankDetails = { ...settings, ...bankDetails };
+
   const submit = (data) => {
     onSubmit({
       reference: data.reference || '',
@@ -19,7 +25,7 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.bank_name || ''}
+          value={resolvedBankDetails.bank_name || ''}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
@@ -28,7 +34,7 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.account_holder_name || ''}
+          value={resolvedBankDetails.account_holder_name || ''}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
@@ -37,7 +43,7 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.account_number || ''}
+          value={resolvedBankDetails.account_number || ''}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
@@ -46,17 +52,17 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.swift_code || ''}
+          value={resolvedBankDetails.swift_code || ''}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
-      {bankDetails.branch_address && (
+      {resolvedBankDetails.branch_address && (
         <label className="block">
           <span className="text-sm">{t('branch_address')}</span>
           <input
             type="text"
             readOnly
-            value={bankDetails.branch_address}
+            value={resolvedBankDetails.branch_address}
             className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
           />
         </label>

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -119,6 +119,24 @@ function getMethodIdentifier(method) {
   return '';
 }
 
+function normalizePaymentMethod(method) {
+  if (!method || typeof method !== 'object') return method;
+  const identifier = getMethodIdentifier(method).toLowerCase();
+  if (identifier !== 'bank') return method;
+
+  const settings =
+    method.settings && typeof method.settings === 'object' && !Array.isArray(method.settings)
+      ? method.settings
+      : {};
+  const mergedConfig = { ...(method.config || {}), ...settings };
+
+  return {
+    ...method,
+    config: mergedConfig,
+    bankSettings: settings,
+  };
+}
+
 const CRYPTO_IDENTIFIERS = ['usdt', 'nft', 'binance', 'coinbase', 'nowpayments'];
 
 function isCryptoMethod(methodOrIdentifier) {
@@ -491,7 +509,7 @@ export default function CheckoutPage() {
         try {
           const data = await fetchPaymentMethods();
           if (!active) return;
-          const methodsList = Array.isArray(data) ? data : [];
+          const methodsList = Array.isArray(data) ? data.map(normalizePaymentMethod) : [];
           setMethods(methodsList);
           const eligibleMethods = filterEligibleMethods(methodsList);
           if (eligibleMethods.length > 0) {

--- a/frontend/src/tests/__tests__/BankTransferForm.test.js
+++ b/frontend/src/tests/__tests__/BankTransferForm.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 jest.mock('next-i18next', () => ({
   useTranslation: () => ({
     t: (key, params) => {
@@ -26,6 +26,7 @@ describe('BankTransferForm', () => {
       account_holder_name: 'John Holder',
       account_number: '123456',
       swift_code: 'ABCDEF',
+      branch_address: '123 Example St',
     };
     render(
       <BankTransferForm
@@ -37,9 +38,37 @@ describe('BankTransferForm', () => {
     );
     const bankInput = screen.getByDisplayValue('Test Bank');
     expect(bankInput).toHaveAttribute('readonly');
+    expect(screen.getByDisplayValue('123 Example St')).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText(/Reference/), {
       target: { value: 'My Ref' },
     });
     fireEvent.submit(screen.getByRole('button', { name: /Pay \$100 with Bank/i }).closest('form'));
+    return waitFor(() =>
+      expect(handleSubmit).toHaveBeenCalledWith({ reference: 'My Ref', receipt: null })
+    );
+  });
+
+  it('supports bank settings nested inside the details object', () => {
+    const handleSubmit = jest.fn();
+    const bank = {
+      settings: {
+        bank_name: 'Nested Bank',
+        account_holder_name: 'Nested Holder',
+        account_number: '654321',
+        swift_code: 'FEDCBA',
+      },
+    };
+    render(
+      <BankTransferForm
+        onSubmit={handleSubmit}
+        processing={false}
+        finalPrice={50}
+        bankDetails={bank}
+      />
+    );
+    expect(screen.getByDisplayValue('Nested Bank')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Nested Holder')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('654321')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('FEDCBA')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- normalize payment methods so bank transfers expose backend settings fields in checkout
- make the bank transfer form consume merged settings data for all displayable instructions
- extend the bank transfer form test coverage for branch details and nested settings

## Testing
- `npm test -- BankTransferForm`


------
https://chatgpt.com/codex/tasks/task_e_68e2a399c3888328b8e279cc73bcfd64