### PR TITLE
Add tenant invite token flow and tenant switcher UI

### DIFF
--- a/backend/src/middleware/tenant.js
+++ b/backend/src/middleware/tenant.js
@@ -58,12 +58,18 @@ const resolveTenant = async (req, res, next) => {
       try {
         tenantId = await resolveTenantByHost(req.headers.host);
       } catch (err) {
-        if (process.env.NODE_ENV === "test") {
+        if (req.user?.current_tenant_id) {
+          tenantId = req.user.current_tenant_id;
+        } else if (process.env.NODE_ENV === "test") {
           tenantId = DEFAULT_TEST_TENANT_ID;
         } else {
           throw err;
         }
       }
+    }
+
+    if (!tenantId && req.user?.current_tenant_id) {
+      tenantId = req.user.current_tenant_id;
     }
 
     if (!tenantId && process.env.NODE_ENV === "test") {

--- a/backend/src/migrations/20260703091500_add_invite_token_to_tenant_memberships.js
+++ b/backend/src/migrations/20260703091500_add_invite_token_to_tenant_memberships.js
@@ -1,0 +1,31 @@
+exports.up = async (knex) => {
+  const hasTable = await knex.schema.hasTable("tenant_memberships");
+  if (!hasTable) return;
+
+  const hasInviteToken = await knex.schema.hasColumn(
+    "tenant_memberships",
+    "invite_token",
+  );
+
+  if (!hasInviteToken) {
+    await knex.schema.alterTable("tenant_memberships", (table) => {
+      table.uuid("invite_token").unique();
+    });
+  }
+};
+
+exports.down = async (knex) => {
+  const hasTable = await knex.schema.hasTable("tenant_memberships");
+  if (!hasTable) return;
+
+  const hasInviteToken = await knex.schema.hasColumn(
+    "tenant_memberships",
+    "invite_token",
+  );
+
+  if (hasInviteToken) {
+    await knex.schema.alterTable("tenant_memberships", (table) => {
+      table.dropColumn("invite_token");
+    });
+  }
+};

--- a/backend/src/modules/auth/controllers/auth.controller.js
+++ b/backend/src/modules/auth/controllers/auth.controller.js
@@ -171,10 +171,20 @@ exports.logout = catchAsync(async (req, res) => {
  * @access Authenticated
  */
 exports.listMemberships = catchAsync(async (req, res) => {
-  const memberships = await db("tenant_memberships")
-    .select("tenant_id", "role", "status")
-    .where({ user_id: req.user.id });
-  res.json({ data: memberships });
+  const memberships = await db("tenant_memberships as tm")
+    .leftJoin("tenants as t", "tm.tenant_id", "t.id")
+    .select(
+      "tm.tenant_id",
+      "tm.role",
+      "tm.status",
+      db.raw("t.name as tenant_name"),
+      db.raw("t.slug as tenant_slug"),
+    )
+    .where({ "tm.user_id": req.user.id });
+  res.json({
+    data: memberships,
+    currentTenantId: req.user?.current_tenant_id || null,
+  });
 });
 
 /**

--- a/backend/src/modules/auth/routes/tenantInvite.routes.js
+++ b/backend/src/modules/auth/routes/tenantInvite.routes.js
@@ -9,8 +9,45 @@ const {
 } = require("../../../middleware/tenant");
 const AppError = require("../../../utils/AppError");
 const { sendMail } = require("../../../services/mailService");
+const { frontendBase } = require("../../../utils/frontend");
 const userModel = require("../../users/user.model");
 const db = require("../../../config/database");
+
+router.post("/accept-token", async (req, res, next) => {
+  try {
+    const token = req.body?.token || req.query?.token;
+    if (!token) throw new AppError("Invite token is required", 400);
+
+    const membership = await db("tenant_memberships")
+      .where({ invite_token: token })
+      .first();
+    if (!membership) throw new AppError("Invite not found", 404);
+
+    if (membership.status === "active") {
+      return res.json({ message: "Already a member", data: membership });
+    }
+
+    const [updated] = await db("tenant_memberships")
+      .where({ id: membership.id })
+      .update({
+        status: "active",
+        invite_token: null,
+        updated_at: new Date(),
+      })
+      .returning("*");
+
+    const tenant = await db("tenants")
+      .where({ id: membership.tenant_id })
+      .first(["id", "name", "slug"]);
+
+    res.json({
+      message: "Membership activated",
+      data: { ...(updated || membership), tenant },
+    });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.use(
   verifyToken,
@@ -51,6 +88,7 @@ router.post("/", async (req, res, next) => {
         .json({ message: "User already invited", data: existingMembership });
     }
 
+    const inviteToken = uuidv4();
     const payload = {
       id: uuidv4(),
       tenant_id: req.tenant.id,
@@ -58,6 +96,7 @@ router.post("/", async (req, res, next) => {
       role: role,
       status: "pending",
       invited_by: req.user.id,
+      invite_token: inviteToken,
       created_at: new Date(),
       updated_at: new Date(),
     };
@@ -66,10 +105,11 @@ router.post("/", async (req, res, next) => {
       .returning("*");
 
     try {
+      const inviteLink = `${frontendBase}/auth/accept-invite?token=${inviteToken}`;
       await sendMail({
         to: normalizedEmail,
         subject: "You have been invited",
-        html: `<p>You have been invited to join ${req.tenant.slug || "our platform"}.</p>`,
+        html: `<p>You have been invited to join ${req.tenant.slug || "our platform"}.</p><p><a href="${inviteLink}">Accept invite</a></p>`,
       });
     } catch (_) {
       /* ignore mail errors */

--- a/backend/src/modules/auth/services/auth.service.js
+++ b/backend/src/modules/auth/services/auth.service.js
@@ -250,9 +250,16 @@ exports.loginUser = async ({ email, password, ip, tenant_id }) => {
       ? await userModel.getUserPermissions(user.id)
       : [];
   const tokenRoles = roles.length ? roles : [user.role];
-  const membershipRows = await db("tenant_memberships")
-    .select("tenant_id", "role", "status")
-    .where({ user_id: user.id, status: "active" });
+  const membershipRows = await db("tenant_memberships as tm")
+    .leftJoin("tenants as t", "tm.tenant_id", "t.id")
+    .select(
+      "tm.tenant_id",
+      "tm.role",
+      "tm.status",
+      db.raw("t.name as tenant_name"),
+      db.raw("t.slug as tenant_slug"),
+    )
+    .where({ "tm.user_id": user.id, "tm.status": "active" });
   const memberships = Array.isArray(membershipRows) ? membershipRows : [];
   if (process.env.NODE_ENV !== "test" && memberships.length === 0) {
     throw new AppError(
@@ -275,7 +282,11 @@ exports.loginUser = async ({ email, password, ip, tenant_id }) => {
     memberships,
     current_tenant_id: currentTenantId,
   });
-  const refreshToken = await issueRefreshToken(user.id, tokenRoles[0]);
+  const refreshToken = await issueRefreshToken(
+    user.id,
+    tokenRoles[0],
+    currentTenantId,
+  );
 
   await notificationService.createNotification({
     user_id: user.id,
@@ -323,9 +334,12 @@ function generateRefreshToken(payload, jti) {
   });
 }
 
-async function issueRefreshToken(userId, role) {
+async function issueRefreshToken(userId, role, currentTenantId = null) {
   const jti = uuidv4();
-  const token = generateRefreshToken({ id: userId, role }, jti);
+  const token = generateRefreshToken(
+    { id: userId, role, current_tenant_id: currentTenantId },
+    jti,
+  );
   const tokenHash = await bcrypt.hash(token, SALT_ROUNDS);
   const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
   await db("refresh_tokens").insert({
@@ -364,17 +378,31 @@ exports.rotateRefreshToken = async (token) => {
   const roles = await userModel.getUserRoles(decoded.id);
   const tokenRoles = roles.length ? roles : [decoded.role];
   const user = await db("users").where({ id: decoded.id }).first();
-  const memberships = await db("tenant_memberships")
-    .select("tenant_id", "role", "status")
-    .where({ user_id: decoded.id, status: "active" });
+  const memberships = await db("tenant_memberships as tm")
+    .leftJoin("tenants as t", "tm.tenant_id", "t.id")
+    .select(
+      "tm.tenant_id",
+      "tm.role",
+      "tm.status",
+      db.raw("t.name as tenant_name"),
+      db.raw("t.slug as tenant_slug"),
+    )
+    .where({ "tm.user_id": decoded.id, "tm.status": "active" });
+  const currentTenantId =
+    decoded.current_tenant_id || memberships[0]?.tenant_id || null;
   const accessToken = generateAccessToken({
     id: decoded.id,
     role: tokenRoles[0],
     roles: tokenRoles,
     platform_role: user?.platform_role || "none",
     memberships,
+    current_tenant_id: currentTenantId,
   });
-  const refreshToken = await issueRefreshToken(decoded.id, tokenRoles[0]);
+  const refreshToken = await issueRefreshToken(
+    decoded.id,
+    tokenRoles[0],
+    currentTenantId,
+  );
   return { decoded, refreshToken, accessToken };
 };
 

--- a/backend/src/modules/auth/services/socialAuth.service.js
+++ b/backend/src/modules/auth/services/socialAuth.service.js
@@ -98,9 +98,16 @@ exports.loginOrRegister = async ({
   const roles = await ensureRoleAssignments(user);
   const permissions = await userModel.getUserPermissions(user.id);
   const tokenRoles = roles.length ? roles : [user.role];
-  const membershipRows = await db("tenant_memberships")
-    .select("tenant_id", "role", "status")
-    .where({ user_id: user.id, status: "active" });
+  const membershipRows = await db("tenant_memberships as tm")
+    .leftJoin("tenants as t", "tm.tenant_id", "t.id")
+    .select(
+      "tm.tenant_id",
+      "tm.role",
+      "tm.status",
+      db.raw("t.name as tenant_name"),
+      db.raw("t.slug as tenant_slug"),
+    )
+    .where({ "tm.user_id": user.id, "tm.status": "active" });
   const memberships = Array.isArray(membershipRows) ? membershipRows : [];
   if (process.env.NODE_ENV !== "test" && memberships.length === 0) {
     throw new AppError(
@@ -121,7 +128,11 @@ exports.loginOrRegister = async ({
     memberships,
     current_tenant_id: currentTenantId,
   });
-  const refreshToken = await issueRefreshToken(user.id, tokenRoles[0]);
+  const refreshToken = await issueRefreshToken(
+    user.id,
+    tokenRoles[0],
+    currentTenantId,
+  );
 
   const now = new Date();
   const loginUpdate = {
@@ -173,6 +184,8 @@ exports.loginOrRegister = async ({
     accessToken,
     refreshToken,
     user: safeUser,
+    memberships,
+    currentTenantId,
     onboarding: {
       profile_complete: user.profile_complete,
       is_email_verified: user.is_email_verified,

--- a/frontend/src/components/dashboard/Header.js
+++ b/frontend/src/components/dashboard/Header.js
@@ -28,6 +28,9 @@ import { studentNavLinks } from "@/components/dashboard/SidebarLinks/studentLink
 export default function Header() {
   const user = useAuthStore((state) => state.user);
   const logout = useAuthStore((state) => state.logout);
+  const memberships = useAuthStore((state) => state.memberships);
+  const currentTenantId = useAuthStore((state) => state.currentTenantId);
+  const switchTenant = useAuthStore((state) => state.switchTenant);
   const userRole = user?.role?.toLowerCase();
   const { t } = useTranslation("common");
   const { t: tDashboard } = useTranslation("dashboard");
@@ -39,6 +42,7 @@ export default function Header() {
   const [searchQuery, setSearchQuery] = useState("");
   const [showSearchResults, setShowSearchResults] = useState(false);
   const [available, setAvailable] = useState(user?.is_online ?? false);
+  const [switchingTenantId, setSwitchingTenantId] = useState(null);
   const dropdownRef = useRef(null);
   const notifRef = useRef(null);
   const msgRef = useRef(null);
@@ -81,6 +85,26 @@ export default function Header() {
       }, 1200);
     } catch (err) {
       toast.error(t('logout_failed'));
+    }
+  };
+
+  const handleTenantSwitch = async (tenantId) => {
+    if (!tenantId || tenantId === currentTenantId) return;
+    try {
+      setSwitchingTenantId(tenantId);
+      await switchTenant(tenantId);
+      toast.success(
+        t("tenant_switched", { defaultValue: "Tenant context updated." })
+      );
+      setDropdownOpen(false);
+    } catch (err) {
+      toast.error(
+        t("tenant_switch_failed", {
+          defaultValue: "Unable to switch tenant right now.",
+        })
+      );
+    } finally {
+      setSwitchingTenantId(null);
     }
   };
 
@@ -599,6 +623,52 @@ export default function Header() {
                       <span>{t('edit_profile')}</span>
                     </Link>
                   </li>
+                  {memberships?.length > 0 && (
+                    <li className="px-3 py-2">
+                      <div className="text-[11px] uppercase tracking-wide text-gray-400 mb-2">
+                        {t("tenant_switcher", {
+                          defaultValue: "Tenant",
+                        })}
+                      </div>
+                      <div className="flex flex-col gap-2">
+                        {memberships.map((membership) => {
+                          const label =
+                            membership.tenant_name ||
+                            membership.tenant_slug ||
+                            membership.tenant_id;
+                          const isActive =
+                            membership.tenant_id === currentTenantId;
+                          return (
+                            <button
+                              key={membership.tenant_id}
+                              type="button"
+                              onClick={() => handleTenantSwitch(membership.tenant_id)}
+                              disabled={switchingTenantId === membership.tenant_id}
+                              className={`flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-left transition ${
+                                isActive
+                                  ? "border-yellow-400 bg-yellow-50 dark:bg-yellow-900/30"
+                                  : "border-transparent hover:border-yellow-200 hover:bg-yellow-50 dark:hover:bg-yellow-900/20"
+                              }`}
+                            >
+                              <div className="flex flex-col">
+                                <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+                                  {label}
+                                </span>
+                                <span className="text-[11px] text-gray-400">
+                                  {membership.role}
+                                </span>
+                              </div>
+                              <span className="text-[11px] font-semibold text-yellow-600">
+                                {isActive
+                                  ? t("active", { defaultValue: "Active" })
+                                  : t("switch", { defaultValue: "Switch" })}
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </li>
+                  )}
                   <li
                     className="flex items-center gap-3 px-4 py-2 cursor-pointer hover:bg-yellow-100 dark:hover:bg-yellow-700 text-red-600 dark:text-red-400"
                     onClick={handleLogout}

--- a/frontend/src/pages/auth/accept-invite.js
+++ b/frontend/src/pages/auth/accept-invite.js
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/router";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { toast } from "react-toastify";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import nextI18NextConfig from "../../../next-i18next.config.js";
+import BackgroundAnimation from "@/shared/components/auth/BackgroundAnimation";
+import styles from "@/shared/components/auth/auth.module.scss";
+import { acceptTenantInviteToken } from "@/services/auth/authService";
+
+export default function AcceptInvite() {
+  const router = useRouter();
+  const { t } = useTranslation("auth");
+  const [status, setStatus] = useState("pending");
+  const [tenantName, setTenantName] = useState(null);
+
+  const token = useMemo(() => {
+    if (!router.isReady) return null;
+    const raw = router.query.token;
+    return Array.isArray(raw) ? raw[0] : raw;
+  }, [router.isReady, router.query.token]);
+
+  useEffect(() => {
+    if (!token) return;
+    const acceptInvite = async () => {
+      try {
+        const res = await acceptTenantInviteToken(token);
+        setTenantName(res?.data?.tenant?.name || null);
+        setStatus("success");
+        toast.success(
+          t("invite_accepted", {
+            defaultValue: "Invite accepted. You can now sign in.",
+          })
+        );
+      } catch (err) {
+        setStatus("error");
+        toast.error(
+          t("invite_accept_failed", {
+            defaultValue: "Unable to accept invite. Please contact support.",
+          })
+        );
+      }
+    };
+    acceptInvite();
+  }, [token, t]);
+
+  useEffect(() => {
+    if (router.isReady && !token) {
+      setStatus("missing");
+    }
+  }, [router.isReady, token]);
+
+  const statusCopy = () => {
+    if (status === "missing") {
+      return t("invite_missing", {
+        defaultValue: "Invite token missing. Please check your link.",
+      });
+    }
+    if (status === "error") {
+      return t("invite_error", {
+        defaultValue: "We could not process your invite.",
+      });
+    }
+    if (status === "success") {
+      return t("invite_success", {
+        defaultValue: tenantName
+          ? `You're now a member of ${tenantName}.`
+          : "You're now a member."
+      });
+    }
+    return t("invite_processing", {
+      defaultValue: "Processing your invite...",
+    });
+  };
+
+  return (
+    <div className={styles.authPage}>
+      <BackgroundAnimation />
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+        className={`${styles.card} ${styles.compactCard}`}
+      >
+        <h2 className={styles.title}>
+          {t("accept_invite", { defaultValue: "Accept invite" })}
+        </h2>
+        <p className={styles.statusText}>{statusCopy()}</p>
+        <div className={styles.centered}>
+          <Link href="/auth/login" className={styles.link}>
+            {t("go_to_login", { defaultValue: "Go to login" })}
+          </Link>
+          {status === "success" && (
+            <Link href="/dashboard" className={styles.link}>
+              {t("go_to_dashboard", { defaultValue: "Go to dashboard" })}
+            </Link>
+          )}
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common", "auth"], nextI18NextConfig)),
+    },
+  };
+}

--- a/frontend/src/pages/auth/login.js
+++ b/frontend/src/pages/auth/login.js
@@ -36,12 +36,18 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading, r
   const { t } = useTranslation("auth");
   const user = useAuthStore((state) => state.user);
   const login = useAuthStore((state) => state.login);
+  const memberships = useAuthStore((state) => state.memberships);
+  const currentTenantId = useAuthStore((state) => state.currentTenantId);
+  const switchTenant = useAuthStore((state) => state.switchTenant);
   const hasHydrated = useAuthStore((state) => state.hasHydrated);
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const settings = useAppConfigStore((state) => state.settings);
   const fetchAppConfig = useAppConfigStore((state) => state.fetch);
   const { executeRecaptcha } = useGoogleReCaptcha() || {};
   const [logoErrored, setLogoErrored] = useState(false);
+  const [showMemberships, setShowMemberships] = useState(false);
+  const [selectedTenantId, setSelectedTenantId] = useState(null);
+  const [isSwitchingTenant, setIsSwitchingTenant] = useState(false);
 
   const logoSrc = useMemo(() => {
     if (logoErrored) return "/images/logo.png";
@@ -70,10 +76,15 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading, r
   });
 
   useEffect(() => {
-    if (!router.isReady || !hasHydrated || !user) return;
+    if (!router.isReady || !hasHydrated || !user || showMemberships) return;
     const destination = getPostLoginDestination({ user, redirectPath });
     router.replace(destination);
-  }, [router.isReady, hasHydrated, user, redirectPath, router]);
+  }, [router.isReady, hasHydrated, user, redirectPath, router, showMemberships]);
+
+  useEffect(() => {
+    if (!memberships?.length) return;
+    setSelectedTenantId((prev) => prev || currentTenantId || memberships[0]?.tenant_id);
+  }, [memberships, currentTenantId]);
 
   useEffect(() => {
     fetchAppConfig();
@@ -101,10 +112,23 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading, r
         fetchNotifications();
       }
 
+      const { memberships: nextMemberships, currentTenantId: nextTenantId } =
+        useAuthStore.getState();
       const destination = getPostLoginDestination({
         user: loggedInUser,
         redirectPath,
       });
+
+      if (nextMemberships?.length > 0) {
+        setShowMemberships(true);
+        setSelectedTenantId(nextTenantId || nextMemberships[0]?.tenant_id);
+        if (nextMemberships.length === 1) {
+          setTimeout(() => {
+            router.push(destination);
+          }, 500);
+        }
+        return;
+      }
 
       // 🚀 Redirect after a short delay so the toast is visible
       setTimeout(() => {
@@ -139,6 +163,32 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading, r
 
 
 
+
+  const handleTenantContinue = async () => {
+    if (!selectedTenantId) return;
+    const destination = getPostLoginDestination({
+      user: useAuthStore.getState().user,
+      redirectPath,
+    });
+    if (selectedTenantId === currentTenantId) {
+      router.push(destination);
+      return;
+    }
+    try {
+      setIsSwitchingTenant(true);
+      await switchTenant(selectedTenantId);
+      router.push(destination);
+    } catch (err) {
+      logger.error("Failed to switch tenant", err);
+      toast.error(
+        t("tenant_switch_failed", {
+          defaultValue: "Unable to switch tenant. Please try again.",
+        })
+      );
+    } finally {
+      setIsSwitchingTenant(false);
+    }
+  };
 
   return (
     <div className={styles.authPage}>
@@ -212,6 +262,62 @@ function LoginForm({ recaptchaCfg, cfgLoading, setRecaptchaCfg, setCfgLoading, r
           <span className={styles.dividerLine} aria-hidden />
         </div>
         <SocialLogin redirectPath={redirectPath} />
+
+        {memberships?.length > 0 && (
+          <div className={styles.membershipSection}>
+            <p className={styles.membershipTitle}>
+              {t("available_memberships", { defaultValue: "Available memberships" })}
+            </p>
+            <div className={styles.membershipList}>
+              {memberships.map((membership) => {
+                const label =
+                  membership.tenant_name ||
+                  membership.tenant_slug ||
+                  membership.tenant_id;
+                return (
+                  <label
+                    key={membership.tenant_id}
+                    className={`${styles.membershipItem} ${
+                      selectedTenantId === membership.tenant_id
+                        ? styles.membershipActive
+                        : ""
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="tenant"
+                      className={styles.membershipRadio}
+                      value={membership.tenant_id}
+                      checked={selectedTenantId === membership.tenant_id}
+                      onChange={() => setSelectedTenantId(membership.tenant_id)}
+                    />
+                    <div className={styles.membershipInfo}>
+                      <span className={styles.membershipName}>{label}</span>
+                      <span className={styles.membershipMeta}>
+                        {membership.role}
+                        {membership.status ? ` • ${membership.status}` : ""}
+                      </span>
+                    </div>
+                  </label>
+                );
+              })}
+            </div>
+            {showMemberships && memberships.length > 1 && (
+              <motion.button
+                type="button"
+                onClick={handleTenantContinue}
+                disabled={isSwitchingTenant || !selectedTenantId}
+                whileHover={{ scale: isSwitchingTenant ? 1 : 1.02 }}
+                whileTap={{ scale: isSwitchingTenant ? 1 : 0.98 }}
+                className={`${styles.primaryButton} ${styles.mutedButton}`}
+              >
+                {isSwitchingTenant
+                  ? t("switching_tenant", { defaultValue: "Switching..." })
+                  : t("continue", { defaultValue: "Continue" })}
+              </motion.button>
+            )}
+          </div>
+        )}
 
         <p className={`${styles.helper} ${styles.smallText}`}>
           {t("dont_have_account")}{" "}

--- a/frontend/src/pages/auth/social-success.js
+++ b/frontend/src/pages/auth/social-success.js
@@ -4,7 +4,7 @@ import { toast } from 'react-toastify';
 import useAuthStore from '@/store/auth/authStore';
 import useNotificationStore from '@/store/notifications/notificationStore';
 import { getFullProfile } from '@/services/profile/profileService';
-import { refreshAccessToken } from '@/services/auth/authService';
+import { fetchMemberships, refreshAccessToken } from '@/services/auth/authService';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import nextI18NextConfig from '../../../next-i18next.config.js';
@@ -16,6 +16,8 @@ export default function SocialSuccess() {
   const router = useRouter();
   const setToken = useAuthStore((state) => state.setToken);
   const setUser = useAuthStore((state) => state.setUser);
+  const setMemberships = useAuthStore((state) => state.setMemberships);
+  const setCurrentTenantId = useAuthStore((state) => state.setCurrentTenantId);
   const fetchNotifications = useNotificationStore((state) => state.fetch);
   const { t } = useTranslation('auth');
   const redirectPath = useMemo(() => {
@@ -34,6 +36,13 @@ export default function SocialSuccess() {
         const res = await getFullProfile();
         const profile = res.data;
         setUser(profile);
+        try {
+          const membershipRes = await fetchMemberships();
+          setMemberships(membershipRes?.data || []);
+          setCurrentTenantId(membershipRes?.currentTenantId || null);
+        } catch (membershipErr) {
+          console.warn("Failed to load memberships after social login", membershipErr);
+        }
         if (profile.profile_complete && profile.is_email_verified) {
           fetchNotifications();
         }

--- a/frontend/src/services/auth/authService.js
+++ b/frontend/src/services/auth/authService.js
@@ -101,3 +101,35 @@ export const logoutUser = async () => {
   const res = await api.post("/auth/logout");
   return res.data;
 };
+
+/**
+ * 🧾 Fetch tenant memberships for the authenticated user.
+ *
+ * @returns {Promise<{ data: Array, currentTenantId: string | null }>}
+ */
+export const fetchMemberships = async () => {
+  const res = await api.get("/auth/memberships");
+  return res.data;
+};
+
+/**
+ * 🔄 Switch active tenant context.
+ *
+ * @param {string} tenantId
+ * @returns {Promise<{ accessToken: string, currentTenantId: string }>}
+ */
+export const switchTenant = async (tenantId) => {
+  const res = await api.post("/auth/switch-tenant", { tenant_id: tenantId });
+  return res.data;
+};
+
+/**
+ * ✉️ Accept a tenant invite using an invite token.
+ *
+ * @param {string} token
+ * @returns {Promise<{ message: string, data: object }>}
+ */
+export const acceptTenantInviteToken = async (token) => {
+  const res = await api.post("/auth/tenant-invites/accept-token", { token });
+  return res.data;
+};

--- a/frontend/src/shared/components/auth/auth.module.scss
+++ b/frontend/src/shared/components/auth/auth.module.scss
@@ -266,6 +266,72 @@ $auth-text: $color-text-dark;
   text-align: center;
 }
 
+.membershipSection {
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba($auth-brand, 0.25);
+  background: rgba($auth-input, 0.35);
+}
+
+.membershipTitle {
+  font-size: 0.85rem;
+  color: $auth-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+.membershipList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.membershipItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: rgba($auth-bg, 0.4);
+  color: $auth-text;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.membershipItem:hover {
+  border-color: rgba($auth-brand, 0.5);
+  background: rgba($auth-brand, 0.08);
+}
+
+.membershipActive {
+  border-color: rgba($auth-brand, 0.6);
+  background: rgba($auth-brand, 0.12);
+}
+
+.membershipInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.membershipName {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.membershipMeta {
+  font-size: 0.75rem;
+  color: $auth-muted;
+}
+
+.membershipRadio {
+  accent-color: $auth-brand;
+}
+
 .smallText {
   font-size: 0.85rem;
   color: color.scale($auth-muted, $lightness: -18%);

--- a/frontend/src/store/auth/authStore.js
+++ b/frontend/src/store/auth/authStore.js
@@ -15,136 +15,176 @@ const createAuthStore = (set, get) => {
   return {
     user: null,
     accessToken: null,
+    memberships: [],
+    currentTenantId: null,
     onboarding: null,
     hasHydrated: !isClient,
 
-      setUser: (userData) =>
-        set({
-          user: userData,
-          onboarding: userData
-            ? {
-                profile_complete: userData.profile_complete,
-                is_email_verified: userData.is_email_verified,
-                complete:
-                  Boolean(userData.profile_complete) &&
-                  Boolean(userData.is_email_verified),
-              }
-            : null,
-        }),
-      setToken: (token) => set({ accessToken: token }),
-      markHydrated: () => set({ hasHydrated: true }),
+    setUser: (userData) =>
+      set({
+        user: userData,
+        onboarding: userData
+          ? {
+              profile_complete: userData.profile_complete,
+              is_email_verified: userData.is_email_verified,
+              complete:
+                Boolean(userData.profile_complete) &&
+                Boolean(userData.is_email_verified),
+            }
+          : null,
+      }),
+    setToken: (token) => set({ accessToken: token }),
+    setMemberships: (memberships = []) => set({ memberships }),
+    setCurrentTenantId: (tenantId) => set({ currentTenantId: tenantId }),
+    markHydrated: () => set({ hasHydrated: true }),
 
-      isAuthenticated: () => !!get().accessToken && !!get().user,
+    isAuthenticated: () => !!get().accessToken && !!get().user,
 
-      login: async (credentials) => {
-        logger.log("🔑 authStore.login invoked");
-        const { accessToken, user, onboarding } = await authService.loginUser(credentials);
+    login: async (credentials) => {
+      logger.log("🔑 authStore.login invoked");
+      const { accessToken, user, onboarding, memberships, currentTenantId } =
+        await authService.loginUser(credentials);
+      if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
+        user.avatar_url = null;
+      }
+      set({
+        accessToken,
+        user,
+        memberships: memberships || [],
+        currentTenantId: currentTenantId || null,
+        onboarding:
+          onboarding ||
+          {
+            profile_complete: user.profile_complete,
+            is_email_verified: user.is_email_verified,
+            complete:
+              Boolean(user.profile_complete) &&
+              Boolean(user.is_email_verified),
+          },
+      });
+      return user;
+    },
+
+    /**
+     * Log in using an already issued access token.
+     * Stores the token, fetches the profile and notifications.
+     */
+    loginWithToken: async (token) => {
+      set({ accessToken: token });
+      try {
+        const res = await getFullProfile();
+        let user = res.data;
         if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
           user.avatar_url = null;
         }
+        let memberships = [];
+        let currentTenantId = null;
+        try {
+          const membershipRes = await authService.fetchMemberships();
+          memberships = membershipRes?.data || [];
+          currentTenantId = membershipRes?.currentTenantId || null;
+        } catch (err) {
+          logger.warn?.("Failed to fetch memberships", err);
+        }
         set({
-          accessToken,
           user,
-          onboarding:
-            onboarding ||
-            {
-              profile_complete: user.profile_complete,
-              is_email_verified: user.is_email_verified,
-              complete:
-                Boolean(user.profile_complete) &&
-                Boolean(user.is_email_verified),
-            },
+          memberships,
+          currentTenantId,
+          onboarding: {
+            profile_complete: user.profile_complete,
+            is_email_verified: user.is_email_verified,
+            complete:
+              Boolean(user.profile_complete) &&
+              Boolean(user.is_email_verified),
+          },
         });
+        const fetchNotifications = useNotificationStore.getState().fetch;
+        fetchNotifications?.();
         return user;
-      },
+      } catch (err) {
+        logger.error("❌ loginWithToken error", { message: err?.message });
+        set({
+          accessToken: null,
+          user: null,
+          memberships: [],
+          currentTenantId: null,
+          onboarding: null,
+        });
+      }
+    },
 
-      /**
-       * Log in using an already issued access token.
-       * Stores the token, fetches the profile and notifications.
-       */
-      loginWithToken: async (token) => {
-        set({ accessToken: token });
+    refreshUser: async () => {
+      try {
+        const res = await getFullProfile();
+        const fresh = res.data;
+        if (fresh.avatar_url?.startsWith("blob:") || fresh.avatar_url === "null") {
+          fresh.avatar_url = null;
+        }
+        set({
+          user: fresh,
+          onboarding: {
+            profile_complete: fresh.profile_complete,
+            is_email_verified: fresh.is_email_verified,
+            complete:
+              Boolean(fresh.profile_complete) &&
+              Boolean(fresh.is_email_verified),
+          },
+        });
+        return fresh;
+      } catch (err) {
+        logger.error("❌ refreshUser error", { message: err?.message });
+      }
+    },
+
+    register: async (data) => {
+      await authService.registerUser(data);
+    },
+
+    switchTenant: async (tenantId) => {
+      const { accessToken, currentTenantId } =
+        await authService.switchTenant(tenantId);
+      set({
+        accessToken,
+        currentTenantId: currentTenantId || tenantId,
+      });
+      return currentTenantId;
+    },
+
+    logout: async (skipRequest = false) => {
+      if (!skipRequest) {
         try {
-          const res = await getFullProfile();
-          let user = res.data;
-          if (user.avatar_url?.startsWith("blob:") || user.avatar_url === "null") {
-            user.avatar_url = null;
-          }
-          set({
-            user,
-            onboarding: {
-              profile_complete: user.profile_complete,
-              is_email_verified: user.is_email_verified,
-              complete:
-                Boolean(user.profile_complete) &&
-                Boolean(user.is_email_verified),
-            },
-          });
-          const fetchNotifications = useNotificationStore.getState().fetch;
-          fetchNotifications?.();
-          return user;
-        } catch (err) {
-          logger.error("❌ loginWithToken error", { message: err?.message });
-          set({ accessToken: null, user: null, onboarding: null });
-        }
-      },
+          await authService.logoutUser();
+        } catch (_) {}
+      }
 
-      refreshUser: async () => {
+      // Stop polling intervals when logging out
+      const notifStop = useNotificationStore.getState().stopPolling;
+      const msgStop = useMessageStore.getState().stopPolling;
+      notifStop?.();
+      msgStop?.();
+      try {
+        const libraryState = useLibraryStore.getState?.();
+        libraryState?.clear?.();
+      } catch (err) {
+        logger.warn?.("Failed to reset library store during logout", err);
+      }
+      if (typeof window !== "undefined") {
+        localStorage.removeItem("auth");
         try {
-          const res = await getFullProfile();
-          const fresh = res.data;
-          if (fresh.avatar_url?.startsWith("blob:") || fresh.avatar_url === "null") {
-            fresh.avatar_url = null;
-          }
-          set({
-            user: fresh,
-            onboarding: {
-              profile_complete: fresh.profile_complete,
-              is_email_verified: fresh.is_email_verified,
-              complete:
-                Boolean(fresh.profile_complete) &&
-                Boolean(fresh.is_email_verified),
-            },
-          });
-          return fresh;
+          localStorage.removeItem("library-store");
         } catch (err) {
-          logger.error("❌ refreshUser error", { message: err?.message });
+          logger.warn?.("Failed to clear persisted library store", err);
         }
-      },
-
-      register: async (data) => {
-        await authService.registerUser(data);
-      },
-
-      logout: async (skipRequest = false) => {
-        if (!skipRequest) {
-          try {
-            await authService.logoutUser();
-          } catch (_) {}
-        }
-
-        // Stop polling intervals when logging out
-        const notifStop = useNotificationStore.getState().stopPolling;
-        const msgStop = useMessageStore.getState().stopPolling;
-        notifStop?.();
-        msgStop?.();
-        try {
-          const libraryState = useLibraryStore.getState?.();
-          libraryState?.clear?.();
-        } catch (err) {
-          logger.warn?.("Failed to reset library store during logout", err);
-        }
-        if (typeof window !== "undefined") {
-          localStorage.removeItem("auth");
-          try {
-            localStorage.removeItem("library-store");
-          } catch (err) {
-            logger.warn?.("Failed to clear persisted library store", err);
-          }
-        }
-        set({ accessToken: null, user: null, onboarding: null });
-      },
-    };
+      }
+      set({
+        accessToken: null,
+        user: null,
+        memberships: [],
+        currentTenantId: null,
+        onboarding: null,
+      });
+    },
+  };
 };
 
 const useAuthStore = create(


### PR DESCRIPTION
### Motivation
- Provide users a way to accept tenant invites via a token link and join tenants without needing an authenticated accept-by-tenant POST flow.
- Surface the user's available tenant memberships on the login screen so they can pick an active tenant after authentication.
- Allow switching the active tenant context in the header/account menu and persist the chosen tenant in tokens and client state.
- Make tenant resolution honor an authenticated user’s current tenant as a fallback for API requests.

### Description
- Backend: add migration to add `invite_token` to `tenant_memberships`, expose a public `POST /auth/tenant-invites/accept-token` endpoint to accept token-based invites, include `invite_token` when creating invites and send an email link to `FRONTEND_URL/auth/accept-invite`; also enrich membership queries with tenant metadata and include `currentTenantId/memberships` in login and refresh responses and refresh token payloads.
- Backend: update tenant middleware to fall back to `req.user.current_tenant_id` when host-based resolution is not available to allow request scoping by persisted tenant context.
- Frontend: add `accept-invite` page that consumes invite tokens and calls the new API, add membership display to the login page with UI for choosing a tenant post-login, and add a tenant switcher to the dashboard header that calls `POST /auth/switch-tenant` and updates client state.
- Frontend: extend `authService` with `fetchMemberships`, `switchTenant`, and `acceptTenantInviteToken`, persist `memberships` and `currentTenantId` in the auth store and wire them into `login`, `loginWithToken`, and social-login flows; add styles for membership list.

### Testing
- No automated unit or integration test suite was executed as part of this change.
- A Playwright screenshot run was attempted to validate the login UI, but the browser failed to launch in this environment (Playwright error), so no screenshot was captured.
- Backend migrations and endpoints were added but not executed against a live database in this rollout, so migration application/results were not validated here.
- Manual inspection and local execution are recommended to validate the migration, email invite link flow, token acceptance, and tenant switching behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696356baac448328a236d0e66b412ee9)