### PR TITLE
Harden admin class normalization

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -280,9 +280,11 @@ export default function AdminClassesTable() {
       return;
     }
 
+    const sanitizedNext = sanitizeClassEntries(nextList) ?? [];
+
     setClassList((previous) => {
-      if (classListLengthRef.current === nextList.length) {
-        const nextSignature = computeListSignature(nextList);
+      if (classListLengthRef.current === sanitizedNext.length) {
+        const nextSignature = computeListSignature(sanitizedNext);
         if (classListSignatureRef.current === nextSignature) {
           return previous;
         }

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -4,11 +4,266 @@ import { toDateInput } from "@/utils/date";
 import { safeEncodeURI } from "@/utils/url";
 import { computeScheduleStatus } from "@/utils/classSchedule";
 
+const DISPLAY_FALLBACK_KEYS = [
+  "name",
+  "title",
+  "full_name",
+  "fullName",
+  "displayName",
+  "label",
+];
+
+const toDisplayString = (value, seen = new Set()) => {
+  if (value == null) {
+    return "";
+  }
+
+  if (seen.has(value)) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : "";
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => toDisplayString(entry)).filter(Boolean).join(", ");
+  }
+
+  if (typeof value === "object") {
+    seen.add(value);
+
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+
+    for (const key of DISPLAY_FALLBACK_KEYS) {
+      if (key in value && value[key] != null) {
+        const nested = toDisplayString(value[key], seen);
+        if (nested) {
+          return nested;
+        }
+      }
+    }
+
+    if ("id" in value && value.id != null) {
+      const idValue = value.id;
+      if (typeof idValue === "string") {
+        return idValue;
+      }
+      if (typeof idValue === "number" && Number.isFinite(idValue)) {
+        return String(idValue);
+      }
+    }
+
+    try {
+      return JSON.stringify(value);
+    } catch (err) {
+      return "";
+    }
+  }
+
+  return "";
+};
+
+const DATE_VALUE_KEYS = [
+  "date",
+  "start",
+  "start_date",
+  "startDate",
+  "end",
+  "end_date",
+  "endDate",
+  "value",
+  "iso",
+  "timestamp",
+];
+
+const resolveDateLikeValue = (candidate, seen = new Set()) => {
+  if (candidate == null) {
+    return null;
+  }
+
+  if (candidate instanceof Date) {
+    return candidate;
+  }
+
+  if (typeof candidate === "string") {
+    const trimmed = candidate.trim();
+    return trimmed || null;
+  }
+
+  if (typeof candidate === "number") {
+    if (!Number.isFinite(candidate)) {
+      return null;
+    }
+    return new Date(candidate);
+  }
+
+  if (typeof candidate === "object") {
+    if (seen.has(candidate)) {
+      return null;
+    }
+    seen.add(candidate);
+
+    for (const key of DATE_VALUE_KEYS) {
+      if (key in candidate) {
+        const nested = resolveDateLikeValue(candidate[key], seen);
+        if (nested) {
+          return nested;
+        }
+      }
+    }
+
+    return toDisplayString(candidate, seen) || null;
+  }
+
+  return null;
+};
+
+const normalizeDateField = (value) => {
+  const resolved = resolveDateLikeValue(value);
+
+  if (!resolved) {
+    return { display: "", input: "", iso: null };
+  }
+
+  if (resolved instanceof Date) {
+    if (Number.isNaN(resolved.getTime())) {
+      return { display: "", input: "", iso: null };
+    }
+    const isoString = resolved.toISOString();
+    return {
+      display: isoString,
+      input: isoString.split("T")[0],
+      iso: isoString,
+    };
+  }
+
+  if (typeof resolved === "string") {
+    const trimmed = resolved.trim();
+    if (!trimmed) {
+      return { display: "", input: "", iso: null };
+    }
+
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) {
+      return { display: trimmed, input: "", iso: null };
+    }
+
+    return {
+      display: trimmed,
+      input: parsed.toISOString().split("T")[0],
+      iso: parsed.toISOString(),
+    };
+  }
+
+  return { display: "", input: "", iso: null };
+};
+
+const normalizeStatus = (value, fallback = "") => {
+  const normalized = toDisplayString(value);
+  return normalized || fallback;
+};
+
+const normalizeNonNegativeNumber = (value, fallback = 0) => {
+  if (value == null) {
+    return fallback;
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return fallback;
+    }
+    return value < 0 ? fallback : value;
+  }
+
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.+-]/g, "");
+    const parsed = Number.parseFloat(cleaned);
+    if (Number.isFinite(parsed)) {
+      return parsed < 0 ? fallback : parsed;
+    }
+    return fallback;
+  }
+
+  if (typeof value === "object") {
+    for (const key of ["value", "amount", "total", "count"]) {
+      if (key in value) {
+        return normalizeNonNegativeNumber(value[key], fallback);
+      }
+    }
+  }
+
+  return fallback;
+};
+
 const formatClass = (cls) => {
+  if (!cls || typeof cls !== "object") {
+    return null;
+  }
+
   const { status, schedule_status, ...rest } = cls;
+  const title = toDisplayString(
+    cls.title ?? cls.name ?? cls.class_title ?? rest.title
+  );
+  const instructor = toDisplayString(
+    cls.instructor ??
+      cls.instructor_name ??
+      cls.instructorName ??
+      cls.instructor_full_name ??
+      cls.instructor?.name ??
+      cls.instructor?.full_name
+  );
+  const category = toDisplayString(
+    cls.category ??
+      cls.category_name ??
+      cls.categoryName ??
+      cls.category?.name ??
+      cls.category?.title
+  );
+
+  const startDate = normalizeDateField(
+    cls.start_date ??
+      cls.startDate ??
+      cls.schedule?.start_date ??
+      cls.schedule?.startDate ??
+      cls.schedule?.start ??
+      cls.schedule_start_date ??
+      cls.scheduleStartDate
+  );
+  const endDate = normalizeDateField(
+    cls.end_date ??
+      cls.endDate ??
+      cls.schedule?.end_date ??
+      cls.schedule?.endDate ??
+      cls.schedule?.end ??
+      cls.schedule_end_date ??
+      cls.scheduleEndDate
+  );
+
+  const priceValue = normalizeNonNegativeNumber(cls.price, 0);
+  const viewsValue = normalizeNonNegativeNumber(cls.views, 0);
+  const publishStatus = normalizeStatus(status, "draft");
+  const approvalStatus = normalizeStatus(cls.moderation_status, "Pending");
+  const scheduleStatus =
+    normalizeStatus(schedule_status) ||
+    computeScheduleStatus(startDate.iso || startDate.display, endDate.iso || endDate.display);
+
   return {
     ...rest,
-    publishStatus: status,
+    title,
+    instructor,
+    category,
+    publishStatus,
     cover_image: cls.cover_image
       ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`
       : null,
@@ -26,16 +281,16 @@ const formatClass = (cls) => {
       : null,
     trending: Boolean(cls.trending),
 
-    start_date: cls.start_date ?? null,
-    end_date: cls.end_date ?? null,
+    start_date: startDate.display || null,
+    end_date: endDate.display || null,
 
-    startDateInput: cls.start_date ? toDateInput(cls.start_date) : "",
-    endDateInput: cls.end_date ? toDateInput(cls.end_date) : "",
+    startDateInput: startDate.display ? toDateInput(startDate.display) : "",
+    endDateInput: endDate.display ? toDateInput(endDate.display) : "",
 
-    approvalStatus: cls.moderation_status || "Pending",
-    scheduleStatus:
-      schedule_status || computeScheduleStatus(cls.start_date, cls.end_date),
-    views: cls.views || 0,
+    approvalStatus,
+    scheduleStatus,
+    views: viewsValue,
+    price: Number(priceValue.toFixed(2)),
   };
 };
 
@@ -63,7 +318,17 @@ export const fetchAdminClasses = async ({
     ? Object.values(rawList)
     : [];
 
-  return { data: list.map(formatClass), meta: data?.meta || {} };
+  const formattedList = [];
+
+  for (const entry of list) {
+    const formatted = formatClass(entry);
+
+    if (formatted) {
+      formattedList.push(formatted);
+    }
+  }
+
+  return { data: formattedList, meta: data?.meta || {} };
 };
 
 export const fetchAdminClassById = async (id) => {


### PR DESCRIPTION
## Summary
- guard display coercion against cyclic objects and nested date structures when formatting admin classes
- normalize dates, statuses, numeric counters, and price values so the admin table never receives objects as children

## Testing
- cd frontend && npx eslint src/services/admin/classService.js

------
https://chatgpt.com/codex/tasks/task_e_68e37f69bc1883289eb8e9fc0ee899ea