### PR TITLE
Fix social login config request path

### DIFF
--- a/frontend/src/services/socialLoginService.js
+++ b/frontend/src/services/socialLoginService.js
@@ -10,6 +10,6 @@ const publicApi = axios.create({
 });
 
 export const fetchSocialLoginConfig = async () => {
-  const { data } = await publicApi.get("/social-login/config");
+  const { data } = await publicApi.get("social-login/config");
   return data?.data ?? null;
 };


### PR DESCRIPTION
## Summary
- update the social login service to request the config with a relative path so the Axios base URL keeps the `/api` prefix

## Testing
- npm test -- loginRecaptchaRefetch

------
https://chatgpt.com/codex/tasks/task_e_68e2d4bb666c832893356dec19ea8925