### PR TITLE
Use browser origin for API fallback

### DIFF
--- a/frontend/src/components/admin/charts/CategoryPieChart.js
+++ b/frontend/src/components/admin/charts/CategoryPieChart.js
@@ -10,7 +10,6 @@ export default function CategoryPieChart({ data = [], title }) {
   const { chartsLib, chartsLoadError, resizeObserverSupported, loading } =
     useLazyRecharts();
 
-  const hasData = Array.isArray(data) && data.length > 0;
   const PieChart = chartsLib?.PieChart;
   const Pie = chartsLib?.Pie;
   const Cell = chartsLib?.Cell;

--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -42,11 +42,23 @@ const ensureAbsoluteUrl = (candidate) => {
   };
 
   if (isBrowser) {
-    const fallbackBrowserBase = [DEFAULT_SERVER_BASE_URL, internalBaseCandidate]
-      .filter((base) => base && /^https?:\/\//i.test(base))
-      .shift();
+    const browserOrigin = typeof window !== "undefined" ? window.location?.origin : null;
 
-    const fallback = fallbackBrowserBase || DEFAULT_SERVER_BASE_URL;
+    if (browserOrigin) {
+      const resolvedFromOrigin = tryResolveWithBase(browserOrigin);
+      if (resolvedFromOrigin) {
+        logger.warn(
+          `API base "${candidate}" is not absolute. Using current origin fallback "${resolvedFromOrigin}".`
+        );
+        return resolvedFromOrigin;
+      }
+    }
+
+    const resolvedFallback = [internalBaseCandidate, DEFAULT_SERVER_BASE_URL]
+      .map((base) => (base && /^https?:\/\//i.test(base) ? tryResolveWithBase(base) : null))
+      .find(Boolean);
+
+    const fallback = resolvedFallback || DEFAULT_SERVER_BASE_URL;
 
     logger.warn(
       `API base "${candidate}" is not absolute. Falling back to "${fallback}".`
@@ -141,7 +153,7 @@ if (
   window.location.hostname !== "localhost"
 ) {
   logger.warn(
-    "NEXT_PUBLIC_API_BASE_URL is not set. Using '/api'. Set this variable in frontend/.env.local to avoid unexpected network errors."
+    `NEXT_PUBLIC_API_BASE_URL is not set. Using the current origin (${window.location.origin}) for API requests. Set this variable in frontend/.env.local to avoid unexpected network errors.`
   );
 }
 


### PR DESCRIPTION
## Summary
- derive the browser fallback API base from the current origin when NEXT_PUBLIC_API_BASE_URL is missing
- clarify the production warning to mention the origin fallback and clean up a duplicate chart helper so the build succeeds

## Testing
- CI=1 npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68e2bf35b1988328be0cf89b561f5b7d