### PR TITLE
Prevent duplicate redirects in auth protection

### DIFF
--- a/frontend/src/hooks/withAuthProtection.js
+++ b/frontend/src/hooks/withAuthProtection.js
@@ -1,5 +1,5 @@
 // src/hooks/withAuthProtection.js
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import useAuthStore from "@/store/auth/authStore";
 import { isTokenExpired } from "@/utils/auth/tokenUtils";
@@ -15,22 +15,50 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
     const { user, accessToken, logout, hasHydrated } = useAuthStore();
     const router = useRouter();
     const [hydrated, setHydrated] = useState(false);
+    const isRedirectingRef = useRef(false);
 
     useEffect(() => {
       setHydrated(true);
     }, []);
 
     useEffect(() => {
+      const handleRouteChangeFinished = () => {
+        isRedirectingRef.current = false;
+      };
+
+      if (!router?.events) {
+        return () => {};
+      }
+
+      router.events.on("routeChangeComplete", handleRouteChangeFinished);
+      router.events.on("routeChangeError", handleRouteChangeFinished);
+
+      return () => {
+        router.events.off("routeChangeComplete", handleRouteChangeFinished);
+        router.events.off("routeChangeError", handleRouteChangeFinished);
+      };
+    }, [router]);
+
+    useEffect(() => {
       if (!hydrated || !hasHydrated) {
         return;
       }
 
+      const attemptRedirect = (path) => {
+        if (isRedirectingRef.current || router.asPath === path) {
+          return;
+        }
+
+        isRedirectingRef.current = true;
+        router.replace(path);
+      };
+
       const normalizedRoles = getNormalizedRoles(user);
       if (!user) {
-        router.replace("/auth/login");
+        attemptRedirect("/auth/login");
       } else if (!accessToken || isTokenExpired(accessToken)) {
         logout();
-        router.replace("/auth/login");
+        attemptRedirect("/auth/login");
       } else if (
         (allowedRoles.length &&
           !allowedRoles.some((allowedRole) =>
@@ -40,7 +68,7 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
           !normalizedRoles.includes("superadmin") &&
           !allowedPerms.some((p) => user.permissions?.includes(p)))
       ) {
-        router.replace("/error/403");
+        attemptRedirect("/error/403");
       }
     }, [
       hydrated,
@@ -49,6 +77,9 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
       accessToken,
       logout,
       router,
+      router.asPath,
+      allowedRoles,
+      allowedPerms,
     ]);
 
     const normalizedRoles = getNormalizedRoles(user);


### PR DESCRIPTION
## Summary
- add a redirect-in-progress guard inside `withAuthProtection`
- reset the guard when navigation completes or errors out
- reuse the guard for both login and 403 redirects to avoid loops

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2bf4a5c448328942528dcd32770b2