### PR TITLE
Wrap support ticket creation in transaction

### DIFF
--- a/backend/src/modules/support/__tests__/support.service.test.js
+++ b/backend/src/modules/support/__tests__/support.service.test.js
@@ -1,0 +1,110 @@
+const buildDbStub = ({ failMessage = false } = {}) => {
+  const state = { tickets: [] };
+
+  const db = jest.fn();
+
+  db.transaction = jest.fn(async (callback) => {
+    const workingTickets = [...state.tickets];
+
+    const trx = (table) => {
+      if (table === 'support_tickets') {
+        return {
+          where({ ticket_number }) {
+            return {
+              async first() {
+                return workingTickets.find((t) => t.ticket_number === ticket_number) || null;
+              },
+            };
+          },
+          insert(data) {
+            return {
+              async returning() {
+                const ticket = {
+                  id: `ticket-${workingTickets.length + 1}`,
+                  ...data,
+                };
+                workingTickets.push(ticket);
+                return [ticket];
+              },
+            };
+          },
+        };
+      }
+
+      if (table === 'support_messages') {
+        return {
+          async insert() {
+            if (failMessage) {
+              throw new Error('message insert failed');
+            }
+            return [{}];
+          },
+        };
+      }
+
+      throw new Error(`Unhandled table ${table}`);
+    };
+
+    trx.isTransaction = true;
+
+    try {
+      const result = await callback(trx);
+      state.tickets = workingTickets;
+      return result;
+    } catch (error) {
+      throw error;
+    }
+  });
+
+  db.__state = state;
+
+  return db;
+};
+
+const buildService = ({ failMessage = false } = {}) => {
+  const mockDb = buildDbStub({ failMessage });
+
+  jest.resetModules();
+
+  let service;
+  jest.isolateModules(() => {
+    jest.doMock('../../../config/database', () => mockDb);
+    // eslint-disable-next-line global-require
+    service = require('../support.service');
+  });
+
+  return { service, mockDb };
+};
+
+describe('support.service.createTicket', () => {
+  test('throws 400 error when subject is empty', async () => {
+    const { service, mockDb } = buildService();
+
+    await expect(
+      service.createTicket({ user_id: 'user-1', subject: '   ', message: 'hello' })
+    ).rejects.toMatchObject({ message: 'Subject is required', statusCode: 400 });
+
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  test('throws 400 error when message is empty', async () => {
+    const { service, mockDb } = buildService();
+
+    await expect(
+      service.createTicket({ user_id: 'user-1', subject: 'Help', message: '\n\n' })
+    ).rejects.toMatchObject({ message: 'Message is required', statusCode: 400 });
+
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  test('rolls back ticket insert when message creation fails', async () => {
+    const { service, mockDb } = buildService({ failMessage: true });
+
+    await expect(
+      service.createTicket({ user_id: 'user-1', subject: 'Help', message: 'Broken' })
+    ).rejects.toThrow('message insert failed');
+
+    expect(mockDb.transaction).toHaveBeenCalled();
+    expect(mockDb.__state.tickets).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -1,4 +1,5 @@
 const db = require("../../config/database");
+const AppError = require("../../utils/AppError");
 
 /**
  * Create a new support ticket and initial message
@@ -8,32 +9,46 @@ const db = require("../../config/database");
  * @param {string} params.message - Initial message content
  */
 exports.createTicket = async ({ user_id, subject, message }) => {
-  // ─────────────────────
-  // 🔢 Generate unique ticket number
-  // ─────────────────────
-  let ticketNumber;
-  do {
-    ticketNumber = Math.floor(100000 + Math.random() * 900000).toString();
-  } while (
-    await db("support_tickets")
-      .where({ ticket_number: ticketNumber })
-      .first()
-  );
+  const normalizedSubject =
+    typeof subject === "string" ? subject.trim() : "";
+  if (!normalizedSubject) {
+    throw new AppError("Subject is required", 400);
+  }
 
-  // ─────────────────────
-  // 💾 Save the ticket
-  // ─────────────────────
-  const [ticket] = await db("support_tickets")
-    .insert({ user_id, subject, ticket_number: ticketNumber })
-    .returning("*");
+  const normalizedMessage =
+    typeof message === "string" ? message.trim() : "";
+  if (!normalizedMessage) {
+    throw new AppError("Message is required", 400);
+  }
 
-  await db("support_messages").insert({
-    ticket_id: ticket.id,
-    sender_id: user_id,
-    message,
+  return db.transaction(async (trx) => {
+    // ─────────────────────
+    // 🔢 Generate unique ticket number
+    // ─────────────────────
+    let ticketNumber;
+    do {
+      ticketNumber = Math.floor(100000 + Math.random() * 900000).toString();
+    } while (
+      await trx("support_tickets")
+        .where({ ticket_number: ticketNumber })
+        .first()
+    );
+
+    // ─────────────────────
+    // 💾 Save the ticket
+    // ─────────────────────
+    const [ticket] = await trx("support_tickets")
+      .insert({ user_id, subject: normalizedSubject, ticket_number: ticketNumber })
+      .returning("*");
+
+    await trx("support_messages").insert({
+      ticket_id: ticket.id,
+      sender_id: user_id,
+      message: normalizedMessage,
+    });
+
+    return ticket;
   });
-
-  return ticket;
 };
 
 exports.listUserTickets = (user_id) => {


### PR DESCRIPTION
## Summary
- wrap support ticket creation logic in a single transaction and add fast subject/message validation
- add unit tests that cover validation failures and ensure ticket inserts are rolled back when message creation fails

## Testing
- npm test -- support.service

------
https://chatgpt.com/codex/tasks/task_e_68e2d5a246948328a490797788024d04