### PR TITLE
Fix admin online class creation lesson submission state references

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -219,7 +219,7 @@ function CreateOnlineClass() {
   }, [user]);
 
   useEffect(() => {
-    setLessonSubmissionResults((prev) => {
+    setLessonSubmissionSummary((prev) => {
       if (!prev || typeof prev !== 'object') {
         return prev;
       }
@@ -1195,7 +1195,7 @@ function CreateOnlineClass() {
 
                           {failedLessonIndices.includes(index) && (
                             <p className="text-sm text-red-600">
-                              {errorMessage ||
+                              {failureMessage ||
                                 t('lesson_requires_attention', {
                                   defaultValue:
                                     'We could not save this lesson. Please review its details and try again.',


### PR DESCRIPTION
## Summary
- correct the lesson submission summary state updater reference in the admin class creation flow
- fix the fallback message rendering for failed lesson submissions to avoid referencing an undefined variable

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e408ffc6c88328a67a68840a8b4507