### PR TITLE
Allow card form submission without Stripe context

### DIFF
--- a/frontend/src/components/payments/forms/CardPaymentForm.js
+++ b/frontend/src/components/payments/forms/CardPaymentForm.js
@@ -2,7 +2,16 @@ import { useState } from 'react';
 import { CardElement, useStripe, useElements } from '@stripe/react-stripe-js';
 import { useForm } from 'react-hook-form';
 
-export default function CardPaymentForm({ onSubmit, processing, allowInstallments, installments, perInstallment, finalPrice, selectedMethodLabel }) {
+export default function CardPaymentForm({
+  onSubmit,
+  processing,
+  allowInstallments,
+  installments,
+  perInstallment,
+  finalPrice,
+  selectedMethodLabel,
+  requireStripeTokenization = true,
+}) {
   const [error, setError] = useState(null);
   const { register, handleSubmit, formState: { errors } } = useForm();
   const stripe = useStripe();
@@ -15,8 +24,18 @@ export default function CardPaymentForm({ onSubmit, processing, allowInstallment
       : `Pay $${finalPrice} with ${selectedMethodLabel}`;
 
   const submit = async (data) => {
-    if (!stripe || !elements) return;
     setError(null);
+
+    if (!requireStripeTokenization) {
+      onSubmit(data);
+      return;
+    }
+
+    if (!stripe || !elements) {
+      setError('Payment service unavailable. Please try again later.');
+      return;
+    }
+
     const cardElement = elements.getElement(CardElement);
     const { error: stripeError, token } = await stripe.createToken(cardElement);
     if (stripeError) {
@@ -49,7 +68,7 @@ export default function CardPaymentForm({ onSubmit, processing, allowInstallment
       {error && <p className="text-red-500 text-sm mb-3">{error}</p>}
       <button
         type="submit"
-        disabled={processing || !stripe}
+        disabled={processing || (requireStripeTokenization && !stripe)}
         className="w-full py-3 bg-yellow-500 text-gray-900 font-bold rounded hover:bg-yellow-600 transition-all"
       >
         {buttonText}

--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -893,6 +893,7 @@ export default function CheckoutPage() {
                 perInstallment={perInstallment}
                 finalPrice={finalPrice}
                 selectedMethodLabel={selectedMethodLabel}
+                requireStripeTokenization
               />
             </Elements>
           ) : (
@@ -904,6 +905,7 @@ export default function CheckoutPage() {
               perInstallment={perInstallment}
               finalPrice={finalPrice}
               selectedMethodLabel={selectedMethodLabel}
+              requireStripeTokenization={false}
             />
           )}
         </div>

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -74,6 +74,7 @@ jest.mock('../../components/payments/forms/CardPaymentForm', () => {
     allowInstallments,
     installments,
     perInstallment,
+    requireStripeTokenization = true,
   }) {
     const usingInstallments = allowInstallments && installments > 1;
     const buttonLabel = usingInstallments
@@ -83,8 +84,12 @@ jest.mock('../../components/payments/forms/CardPaymentForm', () => {
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          global.mockStripeCreateToken();
-          onSubmit({ token: 'tok_123', name: 'John Doe', email: 'john@example.com' });
+          if (requireStripeTokenization) {
+            global.mockStripeCreateToken();
+            onSubmit({ token: 'tok_123', name: 'John Doe', email: 'john@example.com' });
+            return;
+          }
+          onSubmit({ name: 'John Doe', email: 'john@example.com' });
         }}
       >
         <input placeholder="Full Name" />
@@ -197,11 +202,8 @@ test('renders card form without Elements for non-stripe processors', async () =>
   fireEvent.click(
     screen.getByRole('button', { name: /Pay \$100 with Paystack/i })
   );
-  await waitFor(() =>
-    expect(createPayment).toHaveBeenCalledWith(
-      expect.objectContaining({ token: 'tok_123' })
-    )
-  );
+  await waitFor(() => expect(createPayment).toHaveBeenCalledTimes(1));
+  expect(global.mockStripeCreateToken).not.toHaveBeenCalled();
 });
 
 test('submits per-installment amount for multi-installment card payments', async () => {


### PR DESCRIPTION
## Summary
- allow the card payment form to skip Stripe tokenization when the processor does not use Stripe
- pass a flag from the checkout page so the form only requires Stripe context for Stripe payments
- expand the checkout payment flow test to cover non-Stripe methods and ensure createPayment is invoked

## Testing
- npm test -- checkoutPaymentFlow

------
https://chatgpt.com/codex/tasks/task_e_68e2a3a1174483289a92e35458c8d938