### PR TITLE
Avoid persisting auth access tokens

### DIFF
--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -86,13 +86,16 @@ const useAuthStore = create(
           const msgStop = useMessageStore.getState().stopPolling;
           notifStop?.();
           msgStop?.();
-          localStorage.removeItem("auth");
+          authStoreApi?.persist?.clearStorage?.();
           set({ accessToken: null, user: null });
         },
       };
     },
     {
       name: "auth",
+      partialize: (state) => ({
+        user: state.user,
+      }),
       onRehydrateStorage: () => {
         return (state) => {
           logger.log("🔥 Zustand hydrated");


### PR DESCRIPTION
## Summary
- update the auth store persistence configuration to omit access tokens from local storage while keeping the user profile cached
- use the zustand persist helper to clear any stored profile data on logout so in-memory auth state is fully reset

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2d4b73ec48328a9e95ab25bbb5268