### PR TITLE
Fix support attachment upload admin role check

### DIFF
--- a/backend/src/modules/support/support.service.js
+++ b/backend/src/modules/support/support.service.js
@@ -2,6 +2,7 @@ const path = require("path");
 
 const db = require("../../config/database");
 const AppError = require("../../utils/AppError");
+const { isAdminRole } = require("../../utils/role");
 
 /**
  * Create a new support ticket and initial message


### PR DESCRIPTION
## Summary
- import the isAdminRole helper into the support service so attachment uploads can verify admin access without crashing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2d2fdd75083289343dc68c2e67230