### PR TITLE
Remove duplicate plan payment import in tutorial enrollment controller

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -8,7 +8,6 @@ const {
   getActiveStudentPlanId,
   getActiveStudentSubscription,
 } = require("../../../plans/subscription.helper");
-const { recordPlanCoveredPayment } = require("../../../payments/helpers/planPayments");
 const { creditTutorialSubscription } = require("../../../payments/helpers/wallet");
 const { getPlanCoveredMethod } = require("../../../payments/helpers/methods");
 const { recordPlanCoveredPayment } = require("../../../payments/helpers/planPayments");


### PR DESCRIPTION
## Summary
- remove the duplicated recordPlanCoveredPayment import from the tutorial enrollment controller

## Testing
- npm --prefix backend test -- tutorialEnrollment *(fails: existing duplicate identifier mock in tutorialEnrollmentRoutes.test.js and expectation failure)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bba054c083289c6fdba4c639afbb