### PR TITLE
Fix publish immediately flag handling in class creation

### DIFF
--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -76,11 +76,18 @@ const generateUniqueSlug = async (title) => {
 
 exports.createClass = catchAsync(async (req, res) => {
   const slug = await generateUniqueSlug(req.body.title);
-  const { tags: rawTags, status, included_plans, access_type, ...body } = req.body;
+  const {
+    tags: rawTags,
+    status,
+    included_plans,
+    access_type,
+    publish_immediately,
+    ...body
+  } = req.body;
   const roles = req.user?.roles || req.user?.role;
-  const adminCaller = isAdminRole(roles);
+  const isAdminUser = isAdminRole(roles);
   const normalizedStatus = status === "published" ? "published" : "draft";
-  const shouldAutoApprove = adminCaller && normalizedStatus === "published";
+  const shouldAutoApprove = isAdminUser && normalizedStatus === "published";
   const data = {
     ...body,
     id: uuidv4(),
@@ -89,8 +96,6 @@ exports.createClass = catchAsync(async (req, res) => {
     moderation_status: shouldAutoApprove ? "Approved" : "Pending",
     access_type: "paid",
   };
-  const roles = req.user?.roles || req.user?.role;
-  const isAdminUser = isAdminRole(roles);
   const publishImmediately = parseBoolean(publish_immediately);
   if (included_plans) {
     let plansList = included_plans;


### PR DESCRIPTION
## Summary
- ensure the class creation controller only derives user roles once and reuses it for admin checks
- include the publish_immediately flag in the request parsing so the publishImmediately logic reads a defined value

## Testing
- npm test -- class.controller.smoke.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a3b36938832887b0d02d4778c67c