### PR TITLE
Add error boundary for admin online classes table

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/index.js
@@ -1,3 +1,4 @@
+import { Component, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../../../next-i18next.config.js';
@@ -5,11 +6,87 @@ import Link from "next/link";
 import AdminLayout from "@/components/layouts/AdminLayout";
 import withAuthProtection from "@/hooks/withAuthProtection";
 import AdminClassesTable from "@/components/admin/online-classes/AdminClassesTable";
-import { FaChalkboardTeacher, FaPlus } from "react-icons/fa";
+import {
+  FaChalkboardTeacher,
+  FaExclamationTriangle,
+  FaPlus,
+  FaSyncAlt,
+} from "react-icons/fa";
+
+class AdminClassesErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("Failed to render admin classes table", error, info);
+  }
+
+  resetErrorBoundary = () => {
+    this.setState({ hasError: false });
+    if (typeof this.props.onReset === "function") {
+      this.props.onReset();
+    }
+  };
+
+  render() {
+    const { hasError } = this.state;
+    const { children, renderFallback } = this.props;
+
+    if (hasError) {
+      if (typeof renderFallback === "function") {
+        return renderFallback({ resetErrorBoundary: this.resetErrorBoundary });
+      }
+
+      return renderFallback ?? null;
+    }
+
+    return children;
+  }
+}
 
 function AdminOnlineClassesPage() {
   const { t, i18n } = useTranslation('dashboard');
   const direction = typeof i18n?.dir === 'function' ? i18n.dir() : 'ltr';
+  const [tableResetKey, setTableResetKey] = useState(0);
+
+  const renderTableFallback = ({ resetErrorBoundary }) => (
+    <div
+      className="bg-white rounded-2xl shadow-2xl p-8 border border-gray-100 text-center space-y-4"
+      dir={direction}
+    >
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-100 text-red-600">
+        <FaExclamationTriangle className="h-5 w-5" />
+      </div>
+      <p className="text-gray-700 font-semibold">
+        {t(
+          'admin_classes_render_error_title',
+          "We couldn't load the online classes"
+        )}
+      </p>
+      <p className="text-gray-500">
+        {t(
+          'admin_classes_render_error_message',
+          'An unexpected error occurred while rendering the classes list.'
+        )}
+      </p>
+      <div className="flex justify-center gap-3 flex-wrap">
+        <button
+          type="button"
+          onClick={resetErrorBoundary}
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-yellow-500 rounded-xl shadow hover:bg-yellow-600"
+        >
+          <FaSyncAlt className="w-4 h-4" />
+          {t('retry_loading_classes', 'Try again')}
+        </button>
+      </div>
+    </div>
+  );
 
   return (
     <div className="p-6 space-y-6" dir={direction}>
@@ -20,12 +97,31 @@ function AdminOnlineClassesPage() {
         <Link
           href="/dashboard/admin/online-classes/create"
           aria-label={t('create_class')}
-          className="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold px-4 py-2 rounded-lg shadow transition duration-200 flex items-center gap-2"
+          className={[
+            'bg-yellow-500',
+            'hover:bg-yellow-600',
+            'text-white',
+            'font-semibold',
+            'px-4',
+            'py-2',
+            'rounded-lg',
+            'shadow',
+            'transition',
+            'duration-200',
+            'flex',
+            'items-center',
+            'gap-2',
+          ].join(' ')}
         >
           <FaPlus className="w-4 h-4" /> {t('create_class')}
         </Link>
       </div>
-      <AdminClassesTable />
+      <AdminClassesErrorBoundary
+        onReset={() => setTableResetKey((value) => value + 1)}
+        renderFallback={renderTableFallback}
+      >
+        <AdminClassesTable key={tableResetKey} />
+      </AdminClassesErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the admin online classes table in an error boundary that logs failures and provides a retry fallback
- add a localized fallback panel with a retry button to remount the table if rendering fails

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68e4fe08105c832890b6ddbc6a76eacd