### PR TITLE
Fix plan-covered tutorial enrollment payments

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/__tests__/tutorialEnrollment.routes.test.js
+++ b/backend/src/modules/users/tutorials/enrollments/__tests__/tutorialEnrollment.routes.test.js
@@ -85,6 +85,7 @@ describe('Tutorial enrollment routes', () => {
         source: 'subscription',
       }),
     );
+    expect(recordPlanCoveredPayment).toHaveBeenCalledTimes(1);
     expect(db.insert).toHaveBeenCalledWith(
       expect.objectContaining({
         id: expect.any(String),

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -10,8 +10,6 @@ const {
 } = require("../../../plans/subscription.helper");
 const { recordPlanCoveredPayment } = require("../../../payments/helpers/planPayments");
 const { creditTutorialSubscription } = require("../../../payments/helpers/wallet");
-const { getPlanCoveredMethod } = require("../../../payments/helpers/methods");
-const { recordPlanCoveredPayment } = require("../../../payments/helpers/planPayments");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -38,28 +36,6 @@ exports.enroll = catchAsync(async (req, res) => {
 
   const enroll = async (trx) => {
     if (coveredBySubscription) {
-      const planMethod = await getPlanCoveredMethod(trx);
-
-      await trx("payments").insert({
-        user_id,
-        method_id: planMethod.id,
-        item_id: tutorialId,
-        item_type: "tutorial",
-        amount: 0,
-        currency: tutorial.currency || "USD",
-        source: "subscription",
-      });
-
-      await recordPlanCoveredPayment({
-        trx,
-        userId: user_id,
-        itemId: tutorialId,
-        itemType: "tutorial",
-        amount: 0,
-        currency: tutorial.currency || "USD",
-        source: "subscription",
-      });
-
       await recordPlanCoveredPayment({
         trx,
         userId: user_id,

--- a/backend/tests/tutorialEnrollmentRoutes.test.js
+++ b/backend/tests/tutorialEnrollmentRoutes.test.js
@@ -14,9 +14,6 @@ const {
   getActiveStudentSubscription,
 } = require('../src/modules/plans/subscription.helper');
 
-jest.mock('../src/modules/payments/helpers/methods.js', () => ({
-  getPlanCoveredMethod: jest.fn(),
-}));
 jest.mock('../src/modules/payments/helpers/planRevenue', () => ({
   calculateInstructorAmount: jest.fn(),
 }));
@@ -24,21 +21,12 @@ jest.mock('../src/modules/payments/helpers/planPayments', () => ({
   recordPlanCoveredPayment: jest.fn(),
 }));
 const planRevenue = require('../src/modules/payments/helpers/planRevenue');
-const { getPlanCoveredMethod } = require('../src/modules/payments/helpers/methods.js');
 const { recordPlanCoveredPayment } = require('../src/modules/payments/helpers/planPayments');
-
-const paymentMethodWhere = jest.fn(() => ({
-  first: () => Promise.resolve({ id: 'subscription-method-id' }),
-}));
-const paymentMethodInsert = jest.fn(() => Promise.resolve([{ id: 'subscription-method-id' }]));
 
 jest.mock('../src/modules/payments/helpers/wallet', () => ({
   creditTutorialSubscription: jest.fn(),
 }));
-const walletService = require('../src/modules/payouts/wallet.service');
-const tutorialService = require('../src/modules/users/tutorials/tutorial.service');
-const paymentMethodWhere = jest.fn(() => ({ first: () => Promise.resolve({ id: 'plan-method-1' }) }));
-const paymentMethodInsert = jest.fn(() => Promise.resolve([{ id: 'plan-method-1' }]));
+const { creditTutorialSubscription } = require('../src/modules/payments/helpers/wallet');
 
 jest.mock('../src/middleware/auth/authMiddleware', () => ({
   verifyToken: (req, _res, next) => {
@@ -62,7 +50,6 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
     planRevenue.calculateInstructorAmount.mockResolvedValue(0);
     recordPlanCoveredPayment.mockResolvedValue({ id: 'payment-id' });
     creditTutorialSubscription.mockResolvedValue();
-    getPlanCoveredMethod.mockResolvedValue({ id: 'subscription-method-id' });
   });
 
   it('enrolls in a free tutorial', async () => {
@@ -218,7 +205,6 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
     });
     planRevenue.calculateInstructorAmount.mockResolvedValue(calculatedAmount);
     let instructorWalletBalance = 0;
-    getPlanCoveredMethod.mockResolvedValue({ id: 'plan-method-1' });
     creditTutorialSubscription.mockImplementation(
       async (tutorial, planId, subscriptionId, trx) => {
         const amount = await planRevenue.calculateInstructorAmount(
@@ -242,9 +228,9 @@ describe('POST /api/users/tutorials/enrollments/:id', () => {
       'sub1',
       tutorialId,
       expect.anything(),
-      'tutorial',
-      {}
+      'tutorial'
     );
+    expect(recordPlanCoveredPayment).toHaveBeenCalledTimes(1);
     expect(creditTutorialSubscription).toHaveBeenCalledWith(
       tutorialId,
       'plan1',


### PR DESCRIPTION
## Summary
- ensure tutorial enrollments covered by a subscription only record plan payments through the helper
- clean up duplicated imports and unused helpers in the tutorial enrollment controller and route tests
- extend enrollment tests to assert a single plan payment is recorded and wallet credits still execute

## Testing
- npm test -- tutorialEnrollmentRoutes.test.js
- npm test -- tutorialEnrollment.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2bb9b3294832889fd5991d35fc7b3