### PR TITLE
Fix admin online class query grouping error

### DIFF
--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -77,6 +77,7 @@ exports.getAllClasses = async (
       "c.moderation_status",
       "c.included_plans",
       "c.instructor_id",
+      "c.created_at",
       "u.full_name as instructor",
       "cat.name as category",
       db.raw(`${scheduleCaseSql} as schedule_status`),
@@ -112,6 +113,7 @@ exports.getAllClasses = async (
       "c.moderation_status",
       "c.included_plans",
       "c.instructor_id",
+      "c.created_at",
       "u.full_name",
       "cat.name"
     )
@@ -179,6 +181,7 @@ exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } =
       "c.status",
       "c.moderation_status",
       "c.included_plans",
+      "c.created_at",
       "cat.name as category",
       db.raw(
         "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
@@ -198,6 +201,7 @@ exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } =
       "c.status",
       "c.moderation_status",
       "c.included_plans",
+      "c.created_at",
       "cat.name"
     )
     .orderBy("c.created_at", "desc")

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -147,6 +147,7 @@ const formatClass = (cls) => {
     title,
     instructor,
     category,
+    createdAt: cls.created_at ? new Date(cls.created_at).toISOString() : null,
     publishStatus: status,
     cover_image: cls.cover_image
       ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`


### PR DESCRIPTION
## Summary
- include the `created_at` column when selecting admin and instructor class listings so Postgres can order the grouped results without raising errors
- expose the backend `created_at` timestamp through the admin class formatter so the frontend can access the field if needed

## Testing
- npm test -- class.routes

------
https://chatgpt.com/codex/tasks/task_e_68e4cbc1faac832883d9c2b6c9b3719e