### PR TITLE
Prevent admin classes table from refetching on identical payloads

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -126,15 +126,16 @@ export default function AdminClassesTable() {
   const { t } = useTranslation('dashboard');
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
-  const classCount = classList.length;
   const normalizedItemsPerPage = useMemo(() => {
     if (pageSizeSetting === "all") {
-      const totalOrCount = totalItems || classCount || DEFAULT_PAGE_SIZE;
-      return resolvePositiveInteger(totalOrCount, DEFAULT_PAGE_SIZE);
+      return resolvePositiveInteger(
+        totalItemsRef.current,
+        DEFAULT_PAGE_SIZE
+      );
     }
 
     return resolvePositiveInteger(pageSizeSetting, DEFAULT_PAGE_SIZE);
-  }, [pageSizeSetting, totalItems, classCount]);
+  }, [pageSizeSetting]);
 
   const clearFailedSignature = (failureRecord = lastFailedSignatureRef.current) => {
     if (failureRecord?.retryTimer) {
@@ -202,6 +203,21 @@ export default function AdminClassesTable() {
     totalPagesRef.current = value;
     setTotalPages(value);
     return true;
+  };
+
+  const updateClassListIfChanged = (nextList) => {
+    setClassList((previous) => {
+      if (previous.length === nextList.length) {
+        const previousFirstId = previous[0]?.id ?? null;
+        const nextFirstId = nextList[0]?.id ?? null;
+
+        if (previousFirstId === nextFirstId) {
+          return previous;
+        }
+      }
+
+      return nextList;
+    });
   };
 
   const sortClasses = (items, key = sortKey) =>
@@ -429,8 +445,8 @@ export default function AdminClassesTable() {
             return;
           }
 
-          setTotalItems(totalFilteredItems);
-          setTotalPages(totalFilteredPages);
+          setTotalItemsIfNeeded(totalFilteredItems);
+          setTotalPagesIfNeeded(totalFilteredPages);
 
           const startIndex = (effectivePage - 1) * safeLimit;
           const paginatedData = sortedData.slice(
@@ -442,7 +458,7 @@ export default function AdminClassesTable() {
             return;
           }
 
-          setClassList(paginatedData);
+          updateClassListIfChanged(paginatedData);
         } else {
           const sortedData = sortClasses(data, sortValue);
 
@@ -450,7 +466,7 @@ export default function AdminClassesTable() {
             return;
           }
 
-          setClassList(sortedData);
+          updateClassListIfChanged(sortedData);
           const nextTotalPages = meta?.totalPages ? Math.max(meta.totalPages, 1) : 1;
           const nextTotalItems = meta?.total ?? data.length;
           setTotalPagesIfNeeded(nextTotalPages);


### PR DESCRIPTION
## Summary
- keep the online classes pagination limit tied to the page size control without reacting to incoming results
- reuse guarded helpers when applying schedule-filter results to avoid redundant state churn
- skip class list updates when the payload length and leading id match the current data

## Testing
- npm run dev


------
https://chatgpt.com/codex/tasks/task_e_68e2bf359dc083288c7e3bf8da1dcd1d