### PR TITLE
Fix book checkout helpers and add smoke test

### DIFF
--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -47,6 +47,9 @@ jest.mock('../../library/library.service', () => ({
 jest.mock('../../payments/paymentAccess', () => ({
   grantAccess: jest.fn(() => Promise.resolve()),
 }));
+jest.mock('../../paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn().mockResolvedValue(null),
+}));
 
 jest.mock('../../payments/payments.service', () => ({
   STATUS: { PAID: 'paid', AWAITING_APPROVAL: 'awaiting_approval' },
@@ -190,6 +193,30 @@ describe('listBooks', () => {
     const result = await listBooks({ search: 'DetailedMatch' });
     expect(result.data).toHaveLength(1);
     expect(result.data[0].id).toBe(3);
+  });
+});
+
+describe('checkout (smoke)', () => {
+  const studentId = 'student-smoke';
+
+  beforeEach(async () => {
+    await db('book_cart').del();
+    await db('book_purchases').del();
+    await db('payments').del();
+  });
+
+  test('processes checkout without subscription coverage', async () => {
+    await db('book_cart').insert({ student_id: studentId, book_id: 1 });
+
+    const payments = await checkout(studentId);
+
+    expect(payments).toHaveLength(1);
+    expect(payments[0]).toMatchObject({
+      user_id: studentId,
+      item_type: 'book',
+      item_id: 1,
+      amount: 10,
+    });
   });
 });
 

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -10,7 +10,8 @@ const paymentMethodsService = require("../paymentMethods/paymentMethods.service"
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const libraryService = require("../library/library.service");
 const { v4: uuidv4 } = require("uuid");
-const { getActiveStudentPlanId } = require("../plans/subscription.helper");
+const { getActiveStudentSubscription } = require("../plans/subscription.helper");
+const { creditInstructorSubscription } = require("../payments/helpers/wallet");
 const { getPlanCoveredMethod } = require("../payments/helpers/methods");
 
 const { STATUS: PAYMENT_STATUS } = paymentsService;
@@ -287,7 +288,6 @@ exports.checkout = async (studentId) => {
   const activeSubscription = await getActiveStudentSubscription(studentId);
   const activePlanId = activeSubscription?.plan_id;
   const activeSubscriptionId = activeSubscription?.id;
-  let subscriptionMethod = null;
 
   return db.transaction(async (trx) => {
     const items = await trx('book_cart')
@@ -334,8 +334,8 @@ exports.checkout = async (studentId) => {
         if (!planMethodRecord) {
           planMethodRecord = await getPlanCoveredMethod(trx);
         }
-        const [payment] = await trx('payments')
-          .insert({
+        const [payment] = await trx('payments').insert(
+          {
             id: uuidv4(),
             user_id: studentId,
             method_id: planMethodRecord.id,
@@ -343,7 +343,6 @@ exports.checkout = async (studentId) => {
             item_id: b.id,
             amount: 0,
             status: PAYMENT_STATUS.PAID,
-            method_id: subscriptionMethod.id,
             source: 'subscription',
             paid_at: new Date(),
           },


### PR DESCRIPTION
## Summary
- import the subscription and instructor wallet helpers so the checkout flow resolves without runtime reference errors
- adjust the subscription-covered checkout path to reuse the plan-covered method and credit the instructor correctly
- add a book checkout smoke test and mock payment configuration settings to keep the test database self-contained

## Testing
- npm test -- --runInBand src/modules/books/__tests__/book.service.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2b0d9ddb883289e419341cf67215c