### PR TITLE
Normalize admin class display fields

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -280,9 +280,11 @@ export default function AdminClassesTable() {
       return;
     }
 
+    const sanitizedNext = sanitizeClassEntries(nextList) ?? [];
+
     setClassList((previous) => {
-      if (classListLengthRef.current === nextList.length) {
-        const nextSignature = computeListSignature(nextList);
+      if (classListLengthRef.current === sanitizedNext.length) {
+        const nextSignature = computeListSignature(sanitizedNext);
         if (classListSignatureRef.current === nextSignature) {
           return previous;
         }

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -4,10 +4,98 @@ import { toDateInput } from "@/utils/date";
 import { safeEncodeURI } from "@/utils/url";
 import { computeScheduleStatus } from "@/utils/classSchedule";
 
+const DISPLAY_FALLBACK_KEYS = [
+  "name",
+  "title",
+  "full_name",
+  "fullName",
+  "displayName",
+  "label",
+];
+
+const toDisplayString = (value) => {
+  if (value == null) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : "";
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => toDisplayString(entry)).filter(Boolean).join(", ");
+  }
+
+  if (typeof value === "object") {
+    for (const key of DISPLAY_FALLBACK_KEYS) {
+      if (key in value) {
+        const nested = toDisplayString(value[key]);
+        if (nested) {
+          return nested;
+        }
+      }
+    }
+
+    if ("id" in value && value.id != null) {
+      const idValue = value.id;
+      if (typeof idValue === "string") {
+        return idValue;
+      }
+      if (typeof idValue === "number" && Number.isFinite(idValue)) {
+        return String(idValue);
+      }
+    }
+
+    try {
+      return JSON.stringify(value);
+    } catch (err) {
+      return "";
+    }
+  }
+
+  return "";
+};
+
 const formatClass = (cls) => {
+  if (!cls || typeof cls !== "object") {
+    return null;
+  }
+
   const { status, schedule_status, ...rest } = cls;
+  const title = toDisplayString(
+    cls.title ?? cls.name ?? cls.class_title ?? rest.title
+  );
+  const instructor = toDisplayString(
+    cls.instructor ??
+      cls.instructor_name ??
+      cls.instructorName ??
+      cls.instructor_full_name ??
+      cls.instructor?.name ??
+      cls.instructor?.full_name
+  );
+  const category = toDisplayString(
+    cls.category ??
+      cls.category_name ??
+      cls.categoryName ??
+      cls.category?.name ??
+      cls.category?.title
+  );
+
+  const priceValue = Number.parseFloat(cls.price);
+
   return {
     ...rest,
+    title,
+    instructor,
+    category,
     publishStatus: status,
     cover_image: cls.cover_image
       ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`
@@ -36,6 +124,10 @@ const formatClass = (cls) => {
     scheduleStatus:
       schedule_status || computeScheduleStatus(cls.start_date, cls.end_date),
     views: cls.views || 0,
+    price:
+      Number.isFinite(priceValue) && priceValue >= 0
+        ? Number(priceValue.toFixed(2))
+        : cls.price || 0,
   };
 };
 
@@ -63,7 +155,17 @@ export const fetchAdminClasses = async ({
     ? Object.values(rawList)
     : [];
 
-  return { data: list.map(formatClass), meta: data?.meta || {} };
+  const formattedList = [];
+
+  for (const entry of list) {
+    const formatted = formatClass(entry);
+
+    if (formatted) {
+      formattedList.push(formatted);
+    }
+  }
+
+  return { data: formattedList, meta: data?.meta || {} };
 };
 
 export const fetchAdminClassById = async (id) => {


### PR DESCRIPTION
## Summary
- add a helper to coerce nested values into safe display strings when formatting admin classes
- normalize title, instructor, category, and price fields so malformed API payloads no longer crash the dashboard table

## Testing
- cd frontend && npx eslint src/services/admin/classService.js

------
https://chatgpt.com/codex/tasks/task_e_68e37f69bc1883289eb8e9fc0ee899ea