### PR TITLE
Fix admin classes table list updates

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -242,7 +242,8 @@ export default function AdminClassesTable() {
   const updateClassList = (updater) => {
     setClassList((previous) => {
       if (typeof updater === "function") {
-        return updater(previous);
+        const nextValue = updater(previous);
+        return Array.isArray(nextValue) ? nextValue : previous;
       }
 
       return Array.isArray(updater) ? updater : previous;
@@ -250,32 +251,20 @@ export default function AdminClassesTable() {
   };
 
   const updateClassListIfChanged = (nextList) => {
-    setClassList((previous) => {
-      if (previous.length === nextList.length) {
-        const previousFirstId = previous[0]?.id ?? null;
-        const nextFirstId = nextList[0]?.id ?? null;
+    if (!Array.isArray(nextList)) {
+      return;
+    }
 
-        if (previousFirstId === nextFirstId) {
+    setClassList((previous) => {
+      if (classListLengthRef.current === nextList.length) {
+        const nextSignature = computeListSignature(nextList);
+        if (classListSignatureRef.current === nextSignature) {
           return previous;
         }
       }
 
       return nextList;
     });
-  };
-
-  const updateClassList = (updater) => {
-    if (typeof updater === "function") {
-      setClassList((previous) => {
-        const nextValue = updater(previous);
-        return Array.isArray(nextValue) ? nextValue : previous;
-      });
-      return;
-    }
-
-    if (Array.isArray(updater)) {
-      setClassList(updater);
-    }
   };
 
   const sortClasses = (items, key = sortKey) =>


### PR DESCRIPTION
## Summary
- remove the duplicate updateClassList helper definition in the admin classes table
- ensure list updates are only skipped when the incoming list matches the current data signature

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e362335408832882832c9b5f872448