### PR TITLE
Handle pending default payments

### DIFF
--- a/frontend/src/pages/payments/checkout.js
+++ b/frontend/src/pages/payments/checkout.js
@@ -358,10 +358,27 @@ export async function handleDefaultPayment({
     if (itemType === 'plan') payload.interval = interval;
     if (couponId) payload.coupon_id = couponId;
     const response = await createPayment(payload);
-    if (response?.status === 'paid') {
-      await completePayment(response);
-    } else {
-      throw new Error('Payment not confirmed');
+
+    if (!response || typeof response !== 'object') {
+      throw new Error('Invalid payment response');
+    }
+
+    await completePayment(response);
+
+    const status =
+      typeof response.status === 'string' ? response.status.toLowerCase() : '';
+
+    if (!status) {
+      throw new Error('Payment status missing');
+    }
+
+    const failureIndicators = ['fail', 'cancel', 'declin', 'error'];
+    const isFailureStatus = failureIndicators.some((indicator) =>
+      status.includes(indicator)
+    );
+
+    if (isFailureStatus) {
+      throw new Error(`Payment ${status}`);
     }
   } catch (err) {
     console.error('Failed to process payment', err);

--- a/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
+++ b/frontend/src/tests/__tests__/checkoutPaymentFlow.test.js
@@ -166,6 +166,7 @@ test('adjusts inputs based on payment selection and submits bank reference', asy
         account_holder_name: 'John',
         account_number: '123',
         swift_code: 'ABCDEF',
+        branch_address: '123 Finance St',
       },
     },
   ]);
@@ -195,7 +196,7 @@ test('submits payment for non-stripe card processors without Stripe tokenization
   fetchPaymentMethods.mockResolvedValue([
     { id: 1, name: 'Paystack', type: 'paystack' },
   ]);
-  createPayment.mockResolvedValue({ status: 'paid' });
+  createPayment.mockResolvedValue({ status: 'pending_payment' });
   global.mockStripeCreateToken.mockClear();
   render(<CheckoutPage />);
   await screen.findByText('Checkout');
@@ -206,6 +207,14 @@ test('submits payment for non-stripe card processors without Stripe tokenization
   const payload = createPayment.mock.calls[0][0];
   expect(payload.token).toBeUndefined();
   expect(global.mockStripeCreateToken).not.toHaveBeenCalled();
+  await waitFor(() =>
+    expect(require('react-toastify').toast.error).toHaveBeenCalledWith(
+      'payment_pending_confirmation'
+    )
+  );
+  expect(require('react-toastify').toast.error).not.toHaveBeenCalledWith(
+    'payment_generic_failure'
+  );
 });
 
 test('submits per-installment amount for multi-installment card payments', async () => {


### PR DESCRIPTION
## Summary
- ensure the default payment handler forwards every payment response to the shared completion helper while filtering real failure statuses
- expand the checkout flow test to cover pending non-Stripe processors and assert the pending confirmation toast instead of the generic failure

## Testing
- npm test -- checkoutPaymentFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2b0becf4883289dcac68bf03a99ca