### PR TITLE
Remove tracked frontend env file and update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,20 @@ npm --prefix frontend install
      `http://backend:5002/api` value used for development.
 
    The backend's production configuration is loaded from
-   `backend/.env.production`. Copy `backend/.env.production.example` to
-   `backend/.env.production` and provide your database credentials and secrets
-   before deploying.
+     `backend/.env.production`. Copy `backend/.env.production.example` to
+     `backend/.env.production` and provide your database credentials and secrets
+     before deploying.
+
+   - Copy the frontend template so the Next.js app targets your API:
+
+     ```bash
+     cp frontend/.env.local.example frontend/.env.local
+     ```
+
+     Update `frontend/.env.local` before running `npm --prefix frontend run dev`
+     so `NEXT_PUBLIC_API_BASE_URL` points at your backend. For local
+     development keep the default `http://localhost:5002/api`; replace it with
+     your public HTTPS domain when deploying.
 
    - Copy the backend example file and adjust values as needed:
 

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_API_BASE_URL=https://eduskillbridge.net/api

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,7 +29,7 @@ Environment files support variable expansion using [`dotenv-expand`](https://git
 
 Only commit placeholder values. Supply real values in production via environment variables or a mounted `.env.production` so `npm run build` can generate a bundle that connects to the correct services. If `APP_DOMAIN` is defined you may set `NEXT_PUBLIC_API_BASE_URL=/api`; the build expands the relative path to `https://${APP_DOMAIN}/api` while still rejecting non-HTTPS public hosts.
 
-For local development create a `.env.local` file and set `NEXT_PUBLIC_API_BASE_URL` to your backend, for example `http://localhost:5002/api`. Without this the browser falls back to `/api`, causing admin pages to send requests to the Next.js dev server instead of the actual API.
+For local development copy `.env.local.example` to `.env.local` and ensure `NEXT_PUBLIC_API_BASE_URL` points to your backend (the template defaults to `http://localhost:5002/api`). Without this the browser falls back to `/api`, causing admin pages to send requests to the Next.js dev server instead of the actual API.
 
 Docker builds export `STRICT_PUBLIC_API=true`, so container images **must** provide `NEXT_PUBLIC_API_BASE_URL` either by passing `--build-arg NEXT_PUBLIC_API_BASE_URL=https://your-domain/api` (or `/api` alongside `--build-arg APP_DOMAIN=your-domain`) or by including it in `.env.production`. Builds fail if the value is missing or if a non-local host still uses `http://`.
 

--- a/install.sh
+++ b/install.sh
@@ -132,6 +132,10 @@ ensure_env_file() {
   if [[ -f "$example_file" && ! -f "$target_file" ]]; then
     echo "Creating $(basename "$target_file") from example file."
     cp "$example_file" "$target_file"
+
+    if [[ "$target_file" == */frontend/.env.local ]]; then
+      echo "Update frontend/.env.local so NEXT_PUBLIC_API_BASE_URL points at your API before starting the frontend."
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary
- remove the tracked `frontend/.env.local` file so clones rely on the example template
- document copying the frontend environment template in the project README and frontend guide
- add an installer reminder to point `NEXT_PUBLIC_API_BASE_URL` at the buyer's API before starting the frontend

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d5356c7083289bc2af0157314d3a