### PR TITLE
Add approval filtering for tutorials list

### DIFF
--- a/backend/src/modules/users/tutorials/__tests__/tutorial.controller.test.js
+++ b/backend/src/modules/users/tutorials/__tests__/tutorial.controller.test.js
@@ -1,0 +1,117 @@
+const httpMocks = require('node-mocks-http');
+
+jest.mock('../tutorial.service', () => ({
+  getAllTutorials: jest.fn(),
+}));
+
+jest.mock('../../../notifications/notifications.service', () => ({}));
+jest.mock('../../../messages/messages.service', () => ({}));
+jest.mock('../../user.model', () => ({}));
+jest.mock('../../../../services/analyticsService', () => ({}));
+jest.mock('../certificate/certificate.service', () => ({}));
+jest.mock('../enrollments/tutorialEnrollment.service', () => ({}));
+jest.mock('../../../plans/instructor.helper', () => ({
+  getActiveInstructorPlan: jest.fn(),
+}));
+jest.mock('../../../plans/plans.service', () => ({}));
+jest.mock('../../../../utils/planFeatures', () => ({
+  parsePlanFeatures: jest.fn(() => ({})),
+}));
+jest.mock('../tutorial.validator', () => ({
+  create: { parse: jest.fn((value) => value) },
+  update: { parseAsync: jest.fn(async (value) => value) },
+}));
+jest.mock('../../../../utils/role', () => ({
+  normalizeRole: jest.fn(() => 'admin'),
+}));
+jest.mock('../../../../utils/logger.js', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+jest.mock('../../../../utils/email', () => ({
+  sendTutorialApprovedEmail: jest.fn(),
+  sendTutorialRejectedEmail: jest.fn(),
+}));
+jest.mock('../tutorial.helpers', () => ({
+  parseTags: jest.fn((tags) => tags),
+  parseChapters: jest.fn((chapters) => chapters),
+}));
+jest.mock('../tutorial.notifications', () => ({
+  sendCreationNotifications: jest.fn(),
+}));
+
+jest.mock('../../../../utils/response', () => ({
+  sendSuccess: jest.fn(),
+}));
+
+const service = require('../tutorial.service');
+const { sendSuccess } = require('../../../../utils/response');
+const controller = require('../tutorial.controller');
+
+describe('tutorial.controller getAllTutorials approval filter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards approval query parameter to the service', async () => {
+    const req = httpMocks.createRequest({
+      method: 'GET',
+      query: { approval: 'Approved', page: '2', limit: '5' },
+    });
+    const res = httpMocks.createResponse();
+    const result = {
+      data: [{ id: '1', moderation_status: 'Approved' }],
+      meta: { page: 2, limit: 5, total: 1, totalPages: 1 },
+    };
+    service.getAllTutorials.mockResolvedValue(result);
+
+    await controller.getAllTutorials(req, res);
+
+    expect(service.getAllTutorials).toHaveBeenCalledWith({
+      status: undefined,
+      category: undefined,
+      search: undefined,
+      approval: 'Approved',
+      page: '2',
+      limit: '5',
+    });
+    expect(sendSuccess).toHaveBeenCalledWith(
+      res,
+      result.data,
+      'Tutorials fetched',
+      result.meta
+    );
+  });
+
+  it('defaults pagination when only approval filter is provided', async () => {
+    const req = httpMocks.createRequest({
+      method: 'GET',
+      query: { approval: 'Rejected' },
+    });
+    const res = httpMocks.createResponse();
+    const result = {
+      data: [{ id: '2', moderation_status: 'Rejected' }],
+      meta: { page: 1, limit: 10, total: 1, totalPages: 1 },
+    };
+    service.getAllTutorials.mockResolvedValue(result);
+
+    await controller.getAllTutorials(req, res);
+
+    expect(service.getAllTutorials).toHaveBeenLastCalledWith({
+      status: undefined,
+      category: undefined,
+      search: undefined,
+      approval: 'Rejected',
+      page: 1,
+      limit: 10,
+    });
+    expect(sendSuccess).toHaveBeenCalledWith(
+      res,
+      result.data,
+      'Tutorials fetched',
+      result.meta
+    );
+  });
+});

--- a/backend/src/modules/users/tutorials/__tests__/tutorial.service.test.js
+++ b/backend/src/modules/users/tutorials/__tests__/tutorial.service.test.js
@@ -1,0 +1,132 @@
+const { newDb } = require('pg-mem');
+const { v4: uuidv4 } = require('uuid');
+
+const db = newDb();
+db.public.registerFunction({
+  name: 'uuid_generate_v4',
+  returns: 'uuid',
+  implementation: uuidv4,
+});
+
+const mockDb = db.adapters.createKnex();
+
+jest.mock('../../../../config/database', () => mockDb);
+
+const service = require('../tutorial.service');
+const { TUTORIAL_STATUS } = require('../../../../../shared/tutorialStatus');
+
+describe('tutorial.service getAllTutorials approval filter', () => {
+  let instructorId;
+
+  beforeAll(async () => {
+    await mockDb.schema.createTable('users', (table) => {
+      table.uuid('id').primary();
+      table.string('full_name');
+    });
+
+    await mockDb.schema.createTable('categories', (table) => {
+      table.increments('id').primary();
+      table.string('name');
+      table.string('image_url');
+    });
+
+    await mockDb.schema.createTable('tutorials', (table) => {
+      table.uuid('id').primary();
+      table.string('title');
+      table.text('description');
+      table.string('status');
+      table.string('moderation_status');
+      table.uuid('instructor_id').references('users.id');
+      table.integer('category_id').references('categories.id');
+      table.timestamp('created_at').defaultTo(mockDb.fn.now());
+    });
+  });
+
+  afterAll(async () => {
+    await mockDb.destroy();
+  });
+
+  beforeEach(async () => {
+    await mockDb('tutorials').del();
+    await mockDb('users').del();
+    await mockDb('categories').del();
+
+    instructorId = uuidv4();
+
+    await mockDb('users').insert({ id: instructorId, full_name: 'Instructor' });
+    await mockDb('categories').insert({ id: 1, name: 'Category', image_url: null });
+
+    const now = Date.now();
+
+    await mockDb('tutorials').insert([
+      {
+        id: uuidv4(),
+        title: 'Approved tutorial',
+        description: 'A published tutorial',
+        status: TUTORIAL_STATUS.PUBLISHED,
+        moderation_status: 'Approved',
+        instructor_id: instructorId,
+        category_id: 1,
+        created_at: new Date(now - 3000).toISOString(),
+      },
+      {
+        id: uuidv4(),
+        title: 'Rejected tutorial',
+        description: 'A rejected tutorial',
+        status: TUTORIAL_STATUS.PUBLISHED,
+        moderation_status: 'Rejected',
+        instructor_id: instructorId,
+        category_id: 1,
+        created_at: new Date(now - 2000).toISOString(),
+      },
+      {
+        id: uuidv4(),
+        title: 'Pending tutorial',
+        description: 'A pending tutorial',
+        status: TUTORIAL_STATUS.PUBLISHED,
+        moderation_status: 'Pending',
+        instructor_id: instructorId,
+        category_id: 1,
+        created_at: new Date(now - 1000).toISOString(),
+      },
+      {
+        id: uuidv4(),
+        title: 'Draft tutorial',
+        description: 'A draft tutorial awaiting review',
+        status: TUTORIAL_STATUS.DRAFT,
+        moderation_status: null,
+        instructor_id: instructorId,
+        category_id: 1,
+        created_at: new Date(now).toISOString(),
+      },
+    ]);
+  });
+
+  test('approval "Approved" returns only approved tutorials and metadata', async () => {
+    const result = await service.getAllTutorials({ approval: 'Approved', page: 1, limit: 10 });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].moderation_status).toBe('Approved');
+    expect(result.meta.total).toBe(1);
+    expect(result.meta.totalPages).toBe(1);
+  });
+
+  test('approval "Rejected" returns only rejected tutorials and metadata', async () => {
+    const result = await service.getAllTutorials({ approval: 'Rejected', page: 1, limit: 10 });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].moderation_status).toBe('Rejected');
+    expect(result.meta.total).toBe(1);
+    expect(result.meta.totalPages).toBe(1);
+  });
+
+  test('approval "Pending" includes drafts without moderation status', async () => {
+    const result = await service.getAllTutorials({ approval: 'Pending', page: 1, limit: 10 });
+
+    const statuses = result.data.map((item) => item.moderation_status);
+    expect(statuses).toEqual(expect.arrayContaining(['Pending', null]));
+    expect(result.data).toHaveLength(2);
+    expect(result.meta.total).toBe(2);
+    expect(result.meta.totalPages).toBe(1);
+  });
+});

--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -138,11 +138,12 @@ exports.createTutorial = catchAsync(async (req, res) => {
 
 
 exports.getAllTutorials = async (req, res) => {
-  const { status, category, search, page = 1, limit = 10 } = req.query;
+  const { status, category, search, approval, page = 1, limit = 10 } = req.query;
   const result = await service.getAllTutorials({
     status,
     category,
     search,
+    approval,
     page,
     limit,
   });

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -130,7 +130,7 @@ exports.getTutorialAggregates = async (tutorialId) => {
 const { parsePagination } = require("../../../utils/pagination");
 
 exports.getAllTutorials = async (filters = {}) => {
-  const { status, category, search } = filters;
+  const { status, category, search, approval } = filters;
   const { page, limit, offset } = parsePagination(filters);
 
   const baseQuery = db("tutorials as t")
@@ -140,6 +140,17 @@ exports.getAllTutorials = async (filters = {}) => {
     .modify((query) => {
       if (status) query.andWhere("t.status", status);
       if (category) query.andWhere("t.category_id", category);
+      if (approval) {
+        query.andWhere(function () {
+          if (approval === "Pending") {
+            this.where("t.moderation_status", approval).orWhereNull(
+              "t.moderation_status"
+            );
+          } else {
+            this.where("t.moderation_status", approval);
+          }
+        });
+      }
       if (search) {
         query.andWhere(function () {
           this.whereILike("t.title", `%${search}%`);


### PR DESCRIPTION
## Summary
- update the tutorials controller to accept an approval query parameter and forward it to the service
- apply moderation-status filtering in the tutorials service, including pending/null handling
- add controller and service unit tests covering approval filtering and pagination metadata

## Testing
- npm --prefix backend test -- tutorial.controller
- npm --prefix backend test -- tutorial.service

------
https://chatgpt.com/codex/tasks/task_e_68e2bbb1b1388328b08321478bc74e00