### PR TITLE
Add Codecanyon readiness audit report

### DIFF
--- a/docs/codecanyon-readiness.md
+++ b/docs/codecanyon-readiness.md
@@ -1,0 +1,25 @@
+# Codecanyon Readiness Audit
+
+## Summary
+- Automated backend verification is failing, blocking the release checklist requirement for passing tests.
+- Subscription wallet helpers contain duplicate imports and incomplete implementations that currently break the build.
+- Static documentation generation depends on the `markdown` Python package, which is not installed in the default environment.
+
+## Checklist Alignment
+The repository includes a release checklist that must pass before packaging for Envato/Codecanyon distribution. Key items include clean git status, successful backend/frontend tests, and regenerating static docs.
+
+## Repository State
+Running `git status -sb` on the worktree shows no uncommitted changes, so the repository is clean.
+
+## Automated Tests
+Executing `npm test` in the backend fails immediately with syntax errors and duplicate identifier declarations, so the automated test gate is currently red. These failures originate from the payments wallet helper and related imports.
+
+## Code Quality Blockers
+- `book.service.js` declares `creditInstructorSubscription` twice, triggering duplicate-identifier syntax errors under Jest.
+- `wallet.js` leaves `creditTutorialSubscription` unfinished (undefined variables are referenced and the helper never calls the shared credit routine), which causes parsing failures in multiple suites.
+
+## Documentation Build
+The documentation regeneration script required by the release checklist fails because the Python `markdown` dependency is missing in the default environment.
+
+## Conclusion
+SkillBridge is **not** Codecanyon-ready. Automated tests fail, blocking the release checklist; core subscription helpers require fixes; and static documentation generation needs dependency setup. Address these blockers, rerun the checklist, and only then prepare the Codecanyon submission package.


### PR DESCRIPTION
## Summary
- document the current Codecanyon readiness status and highlight blockers preventing a release package

## Testing
- npm test *(fails: backend suites aborted by wallet helper syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e361c964b48328801765c5a2ad40bb