### PR TITLE
Handle coupon discounts for plan payments

### DIFF
--- a/backend/src/modules/payments/__tests__/paymentUrls.test.js
+++ b/backend/src/modules/payments/__tests__/paymentUrls.test.js
@@ -30,6 +30,9 @@ jest.mock('../paymentAccess', () => ({
 jest.mock('../../plans/plans.service', () => ({
   getPlanById: jest.fn(),
 }));
+jest.mock('../../coupons/coupons.service', () => ({
+  getCouponById: jest.fn(),
+}));
 jest.mock('../../../utils/response', () => ({
   sendSuccess: jest.fn(),
 }));
@@ -65,6 +68,8 @@ describe('payment controller URLs', () => {
   let paymentMethodsService;
   let paymentsService;
   let backendUrl;
+  let plansService;
+  let couponService;
 
   beforeEach(() => {
     jest.resetModules();
@@ -74,6 +79,8 @@ describe('payment controller URLs', () => {
     paypalService = require('../../../services/paypalService');
     paymentMethodsService = require('../../paymentMethods/paymentMethods.service');
     paymentsService = require('../payments.service');
+    plansService = require('../../plans/plans.service');
+    couponService = require('../../coupons/coupons.service');
     backendUrl = require('../../../config/backendUrl');
     backendUrl.requireBackendBaseUrl.mockReturnValue('https://api.example.com/base');
     backendUrl.getBackendBaseUrlError.mockReturnValue(undefined);
@@ -171,6 +178,75 @@ describe('payment controller URLs', () => {
 
     await expect(cryptoController.initiateCryptoPayment(req, createResponseMock())).rejects.toThrow(
       'Backend base URL is not configured',
+    );
+  });
+
+  it('accepts discounted plan payments for PayPal using coupons', async () => {
+    plansService.getPlanById.mockResolvedValue({
+      id: 'plan-1',
+      price_monthly: '100.00',
+      price_yearly: '1000.00',
+    });
+    couponService.getCouponById.mockResolvedValue({
+      id: 'coupon-1',
+      discount_percent: 10,
+      applies_to: 'plan',
+      applies_to_id: null,
+      starts_at: null,
+      expires_at: null,
+      usage_limit: null,
+      times_used: 0,
+    });
+
+    const req = {
+      body: {
+        item_type: 'plan',
+        item_id: 'plan-1',
+        amount: 90,
+        coupon_id: 'coupon-1',
+      },
+      user: { id: 'user-1' },
+    };
+
+    await paypalController.createPayPalPayment(req, createResponseMock());
+
+    expect(paymentsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 90 }),
+    );
+  });
+
+  it('accepts discounted plan payments for crypto using coupons', async () => {
+    plansService.getPlanById.mockResolvedValue({
+      id: 'plan-1',
+      price_monthly: '50.00',
+      price_yearly: '500.00',
+    });
+    couponService.getCouponById.mockResolvedValue({
+      id: 'coupon-1',
+      discount_percent: 20,
+      applies_to: 'plan',
+      applies_to_id: null,
+      starts_at: null,
+      expires_at: null,
+      usage_limit: null,
+      times_used: 0,
+    });
+
+    const req = {
+      body: {
+        item_type: 'plan',
+        item_id: 'plan-1',
+        amount: 40,
+        method_type: 'crypto',
+        coupon_id: 'coupon-1',
+      },
+      user: { id: 'user-1' },
+    };
+
+    await cryptoController.initiateCryptoPayment(req, createResponseMock());
+
+    expect(paymentsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 40 }),
     );
   });
 });

--- a/backend/src/modules/payments/crypto.controller.js
+++ b/backend/src/modules/payments/crypto.controller.js
@@ -10,6 +10,7 @@ const nowPayments = require('../../services/nowPaymentsService');
 const { v4: uuidv4 } = require('uuid');
 const { grantAccess } = require('./paymentAccess');
 const plansService = require('../plans/plans.service');
+const couponService = require('../coupons/coupons.service');
 const { buildBackendUrl } = require('../../config/env');
 const { requireBackendBaseUrl, getBackendBaseUrlError } = require('../../config/backendUrl');
 
@@ -26,7 +27,7 @@ const SUPPORTED_FIAT = [
 ];
 
 exports.initiateCryptoPayment = catchAsync(async (req, res) => {
-  const { item_type, item_id, amount, currency, method_type } = req.body;
+  const { item_type, item_id, amount, currency, method_type, coupon_id } = req.body;
   const user_id = req.user?.id;
   if (!user_id || !item_type || !item_id || amount === undefined) {
     throw new AppError('Missing required fields', 400);
@@ -43,13 +44,38 @@ exports.initiateCryptoPayment = catchAsync(async (req, res) => {
     throw new AppError('Unsupported currency', 400);
   }
 
+  let coupon = null;
+  if (coupon_id) {
+    coupon = await couponService.getCouponById(coupon_id);
+    if (!coupon) throw new AppError('Invalid coupon', 400);
+    if (coupon.applies_to && coupon.applies_to !== item_type) {
+      throw new AppError('Coupon not valid for this item type', 400);
+    }
+    if (coupon.applies_to_id && coupon.applies_to_id !== item_id) {
+      throw new AppError('Coupon not valid for this item', 400);
+    }
+    if (coupon.starts_at && new Date(coupon.starts_at) > new Date()) {
+      throw new AppError('Coupon not active', 400);
+    }
+    if (coupon.expires_at && new Date(coupon.expires_at) < new Date()) {
+      throw new AppError('Coupon expired', 400);
+    }
+    if (coupon.usage_limit !== null && coupon.times_used >= coupon.usage_limit) {
+      throw new AppError('Coupon usage limit reached', 400);
+    }
+  }
+
   // Validate plan payments to ensure the amount aligns with one of the plan's
   // published prices (monthly or yearly). This keeps plan validation consistent
   // with other item types.
   if (item_type === 'plan') {
     const plan = await plansService.getPlanById(item_id);
     if (!plan) throw new AppError('Plan not found', 404);
-    const prices = [Number(plan.price_monthly), Number(plan.price_yearly)];
+    let prices = [Number(plan.price_monthly), Number(plan.price_yearly)];
+    prices = prices.filter((p) => Number.isFinite(p) && p > 0);
+    if (coupon) {
+      prices = prices.map((p) => +(p * (1 - coupon.discount_percent / 100)).toFixed(2));
+    }
     const matched = prices.find((p) => Math.abs(numericAmount - p) < 0.01);
     if (!matched) {
       throw new AppError('Payment amount does not match plan price', 400);

--- a/backend/src/modules/payments/paypal.controller.js
+++ b/backend/src/modules/payments/paypal.controller.js
@@ -10,6 +10,7 @@ const paypalService = require('../../services/paypalService');
 const { grantAccess } = require('./paymentAccess');
 const { v4: uuidv4 } = require('uuid');
 const plansService = require('../plans/plans.service');
+const couponService = require('../coupons/coupons.service');
 const { buildBackendUrl } = require('../../config/env');
 const { requireBackendBaseUrl, getBackendBaseUrlError } = require('../../config/backendUrl');
 
@@ -25,7 +26,7 @@ const SUPPORTED_CURRENCIES = [
 ];
 
 exports.createPayPalPayment = catchAsync(async (req, res) => {
-  const { item_type, item_id, amount, currency } = req.body;
+  const { item_type, item_id, amount, currency, coupon_id } = req.body;
   const user_id = req.user?.id;
   if (!user_id || !item_type || !item_id || amount === undefined) {
     throw new AppError('Missing required fields', 400);
@@ -42,13 +43,38 @@ exports.createPayPalPayment = catchAsync(async (req, res) => {
     throw new AppError('Unsupported currency', 400);
   }
 
+  let coupon = null;
+  if (coupon_id) {
+    coupon = await couponService.getCouponById(coupon_id);
+    if (!coupon) throw new AppError('Invalid coupon', 400);
+    if (coupon.applies_to && coupon.applies_to !== item_type) {
+      throw new AppError('Coupon not valid for this item type', 400);
+    }
+    if (coupon.applies_to_id && coupon.applies_to_id !== item_id) {
+      throw new AppError('Coupon not valid for this item', 400);
+    }
+    if (coupon.starts_at && new Date(coupon.starts_at) > new Date()) {
+      throw new AppError('Coupon not active', 400);
+    }
+    if (coupon.expires_at && new Date(coupon.expires_at) < new Date()) {
+      throw new AppError('Coupon expired', 400);
+    }
+    if (coupon.usage_limit !== null && coupon.times_used >= coupon.usage_limit) {
+      throw new AppError('Coupon usage limit reached', 400);
+    }
+  }
+
   // For plan subscriptions, ensure the payment amount matches one of the
   // published plan prices. This mirrors the validation applied to other
   // purchasable items like classes or books.
   if (item_type === 'plan') {
     const plan = await plansService.getPlanById(item_id);
     if (!plan) throw new AppError('Plan not found', 404);
-    const prices = [Number(plan.price_monthly), Number(plan.price_yearly)];
+    let prices = [Number(plan.price_monthly), Number(plan.price_yearly)];
+    prices = prices.filter((p) => Number.isFinite(p) && p > 0);
+    if (coupon) {
+      prices = prices.map((p) => +(p * (1 - coupon.discount_percent / 100)).toFixed(2));
+    }
     const matched = prices.find((p) => Math.abs(numericAmount - p) < 0.01);
     if (!matched) {
       throw new AppError('Payment amount does not match plan price', 400);


### PR DESCRIPTION
## Summary
- load and validate optional coupons in the PayPal and crypto payment controllers
- adjust plan price validation to account for coupon discounts before accepting payment amounts
- extend payment URL controller tests to cover discounted plan payments for both gateways

## Testing
- npm test -- paymentUrls.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2b0baec688328b86dfd918fbd5984