### PR TITLE
Handle non-array admin class responses

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -114,6 +114,29 @@ const computeListSignature = (items) => {
     .join("|");
 };
 
+const sanitizeClassEntries = (items) => {
+  if (!Array.isArray(items)) {
+    return null;
+  }
+
+  let encounteredInvalid = false;
+  const sanitized = [];
+
+  for (const item of items) {
+    if (item && typeof item === "object") {
+      sanitized.push(item);
+    } else {
+      encounteredInvalid = true;
+    }
+  }
+
+  if (!encounteredInvalid) {
+    return items;
+  }
+
+  return sanitized;
+};
+
 export default function AdminClassesTable() {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterStatus, setFilterStatus] = useState("All");
@@ -240,42 +263,37 @@ export default function AdminClassesTable() {
   };
 
   const updateClassList = (updater) => {
-    setClassList((previous) => {
+    setClassList((previousRaw) => {
+      const previous = sanitizeClassEntries(previousRaw) ?? [];
+
       if (typeof updater === "function") {
-        return updater(previous);
+        const nextValue = updater(previous);
+        const sanitizedNext = sanitizeClassEntries(nextValue);
+        return Array.isArray(sanitizedNext) ? sanitizedNext : previous;
       }
 
-      return Array.isArray(updater) ? updater : previous;
+      const sanitizedNext = sanitizeClassEntries(updater);
+      return Array.isArray(sanitizedNext) ? sanitizedNext : previous;
     });
   };
 
   const updateClassListIfChanged = (nextList) => {
-    setClassList((previous) => {
-      if (previous.length === nextList.length) {
-        const previousFirstId = previous[0]?.id ?? null;
-        const nextFirstId = nextList[0]?.id ?? null;
+    const sanitizedNext = sanitizeClassEntries(nextList);
 
-        if (previousFirstId === nextFirstId) {
+    if (!Array.isArray(sanitizedNext)) {
+      return;
+    }
+
+    setClassList((previous) => {
+      if (classListLengthRef.current === sanitizedNext.length) {
+        const nextSignature = computeListSignature(sanitizedNext);
+        if (classListSignatureRef.current === nextSignature) {
           return previous;
         }
       }
 
-      return nextList;
+      return sanitizedNext;
     });
-  };
-
-  const updateClassList = (updater) => {
-    if (typeof updater === "function") {
-      setClassList((previous) => {
-        const nextValue = updater(previous);
-        return Array.isArray(nextValue) ? nextValue : previous;
-      });
-      return;
-    }
-
-    if (Array.isArray(updater)) {
-      setClassList(updater);
-    }
   };
 
   const sortClasses = (items, key = sortKey) =>

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -55,7 +55,14 @@ export const fetchAdminClasses = async ({
   const { data } = await api.get("users/classes/admin", {
     params: Object.fromEntries(params.entries()),
   });
-  const list = data?.data ?? [];
+
+  const rawList = data?.data;
+  const list = Array.isArray(rawList)
+    ? rawList
+    : rawList
+    ? [rawList]
+    : [];
+
   return { data: list.map(formatClass), meta: data?.meta || {} };
 };
 


### PR DESCRIPTION
## Summary
- normalize admin class fetch responses so singular payloads are coerced into arrays before formatting
- keep downstream table rendering resilient to API responses that sometimes return a single object instead of a list

## Testing
- npm test -- AdminClassesTable *(fails: existing pagination expectation in AdminClassesTableOutOfRange.test.js)*
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e362335408832882832c9b5f872448