### PR TITLE
Add API base URL helper with fallback and tests

### DIFF
--- a/frontend/src/pages/api/_utils/baseUrl.js
+++ b/frontend/src/pages/api/_utils/baseUrl.js
@@ -1,0 +1,7 @@
+export default function getApiBaseUrl() {
+  return (
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    process.env.INTERNAL_API_BASE_URL ||
+    'http://localhost:5002/api'
+  );
+}

--- a/frontend/src/pages/api/app-config/index.js
+++ b/frontend/src/pages/api/app-config/index.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+import getApiBaseUrl from '@/pages/api/_utils/baseUrl';
+
 export default async function handler(req, res) {
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const base = getApiBaseUrl();
   const url = `${base}/app-config`;
   try {
     const headers = req.headers.cookie ? { Cookie: req.headers.cookie } : {};

--- a/frontend/src/pages/api/classes/[classId]/students/[studentId].js
+++ b/frontend/src/pages/api/classes/[classId]/students/[studentId].js
@@ -1,11 +1,13 @@
 import axios from 'axios';
 
+import getApiBaseUrl from '@/pages/api/_utils/baseUrl';
+
 export default async function handler(req, res) {
   const { classId, studentId } = req.query;
 
   try {
     const { data } = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/users/classes/admin/${classId}/students/${studentId}`
+      `${getApiBaseUrl()}/users/classes/admin/${classId}/students/${studentId}`
     );
     return res.status(200).json(data.data || data);
   } catch (err) {

--- a/frontend/src/pages/api/classes/[classId]/students/index.js
+++ b/frontend/src/pages/api/classes/[classId]/students/index.js
@@ -1,10 +1,12 @@
 import axios from 'axios';
 
+import getApiBaseUrl from '@/pages/api/_utils/baseUrl';
+
 export default async function handler(req, res) {
   const { classId } = req.query;
   try {
     const { data } = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/users/classes/admin/${classId}/students`
+      `${getApiBaseUrl()}/users/classes/admin/${classId}/students`
     );
     return res.status(200).json(data.data || data);
   } catch (err) {

--- a/frontend/src/pages/api/policies/index.js
+++ b/frontend/src/pages/api/policies/index.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+import getApiBaseUrl from '@/pages/api/_utils/baseUrl';
+
 export default async function handler(req, res) {
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const base = getApiBaseUrl();
   const url = `${base}/policies`;
   try {
     const headers = req.headers.cookie ? { Cookie: req.headers.cookie } : {};

--- a/frontend/src/pages/api/tutorials/[id]/analytics.js
+++ b/frontend/src/pages/api/tutorials/[id]/analytics.js
@@ -1,6 +1,8 @@
 // pages/api/tutorials/[id]/analytics.js
 import axios from 'axios';
 
+import getApiBaseUrl from '@/pages/api/_utils/baseUrl';
+
 const EMPTY_ANALYTICS = {
   totalStudents: 0,
   completed: 0,
@@ -12,7 +14,7 @@ export default async function handler(req, res) {
   const { id } = req.query;
   try {
     const { data } = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/users/tutorials/admin/${id}/analytics`,
+      `${getApiBaseUrl()}/users/tutorials/admin/${id}/analytics`,
       {
         headers: req.headers.cookie ? { Cookie: req.headers.cookie } : {},
         withCredentials: true,

--- a/frontend/src/tests/pages/api/baseUrlHandlers.test.js
+++ b/frontend/src/tests/pages/api/baseUrlHandlers.test.js
@@ -1,0 +1,103 @@
+import axios from 'axios';
+
+import appConfigHandler from '@/pages/api/app-config';
+import policiesHandler from '@/pages/api/policies';
+import classRosterHandler from '@/pages/api/classes/[classId]/students';
+import classRosterStudentHandler from '@/pages/api/classes/[classId]/students/[studentId]';
+import tutorialAnalyticsHandler from '@/pages/api/tutorials/[id]/analytics';
+
+jest.mock('axios');
+
+const createResponse = () => {
+  const response = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  };
+
+  return response;
+};
+
+describe('API routes base URL fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    delete process.env.INTERNAL_API_BASE_URL;
+  });
+
+  it('app-config handler uses fallback URL', async () => {
+    axios.get.mockResolvedValue({ data: {} });
+
+    const req = { method: 'GET', headers: {} };
+    const res = createResponse();
+
+    await appConfigHandler(req, res);
+
+    expect(axios.get).toHaveBeenCalledWith('http://localhost:5002/api/app-config', {
+      headers: {},
+      withCredentials: true,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('policies handler uses fallback URL', async () => {
+    axios.get.mockResolvedValue({ data: {} });
+
+    const req = { method: 'GET', headers: {} };
+    const res = createResponse();
+
+    await policiesHandler(req, res);
+
+    expect(axios.get).toHaveBeenCalledWith('http://localhost:5002/api/policies', {
+      headers: {},
+      withCredentials: true,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('class roster handler uses fallback URL', async () => {
+    axios.get.mockResolvedValue({ data: {} });
+
+    const req = { query: { classId: '123' } };
+    const res = createResponse();
+
+    await classRosterHandler(req, res);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://localhost:5002/api/users/classes/admin/123/students'
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('class roster student handler uses fallback URL', async () => {
+    axios.get.mockResolvedValue({ data: {} });
+
+    const req = { query: { classId: '123', studentId: '456' } };
+    const res = createResponse();
+
+    await classRosterStudentHandler(req, res);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://localhost:5002/api/users/classes/admin/123/students/456'
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('tutorial analytics handler uses fallback URL', async () => {
+    axios.get.mockResolvedValue({ data: { data: {} } });
+
+    const req = { query: { id: 'abc' }, headers: {} };
+    const res = createResponse();
+
+    await tutorialAnalyticsHandler(req, res);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://localhost:5002/api/users/tutorials/admin/abc/analytics',
+      {
+        headers: {},
+        withCredentials: true,
+      }
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared helper that chooses the API base URL with environment fallbacks
- refactor app-config, policies, tutorial analytics, and class roster API routes to use the helper
- add Jest coverage proving routes still build valid URLs when the base env var is missing

## Testing
- npm test -- --runTestsByPath src/tests/pages/api/baseUrlHandlers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2d537446c8328971b662517c184ac