### PR TITLE
Fix admin dashboard auth persistence

### DIFF
--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -95,11 +95,20 @@ const useAuthStore = create(
       name: "auth",
       partialize: (state) => ({
         user: state.user,
+        accessToken: typeof state.accessToken === "string" ? state.accessToken : null,
       }),
       onRehydrateStorage: () => {
         return (state) => {
           logger.log("🔥 Zustand hydrated");
-          authStoreApi?.setState({ hasHydrated: true });
+          const sanitizedToken =
+            typeof state?.accessToken === "string" && state.accessToken.trim().length > 0
+              ? state.accessToken
+              : null;
+
+          authStoreApi?.setState({
+            hasHydrated: true,
+            accessToken: sanitizedToken,
+          });
         };
       },
     }

--- a/frontend/src/utils/auth/tokenUtils.js
+++ b/frontend/src/utils/auth/tokenUtils.js
@@ -1,14 +1,58 @@
-export function getTokenExpiration(token) {
+const decodeBase64Url = (value) => {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+
   try {
-    const payloadPart = token.split('.')[1];
-    const decoded = JSON.parse(atob(payloadPart));
-    return typeof decoded.exp === 'number' ? decoded.exp * 1000 : null;
+    if (typeof atob === "function") {
+      return atob(padded);
+    }
+  } catch (error) {
+    // Ignore and attempt Buffer fallback below.
+  }
+
+  if (typeof Buffer !== "undefined") {
+    try {
+      return Buffer.from(padded, "base64").toString("utf-8");
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  return null;
+};
+
+export function getTokenExpiration(token) {
+  if (typeof token !== "string" || token.trim().length === 0) {
+    return null;
+  }
+
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    return null;
+  }
+
+  try {
+    const decoded = decodeBase64Url(parts[1]);
+    if (!decoded) {
+      return null;
+    }
+
+    const payload = JSON.parse(decoded);
+    return typeof payload.exp === "number" ? payload.exp * 1000 : null;
   } catch (_err) {
     return null;
   }
 }
 
 export function isTokenExpired(token) {
+  if (typeof token !== "string" || token.trim().length === 0) {
+    return true;
+  }
+
   const exp = getTokenExpiration(token);
   if (!exp) return true;
   return Date.now() >= exp;


### PR DESCRIPTION
## Summary
- persist the access token in the auth store so admin pages retain credentials after reloads
- sanitize hydrated auth state to avoid leaking blank tokens and keep hasHydrated accurate
- harden token expiry parsing to tolerate malformed or base64url JWT payloads in both browser and Node contexts

## Testing
- `npm run lint -- --max-warnings=0` *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cbc1faac832883d9c2b6c9b3719e