### PR TITLE
Add regression test guarding global tables from tenant scoping

### DIFF
--- a/backend/tests/globalTables.test.js
+++ b/backend/tests/globalTables.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+const GLOBAL_TABLES = [
+  'plans',
+  'plan_features',
+  'tenants',
+  'tenant_memberships',
+  'tenant_domains',
+  'subscriptions',
+  'feature_overrides',
+  'usage_counters',
+  'users',
+];
+
+const SQL_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'migrations',
+  'saas_multitenant.sql'
+);
+
+const extractTenantTables = (sql) => {
+  const match = sql.match(/tenant_tables\s+TEXT\[]\s*:=\s*ARRAY\[(.*?)\];/s);
+  if (!match) {
+    throw new Error('tenant_tables array not found in saas_multitenant.sql');
+  }
+
+  return match[1]
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => entry.replace(/'/g, '').trim());
+};
+
+describe('global tables are not tenant-scoped', () => {
+  test('tenant_tables excludes global tables', () => {
+    const sql = fs.readFileSync(SQL_PATH, 'utf8');
+    const tenantTables = extractTenantTables(sql);
+
+    GLOBAL_TABLES.forEach((table) => {
+      expect(tenantTables).not.toContain(table);
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Ensure core/global tables (plans, plan_features, users, etc.) are not accidentally included in tenant-scoped migrations.
- Prevent regressions where a global table is modified to be tenant-scoped by mistake.
- Surface migration/tenant-scoping mistakes early in CI via automated tests.
- Preserve intended separation between global configuration data and tenant-owned data.

### Description

- Add a new Jest test at `backend/tests/globalTables.test.js` that loads `migrations/saas_multitenant.sql` and extracts the `tenant_tables` array.
- Define a `GLOBAL_TABLES` list containing known global tables (`plans`, `plan_features`, `users`, `tenants`, `tenant_memberships`, `tenant_domains`, `subscriptions`, `feature_overrides`, `usage_counters`).
- Assert that none of the `GLOBAL_TABLES` appear in the `tenant_tables` array to prevent accidental tenant scoping.
- Implement parsing using a regex to find the `tenant_tables TEXT[] := ARRAY[...]` block and normalize entries before comparison.

### Testing

- Ran the new test with `npm test -- globalTables.test.js` as an automated Jest test.
- The test suite ran the single test and it passed (`1 passed, 1 total`).
- No other tests were modified or run as part of this change.
- The test will fail in CI if any global table is added to the tenant-scoped list, preventing future regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696356c01710832894cf1dbaaab32220)