### PR TITLE
Guard demo license bypass behind dev flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,8 @@ STRIPE_SECRET_KEY=your_stripe_secret_key
 DEFAULT_AD_DURATION_DAYS=0
 # Envato API token used for license verification
 ENVATO_TOKEN=your_envato_api_token_here
+# Allow the demo purchase code to bypass Envato checks in local development. Ignored when NODE_ENV=production.
+# LICENSE_DEMO_BYPASS=false
 
 # OAuth provider credentials
 GITHUB_CLIENT_ID=your_github_client_id

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,8 @@ MAX_BLOG_IMAGE_BYTES=10485760
 CLOUDINARY_API_KEY=your_key
 # Envato API token for purchase code verification
 ENVATO_TOKEN=your_envato_api_token_here
+# Enable the demo purchase code bypass for local development. This flag is ignored when NODE_ENV=production.
+# LICENSE_DEMO_BYPASS=false
 # SMTP configuration
 # Port 587 uses STARTTLS; keep SMTP_SECURE=false for this port.
 # For TLS-over-SSL use port 465 and set SMTP_SECURE=true.

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -3,3 +3,4 @@ FRONTEND_URL=https://eduskillbridge.net,https://www.eduskillbridge.net
 ALLOWED_ORIGINS=https://eduskillbridge.net,https://www.eduskillbridge.net
 APP_DOMAIN=eduskillbridge.net
 COOKIE_DOMAIN=.eduskillbridge.net
+# LICENSE_DEMO_BYPASS must remain unset in production builds. Demo codes are disabled automatically when NODE_ENV=production.

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -20,6 +20,7 @@ COOKIE_DOMAIN=.example.com
 # Maximum upload size for blog images in bytes
 MAX_BLOG_IMAGE_BYTES=10485760
 NODE_ENV=production
+# Do not set LICENSE_DEMO_BYPASS in production artifacts. The demo code bypass is automatically disabled when NODE_ENV=production.
 
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587

--- a/backend/src/services/licenseService.js
+++ b/backend/src/services/licenseService.js
@@ -4,6 +4,22 @@ const db = require('../config/database');
 const ENVATO_SALE_URL = 'https://api.envato.com/v3/market/author/sale';
 const PLACEHOLDER_EMAIL = 'license@placeholder.invalid';
 
+const parseTruthy = (value) => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+};
+
+const isDemoBypassEnabled = () => {
+  if (process.env.NODE_ENV === 'production') {
+    return false;
+  }
+
+  return parseTruthy(process.env.LICENSE_DEMO_BYPASS);
+};
+
 const normaliseDomain = (domain) => {
   if (typeof domain !== 'string') {
     return domain === undefined ? undefined : null;
@@ -85,7 +101,7 @@ async function validatePurchaseCode(code, domain, options = {}) {
     }
   }
 
-  if (code === 'DEMO-CODE-1234') {
+  if (code === 'DEMO-CODE-1234' && isDemoBypassEnabled()) {
     let licenseId = null;
     if (shouldPersist) {
       licenseId = await upsertLicense(code, {

--- a/backend/tests/services/licenseService.test.js
+++ b/backend/tests/services/licenseService.test.js
@@ -33,10 +33,18 @@ const db = require('../../src/config/database');
 const { validatePurchaseCode } = require('../../src/services/licenseService');
 
 describe('licenseService.validatePurchaseCode', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
   beforeEach(() => {
     jest.clearAllMocks();
     db.__reset();
     delete process.env.ENVATO_TOKEN;
+    delete process.env.LICENSE_DEMO_BYPASS;
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it('returns Envato verification payload including persisted licenseId', async () => {
@@ -69,7 +77,8 @@ describe('licenseService.validatePurchaseCode', () => {
     );
   });
 
-  it('returns demo license payload including persisted licenseId', async () => {
+  it('returns demo license payload including persisted licenseId when bypass enabled', async () => {
+    process.env.LICENSE_DEMO_BYPASS = 'true';
     db.__setFirstQueue([null, { id: 456 }]);
 
     const result = await validatePurchaseCode('DEMO-CODE-1234', 'demo.example', { persist: true });
@@ -88,4 +97,31 @@ describe('licenseService.validatePurchaseCode', () => {
       })
     );
   });
-})
+
+  it('rejects demo codes when bypass flag is disabled', async () => {
+    const result = await validatePurchaseCode('DEMO-CODE-1234', 'demo.example', { persist: true });
+
+    expect(result).toEqual({ valid: false, message: 'Invalid purchase code', licenseId: null });
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(db.__getInsertMock()).not.toHaveBeenCalled();
+  });
+
+  it('rejects demo codes in production even when bypass flag is enabled', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.LICENSE_DEMO_BYPASS = 'true';
+
+    const result = await validatePurchaseCode('DEMO-CODE-1234', 'demo.example', { persist: true });
+
+    expect(result).toEqual({ valid: false, message: 'Invalid purchase code', licenseId: null });
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(db.__getInsertMock()).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid when Envato verification is unavailable and no bypass exists', async () => {
+    const result = await validatePurchaseCode('CODE-789', 'invalid.example', { persist: true });
+
+    expect(result).toEqual({ valid: false, message: 'Invalid purchase code', licenseId: null });
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(db.__getInsertMock()).not.toHaveBeenCalled();
+  });
+});

--- a/docs/license-verification.html
+++ b/docs/license-verification.html
@@ -158,6 +158,7 @@
 <h2 id="prerequisites">Prerequisites</h2>
 <ul>
 <li><strong>Envato personal token</strong> with permission to view sales (stored in <code>ENVATO_TOKEN</code>).</li>
+<li><strong>(Optional) Development bypass flag</strong> – set <code>LICENSE_DEMO_BYPASS=true</code> only in non-production environments to accept the demo code <code>DEMO-CODE-1234</code>. The flag is ignored when <code>NODE_ENV=production</code>.</li>
 <li><strong>Backend endpoint</strong> capable of making HTTPS requests.</li>
 <li><strong>Database table</strong> for tracking <code>purchase_code</code>, <code>domain</code>, <code>email</code>, <code>ip</code>, <code>status</code>, <code>activated_at</code>, <code>last_check</code>, and <code>logs</code>.</li>
 </ul>
@@ -181,6 +182,7 @@
 <h2 id="security-logging-tips">Security &amp; Logging Tips</h2>
 <ul>
 <li>Keep <code>ENVATO_TOKEN</code> on the server; never expose it client-side.</li>
+<li>Avoid enabling <code>LICENSE_DEMO_BYPASS</code> in packaged or production builds. Because the flag is ignored in production mode, leave it unset in distributed environment files to prevent accidental activation.</li>
 <li>Sanitize and validate all user input before contacting Envato.</li>
 <li>Rate-limit activation attempts and hash sensitive data where possible.</li>
 <li>Log activations, validations and domain mismatches for audit trails.</li>

--- a/docs/license-verification.md
+++ b/docs/license-verification.md
@@ -4,6 +4,8 @@ This guide explains how to validate purchases of your CodeCanyon product to ensu
 
 ## Prerequisites
 - **Envato personal token** with permission to view sales (stored in `ENVATO_TOKEN`).
+- **(Optional) Development bypass flag** – set `LICENSE_DEMO_BYPASS=true` only in non-production environments to accept the demo
+  code `DEMO-CODE-1234` for local testing. The flag is ignored when `NODE_ENV=production`.
 - **Backend endpoint** capable of making HTTPS requests.
 - **Database table** for tracking `purchase_code`, `domain`, `email`, `ip`, `status`, `activated_at`, `last_check`, and `logs`.
 
@@ -25,6 +27,8 @@ This guide explains how to validate purchases of your CodeCanyon product to ensu
 
 ## Security & Logging Tips
 - Keep `ENVATO_TOKEN` on the server; never expose it client-side.
+- Avoid enabling `LICENSE_DEMO_BYPASS` in packaged or production builds. Because the flag is ignored in production mode, leave it
+  unset in distributed environment files to prevent accidental activation.
 - Sanitize and validate all user input before contacting Envato.
 - Rate-limit activation attempts and hash sensitive data where possible.
 - Log activations, validations and domain mismatches for audit trails.

--- a/frontend/src/services/licenseService.js
+++ b/frontend/src/services/licenseService.js
@@ -5,6 +5,25 @@ export async function verifyLicense(purchaseCode, domain) {
     purchase_code: purchaseCode,
     ...(domain ? { domain } : {}),
   };
-  const { data } = await api.post("/license/verify", payload);
-  return data;
+  try {
+    const { data } = await api.post("/license/verify", payload);
+    return data;
+  } catch (error) {
+    const response = error?.response;
+    const message =
+      response?.data?.message ||
+      response?.data?.error ||
+      error?.statusMessage ||
+      error?.message ||
+      "Unable to verify Envato purchase code.";
+    const wrappedError = new Error(message);
+    if (response?.status) {
+      wrappedError.status = response.status;
+    }
+    if (response?.data) {
+      wrappedError.data = response.data;
+    }
+    wrappedError.cause = error;
+    throw wrappedError;
+  }
 }


### PR DESCRIPTION
## Summary
- guard the demo purchase code so it only works when LICENSE_DEMO_BYPASS is explicitly enabled outside production
- document the new development-only flag and surface Envato verification errors from the frontend installer
- add regression coverage ensuring demo bypass gating and invalid code handling when Envato is unavailable

## Testing
- npm test -- licenseService

------
https://chatgpt.com/codex/tasks/task_e_68e2d479ad908328b6d91098e259679b