### PR TITLE
Stabilize admin online class listing queries

### DIFF
--- a/backend/src/modules/classes/class.service.js
+++ b/backend/src/modules/classes/class.service.js
@@ -59,11 +59,20 @@ exports.getAllClasses = async (
   const totalRow = await countQuery.countDistinct("c.id as count").first();
   const total = parseInt(totalRow.count, 10) || 0;
 
+  const tagsSubquery = db("class_tag_map as m")
+    .leftJoin("class_tags as t", "m.tag_id", "t.id")
+    .select("m.class_id")
+    .select(
+      db.raw(
+        "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
+      )
+    )
+    .groupBy("m.class_id");
+
   const query = db("online_classes as c")
     .leftJoin("users as u", "c.instructor_id", "u.id")
     .leftJoin("categories as cat", "c.category_id", "cat.id")
-    .leftJoin("class_tag_map as m", "c.id", "m.class_id")
-    .leftJoin("class_tags as t", "m.tag_id", "t.id")
+    .leftJoin(tagsSubquery.as("tags"), "tags.class_id", "c.id")
     .select(
       "c.id",
       "c.title",
@@ -77,12 +86,11 @@ exports.getAllClasses = async (
       "c.moderation_status",
       "c.included_plans",
       "c.instructor_id",
+      "c.created_at",
       "u.full_name as instructor",
       "cat.name as category",
       db.raw(`${scheduleCaseSql} as schedule_status`),
-      db.raw(
-        "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
-      )
+      db.raw("COALESCE(tags.tags, '[]'::json) as tags")
     );
 
   if (filter) {
@@ -99,22 +107,6 @@ exports.getAllClasses = async (
     query.whereRaw(`LOWER(${scheduleCaseSql}) = ?`, [scheduleNormalized]);
 
   const classes = await query
-    .groupBy(
-      "c.id",
-      "c.title",
-      "c.slug",
-      "c.cover_image",
-      "c.start_date",
-      "c.end_date",
-      "c.price",
-      "c.access_type",
-      "c.status",
-      "c.moderation_status",
-      "c.included_plans",
-      "c.instructor_id",
-      "u.full_name",
-      "cat.name"
-    )
     .orderBy("c.created_at", "desc")
     .limit(lim)
     .offset(offset);
@@ -162,10 +154,19 @@ exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } =
     .first();
   const total = parseInt(totalRow.count, 10) || 0;
 
+  const instructorTagsSubquery = db("class_tag_map as m")
+    .leftJoin("class_tags as t", "m.tag_id", "t.id")
+    .select("m.class_id")
+    .select(
+      db.raw(
+        "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
+      )
+    )
+    .groupBy("m.class_id");
+
   const classes = await db("online_classes as c")
     .leftJoin("categories as cat", "c.category_id", "cat.id")
-    .leftJoin("class_tag_map as m", "c.id", "m.class_id")
-    .leftJoin("class_tags as t", "m.tag_id", "t.id")
+    .leftJoin(instructorTagsSubquery.as("tags"), "tags.class_id", "c.id")
     .select(
       "c.id",
       "c.title",
@@ -179,27 +180,11 @@ exports.getClassesByInstructor = async (instructorId, { page = 1, limit = 10 } =
       "c.status",
       "c.moderation_status",
       "c.included_plans",
+      "c.created_at",
       "cat.name as category",
-      db.raw(
-        "COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name, 'slug', t.slug)) FILTER (WHERE t.id IS NOT NULL), '[]'::json) as tags"
-      )
+      db.raw("COALESCE(tags.tags, '[]'::json) as tags")
     )
     .where("c.instructor_id", instructorId)
-    .groupBy(
-      "c.id",
-      "c.title",
-      "c.slug",
-      "c.cover_image",
-      "c.start_date",
-      "c.end_date",
-      "c.price",
-      "c.max_students",
-      "c.access_type",
-      "c.status",
-      "c.moderation_status",
-      "c.included_plans",
-      "cat.name"
-    )
     .orderBy("c.created_at", "desc")
     .limit(lim)
     .offset(offset);

--- a/frontend/src/services/admin/classService.js
+++ b/frontend/src/services/admin/classService.js
@@ -147,6 +147,7 @@ const formatClass = (cls) => {
     title,
     instructor,
     category,
+    createdAt: cls.created_at ? new Date(cls.created_at).toISOString() : null,
     publishStatus: status,
     cover_image: cls.cover_image
       ? `${process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL}${cls.cover_image}`


### PR DESCRIPTION
## Summary
- replace the admin and instructor class listing tag joins with a reusable subquery so Postgres can order by created_at without grouping errors
- keep pagination and filtering logic intact while returning the same tag payload to the frontend

## Testing
- npm --prefix backend test -- class.routes
- npm --prefix backend test -- class.service

------
https://chatgpt.com/codex/tasks/task_e_68e4cbc1faac832883d9c2b6c9b3719e