### PR TITLE
Add tenant-aware database backup and restore scripts

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -172,6 +172,63 @@ data. Manually deleting the `postgres_data` or `pgadmin_data` volumes will also
 erase data. Consider mounting these volumes to external storage or setting up
 regular backups to protect critical information.
 
+## Backup and restore (tenant-aware)
+
+SkillBridge ships with database backup and restore scripts:
+
+- `scripts/backup_db.sh` — generates a full backup or a tenant-scoped backup.
+- `scripts/restore_db.sh` — restores a backup SQL file.
+
+Both scripts use `DATABASE_URL` when set, or fall back to the `db` container
+from Docker Compose.
+
+### Full database backup
+
+```bash
+./scripts/backup_db.sh --output backups/skillbridge_full.sql
+```
+
+### Tenant-scoped backup
+
+Use the tenant UUID to export only rows tied to that tenant (plus referenced
+tenant configuration and users).
+
+```bash
+./scripts/backup_db.sh --output backups/tenant_123.sql --tenant-id 00000000-0000-0000-0000-000000000001
+```
+
+The script validates the tenant ID format and verifies the tenant exists before
+writing the backup.
+
+### Restore a backup
+
+```bash
+./scripts/restore_db.sh --input backups/skillbridge_full.sql
+```
+
+For tenant-scoped backups, pass the tenant ID that the backup was created for:
+
+```bash
+./scripts/restore_db.sh --input backups/tenant_123.sql --tenant-id 00000000-0000-0000-0000-000000000001
+```
+
+The restore script reads the tenant ID header and refuses to restore if the
+value does not match.
+
+### Recovery steps and verification checks
+
+1. **Stop application traffic** (or place the system in maintenance mode).
+2. **Restore the backup** using the commands above.
+3. **Run migrations** to ensure the schema matches the application:
+   ```bash
+   npm --prefix backend run migrate
+   ```
+4. **Restart services** and verify the environment:
+   - `curl https://<domain>/api/health` returns `{"status":"ok"}`.
+   - Log in to `/dashboard/admin` and confirm tenant data loads.
+   - Run `docker compose logs backend` to confirm there are no migration or
+     tenant resolution errors.
+
 ## Next.js image domains
 
 Uploads served from the backend domain are now automatically whitelisted for

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/backup_db.sh --output <file> [--tenant-id <uuid>]
+
+Options:
+  --output <file>     Destination SQL file.
+  --tenant-id <uuid>  Scope backup to a single tenant (UUID).
+  -h, --help          Show this help message.
+EOF
+}
+
+OUTPUT=""
+TENANT_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      OUTPUT="${2:-}"
+      shift 2
+      ;;
+    --tenant-id)
+      TENANT_ID="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$OUTPUT" ]]; then
+  echo "Missing required --output value." >&2
+  usage
+  exit 1
+fi
+
+if [[ -n "$TENANT_ID" ]]; then
+  if [[ ! "$TENANT_ID" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+    echo "Invalid tenant ID format; expected UUID." >&2
+    exit 1
+  fi
+fi
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+if command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  DOCKER_COMPOSE="docker compose"
+fi
+
+DB_URL="${DATABASE_URL:-}"
+
+run_psql() {
+  local query=$1
+  if [[ -n "$DB_URL" ]]; then
+    psql "$DB_URL" -tAc "$query"
+  elif $DOCKER_COMPOSE ps -q db >/dev/null 2>&1; then
+    $DOCKER_COMPOSE exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "$query"
+  else
+    echo "DATABASE_URL is not set and no docker compose db service is running." >&2
+    exit 1
+  fi
+}
+
+run_pg_dump() {
+  if [[ -n "$DB_URL" ]]; then
+    pg_dump "$DB_URL" "$@"
+  elif $DOCKER_COMPOSE ps -q db >/dev/null 2>&1; then
+    $DOCKER_COMPOSE exec -T db pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" "$@"
+  else
+    echo "DATABASE_URL is not set and no docker compose db service is running." >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+if [[ -z "$TENANT_ID" ]]; then
+  run_pg_dump --no-owner --no-privileges --format=plain > "$OUTPUT"
+  echo "Full database backup written to $OUTPUT"
+  exit 0
+fi
+
+tenant_exists=$(run_psql "SELECT 1 FROM tenants WHERE id = '$TENANT_ID' LIMIT 1;")
+if [[ "$tenant_exists" != "1" ]]; then
+  echo "Tenant $TENANT_ID does not exist." >&2
+  exit 1
+fi
+
+{
+  echo "-- SkillBridge tenant-scoped backup"
+  echo "-- tenant_id: $TENANT_ID"
+  echo "-- created_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo
+} > "$OUTPUT"
+
+tenant_tables=$(run_psql "SELECT table_name FROM information_schema.columns WHERE table_schema = 'public' AND column_name = 'tenant_id' ORDER BY table_name;")
+
+run_pg_dump --data-only --column-inserts --no-owner --no-privileges \
+  --table=tenants --where="id = '$TENANT_ID'" >> "$OUTPUT"
+
+subscriptions_exists=$(run_psql "SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'subscriptions' LIMIT 1;")
+if [[ "$subscriptions_exists" == "1" ]]; then
+  plan_ids=$(run_psql "SELECT DISTINCT plan_id FROM subscriptions WHERE tenant_id = '$TENANT_ID' AND plan_id IS NOT NULL;")
+  if [[ -n "$plan_ids" ]]; then
+    plan_list=$(echo "$plan_ids" | awk '{printf "%s%s%s", sep, "'\''" $0 "'\''"; sep=","}')
+    run_pg_dump --data-only --column-inserts --no-owner --no-privileges \
+      --table=plans --where="id IN (${plan_list})" >> "$OUTPUT"
+    run_pg_dump --data-only --column-inserts --no-owner --no-privileges \
+      --table=plan_features --where="plan_id IN (${plan_list})" >> "$OUTPUT"
+  fi
+fi
+
+memberships_exists=$(run_psql "SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'tenant_memberships' LIMIT 1;")
+if [[ "$memberships_exists" == "1" ]]; then
+  user_ids=$(run_psql "SELECT DISTINCT user_id FROM tenant_memberships WHERE tenant_id = '$TENANT_ID' AND user_id IS NOT NULL;")
+  if [[ -n "$user_ids" ]]; then
+    user_list=$(echo "$user_ids" | awk '{printf "%s%s%s", sep, "'\''" $0 "'\''"; sep=","}')
+    run_pg_dump --data-only --column-inserts --no-owner --no-privileges \
+      --table=users --where="id IN (${user_list})" >> "$OUTPUT"
+  fi
+fi
+
+while IFS= read -r table; do
+  [[ -z "$table" ]] && continue
+  run_pg_dump --data-only --column-inserts --no-owner --no-privileges \
+    --table="$table" --where="tenant_id = '$TENANT_ID'" >> "$OUTPUT"
+done <<< "$tenant_tables"
+
+echo "Tenant-scoped backup written to $OUTPUT"

--- a/scripts/restore_db.sh
+++ b/scripts/restore_db.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/restore_db.sh --input <file> [--tenant-id <uuid>]
+
+Options:
+  --input <file>      SQL backup file to restore.
+  --tenant-id <uuid>  Expected tenant ID for tenant-scoped backups.
+  -h, --help          Show this help message.
+EOF
+}
+
+INPUT=""
+TENANT_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input)
+      INPUT="${2:-}"
+      shift 2
+      ;;
+    --tenant-id)
+      TENANT_ID="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$INPUT" ]]; then
+  echo "Missing required --input value." >&2
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$INPUT" ]]; then
+  echo "Input file not found: $INPUT" >&2
+  exit 1
+fi
+
+if [[ -n "$TENANT_ID" ]]; then
+  if [[ ! "$TENANT_ID" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+    echo "Invalid tenant ID format; expected UUID." >&2
+    exit 1
+  fi
+fi
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+if command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  DOCKER_COMPOSE="docker compose"
+fi
+
+DB_URL="${DATABASE_URL:-}"
+
+run_psql() {
+  if [[ -n "$DB_URL" ]]; then
+    psql "$DB_URL" "$@"
+  elif $DOCKER_COMPOSE ps -q db >/dev/null 2>&1; then
+    $DOCKER_COMPOSE exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" "$@"
+  else
+    echo "DATABASE_URL is not set and no docker compose db service is running." >&2
+    exit 1
+  fi
+}
+
+file_tenant_id=$(awk '/^-- tenant_id:/ {print $3; exit}' "$INPUT" || true)
+if [[ -n "$file_tenant_id" ]]; then
+  if [[ -z "$TENANT_ID" ]]; then
+    echo "Tenant-scoped backup detected. Provide --tenant-id $file_tenant_id to confirm restore." >&2
+    exit 1
+  fi
+  if [[ "$file_tenant_id" != "$TENANT_ID" ]]; then
+    echo "Tenant ID mismatch: file expects $file_tenant_id, received $TENANT_ID." >&2
+    exit 1
+  fi
+fi
+
+run_psql -v ON_ERROR_STOP=1 -f "$INPUT"
+echo "Restore completed from $INPUT"


### PR DESCRIPTION
### Motivation
- Provide an easy, auditable way to back up and restore the database with optional tenant scoping.  
- Allow exporting only tenant-related rows and referenced configuration (plans, users) to simplify tenant-level recovery.  
- Add validation and safeguards to avoid accidental restores to the wrong tenant.  
- Document the recommended recovery procedure and verification checks for operators.

### Description
- Add `scripts/backup_db.sh`, which produces a full dump or a tenant-scoped SQL export and validates tenant UUID format and existence.  
- Add `scripts/restore_db.sh`, which restores an SQL file and enforces tenant ID confirmation for tenant-scoped backups.  
- Both scripts use `DATABASE_URL` when present or execute inside the `db` Docker Compose service, and the backup script includes referenced `plans`/`plan_features` and `users` when applicable.  
- Update `docs/deployment.md` with usage examples, recovery steps, and verification checks for both full and tenant-scoped workflows.

### Testing
- New scripts were made executable (`chmod +x`) and inspected to confirm content and usage examples.  
- Basic sanity checks were performed by printing the new script contents and updated docs.  
- No automated test suite was run against these changes.  
- Operators should perform a dry-run backup and restore in a staging environment before using in production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696356c1d1e08328b49a27cb4a767452)