### PR TITLE
Stabilize class tag aggregation queries

### DIFF
--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -62,8 +62,6 @@ exports.getAllClasses = async (
   const query = db("online_classes as c")
     .leftJoin("users as u", "c.instructor_id", "u.id")
     .leftJoin("categories as cat", "c.category_id", "cat.id")
-    .leftJoin("class_tag_map as m", "c.id", "m.class_id")
-    .leftJoin("class_tags as t", "m.tag_id", "t.id")
     .select(
       "c.id",
       "c.title",
@@ -77,12 +75,21 @@ exports.getAllClasses = async (
       "c.moderation_status",
       "c.included_plans",
       "c.instructor_id",
+      "c.created_at",
       "u.full_name as instructor",
       "cat.name as category",
       db.raw(`${scheduleCaseSql} as schedule_status`),
-      db.raw(
-        "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
-      )
+      db.raw(`
+        COALESCE(
+          (
+            SELECT json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug))
+            FROM class_tag_map AS m
+            LEFT JOIN class_tags AS t ON t.id = m.tag_id
+            WHERE m.class_id = c.id AND t.id IS NOT NULL
+          ),
+          '[]'::json
+        ) AS tags
+      `)
     );
 
   if (filter) {
@@ -99,22 +106,6 @@ exports.getAllClasses = async (
     query.whereRaw(`LOWER(${scheduleCaseSql}) = ?`, [scheduleNormalized]);
 
   const classes = await query
-    .groupBy(
-      "c.id",
-      "c.title",
-      "c.slug",
-      "c.cover_image",
-      "c.start_date",
-      "c.end_date",
-      "c.price",
-      "c.access_type",
-      "c.status",
-      "c.moderation_status",
-      "c.included_plans",
-      "c.instructor_id",
-      "u.full_name",
-      "cat.name"
-    )
     .orderBy("c.created_at", "desc")
     .limit(lim)
     .offset(offset);
@@ -134,19 +125,24 @@ exports.getClassById = async (id) => {
   const cls = await db("online_classes as c")
     .leftJoin("users as u", "c.instructor_id", "u.id")
     .leftJoin("categories as cat", "c.category_id", "cat.id")
-    .leftJoin("class_tag_map as m", "c.id", "m.class_id")
-    .leftJoin("class_tags as t", "m.tag_id", "t.id")
     .select(
       "c.*",
       "u.full_name as instructor",
       "u.avatar_url as instructor_image",
       "cat.name as category",
-      db.raw(
-        "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
-      )
+      db.raw(`
+        COALESCE(
+          (
+            SELECT json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug))
+            FROM class_tag_map AS m
+            LEFT JOIN class_tags AS t ON t.id = m.tag_id
+            WHERE m.class_id = c.id AND t.id IS NOT NULL
+          ),
+          '[]'::json
+        ) AS tags
+      `)
     )
     .where("c.id", id)
-    .groupBy("c.id", "u.full_name", "u.avatar_url", "cat.name")
     .first();
   if (cls) {
     cls.views = await exports.getClassViewCount(id);
@@ -164,8 +160,6 @@ exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } =
 
   const classes = await db("online_classes as c")
     .leftJoin("categories as cat", "c.category_id", "cat.id")
-    .leftJoin("class_tag_map as m", "c.id", "m.class_id")
-    .leftJoin("class_tags as t", "m.tag_id", "t.id")
     .select(
       "c.id",
       "c.title",
@@ -179,27 +173,21 @@ exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } =
       "c.status",
       "c.moderation_status",
       "c.included_plans",
+      "c.created_at",
       "cat.name as category",
-      db.raw(
-        "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
-      )
+      db.raw(`
+        COALESCE(
+          (
+            SELECT json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug))
+            FROM class_tag_map AS m
+            LEFT JOIN class_tags AS t ON t.id = m.tag_id
+            WHERE m.class_id = c.id AND t.id IS NOT NULL
+          ),
+          '[]'::json
+        ) AS tags
+      `)
     )
     .where("c.instructor_id", instructorId)
-    .groupBy(
-      "c.id",
-      "c.title",
-      "c.slug",
-      "c.cover_image",
-      "c.start_date",
-      "c.end_date",
-      "c.price",
-      "c.max_students",
-      "c.access_type",
-      "c.status",
-      "c.moderation_status",
-      "c.included_plans",
-      "cat.name"
-    )
     .orderBy("c.created_at", "desc")
     .limit(lim)
     .offset(offset);

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -147,6 +147,7 @@ const formatClass = (cls) => {
     title,
     instructor,
     category,
+    createdAt: cls.created_at ? new Date(cls.created_at).toISOString() : null,
     publishStatus: status,
     cover_image: cls.cover_image
       ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`


### PR DESCRIPTION
## Summary
- replace the admin and instructor class listing tag aggregation joins with correlated subqueries so ordering by created_at no longer requires fragile group-by clauses
- update the single-class fetch to use the same subquery approach for consistent tag payloads

## Testing
- npm test -- class.routes

------
https://chatgpt.com/codex/tasks/task_e_68e4cbc1faac832883d9c2b6c9b3719e