### PR TITLE
Handle tutorial slug creation

### DIFF
--- a/backend/src/modules/users/tutorials/tutorial.controller.js
+++ b/backend/src/modules/users/tutorials/tutorial.controller.js
@@ -25,6 +25,7 @@ const { sendSuccess } = require("../../../utils/response");
 const { parseTags, parseChapters } = require("./tutorial.helpers");
 const { sendCreationNotifications } = require("./tutorial.notifications");
 const { ZodError } = require("zod");
+const slugify = require("slugify");
 
 // Helper to resolve uploads subdirectory based on user role
 const getRoleDir = (req) => {
@@ -95,6 +96,8 @@ exports.createTutorial = catchAsync(async (req, res) => {
   const thumbnailFile = req.files?.thumbnail?.[0];
   const previewFile = req.files?.preview?.[0];
 
+  const baseSlug = slugify(title, { lower: true, strict: true });
+
   const tutorialData = {
     id,
     title,
@@ -114,6 +117,7 @@ exports.createTutorial = catchAsync(async (req, res) => {
     preview_video: previewFile
       ? `/uploads/tutorials/${roleDir}/${previewFile.filename}`
       : null,
+    slug: baseSlug || id,
   };
 
   try {

--- a/backend/src/modules/users/tutorials/tutorial.service.js
+++ b/backend/src/modules/users/tutorials/tutorial.service.js
@@ -8,11 +8,41 @@ const { v4: uuidv4 } = require("uuid");
 const slugify = require("slugify");
 const { TUTORIAL_STATUS } = require("../../../../shared/tutorialStatus");
 
+const isUniqueSlugError = (error) => {
+  if (!error || error.code !== "23505") return false;
+  const constraint = String(error.constraint || "").toLowerCase();
+  if (constraint.includes("slug")) return true;
+  const detail = String(error.detail || "").toLowerCase();
+  if (detail.includes("(slug)") || detail.includes("slug")) return true;
+  const message = String(error.message || "").toLowerCase();
+  return message.includes("slug");
+};
+
 exports.createTutorial = async (data, trx = db) => {
   const insertData = { included_plans: [], ...data };
   if (!insertData.included_plans) insertData.included_plans = [];
-  const [tutorial] = await trx("tutorials").insert(insertData).returning("*");
-  return tutorial;
+
+  const fallbackSlug = slugify(insertData.title || uuidv4(), {
+    lower: true,
+    strict: true,
+  });
+  const baseSlug = (insertData.slug || "").trim() || fallbackSlug || uuidv4();
+
+  let attempt = 0;
+  while (attempt < 50) {
+    const slugCandidate = attempt === 0 ? baseSlug : `${baseSlug}-${attempt}`;
+    try {
+      const [tutorial] = await trx("tutorials")
+        .insert({ ...insertData, slug: slugCandidate })
+        .returning("*");
+      return tutorial;
+    } catch (error) {
+      if (!isUniqueSlugError(error)) throw error;
+      attempt += 1;
+    }
+  }
+
+  throw new Error("Unable to generate a unique slug for tutorial");
 };
 
 exports.createTutorialWithRelations = async (

--- a/backend/tests/tutorialCreate.test.js
+++ b/backend/tests/tutorialCreate.test.js
@@ -51,11 +51,15 @@ jest.mock('../src/modules/plans/plans.service', () => ({
   getPlanById: jest.fn(),
 }));
 
+process.env.TEST_DATABASE_URL =
+  process.env.TEST_DATABASE_URL || 'postgres://user:pass@localhost:5432/testdb';
+
 const controller = require('../src/modules/users/tutorials/tutorial.controller');
 const service = require('../src/modules/users/tutorials/tutorial.service');
 const userModel = require('../src/modules/users/user.model');
 const { getActiveInstructorPlan } = require('../src/modules/plans/instructor.helper');
 const planService = require('../src/modules/plans/plans.service');
+const slugify = require('slugify');
 
 
 describe('createTutorial', () => {
@@ -95,6 +99,7 @@ describe('createTutorial', () => {
     expect(service.createTutorialWithRelations).toHaveBeenCalled();
     const data = service.createTutorialWithRelations.mock.calls[0][0];
     expect(data.instructor_id).toBe(instructorId);
+    expect(data.slug).toBe(slugify('Test Tut', { lower: true, strict: true }));
   });
 
   it('prevents instructor from creating tutorial for another instructor', async () => {
@@ -161,6 +166,27 @@ describe('createTutorial', () => {
     await new Promise((resolve) => setImmediate(resolve));
     const data = service.createTutorialWithRelations.mock.calls[0][0];
     expect(data.is_paid).toBe(true);
+  });
+
+  it('derives a slug from the tutorial title before creation', async () => {
+    service.createTutorialWithRelations.mockResolvedValue({ id: 'slug-tut' });
+
+    const req = {
+      body: {
+        title: 'Slug Test Tutorial',
+        category_id: 'cat',
+        level: 'beginner',
+      },
+      user: { id: 'inst1', role: 'instructor' },
+      files: {},
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await controller.createTutorial(req, res, jest.fn());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const data = service.createTutorialWithRelations.mock.calls[0][0];
+    expect(data.slug).toBe(slugify('Slug Test Tutorial', { lower: true, strict: true }));
   });
 
   it('rejects duplicate titles regardless of case', async () => {

--- a/backend/tests/tutorialServiceCreate.test.js
+++ b/backend/tests/tutorialServiceCreate.test.js
@@ -1,0 +1,83 @@
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_URL =
+  process.env.TEST_DATABASE_URL || 'postgres://user:pass@localhost:5432/testdb';
+
+const slugify = require('slugify');
+
+const service = require('../src/modules/users/tutorials/tutorial.service');
+
+const createMockTrx = (returningMock) => {
+  const builder = {};
+  const insertMock = jest.fn().mockReturnValue(builder);
+  builder.insert = insertMock;
+  builder.returning = returningMock;
+  const trx = jest.fn(() => builder);
+  return { trx, insertMock, returningMock, builder };
+};
+
+describe('tutorial.service createTutorial', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the provided slug when inserting a tutorial', async () => {
+    const returningMock = jest
+      .fn()
+      .mockResolvedValue([{ id: 'tutorial-1', slug: 'custom-slug' }]);
+    const { trx, insertMock } = createMockTrx(returningMock);
+
+    const result = await service.createTutorial(
+      { title: 'My Tutorial', slug: 'custom-slug', included_plans: [] },
+      trx
+    );
+
+    expect(trx).toHaveBeenCalledWith('tutorials');
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'custom-slug' })
+    );
+    expect(result).toEqual({ id: 'tutorial-1', slug: 'custom-slug' });
+  });
+
+  it('retries with a numeric suffix when the slug is taken', async () => {
+    const returningMock = jest
+      .fn()
+      .mockRejectedValueOnce({
+        code: '23505',
+        constraint: 'tutorials_slug_key',
+      })
+      .mockResolvedValueOnce([
+        { id: 'tutorial-2', slug: 'custom-slug-1' },
+      ]);
+    const { trx, insertMock, returningMock: returningSpy } = createMockTrx(returningMock);
+
+    const result = await service.createTutorial(
+      { title: 'My Tutorial', slug: 'custom-slug' },
+      trx
+    );
+
+    expect(returningSpy).toHaveBeenCalledTimes(2);
+    expect(insertMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ slug: 'custom-slug' })
+    );
+    expect(insertMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ slug: 'custom-slug-1' })
+    );
+    expect(result.slug).toBe('custom-slug-1');
+  });
+
+  it('derives a slug from the title when one is not provided', async () => {
+    const derived = slugify('Another Tutorial', { lower: true, strict: true });
+    const returningMock = jest
+      .fn()
+      .mockResolvedValue([{ id: 'tutorial-3', slug: derived }]);
+    const { trx, insertMock } = createMockTrx(returningMock);
+
+    await service.createTutorial({ title: 'Another Tutorial' }, trx);
+
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: derived })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- derive tutorial slugs from titles before persisting new tutorials
- ensure tutorial creation writes unique slugs by retrying with numeric suffixes on conflicts
- expand unit coverage for controller and service to verify slug generation and conflict handling

## Testing
- npm test -- tutorialCreate.test.js --runInBand
- npm test -- tutorialServiceCreate.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e2bbb6e2cc8328aa601122d7d6f69f