### PR TITLE
Fix subscription wallet credit order and update tests

### DIFF
--- a/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
+++ b/backend/src/modules/classes/enrollments/__tests__/classEnrollment.routes.test.js
@@ -51,12 +51,38 @@ jest.mock('../../../payments/helpers/planRevenue', () => ({
   calculateInstructorAmount: jest.fn(),
 }));
 
+jest.mock('../../../payments/helpers/planPayments', () => ({
+  recordPlanCoveredPayment: jest.fn(),
+}));
+
 jest.mock('../../../payouts/wallet.service', () => ({
   increment: jest.fn(),
 }));
 
 jest.mock('../../class.service', () => ({
   getClassById: jest.fn(),
+}));
+
+jest.mock('../../class.controller', () => ({
+  createClass: jest.fn(),
+  getAllClasses: jest.fn(),
+  getMyClasses: jest.fn(),
+  getClassById: jest.fn(),
+  getManagementData: jest.fn(),
+  getClassAnalytics: jest.fn(),
+  updateClass: jest.fn(),
+  deleteClass: jest.fn(),
+  bulkDeleteClasses: jest.fn(),
+  toggleClassStatus: jest.fn(),
+  approveClass: jest.fn(),
+  rejectClass: jest.fn(),
+  getPublishedClasses: jest.fn(),
+  getPublicClassDetails: jest.fn(),
+}));
+
+jest.mock('../../classTag.controller', () => ({
+  listTags: jest.fn(),
+  createTag: jest.fn(),
 }));
 
 jest.mock('../../../../utils/logger.js', () => ({
@@ -66,7 +92,10 @@ jest.mock('../../../../utils/logger.js', () => ({
   error: jest.fn(),
 }));
 
-const { getActiveStudentPlanId } = require('../../../plans/subscription.helper');
+const {
+  getActiveStudentPlanId,
+  getActiveStudentSubscription,
+} = require('../../../plans/subscription.helper');
 const { calculateInstructorAmount } = require('../../../payments/helpers/planRevenue');
 const walletService = require('../../../payouts/wallet.service');
 const classService = require('../../class.service');
@@ -148,7 +177,7 @@ describe('Class enrollment routes', () => {
   test('allow enrollment when class covered by subscription', async () => {
     const usageTracker = { count: 0 };
     calculateInstructorAmount.mockImplementation(
-      async (_planId, _itemId, trx, _itemType) => {
+      async (_planId, _subscriptionId, _itemId, trx, _itemType) => {
         usageTracker.count += 1;
         await trx('plan_usage_metrics').update({
           usage_count: usageTracker.count,
@@ -177,14 +206,13 @@ describe('Class enrollment routes', () => {
     });
     service.createEnrollment.mockResolvedValue({ id: '1' });
     recordPlanCoveredPayment.mockResolvedValue({ id: 'payment-id' });
-    classService.getClassById.mockResolvedValue({ instructor_id: 'inst-1' });
-    planRevenue.calculateInstructorAmount.mockResolvedValue(7.5);
     const res = await request(app).post('/classes/enroll/abc');
     expect(res.statusCode).toBe(200);
     expect(service.createEnrollment).toHaveBeenCalled();
     expect(calculateInstructorAmount).toHaveBeenCalledTimes(1);
     expect(calculateInstructorAmount).toHaveBeenCalledWith(
       'plan1',
+      'sub1',
       'abc',
       expect.anything(),
       'class'
@@ -193,18 +221,17 @@ describe('Class enrollment routes', () => {
     expect(db.update).toHaveBeenCalledWith(
       expect.objectContaining({ usage_count: 1, instructor_amount: 5 })
     );
+    expect(walletService.increment).toHaveBeenCalledTimes(1);
     expect(walletService.increment).toHaveBeenCalledWith(
       'instructor-42',
       5,
       expect.anything()
     );
-    expect(planRevenue.calculateInstructorAmount.getUsageCount()).toBe(1);
     const usageUpdates = db.update.mock.calls.filter(([data]) =>
       data && Object.prototype.hasOwnProperty.call(data, 'usage_count'),
     );
     expect(usageUpdates).toHaveLength(1);
     expect(usageUpdates[0][0].usage_count).toBe(1);
-    expect(creditInstructorSubscription.getCredits()).toBe(1);
     expect(recordPlanCoveredPayment).toHaveBeenCalledWith(
       expect.objectContaining({
         trx: db,
@@ -234,7 +261,7 @@ describe('Class enrollment routes', () => {
       plan_id: 'plan1',
     });
     const res = await request(app).post('/classes/enroll/abc');
-    expect(trx.first).toHaveBeenCalledTimes(2);
+    expect(db.first).toHaveBeenCalledTimes(2);
     expect(res.statusCode).toBe(400);
   });
 

--- a/backend/src/modules/classes/enrollments/classEnrollment.controller.js
+++ b/backend/src/modules/classes/enrollments/classEnrollment.controller.js
@@ -57,8 +57,8 @@ exports.enroll = catchAsync(async (req, res) => {
         "class",
         classId,
         activePlanId,
-        trx,
-        instructorDelta
+        activeSubscriptionId,
+        trx
       );
     } else if (Number(cls.price) > 0) {
       const payment = await trx("payments")

--- a/backend/src/modules/payments/__tests__/payments.controller.test.js
+++ b/backend/src/modules/payments/__tests__/payments.controller.test.js
@@ -104,7 +104,10 @@ jest.mock('../../paymentMethods/paymentMethods.service', () => ({
 const { validatePaymentData } = require('../helpers/validation');
 const { calculatePlatformFee } = require('../helpers/platformFee');
 const enrollmentService = require('../../classes/enrollments/classEnrollment.service');
-const { creditInstructorWallet } = require('../helpers/wallet');
+const {
+  creditInstructorWallet,
+  creditInstructorSubscription,
+} = require('../helpers/wallet');
 const service = require('../payments.service');
 const AppError = require('../../../utils/AppError');
 const studentRoutes = require('../student.routes');
@@ -223,5 +226,53 @@ describe('Payments controller - enrollment failures', () => {
       paid_at: null,
     });
     expect(creditInstructorWallet).not.toHaveBeenCalled();
+  });
+
+  test('credits instructor subscription once for plan-covered book payment', async () => {
+    validatePaymentData.mockResolvedValue({
+      method: { type: 'card', id: 'method-1' },
+      verifiedAmount: 0,
+      verifiedCurrency: 'USD',
+      finalStatus: STATUS.PAID,
+      verifiedReference: 'ref-plan',
+      planInterval: null,
+      schedules: [],
+      next_due_date: null,
+      totalInstallments: 1,
+      subscriptionPlanId: 'plan-1',
+      subscriptionId: 'sub-1',
+    });
+
+    calculatePlatformFee.mockResolvedValue({
+      platform_fee: 0,
+      instructor_amount: 0,
+    });
+
+    service.create.mockResolvedValue({
+      id: 'payment-plan',
+      user_id: 'student-1',
+      item_type: 'book',
+      item_id: 'book-1',
+      status: STATUS.PAID,
+      reference_id: 'ref-plan',
+    });
+
+    const response = await request(app)
+      .post('/payments')
+      .send({
+        method_id: 'method-1',
+        item_type: 'book',
+        item_id: 'book-1',
+      });
+
+    expect(response.statusCode).toBe(200);
+    expect(creditInstructorSubscription).toHaveBeenCalledTimes(1);
+    expect(creditInstructorSubscription).toHaveBeenCalledWith(
+      'book',
+      'book-1',
+      'plan-1',
+      'sub-1',
+      null,
+    );
   });
 });

--- a/backend/src/modules/payments/helpers/wallet.js
+++ b/backend/src/modules/payments/helpers/wallet.js
@@ -54,16 +54,21 @@ async function creditInstructorSubscription(
   item_type,
   item_id,
   planId,
+  subscriptionId,
   trx,
-  delta,
+  precomputedAmount,
 ) {
   try {
-    const amount = await calculateInstructorAmount(
-      planId,
-      item_id,
-      trx,
-      item_type
-    );
+    const rawAmount =
+      precomputedAmount ??
+      (await calculateInstructorAmount(
+        planId,
+        subscriptionId,
+        item_id,
+        trx,
+        item_type
+      ));
+    const amount = Number.isFinite(rawAmount) ? rawAmount : 0;
     if (amount <= 0) return amount;
 
     let instructorId;

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -135,6 +135,7 @@ exports.createPayment = catchAsync(async (req, res) => {
         item_id,
         subscriptionPlanId,
         subscriptionId,
+        null
       );
     } catch (err) {
       logger.error("Failed to record subscription usage:", err);
@@ -142,12 +143,25 @@ exports.createPayment = catchAsync(async (req, res) => {
   }
 
   if (payment.status === STATUS.PAID) {
-    await walletHelpers.creditInstructorWallet(
-      item_type,
-      item_id,
-      instructor_amount
-    );
-    await handleEnrollment(item_type, user_id, item_id);
+    try {
+      await handleEnrollment(item_type, user_id, item_id);
+      await walletHelpers.creditInstructorWallet(
+        item_type,
+        item_id,
+        instructor_amount
+      );
+    } catch (err) {
+      await service.update(payment.id, {
+        status: STATUS.AWAITING_APPROVAL,
+        paid_at: null,
+      });
+
+      if (err instanceof AppError) {
+        throw err;
+      }
+
+      throw new AppError(err.message || "Enrollment failed", 400);
+    }
   }
 
   if (item_type === "plan" && payment.status === STATUS.PAID) {

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -4,7 +4,11 @@ const AppError = require("../../../../utils/AppError");
 const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
-const { getActiveStudentPlanId } = require("../../../plans/subscription.helper");
+const {
+  getActiveStudentPlanId,
+  getActiveStudentSubscription,
+} = require("../../../plans/subscription.helper");
+const { recordPlanCoveredPayment } = require("../../../payments/helpers/planPayments");
 const { creditTutorialSubscription } = require("../../../payments/helpers/wallet");
 const { getPlanCoveredMethod } = require("../../../payments/helpers/methods");
 
@@ -46,12 +50,21 @@ exports.enroll = catchAsync(async (req, res) => {
         source: "subscription",
       });
 
+      await recordPlanCoveredPayment({
+        trx,
+        userId: user_id,
+        itemId: tutorialId,
+        itemType: "tutorial",
+        amount: 0,
+        currency: tutorial.currency || "USD",
+        source: "subscription",
+      });
+
       await creditTutorialSubscription(
         tutorialId,
         activePlanId,
         activeSubscriptionId,
-        trx,
-        instructorShare
+        trx
       );
     } else if (Number(tutorial.price) > 0) {
       const payment = await trx("payments")

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -61,6 +61,15 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
   });
 
   it('enrolls in a free tutorial', async () => {
+    const tutorialId = '123e4567-e89b-12d3-a456-426614174003';
+
+    const paymentMethodWhere = jest.fn(() => ({
+      first: () => Promise.resolve({ id: 'plan-method-1' }),
+    }));
+    const paymentMethodInsert = jest.fn(() =>
+      Promise.resolve([{ id: 'plan-method-1' }]),
+    );
+
     db.mockImplementation((table) => {
       if (table === 'tutorials')
         return {
@@ -155,6 +164,14 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
 
   it('enrolls in paid tutorial covered by subscription', async () => {
     const calculatedAmount = 42;
+    const tutorialId = '123e4567-e89b-12d3-a456-426614174003';
+
+    const paymentMethodWhere = jest.fn(() => ({
+      first: () => Promise.resolve({ id: 'plan-method-1' }),
+    }));
+    const paymentMethodInsert = jest.fn(() =>
+      Promise.resolve([{ id: 'plan-method-1' }]),
+    );
 
     db.mockImplementation((table) => {
       if (table === 'tutorials')
@@ -175,6 +192,17 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
           where: () => ({ first: () => Promise.resolve(null) }),
           insert: jest.fn(() => Promise.resolve()),
         };
+      if (table === 'payments')
+        return {
+          insert: jest.fn(async () => [
+            {
+              id: 'payment-sub',
+              user_id: 'user1',
+              item_id: tutorialId,
+              status: 'paid',
+            },
+          ]),
+        };
       if (table === 'payment_methods_config')
         return { where: paymentMethodWhere, insert: paymentMethodInsert };
     });
@@ -185,16 +213,20 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
     });
     planRevenue.calculateInstructorAmount.mockResolvedValue(calculatedAmount);
     let instructorWalletBalance = 0;
-    creditTutorialSubscription.mockImplementation(async (
-      _tutorialId,
-      _planId,
-      _trx,
-      amountDelta,
-    ) => {
-      instructorWalletBalance += amountDelta;
-    });
+    getPlanCoveredMethod.mockResolvedValue({ id: 'plan-method-1' });
+    creditTutorialSubscription.mockImplementation(
+      async (tutorial, planId, subscriptionId, trx) => {
+        const amount = await planRevenue.calculateInstructorAmount(
+          planId,
+          subscriptionId,
+          tutorial,
+          trx,
+          'tutorial',
+        );
+        instructorWalletBalance += amount;
+      },
+    );
 
-    const tutorialId = '123e4567-e89b-12d3-a456-426614174003';
     const res = await request(app).post(
       `/api/users/tutorials/enrollments/${tutorialId}`,
     );
@@ -220,8 +252,8 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
       'plan1',
       'sub1',
       expect.anything(),
-      calculatedAmount,
     );
+    expect(creditTutorialSubscription).toHaveBeenCalledTimes(1);
     expect(instructorWalletBalance).toBe(calculatedAmount);
   });
 });


### PR DESCRIPTION
## Summary
- ensure wallet subscription credits call calculateInstructorAmount with the correct argument order and optional precomputed values
- update class, payment, and tutorial enrollment flows to pass subscription identifiers, handle enrollment failures safely, and record plan-covered usage
- expand enrollment and payments tests to assert subscription credits execute once and capture the correct amounts

## Testing
- npm test -- classEnrollment.routes.test.js --runInBand
- npm test -- payments.controller.test.js --runInBand
- npm test -- tutorialEnrollmentRoutes.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e2a3b01f7483288b5706e6a99e5a06