### PR TITLE
Enforce invite-only registration and social OAuth membership checks

### DIFF
--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -19,6 +19,7 @@ const notificationService = require("../../notifications/notifications.service")
 const messageService = require("../../messages/messages.service");
 const smsService = require("../../../services/smsService");
 const verificationService = require("../../verify/verify.service");
+const appConfigService = require("../../appConfig/appConfig.service");
 
 // ─────────────────────────────────────────────────────────────
 // 🔧 Config Constants
@@ -63,20 +64,96 @@ function cleanupFailedAttempts() {
 
 setInterval(cleanupFailedAttempts, CLEANUP_INTERVAL);
 
+async function getRegistrationGuardrails() {
+  const settings = (await appConfigService.getSettings()) || {};
+  return {
+    inviteOnly: Boolean(settings.invite_only ?? settings.inviteOnly),
+  };
+}
+
+async function ensureInviteOrMembership(userId) {
+  return db("tenant_memberships")
+    .where({ user_id: userId })
+    .whereIn("status", ["pending", "active"])
+    .first();
+}
+
 /**
  * Register a new user
  */
 exports.registerUser = async (data) => {
   // Check duplicate email
+  const { inviteOnly } = await getRegistrationGuardrails();
   const existingEmail = await userModel.findByEmail(data.email);
-  if (existingEmail) throw new AppError("Email is already in use", 409);
+  if (existingEmail) {
+    if (!inviteOnly) {
+      throw new AppError("Email is already in use", 409);
+    }
+
+    const membership = await ensureInviteOrMembership(existingEmail.id);
+    if (!membership) {
+      throw new AppError(
+        "Registration is invite-only. Please contact your administrator.",
+        403,
+      );
+    }
+
+    if (existingEmail.password_hash) {
+      throw new AppError("Email is already in use", 409);
+    }
+
+    if (data.phone) {
+      const existingPhone = await userModel.findByPhone(data.phone);
+      if (existingPhone && existingPhone.id !== existingEmail.id) {
+        throw new AppError("Phone number is already in use", 409);
+      }
+    }
+
+    const hashed = await bcrypt.hash(data.password, SALT_ROUNDS);
+    const roleName = existingEmail.role || data.role || "Student";
+    const [updatedUser] = await userModel.updateUser(existingEmail.id, {
+      full_name: data.full_name,
+      email: data.email,
+      phone: data.phone || null,
+      password_hash: hashed,
+      role: roleName,
+      status: existingEmail.status || "pending",
+      is_email_verified: existingEmail.is_email_verified || false,
+      is_phone_verified: existingEmail.is_phone_verified || false,
+      profile_complete: false,
+      updated_at: new Date(),
+    });
+
+    const roleRow = await db("roles").where({ name: roleName }).first();
+    if (roleRow) {
+      await db("user_roles")
+        .insert({ user_id: existingEmail.id, role_id: roleRow.id })
+        .onConflict(["user_id", "role_id"])
+        .ignore();
+    }
+
+    const roles = await userModel.getUserRoles(existingEmail.id);
+    const permissions =
+      typeof userModel.getUserPermissions === "function"
+        ? await userModel.getUserPermissions(existingEmail.id)
+        : [];
+    const safeUser = sanitizeUserUtil(updatedUser || existingEmail);
+    return { user: { ...safeUser, roles, permissions } };
+  }
 
   // ✅ Check duplicate phone
-  const existingPhone = await userModel.findByPhone(data.phone);
   if (data.phone) {
     const existingPhone = await userModel.findByPhone(data.phone);
-    if (existingPhone)
+    if (existingPhone) {
       throw new AppError("Phone number is already in use", 409);
+    }
+  }
+
+  if (inviteOnly) {
+    throw new AppError(
+      "Registration is invite-only. Please contact your administrator.",
+      403,
+    );
   }
 
   const hashed = await bcrypt.hash(data.password, SALT_ROUNDS);

--- a/backend/src/modules/auth/services/socialAuth.service.js
+++ b/backend/src/modules/auth/services/socialAuth.service.js
@@ -5,6 +5,7 @@ const AppError = require("../../../utils/AppError");
 const sanitizeUser = require("../utils/sanitizeUser");
 const db = require("../../../config/database");
 const notificationService = require("../../notifications/notifications.service");
+const appConfigService = require("../../appConfig/appConfig.service");
 
 const SALT_ROUNDS = 12;
 
@@ -41,6 +42,11 @@ exports.loginOrRegister = async ({
   avatarUrl,
   tenant_id = null,
 }) => {
+  const settings = (await appConfigService.getSettings()) || {};
+  const allowNewTenantCreation = Boolean(
+    settings.allow_new_tenant_creation ?? settings.allowNewTenantCreation,
+  );
+  const inviteOnly = Boolean(settings.invite_only ?? settings.inviteOnly);
   let account = await userModel.findBySocialAccount(provider, providerId);
   let user;
 
@@ -53,6 +59,12 @@ exports.loginOrRegister = async ({
       if (existing) {
         user = existing;
       }
+    }
+    if (!user && (inviteOnly || !allowNewTenantCreation)) {
+      throw new AppError(
+        "No active tenant membership found. Please accept an invite or contact your admin.",
+        403,
+      );
     }
     if (!user) {
       const hashed = await bcrypt.hash(providerId, SALT_ROUNDS);
@@ -102,7 +114,11 @@ exports.loginOrRegister = async ({
     .select("tenant_id", "role", "status")
     .where({ user_id: user.id, status: "active" });
   const memberships = Array.isArray(membershipRows) ? membershipRows : [];
-  if (process.env.NODE_ENV !== "test" && memberships.length === 0) {
+  if (
+    process.env.NODE_ENV !== "test" &&
+    memberships.length === 0 &&
+    !allowNewTenantCreation
+  ) {
     throw new AppError(
       "No active tenant membership found. Please accept an invite or contact your admin.",
       403,


### PR DESCRIPTION
### Motivation

- Prevent open signup when the platform is configured as invite-only and ensure invited accounts can complete registration.  
- Block social OAuth signups from creating or logging into accounts without a tenant membership unless tenant creation is explicitly allowed.  
- Add server-side guardrails so API calls cannot bypass invite/membership checks enforced in the UI.  

### Description

- Added `getRegistrationGuardrails` and `ensureInviteOrMembership` and wired them into `registerUser` so `registerUser` consults `appConfigService.getSettings()` and enforces invite-only behavior.  
- Updated `registerUser` to allow invited/pre-created user rows (no `password_hash`) to complete registration rather than failing with duplicate-email errors.  
- Updated social auth flow in `loginOrRegister` to read settings from `appConfigService.getSettings()` and throw a `403` when no active tenant membership exists and new-tenant-creation is not allowed.  
- All membership checks use the `tenant_memberships` table to determine pending/active invites and prevent bypass via direct API calls.  

### Testing

- No automated tests were executed as part of this change.  
- Changes were committed locally; please run the test suite and CI to validate behavior in your environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696356bb4cac8328ac0a61367bd80beb)