### PR TITLE
Ensure free checkouts create backend payments

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -551,51 +551,27 @@ export default function CheckoutPage() {
   };
 
 
-  const completePayment = async (existingPayment) => {
-    let payment = existingPayment;
-    if (itemType === 'plan' && finalPrice <= Number.EPSILON) {
-      setPaymentStatus('processing');
-      try {
-        await subscribeToPlan(itemInfo.id, interval);
-      } catch (err) {
-        console.error('Failed to subscribe to plan', err);
-        toast.error(t('payment_generic_failure'));
-        setPaymentStatus('idle');
-        return;
-      }
-      setPaymentStatus('success');
-      setTimeout(() => {
-        router.push(`/payments/success?itemType=${itemType}&itemId=${itemInfo.id}`);
-      }, 1500);
+  const buildBasePaymentPayload = ({ amount }) => {
+    const payload = {
+      item_type: itemType,
+      item_id: itemInfo.id,
+      amount,
+    };
+    if (itemType === 'plan') payload.interval = interval;
+    if (couponId) payload.coupon_id = couponId;
+    return payload;
+  };
+
+  const completePayment = async (paymentOverride) => {
+    const payment = paymentOverride || existingPayment;
+    const status = payment?.status;
+
+    if (payment && status && status !== 'paid') {
+      toast.error(t('payment_pending_confirmation'));
+      setPaymentStatus(status);
       return;
     }
-    if (itemType === 'plan' && !payment) {
-      setPaymentStatus('processing');
-      const eligible = filterEligibleMethods(methods);
-      if (eligible.length === 0) {
-        toast.error(t('no_payment_methods_plan'));
-        setPaymentStatus('idle');
-        return;
-      }
-      const defaultMethod = eligible[0];
-      try {
-        const payload = {
-          item_type: itemType,
-          item_id: itemInfo.id,
-          amount: finalPrice,
-          status: 'paid',
-          interval,
-        };
-        if (defaultMethod?.id) payload.method_id = defaultMethod.id;
-        if (couponId) payload.coupon_id = couponId;
-        payment = await createPayment(payload);
-      } catch (err) {
-        console.error('Failed to create payment', err);
-        toast.error(t('payment_generic_failure'));
-        setPaymentStatus('idle');
-        return;
-      }
-    }
+
     if (itemType === 'plan') {
       try {
         await subscribeToPlan(itemInfo.id, interval, payment?.id);
@@ -614,47 +590,42 @@ export default function CheckoutPage() {
       }, 1500);
       return;
     }
-    const storageKey =
-      itemType === 'tutorial'
-        ? 'enrolledTutorials'
-        : itemType === 'book'
-        ? 'purchasedBooks'
-        : 'enrolledClasses';
-    let enrolled = [];
+
+    setPaymentStatus('success');
+
     if (typeof window !== 'undefined') {
+      const storageKey =
+        itemType === 'tutorial'
+          ? 'enrolledTutorials'
+          : itemType === 'book'
+          ? 'purchasedBooks'
+          : 'enrolledClasses';
       try {
-        enrolled = JSON.parse(localStorage.getItem(storageKey) || '[]');
-      } catch {
-        enrolled = [];
-      }
-    }
-    const newItem =
-      itemType === 'book'
-        ? {
-            id: itemInfo.id,
-            title: itemInfo.title,
-            author: itemInfo.author,
-            purchaseDate: new Date().toISOString(),
-          }
-        : {
-            id: itemInfo.id,
-            title: itemInfo.title,
-            instructor: itemInfo.instructor,
-            startDate: new Date().toISOString(),
-            status: 'Live',
-            joined: true,
-          };
-    if (typeof window !== 'undefined') {
-      try {
-        enrolled.push(newItem);
-        localStorage.setItem(storageKey, JSON.stringify(enrolled));
+        const existing = JSON.parse(localStorage.getItem(storageKey) || '[]');
+        const newItem =
+          itemType === 'book'
+            ? {
+                id: itemInfo.id,
+                title: itemInfo.title,
+                author: itemInfo.author,
+                purchaseDate: new Date().toISOString(),
+              }
+            : {
+                id: itemInfo.id,
+                title: itemInfo.title,
+                instructor: itemInfo.instructor,
+                startDate: new Date().toISOString(),
+                status: 'Live',
+                joined: true,
+              };
+        const updated = Array.isArray(existing) ? [...existing, newItem] : [newItem];
+        localStorage.setItem(storageKey, JSON.stringify(updated));
         await Promise.resolve(removeItem(itemInfo.id));
       } catch (err) {
-        console.error('Failed to persist enrollment', err);
-        toast.error(t('payment_generic_failure'));
+        console.warn('Failed to update local enrollment cache', err);
       }
     }
-    setPaymentStatus('success');
+
     setTimeout(() => {
       const paymentIdParam = payment?.id ? `&payment_id=${payment.id}` : '';
       router.push(
@@ -665,7 +636,16 @@ export default function CheckoutPage() {
 
   const handlePayment = async (_formData = {}) => {
     if (finalPrice <= Number.EPSILON) {
-      await completePayment();
+      try {
+        setPaymentStatus('processing');
+        const payload = { ...buildBasePaymentPayload({ amount: finalPrice }), status: 'paid' };
+        const payment = await createPayment(payload);
+        await completePayment(payment);
+      } catch (err) {
+        console.error('Failed to finalize free payment', err);
+        toast.error(t('payment_generic_failure'));
+        setPaymentStatus('idle');
+      }
       return;
     }
     const method = filteredMethods.find(
@@ -846,7 +826,7 @@ export default function CheckoutPage() {
           {isFree ? (
             <div className="text-center">
               <p className="mb-4">{t('free_item_notice')}</p>
-              <button onClick={() => completePayment()} className="px-6 py-2 bg-yellow-500 text-gray-900 font-bold rounded">
+              <button onClick={() => handlePayment()} className="px-6 py-2 bg-yellow-500 text-gray-900 font-bold rounded">
                 {t('enroll_for_free')}
               </button>
             </div>

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -301,7 +301,7 @@ test('shows available payment methods for plans', async () => {
   expect(await screen.findByText('USDT')).toBeInTheDocument();
 });
 
-test.skip('enrolls in free plan without payment', async () => {
+test('enrolls in free plan through zero-amount payment', async () => {
   jest.useFakeTimers();
   const push = jest.fn();
   mockUseRouter.mockReturnValue({
@@ -310,25 +310,38 @@ test.skip('enrolls in free plan without payment', async () => {
     push,
   });
   fetchPlanDetails.mockResolvedValue({
-    data: { id: 1, name: 'Free Plan', price_monthly: 0 },
+    data: { id: 1, name: 'Free Plan', price_monthly: 0, price_yearly: 0 },
   });
   fetchPaymentMethods.mockResolvedValue([]);
+  createPayment.mockResolvedValue({ id: 101, status: 'paid' });
 
   render(<CheckoutPage />);
+  await screen.findByText('Checkout');
   await waitFor(() => expect(fetchPlanDetails).toHaveBeenCalled());
-  await act(async () => {});
   const button = await screen.findByRole('button', {
     name: /enroll_for_free/i,
   });
   fireEvent.click(button);
   await waitFor(() =>
-    expect(subscribeToPlan).toHaveBeenCalledWith(1, 'monthly')
+    expect(createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item_type: 'plan',
+        item_id: 1,
+        amount: 0,
+        status: 'paid',
+        interval: 'monthly',
+      })
+    )
+  );
+  await waitFor(() =>
+    expect(subscribeToPlan).toHaveBeenCalledWith(1, 'monthly', 101)
   );
   jest.runAllTimers();
   await waitFor(() =>
-    expect(push).toHaveBeenCalledWith('/payments/success?itemType=plan&itemId=1')
+    expect(push).toHaveBeenCalledWith(
+      '/payments/success?itemType=plan&itemId=1&payment_id=101'
+    )
   );
-  expect(createPayment).not.toHaveBeenCalled();
   jest.useRealTimers();
 });
 

--- a/frontend/src/tests/__tests__/checkoutPromo.test.js
+++ b/frontend/src/tests/__tests__/checkoutPromo.test.js
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CheckoutPage from '../../pages/payments/checkout';
 import { validateCode } from '../../services/couponService';
+import { createPayment } from '../../services/student/paymentService';
 import { fetchClassDetails } from '../../services/classService';
 import { fetchPaymentMethods } from '../../services/paymentMethodService';
 jest.mock('next-i18next', () => ({ useTranslation: () => ({ t: (key) => key }) }));
@@ -51,6 +52,9 @@ jest.mock('../../components/payments/forms/CardPaymentForm', () => {
 jest.mock('../../services/couponService', () => ({
   validateCode: jest.fn(),
 }));
+jest.mock('../../services/student/paymentService', () => ({
+  createPayment: jest.fn(),
+}));
 
 const mockUseRouter = jest.fn();
 jest.mock('next/router', () => ({
@@ -73,6 +77,55 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+});
+
+test('creates payment when promo reduces price to zero', async () => {
+  jest.useFakeTimers();
+  const push = jest.fn();
+  mockUseRouter.mockReturnValue({
+    query: { itemId: '1', itemType: 'class' },
+    isReady: true,
+    push,
+  });
+  validateCode.mockResolvedValue({ id: 9, discount_percent: 100 });
+  createPayment.mockResolvedValue({ id: 202, status: 'paid' });
+
+  render(<CheckoutPage />);
+  await screen.findByText('checkout');
+
+  fireEvent.change(screen.getByPlaceholderText('enter_promo_code'), {
+    target: { value: 'FREE100' },
+  });
+  fireEvent.click(screen.getByText('apply'));
+
+  await waitFor(() =>
+    expect(validateCode).toHaveBeenCalledWith('FREE100', 'class', '1')
+  );
+
+  const enrollButton = await screen.findByRole('button', {
+    name: /enroll_for_free/i,
+  });
+  fireEvent.click(enrollButton);
+
+  await waitFor(() =>
+    expect(createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item_type: 'class',
+        item_id: 1,
+        amount: 0,
+        status: 'paid',
+        coupon_id: 9,
+      })
+    )
+  );
+
+  jest.runAllTimers();
+  await waitFor(() =>
+    expect(push).toHaveBeenCalledWith(
+      '/payments/success?itemType=class&itemId=1&payment_id=202'
+    )
+  );
+  jest.useRealTimers();
 });
 
 test('applies promo code successfully', async () => {


### PR DESCRIPTION
## Summary
- route zero-cost checkouts through createPayment so the backend records free payments and maintain unified handling
- update completion logic to rely on confirmed payment status before optionally updating local caches
- add coverage for zero-cost plans and 100% coupons to confirm backend enrollment is triggered

## Testing
- npm test -- --runTestsByPath src/tests/__tests__/checkoutPaymentFlow.test.js src/tests/__tests__/checkoutPromo.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a39b3cc08328ae7e2e7825716f9e