### PR TITLE
Fix admin classes table memoization loop

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -89,6 +89,31 @@ export function compareValues(a, b, key) {
   return 0;
 }
 
+const computeListSignature = (items) => {
+  if (!Array.isArray(items) || items.length === 0) {
+    return "";
+  }
+
+  return items
+    .map((item) => {
+      if (item && typeof item === "object") {
+        if ("id" in item) {
+          return String(item.id);
+        }
+        if ("_id" in item) {
+          return String(item._id);
+        }
+      }
+
+      try {
+        return JSON.stringify(item);
+      } catch (err) {
+        return String(item);
+      }
+    })
+    .join("|");
+};
+
 export default function AdminClassesTable() {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterStatus, setFilterStatus] = useState("All");
@@ -117,6 +142,8 @@ export default function AdminClassesTable() {
   const totalItemsRef = useRef(totalItems);
   const totalPagesRef = useRef(totalPages);
   const loadingRef = useRef(false);
+  const classListLengthRef = useRef(0);
+  const classListSignatureRef = useRef("");
   const { user, hasHydrated } = useAuthStore((state) => ({
     user: state.user,
     hasHydrated: state.hasHydrated,
@@ -126,15 +153,55 @@ export default function AdminClassesTable() {
   const { t } = useTranslation('dashboard');
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
-  const classCount = classList.length;
   const normalizedItemsPerPage = useMemo(() => {
     if (pageSizeSetting === "all") {
-      const totalOrCount = totalItems || classCount || DEFAULT_PAGE_SIZE;
+      const totalOrCount =
+        (Number.isFinite(totalItems) && totalItems > 0
+          ? totalItems
+          : classListLengthRef.current) || DEFAULT_PAGE_SIZE;
       return resolvePositiveInteger(totalOrCount, DEFAULT_PAGE_SIZE);
     }
 
     return resolvePositiveInteger(pageSizeSetting, DEFAULT_PAGE_SIZE);
-  }, [pageSizeSetting, totalItems, classCount]);
+  }, [pageSizeSetting, totalItems]);
+
+  const updateClassList = (valueOrUpdater) => {
+    setClassList((previousList) => {
+      const nextList =
+        typeof valueOrUpdater === "function"
+          ? valueOrUpdater(previousList)
+          : valueOrUpdater;
+
+      if (nextList === previousList) {
+        return previousList;
+      }
+
+      if (Array.isArray(nextList) && Array.isArray(previousList)) {
+        if (nextList.length === previousList.length) {
+          const prevSignature = computeListSignature(previousList);
+          const nextSignature = computeListSignature(nextList);
+
+          if (nextSignature === prevSignature) {
+            return previousList;
+          }
+
+          classListSignatureRef.current = nextSignature;
+        } else {
+          classListSignatureRef.current = computeListSignature(nextList);
+        }
+
+        classListLengthRef.current = nextList.length;
+      } else if (Array.isArray(nextList)) {
+        classListSignatureRef.current = computeListSignature(nextList);
+        classListLengthRef.current = nextList.length;
+      } else {
+        classListSignatureRef.current = "";
+        classListLengthRef.current = 0;
+      }
+
+      return nextList;
+    });
+  };
 
   const clearFailedSignature = (failureRecord = lastFailedSignatureRef.current) => {
     if (failureRecord?.retryTimer) {
@@ -173,6 +240,13 @@ export default function AdminClassesTable() {
   useEffect(() => {
     authIdentifierRef.current = authIdentifier;
   }, [authIdentifier]);
+
+  useEffect(() => {
+    classListLengthRef.current = Array.isArray(classList)
+      ? classList.length
+      : 0;
+    classListSignatureRef.current = computeListSignature(classList);
+  }, [classList]);
 
   const setCurrentPageIfNeeded = (value) => {
     if (!Number.isFinite(value)) {
@@ -442,7 +516,7 @@ export default function AdminClassesTable() {
             return;
           }
 
-          setClassList(paginatedData);
+          updateClassList(paginatedData);
         } else {
           const sortedData = sortClasses(data, sortValue);
 
@@ -450,7 +524,7 @@ export default function AdminClassesTable() {
             return;
           }
 
-          setClassList(sortedData);
+          updateClassList(sortedData);
           const nextTotalPages = meta?.totalPages ? Math.max(meta.totalPages, 1) : 1;
           const nextTotalItems = meta?.total ?? data.length;
           setTotalPagesIfNeeded(nextTotalPages);
@@ -479,7 +553,7 @@ export default function AdminClassesTable() {
           authFailureRef.current = true;
           if (isComponentMountedRef.current) {
             setAuthError(true);
-            setClassList([]);
+            updateClassList([]);
             setTotalItemsIfNeeded(0);
             setTotalPagesIfNeeded(1);
           }
@@ -656,7 +730,7 @@ export default function AdminClassesTable() {
 
       if (action === "approve") {
         const updated = await approveAdminClass(id);
-        setClassList((prev) =>
+        updateClassList((prev) =>
           prev.map((c) =>
             c.id === id
               ? { ...c, approvalStatus: "Approved", publishStatus: updated?.publishStatus }
@@ -681,7 +755,7 @@ export default function AdminClassesTable() {
         refreshMessages?.();
       } else if (action === "reject") {
         await rejectAdminClass(id, reason);
-        setClassList((prev) =>
+        updateClassList((prev) =>
           prev.map((c) =>
             c.id === id ? { ...c, approvalStatus: "Rejected" } : c
           )
@@ -707,7 +781,7 @@ export default function AdminClassesTable() {
         if (!updated) {
           throw new Error("Failed to toggle class status");
         }
-        setClassList((prev) =>
+        updateClassList((prev) =>
           prev.map((c) => (c.id === id ? { ...c, ...updated } : c))
         );
         toast.success("Status updated");
@@ -769,7 +843,7 @@ export default function AdminClassesTable() {
         )
       );
 
-      setClassList(updatedList);
+      updateClassList(updatedList);
       setTotalItemsIfNeeded(nextTotalItems);
       setTotalPagesIfNeeded(nextTotalPages);
 


### PR DESCRIPTION
## Summary
- decouple the normalized items-per-page memo from class list mutations by using refs
- guard class list state updates to avoid redundant re-renders when data length and signature are unchanged

## Testing
- npm run lint *(fails: existing warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bf4497908328b8dd4fb940ef7719