### PR TITLE
Fix admin auth guard to allow refresh-based sessions

### DIFF
--- a/frontend/src/hooks/withAuthProtection.js
+++ b/frontend/src/hooks/withAuthProtection.js
@@ -97,7 +97,7 @@ export default function withAuthProtection(Component, rolesOrOptions = []) {
       if (!user) {
         logoutInProgressRef.current = false;
         attemptRedirect("/auth/login");
-      } else if (!accessToken || isTokenExpired(accessToken)) {
+      } else if (accessToken && isTokenExpired(accessToken)) {
         if (!logoutInProgressRef.current) {
           logoutInProgressRef.current = true;
           Promise.resolve(logout())

--- a/frontend/src/tests/hooks/withAuthProtection.test.jsx
+++ b/frontend/src/tests/hooks/withAuthProtection.test.jsx
@@ -63,6 +63,31 @@ describe("withAuthProtection permission handling", () => {
     expect(replaceMock).not.toHaveBeenCalledWith("/error/403");
   });
 
+  it("does not trigger a logout when the user is present but the access token is missing", async () => {
+    useAuthStore.mockReturnValue({
+      user: {
+        id: "admin-missing-token",
+        role: "admin",
+        permissions: ["MANAGE_ONLINE_CLASSES"],
+      },
+      accessToken: null,
+      logout: mockLogout,
+      hasHydrated: true,
+    });
+
+    const Dummy = () => <div data-testid="protected">Protected</div>;
+    const ProtectedDummy = withAuthProtection(Dummy, {
+      roles: ["admin"],
+      permissions: ["manage_online_classes"],
+    });
+
+    const { findByTestId } = render(<ProtectedDummy />);
+
+    expect(await findByTestId("protected")).toBeInTheDocument();
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalledWith("/auth/login");
+  });
+
   it("redirects to 403 when the user lacks the normalized permission", async () => {
     useAuthStore.mockReturnValue({
       user: {


### PR DESCRIPTION
## Summary
- avoid forcing a logout in `withAuthProtection` when the access token is temporarily missing so the refresh interceptor can recover
- add a regression test to cover the missing-token scenario for admin dashboard access

## Testing
- npm test -- --runTestsByPath src/tests/hooks/withAuthProtection.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e4cbc1faac832883d9c2b6c9b3719e