### PR TITLE
Fix instructor auto-selection on admin class creation

### DIFF
--- a/frontend/src/pages/dashboard/admin/online-classes/create.js
+++ b/frontend/src/pages/dashboard/admin/online-classes/create.js
@@ -34,6 +34,7 @@ import FloatingInput from '@/components/shared/FloatingInput';
 import { toDateTimeISO } from '@/utils/date';
 import { getPendingLessonEntries } from '@/utils/lessonSubmission';
 import useMediaUploader from '@/hooks/useMediaUploader';
+import { getNormalizedRoles } from '@/utils/auth/roleUtils';
 import nextI18NextConfig from '@/../next-i18next.config.js';
 
 const ReactQuill = dynamic(() => import('react-quill'), {
@@ -213,11 +214,32 @@ function CreateOnlineClass() {
     loadInstructors(1, true);
   }, [loadInstructors]);
 
-  useEffect(() => {
-    if (user?.role === 'instructor' && user?.id) {
-      setInstructorId(String(user.id));
+  const normalizedRoles = useMemo(() => getNormalizedRoles(user), [user]);
+  const shouldAutofillInstructor = useMemo(() => {
+    if (!user?.id) {
+      return false;
     }
-  }, [user]);
+
+    if (!normalizedRoles.length) {
+      return false;
+    }
+
+    const hasAdminPrivileges = normalizedRoles.some((role) =>
+      ['admin', 'superadmin'].includes(role)
+    );
+
+    if (hasAdminPrivileges) {
+      return false;
+    }
+
+    return normalizedRoles.length === 1 && normalizedRoles[0] === 'instructor';
+  }, [normalizedRoles, user?.id]);
+
+  useEffect(() => {
+    if (shouldAutofillInstructor) {
+      setInstructorId((prev) => prev || String(user.id));
+    }
+  }, [shouldAutofillInstructor, user?.id]);
 
   useEffect(() => {
     setLessonSubmissionSummary((prev) => {


### PR DESCRIPTION
## Summary
- prevent the admin class creation form from overwriting the selected instructor with the logged-in account
- infer normalized user roles so only instructor-only accounts receive the automatic instructor selection

## Testing
- npm test -- --runTestsByPath src/tests/pages/dashboard/admin/online-classes/create.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e6293d9a008328a2e69de7b57aadad