### PR TITLE
Normalize support ticket customer names

### DIFF
--- a/frontend/src/components/support/TicketCard.js
+++ b/frontend/src/components/support/TicketCard.js
@@ -33,7 +33,9 @@ export default function TicketCard({ ticket, onClick }) {
           <Image
             src={ticket.user_avatar || '/images/default-avatar.png'}
             alt={
-              ticket.user_name
+              ticket.customerName
+                ? `${ticket.customerName}'s avatar`
+                : ticket.user_name
                 ? `${ticket.user_name}'s avatar`
                 : ticket.user
                 ? `${ticket.user}'s avatar`
@@ -43,7 +45,7 @@ export default function TicketCard({ ticket, onClick }) {
             height={16}
             className="w-4 h-4 rounded-full object-cover"
           />
-          {ticket.user_name || ticket.user || 'Unknown'}
+          {ticket.customerName || ticket.user_name || ticket.user || 'Unknown'}
         </span>
         <span className="flex items-center gap-1">
           <FiClock className="text-gray-400" />

--- a/frontend/src/components/support/TicketDetailPanel.js
+++ b/frontend/src/components/support/TicketDetailPanel.js
@@ -12,7 +12,9 @@ export default function TicketDetailPanel({ ticket }) {
         <Image
           src={ticket.user_avatar || '/images/default-avatar.png'}
           alt={
-            ticket.user_name
+            ticket.customerName
+              ? `${ticket.customerName}'s avatar`
+              : ticket.user_name
               ? `${ticket.user_name}'s avatar`
               : ticket.user
               ? `${ticket.user}'s avatar`
@@ -24,7 +26,9 @@ export default function TicketDetailPanel({ ticket }) {
         />
         <div>
           <h2 className="text-xl font-semibold mb-1">{ticket.subject}</h2>
-          <p className="text-sm text-gray-500">{ticket.user_name || ticket.user}</p>
+          <p className="text-sm text-gray-500">
+            {ticket.customerName || ticket.user_name || ticket.user}
+          </p>
         </div>
         <div className="ml-auto">
           <StatusBadge status={ticket.status} />

--- a/frontend/src/services/supportService.js
+++ b/frontend/src/services/supportService.js
@@ -11,6 +11,13 @@ const formatUrl = (url) => {
   return `${apiBase}${url}`;
 };
 
+const attachCustomerName = ({ user_name, user, ...rest }) => ({
+  ...rest,
+  user_name,
+  user,
+  customerName: user_name || user || rest.customerName || null,
+});
+
 // ─────────────────────
 // 📨 Create a support ticket
 // ─────────────────────
@@ -23,21 +30,25 @@ export const fetchMyTickets = async (config = {}) => {
   const cfg = Object.keys(config).length ? config : undefined;
   const { data } = await api.get("/support/my-tickets", cfg);
   const list = data?.data ?? [];
-  return list.map(({ created_at, user_avatar, ...rest }) => ({
-    ...rest,
-    createdAt: created_at,
-    user_avatar: formatUrl(user_avatar),
-  }));
+  return list.map(({ created_at, user_avatar, ...rest }) =>
+    attachCustomerName({
+      ...rest,
+      createdAt: created_at,
+      user_avatar: formatUrl(user_avatar),
+    })
+  );
 };
 
 export const fetchAllTickets = async (filters = {}) => {
   const { data } = await api.get("/support/admin/tickets", { params: filters });
   const list = data?.data ?? [];
-  return list.map(({ created_at, user_avatar, ...rest }) => ({
-    ...rest,
-    createdAt: created_at,
-    user_avatar: formatUrl(user_avatar),
-  }));
+  return list.map(({ created_at, user_avatar, ...rest }) =>
+    attachCustomerName({
+      ...rest,
+      createdAt: created_at,
+      user_avatar: formatUrl(user_avatar),
+    })
+  );
 };
 
 export const fetchTicketById = async (id) => {
@@ -46,7 +57,7 @@ export const fetchTicketById = async (id) => {
   if (!ticket) return null;
   const { created_at, user_avatar, messages = [], ...rest } = ticket;
   return {
-    ...rest,
+    ...attachCustomerName(rest),
     createdAt: created_at,
     user_avatar: formatUrl(user_avatar),
     messages: messages.map(

--- a/frontend/src/tests/components/support/TicketCard.test.js
+++ b/frontend/src/tests/components/support/TicketCard.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import TicketCard from '@/components/support/TicketCard';
+
+jest.mock('next/image', () => (props) => {
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img {...props} />;
+});
+
+jest.mock('@/components/support/StatusBadge', () => ({ status }) => (
+  <span data-testid="status-badge">{status}</span>
+));
+
+describe('TicketCard', () => {
+  it('renders the provided customer name', () => {
+    const ticket = {
+      id: 1,
+      subject: 'Login issue',
+      status: 'Open',
+      ticket_number: 'SB-1001',
+      priority: 'High',
+      createdAt: new Date('2024-01-01T10:00:00Z').toISOString(),
+      customerName: 'Alex Johnson',
+    };
+
+    render(<TicketCard ticket={ticket} onClick={jest.fn()} />);
+
+    expect(screen.getByText('Alex Johnson')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/support/TicketDetailPanel.test.js
+++ b/frontend/src/tests/components/support/TicketDetailPanel.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import TicketDetailPanel from '@/components/support/TicketDetailPanel';
+
+jest.mock('next/image', () => (props) => {
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img {...props} />;
+});
+
+jest.mock('@/components/support/StatusBadge', () => ({ status }) => (
+  <span data-testid="status-badge">{status}</span>
+));
+
+describe('TicketDetailPanel', () => {
+  it('shows the ticket customer name when available', () => {
+    const ticket = {
+      id: 1,
+      subject: 'Payment failed',
+      status: 'open',
+      description: 'My payment did not go through',
+      customerName: 'Jamie Lee',
+      user_avatar: null,
+      messages: [],
+    };
+
+    render(<TicketDetailPanel ticket={ticket} />);
+
+    expect(screen.getByText('Jamie Lee')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable mapper that surfaces a customerName alongside the existing support ticket payloads
- ensure support ticket components prefer the normalized customerName when showing avatars and text
- add TicketCard and TicketDetailPanel tests that confirm the customer name renders once data is available

## Testing
- npm test -- TicketCard
- npm test -- TicketDetailPanel

------
https://chatgpt.com/codex/tasks/task_e_68e2d5a347148328a31f3baf529df7a7