### PR TITLE
Fix admin social link platform validation

### DIFF
--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -12,16 +12,7 @@ const adminService = require("./admin.service");
 const handleControllerError = require("../../../utils/handleControllerError");
 const { adminProfileSchema } = require("./admin.validator");
 
-// Allowed social platforms for links
-const allowedPlatforms = [
-  "linkedin",
-  "github",
-  "twitter",
-  "youtube",
-  "facebook",
-  "instagram",
-  "website",
-];
+const { allowedPlatforms } = require("../common/socialPlatforms");
 
 /**
  * @desc Get full admin profile (user data + admin-specific + social links)
@@ -149,11 +140,21 @@ exports.updateProfile = async (req, res) => {
     await trx("user_social_links").where({ user_id: userId }).del();
 
     for (const link of social_links) {
-      if (link.url?.trim() && allowedPlatforms.includes(link.platform)) {
+      const sanitizedPlatform =
+        typeof link.platform === "string"
+          ? link.platform.trim().toLowerCase()
+          : "";
+      const sanitizedUrl =
+        typeof link.url === "string" ? link.url.trim() : "";
+      if (
+        sanitizedUrl &&
+        sanitizedPlatform &&
+        allowedPlatforms.includes(sanitizedPlatform)
+      ) {
         await trx("user_social_links").insert({
           user_id: userId,
-          platform: link.platform,
-          url: link.url,
+          platform: sanitizedPlatform,
+          url: sanitizedUrl,
           created_at: new Date(),
         });
       }


### PR DESCRIPTION
## Summary
- reuse the shared social platform list in the admin profile controller
- sanitize platform and URL values before storing admin social links

## Testing
- npm test -- adminProfileControllerNoProfile.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e41c434950832882b65cd7131e5009