### PR TITLE
Normalize admin permission checks for dashboard access

### DIFF
--- a/frontend/src/hooks/withAuthProtection.js
+++ b/frontend/src/hooks/withAuthProtection.js
@@ -1,9 +1,29 @@
 // src/hooks/withAuthProtection.js
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import useAuthStore from "@/store/auth/authStore";
 import { isTokenExpired } from "@/utils/auth/tokenUtils";
 import { getNormalizedRoles } from "@/utils/auth/roleUtils";
+
+const normalizePermission = (permission) => {
+  if (typeof permission !== "string") {
+    return "";
+  }
+
+  return permission.trim().toLowerCase();
+};
+
+const buildNormalizedPermissionSet = (permissions) => {
+  if (!Array.isArray(permissions) || permissions.length === 0) {
+    return new Set();
+  }
+
+  return new Set(
+    permissions
+      .map(normalizePermission)
+      .filter((permission) => permission.length > 0)
+  );
+};
 
 export default function withAuthProtection(Component, rolesOrOptions = []) {
   const { roles: allowedRoles = [], permissions: allowedPerms = [] } =
@@ -17,6 +37,19 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
     const [hydrated, setHydrated] = useState(false);
     const isRedirectingRef = useRef(false);
     const logoutInProgressRef = useRef(false);
+
+    const normalizedAllowedPerms = useMemo(
+      () =>
+        allowedPerms
+          .map(normalizePermission)
+          .filter((permission) => permission.length > 0),
+      [allowedPerms]
+    );
+
+    const normalizedUserPerms = useMemo(
+      () => buildNormalizedPermissionSet(user?.permissions),
+      [user?.permissions]
+    );
 
     useEffect(() => {
       setHydrated(true);
@@ -55,6 +88,12 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
       };
 
       const normalizedRoles = getNormalizedRoles(user);
+      const lacksRequiredPermissions =
+        normalizedAllowedPerms.length > 0 &&
+        !normalizedRoles.includes("superadmin") &&
+        !normalizedAllowedPerms.some((permission) =>
+          normalizedUserPerms.has(permission)
+        );
       if (!user) {
         logoutInProgressRef.current = false;
         attemptRedirect("/auth/login");
@@ -75,9 +114,7 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
           !allowedRoles.some((allowedRole) =>
             normalizedRoles.includes(allowedRole)
           )) ||
-        (allowedPerms.length &&
-          !normalizedRoles.includes("superadmin") &&
-          !allowedPerms.some((p) => user.permissions?.includes(p)))
+        lacksRequiredPermissions
       ) {
         attemptRedirect("/error/403");
       }
@@ -90,23 +127,26 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
       router,
       router.asPath,
       allowedRoles,
-      allowedPerms,
+      normalizedAllowedPerms,
+      normalizedUserPerms,
     ]);
 
     const normalizedRoles = getNormalizedRoles(user);
     const hasAllowedRole =
       !allowedRoles.length ||
       allowedRoles.some((allowedRole) => normalizedRoles.includes(allowedRole));
-    const hasRequiredPerms =
-      !allowedPerms.length ||
-      normalizedRoles.includes("superadmin") ||
-      allowedPerms.some((p) => user?.permissions?.includes(p));
+    const lacksRequiredPermissions =
+      normalizedAllowedPerms.length > 0 &&
+      !normalizedRoles.includes("superadmin") &&
+      !normalizedAllowedPerms.some((permission) =>
+        normalizedUserPerms.has(permission)
+      );
     if (
       !hydrated ||
       !hasHydrated ||
       !user ||
       !hasAllowedRole ||
-      !hasRequiredPerms
+      lacksRequiredPermissions
     ) {
       return null;
     }

--- a/frontend/src/tests/hooks/withAuthProtection.test.jsx
+++ b/frontend/src/tests/hooks/withAuthProtection.test.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import withAuthProtection from "@/hooks/withAuthProtection";
+import useAuthStore from "@/store/auth/authStore";
+import { useRouter } from "next/router";
+
+jest.mock("@/store/auth/authStore", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("next/router", () => ({
+  __esModule: true,
+  useRouter: jest.fn(),
+}));
+
+describe("withAuthProtection permission handling", () => {
+  const mockLogout = jest.fn();
+  let replaceMock;
+  let mockEvents;
+  const buildValidToken = () => {
+    const future = Math.floor(Date.now() / 1000) + 60;
+    const payload = Buffer.from(JSON.stringify({ exp: future })).toString("base64");
+    return `header.${payload}.signature`;
+  };
+
+  beforeEach(() => {
+    replaceMock = jest.fn();
+    mockEvents = {
+      on: jest.fn(),
+      off: jest.fn(),
+    };
+    jest.clearAllMocks();
+    mockLogout.mockReset();
+    useRouter.mockReturnValue({
+      replace: replaceMock,
+      asPath: "/dashboard/admin/online-classes",
+      events: mockEvents,
+    });
+  });
+
+  it("allows access when the user has the required permission regardless of casing", async () => {
+    useAuthStore.mockReturnValue({
+      user: {
+        id: "admin-1",
+        role: "ADMIN",
+        permissions: ["MANAGE_ONLINE_CLASSES"],
+      },
+      accessToken: buildValidToken(),
+      logout: mockLogout,
+      hasHydrated: true,
+    });
+
+    const Dummy = () => <div data-testid="protected">Protected</div>;
+    const ProtectedDummy = withAuthProtection(Dummy, {
+      roles: ["admin"],
+      permissions: ["manage_online_classes"],
+    });
+
+    const { findByTestId } = render(<ProtectedDummy />);
+
+    expect(await findByTestId("protected")).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalledWith("/error/403");
+  });
+
+  it("redirects to 403 when the user lacks the normalized permission", async () => {
+    useAuthStore.mockReturnValue({
+      user: {
+        id: "admin-2",
+        role: "admin",
+        permissions: ["VIEW_DASHBOARD"],
+      },
+      accessToken: buildValidToken(),
+      logout: mockLogout,
+      hasHydrated: true,
+    });
+
+    const Dummy = () => <div data-testid="protected">Protected</div>;
+    const ProtectedDummy = withAuthProtection(Dummy, {
+      roles: ["admin"],
+      permissions: ["manage_online_classes"],
+    });
+
+    render(<ProtectedDummy />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/error/403");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize permission comparisons in the authentication guard so admin dashboards accept backend permission casing
- add unit coverage confirming admins with uppercase permissions retain access and unauthorized users are redirected

## Testing
- npm test -- --runTestsByPath src/tests/hooks/withAuthProtection.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e4c124f06883288fcad0e1be8b6fef