### PR TITLE
Add tenant scoping and storage cleanup for uploaded assets and chat messages

### DIFF
--- a/backend/src/middleware/storage.js
+++ b/backend/src/middleware/storage.js
@@ -126,4 +126,5 @@ module.exports = {
   sumUploadedBytes,
   getStorageUsage,
   addStorageUsage,
+  subtractStorageUsage,
 };

--- a/backend/src/migrations/20260703090000_add_upload_tenant_scopes.js
+++ b/backend/src/migrations/20260703090000_add_upload_tenant_scopes.js
@@ -1,0 +1,168 @@
+/**
+ * Ensure upload-related tables have tenant_id set for multitenancy:
+ * - users (avatars)
+ * - payments (receipts)
+ * - admin_profiles/student_profiles (identity docs)
+ * - messages (chat DMs)
+ */
+
+const TABLES = {
+  users: {
+    userColumn: "id",
+    nullable: true,
+    onDelete: "SET NULL",
+  },
+  payments: {
+    userColumn: "user_id",
+    nullable: false,
+    onDelete: "CASCADE",
+  },
+  admin_profiles: {
+    userColumn: "user_id",
+    nullable: false,
+    onDelete: "CASCADE",
+  },
+  student_profiles: {
+    userColumn: "user_id",
+    nullable: false,
+    onDelete: "CASCADE",
+  },
+  messages: {
+    senderColumn: "sender_id",
+    receiverColumn: "receiver_id",
+    nullable: false,
+    onDelete: "CASCADE",
+  },
+};
+
+const getFallbackTenantId = async (knex) => {
+  const hasTenants = await knex.schema.hasTable("tenants");
+  if (!hasTenants) return null;
+  const row = await knex("tenants").select("id").orderBy("created_at", "asc").first();
+  return row?.id || null;
+};
+
+const ensureTenantColumn = async (knex, tableName) => {
+  const hasTable = await knex.schema.hasTable(tableName);
+  if (!hasTable) return false;
+  const hasTenantId = await knex.schema.hasColumn(tableName, "tenant_id");
+  if (!hasTenantId) {
+    await knex.schema.alterTable(tableName, (table) => {
+      table.uuid("tenant_id").nullable();
+    });
+  }
+  return true;
+};
+
+const backfillFromMemberships = async (knex, tableName, config) => {
+  const hasMemberships = await knex.schema.hasTable("tenant_memberships");
+  if (!hasMemberships) return;
+
+  if (config.senderColumn && config.receiverColumn) {
+    await knex.raw(
+      `
+        UPDATE ${tableName} AS t
+        SET tenant_id = COALESCE(
+          (
+            SELECT tm.tenant_id
+            FROM tenant_memberships tm
+            WHERE tm.user_id = t.${config.senderColumn}
+            ORDER BY tm.created_at ASC
+            LIMIT 1
+          ),
+          (
+            SELECT tm.tenant_id
+            FROM tenant_memberships tm
+            WHERE tm.user_id = t.${config.receiverColumn}
+            ORDER BY tm.created_at ASC
+            LIMIT 1
+          )
+        )
+        WHERE t.tenant_id IS NULL
+      `,
+    );
+    return;
+  }
+
+  const userColumn = config.userColumn;
+  if (!userColumn) return;
+  await knex.raw(
+    `
+      UPDATE ${tableName} AS t
+      SET tenant_id = tm.tenant_id
+      FROM LATERAL (
+        SELECT tenant_id
+        FROM tenant_memberships
+        WHERE user_id = t.${userColumn}
+        ORDER BY created_at ASC
+        LIMIT 1
+      ) tm
+      WHERE t.tenant_id IS NULL AND tm.tenant_id IS NOT NULL
+    `,
+  );
+};
+
+const backfillFallbackTenant = async (knex, tableName, fallbackTenantId) => {
+  if (!fallbackTenantId) return;
+  await knex(tableName)
+    .whereNull("tenant_id")
+    .update({ tenant_id: fallbackTenantId });
+};
+
+const addTenantConstraints = async (knex, tableName, config) => {
+  const hasTenants = await knex.schema.hasTable("tenants");
+  if (!hasTenants) return;
+  if (!config.nullable) {
+    await knex.schema.alterTable(tableName, (table) => {
+      table.uuid("tenant_id").notNullable().alter();
+    });
+  }
+  const constraintName = `${tableName}_tenant_id_foreign`;
+  await knex.raw(
+    `
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = '${constraintName}'
+      ) THEN
+        ALTER TABLE ${tableName}
+          ADD CONSTRAINT ${constraintName}
+          FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE ${config.onDelete};
+      END IF;
+    END$$;
+    `,
+  );
+  await knex.raw(
+    `CREATE INDEX IF NOT EXISTS ${tableName}_tenant_idx ON ${tableName}(tenant_id);`,
+  );
+};
+
+exports.up = async function up(knex) {
+  const fallbackTenantId = await getFallbackTenantId(knex);
+
+  for (const [tableName, config] of Object.entries(TABLES)) {
+    const exists = await ensureTenantColumn(knex, tableName);
+    if (!exists) continue;
+
+    await backfillFromMemberships(knex, tableName, config);
+    await backfillFallbackTenant(knex, tableName, fallbackTenantId);
+    await addTenantConstraints(knex, tableName, config);
+  }
+};
+
+exports.down = async function down(knex) {
+  for (const tableName of Object.keys(TABLES)) {
+    const hasTable = await knex.schema.hasTable(tableName);
+    if (!hasTable) continue;
+    const hasColumn = await knex.schema.hasColumn(tableName, "tenant_id");
+    if (!hasColumn) continue;
+
+    await knex.raw(`DROP INDEX IF EXISTS ${tableName}_tenant_idx;`);
+    await knex.raw(
+      `ALTER TABLE ${tableName} DROP CONSTRAINT IF EXISTS ${tableName}_tenant_id_foreign;`,
+    );
+    await knex.schema.alterTable(tableName, (table) => {
+      table.dropColumn("tenant_id");
+    });
+  }
+};

--- a/backend/src/modules/chat/chat.controller.js
+++ b/backend/src/modules/chat/chat.controller.js
@@ -2,16 +2,37 @@ const catchAsync = require("../../utils/catchAsync");
 const { sendSuccess } = require("../../utils/response");
 const AppError = require("../../utils/AppError");
 const service = require("./chat.service");
+const logger = require("../../utils/logger");
+const { resolveUploadFilePath } = require("../../utils/uploads");
+const { subtractStorageUsage } = require("../../middleware/storage");
+const fs = require("fs");
+
+const removeAttachment = async (url, tenantId) => {
+  if (!url || !url.includes("/uploads/")) return;
+  const filePath = resolveUploadFilePath(url);
+  if (!filePath) return;
+  try {
+    const stat = await fs.promises.stat(filePath);
+    await fs.promises.unlink(filePath);
+    if (tenantId && stat?.size) {
+      await subtractStorageUsage(tenantId, stat.size);
+    }
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      logger.warn("Failed to delete chat attachment", err.message);
+    }
+  }
+};
 
 exports.searchUsers = catchAsync(async (req, res) => {
   const term = req.query.q || "";
-  const users = await service.searchUsers(req.user.id, term);
+  const users = await service.searchUsers(req.user.id, term, req.tenant?.id || null);
   sendSuccess(res, users);
 });
 
 exports.getConversation = catchAsync(async (req, res) => {
   const otherId = req.params.userId;
-  const convo = await service.getConversation(req.user.id, otherId);
+  const convo = await service.getConversation(req.user.id, otherId, req.tenant?.id || null);
   sendSuccess(res, convo);
 });
 
@@ -36,18 +57,24 @@ exports.sendMessage = catchAsync(async (req, res) => {
     file_url: fileUrl,
     audio_url: audioUrl,
     reply_to_id: replyTo || null,
+    tenant_id: req.tenant?.id || null,
   });
   sendSuccess(res, msg, "Message sent");
 });
 
 exports.deleteMessage = catchAsync(async (req, res) => {
-  const msg = await service.deleteMessage(req.user.id, req.params.id);
+  const tenantId = req.tenant?.id || null;
+  const msg = await service.deleteMessage(req.user.id, req.params.id, tenantId);
   if (!msg) throw new AppError("Message not found", 404);
+  await Promise.all([
+    removeAttachment(msg.file_url, msg.tenant_id || tenantId),
+    removeAttachment(msg.audio_url, msg.tenant_id || tenantId),
+  ]);
   sendSuccess(res, msg, "Message deleted");
 });
 
 exports.togglePin = catchAsync(async (req, res) => {
-  const msg = await service.togglePin(req.user.id, req.params.id);
+  const msg = await service.togglePin(req.user.id, req.params.id, req.tenant?.id || null);
   if (!msg) throw new AppError("Message not found", 404);
   sendSuccess(res, msg, msg.pinned ? "Pinned" : "Unpinned");
 });

--- a/backend/src/modules/chat/chat.routes.js
+++ b/backend/src/modules/chat/chat.routes.js
@@ -2,6 +2,8 @@ const express = require("express");
 const router = express.Router();
 const controller = require("./chat.controller");
 const { verifyToken } = require("../../middleware/auth/authMiddleware");
+const { resolveTenant, ensureTenantMembership } = require("../../middleware/tenant");
+const { checkAndConsumeStorage } = require("../../middleware/storage");
 const upload = require("./chatUpload.middleware");
 const validate = require("../../middleware/validate");
 const validator = require("./chat.validator");
@@ -14,7 +16,7 @@ const mapFilesToBody = (req, _res, next) => {
   next();
 };
 
-router.use(verifyToken);
+router.use(verifyToken, resolveTenant, ensureTenantMembership());
 
 router.get("/users", controller.searchUsers);
 router.post(
@@ -28,6 +30,7 @@ router.post(
   upload,
   mapFilesToBody,
   validate(validator.sendMessage),
+  checkAndConsumeStorage(),
   controller.sendMessage
 );
 router.delete("/messages/:id", controller.deleteMessage);

--- a/backend/src/modules/chat/chat.service.js
+++ b/backend/src/modules/chat/chat.service.js
@@ -4,14 +4,33 @@ const notificationService = require("../notifications/notifications.service");
 const userModel = require("../users/user.model");
 const messageService = require("../messages/messages.service");
 
-exports.searchUsers = async (currentUserId, term) => {
+let messageTenantColumnPromise;
+const hasMessageTenantColumn = async () => {
+  if (!messageTenantColumnPromise) {
+    messageTenantColumnPromise = db.schema.hasColumn("messages", "tenant_id");
+  }
+  return messageTenantColumnPromise;
+};
+
+const applyTenantScope = (query, tenantId, hasTenantId, alias = "messages") => {
+  if (tenantId && hasTenantId) {
+    query.andWhere(`${alias}.tenant_id`, tenantId);
+  }
+  return query;
+};
+
+exports.searchUsers = async (currentUserId, term, tenantId = null) => {
+  const hasTenantId = await hasMessageTenantColumn();
   const subquery = db("messages")
     .select("sender_id")
     .count("id as count")
     .where({ receiver_id: currentUserId, read: false })
+    .modify((query) => applyTenantScope(query, tenantId, hasTenantId, "messages"))
     .groupBy("sender_id")
     .as("unread");
 
+  const tenantFilter = hasTenantId && tenantId ? " AND tenant_id = ?" : "";
+  const tenantParams = hasTenantId && tenantId ? [tenantId] : [];
   const lastMessageSub = db.raw(
     `(
       SELECT DISTINCT ON (other_user)
@@ -24,11 +43,11 @@ exports.searchUsers = async (currentUserId, term) => {
           message,
           sent_at
         FROM messages
-        WHERE sender_id = ? OR receiver_id = ?
+        WHERE (sender_id = ? OR receiver_id = ?)${tenantFilter}
       ) m
       ORDER BY other_user, sent_at DESC
     ) as last_msg`,
-    [currentUserId, currentUserId, currentUserId]
+    [currentUserId, currentUserId, currentUserId, ...tenantParams]
   );
 
   return db("users")
@@ -55,17 +74,30 @@ exports.searchUsers = async (currentUserId, term) => {
           .orWhere("users.phone", "ilike", t);
       }
     })
+    .modify((query) => {
+      if (tenantId) {
+        query.whereExists(function () {
+          this.select(1)
+            .from("tenant_memberships as tm")
+            .whereRaw("tm.user_id = users.id")
+            .andWhere("tm.tenant_id", tenantId)
+            .andWhere("tm.status", "active");
+        });
+      }
+    })
     .whereNot("users.id", currentUserId)
     .whereNotIn("users.role", ["Admin", "SuperAdmin"])
     .limit(20);
 };
 
-exports.getConversation = async (userId, otherId) => {
+exports.getConversation = async (userId, otherId, tenantId = null) => {
+  const hasTenantId = await hasMessageTenantColumn();
   await db("messages")
     .where({ sender_id: otherId, receiver_id: userId, read: false })
+    .modify((query) => applyTenantScope(query, tenantId, hasTenantId, "messages"))
     .update({ read: true, read_at: new Date() });
 
-  return db({ m: "messages" })
+  const convoQuery = db({ m: "messages" })
     .leftJoin({ r: "messages" }, "m.reply_to_id", "r.id")
     .select(
       "m.*",
@@ -78,6 +110,8 @@ exports.getConversation = async (userId, otherId) => {
         .orWhere({ "m.sender_id": otherId, "m.receiver_id": userId });
     })
     .orderBy("m.sent_at");
+  applyTenantScope(convoQuery, tenantId, hasTenantId, "m");
+  return convoQuery;
 };
 
 exports.sendMessage = async ({
@@ -87,6 +121,7 @@ exports.sendMessage = async ({
   file_url,
   audio_url,
   reply_to_id,
+  tenant_id,
 }) =>
   messageService.createMessage({
     sender_id,
@@ -95,29 +130,35 @@ exports.sendMessage = async ({
     file_url,
     audio_url,
     reply_to_id,
+    tenant_id,
   });
 
-exports.deleteMessage = async (userId, id) => {
+exports.deleteMessage = async (userId, id, tenantId = null) => {
+  const hasTenantId = await hasMessageTenantColumn();
   const [row] = await db("messages")
     .where({ id })
     .andWhere(function () {
       this.where({ sender_id: userId }).orWhere({ receiver_id: userId });
     })
+    .modify((query) => applyTenantScope(query, tenantId, hasTenantId, "messages"))
     .del()
     .returning("*");
   return row;
 };
 
-exports.togglePin = async (userId, id) => {
+exports.togglePin = async (userId, id, tenantId = null) => {
+  const hasTenantId = await hasMessageTenantColumn();
   const msg = await db("messages")
     .where({ id })
     .andWhere(function () {
       this.where({ sender_id: userId }).orWhere({ receiver_id: userId });
     })
+    .modify((query) => applyTenantScope(query, tenantId, hasTenantId, "messages"))
     .first();
   if (!msg) return null;
   const [updated] = await db("messages")
     .where({ id })
+    .modify((query) => applyTenantScope(query, tenantId, hasTenantId, "messages"))
     .update({ pinned: !msg.pinned })
     .returning("*");
   return updated;

--- a/backend/src/modules/messages/messages.service.js
+++ b/backend/src/modules/messages/messages.service.js
@@ -11,6 +11,52 @@ const MESSAGE_RETENTION_MS =
   60 *
   1000;
 
+let messageColumnInfoPromise;
+const getMessageColumnInfo = async () => {
+  if (!messageColumnInfoPromise) {
+    messageColumnInfoPromise = Promise.all([
+      db.schema.hasColumn("messages", "tenant_id"),
+      db.schema.hasTable("tenant_memberships"),
+      db.schema.hasTable("tenants"),
+    ]).then(([hasTenantId, hasMemberships, hasTenants]) => ({
+      hasTenantId,
+      hasMemberships,
+      hasTenants,
+    }));
+  }
+  return messageColumnInfoPromise;
+};
+
+const resolveTenantId = async ({ tenant_id, sender_id, receiver_id }) => {
+  if (tenant_id) return tenant_id;
+  const { hasMemberships, hasTenants } = await getMessageColumnInfo();
+  if (hasMemberships) {
+    const senderMembership = await db("tenant_memberships")
+      .select("tenant_id")
+      .where({ user_id: sender_id })
+      .orderBy("created_at", "asc")
+      .first();
+    if (senderMembership?.tenant_id) return senderMembership.tenant_id;
+
+    const receiverMembership = await db("tenant_memberships")
+      .select("tenant_id")
+      .where({ user_id: receiver_id })
+      .orderBy("created_at", "asc")
+      .first();
+    if (receiverMembership?.tenant_id) return receiverMembership.tenant_id;
+  }
+
+  if (hasTenants) {
+    const fallback = await db("tenants")
+      .select("id")
+      .orderBy("created_at", "asc")
+      .first();
+    return fallback?.id || null;
+  }
+
+  return null;
+};
+
 exports.createMessage = async (
   {
     sender_id,
@@ -21,6 +67,7 @@ exports.createMessage = async (
     file_url = null,
     audio_url = null,
     reply_to_id = null,
+    tenant_id = null,
   },
   trx = null,
   emit = true,
@@ -67,6 +114,25 @@ exports.createMessage = async (
     audio_url,
     reply_to_id,
   };
+
+  const { hasTenantId } = await getMessageColumnInfo();
+  if (hasTenantId) {
+    payload.tenant_id = await resolveTenantId({
+      tenant_id,
+      sender_id,
+      receiver_id,
+    });
+    if (!payload.tenant_id) {
+      logger.warn("Skipping message: tenant_id missing for scoped table", {
+        sender_id,
+        receiver_id,
+        type,
+      });
+      return null;
+    }
+  } else if (payload.tenant_id !== undefined) {
+    delete payload.tenant_id;
+  }
 
   const run = async (transaction) => {
     const [row] = await transaction("messages")

--- a/backend/src/modules/payments/payments.controller.js
+++ b/backend/src/modules/payments/payments.controller.js
@@ -32,6 +32,9 @@ const {
 const paymentScheduleService = require("./paymentSchedule.service");
 const { markCouponRedeemed } = require("./helpers/coupon");
 const db = require("../../config/database");
+const { resolveUploadFilePath } = require("../../utils/uploads");
+const { subtractStorageUsage } = require("../../middleware/storage");
+const fs = require("fs");
 const resolveInvoicePath = (invoice) => {
   if (!invoice) return null;
   if (invoice.file_path) return invoice.file_path;
@@ -496,6 +499,25 @@ exports.updatePayment = catchAsync(async (req, res) => {
 });
 
 exports.deletePayment = catchAsync(async (req, res) => {
-  await service.delete(req.params.id, req.tenant?.id);
+  const tenantId = req.tenant?.id || null;
+  const payment = await service.getById(req.params.id, tenantId);
+  await service.delete(req.params.id, tenantId);
+
+  if (payment?.receipt_url && payment.receipt_url.includes("/uploads/")) {
+    const receiptPath = resolveUploadFilePath(payment.receipt_url);
+    if (receiptPath) {
+      try {
+        const stat = await fs.promises.stat(receiptPath);
+        await fs.promises.unlink(receiptPath);
+        if (tenantId && stat?.size) {
+          await subtractStorageUsage(tenantId, stat.size);
+        }
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          logger.warn("Failed to delete payment receipt", err.message);
+        }
+      }
+    }
+  }
   sendSuccess(res, null, "Payment deleted");
 });

--- a/backend/src/modules/users/admin/admin.controller.js
+++ b/backend/src/modules/users/admin/admin.controller.js
@@ -288,9 +288,12 @@ exports.updateAvatar = async (req, res) => {
     }
   }
 
-  await db("users")
-    .where({ id: existing.id })
-    .update({ avatar_url: filePath, updated_at: new Date() });
+  const updateData = { avatar_url: filePath, updated_at: new Date() };
+  if (req.tenant?.id) {
+    updateData.tenant_id = req.tenant.id;
+  }
+
+  await db("users").where({ id: existing.id }).update(updateData);
 
   res.json({ message: "Avatar updated", avatar_url: filePath });
 };

--- a/backend/src/modules/users/instructor/instructor.controller.js
+++ b/backend/src/modules/users/instructor/instructor.controller.js
@@ -262,9 +262,11 @@ exports.updateAvatar = async (req, res) => {
             }
         }
 
-        await db("users")
-            .where({ id: targetId })
-            .update({ avatar_url: avatarUrl });
+        const updateData = { avatar_url: avatarUrl };
+        if (req.tenant?.id) {
+            updateData.tenant_id = req.tenant.id;
+        }
+        await db("users").where({ id: targetId }).update(updateData);
 
         res.json({ avatar_url: avatarUrl });
     } catch (err) {

--- a/backend/src/modules/users/student/student.controller.js
+++ b/backend/src/modules/users/student/student.controller.js
@@ -153,9 +153,11 @@ exports.updateAvatar = async (req, res) => {
     }
 
     const avatarUrl = `/uploads/avatars/student/${req.file.filename}`;
-    await db("users")
-      .where({ id: req.user.id })
-      .update({ avatar_url: avatarUrl });
+    const updateData = { avatar_url: avatarUrl };
+    if (tenantId) {
+      updateData.tenant_id = tenantId;
+    }
+    await db("users").where({ id: req.user.id }).update(updateData);
     res.json({ avatar_url: avatarUrl });
   } catch (error) {
     logger.error(error);


### PR DESCRIPTION
### Motivation

- Ensure all upload-related records (avatars, receipts, identity docs, chat DMs) are properly scoped to a tenant for multi-tenancy correctness.  
- Backfill existing rows with `tenant_id` where missing and add constraints/indexes to prevent future orphaned records.  
- Make delete flows remove filesystem artifacts and decrement tenant storage usage to keep `usage_counters` accurate.  

### Description

- Added a migration `20260703090000_add_upload_tenant_scopes.js` which adds nullable `tenant_id` columns to upload-related tables, backfills values from `tenant_memberships` or a fallback tenant, and adds NOT NULL constraints, foreign keys and indexes where appropriate.  
- Messages were updated to resolve and attach a `tenant_id` on create via `messages.service.js`, and chat queries/operations were scoped to the tenant in `chat.service.js` and `chat.controller.js`.  
- Upload/delete flows now remove on-disk files and decrement usage counters using `subtractStorageUsage`; payment receipt deletion was enhanced in `payments.controller.js` and chat attachment deletion is performed in `chat.controller.js`, and `subtractStorageUsage` is exported from `middleware/storage.js`.  
- Avatar upload handlers for admin/instructor/student now persist `tenant_id` on the `users` row when available, and chat routes enforce tenant resolution and storage checks (`checkAndConsumeStorage`).  

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696356c038c083289096905a86226435)