### PR TITLE
Fix dotenv comment syntax in backend env example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
-// 📁 .env.example
+# 📁 .env.example
 # Default API port. Docker Compose and nginx expect 5002.
 BACKEND_PORT=5002
 DATABASE_URL=postgres://user:password@localhost:5432/eduSkillbridge


### PR DESCRIPTION
## Summary
- replace the leading // comment in backend/.env.example with a dotenv-compatible # comment to avoid parsing errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e361c964b48328801765c5a2ad40bb