### PR TITLE
Refine SuperAdmin seed to preserve existing accounts

### DIFF
--- a/backend/src/seeds/seed_superadmin_user.js
+++ b/backend/src/seeds/seed_superadmin_user.js
@@ -1,12 +1,9 @@
 const logger = require('../utils/logger.js');
 const bcrypt = require("bcrypt");
+const crypto = require("crypto");
 
 const APP_DOMAIN = process.env.APP_DOMAIN || "example.com";
 exports.seed = async function (knex) {
-  // Clear existing user accounts but keep role definitions
-  await knex("user_roles").del();
-  await knex("users").del();
-
   // Ensure the SuperAdmin role exists
   let roleRecord = await knex("roles").where({ name: "SuperAdmin" }).first();
   if (!roleRecord) {
@@ -19,39 +16,82 @@ exports.seed = async function (knex) {
       .returning("*");
   }
 
-  // 🔐 Create SuperAdmin User with a fixed password
-  const rawPassword = "Javaheat@18880";
-  const hashedPassword = await bcrypt.hash(rawPassword, 10);
+  const email = `support@${APP_DOMAIN}`;
 
-  const [superAdminUserId] = await knex("users")
-    .insert({
-      full_name: "Platform Owner",
-      email: `support@${APP_DOMAIN}`,
-      phone: "+966531505513",
-      password_hash: hashedPassword,
-      role: "SuperAdmin",
-      avatar_url: null,
-      is_email_verified: true,
-      status: "active",
+  let superAdminUser = await knex("users").where({ email }).first();
+  let generatedPassword;
+
+  const buildRandomPassword = () => {
+    const base = crypto.randomBytes(32).toString("base64");
+    const sanitized = base.replace(/[^a-zA-Z0-9]/g, "");
+    if (sanitized.length >= 32) {
+      return sanitized.slice(0, 32);
+    }
+    return sanitized || crypto.randomBytes(32).toString("hex");
+  };
+
+  if (!superAdminUser) {
+    const rawPassword = process.env.SUPERADMIN_INITIAL_PASSWORD;
+    if (!rawPassword) {
+      generatedPassword = buildRandomPassword();
+    }
+
+    const passwordToHash = rawPassword || generatedPassword;
+    const hashedPassword = await bcrypt.hash(passwordToHash, 10);
+
+    const [insertedUser] = await knex("users")
+      .insert({
+        full_name: "Platform Owner",
+        email,
+        phone: "+966531505513",
+        password_hash: hashedPassword,
+        role: "SuperAdmin",
+        avatar_url: null,
+        is_email_verified: true,
+        status: "active",
+        created_at: knex.fn.now(),
+        updated_at: knex.fn.now(),
+      })
+      .returning("id");
+
+    const insertedUserId = insertedUser?.id ?? insertedUser;
+    superAdminUser = await knex("users").where({ id: insertedUserId }).first();
+
+    if (generatedPassword) {
+      logger.log(
+        `🔐 Generated SuperAdmin password for ${email}: ${generatedPassword}`
+      );
+    }
+  } else if (superAdminUser.role !== "SuperAdmin") {
+    await knex("users")
+      .where({ id: superAdminUser.id })
+      .update({ role: "SuperAdmin", updated_at: knex.fn.now() });
+    superAdminUser.role = "SuperAdmin";
+  }
+
+  const userId = superAdminUser.id;
+  const roleId = roleRecord.id || roleRecord;
+
+  const existingProfile = await knex("admin_profiles").where({ user_id: userId }).first();
+  if (!existingProfile) {
+    await knex("admin_profiles").insert({
+      user_id: userId,
+      job_title: "Super Administrator",
+      department: "Management",
       created_at: knex.fn.now(),
       updated_at: knex.fn.now(),
-    })
-    .returning("id");
+    });
+  }
 
-  // Create matching admin profile
-  await knex("admin_profiles").insert({
-    user_id: superAdminUserId.id || superAdminUserId,
-    job_title: "Super Administrator",
-    department: "Management",
-    created_at: knex.fn.now(),
-    updated_at: knex.fn.now(),
-  });
+  const existingUserRole = await knex("user_roles")
+    .where({ user_id: userId, role_id: roleId })
+    .first();
+  if (!existingUserRole) {
+    await knex("user_roles").insert({
+      user_id: userId,
+      role_id: roleId,
+    });
+  }
 
-  // 🔗 Link user to role (if using a many-to-many system)
-  await knex("user_roles").insert({
-    user_id: superAdminUserId.id || superAdminUserId,
-    role_id: roleRecord.id || roleRecord,
-  });
-
-  logger.log("✅ SuperAdmin seeded");
+  logger.log("✅ SuperAdmin role and account ensured");
 };

--- a/docs/README.md
+++ b/docs/README.md
@@ -271,8 +271,9 @@ disable the API when setup is complete.
 
 Set `ADMIN_INITIAL_PASSWORD` and `SUPERADMIN_INITIAL_PASSWORD` before running
 seed scripts if you want to control the passwords for the seeded Admin and
-SuperAdmin accounts. When left unset, the seed process generates secure random
-passwords and prints them to the console.
+SuperAdmin accounts. If you omit `SUPERADMIN_INITIAL_PASSWORD`, the SuperAdmin
+seed generates a secure random password the first time it creates the account
+and logs it once—capture the output so operators can sign in later.
 
 #### Frontend (optional)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -464,9 +464,11 @@ After you finish the installation or automation tasks, immediately disable the A
 
 Set `ADMIN_INITIAL_PASSWORD` and `SUPERADMIN_INITIAL_PASSWORD` in
 `backend/.env` before running the seed scripts if you want to control the
-passwords for the seeded Admin and SuperAdmin accounts. When left unset, the
-seed process will generate secure random passwords and print them to the
-console.
+passwords for the seeded Admin and SuperAdmin accounts. When
+`SUPERADMIN_INITIAL_PASSWORD` is omitted, the SuperAdmin seed generates a
+secure random password the first time it creates the account and logs the value
+once—capture it from the seeding output so operators can sign in. Subsequent
+runs leave existing credentials unchanged.
 
 ### Frontend (optional)
 


### PR DESCRIPTION
## Summary
- stop clearing user tables in the SuperAdmin seed and instead upsert the role, account, and related links
- source the SuperAdmin seed password from SUPERADMIN_INITIAL_PASSWORD or log a generated fallback once when creating the account
- document how operators capture the generated SuperAdmin password and note that reruns preserve existing credentials

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d473edac832880bb3fbf9f55aed6