### PR TITLE
Fix subscription checkout method handling and tests

### DIFF
--- a/backend/src/modules/books/__tests__/book.service.test.js
+++ b/backend/src/modules/books/__tests__/book.service.test.js
@@ -20,6 +20,26 @@ const mockDb = knex({
   useNullAsDefault: true,
 });
 
+const normalizeRow = (row) => {
+  if (row && typeof row === 'object' && !Array.isArray(row)) {
+    if (typeof row.included_plans === 'string') {
+      try {
+        row.included_plans = JSON.parse(row.included_plans);
+      } catch (_) {
+        row.included_plans = [];
+      }
+    }
+  }
+  return row;
+};
+
+mockDb.client.config.postProcessResponse = (result) => {
+  if (Array.isArray(result)) {
+    return result.map((row) => normalizeRow(row));
+  }
+  return normalizeRow(result);
+};
+
 // Mock the database module used in the service
 jest.mock('../../../config/database', () => mockDb);
 jest.mock('../../plans/subscription.helper', () => ({
@@ -109,6 +129,12 @@ beforeAll(async () => {
     active: 1,
     name: 'Bank',
   });
+  await db('payment_methods_config').insert({
+    id: 'sub-method-1',
+    type: 'subscription',
+    active: 1,
+    name: 'Subscription',
+  });
 
   await db.schema.createTable('payments', (table) => {
     table.uuid('id').primary();
@@ -119,6 +145,7 @@ beforeAll(async () => {
     table.decimal('amount', 10, 2);
     table.string('currency');
     table.string('status');
+    table.string('source');
     table.decimal('platform_fee', 10, 2).defaultTo(0);
     table.decimal('instructor_amount', 10, 2).defaultTo(0);
     table.timestamp('paid_at');
@@ -193,7 +220,7 @@ describe('listBooks', () => {
   });
 });
 
-describe.skip('checkout', () => {
+describe('checkout', () => {
   const studentId = 'student1';
 
   beforeEach(async () => {

--- a/backend/src/modules/books/__tests__/checkout.subscription.unit.test.js
+++ b/backend/src/modules/books/__tests__/checkout.subscription.unit.test.js
@@ -1,0 +1,155 @@
+jest.mock('../../../config/database', () => ({
+  transaction: jest.fn(),
+}));
+
+jest.mock('../../paymentMethods/paymentMethods.service', () => ({
+  getByType: jest.fn(),
+}));
+
+jest.mock('../../payments/helpers/methods', () => ({
+  getPlanCoveredMethod: jest.fn(),
+}));
+
+jest.mock('../../payments/helpers/wallet', () => ({
+  creditInstructorSubscription: jest.fn(),
+}));
+
+jest.mock('../../plans/subscription.helper', () => ({
+  getActiveStudentSubscription: jest.fn(),
+}));
+
+jest.mock('../../paymentConfig/paymentConfig.service', () => ({
+  getSettings: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../../payments/payments.service', () => ({
+  STATUS: { PAID: 'paid', AWAITING_APPROVAL: 'awaiting_approval' },
+  create: jest.fn(),
+}));
+
+jest.mock('../../library/library.service', () => ({
+  recordPurchase: jest.fn(),
+}));
+
+jest.mock('uuid', () => ({
+  v4: () => 'payment-uuid',
+}));
+
+const db = require('../../../config/database');
+const paymentMethodsService = require('../../paymentMethods/paymentMethods.service');
+const { getPlanCoveredMethod } = require('../../payments/helpers/methods');
+const { creditInstructorSubscription } = require('../../payments/helpers/wallet');
+const { getActiveStudentSubscription } = require('../../plans/subscription.helper');
+const libraryService = require('../../library/library.service');
+const { checkout } = require('../book.service');
+
+describe('checkout subscription coverage (unit)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    paymentMethodsService.getByType.mockImplementation((type) => {
+      if (type === 'bank') {
+        return { id: 'bank-method' };
+      }
+      throw new Error(`Unexpected payment type: ${type}`);
+    });
+    getPlanCoveredMethod.mockResolvedValue({ id: 'subscription-method' });
+    getActiveStudentSubscription.mockResolvedValue({
+      id: 'subscription-1',
+      plan_id: 'plan-1',
+    });
+    libraryService.recordPurchase.mockResolvedValue(undefined);
+  });
+
+  test('credits instructor when book checkout is covered by subscription', async () => {
+    const insertedPayments = [];
+    const insertedPurchases = [];
+
+    const bookCartQuery = {
+      where: jest.fn(() => bookCartQuery),
+      whereIn: jest.fn(() => bookCartQuery),
+      select: jest.fn(async () => [{ book_id: 'book-1' }]),
+      del: jest.fn(async () => undefined),
+    };
+
+    const bookPurchasesQuery = {
+      where: jest.fn(() => bookPurchasesQuery),
+      whereIn: jest.fn(() => bookPurchasesQuery),
+      select: jest.fn(async () => []),
+      insert: jest.fn(async (data) => {
+        insertedPurchases.push(data);
+        return [data];
+      }),
+    };
+
+    const booksQuery = {
+      whereIn: jest.fn(() => booksQuery),
+      where: jest.fn(() => booksQuery),
+      select: jest.fn(async () => [
+        { id: 'book-1', price: 15, included_plans: ['plan-1'] },
+      ]),
+    };
+
+    const paymentsQuery = {
+      insert: jest.fn(async (data) => {
+        insertedPayments.push(data);
+        return [data];
+      }),
+    };
+
+    db.transaction.mockImplementation(async (callback) => {
+      const trx = (table) => {
+        switch (table) {
+          case 'book_cart':
+            return bookCartQuery;
+          case 'book_purchases':
+            return bookPurchasesQuery;
+          case 'books':
+            return booksQuery;
+          case 'payments':
+            return paymentsQuery;
+          default:
+            throw new Error(`Unexpected table: ${table}`);
+        }
+      };
+      return callback(trx);
+    });
+
+    const payments = await checkout('student-1');
+
+    expect(bookCartQuery.select).toHaveBeenCalledTimes(1);
+    expect(bookPurchasesQuery.select).toHaveBeenCalledTimes(1);
+    expect(booksQuery.select).toHaveBeenCalledTimes(1);
+    expect(paymentsQuery.insert).toHaveBeenCalledTimes(1);
+
+    expect(insertedPayments).toHaveLength(1);
+    expect(insertedPayments[0]).toMatchObject({
+      method_id: 'subscription-method',
+      amount: 0,
+      source: 'subscription',
+    });
+
+    expect(insertedPurchases).toContainEqual({
+      student_id: 'student-1',
+      book_id: 'book-1',
+      price_paid: 0,
+    });
+
+    expect(payments).toEqual([
+      expect.objectContaining({
+        id: 'payment-uuid',
+        method_id: 'subscription-method',
+        amount: 0,
+      }),
+    ]);
+
+    expect(creditInstructorSubscription).toHaveBeenCalledTimes(1);
+    expect(creditInstructorSubscription).toHaveBeenCalledWith(
+      'book',
+      'book-1',
+      'plan-1',
+      'subscription-1',
+      expect.any(Function)
+    );
+    expect(libraryService.recordPurchase).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -10,8 +10,11 @@ const paymentMethodsService = require("../paymentMethods/paymentMethods.service"
 const paymentConfigService = require("../paymentConfig/paymentConfig.service");
 const libraryService = require("../library/library.service");
 const { v4: uuidv4 } = require("uuid");
-const { getActiveStudentPlanId } = require("../plans/subscription.helper");
+const {
+  getActiveStudentSubscription,
+} = require("../plans/subscription.helper");
 const { getPlanCoveredMethod } = require("../payments/helpers/methods");
+const { creditInstructorSubscription } = require("../payments/helpers/wallet");
 
 const { STATUS: PAYMENT_STATUS } = paymentsService;
 
@@ -334,16 +337,18 @@ exports.checkout = async (studentId) => {
         if (!planMethodRecord) {
           planMethodRecord = await getPlanCoveredMethod(trx);
         }
+        if (!subscriptionMethod) {
+          subscriptionMethod = planMethodRecord;
+        }
         const [payment] = await trx('payments')
           .insert({
             id: uuidv4(),
             user_id: studentId,
-            method_id: planMethodRecord.id,
+            method_id: subscriptionMethod.id,
             item_type: 'book',
             item_id: b.id,
             amount: 0,
             status: PAYMENT_STATUS.PAID,
-            method_id: subscriptionMethod.id,
             source: 'subscription',
             paid_at: new Date(),
           },


### PR DESCRIPTION
## Summary
- ensure the books checkout service loads the subscription payment method once and records it on subscription-covered purchases
- normalize included plan data in the existing book service tests so JSON columns are parsed consistently
- add a focused unit test that exercises the subscription-covered checkout path and verifies the instructor wallet credit helper is invoked

## Testing
- npm test -- checkout.subscription.unit.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2b0ef7ac883288eeed1228d8e167c