### PR TITLE
Fix support ticket attachment handling

### DIFF
--- a/backend/src/modules/support/__tests__/support.service.test.js
+++ b/backend/src/modules/support/__tests__/support.service.test.js
@@ -1,4 +1,18 @@
-const buildDbStub = ({ failMessage = false } = {}) => {
+const loadServiceWithDb = (mockDb) => {
+  jest.resetModules();
+
+  jest.doMock('../../../config/database', () => mockDb);
+
+  let service;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line global-require
+    service = require('../support.service');
+  });
+
+  return { service, mockDb };
+};
+
+const buildCreateTicketDbStub = ({ failMessage = false } = {}) => {
   const state = { tickets: [] };
 
   const db = jest.fn();
@@ -12,7 +26,9 @@ const buildDbStub = ({ failMessage = false } = {}) => {
           where({ ticket_number }) {
             return {
               async first() {
-                return workingTickets.find((t) => t.ticket_number === ticket_number) || null;
+                return (
+                  workingTickets.find((t) => t.ticket_number === ticket_number) || null
+                );
               },
             };
           },
@@ -61,24 +77,57 @@ const buildDbStub = ({ failMessage = false } = {}) => {
   return db;
 };
 
-const buildService = ({ failMessage = false } = {}) => {
-  const mockDb = buildDbStub({ failMessage });
+const buildUploadDbStub = ({
+  message = { id: 'message-1', ticket_id: 'ticket-1', sender_id: 'user-1' },
+  ticket = { id: 'ticket-1', user_id: 'user-1' },
+  attachmentRow = {
+    id: 'attachment-1',
+    message_id: 'message-1',
+    file_url: '/uploads/support_attachments/file.png',
+    file_name: 'file.png',
+  },
+} = {}) => {
+  const messageFirst = jest.fn().mockResolvedValue(message ?? null);
+  const messageWhere = jest.fn().mockReturnValue({ first: messageFirst });
 
-  jest.resetModules();
+  const ticketFirst = jest.fn().mockResolvedValue(ticket ?? null);
+  const ticketWhere = jest.fn().mockReturnValue({ first: ticketFirst });
 
-  let service;
-  jest.isolateModules(() => {
-    jest.doMock('../../../config/database', () => mockDb);
-    // eslint-disable-next-line global-require
-    service = require('../support.service');
+  const insertReturning = jest.fn().mockResolvedValue([attachmentRow]);
+  const attachmentInsert = jest.fn().mockReturnValue({ returning: insertReturning });
+
+  const db = jest.fn((table) => {
+    if (table === 'support_messages') {
+      return { where: messageWhere };
+    }
+
+    if (table === 'support_tickets') {
+      return { where: ticketWhere };
+    }
+
+    if (table === 'support_attachments') {
+      return { insert: attachmentInsert };
+    }
+
+    throw new Error(`Unhandled table ${table}`);
   });
 
-  return { service, mockDb };
+  db.__mocks = {
+    messageFirst,
+    messageWhere,
+    ticketFirst,
+    ticketWhere,
+    attachmentInsert,
+    insertReturning,
+  };
+
+  return db;
 };
 
 describe('support.service.createTicket', () => {
   test('throws 400 error when subject is empty', async () => {
-    const { service, mockDb } = buildService();
+    const mockDb = buildCreateTicketDbStub();
+    const { service } = loadServiceWithDb(mockDb);
 
     await expect(
       service.createTicket({ user_id: 'user-1', subject: '   ', message: 'hello' })
@@ -88,7 +137,8 @@ describe('support.service.createTicket', () => {
   });
 
   test('throws 400 error when message is empty', async () => {
-    const { service, mockDb } = buildService();
+    const mockDb = buildCreateTicketDbStub();
+    const { service } = loadServiceWithDb(mockDb);
 
     await expect(
       service.createTicket({ user_id: 'user-1', subject: 'Help', message: '\n\n' })
@@ -98,7 +148,8 @@ describe('support.service.createTicket', () => {
   });
 
   test('rolls back ticket insert when message creation fails', async () => {
-    const { service, mockDb } = buildService({ failMessage: true });
+    const mockDb = buildCreateTicketDbStub({ failMessage: true });
+    const { service } = loadServiceWithDb(mockDb);
 
     await expect(
       service.createTicket({ user_id: 'user-1', subject: 'Help', message: 'Broken' })
@@ -106,5 +157,83 @@ describe('support.service.createTicket', () => {
 
     expect(mockDb.transaction).toHaveBeenCalled();
     expect(mockDb.__state.tickets).toHaveLength(0);
+  });
+});
+
+describe('support.service.uploadAttachment', () => {
+  const defaultFile = {
+    filename: 'file.png',
+    originalname: 'receipt.png',
+  };
+
+  test('stores attachment when user owns the ticket', async () => {
+    const mockDb = buildUploadDbStub();
+    const { service } = loadServiceWithDb(mockDb);
+
+    const result = await service.uploadAttachment({
+      messageId: 'message-1',
+      file: defaultFile,
+      user: { id: 'user-1' },
+    });
+
+    expect(mockDb.__mocks.attachmentInsert).toHaveBeenCalledWith({
+      message_id: 'message-1',
+      file_url: '/uploads/support_attachments/file.png',
+      file_name: 'receipt.png',
+    });
+    expect(result).toEqual({
+      id: 'attachment-1',
+      message_id: 'message-1',
+      file_url: '/uploads/support_attachments/file.png',
+      file_name: 'file.png',
+    });
+  });
+
+  test('throws 404 when support message cannot be found', async () => {
+    const mockDb = buildUploadDbStub({ message: null });
+    const { service } = loadServiceWithDb(mockDb);
+
+    await expect(
+      service.uploadAttachment({
+        messageId: 'missing-message',
+        file: defaultFile,
+        user: { id: 'user-1' },
+      })
+    ).rejects.toMatchObject({ message: 'Support message not found', statusCode: 404 });
+
+    expect(mockDb.__mocks.attachmentInsert).not.toHaveBeenCalled();
+  });
+
+  test('throws 404 when related ticket is missing', async () => {
+    const mockDb = buildUploadDbStub({ ticket: null });
+    const { service } = loadServiceWithDb(mockDb);
+
+    await expect(
+      service.uploadAttachment({
+        messageId: 'message-1',
+        file: defaultFile,
+        user: { id: 'user-1' },
+      })
+    ).rejects.toMatchObject({ message: 'Support ticket not found', statusCode: 404 });
+
+    expect(mockDb.__mocks.attachmentInsert).not.toHaveBeenCalled();
+  });
+
+  test('rejects when user lacks permissions', async () => {
+    const mockDb = buildUploadDbStub({
+      message: { id: 'message-1', ticket_id: 'ticket-1', sender_id: 'other-user' },
+      ticket: { id: 'ticket-1', user_id: 'other-user' },
+    });
+    const { service } = loadServiceWithDb(mockDb);
+
+    await expect(
+      service.uploadAttachment({
+        messageId: 'message-1',
+        file: defaultFile,
+        user: { id: 'user-1', roles: ['student'] },
+      })
+    ).rejects.toMatchObject({ message: 'Access denied', statusCode: 403 });
+
+    expect(mockDb.__mocks.attachmentInsert).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -2,6 +2,7 @@ const path = require("path");
 
 const db = require("../../config/database");
 const AppError = require("../../utils/AppError");
+const { isAdminRole } = require("../../utils/role");
 
 /**
  * Create a new support ticket and initial message


### PR DESCRIPTION
## Summary
- add the missing role utility import so support attachment uploads can authorize correctly
- add focused unit tests that stub the database layer to cover ticket creation rollback and attachment upload edge cases

## Testing
- npm test -- support.service.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2d2fdd75083289343dc68c2e67230