### PR TITLE
Remove unreachable return in checkout filter

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -138,7 +138,6 @@ export function filterEligibleMethods(methods) {
   return Array.isArray(methods)
     ? methods.filter((m) => m.active !== false)
     : [];
-  return active;
 }
 
 export function resolveCheckoutItem(query, cartItems) {


### PR DESCRIPTION
## Summary
- remove the unreachable return statement from `filterEligibleMethods` in the checkout page so the helper simply returns the filtered array

## Testing
- npm run lint *(fails: existing lint warnings/errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a39731848328b10bab5ec7a00f03