### PR TITLE
Handle malformed admin class responses

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -280,9 +280,11 @@ export default function AdminClassesTable() {
       return;
     }
 
+    const sanitizedNext = sanitizeClassEntries(nextList) ?? [];
+
     setClassList((previous) => {
-      if (classListLengthRef.current === nextList.length) {
-        const nextSignature = computeListSignature(nextList);
+      if (classListLengthRef.current === sanitizedNext.length) {
+        const nextSignature = computeListSignature(sanitizedNext);
         if (classListSignatureRef.current === nextSignature) {
           return previous;
         }

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -5,6 +5,10 @@ import { safeEncodeURI } from "@/utils/url";
 import { computeScheduleStatus } from "@/utils/classSchedule";
 
 const formatClass = (cls) => {
+  if (!cls || typeof cls !== "object") {
+    return null;
+  }
+
   const { status, schedule_status, ...rest } = cls;
   return {
     ...rest,
@@ -63,7 +67,17 @@ export const fetchAdminClasses = async ({
     ? Object.values(rawList)
     : [];
 
-  return { data: list.map(formatClass), meta: data?.meta || {} };
+  const formattedList = [];
+
+  for (const entry of list) {
+    const formatted = formatClass(entry);
+
+    if (formatted) {
+      formattedList.push(formatted);
+    }
+  }
+
+  return { data: formattedList, meta: data?.meta || {} };
 };
 
 export const fetchAdminClassById = async (id) => {


### PR DESCRIPTION
## Summary
- guard the admin class formatter against null or non-object entries
- filter out malformed entries when building the admin class list so unexpected API data no longer crashes the dashboard

## Testing
- npx eslint src/services/admin/classService.js

------
https://chatgpt.com/codex/tasks/task_e_68e37f69bc1883289eb8e9fc0ee899ea