### PR TITLE
Ensure subscription enrollments only record one payment

### DIFF
--- a/backend/src/modules/users/tutorials/enrollments/__tests__/tutorialEnrollment.routes.test.js
+++ b/backend/src/modules/users/tutorials/enrollments/__tests__/tutorialEnrollment.routes.test.js
@@ -25,7 +25,6 @@ jest.mock('../../../../../middleware/auth/authMiddleware', () => ({
 }));
 
 jest.mock('../../../../plans/subscription.helper', () => ({
-  getActiveStudentPlanId: jest.fn(),
   getActiveStudentSubscription: jest.fn(),
 }));
 
@@ -38,10 +37,7 @@ jest.mock('../../../../payments/helpers/planPayments', () => ({
 }));
 
 const db = require('../../../../../config/database');
-const {
-  getActiveStudentPlanId,
-  getActiveStudentSubscription,
-} = require('../../../../plans/subscription.helper');
+const { getActiveStudentSubscription } = require('../../../../plans/subscription.helper');
 const { recordPlanCoveredPayment } = require('../../../../payments/helpers/planPayments');
 
 const routes = require('../../tutorial.routes');
@@ -85,6 +81,8 @@ describe('Tutorial enrollment routes', () => {
         source: 'subscription',
       }),
     );
+    expect(recordPlanCoveredPayment).toHaveBeenCalledTimes(1);
+    expect(db).not.toHaveBeenCalledWith('payments');
     expect(db.insert).toHaveBeenCalledWith(
       expect.objectContaining({
         id: expect.any(String),

--- a/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
+++ b/backend/src/modules/users/tutorials/enrollments/tutorialEnrollment.controller.js
@@ -4,14 +4,9 @@ const AppError = require("../../../../utils/AppError");
 const { sendSuccess } = require("../../../../utils/response");
 const { v4: uuidv4 } = require("uuid");
 const { requireUser, requireUserAndTutorial } = require("../utils");
-const {
-  getActiveStudentPlanId,
-  getActiveStudentSubscription,
-} = require("../../../plans/subscription.helper");
+const { getActiveStudentSubscription } = require("../../../plans/subscription.helper");
 const { recordPlanCoveredPayment } = require("../../../payments/helpers/planPayments");
 const { creditTutorialSubscription } = require("../../../payments/helpers/wallet");
-const { getPlanCoveredMethod } = require("../../../payments/helpers/methods");
-const { recordPlanCoveredPayment } = require("../../../payments/helpers/planPayments");
 
 // Enroll in tutorial
 exports.enroll = catchAsync(async (req, res) => {
@@ -38,28 +33,6 @@ exports.enroll = catchAsync(async (req, res) => {
 
   const enroll = async (trx) => {
     if (coveredBySubscription) {
-      const planMethod = await getPlanCoveredMethod(trx);
-
-      await trx("payments").insert({
-        user_id,
-        method_id: planMethod.id,
-        item_id: tutorialId,
-        item_type: "tutorial",
-        amount: 0,
-        currency: tutorial.currency || "USD",
-        source: "subscription",
-      });
-
-      await recordPlanCoveredPayment({
-        trx,
-        userId: user_id,
-        itemId: tutorialId,
-        itemType: "tutorial",
-        amount: 0,
-        currency: tutorial.currency || "USD",
-        source: "subscription",
-      });
-
       await recordPlanCoveredPayment({
         trx,
         userId: user_id,


### PR DESCRIPTION
## Summary
- remove redundant payment handling when tutorials are covered by a subscription so only the plan-covered helper creates the payment entry
- adjust tutorial enrollment route test to verify only one plan-covered payment is recorded and no manual payment insertion occurs

## Testing
- npm test -- tutorialEnrollment.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2bba34b7083288a1522c3b3e710fd