### PR TITLE
Fix tutorial subscription wallet helper

### DIFF
--- a/backend/src/modules/books/book.service.js
+++ b/backend/src/modules/books/book.service.js
@@ -13,7 +13,6 @@ const { v4: uuidv4 } = require("uuid");
 const { getActiveStudentSubscription } = require("../plans/subscription.helper");
 const { creditInstructorSubscription } = require("../payments/helpers/wallet");
 const { getPlanCoveredMethod } = require("../payments/helpers/methods");
-const { creditInstructorSubscription } = require("../payments/helpers/wallet");
 
 const { STATUS: PAYMENT_STATUS } = paymentsService;
 

--- a/backend/src/modules/payments/helpers/wallet.js
+++ b/backend/src/modules/payments/helpers/wallet.js
@@ -105,9 +105,19 @@ async function creditTutorialSubscription(
   subscriptionId,
   trx,
   overrideOrOptions,
-  legacyOptions,
+  legacyOptions
 ) {
-  const args = [
+  let precomputedAmount;
+  let options;
+
+  if (typeof overrideOrOptions === "number") {
+    precomputedAmount = overrideOrOptions;
+    options = legacyOptions;
+  } else {
+    options = overrideOrOptions;
+  }
+
+  return creditInstructorSubscription(
     "tutorial",
     tutorialId,
     planId,


### PR DESCRIPTION
## Summary
- fix `creditTutorialSubscription` to delegate to the shared instructor subscription helper and handle optional overrides
- remove a duplicate import in the book service caused by the previous helper stub

## Testing
- not run (tests require environment configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e41c434950832882b65cd7131e5009