### PR TITLE
Fix admin online classes table list updates

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -4,7 +4,6 @@ import { useTranslation } from "next-i18next";
 import Link from "next/link";
 import { toast } from "react-toastify";
 import {
-  updateAdminClass,
   deleteAdminClass,
   approveAdminClass,
   rejectAdminClass,
@@ -237,16 +236,6 @@ export default function AdminClassesTable() {
     totalPagesRef.current = value;
     setTotalPages(value);
     return true;
-  };
-
-  const updateClassList = (updater) => {
-    setClassList((previous) => {
-      if (typeof updater === "function") {
-        return updater(previous);
-      }
-
-      return Array.isArray(updater) ? updater : previous;
-    });
   };
 
   const updateClassListIfChanged = (nextList) => {


### PR DESCRIPTION
## Summary
- remove the unused updateAdminClass import from the admin online classes table
- keep a single updateClassList helper so list updates can safely validate returned data

## Testing
- npm test -- AdminClassesTableSorting.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e362335408832882832c9b5f872448