### PR TITLE
Handle nested bank transfer settings in checkout

### DIFF
--- a/frontend/src/components/payments/forms/BankTransferForm.js
+++ b/frontend/src/components/payments/forms/BankTransferForm.js
@@ -5,6 +5,17 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
   const { t } = useTranslation('common');
   const { register, handleSubmit } = useForm();
 
+  const resolvedDetails =
+    bankDetails?.bank ||
+    bankDetails?.bank_details ||
+    bankDetails?.details ||
+    bankDetails || {};
+
+  const getDetail = (key) =>
+    resolvedDetails?.[key] ?? bankDetails?.[key] ?? '';
+
+  const branchAddress = getDetail('branch_address');
+
   const submit = (data) => {
     onSubmit({
       reference: data.reference || '',
@@ -19,7 +30,7 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.bank_name || ''}
+          value={getDetail('bank_name')}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
@@ -28,7 +39,7 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.account_holder_name || ''}
+          value={getDetail('account_holder_name')}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
@@ -37,7 +48,7 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.account_number || ''}
+          value={getDetail('account_number')}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
@@ -46,17 +57,17 @@ export default function BankTransferForm({ onSubmit, processing, finalPrice, ban
         <input
           type="text"
           readOnly
-          value={bankDetails.swift_code || ''}
+          value={getDetail('swift_code')}
           className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
         />
       </label>
-      {bankDetails.branch_address && (
+      {branchAddress && (
         <label className="block">
           <span className="text-sm">{t('branch_address')}</span>
           <input
             type="text"
             readOnly
-            value={bankDetails.branch_address}
+            value={branchAddress}
             className="w-full p-3 text-sm rounded bg-gray-700 text-white mb-1"
           />
         </label>

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -873,7 +873,11 @@ export default function CheckoutPage() {
           ) : selectedMethodIdentifier === 'bank' ? (
             <BankTransferForm
               onSubmit={handlePayment}
-              bankDetails={selectedMethodObj?.config || selectedMethodObj}
+              bankDetails={
+                selectedMethodObj?.settings ??
+                selectedMethodObj?.config ??
+                selectedMethodObj
+              }
               processing={paymentStatus === 'processing'}
               finalPrice={finalPrice}
             />

--- a/frontend/src/tests/__tests__/BankTransferForm.test.js
+++ b/frontend/src/tests/__tests__/BankTransferForm.test.js
@@ -42,4 +42,27 @@ describe('BankTransferForm', () => {
     });
     fireEvent.submit(screen.getByRole('button', { name: /Pay \$100 with Bank/i }).closest('form'));
   });
+
+  it('supports nested bank settings structures', () => {
+    const handleSubmit = jest.fn();
+    const bank = {
+      bank: {
+        bank_name: 'Nested Bank',
+        account_holder_name: 'Nested Holder',
+        account_number: '987654',
+        swift_code: 'ZXCVBN',
+        branch_address: '456 Nested Ave',
+      },
+    };
+    render(
+      <BankTransferForm
+        onSubmit={handleSubmit}
+        processing={false}
+        finalPrice={200}
+        bankDetails={bank}
+      />
+    );
+    expect(screen.getByDisplayValue('Nested Bank')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('456 Nested Ave')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -156,7 +156,13 @@ test('adjusts inputs based on payment selection and submits bank reference', asy
       id: 3,
       name: 'Bank',
       type: 'bank',
-      config: { bank_name: 'Test Bank', account_holder_name: 'John', account_number: '123', swift_code: 'ABCDEF' },
+      settings: {
+        bank_name: 'Test Bank',
+        account_holder_name: 'John',
+        account_number: '123',
+        swift_code: 'ABCDEF',
+        branch_address: '123 Finance St',
+      },
     },
   ]);
   initiateBankPayment.mockResolvedValue({ id: 42 });
@@ -166,6 +172,7 @@ test('adjusts inputs based on payment selection and submits bank reference', asy
   expect(screen.getByRole('button', { name: /Pay \$100 with PayPal/i })).toBeInTheDocument();
   fireEvent.click(screen.getByText('Bank'));
   expect(screen.getByDisplayValue('Test Bank')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('123 Finance St')).toBeInTheDocument();
   fireEvent.change(screen.getByPlaceholderText(/Reference/), { target: { value: 'ref' } });
   fireEvent.click(screen.getByRole('button', { name: /Pay \$100 with Bank/i }));
   await waitFor(() => expect(initiateBankPayment).toHaveBeenCalled());


### PR DESCRIPTION
## Summary
- update the checkout bank transfer flow to pass nested payment method settings to the form
- normalize BankTransferForm to read from nested settings while preserving legacy fallbacks
- extend checkout and form tests to cover bank settings coming from the new structure

## Testing
- npm test -- checkoutPaymentFlow.test.js
- npm test -- BankTransferForm.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a39edcb483289155bdde6cddb9ee