### PR TITLE
Use browser origin as API fallback base URL

### DIFF
--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -9,9 +9,28 @@ import axios from "axios";
 import logger from "@/utils/logger";
 
 const isBrowser = typeof window !== "undefined";
-const DEFAULT_SERVER_BASE_URL = "http://localhost:5002/api";
 const publicBaseCandidate = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 const internalBaseCandidate = process.env.INTERNAL_API_BASE_URL;
+
+const resolveBrowserDerivedBase = (candidate) => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  try {
+    const origin = window?.location?.origin;
+    if (!origin) {
+      return null;
+    }
+
+    return new URL(candidate, origin).toString();
+  } catch (error) {
+    logger.warn(
+      `Failed to resolve API base URL from "${candidate}" against window.location.origin: ${error.message}`
+    );
+    return null;
+  }
+};
 
 const pickBaseCandidate = () => {
   if (!isBrowser && internalBaseCandidate) {
@@ -42,17 +61,30 @@ const ensureAbsoluteUrl = (candidate) => {
   };
 
   if (isBrowser) {
-    const fallbackBrowserBase = [DEFAULT_SERVER_BASE_URL, internalBaseCandidate]
+    const derivedFromOrigin = resolveBrowserDerivedBase(candidate);
+    if (derivedFromOrigin) {
+      logger.warn(
+        `API base "${candidate}" is not absolute. Deriving fallback from window.location.origin: "${derivedFromOrigin}".`
+      );
+      return derivedFromOrigin;
+    }
+
+    const fallbackBrowserBase = [internalBaseCandidate]
       .filter((base) => base && /^https?:\/\//i.test(base))
       .shift();
 
-    const fallback = fallbackBrowserBase || DEFAULT_SERVER_BASE_URL;
+    if (fallbackBrowserBase) {
+      logger.warn(
+        `API base "${candidate}" is not absolute. Falling back to "${fallbackBrowserBase}".`
+      );
+      return fallbackBrowserBase;
+    }
 
     logger.warn(
-      `API base "${candidate}" is not absolute. Falling back to "${fallback}".`
+      `API base "${candidate}" is not absolute and no fallback could be resolved. Using "${candidate}" as-is.`
     );
 
-    return fallback;
+    return candidate;
   }
 
   const appDomain = process.env.APP_DOMAIN;
@@ -68,7 +100,7 @@ const ensureAbsoluteUrl = (candidate) => {
 
   const fallback = internalBaseCandidate && /^https?:\/\//i.test(internalBaseCandidate)
     ? internalBaseCandidate
-    : DEFAULT_SERVER_BASE_URL;
+    : candidate;
 
   logger.warn(
     `API base "${candidate}" is not absolute and could not be resolved. Falling back to "${fallback}".`
@@ -141,7 +173,7 @@ if (
   window.location.hostname !== "localhost"
 ) {
   logger.warn(
-    "NEXT_PUBLIC_API_BASE_URL is not set. Using '/api'. Set this variable in frontend/.env.local to avoid unexpected network errors."
+    `NEXT_PUBLIC_API_BASE_URL is not set. Falling back to "${baseURL}" derived from the current origin. Set this variable in frontend/.env.local to avoid unexpected network errors.`
   );
 }
 


### PR DESCRIPTION
## Summary
- derive the browser API fallback URL from `window.location.origin` when environment configuration is missing
- log clearer warnings to highlight the origin-derived fallback for developers

## Testing
- npm run build *(fails: existing duplicate identifier in `CategoryPieChart.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bf45f17c832880b1c85c08487289