### PR TITLE
Handle missing social platform configuration

### DIFF
--- a/backend/src/modules/users/common/socialPlatforms.js
+++ b/backend/src/modules/users/common/socialPlatforms.js
@@ -1,9 +1,16 @@
+const fs = require("fs");
 const path = require("path");
 
-const allowedPlatforms = require(path.join(
+const socialPlatformsPath = path.join(
   __dirname,
   "../../../../shared/socialPlatforms.json"
-));
+);
+
+if (!fs.existsSync(socialPlatformsPath)) {
+  throw new Error("socialPlatforms.json file not found");
+}
+
+const allowedPlatforms = require(socialPlatformsPath);
 
 module.exports = { allowedPlatforms };
 


### PR DESCRIPTION
## Summary
- add an existence check for the shared socialPlatforms.json file before requiring it
- raise a clear error when the social platform configuration file is missing to satisfy existing tests

## Testing
- npm test -- socialPlatforms.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e41c434950832882b65cd7131e5009