### PR TITLE
Improve admin online class detail handling

### DIFF
--- a/frontend/public/locales/ar/dashboard.json
+++ b/frontend/public/locales/ar/dashboard.json
@@ -641,7 +641,9 @@
     "loading": "جارٍ تحميل تفاصيل الصف...",
     "views_label": "المشاهدات",
     "view_students": "عرض الطلاب",
-    "view_analytics": "عرض التحليلات"
+    "view_analytics": "عرض التحليلات",
+    "not_found": "لم يتم العثور على الصف.",
+    "error_loading": "تعذر تحميل هذا الصف. يرجى المحاولة لاحقًا."
   },
   "popupAnnouncementsPage": {
     "title": "الإعلانات المنبثقة",

--- a/frontend/public/locales/de/dashboard.json
+++ b/frontend/public/locales/de/dashboard.json
@@ -655,7 +655,9 @@
     "loading": "Loading class details...",
     "views_label": "Views",
     "view_students": "View Students",
-    "view_analytics": "View Analytics"
+    "view_analytics": "View Analytics",
+    "not_found": "Klasse nicht gefunden.",
+    "error_loading": "Diese Klasse konnte nicht geladen werden. Bitte versuche es später erneut."
   },
   "popupAnnouncementsPage": {
     "title": "Popup Announcements",

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -660,7 +660,9 @@
     "loading": "Loading class details...",
     "views_label": "Views",
     "view_students": "View Students",
-    "view_analytics": "View Analytics"
+    "view_analytics": "View Analytics",
+    "not_found": "Class not found.",
+    "error_loading": "We couldn't load this class. Please try again later."
   },
   "popupAnnouncementsPage": {
     "title": "Popup Announcements",

--- a/frontend/public/locales/es/dashboard.json
+++ b/frontend/public/locales/es/dashboard.json
@@ -641,7 +641,9 @@
     "loading": "Carga de detalles de la clase ...",
     "views_label": "Vistas",
     "view_students": "Ver a los estudiantes",
-    "view_analytics": "Ver análisis"
+    "view_analytics": "Ver análisis",
+    "not_found": "Clase no encontrada.",
+    "error_loading": "No se pudo cargar esta clase. Inténtalo de nuevo más tarde."
   },
   "popupAnnouncementsPage": {
     "title": "Anuncios emergentes",

--- a/frontend/public/locales/fr/dashboard.json
+++ b/frontend/public/locales/fr/dashboard.json
@@ -641,7 +641,9 @@
     "loading": "Chargement des détails du cours...",
     "views_label": "Vues",
     "view_students": "Voir les étudiants",
-    "view_analytics": "Voir les analyses"
+    "view_analytics": "Voir les analyses",
+    "not_found": "Cours introuvable.",
+    "error_loading": "Impossible de charger ce cours. Veuillez réessayer plus tard."
   },
   "popupAnnouncementsPage": {
     "title": "Annonces pop-up",

--- a/frontend/public/locales/hi/dashboard.json
+++ b/frontend/public/locales/hi/dashboard.json
@@ -641,7 +641,9 @@
     "loading": "लोडिंग क्लास विवरण ...",
     "views_label": "दृश्य",
     "view_students": "छात्र देखें",
-    "view_analytics": "एनालिटिक्स देखें"
+    "view_analytics": "एनालिटिक्स देखें",
+    "not_found": "कक्षा नहीं मिली।",
+    "error_loading": "इस कक्षा को लोड नहीं किया जा सका। कृपया बाद में पुनः प्रयास करें।"
   },
   "popupAnnouncementsPage": {
     "title": "पॉपअप घोषणाएँ",

--- a/frontend/public/locales/it/dashboard.json
+++ b/frontend/public/locales/it/dashboard.json
@@ -655,7 +655,9 @@
     "loading": "Caricamento dei dettagli della classe ...",
     "views_label": "Viste",
     "view_students": "Visualizza gli studenti",
-    "view_analytics": "Visualizza l'analisi"
+    "view_analytics": "Visualizza l'analisi",
+    "not_found": "Classe non trovata.",
+    "error_loading": "Impossibile caricare questa classe. Riprova più tardi."
   },
   "popupAnnouncementsPage": {
     "title": "Annunci popup",

--- a/frontend/public/locales/zh/dashboard.json
+++ b/frontend/public/locales/zh/dashboard.json
@@ -641,7 +641,9 @@
     "loading": "加载类详细信息...",
     "views_label": "视图",
     "view_students": "查看学生",
-    "view_analytics": "查看分析"
+    "view_analytics": "查看分析",
+    "not_found": "未找到课程。",
+    "error_loading": "无法加载此课程。请稍后重试。"
   },
   "popupAnnouncementsPage": {
     "title": "弹出公告",

--- a/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/[id]/index.js
@@ -1,6 +1,6 @@
 // pages/dashboard/admin/online-classes/[id]/index.js
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import Link from "next/link";
@@ -14,28 +14,44 @@ import DOMPurify from 'isomorphic-dompurify';
 function AdminClassDetailPage() {
   const { id } = useRouter().query;
   const [details, setDetails] = useState(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const { t, i18n } = useTranslation('dashboard');
+  const direction = typeof i18n?.dir === 'function' ? i18n.dir() : 'ltr';
 
   useEffect(() => {
     if (!id) return;
     const load = async () => {
       setLoading(true);
+      setError(null);
       try {
         const data = await fetchAdminClassById(id);
+        if (!data) {
+          setError(t('adminClassDetailPage.not_found'));
+          setDetails(null);
+          return;
+        }
+
         setDetails(data);
+        setError(null);
       } catch (err) {
         console.error("Failed to load class", err);
+        setError(t('adminClassDetailPage.error_loading'));
       } finally {
         setLoading(false);
       }
     };
     load();
-  }, [id]);
+  }, [id, t]);
+
+  const sanitizedDescription = useMemo(
+    () => DOMPurify.sanitize(details?.description || ""),
+    [details?.description]
+  );
 
   return (
-    <div className="p-6 space-y-8" dir={i18n.dir()}>
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4" dir={i18n.dir()}>
+    <div className="p-6 space-y-8" dir={direction}>
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4" dir={direction}>
         <div>
           <h1 className="text-2xl md:text-3xl font-bold text-gray-800">{t('adminClassDetailPage.title')}</h1>
           <p className="text-gray-500 text-sm mt-1">ID: {id}</p>
@@ -58,8 +74,16 @@ function AdminClassDetailPage() {
           </div>
           <p className="mt-3 text-gray-600">{t('adminClassDetailPage.loading')}</p>
         </div>
+      ) : error ? (
+        <div className="bg-white rounded-lg shadow-sm p-8 border border-gray-100 text-center">
+          <p className="text-gray-700">{error}</p>
+        </div>
+      ) : !details ? (
+        <div className="bg-white rounded-lg shadow-sm p-8 border border-gray-100 text-center">
+          <p className="text-gray-700">{t('adminClassDetailPage.not_found')}</p>
+        </div>
       ) : (
-      <div className="bg-white rounded-lg shadow-sm overflow-hidden border border-gray-100">
+        <div className="bg-white rounded-lg shadow-sm overflow-hidden border border-gray-100">
         {/* Media section */}
         <div className="p-6 md:p-8 space-y-6">
           {/* Cover image and video */}
@@ -208,7 +232,7 @@ function AdminClassDetailPage() {
             <h3 className="text-lg font-semibold text-gray-700 mb-3 pb-2 border-b border-gray-100">{t('description_label')}</h3>
             <div
               className="prose max-w-none text-gray-600"
-              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(details?.description || "") }}
+              dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
             />
           </div>
 
@@ -264,7 +288,7 @@ export default ProtectedAdminClassDetailPage;
 export async function getServerSideProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['dashboard'], nextI18NextConfig)),
+      ...(await serverSideTranslations(locale, ['common', 'dashboard'], nextI18NextConfig)),
     },
   };
 }


### PR DESCRIPTION
## Summary
- add explicit loading, error, and empty states to the admin online class detail page while reusing sanitized descriptions
- ensure the detail view respects locale direction and requests both common and dashboard translations
- surface matching "not found" and "error loading" strings across all supported dashboard locales

## Testing
- npm run lint -- --max-warnings=0 *(fails: existing lint warnings unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e362335408832882832c9b5f872448