### PR TITLE
Fix admin online classes table error handling

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/index.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/index.js
@@ -60,6 +60,35 @@ function AdminOnlineClassesPage() {
   const direction = typeof i18n?.dir === 'function' ? i18n.dir() : 'ltr';
   const createButtonClasses =
     'bg-yellow-500 hover:bg-yellow-600 text-white font-semibold px-4 py-2 rounded-lg shadow transition duration-200 flex items-center gap-2';
+  const [tableResetKey, setTableResetKey] = useState(0);
+
+  const renderTableFallback = ({ resetErrorBoundary }) => (
+    <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center space-y-4">
+      <div className="flex flex-col items-center gap-2 text-red-600">
+        <FaExclamationTriangle className="w-8 h-8" />
+        <p className="text-lg font-semibold">{t('classes_table_error_title', 'Unable to load classes')}</p>
+        <p className="text-sm text-red-500">
+          {t(
+            'classes_table_error_message',
+            'Something went wrong while loading the classes list. Please try again.'
+          )}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          setTableResetKey((value) => value + 1);
+          if (typeof resetErrorBoundary === 'function') {
+            resetErrorBoundary();
+          }
+        }}
+        className="inline-flex items-center gap-2 px-4 py-2 bg-yellow-500 text-white font-semibold rounded-lg shadow hover:bg-yellow-600 transition"
+      >
+        <FaSyncAlt className="w-4 h-4" />
+        {t('retry', 'Retry')}
+      </button>
+    </div>
+  );
 
   return (
     <div className="p-6 space-y-6" dir={direction}>


### PR DESCRIPTION
## Summary
- add a reset key state to the admin online classes page so the table can re-render after failures
- render an accessible fallback UI with retry handling when the classes table fails to load

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5fe8581b48328893820f8cdf50b12