### PR TITLE
Fix admin online class SSR crash by hardening API base fallback

### DIFF
--- a/frontend/src/services/api/api.js
+++ b/frontend/src/services/api/api.js
@@ -11,6 +11,8 @@ import logger from "@/utils/logger";
 const isBrowser = typeof window !== "undefined";
 const publicBaseCandidate = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 const internalBaseCandidate = process.env.INTERNAL_API_BASE_URL;
+const serverFallbackBase =
+  process.env.SERVER_FALLBACK_API_BASE_URL || "http://localhost:5002/api";
 const LOCALHOST_HOSTNAMES = new Set([
   "localhost",
   "127.0.0.1",
@@ -114,7 +116,7 @@ const ensureAbsoluteUrl = (candidate) => {
 
   const fallback = internalBaseCandidate && /^https?:\/\//i.test(internalBaseCandidate)
     ? internalBaseCandidate
-    : candidate;
+    : serverFallbackBase;
 
   logger.warn(
     `API base "${candidate}" is not absolute and could not be resolved. Falling back to "${fallback}".`


### PR DESCRIPTION
## Summary
- ensure the Axios API client resolves a valid absolute base URL when running on the server
- fall back to a configurable SERVER_FALLBACK_API_BASE_URL (defaulting to http://localhost:5002/api) when no internal URL is provided
- prevent server-side requests for admin online class pages from crashing due to invalid relative URLs

## Testing
- npx eslint src/services/api/api.js
- npm test -- urlUtils.node.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4c124f06883288fcad0e1be8b6fef