### PR TITLE
Stop invoking subscribeToPlan during plan checkout

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -8,7 +8,6 @@ import { fetchPlanDetails } from '@/services/public/planService';
 import { validateCode } from '@/services/couponService';
 import { initiateBankPayment, initiateCoinbasePayment, initiateCryptoPayment, initiatePayPalPayment } from '@/services/paymentService';
 import { createPayment, fetchPayment } from '@/services/student/paymentService';
-import { subscribeToPlan } from '@/services/subscriptionService';
 import useCartStore from '@/store/cart/cartStore';
 import { useShallow } from 'zustand/react/shallow';
 import Navbar from '@/components/website/sections/Navbar';
@@ -626,14 +625,6 @@ export default function CheckoutPage() {
     }
 
     if (itemType === 'plan') {
-      try {
-        await subscribeToPlan(itemInfo.id, interval, payment?.id);
-      } catch (err) {
-        console.error('Failed to subscribe to plan', err);
-        toast.error(t('payment_generic_failure'));
-        setPaymentStatus('idle');
-        return;
-      }
       setPaymentStatus('success');
       setTimeout(() => {
         const paymentIdParam = payment?.id ? `&payment_id=${payment.id}` : '';

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -166,6 +166,7 @@ test('adjusts inputs based on payment selection and submits bank reference', asy
         account_holder_name: 'John',
         account_number: '123',
         swift_code: 'ABCDEF',
+        branch_address: '123 Finance St',
       },
     },
   ]);
@@ -337,9 +338,7 @@ test('enrolls in free plan through zero-amount payment', async () => {
       })
     )
   );
-  await waitFor(() =>
-    expect(subscribeToPlan).toHaveBeenCalledWith(1, 'monthly', 101)
-  );
+  expect(subscribeToPlan).not.toHaveBeenCalled();
   jest.runAllTimers();
   await waitFor(() =>
     expect(push).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- stop calling subscribeToPlan during the plan checkout completion flow and rely on the backend for activation
- align checkout flow tests with the updated behavior and ensure mocked bank details cover optional fields

## Testing
- npm test -- checkoutPaymentFlow

------
https://chatgpt.com/codex/tasks/task_e_68e2ad6580608328a7b22c2c2cc2e1f2