### PR TITLE
Fix admin class creation instructor assignment

### DIFF
--- a/backend/src/modules/classes/__tests__/class.controller.test.js
+++ b/backend/src/modules/classes/__tests__/class.controller.test.js
@@ -107,6 +107,39 @@ describe('class.controller createClass', () => {
     );
   });
 
+  test('admin with instructor role can create class for selected instructor', async () => {
+    service.createClass.mockImplementation(async (data) => data);
+
+    const req = {
+      body: { instructor_id: 'other-instructor', title: 'Admin Created' },
+      user: { id: 'admin-1', role: 'instructor', roles: ['admin', 'instructor'] },
+      files: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await new Promise((resolve) => {
+      res.json.mockImplementation((data) => {
+        resolve();
+        return data;
+      });
+      next.mockImplementation((err) => {
+        resolve();
+        return err;
+      });
+      controller.createClass(req, res, next);
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(service.createClass).toHaveBeenCalledWith(
+      expect.objectContaining({ instructor_id: 'other-instructor' })
+    );
+    expect(getActiveInstructorPlan).not.toHaveBeenCalled();
+  });
+
   test('resolves plan slugs to ids', async () => {
     service.createClass.mockImplementation(async (data) => data);
 

--- a/backend/src/modules/classes/class.controller.js
+++ b/backend/src/modules/classes/class.controller.js
@@ -11,7 +11,7 @@ const { getActiveInstructorPlan } = require("../plans/instructor.helper");
 const planService = require("../plans/plans.service");
 const AppError = require("../../utils/AppError");
 const { parsePlanFeatures } = require("../../utils/planFeatures");
-const { isAdminRole } = require("../../utils/role");
+const { isAdminRole, normalizeRole } = require("../../utils/role");
 
 const slugify = require("slugify");
 const db = require("../../config/database");
@@ -86,6 +86,18 @@ exports.createClass = catchAsync(async (req, res) => {
   } = req.body;
   const roles = req.user?.roles || req.user?.role;
   const isAdminUser = isAdminRole(roles);
+
+  const ensureArray = (value) =>
+    Array.isArray(value) ? value : value ? [value] : [];
+  const normalizedRoles = [
+    ...ensureArray(req.user?.roles),
+    ...ensureArray(req.user?.role),
+  ]
+    .map((role) =>
+      typeof role === "string" ? normalizeRole(role) : ""
+    )
+    .filter(Boolean);
+  const isInstructorUser = normalizedRoles.includes("instructor");
   const normalizedStatus = status === "published" ? "published" : "draft";
   const shouldAutoApprove = isAdminUser && normalizedStatus === "published";
   const data = {
@@ -125,7 +137,7 @@ exports.createClass = catchAsync(async (req, res) => {
       ? access_type
       : "paid";
   data.access_type = normalizedAccessType;
-  if (req.user?.role === "instructor") {
+  if (!isAdminUser && isInstructorUser) {
     data.instructor_id = req.user.id;
     const plan = await getActiveInstructorPlan(req.user.id);
     if (!plan) {


### PR DESCRIPTION
## Summary
- prevent admin users who also have instructor roles from overwriting the selected instructor when creating classes
- add regression coverage ensuring mixed-role admins can assign other instructors without triggering instructor plan validation

## Testing
- npm test -- class.controller

------
https://chatgpt.com/codex/tasks/task_e_68e6293d9a008328a2e69de7b57aadad