### PR TITLE
Prevent repeated logout loops on admin dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3297,18 +3297,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@testing-library/react/node_modules/@types/react": {
-      "version": "18.3.24",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
-      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@testing-library/react/node_modules/@types/react-dom": {
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
@@ -3590,14 +3578,6 @@
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
       "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
       "license": "MIT"
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/quill": {
       "version": "1.3.10",
@@ -15903,7 +15883,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -280,9 +280,11 @@ export default function AdminClassesTable() {
       return;
     }
 
+    const sanitizedNext = sanitizeClassEntries(nextList) ?? [];
+
     setClassList((previous) => {
-      if (classListLengthRef.current === nextList.length) {
-        const nextSignature = computeListSignature(nextList);
+      if (classListLengthRef.current === sanitizedNext.length) {
+        const nextSignature = computeListSignature(sanitizedNext);
         if (classListSignatureRef.current === nextSignature) {
           return previous;
         }

--- a/frontend/src/components/admin/online-classes/__tests__/AdminClassesTable.test.jsx
+++ b/frontend/src/components/admin/online-classes/__tests__/AdminClassesTable.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import AdminClassesTable from '../AdminClassesTable';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children }) => <a>{children}</a>,
+}));
+
+jest.mock('@/services/admin/classService', () => ({
+  fetchAdminClasses: jest.fn(() => {
+    const error = new Error('Forbidden');
+    error.response = { status: 403 };
+    return Promise.reject(error);
+  }),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: { error: jest.fn(), success: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('@/store/notifications/notificationStore', () => () => ({ fetch: jest.fn() }));
+jest.mock('@/store/messages/messageStore', () => () => ({ fetch: jest.fn() }));
+
+const mockUser = { id: 1, permissions: ['ADD_ONLINE_CLASS_RULE'] };
+
+const storeState = {
+  user: mockUser,
+  accessToken: 'token',
+  hasHydrated: true,
+  setState: (partial) => Object.assign(storeState, partial),
+};
+
+const useAuthStoreMock = jest.fn((selector = (state) => state) => selector(storeState));
+useAuthStoreMock.getState = () => storeState;
+
+jest.mock('@/store/auth/authStore', () => {
+  const store = (selector) => useAuthStoreMock(selector || ((state) => state));
+  store.getState = () => storeState;
+  return store;
+});
+
+describe('AdminClassesTable', () => {
+  it('handles forbidden response without crashing', async () => {
+    render(<AdminClassesTable />);
+    await waitFor(() => {
+      const message = document.body.textContent;
+      if (!message?.includes('Unable to load classes')) {
+        throw new Error('Auth error message not rendered yet');
+      }
+    });
+  });
+});

--- a/frontend/src/hooks/withAuthProtection.js
+++ b/frontend/src/hooks/withAuthProtection.js
@@ -16,6 +16,7 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
     const router = useRouter();
     const [hydrated, setHydrated] = useState(false);
     const isRedirectingRef = useRef(false);
+    const logoutInProgressRef = useRef(false);
 
     useEffect(() => {
       setHydrated(true);
@@ -55,9 +56,19 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
 
       const normalizedRoles = getNormalizedRoles(user);
       if (!user) {
+        logoutInProgressRef.current = false;
         attemptRedirect("/auth/login");
       } else if (!accessToken || isTokenExpired(accessToken)) {
-        logout();
+        if (!logoutInProgressRef.current) {
+          logoutInProgressRef.current = true;
+          Promise.resolve(logout())
+            .catch(() => {
+              // ignore errors from logout, we'll still redirect below
+            })
+            .finally(() => {
+              logoutInProgressRef.current = false;
+            });
+        }
         attemptRedirect("/auth/login");
       } else if (
         (allowedRoles.length &&

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -5,6 +5,10 @@ import { safeEncodeURI } from "@/utils/url";
 import { computeScheduleStatus } from "@/utils/classSchedule";
 
 const formatClass = (cls) => {
+  if (!cls || typeof cls !== "object") {
+    return null;
+  }
+
   const { status, schedule_status, ...rest } = cls;
   return {
     ...rest,
@@ -63,7 +67,17 @@ export const fetchAdminClasses = async ({
     ? Object.values(rawList)
     : [];
 
-  return { data: list.map(formatClass), meta: data?.meta || {} };
+  const formattedList = [];
+
+  for (const entry of list) {
+    const formatted = formatClass(entry);
+
+    if (formatted) {
+      formattedList.push(formatted);
+    }
+  }
+
+  return { data: formattedList, meta: data?.meta || {} };
 };
 
 export const fetchAdminClassById = async (id) => {


### PR DESCRIPTION
## Summary
- guard the auth protection HOC against repeated logout attempts so failed refreshes no longer trigger an infinite render loop
- add a regression test that simulates a forbidden admin class fetch and expects the dashboard to render the fallback message

## Testing
- npm test -- AdminClassesTable.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e37f69bc1883289eb8e9fc0ee899ea