### PR TITLE
Fix book checkout plan payments and extend tests

### DIFF
--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -20,48 +20,109 @@ const mockDb = knex({
   useNullAsDefault: true,
 });
 
+const parseJsonColumns = (result) => {
+  const parseRow = (row) => {
+    if (row && typeof row === 'object' && 'included_plans' in row) {
+      const value = row.included_plans;
+      if (typeof value === 'string') {
+        try {
+          row.included_plans = JSON.parse(value);
+        } catch (_) {
+          // ignore parsing errors for non-JSON values
+        }
+      }
+    }
+    return row;
+  };
+
+  if (Array.isArray(result)) {
+    return result.map((row) => parseRow(row));
+  }
+  return parseRow(result);
+};
+
+mockDb.client.config.postProcessResponse = parseJsonColumns;
+
 // Mock the database module used in the service
 jest.mock('../../../config/database', () => mockDb);
+
 jest.mock('../../plans/subscription.helper', () => ({
-  getActiveStudentPlanId: jest.fn().mockResolvedValue(null),
   getActiveStudentSubscription: jest.fn().mockResolvedValue(null),
 }));
+
 jest.mock('../../payments/helpers/wallet', () => ({
-  creditInstructorSubscription: jest
-    .fn()
-    .mockImplementation(() => Promise.resolve()),
+  creditInstructorSubscription: jest.fn().mockResolvedValue(undefined),
   creditInstructorWallet: jest.fn(),
-}));
-jest.mock('../../payments/payments.service', () => ({
-  create: jest.fn(async (data) => ({ ...data, status: 'awaiting_approval' })),
-  approveBankPayment: jest.fn(async (id, payload) => ({
-    id,
-    ...payload,
-    status: 'paid',
-  })),
-  STATUS: { AWAITING_APPROVAL: 'awaiting_approval', PAID: 'paid' },
-}));
-jest.mock('../../library/library.service', () => ({
-  recordPurchase: jest.fn(),
-}));
-jest.mock('../../payments/paymentAccess', () => ({
-  grantAccess: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock('../../payments/payments.service', () => ({
   STATUS: { PAID: 'paid', AWAITING_APPROVAL: 'awaiting_approval' },
-  create: jest.fn(async (data) => ({ id: 'pay-' + Math.random(), ...data, status: 'awaiting_approval' })),
-  approveBankPayment: jest.fn(async (id, data) => ({ id, ...data, status: 'paid' })),
+  create: jest.fn(async (data) => ({
+    ...data,
+    status: 'awaiting_approval',
+  })),
+  approveBankPayment: jest.fn(async (id, data) => ({
+    id,
+    ...data,
+    status: 'paid',
+  })),
+}));
+
+jest.mock('../../library/library.service', () => ({
+  recordPurchase: jest.fn(),
 }));
 
 jest.mock('../../payments/paymentAccess', () => ({
   grantAccess: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn().mockResolvedValue(null),
 }));
 
 const db = require('../../../config/database');
 const { listBooks, checkout, updateBook } = require('../book.service');
 const paymentsService = require('../../payments/payments.service');
 const { grantAccess } = require('../../payments/paymentAccess');
+const { creditInstructorSubscription } = require('../../payments/helpers/wallet');
+const { getActiveStudentSubscription } = require('../../plans/subscription.helper');
+
+paymentsService.create.mockImplementation(async (data, _returning = [], trx) => {
+  const client = trx || db;
+  await client('payments').insert({
+    ...data,
+    status: data.status ?? paymentsService.STATUS.AWAITING_APPROVAL,
+  });
+  return { ...data, status: paymentsService.STATUS.AWAITING_APPROVAL };
+});
+
+grantAccess.mockImplementation(async (payment) => {
+  if (payment.status === paymentsService.STATUS.PAID) {
+    await db('book_purchases').insert({
+      student_id: payment.user_id,
+      book_id: payment.item_id,
+      price_paid: payment.amount,
+    });
+  }
+});
+
+paymentsService.approveBankPayment.mockImplementation(async (id, data) => {
+  const payment = await db('payments').where({ id }).first();
+  const updated = {
+    ...payment,
+    ...data,
+    status: paymentsService.STATUS.PAID,
+  };
+  await db('payments')
+    .where({ id })
+    .update({
+      amount: updated.amount,
+      item_id: updated.item_id,
+      item_type: updated.item_type,
+      status: paymentsService.STATUS.PAID,
+    });
+  return updated;
+});
 
 beforeAll(async () => {
   await db.schema.createTable('books', (table) => {
@@ -109,6 +170,12 @@ beforeAll(async () => {
     active: 1,
     name: 'Bank',
   });
+  await db('payment_methods_config').insert({
+    id: 'sub1',
+    type: 'subscription',
+    active: 1,
+    name: 'Subscription',
+  });
 
   await db.schema.createTable('payments', (table) => {
     table.uuid('id').primary();
@@ -122,6 +189,13 @@ beforeAll(async () => {
     table.decimal('platform_fee', 10, 2).defaultTo(0);
     table.decimal('instructor_amount', 10, 2).defaultTo(0);
     table.timestamp('paid_at');
+    table.string('source');
+  });
+
+  await db.schema.createTable('settings', (table) => {
+    table.string('key').primary();
+    table.text('value');
+    table.timestamp('updated_at');
   });
 
   const books = [
@@ -193,13 +267,50 @@ describe('listBooks', () => {
   });
 });
 
-describe.skip('checkout', () => {
+describe('checkout', () => {
   const studentId = 'student1';
 
   beforeEach(async () => {
     await db('book_cart').del();
     await db('book_purchases').del();
     await db('payments').del();
+    await db('books').update({ included_plans: JSON.stringify([]) });
+    jest.clearAllMocks();
+    getActiveStudentSubscription.mockResolvedValue(null);
+    paymentsService.create.mockImplementation(async (data, _returning = [], trx) => {
+      const client = trx || db;
+      await client('payments').insert({
+        ...data,
+        status: data.status ?? paymentsService.STATUS.AWAITING_APPROVAL,
+      });
+      return { ...data, status: paymentsService.STATUS.AWAITING_APPROVAL };
+    });
+    grantAccess.mockImplementation(async (payment) => {
+      if (payment.status === paymentsService.STATUS.PAID) {
+        await db('book_purchases').insert({
+          student_id: payment.user_id,
+          book_id: payment.item_id,
+          price_paid: payment.amount,
+        });
+      }
+    });
+    paymentsService.approveBankPayment.mockImplementation(async (id, data) => {
+      const payment = await db('payments').where({ id }).first();
+      const updated = {
+        ...payment,
+        ...data,
+        status: paymentsService.STATUS.PAID,
+      };
+      await db('payments')
+        .where({ id })
+        .update({
+          amount: updated.amount,
+          item_id: updated.item_id,
+          item_type: updated.item_type,
+          status: paymentsService.STATUS.PAID,
+        });
+      return updated;
+    });
   });
 
   test('throws error when book already purchased', async () => {
@@ -216,6 +327,44 @@ describe.skip('checkout', () => {
     expect(purchases).toHaveLength(1);
     const payments = await db('payments');
     expect(payments).toHaveLength(0);
+  });
+
+  test('uses subscription payment method for plan-covered checkout', async () => {
+    await db('books')
+      .where({ id: 1 })
+      .update({ included_plans: JSON.stringify(['plan-123']) });
+    await db('book_cart').insert({ student_id: studentId, book_id: 1 });
+    getActiveStudentSubscription.mockResolvedValue({
+      id: 'sub-123',
+      plan_id: 'plan-123',
+    });
+
+    const payments = await checkout(studentId);
+
+    expect(payments).toHaveLength(1);
+    const paymentRecord = await db('payments')
+      .where({ user_id: studentId, item_id: 1, item_type: 'book' })
+      .first();
+    expect(paymentRecord).toBeTruthy();
+    expect(paymentRecord.method_id).toBe('sub1');
+    expect(Number(paymentRecord.amount)).toBe(0);
+    expect(paymentRecord.status).toBe('paid');
+    expect(paymentRecord.source).toBe('subscription');
+
+    const purchaseRecord = await db('book_purchases')
+      .where({ student_id: studentId, book_id: 1 })
+      .first();
+    expect(purchaseRecord).toBeTruthy();
+    expect(Number(purchaseRecord.price_paid)).toBe(0);
+
+    expect(creditInstructorSubscription).toHaveBeenCalledTimes(1);
+    expect(creditInstructorSubscription).toHaveBeenCalledWith(
+      'book',
+      1,
+      'plan-123',
+      'sub-123',
+      expect.any(Function)
+    );
   });
 
   test('completes checkout when no duplicates', async () => {

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -10,8 +10,9 @@ const paymentMethodsService = require("../paymentMethods/paymentMethods.service"
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const libraryService = require("../library/library.service");
 const { v4: uuidv4 } = require("uuid");
-const { getActiveStudentPlanId } = require("../plans/subscription.helper");
+const { getActiveStudentSubscription } = require("../plans/subscription.helper");
 const { getPlanCoveredMethod } = require("../payments/helpers/methods");
+const { creditInstructorSubscription } = require("../payments/helpers/wallet");
 
 const { STATUS: PAYMENT_STATUS } = paymentsService;
 
@@ -287,7 +288,6 @@ exports.checkout = async (studentId) => {
   const activeSubscription = await getActiveStudentSubscription(studentId);
   const activePlanId = activeSubscription?.plan_id;
   const activeSubscriptionId = activeSubscription?.id;
-  let subscriptionMethod = null;
 
   return db.transaction(async (trx) => {
     const items = await trx('book_cart')
@@ -334,22 +334,26 @@ exports.checkout = async (studentId) => {
         if (!planMethodRecord) {
           planMethodRecord = await getPlanCoveredMethod(trx);
         }
-        const [payment] = await trx('payments')
-          .insert({
-            id: uuidv4(),
+        const paymentId = uuidv4();
+        await trx('payments').insert(
+          {
+            id: paymentId,
             user_id: studentId,
             method_id: planMethodRecord.id,
             item_type: 'book',
             item_id: b.id,
             amount: 0,
             status: PAYMENT_STATUS.PAID,
-            method_id: subscriptionMethod.id,
             source: 'subscription',
             paid_at: new Date(),
           },
           [],
           trx
         );
+
+        const payment = await trx('payments')
+          .where({ id: paymentId })
+          .first();
 
         await trx('book_purchases').insert({
           student_id: studentId,


### PR DESCRIPTION
## Summary
- ensure book checkout uses the plan-covered payment method and credits instructors when a subscription covers the book
- clean up subscription payment creation to persist the record before returning it
- expand the book service test suite to cover subscription checkouts and emulate related payment flows

## Testing
- npm test -- book.service.test.js --runInBand --detectOpenHandles

------
https://chatgpt.com/codex/tasks/task_e_68e2b0f2f524832888dfa9987dc81046