### PR TITLE
Fix class publish flag handling and add tests

### DIFF
--- a/backend/src/modules/classes/__tests__/class.controller.test.js
+++ b/backend/src/modules/classes/__tests__/class.controller.test.js
@@ -212,6 +212,7 @@ describe('class.controller createClass', () => {
         title: 'Admin Published Class',
         status: 'published',
         instructor_id: 'instructor1',
+        publish_immediately: 'true',
       },
       user: { id: 'admin1', role: 'admin', roles: ['admin'] },
       files: {},
@@ -246,6 +247,53 @@ describe('class.controller createClass', () => {
         data: expect.objectContaining({
           status: 'published',
           moderation_status: 'Approved',
+        }),
+      })
+    );
+  });
+
+  test('instructors requesting publish immediately still require approval', async () => {
+    service.createClass.mockImplementation(async (data) => data);
+
+    const req = {
+      body: {
+        title: 'Instructor Published Class',
+        status: 'published',
+        publish_immediately: 'true',
+      },
+      user: { id: 'instructor1', role: 'instructor' },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      res.json.mockImplementation((data) => {
+        resolve();
+        return data;
+      });
+      next.mockImplementation((err) => {
+        resolve();
+        return err;
+      });
+      controller.createClass(req, res, next);
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(service.createClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'published',
+        moderation_status: 'Pending',
+      })
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'published',
+          moderation_status: 'Pending',
         }),
       })
     );

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -76,11 +76,18 @@ const generateUniqueSlug = async (title) => {
 
 exports.createClass = catchAsync(async (req, res) => {
   const slug = await generateUniqueSlug(req.body.title);
-  const { tags: rawTags, status, included_plans, access_type, ...body } = req.body;
+  const {
+    tags: rawTags,
+    status,
+    included_plans,
+    access_type,
+    publish_immediately,
+    ...body
+  } = req.body;
   const roles = req.user?.roles || req.user?.role;
-  const adminCaller = isAdminRole(roles);
+  const isAdminUser = isAdminRole(roles);
   const normalizedStatus = status === "published" ? "published" : "draft";
-  const shouldAutoApprove = adminCaller && normalizedStatus === "published";
+  const shouldAutoApprove = isAdminUser && normalizedStatus === "published";
   const data = {
     ...body,
     id: uuidv4(),
@@ -89,8 +96,6 @@ exports.createClass = catchAsync(async (req, res) => {
     moderation_status: shouldAutoApprove ? "Approved" : "Pending",
     access_type: "paid",
   };
-  const roles = req.user?.roles || req.user?.role;
-  const isAdminUser = isAdminRole(roles);
   const publishImmediately = parseBoolean(publish_immediately);
   if (included_plans) {
     let plansList = included_plans;


### PR DESCRIPTION
## Summary
- reuse the existing role lookup when determining admin status and parse the publish_immediately flag safely in the class controller
- cover admin and instructor publish-immediately scenarios in the class controller test suite

## Testing
- npm test -- --runTestsByPath src/modules/classes/__tests__/class.controller.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a3bf952083289513d1a5135f91c4