### PR TITLE
Add tenant subscription replay sync and enforce grace/suspended gating

### DIFF
--- a/backend/src/middleware/tenant.js
+++ b/backend/src/middleware/tenant.js
@@ -173,11 +173,14 @@ const enforceTenantStatus = ({ allowBillingPaths = [] } = {}) => {
     const isBillingPath = allowBillingPaths.some((pattern) =>
       pattern.test(req.path || ""),
     );
+    if (isBillingPath) return next();
 
     if (["suspended", "cancelled"].includes(status) && isMutating(req.method)) {
-      if (!isBillingPath) {
-        return res.status(423).json({ error: "tenant_suspended" });
-      }
+      return res.status(423).json({ error: "tenant_suspended" });
+    }
+
+    if (status === "grace" && isMutating(req.method)) {
+      return res.status(423).json({ error: "tenant_grace" });
     }
 
     return next();

--- a/backend/src/modules/tenantSubscriptions/tenantSubscriptions.controller.js
+++ b/backend/src/modules/tenantSubscriptions/tenantSubscriptions.controller.js
@@ -1,0 +1,9 @@
+const catchAsync = require("../../utils/catchAsync");
+const { sendSuccess } = require("../../utils/response");
+const subscriptionSync = require("../../services/subscriptionSyncService");
+
+exports.replaySubscriptions = catchAsync(async (req, res) => {
+  const tenantId = req.body?.tenant_id || req.query?.tenant_id || null;
+  const result = await subscriptionSync.replayTenantSubscriptions({ tenantId });
+  sendSuccess(res, result, "Subscription replay completed");
+});

--- a/backend/src/modules/tenantSubscriptions/tenantSubscriptions.routes.js
+++ b/backend/src/modules/tenantSubscriptions/tenantSubscriptions.routes.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("./tenantSubscriptions.controller");
+const { verifyToken, isAdmin } = require("../../middleware/auth/authMiddleware");
+
+router.post("/replay", verifyToken, isAdmin, controller.replaySubscriptions);
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -173,6 +173,10 @@ router.use(
 );
 router.use("/api/admin/cache", require("./cache.routes"));
 router.use(
+  "/api/admin/tenant-subscriptions",
+  require("../modules/tenantSubscriptions/tenantSubscriptions.routes"),
+);
+router.use(
   "/api/payments/config",
   require("../modules/paymentConfig/paymentConfig.routes"),
 );

--- a/backend/src/services/entitlements.js
+++ b/backend/src/services/entitlements.js
@@ -295,7 +295,7 @@ async function can({ tenantId, role, userId }, action) {
   if (BLOCKED_STATES.has(sub.state))
     return deny("subscription_blocked", { state: sub.state });
   if (LIMITED_STATES.has(sub.state) && isWriteAction(action)) {
-    // customize behavior during grace; here we allow unless plan/limits block
+    return deny("subscription_grace", { state: sub.state });
   }
 
   if (rule.feature) {

--- a/backend/src/services/subscriptionSyncService.js
+++ b/backend/src/services/subscriptionSyncService.js
@@ -1,0 +1,235 @@
+const db = require("../config/database");
+const logger = require("../utils/logger");
+
+const SEAT_FEATURES = [
+  {
+    featureKey: "max_users",
+    roles: ["tenant_admin", "instructor", "student"],
+  },
+  {
+    featureKey: "max_instructors",
+    roles: ["instructor"],
+  },
+];
+
+const normalizeOverrideEntry = (featureKey, value) => {
+  if (!featureKey) return null;
+  if (value === null || value === undefined) return null;
+  if (typeof value === "boolean") {
+    return {
+      feature_key: featureKey,
+      limit_type: "boolean",
+      enabled: value,
+    };
+  }
+  if (typeof value === "number") {
+    return {
+      feature_key: featureKey,
+      limit_type: "count",
+      limit_value: value,
+    };
+  }
+  if (typeof value === "object") {
+    const limitType = value.limit_type || value.limitType;
+    const limitValue =
+      value.limit_value !== undefined ? value.limit_value : value.limitValue;
+    const enabled = value.enabled;
+    if (!limitType && limitValue === undefined && enabled === undefined) {
+      return null;
+    }
+    return {
+      feature_key: featureKey,
+      limit_type: limitType || (enabled !== undefined ? "boolean" : "count"),
+      limit_value: limitValue,
+      enabled,
+    };
+  }
+  return null;
+};
+
+const normalizeFeatureOverrides = (rawOverrides) => {
+  if (!rawOverrides) return [];
+  if (Array.isArray(rawOverrides)) {
+    return rawOverrides
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") return null;
+        const featureKey = entry.feature_key || entry.featureKey;
+        return normalizeOverrideEntry(featureKey, entry);
+      })
+      .filter(Boolean);
+  }
+  if (typeof rawOverrides === "object") {
+    return Object.entries(rawOverrides)
+      .map(([key, value]) => normalizeOverrideEntry(key, value))
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const upsertUsageCounter = async (tenantId, featureKey, value, trx) => {
+  if (!featureKey) return;
+  const payload = {
+    tenant_id: tenantId,
+    feature_key: featureKey,
+    current_value: Number(value) || 0,
+  };
+  const query = trx || db;
+  await query("usage_counters")
+    .insert(payload)
+    .onConflict(["tenant_id", "feature_key"])
+    .merge({
+      current_value: payload.current_value,
+      updated_at: query.fn.now(),
+    });
+};
+
+const syncSeatUsage = async (tenantId, trx) => {
+  const query = trx || db;
+  const results = [];
+  for (const seat of SEAT_FEATURES) {
+    const row = await query("tenant_memberships")
+      .where({ tenant_id: tenantId, status: "active" })
+      .whereIn("role", seat.roles)
+      .count("* as c")
+      .first();
+    const count = parseInt(row?.c, 10) || 0;
+    await upsertUsageCounter(tenantId, seat.featureKey, count, query);
+    results.push({ feature_key: seat.featureKey, count });
+  }
+  return results;
+};
+
+const syncFeatureOverrides = async (tenantId, overrides, trx) => {
+  if (!overrides.length) return 0;
+  const query = trx || db;
+  const seen = new Set();
+  const rows = overrides
+    .map((override) => {
+      if (!override?.feature_key) return null;
+      const key = override.feature_key;
+      if (seen.has(key)) return null;
+      seen.add(key);
+      return {
+        tenant_id: tenantId,
+        feature_key: key,
+        limit_type: override.limit_type,
+        limit_value: override.limit_value ?? null,
+        enabled:
+          override.limit_type === "boolean"
+            ? override.enabled ?? false
+            : null,
+      };
+    })
+    .filter(Boolean);
+
+  if (!rows.length) return 0;
+
+  await query("feature_overrides")
+    .insert(rows)
+    .onConflict(["tenant_id", "feature_key"])
+    .merge({
+      limit_type: query.raw("EXCLUDED.limit_type"),
+      limit_value: query.raw("EXCLUDED.limit_value"),
+      enabled: query.raw("EXCLUDED.enabled"),
+    });
+  return rows.length;
+};
+
+const getSubscriptionSnapshot = async (tenantId) => {
+  if (!tenantId) return null;
+  const subscription = await db("subscriptions as s")
+    .leftJoin("plans as p", "p.id", "s.plan_id")
+    .select(
+      "s.tenant_id",
+      "s.plan_id",
+      "s.state",
+      "s.meta",
+      "p.features as plan_features",
+    )
+    .where("s.tenant_id", tenantId)
+    .first();
+  return subscription || null;
+};
+
+const syncTenantSubscriptionState = async (tenantId) => {
+  if (!tenantId) return { tenantId, updated: false, reason: "tenant_missing" };
+  const subscription = await getSubscriptionSnapshot(tenantId);
+  if (!subscription) {
+    return { tenantId, updated: false, reason: "subscription_missing" };
+  }
+
+  return db.transaction(async (trx) => {
+    const tenant = await trx("tenants")
+      .select("status", "plan_id")
+      .where({ id: tenantId })
+      .first();
+
+    const updates = {};
+    if (tenant?.status !== subscription.state) {
+      updates.status = subscription.state;
+    }
+    if (tenant?.plan_id !== subscription.plan_id) {
+      updates.plan_id = subscription.plan_id;
+    }
+
+    if (Object.keys(updates).length) {
+      updates.updated_at = trx.fn.now();
+      await trx("tenants").where({ id: tenantId }).update(updates);
+    }
+
+    const seatCounts = await syncSeatUsage(tenantId, trx);
+
+    const overrides = normalizeFeatureOverrides(
+      subscription?.meta?.feature_overrides ||
+        subscription?.meta?.featureOverrides ||
+        null,
+    );
+    const overrideCount = await syncFeatureOverrides(
+      tenantId,
+      overrides,
+      trx,
+    );
+
+    return {
+      tenantId,
+      updated: Object.keys(updates).length > 0,
+      status: subscription.state,
+      plan_id: subscription.plan_id,
+      seatCounts,
+      overridesUpdated: overrideCount,
+    };
+  });
+};
+
+const replayTenantSubscriptions = async ({ tenantId = null } = {}) => {
+  if (tenantId) {
+    return {
+      results: [await syncTenantSubscriptionState(tenantId)],
+    };
+  }
+
+  const subscriptions = await db("subscriptions").select("tenant_id");
+  const results = [];
+  for (const sub of subscriptions) {
+    try {
+      results.push(await syncTenantSubscriptionState(sub.tenant_id));
+    } catch (err) {
+      logger.warn?.("failed to sync subscription", {
+        tenantId: sub.tenant_id,
+        error: err.message,
+      });
+      results.push({
+        tenantId: sub.tenant_id,
+        updated: false,
+        reason: "sync_failed",
+      });
+    }
+  }
+  return { results };
+};
+
+module.exports = {
+  getSubscriptionSnapshot,
+  syncTenantSubscriptionState,
+  replayTenantSubscriptions,
+};


### PR DESCRIPTION
### Motivation
- Provide an admin-only mechanism to replay and reconcile tenant subscription records with tenant state and entitlement data.
- Ensure subscription state and metadata (plan, feature overrides) are reflected in runtime entitlements and usage counters.
- Harden tenant request handling so suspended or grace-state tenants are consistently gated across endpoints.

### Description
- Add a new subscription sync service `backend/src/services/subscriptionSyncService.js` that synchronizes `subscriptions` -> `tenants`, writes `feature_overrides`, and updates `usage_counters` for seat counts.
- Introduce an admin-only endpoint `POST /api/admin/tenant-subscriptions/replay` via `backend/src/modules/tenantSubscriptions/*` protected by `verifyToken` + `isAdmin` to replay for a tenant or all tenants.
- Tighten tenant middleware and entitlement checks by returning `423` for mutating requests when tenant `status` is `suspended`, `cancelled`, or `grace`; updated `backend/src/middleware/tenant.js` and `backend/src/services/entitlements.js` accordingly.
- Small query/context fixes in the sync service to consistently use the transaction/query object for `now()`/`raw` calls to avoid db context mismatches.

### Testing
- No automated tests were run as part of this change.
- Existing test suites were not modified by this PR and should continue to run normally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696356bb29248328bdc29e7606596cd6)