### PR TITLE
Fix infinite render loop in admin online classes table

### DIFF
--- a/frontend/src/components/admin/online-classes/AdminClassesTable.js
+++ b/frontend/src/components/admin/online-classes/AdminClassesTable.js
@@ -249,10 +249,8 @@ const downloadCSV = (rows, headers) => {
 
 export default function AdminClassesTable() {
   const { t } = useTranslation("dashboard");
-  const { user, hasHydrated } = useAuthStore((state) => ({
-    user: state.user,
-    hasHydrated: state.hasHydrated,
-  }));
+  const user = useAuthStore((state) => state.user);
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
   const refreshNotifications = useNotificationStore((state) => state.fetch);
   const refreshMessages = useMessageStore((state) => state.fetch);
 


### PR DESCRIPTION
## Summary
- subscribe to the auth store with separate selectors to avoid triggering repeated updates when the store hydrates

## Testing
- npm test -- src/tests/pages/dashboard/admin/online-classes/index.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e606e4ea7c8328a64e86e3cc63c5e5